### PR TITLE
Undo metadata attributes added in 3.1

### DIFF
--- a/epub32/spec/epub-mediaoverlays.html
+++ b/epub32/spec/epub-mediaoverlays.html
@@ -1056,6 +1056,11 @@
 							><code>playback-active-class</code></a> [[!OverlaysVocab]]. The class names are then
 					discoverable by Reading Systems.</p>
 
+				<p>The <code>active-class</code> and <code>playback-active-class</code> properties MUST NOT be used in
+					conjunction with a <a href="epub-packages.html#attrdef-meta-refines"><code>refines</code>
+						attribute</a> [[!Packages32]], as they are always considered to apply to the entire
+					Rendition.</p>
+
 				<p>This example demonstrates how Authors can associate style information with the currently-playing EPUB
 					Content Document.</p>
 
@@ -1120,30 +1125,28 @@ html.-epub-media-overlay-playing * {
 				<section id="sec-package-including">
 					<h3>Including Media Overlays</h3>
 
-					<p><a class="glossterm" href="epub-spec.html#gloss-manifest">Manifest</a>
-						<a href="epub-packages.html#elemdef-package-item"><code>item</code> elements</a> [[!Packages32]]
-						that reference <a class="glossterm" href="epub-spec.html#gloss-content-document-epub">EPUB
-							Content Documents</a> MAY specify a Media Overlay via the <a
-							href="epub-packages.html#attrdef-item-media-overlay"><code>media-overlay</code>
-							attribute</a>. The attribute MUST reference the ID [[!XML]] of the manifest
-							<code>item</code> for the corresponding Media Overlay Document.</p>
+					<p>If an <a class="glossterm" href="epub-spec.html#gloss-content-document-epub">EPUB Content
+							Document</a> is wholly or partially referenced by a Media Overlay, then its <a
+							class="glossterm" href="epub-spec.html#gloss-manifest">manifest</a>
+						<a href="epub-packages.html#elemdef-package-item"><code>item</code> element</a> [[!Packages32]]
+						MUST include a <code>media-overlay</code> attribute. The attribute MUST reference the ID
+						[[!XML]] of the manifest <code>item</code> for the corresponding Media Overlay Document.</p>
+
+					<p>The <code>media-overlay</code> attribute MUST NOT be attached to manifest <code>item</code>
+						elements that do not reference <a class="glossterm"
+							href="epub-spec.html#gloss-content-document-epub">EPUB Content Documents</a>.</p>
 
 					<p>Manifest items for Media Overlay Documents MUST have the media type
 							<code>application/smil+xml</code>.</p>
 
-					<p>The duration of an EPUB Content Document MUST be specified in a <a
-							href="epub-packages.html#attrdef-item-duration"><code>duration</code> attribute</a>
-						[[!Packages32]] on its manifest <code>item</code>.</p>
-
 					<aside class="example">
-						<p>The following example shows how to include Media Overlays in the manifest of a Package
-							Document.</p>
+						<p>The following example shows the entries for an EPUB Content Document and its associated Media
+							Overlay in the manifest of a Package Document.</p>
 						<pre>&lt;manifest&gt;
    &lt;item id="ch1" 
          href="chapter1.xhtml" 
          media-type="application/xhtml+xml" 
-         media-overlay="ch1_audio"
-         duration="0:32:29"/&gt;
+         media-overlay="ch1_audio"/&gt;
    
    &lt;item id="ch1_audio" 
          href="chapter1_audio.smil" 
@@ -1151,14 +1154,6 @@ html.-epub-media-overlay-playing * {
    …
 &lt;/manifest&gt;</pre>
 					</aside>
-
-					<p>If an EPUB Content Document is wholly or partially referenced by a Media Overlay, then its
-						manifest <code>item</code> entry MUST include a <code>media-overlay</code> attribute.</p>
-
-					<p>The <code>media-overlay</code> attribute MUST NOT be attached to manifest <code>item</code>
-						elements that do not reference <a class="glossterm"
-							href="epub-spec.html#gloss-content-document-epub">EPUB Content Documents</a>.</p>
-
 				</section>
 
 				<section id="sec-package-metadata">
@@ -1168,7 +1163,13 @@ html.-epub-media-overlay-playing * {
 						include the duration of the entire <a class="glossterm" href="epub-spec.html#gloss-rendition"
 							>Rendition</a> in a <a href="epub-packages.html#elemdef-package-item"><code>meta</code>
 							element</a> with the <a href="http://www.idpf.org/epub/vocab/overlays/#duration"
-								><code>duration</code> [<abbr class="abbrev">Overlays Vocab</abbr>] property</a>.</p>
+								><code>duration</code> property</a> [[!OverlaysVocab]].</p>
+
+					<p>In addition, the duration of each EPUB Content Document with an associated Media Overlay MUST be
+						provided. The <a href="epub-packages.html#attrdef-meta-refines"><code>refines</code>
+							attribute</a> [[!Packages32]] is used to associate each duration declaration to the
+						corresponding <a class="glossterm" href="epub-spec.html#gloss-manifest">manifest</a>
+						<a href="epub-packages.html#elemdef-package-item"><code>item</code></a> [[!Packages32]].</p>
 
 					<p><a class="glossterm" href="epub-spec.html#gloss-author">Authors</a> also MAY include <a
 							href="http://www.idpf.org/epub/vocab/overlays/#narrator"><code>narrator</code></a>
@@ -1180,6 +1181,9 @@ html.-epub-media-overlay-playing * {
 						<p>The following example shows a Package Document with metadata about Media Overlays.</p>
 						<pre>&lt;metadata&gt;
    …
+   &lt;meta property="media:duration" refines="#ch1_audio">0:32:29&lt;/meta>
+   &lt;meta property="media:duration" refines="#ch2_audio">0:34:02&lt;/meta>
+   &lt;meta property="media:duration" refines="#ch3_audio">0:29:49&lt;/meta>
    &lt;meta property="media:duration"&gt;1:36:20&lt;/meta&gt;
    &lt;meta property="media:narrator"&gt;Joe Speaker&lt;/meta&gt;
    &lt;meta property="media:active-class"&gt;-epub-media-overlay-active&lt;/meta&gt;
@@ -1378,8 +1382,8 @@ html.-epub-media-overlay-playing * {
 						<li>
 							<p>All referenced audio and video media embedded within an EPUB Content Document MUST be
 								initialized to their "stopped" state, and be ready to be played from the zero-position
-								within their content stream (possibly displaying the image specified using the
-								[[!HTML]] <a
+								within their content stream (possibly displaying the image specified using the [[!HTML]]
+									<a
 									href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-video-element"
 										><code>poster</code></a> attribute). This requirement overrides the default
 								behavior defined by the [[!HTML]] <a
@@ -1444,8 +1448,7 @@ html.-epub-media-overlay-playing * {
 							<p>When a <code>text</code> element becomes inactive in the Media Overlay, and when it
 								points to embedded video or audio media, that referenced media MUST be reset to its
 								initial "stopped" state, ready to be played from the zero-position within their content
-								stream (possibly displaying the poster image specified using the [[!HTML]]
-								markup).</p>
+								stream (possibly displaying the poster image specified using the [[!HTML]] markup).</p>
 						</li>
 					</ul>
 

--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -404,7 +404,7 @@
 								</li>
 								<li>
 									<p>
-										<a href="#elemdef-opf-bindings"><code>bindings</code></a>
+										<a href="#sec-opf-bindings"><code>bindings</code></a>
 										<code>[0 or 1]</code>
 										<a href="epub-spec.html#deprecated" class="deprecated">(deprecated)</a></p>
 								</li>
@@ -440,9 +440,6 @@
 					<p>This section provides definitions for shared attributes (i.e., attributes that are allowed on two
 						or more elements).</p>
 
-					<p>Attributes with the prefix "<code>opf:</code>" are in the namespace
-							<code>http://www.idpf.org/2007/opf</code>.</p>
-
 					<dl class="variablelist">
 						<dt id="attrdef-dir"><code>dir</code></dt>
 						<dd>
@@ -467,9 +464,7 @@
 										><code>dc:title</code></a>, <a href="#sec-meta-elem"><code>meta</code></a> and
 									<a href="#sec-package-elem"><code>package</code></a>.</p>
 						</dd>
-						<dt id="attrdef-href">
-							<code>href</code>
-						</dt>
+						<dt id="attrdef-href"><code>href</code></dt>
 						<dd>
 							<p>An absolute or relative IRI reference [[!RFC3987]] to a resource.</p>
 							<div class="example">
@@ -507,9 +502,7 @@
 										><code>meta</code></a>, <a href="#sec-package-elem"><code>package</code></a> and
 									<a href="#sec-spine-elem"><code>spine</code></a>.</p>
 						</dd>
-						<dt id="attrdef-media-type">
-							<code>media-type</code>
-						</dt>
+						<dt id="attrdef-media-type"><code>media-type</code></dt>
 						<dd>
 							<p>A media type [[!RFC2046]] that specifies the type and format of the referenced
 								resource.</p>
@@ -521,72 +514,6 @@
 							</div>
 							<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
 										><code>link</code></a>.</p>
-						</dd>
-						<dt id="attrdef-opf-alt-rep"><code>opf:alt-rep</code></dt>
-						<dd>
-							<p>Provides an alternative representation of the element's value in the language and
-								optional script identified by the <a href="#attrdef-opf-alt-rep-lang"
-										><code>opf:alt-rep-lang</code></a> attribute.</p>
-							<div class="example">
-								<pre>&lt;dc:creator opf:alt-rep-lang="ja" opf:alt-rep="村上 春樹"&gt;
-    Haruki Murakami
-&lt;/dc:creator&gt;</pre>
-							</div>
-							<p>Allowed on: <a href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-									href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-									href="#sec-opf-dctitle"><code>dc:title</code></a> and <a href="#sec-meta-elem"
-										><code>meta</code></a>.</p>
-							<div class="note">
-								<p>As attributes cannot be repeated, only a single alternative representation can be
-									declared for any element.</p>
-							</div>
-						</dd>
-						<dt id="attrdef-opf-alt-rep-lang"><code>opf:alt-rep-lang</code></dt>
-						<dd>
-							<p>Specifies the language and OPTIONAL script of the value of the <a
-									href="#attrdef-opf-alt-rep"><code>opf:alt-rep</code></a> attribute. The value of the
-								attribute MUST be a language identifier as defined by [[!BCP47]].</p>
-							<div class="example">
-								<pre>&lt;dc:creator opf:alt-rep-lang="ja" opf:alt-rep="村上 春樹"&gt;
-    Haruki Murakami
-&lt;/dc:creator&gt;</pre>
-							</div>
-							<p>The attribute is REQUIRED whenever <code>opf:alt-rep</code> is used on an element. It
-								MUST NOT appear on its own.</p>
-						</dd>
-						<dt id="attrdef-opf-file-as"><code>opf:file-as</code></dt>
-						<dd>
-							<p>Provides the normalized form of the element's value for sorting.</p>
-							<div class="example">
-								<pre>&lt;dc:creator opf:file-as="Murakami, Haruki"&gt;Haruki Murakami&lt;/dc:creator&gt;</pre>
-							</div>
-							<p>Reading Systems MUST trim all leading and trailing white space from the attribute value,
-								as defined by the XML specification [[!XML]], prior to processing.</p>
-							<p>Allowed on: <a href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-									href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-									href="#sec-opf-dctitle"><code>dc:title</code></a> and <a href="#sec-meta-elem"
-										><code>meta</code></a>.</p>
-						</dd>
-						<dt id="attrdef-opf-role"><code>opf:role</code></dt>
-						<dd>
-							<p>Identifies the role of a creator or contributor. The value MUST be a three-letter
-								lowercase code from [[!MARCRelators]].</p>
-							<div class="example">
-								<pre>&lt;dc:creator opf:role="aut"&gt;Haruki Murakami&lt;/dc:creator&gt;</pre>
-							</div>
-							<p>Allowed on: <a href="#sec-opf-dccontributor"><code>dc:contributor</code></a> and <a
-									href="#sec-opf-dccreator"><code>dc:creator</code></a>.</p>
-						</dd>
-						<dt id="attrdef-opf-scheme"><code>opf:scheme</code></dt>
-						<dd>
-							<p>Identifies the type of identifier.</p>
-							<div class="example">
-								<pre>&lt;dc:identifier opf:scheme="isbn"&gt;9780123456789&lt;/dc:identifier&gt;</pre>
-							</div>
-							<p>Allowed on: <a href="#sec-opf-dcidentifier"><code>dc:identifier</code></a> and <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>.</p>
 						</dd>
 						<dt id="attrdef-properties"><code>properties</code></dt>
 						<dd>
@@ -602,6 +529,15 @@
 							<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a href="#sec-itemref-elem"
 										><code>itemref</code></a> and <a href="#sec-link-elem"
 								><code>link</code></a>.</p>
+						</dd>
+						<dt id="attrdef-refines"><code>refines</code></dt>
+						<dd>
+							<p>Identifies the expression or resource augmented by the element. The value of the
+								attribute must be a relative IRI [[!RFC3987]] referencing the resource or element being
+								described.</p>
+							<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata being
+								expressed. When omitted, the element defines a <a href="#primary-expression">primary
+									expression</a>.</p>
 						</dd>
 						<dt id="attrdef-xml-lang"><code>xml:lang</code></dt>
 						<dd>
@@ -785,11 +721,6 @@
 												<a href="#attrdef-id"><code>id</code></a>
 												<code>[optional]</code></p>
 										</li>
-										<li>
-											<p>
-												<a href="#attrdef-identifier-scheme"><code>opf:scheme</code></a>
-												<code>[optional]</code></p>
-										</li>
 									</ul>
 								</dd>
 								<dt>Content Model</dt>
@@ -910,22 +841,7 @@
 									<ul class="nomark">
 										<li>
 											<p>
-												<a href="#attrdef-opf-alt-rep"><code>opf:alt-rep</code></a>
-												<code>[optional]</code></p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-opf-alt-rep-lang"><code>opf:alt-rep-lang</code></a>
-												<code>[conditionally required]</code></p>
-										</li>
-										<li>
-											<p>
 												<a href="#attrdef-dir"><code>dir</code></a>
-												<code>[optional]</code></p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-opf-file-as"><code>opf:file-as</code></a>
 												<code>[optional]</code></p>
 										</li>
 										<li>
@@ -1067,19 +983,6 @@
 								<dd>
 									<ul class="nomark">
 										<li>
-											<p>
-												<a href="#attrdef-opf-alt-rep"><code>opf:alt-rep</code></a>
-												<code>[optional]</code> – only allowed on <code>contributor</code>,
-													<code>creator</code>, and <code>publisher</code>.</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-opf-alt-rep-lang"><code>opf:alt-rep-lang</code></a>
-												<code>[conditionally required]</code> – only allowed on
-													<code>contributor</code>, <code>creator</code>, and
-													<code>publisher</code>.</p>
-										</li>
-										<li>
 											<p><a href="#attrdef-dir"><code>dir</code></a>
 												<code>[optional]</code> – only allowed on <code>contributor</code>,
 													<code>coverage</code>, <code>creator</code>,
@@ -1088,26 +991,8 @@
 												<code>subject</code>.</p>
 										</li>
 										<li>
-											<p>
-												<a href="#attrdef-opf-file-as"><code>opf:file-as</code></a>
-												<code>[optional]</code> – only allowed on <code>contributor</code>,
-													<code>creator</code>, and <code>publisher</code>.</p>
-										</li>
-										<li>
 											<p><a href="#attrdef-id"><code>id</code></a>
 												<code>[optional]</code> – allowed on any element.</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-opf-role"><code>opf:role</code></a>
-												<code>[optional]</code> – only allowed on <code>contributor</code> and
-													<code>creator</code>.</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-opf-scheme"><code>opf:scheme</code></a>
-												<code>[optional]</code> – only allowed on <code>identifier</code> and
-													<code>source</code>.</p>
 										</li>
 										<li>
 											<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
@@ -1326,22 +1211,7 @@
 								<ul class="nomark">
 									<li>
 										<p>
-											<a href="#attrdef-opf-alt-rep"><code>opf:alt-rep</code></a>
-											<code>[optional]</code></p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-opf-alt-rep-lang"><code>opf:alt-rep-lang</code></a>
-											<code>[conditionally required]</code></p>
-									</li>
-									<li>
-										<p>
 											<a href="#attrdef-dir"><code>dir</code></a>
-											<code>[optional]</code></p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-opf-file-as"><code>opf:file-as</code></a>
 											<code>[optional]</code></p>
 									</li>
 									<li>
@@ -1356,7 +1226,7 @@
 									</li>
 									<li>
 										<p>
-											<a href="#attrdef-meta-refines"><code>refines</code></a>
+											<a href="#attrdef-refines"><code>refines</code></a>
 											<code>[optional]</code></p>
 									</li>
 									<li>
@@ -1377,15 +1247,37 @@
 							</dd>
 						</dl>
 
-						<p id="attrdef-meta-property">Each <code>meta</code> element defines a metadata expression that
-							establishes some aspect of the <a>EPUB Publication</a>. The <code>property</code> attribute
-							takes a <a href="#sec-property-datatype">property</a> data type value that defines the
-							statement being made in the expression; the text content of the element represents the
-							assertion. (Refer to <a href="#sec-metadata-assoc">Vocabulary Association Mechanisms</a> for
-							more information.)</p>
+						<p id="attrdef-meta-property">Each <code>meta</code> element defines a metadata expression. The
+								<code>property</code> attribute takes a <a href="#sec-property-datatype">property</a>
+							data type value that defines the statement being made in the expression, and the text
+							content of the element represents the assertion. (Refer to <a href="#sec-metadata-assoc"
+								>Vocabulary Association Mechanisms</a> for more information.)</p>
+
+						<p>This specification defines two types of metadata expressions that can be defined using the
+								<code>meta</code> element:</p>
+
+						<ul>
+							<li id="primary-expression">A <em>primary expression</em> is one in which the expression
+								defined in the <code>meta</code> element establishes some aspect of the <a>EPUB
+									Publication</a>. A <code>meta</code> element that omits a refines attribute defines
+								a primary expression.</li>
+
+							<li>A <em>subexpression</em> is one in which the expression defined in the <code>meta</code>
+								element enhances the meaning of the expression or resource referenced in its
+									<code>refines</code> attribute. A subexpression might refine a media clip, for
+								example, by expressing its duration, or refine a creator or contributor expression by
+								defining the role of the person.</li>
+						</ul>
+
+						<p>Subexpressions are not limited to refining only primary expressions and resources; they may
+							be used to refine the meaning of other subexpressions, thereby creating chains of
+							information.</p>
+
+						<p class="note">All of the [DCMES] elements represent primary expressions, and permit refinement
+							by meta element subexpressions.</p>
 
 						<p>This specification <a href="#sec-metadata-default-vocab">reserves</a> the [[!MetaVocab]] for
-							use with the <code>property</code> attribute. Terms from any other vocabulary MAY be used
+							use with the <code>property</code> attribute. Terms from other vocabularies MAY be used
 							provided they have a <a href="#sec-prefix-attr">prefix</a> (refer to <a
 								href="#sec-metadata-reserved-prefixes">Reserved Prefixes</a> for a list of prefixes that
 							do not have to be declared).</p>
@@ -1460,6 +1352,11 @@
 									<li>
 										<p>
 											<a href="#attrdef-properties"><code>properties</code></a>
+											<code>[optional]</code></p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-refines"><code>refines</code></a>
 											<code>[optional]</code></p>
 									</li>
 									<li>
@@ -1675,11 +1572,6 @@
 								<ul class="nomark">
 									<li>
 										<p>
-											<a href="#attrdef-item-duration"><code>duration</code></a>
-											<code>[conditionally required]</code></p>
-									</li>
-									<li>
-										<p>
 											<a href="#attrdef-item-fallback"><code>fallback</code></a>
 											<code>[conditionally required]</code></p>
 									</li>
@@ -1762,13 +1654,6 @@
 							[[!XML]] that identifies the <a>Media Overlay Document</a> for the resource described by
 							this <code>item</code>. Refer to <a href="epub-mediaoverlays.html#sec-docs-package"
 								>Packaging</a> [[!MediaOverlays32]] for more information.</p>
-
-						<p id="attrdef-item-duration">The <code>duration</code> attribute takes a [[!SMIL]] <a
-								href="https://www.w3.org/TR/2008/REC-SMIL3-20081201/smil-timing.html#q22">clock
-								value</a> that provides the total duration of the audio media referenced from a Media
-							Overlay Document or, in the case of timed media, the total duration of the referenced media
-							file. Refer to <a href="epub-mediaoverlays.html#sec-package-metadata">Package Metadata</a>
-							[[!MediaOverlays32]] for more information.</p>
 
 						<div class="note">
 							<p>The order of <code>item</code> elements in the <code>manifest</code> is not significant.
@@ -2286,6 +2171,18 @@ Manifest:
 							<li>
 								<p>Package-level restrictions on the use of metadata elements MAY be overridden.</p>
 							</li>
+							<li>
+								<p>All <a href="#primary-expression">primary metadata expressions</a> apply to the
+										<code>collection</code>.</p>
+							</li>
+							<li>
+								<p>The <a href="attrdef-refines"><code>refines</code> attribute</a> MUST NOT reference
+									elements outside the containing <code>collection</code>.</p>
+							</li>
+							<li>
+								<p>The <a href="#sec-opf2-meta">OPF2 <code>meta</code> element</a> MUST NOT be
+									included.</p>
+							</li>
 						</ul>
 
 						<p>A <code>collection</code> MAY define sub-collections through the inclusion of one or more
@@ -2304,6 +2201,9 @@ Manifest:
 										href="http://www.idpf.org/epub/vocab/package/item/">manifest <code>item</code>
 										properties</a> [[!ManifestVocab]] without a prefix (e.g., so that a collection
 									can declare its own Navigation Document or cover image).</p>
+							</li>
+							<li>
+								<p>The <code>refines</code> attribute MUST NOT be attached.</p>
 							</li>
 						</ul>
 
@@ -2451,6 +2351,10 @@ Manifest:
 					<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST be
 						terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
 
+					<p>Additional modified properties MAY be included in the package metadata, but they MUST have a
+						different subject (i.e., they require a <code>refines</code> attribute that references an
+						element or resource).</p>
+
 					<p>Although not a part of the package metadata, for referencing and other purposes all string
 						representations of the identifier MUST be constructed using the at sign (<code>@</code>) as the
 						separator (i.e., of the form "id<code>@</code>date"). Whitespace MUST NOT be included when
@@ -2487,14 +2391,12 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 					<div class="note">
 						<p>When an <a>EPUB Container</a> includes more than one <a>Rendition</a> of an EPUB Publication,
-							updating the last modified date of the <a href="spec-ocf.html#dfn-default-rendition">default
+							updating the last modified date of the <a href="epub-ocf.html#dfn-default-rendition">default
 								rendition</a> for each release — even if it has not been updated — will help ensure that
 							the EPUB Publication does not appear to be the same version as an earlier release, as
 							Reading Systems only have to process the default rendition.</p>
 					</div>
-
 				</section>
-
 			</section>
 
 			<section id="sec-metadata-assoc">
@@ -3562,16 +3464,15 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						<dt>Content Model</dt>
 						<dd>
 							<dl class="variablelist">
-								<dt><a href="https://www.w3.org/TR/html51/sections.html#the-nav-element"
-											><code>nav</code></a></dt>
+								<dt><a href="https://www.w3.org/TR/html/sections.html#the-nav-element"
+										><code>nav</code></a></dt>
 								<dd>
 									<p>In this order:</p>
 									<ul class="nomark">
 										<li>
 											<p>
-												<a
-													href="https://www.w3.org/TR/html51/dom.html#kinds-of-content-heading-content"
-														><code>HTML Heading content</code></a>
+												<a href="https://www.w3.org/TR/html/dom.html#heading-content"><code>HTML
+														Heading content</code></a>
 												<code>[0 or 1]</code></p>
 										</li>
 										<li>
@@ -3581,7 +3482,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 										</li>
 									</ul>
 								</dd>
-								<dt><a href="https://www.w3.org/TR/html51/grouping-content.html#the-ol-element"
+								<dt><a href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element"
 											><code>ol</code></a></dt>
 								<dd>
 									<p>In this order:</p>
@@ -3617,8 +3518,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 									<ul class="nomark">
 										<li>
 											<p>
-												<a
-													href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content"
+												<a href="https://www.w3.org/TR/html/dom.html#phrasing-content"
 														><code>HTML Phrasing content</code></a>
 												<code>[1 or more]</code></p>
 										</li>
@@ -3654,8 +3554,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						</li>
 						<li>
 							<p id="confreq-nav-a-title">If an <code>a</code> or <code>span</code> element contains
-								instances of <a
-									href="https://www.w3.org/TR/html/dom.html#kinds-of-content-embedded-content">HTML
+								instances of <a href="https://www.w3.org/TR/html/dom.html#embedded-content">HTML
 									embedded content</a> that do not provide intrinsic text alternatives, the element
 								MUST also include a <code>title</code> attribute with an alternate text rendering of the
 								link label.</p>

--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -780,28 +780,22 @@
 
 							<p id="attrdef-identifier-scheme">For additional precision (e.g., if the scheme cannot be
 								determined from the value or could lead to an ambiguous result), Authors MAY attach an
-									<a href="#attrdef-opf-scheme"><code>opf:scheme</code></a> attribute to assist in
-								Reading System identification. This attribute identifies the system or authority that
-								generated or assigned the value of the element. Its value MUST be either:</p>
-
-							<ul>
-								<li>
-									<p>a <a href="http://www.idpf.org/epub/vocab/package/id/">reserved identifier
-											value</a> [[!IDRegistry]] (case-insensitive); or</p>
-								</li>
-								<li>
-									<p>an absolute IRI [[!RFC3987]] that identifies the scheme. The IRI SHOULD refer to
-										a resource that provides more information about the scheme.</p>
-								</li>
-							</ul>
+									<a href="http://www.idpf.org/epub/vocab/package/meta/#identifier-type"
+										><code>identifier-type</code> property</a> [[!MetaVocab]] to assist in Reading
+								System identification. When included, the <code>identifier-type</code> property should
+								take precedence over value parsing the identifier.</p>
 
 							<aside class="example">
-								<p>The following example shows the <code>opf:scheme</code> attribute used to indicate a
-										<code>dc:identifier</code> element contains an ISBN.</p>
-								<pre>&lt;dc:identifier opf:scheme="isbn"&gt;9780123456789&lt;/dc:identifier&gt;</pre>
+								<p>The following example shows how an identifier can be additionally marked as a DOI
+									using the identifier-type property.</p>
+								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    &lt;dc:identifier id="pub-id">urn:doi:10.1016/j.iheduc.2008.03.001&lt;/dc:identifier>
+    &lt;meta refines="#pub-id" property="identifier-type" scheme="onix:codelist5">06&lt;/meta>
+    …
+&lt;/metadata></pre>
 							</aside>
 
-							<p>When included, the <code>opf:scheme</code> value SHOULD take precedence over value
+							<p>When included, the <code>identifier-type</code> value SHOULD take precedence over value
 								parsing the identifier. This specification does not require or endorse the use of any
 								particular scheme for identifiers.</p>
 
@@ -867,9 +861,8 @@
 
 							<aside class="example">
 								<p>The following example shows a multi-part title.</p>
-								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"
-          xmlns:opf="http://www.idpf.org/2007/opf"&gt;
-    &lt;dc:title opf:file-as="Fellowship of the Ring"&gt;
+								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
+    &lt;dc:title&gt;
         THE LORD OF THE RINGS, Part One: The Fellowship of the Ring
     &lt;/dc:title&gt;
     …
@@ -1040,31 +1033,41 @@
 							<h5>The <code>creator</code> Element</h5>
 
 							<p>The [[!DC11]] <code>creator</code> element represents the name of a person, organization,
-								etc. responsible for the creation of the content of the <a>Rendition</a>.</p>
+								etc. responsible for the creation of the content of the <a>Rendition</a>. The <a
+									href="http://www.idpf.org/epub/vocab/package/meta/#role"><code>role</code>
+									property</a> [[!MetaVocab]] can be attached to the element to indicate the function
+								the creator played in the creation of the content.</p>
+
+							<aside class="example">
+								<p>The following example shows how to represent a creator as an author using a MARC
+									relators term.</p>
+								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    …
+    &lt;dc:creator id="creator">Haruki Murakami&lt;/dc:creator>
+    &lt;meta refines="#creator" property="role" scheme="marc:relators" id="role">aut&lt;/meta>
+    …
+&lt;/metadata></pre>
+							</aside>
 
 							<p>The <code>creator</code> element SHOULD contain the name of the creator as a Reading
-								System will present it to a user. The <a href="#attrdef-opf-file-as"
-										><code>opf:file-as</code></a> attribute MAY be attached to include a normalized
-								form of the name, and the <a href="#attrdef-opf-alt-rep"><code>opf:alt-rep</code></a>
-								attribute MAY be used to represent a creator's name in another language or script (as
-								indicated in the <a href="#attrdef-opf-alt-rep-lang"><code>opf:alt-rep-lang</code></a>
-								attribute).</p>
-
-							<p>The <a href="#attrdef-opf-role"><code>role</code></a> attribute MAY be attached to
-								distinguish the role the creator played in the creation of the content (e.g., an author
-								or illustrator).</p>
+								System will present it to a user. The <a
+									href="http://www.idpf.org/epub/vocab/package/meta/#file-as"><code>file-as</code>
+									property</a> MAY be attached to include a normalized form of the name, and the <a
+									href="http://www.idpf.org/epub/vocab/package/meta/#alternate-script"
+										><code>alternate-script</code> property</a> to represent a creator's name in
+								another language or script. [[!MetaVocab]]</p>
 
 							<aside class="example">
 								<p>The following example shows how a creator name can be included to facilitate sorting
 									and rendering.</p>
-								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"
-          xmlns:opf="http://www.idpf.org/2007/opf"&gt;
+								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     …
-    &lt;dc:creator id="creator" opf:file-as="Murakami, Haruki"&gt;
-        Haruki Murakami
-    &lt;/dc:creator&gt;
+    &lt;dc:creator id="creator">Haruki Murakami&lt;/dc:creator>
+    &lt;meta refines="#creator" property="role" scheme="marc:relators" id="role">aut&lt;/meta>
+    &lt;meta refines="#creator" property="alternate-script" xml:lang="ja">村上 春樹&lt;/meta>
+    &lt;meta refines="#creator" property="file-as">Murakami, Haruki&lt;/meta>
     …
-&lt;/metadata&gt;</pre>
+&lt;/metadata></pre>
 							</aside>
 
 							<p>If an EPUB Publication has more than one creator, each SHOULD be included in a separate
@@ -1130,50 +1133,37 @@
 							<h5>The <code>subject</code> Element</h5>
 
 							<p>The [[!DC11]] <code>subject</code> element identifies the subject of the EPUB
-								Publication.</p>
+								Publication. The value of the element SHOULD be the human-readable heading or label, but
+								MAY be the code value if the subject taxonomy does not provide a separate descriptive
+								label.</p>
 
-							<p id="attrdef-opf-authority">In addition to the attributes listed in the <a
-									href="#sec-opf-dcmes-optional-def">general definition</a>, the element takes an
-								OPTIONAL <code>opf:authority</code> attribute that identifies the system or scheme the
-								element's value is drawn from. The value of the attribute MUST be either:</p>
+							<p>Authors MAY identify the system or scheme the element's value is drawn from using the <a
+									href="http://www.idpf.org/epub/vocab/package/meta/#authority"><code>authority</code>
+									property</a> [[!MetaVocab]].</p>
 
-							<ul>
-								<li>
-									<p>a <a href="http://idpf.org/epub/registries/authorities/">reserved authority
-											value</a> [[!AuthorityRegistry]] (case-insensitive); or</p>
-								</li>
-								<li>
-									<p>an absolute IRI [[!RFC3987]] that identifies the scheme. The IRI SHOULD refer to
-										a resource that provides more information about the scheme.</p>
-								</li>
-							</ul>
-
-							<p id="attrdef-opf-term">When a scheme is identified in the <code>opf:authority</code>
-								attribute, the subject code MUST be included in an <code>opf:term</code> attribute. The
-								value of the element SHOULD be the human-readable heading or label, but MAY be the code
-								value if the subject taxonomy does not provide a separate descriptive label.</p>
+							<p>When a scheme is identified, a subject code MUST be attached using the <a
+									href="http://www.idpf.org/epub/vocab/package/meta/#term"><code>term</code>
+									property</a>.</p>
 
 							<aside class="example">
 								<p>The following example shows a BISAC code and heading.</p>
-								<pre>&lt;dc:subject opf:authority="BISAC" opf:term="FIC024000"&gt;
-    FICTION / Occult &amp;amp; Supernatural
-&lt;/dc:subject&gt;</pre>
+								<pre>&lt;dc:subject id="subject01"&gt;FICTION / Occult &amp;amp; Supernatural&lt;/dc:subject&gt;
+&lt;meta refines="#subject01" property="authority">BISAC&lt;/meta>
+&lt;meta refines="#subject01" property="term">FIC024000&lt;/meta></pre>
 							</aside>
 
 							<aside class="example">
 								<p>The following example shows the use of an IRI for the scheme.</p>
-								<pre>&lt;dc:subject opf:authority="http://www.ams.org/msc/msc2010.html"
-            opf:term="11"&gt;
-    Number Theory
-&lt;/dc:subject&gt;</pre>
+								<pre>&lt;dc:subject id="sbj01"&gt;Number Theory&lt;/dc:subject&gt;
+&lt;meta refines="#sbj01" property="authority">http://www.ams.org/msc/msc2010.html&lt;/meta>
+&lt;meta refines="#sbj01" property="term">11&lt;/meta></pre>
 							</aside>
 
-							<p>The <code>opf:term</code> attribute MUST NOT occur on a <code>subject</code> element that
-								does not specify a scheme.</p>
+							<p>The <code>term</code> property MUST NOT be attached to a <code>subject</code> element
+								that does not specify a scheme.</p>
 
-							<p>The values of the <code>subject</code> element and <code>opf:term</code> attribute are
-								case sensitive only when the designated scheme requires.</p>
-
+							<p>The values of the <code>subject</code> element and <code>term</code> property are case
+								sensitive only when the designated scheme requires.</p>
 						</section>
 
 						<section id="sec-opf-dctype">


### PR DESCRIPTION
This PR removes all traces I was able to find of the new opf:* attributes that were added during the 3.1 revision (including duration), and restores the use of refines where applicable.

One noteworthy issue I encountered is that we added opf:authority and opf:term for layering information on dc:subject, but these were completely new and not replacing former properties. I've added corresponding properties to the [meta properties vocabulary](https://idpf.github.io/epub-vocabs/package/meta/meta.html) to account for the attributes, as my assumption is we're keeping consistency with how 3.0.1 did things and not starting to explore additions on the attribute axis for Dublin Core elements.