### PR TITLE
Add core media type table

### DIFF
--- a/common/css/common.css
+++ b/common/css/common.css
@@ -108,3 +108,79 @@ a.legacy {
 	font-size: 85%;
 	text-transform: uppercase;
 }
+
+/* styles for core media types */
+
+table#tbl-core-media-types {
+    border-spacing: 0px;
+    padding: 1em;
+    margin-top: 1.5em;
+    margin-bottom: 2em;    
+}
+
+table#tbl-core-media-types th {
+    border-bottom: 1px solid #005A9C;
+    font-weight: bold;
+    padding: 0.5em;
+    font-weight: bold;
+    color: #000090;
+    font-size: 90%
+}
+
+table#tbl-core-media-types td {
+    border-bottom: 1px solid #005A9C;
+    border-right: 1px solid #efefef;
+    padding: 0.5em;
+    text-align: left
+}
+
+table#tbl-core-media-types tr td:last-child {
+    border-right: none;
+}
+
+table#tbl-core-media-types td *, table#tbl-core-media-types td > * {
+    text-align: left;
+}
+
+table#tbl-core-media-types, table#tbl-core-media-types tbody {
+    padding: 0;
+}
+
+table#tbl-core-media-types caption {
+    text-align: left;
+    font-size: 90%
+}
+
+.tbl-group {
+	text-align: left;
+	border-bottom: none;
+	color: rgb(0, 0, 0);
+	background-color: rgb(240, 248, 255);
+}
+
+table#tbl-core-media-types > thead > tr > th {
+    background-color: rgb(240,240,240);
+    text-align: left;
+    white-space:nowrap;
+}
+
+table#tbl-core-media-types > tbody > tr > th {    
+    text-align: left;
+    font-weight: normal;
+    font-style: italic;
+    padding: 3px;
+}
+
+table#tbl-core-media-types td, table#tbl-core-media-types th, table#tbl-core-media-types tr {
+    border-color: #005A9C;
+    margin: 0em;
+}
+
+table#tbl-core-media-types td code, table#tbl-core-media-types td a {
+    white-space:nowrap;
+}
+
+td[headers="tbl-cmt-appl"] {
+    font-size: .9em;
+}
+

--- a/epub32/spec/epub-changes.html
+++ b/epub32/spec/epub-changes.html
@@ -167,8 +167,8 @@
 			<section id="sec-epub32-cmt">
 				<h2>New Core Media Types</h2>
 
-				<p>EPUB 3.2 adds the <a href="http://www.idpf.org/epub/cmt/v3/#cmt-woff2">WOFF 2.0</a> and <a
-						href="http://www.idpf.org/epub/cmt/v3/#cmt-sfnt">SFNT</a> font formats as Core Media Types
+				<p>EPUB 3.2 adds the <a href="epub-spec.html#cmt-woff2">WOFF 2.0</a> and <a
+					href="epub-spec.html#cmt-sfnt">SFNT</a> font formats as Core Media Types
 					[[CoreMediaTypes]].</p>
 			</section>
 

--- a/epub32/spec/epub-changes.html
+++ b/epub32/spec/epub-changes.html
@@ -169,7 +169,7 @@
 
 				<p>EPUB 3.2 adds the <a href="epub-spec.html#cmt-woff2">WOFF 2.0</a> and <a
 					href="epub-spec.html#cmt-sfnt">SFNT</a> font formats as Core Media Types
-					[[CoreMediaTypes]].</p>
+					[[EPUB32]].</p>
 			</section>
 
 			<section id="sec-epub32-fallbacks">

--- a/epub32/spec/epub-overview.html
+++ b/epub32/spec/epub-overview.html
@@ -281,7 +281,7 @@
 				<p>EPUB 3.2 supports audio and video embedded in <a>XHTML Content Documents</a> via the [[HTML]]
 						<code>audio</code> and <code>video</code> elements, inheriting all the functionality and
 					features these elements provide. For more information on audio and video formats, refer to
-					[[CoreMediaTypes]].</p>
+					[[EPUB32]].</p>
 
 				<p>Another key multimedia feature in EPUB 3.2 is the inclusion of <a>Media Overlay Documents</a>
 					[[MediaOverlays32]]. When pre-recorded narration is available for a Rendition of an EPUB

--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -1734,7 +1734,8 @@
 						<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
 							element MUST conform to the applicable specification(s) as inferred from the MIME media type
 							provided in the <a href="#attrdef-media-type"><code>media-type</code></a> attribute. <a>Core
-								Media Type Resources</a> MUST use the media type designated in [[!CoreMediaTypes]].</p>
+								Media Type Resources</a> MUST use the media type designated in <a
+								href="epub-spec.html#sec-cmt-supported">Supported Media Types</a> [[!EPUB32]].</p>
 
 						<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[!XML]] that
 							identifies a fallback for the Publication Resource referenced from the <code>item</code>
@@ -2377,15 +2378,15 @@ Manifest:
 						<p>For more information about the <code>guide</code> element, refer to its definition in
 							[[!OPF2]].</p>
 					</section>
-					
+
 					<section id="sec-opf2-ncx">
 						<h4>NCX</h4>
-						
+
 						<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a>
 							[[!OPF2]] is a <a href="epub-spec.html#legacy">legacy</a> feature that previously provided
 							the table of contents for <a>EPUB Publications</a>. It is replaced in EPUB 3 by the <a
 								href="#sec-package-nav">EPUB Navigation Document</a>.</p>
-						
+
 						<p>For more information about the NCX, refer to its definition in [[!OPF2]].</p>
 					</section>
 				</section>
@@ -3228,11 +3229,11 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								<dt>portrait (deprecated)</dt>
 								<dd>
 									<p>The use of spreads only in portrait orientation is <a
-										href="epub-spec.html#deprecated">deprecated</a>.</p>
+											href="epub-spec.html#deprecated">deprecated</a>.</p>
 									<p>Authors are advised to use the value "<code>both</code>" instead, as spreads that
 										are readable in portrait orientation are also readable in landscape. Reading
 										Systems SHOULD treat the value "<code>portrait</code>" as a synonym of
-										"<code>both</code>" and create spreads regardless of orientation.</p>
+											"<code>both</code>" and create spreads regardless of orientation.</p>
 								</dd>
 								<dt>both</dt>
 								<dd>

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -622,8 +622,183 @@
 					<p><a>Publication Resources</a> that conform to a Core Media Type specification are <a>Core Media
 							Type Resources</a> and can be included in an EPUB Publication without fallbacks.</p>
 
-					<p>Refer to [[!CoreMediaTypes]] for the current list of <a>Core Media Types</a>.</p>
+					<p>The following table lists the EPUB 3 Core Media Types. The columns in the table represent the
+						following information:</p>
 
+					<ul>
+						<li><strong>Media Type</strong>&#8212;The MIME media type [[!RFC2046]] used to represent the
+							given Publication Resource in the <a
+								href="http://www.idpf.org/epub3/latest/packages#sec-manifest-elem">manifest</a>
+							[[!Packages]].</li>
+
+						<li><strong>Content Type Definition</strong>&#8212;The specification to which the given <a
+								href="http://www.idpf.org/epub3/latest#gloss-publication-resource-cmt">Core Media Type
+								Resource</a> has to conform.</li>
+
+						<li><strong>Applies to</strong>&#8212;The Publication Resource type(s) that the Media Type and
+							Content Type Definition applies to.</li>
+					</ul>
+
+					<table id="tbl-core-media-types">
+						<thead>
+							<tr>
+								<th id="tbl-cmt-string">Media Type</th>
+								<th id="tbl-cmt-def">Content Type Definition</th>
+								<th id="tbl-cmt-appl">Applies to</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<th colspan="3" id="cmt-grp-image" class="tbl-group">Image Types</th>
+							</tr>
+							<tr>
+								<td id="cmt-gif">
+									<code>image/gif</code>
+								</td>
+								<td> [[!GIF]] </td>
+								<td>GIF Images</td>
+							</tr>
+
+							<tr>
+								<td id="cmt-jpeg">
+									<code>image/jpeg</code>
+								</td>
+								<td> [[!JPEG]] </td>
+								<td>JPEG Images</td>
+							</tr>
+							<tr>
+								<td id="cmt-png">
+									<code>image/png</code>
+								</td>
+								<td> [[!PNG]] </td>
+								<td>PNG Images</td>
+							</tr>
+							<tr>
+								<td id="cmt-svg">
+									<code>image/svg+xml</code>
+								</td>
+								<td>
+									<a href="http://www.idpf.org/epub3/latest/contentdocs#sec-svg">SVG Content
+										Documents</a> [[!ContentDocs]] </td>
+								<td>SVG documents</td>
+							</tr>
+
+							<tr>
+								<th colspan="3" id="cmt-grp-content-documents" class="tbl-group">Application
+									Types</th>
+							</tr>
+
+							<tr>
+								<td id="cmt-xhtml">
+									<code>application/xhtml+xml</code>
+								</td>
+								<td>
+									<a href="http://www.idpf.org/epub3/latest/contentdocs#sec-xhtml">XHTML
+										Content Documents</a> [[!ContentDocs]] </td>
+								<td><a class="glossterm"
+										href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-xhtml"
+										>XHTML Content Documents</a> that use the <a
+										href="http://www.w3.org/TR/html/the-xhtml-syntax.html#the-xhtml-syntax"
+										>XHTML syntax</a> [[!HTML]]. </td>
+							</tr>
+							<tr>
+								<td id="cmt-js">
+									<code>application/javascript</code>
+								</td>
+								<td> [[!RFC4329]] </td>
+								<td>Scripts. <a href="http://www.idpf.org/epub3/latest#deprecated"
+										>Deprecates</a>
+									<code>text/javascript</code></td>
+							</tr>
+							<tr>
+								<td id="cmt-ncx">
+									<code>application/x-dtbncx+xml</code>
+								</td>
+								<td> [[!OPF2]] </td>
+								<td>The <a href="http://www.idpf.org/epub3/latest#superseded-removal"
+										>superseded</a> NCX.</td>
+							</tr>
+							<tr>
+								<td id="cmt-sfnt">
+									<code>application/font-sfnt</code>
+								</td>
+								<td> [[!OpenType]] [[!TrueType]] </td>
+								<td>OpenType and TrueType fonts. <a
+										href="http://www.idpf.org/epub3/latest#deprecated">Deprecate</a>
+									<code>application/vnd.ms-opentype</code>. </td>
+							</tr>
+							<tr>
+								<td id="cmt-woff">
+									<code>application/font-woff</code>
+								</td>
+								<td> [[!WOFF]] </td>
+								<td>WOFF fonts</td>
+							</tr>
+							<tr>
+								<td id="cmt-smil">
+									<code>application/smil+xml</code>
+								</td>
+								<td> [[!MediaOverlays]] </td>
+								<td>EPUB Media Overlay documents</td>
+							</tr>
+							<tr>
+								<td id="cmt-pls">
+									<code>application/pls+xml</code>
+								</td>
+								<td> [[!PRONUNCIATION-LEXICON]] </td>
+								<td><a class="glossterm" href="http://www.idpf.org/epub3/latest#gloss-tts"
+										>Text-to-Speech (TTS)</a> Pronunciation lexicons</td>
+							</tr>
+							<tr>
+								<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio Types</th>
+							</tr>
+							<tr>
+								<td id="cmt-mp3">
+									<code>audio/mpeg</code></td>
+								<td> [[!MP3]] </td>
+								<td>MP3 audio</td>
+							</tr>
+							<tr>
+								<td id="cmt-mp4-aac">
+									<code>audio/mp4</code>
+								</td>
+								<td> [[!MPEG4-Audio]], [[!MP4]] </td>
+								<td>AAC LC audio using MP4 container</td>
+							</tr>
+							<tr>
+								<th colspan="3" id="cmt-grp-video" class="tbl-group">Video Types</th>
+							</tr>
+							<tr>
+								<td colspan="3" id="cmt-vide-note">EPUB 3 does not currently define any video
+									codecs as Core Media Types. Refer to the note in <a
+										href="http://www.idpf.org/epub3/latest#note-video-codecs">EPUB
+										Publications — Reading System Conformance</a> for informative
+									recommendations on support for video codecs in EPUB Publications. </td>
+							</tr>
+							<tr>
+								<th colspan="3" id="cmt-grp-text" class="tbl-group">Text Types</th>
+							</tr>
+							<tr>
+								<td id="cmt-css">
+									<code>text/css</code>
+								</td>
+								<td>
+									<a href="http://www.idpf.org/epub3/latest/contentdocs#sec-css">CSS Style
+										Sheets</a> [[!ContentDocs]] </td>
+								<td>CSS Style Sheets. </td>
+							</tr>
+							<tr>
+								<th colspan="3" id="cmt-grp-font" class="tbl-group">Font Types</th>
+							</tr>
+							<tr>
+								<td id="cmt-woff2">
+									<code>font/woff2</code>
+								</td>
+								<td> [[!WOFF2]] </td>
+								<td>WOFF2 fonts</td>
+							</tr>
+						</tbody>
+					</table>
 				</section>
 
 				<section id="sec-foreign-restrictions">

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -532,12 +532,10 @@
 								href="epub-contentdocs.html#sec-css-rs-conf">CSS Style Sheets — Reading System
 								Conformance</a> [[!ContentDocs32]].</p>
 						<p id="confreq-rs-epub3-images">If it has a Viewport, it MUST support the <a
-								href="http://www.idpf.org/epub/cmt/v3/#cmt-grp-image">image Core Media Types</a>
-							[[!CoreMediaTypes]].</p>
+								href="#cmt-grp-image">image Core Media Types</a> [[!CoreMediaTypes]].</p>
 						<p id="confreq-rs-epub3-mp3-aac">If it has the capability to render pre-recorded audio, it MUST
-							support the <a href="http://www.idpf.org/epub/cmt/v3/#cmt-grp-audio">audio Core Media
-								Types</a> [[!CoreMediaTypes]] and SHOULD support Media Overlays
-							[[!MediaOverlays32]].</p>
+							support the <a href="#cmt-grp-audio">audio Core Media Types</a> [[!CoreMediaTypes]] and
+							SHOULD support Media Overlays [[!MediaOverlays32]].</p>
 						<p id="confreq-rs-epub3-tts">If it supports <a>Text-to-Speech (TTS)</a> rendering, it SHOULD
 							support <a href="epub-contentdocs.html#sec-pls">Pronunciation Lexicons</a>
 							[[!ContentDocs32]], [[!CSS3Speech]] and <a
@@ -631,9 +629,8 @@
 								href="http://www.idpf.org/epub3/latest/packages#sec-manifest-elem">manifest</a>
 							[[!Packages]].</li>
 
-						<li><strong>Content Type Definition</strong>&#8212;The specification to which the given <a
-								href="http://www.idpf.org/epub3/latest#gloss-publication-resource-cmt">Core Media Type
-								Resource</a> has to conform.</li>
+						<li><strong>Content Type Definition</strong>&#8212;The specification to which the given Core
+							Media Type Resource has to conform.</li>
 
 						<li><strong>Applies to</strong>&#8212;The Publication Resource type(s) that the Media Type and
 							Content Type Definition applies to.</li>
@@ -684,8 +681,7 @@
 							</tr>
 
 							<tr>
-								<th colspan="3" id="cmt-grp-content-documents" class="tbl-group">Application
-									Types</th>
+								<th colspan="3" id="cmt-grp-content-documents" class="tbl-group">Application Types</th>
 							</tr>
 
 							<tr>
@@ -693,21 +689,20 @@
 									<code>application/xhtml+xml</code>
 								</td>
 								<td>
-									<a href="http://www.idpf.org/epub3/latest/contentdocs#sec-xhtml">XHTML
-										Content Documents</a> [[!ContentDocs]] </td>
+									<a href="http://www.idpf.org/epub3/latest/contentdocs#sec-xhtml">XHTML Content
+										Documents</a> [[!ContentDocs]] </td>
 								<td><a class="glossterm"
-										href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-xhtml"
-										>XHTML Content Documents</a> that use the <a
-										href="http://www.w3.org/TR/html/the-xhtml-syntax.html#the-xhtml-syntax"
-										>XHTML syntax</a> [[!HTML]]. </td>
+										href="http://www.idpf.org/epub3/latest#gloss-content-document-epub-xhtml">XHTML
+										Content Documents</a> that use the <a
+										href="http://www.w3.org/TR/html/the-xhtml-syntax.html#the-xhtml-syntax">XHTML
+										syntax</a> [[!HTML]]. </td>
 							</tr>
 							<tr>
 								<td id="cmt-js">
 									<code>application/javascript</code>
 								</td>
 								<td> [[!RFC4329]] </td>
-								<td>Scripts. <a href="http://www.idpf.org/epub3/latest#deprecated"
-										>Deprecates</a>
+								<td>Scripts. <a href="http://www.idpf.org/epub3/latest#deprecated">Deprecates</a>
 									<code>text/javascript</code></td>
 							</tr>
 							<tr>
@@ -715,16 +710,16 @@
 									<code>application/x-dtbncx+xml</code>
 								</td>
 								<td> [[!OPF2]] </td>
-								<td>The <a href="http://www.idpf.org/epub3/latest#superseded-removal"
-										>superseded</a> NCX.</td>
+								<td>The <a href="http://www.idpf.org/epub3/latest#superseded-removal">superseded</a>
+									NCX.</td>
 							</tr>
 							<tr>
 								<td id="cmt-sfnt">
 									<code>application/font-sfnt</code>
 								</td>
 								<td> [[!OpenType]] [[!TrueType]] </td>
-								<td>OpenType and TrueType fonts. <a
-										href="http://www.idpf.org/epub3/latest#deprecated">Deprecate</a>
+								<td>OpenType and TrueType fonts. <a href="http://www.idpf.org/epub3/latest#deprecated"
+										>Deprecate</a>
 									<code>application/vnd.ms-opentype</code>. </td>
 							</tr>
 							<tr>
@@ -769,11 +764,11 @@
 								<th colspan="3" id="cmt-grp-video" class="tbl-group">Video Types</th>
 							</tr>
 							<tr>
-								<td colspan="3" id="cmt-vide-note">EPUB 3 does not currently define any video
-									codecs as Core Media Types. Refer to the note in <a
-										href="http://www.idpf.org/epub3/latest#note-video-codecs">EPUB
-										Publications — Reading System Conformance</a> for informative
-									recommendations on support for video codecs in EPUB Publications. </td>
+								<td colspan="3" id="cmt-vide-note">EPUB 3 does not currently define any video codecs as
+									Core Media Types. Refer to the note in <a
+										href="http://www.idpf.org/epub3/latest#note-video-codecs">EPUB Publications —
+										Reading System Conformance</a> for informative recommendations on support for
+									video codecs in EPUB Publications. </td>
 							</tr>
 							<tr>
 								<th colspan="3" id="cmt-grp-text" class="tbl-group">Text Types</th>
@@ -783,8 +778,8 @@
 									<code>text/css</code>
 								</td>
 								<td>
-									<a href="http://www.idpf.org/epub3/latest/contentdocs#sec-css">CSS Style
-										Sheets</a> [[!ContentDocs]] </td>
+									<a href="http://www.idpf.org/epub3/latest/contentdocs#sec-css">CSS Style Sheets</a>
+									[[!ContentDocs]] </td>
 								<td>CSS Style Sheets. </td>
 							</tr>
 							<tr>
@@ -854,8 +849,8 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="sec-resource-locations-audio"><a href="http://www.idpf.org/epub/cmt/v3/#cmt-grp-audio"
-								>Audio resources</a> [[!CoreMediaTypes]] MAY be located outside the EPUB Container.</p>
+						<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a>
+							[[!CoreMediaTypes]] MAY be located outside the EPUB Container.</p>
 					</li>
 					<li>
 						<p id="sec-resource-locations-video">Video resources MAY be located outside the EPUB
@@ -868,8 +863,8 @@
 								<code>src</code> or <code>href</code> attributes, respectively).</p>
 					</li>
 					<li>
-						<p id="sec-resource-locations-fonts"><a href="http://www.idpf.org/epub/cmt/v3/#cmt-grp-font"
-								>Font resources</a> MAY be located outside the EPUB Container.</p>
+						<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a> MAY be located
+							outside the EPUB Container.</p>
 					</li>
 				</ul>
 

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -532,10 +532,10 @@
 								href="epub-contentdocs.html#sec-css-rs-conf">CSS Style Sheets — Reading System
 								Conformance</a> [[!ContentDocs32]].</p>
 						<p id="confreq-rs-epub3-images">If it has a Viewport, it MUST support the <a
-								href="#cmt-grp-image">image Core Media Types</a> [[!CoreMediaTypes]].</p>
+								href="#cmt-grp-image">image Core Media Types</a>.</p>
 						<p id="confreq-rs-epub3-mp3-aac">If it has the capability to render pre-recorded audio, it MUST
-							support the <a href="#cmt-grp-audio">audio Core Media Types</a> [[!CoreMediaTypes]] and
-							SHOULD support Media Overlays [[!MediaOverlays32]].</p>
+							support the <a href="#cmt-grp-audio">audio Core Media Types</a> and SHOULD support Media
+							Overlays [[!MediaOverlays32]].</p>
 						<p id="confreq-rs-epub3-tts">If it supports <a>Text-to-Speech (TTS)</a> rendering, it SHOULD
 							support <a href="epub-contentdocs.html#sec-pls">Pronunciation Lexicons</a>
 							[[!ContentDocs32]], [[!CSS3Speech]] and <a
@@ -849,8 +849,8 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a>
-							[[!CoreMediaTypes]] MAY be located outside the EPUB Container.</p>
+						<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a> MAY be located
+							outside the EPUB Container.</p>
 					</li>
 					<li>
 						<p id="sec-resource-locations-video">Video resources MAY be located outside the EPUB


### PR DESCRIPTION
As identified in issue #1037 and discussed on the 2018-05-03 telecon, this PR adds the core media type table back to the 3.2 specification.