### PR TITLE
add clarifying note about foreign resource exception

### DIFF
--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -639,6 +639,12 @@
 							href="https://www.w3.org/TR/SVG/extend.html#ForeignObjectElement"
 							><code>foreignObject</code></a> elements).</p>
 
+					<p class="note">This exception allows Authors to include resources in the <a>EPUB Container</a> that
+						are not for use by EPUB Reading Systems. The primary case for this exception is to allow data
+						files to travel with an EPUB Publication, whether for use by scripts in its constituent EPUB
+						Content Documents or for use by external applications (e.g., a scientific journal might include
+						a data set with instructions on how to extract it from the EPUB Container).</p>
+
 					<p id="confreq-cmt">When a <a>Foreign Resource</a> is included in the spine or directly rendered in
 						its native format in an EPUB Content Document, a Core Media Type fallback MUST be included.
 						Fallbacks take one of the two following forms:</p>


### PR DESCRIPTION
As discussed on the 2018-04-26 telecon, this a possible clarifying note about why we allow some foreign resources without fallbacks. Text of the note is as follows:

> This exception allows Authors to include resources in the EPUB Container that are not for use by EPUB Reading Systems. The primary case for this exception is to allow data files to travel with an EPUB Publication, whether for use by scripts in its constituent EPUB Content Documents or for use by external applications (e.g., a scientific journal might include a data set with instructions on how to extract it from the EPUB Container).