### PR TITLE
remove references to alternate style tags and the non-core specs

### DIFF
--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -559,18 +559,6 @@
 						Refer to its definition in [[!ContentDocs301]] for usage information.</p>
 				</section>
 
-				<section id="sec-xhtml-alternate-style-tags">
-					<h3>Alternate Style Tags</h3>
-
-					<p>In accordance with [[!AltStyleTags]] , the <code>link</code> element <code>class</code> attribute
-						MAY include any of the following values: <code>horizontal</code>, <code>vertical</code>,
-							<code>day</code> and <code>night</code>. These values inherit the semantics defined by that
-						specification for their use.</p>
-
-					<p>Reading Systems SHOULD select and utilize such tagged style sets as appropriate, and as described
-						in that specification.</p>
-				</section>
-
 				<section id="sec-xhtml-custom-attributes">
 					<h3>Custom Attributes</h3>
 

--- a/epub32/spec/epub-overview.html
+++ b/epub32/spec/epub-overview.html
@@ -268,11 +268,6 @@
 				<p>EPUB 3.2 also supports CSS styles that enable both horizontal and vertical layout and both
 					left-to-right and right-to-left writing. Refer to <a href="#sec-gls-css">CSS</a> in the Global
 					Language Support section for more information.</p>
-
-				<p>EPUB 3.2 also includes the ability to provide multiple style sheets that allow users to select
-					between day/night reading modes or change the rendering direction of the text. Refer to
-					[[AltStyleTags]] for more information.</p>
-
 			</section>
 
 			<section id="sec-multimedia">

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -347,56 +347,13 @@
 							[[!EPUBAccessibility]] — defines accessibility conformance and discovery metadata
 							requirements for EPUB Publications.</p>
 					</li>
-					<li>
-						<p><a href="altss-tags.html">Alternate Style Tags</a> [[!AltStyleTags]] — defines a pattern for
-							tagging alternate style sheets using microformats.</p>
-					</li>
 				</ul>
 
 				<p>These specifications represent the formal list recognized as belonging to EPUB 3.2, and that contain
-					functionality referenced as part of the standard.</p>
-
-				<p>The IDPF has also developed a set of specifications that complement the core functionality of EPUB
-					3.2, but whose support in Reading Systems and use in authoring is OPTIONAL:</p>
-
-				<ul>
-					<li>
-						<p><a href="http://www.idpf.org/epub/linking/cfi/">EPUB Canonical Fragment Identifiers</a>
-							[[!EPUB-CFI]] — defines a standardized method for referencing arbitrary content within an
-							EPUB Publication through the use of fragment identifiers.</p>
-					</li>
-					<li>
-						<p><a href="http://www.idpf.org/epub/dict/">EPUB Dictionaries and Glossaries</a>
-							[[!Dictionaries]] — provides a framework for a rich user experience of dictionary
-							publications.</p>
-					</li>
-					<li>
-						<p><a href="http://www.idpf.org/epub/idx/">EPUB Indexes</a> [[!Indexes]] — defines a consistent
-							way of encoding the structure and content of indexes in EPUB Publications.</p>
-					</li>
-					<li>
-						<p><a href="http://www.idpf.org/epub/renditions/multiple/">EPUB Multiple Renditions</a>
-							[[!MultipleRenditions]] — defines the creation and rendering of EPUB Publications consisting
-							of more than one Rendition.</p>
-					</li>
-					<li>
-						<p><a href="http://www.idpf.org/epub/previews/">EPUB Previews</a> [[!Previews]] — describes how
-							preview content can be included in EPUB Publications.</p>
-					</li>
-					<li>
-						<p><a href="http://www.idpf.org/epub/renditions/region-nav/">EPUB Region-Based Navigation</a>
-							[[!RegionNav]] — introduces conventions for region-based navigation through a visual
-							rendition of an EPUB Publication based on regions of interest.</p>
-					</li>
-				</ul>
-
-				<p>New functionality is also added periodically through the development of extension specifications.
-					Features and functionality defined outside of core revisions to the standard, while not formally
-					recognized in this specification, are nonetheless available for use by <a>Authors</a> and Reading
-					System developers (but are not stable until they reach the status of <a
-						href="http://idpf.org/about_us/corp_docs/policies_and_procedures">Recommended
-					Specifications</a>).</p>
-
+					functionality referenced as part of the standard. New functionality is also added periodically
+					through the development of extension specifications. Features and functionality defined outside of
+					core revisions to the standard, while not formally recognized in this specification, are nonetheless
+					available for use by <a>Authors</a> and Reading System developers.</p>
 			</section>
 
 			<section id="sec-epub-roadmap" class="informative">


### PR DESCRIPTION
As discussed on the 2018-04-26 telecon, this pull request removes the section on alternate style tags from the content documents specification, since the section is not enabling behaviour that is otherwise invalid.

It also removes the reference to the document being a core specification, as well as strips the specific list of IDPF non-core specifications. The existing paragraph that notes that extension specifications are valid for use continues to provide the option to use/support any of these technologies (similar to how EPUB CFI was removed but remains available for use).