### PR TITLE
reading systems should treat deprecated rendition:spread "portrait" like "both"

### DIFF
--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -3228,9 +3228,11 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								<dt>portrait (deprecated)</dt>
 								<dd>
 									<p>The use of spreads only in portrait orientation is <a
-											href="epub-spec.html#deprecated">deprecated</a>. Authors are advised to use
-										the value "both" instead, as spreads that are readable in portrait orientation
-										are also readable in landscape.</p>
+										href="epub-spec.html#deprecated">deprecated</a>.</p>
+									<p>Authors are advised to use the value "<code>both</code>" instead, as spreads that
+										are readable in portrait orientation are also readable in landscape. Reading
+										Systems SHOULD treat the value "<code>portrait</code>" as a synonym of
+										"<code>both</code>" and create spreads regardless of orientation.</p>
 								</dd>
 								<dt>both</dt>
 								<dd>


### PR DESCRIPTION
As discussed on the 2018-04-26 telecon, this PR adds a reading system recommendation to treat portrait like spread:

> Reading Systems SHOULD treat the value "<code>portrait</code>" as a synonym of "<code>both</code>" and create spreads regardless of orientation.