### PR TITLE
update zip and sha-1 references to latest versions

### DIFF
--- a/common/js/biblio.js
+++ b/common/js/biblio.js
@@ -347,11 +347,5 @@ var biblio = {
       "title": "XPointer Shorthand Notation",
       "href": "https://www.w3.org/TR/2003/REC-xptr-framework-20030325/",
       "date": "25 March 2003"
-    },
-    "ZIPAPPNOTE633": {
-      "title": "ZIP File Format Specification",
-      "href": "http://www.pkware.com/documents/APPNOTE/APPNOTE-6.3.3.TXT",
-      "date": "September 1, 2012",
-      "publisher": "PKWARE, Inc."
     }
 }

--- a/epub32/spec/epub-ocf.html
+++ b/epub32/spec/epub-ocf.html
@@ -912,8 +912,8 @@
 			<section id="sec-zip-container-zipreqs">
 				<h2>ZIP File Requirements</h2>
 
-				<p>An <a>OCF ZIP Container</a> uses the ZIP format as specified by [[!ZIPAPPNOTE633]], but with the
-					following constraints and clarifications:</p>
+				<p>An <a>OCF ZIP Container</a> uses the ZIP format as specified by [[!ZIP]], but with the following
+					constraints and clarifications:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -922,7 +922,7 @@
 					</li>
 					<li>
 						<p id="confreq-zip-mult">OCF ZIP Containers MUST NOT use the features in the ZIP application
-							note [[!ZIPAPPNOTE633]] that allow ZIP files to be split across multiple storage media. <a
+							note [[!ZIP]] that allow ZIP files to be split across multiple storage media. <a
 								class="glossterm" href="#gloss-ocf-processor">OCF Processors</a> MUST treat any OCF
 							files that specify that the ZIP file is split across multiple storage media as being in
 							error.</p>
@@ -934,7 +934,7 @@
 					</li>
 					<li>
 						<p id="confreq-zip-64">OCF ZIP Containers MAY use the ZIP64 extensions defined as "Version 1" in
-							section V, subsection G of the application note [[!ZIPAPPNOTE633]] and SHOULD use only those
+							section V, subsection G of the application note [[!ZIP]] and SHOULD use only those
 							extensions when the content requires them. OCF Processors MUST support the ZIP64 extensions
 							defined as "Version 1".</p>
 					</li>
@@ -1065,7 +1065,7 @@
 					<code>U+000A</code>.</p>
 
 				<p>A SHA-1 digest of the UTF-8 representation of the resulting string SHOULD be generated as specified
-					by the Secure Hash Standard [[!FIPS-180-3]]. This digest is then directly used as the key for the
+					by the Secure Hash Standard [[!FIPS-180-4]]. This digest is then directly used as the key for the
 					algorithm.</p>
 
 			</section>
@@ -1233,7 +1233,7 @@ EPUB/images/cover.png</pre>
         
         &lt;!-- 
              SignedInfo is the information that is actually signed.
-             In this case the SHA1 algorithm is used to sign the 
+             In this case the SHA-1 algorithm is used to sign the 
              canonical form of the XML documents enumerated in the
              Object element below
         --&gt;


### PR DESCRIPTION
Use the specref reference for the zip note (6.3.4) and update fips-180-3 to -4, as noted in issue #964.