### PR TITLE
Fixed broken link to custom attribute registry

### DIFF
--- a/archive/301/spec/epub-changes.html
+++ b/archive/301/spec/epub-changes.html
@@ -419,7 +419,7 @@
                      <a class="link" href="epub-contentdocs.html#sec-xhtml-custom-attributes">Custom attributes</a> 
                      <a class="biblioref" href="#refContentDocs3" title="EPUB Content Documents 3.0.1">[<abbr>ContentDocs301</abbr>]</a>
                   </span> are now allowed in XHTML Content Documents.</p>
-               <p>To improve interoperability, the IDPF is maintaining a <a class="link" href="http://www.idpf.org/extensions/attributes/index.html">registry of custom attributes</a>. </p>
+               <p>To improve interoperability, the IDPF is maintaining a <a class="link" href="http://www.idpf.org/epub/extensions/attributes/index.html">registry of custom attributes</a>. </p>
                <p>(Note that custom attributes have always been allowed in SVG provided they meet the requirements outlined in that specification.)</p>
             </div>
             <div class="section" title="3.5 The aria-describedat attribute"


### PR DESCRIPTION
Former link was to `http://idpf.org/extensions/attributes/index.html`, instead of `http://idpf.org/epub/extensions/attributes/index.html` (which in turn redirects to `https://idpf.github.io/`)
