### PR TITLE
add preferred media types

### DIFF
--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -581,10 +581,13 @@
 						following information:</p>
 
 					<ul>
-						<li><strong>Media Type</strong>&#8212;The MIME media type [[!RFC2046]] used to represent the
-							given Publication Resource in the <a
-								href="http://www.idpf.org/epub3/latest/packages#sec-manifest-elem">manifest</a>
-							[[!Packages]].</li>
+						<li><p><strong>Media Type</strong>&#8212;The MIME media type [[!RFC2046]] used to represent the
+								given Publication Resource in the <a
+									href="http://www.idpf.org/epub3/latest/packages#sec-manifest-elem">manifest</a>
+								[[!Packages]].</p>
+							<p>If more than one media type is listed, the first one is the preferred media type. The
+								preferred media type is RECOMMENDED for all new EPUB Publications.</p>
+						</li>
 
 						<li><strong>Content Type Definition</strong>&#8212;The specification to which the given Core
 							Media Type Resource has to conform.</li>
@@ -656,11 +659,11 @@
 							</tr>
 							<tr>
 								<td id="cmt-js">
-									<code>application/javascript</code>
+									<code>application/javascript</code><br />
+									<code>text/javascript</code>
 								</td>
 								<td> [[!RFC4329]] </td>
-								<td>Scripts. <a href="http://www.idpf.org/epub3/latest#deprecated">Deprecates</a>
-									<code>text/javascript</code></td>
+								<td>Scripts.</td>
 							</tr>
 							<tr>
 								<td id="cmt-ncx">
@@ -672,12 +675,11 @@
 							</tr>
 							<tr>
 								<td id="cmt-sfnt">
-									<code>application/font-sfnt</code>
+									<code>application/font-sfnt</code><br />
+									<code>application/vnd.ms-opentype</code>
 								</td>
 								<td> [[!OpenType]] [[!TrueType]] </td>
-								<td>OpenType and TrueType fonts. <a href="http://www.idpf.org/epub3/latest#deprecated"
-										>Deprecate</a>
-									<code>application/vnd.ms-opentype</code>. </td>
+								<td>OpenType and TrueType fonts.</td>
 							</tr>
 							<tr>
 								<td id="cmt-woff">

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -586,7 +586,7 @@
 									href="http://www.idpf.org/epub3/latest/packages#sec-manifest-elem">manifest</a>
 								[[!Packages]].</p>
 							<p>If more than one media type is listed, the first one is the preferred media type. The
-								preferred media type is RECOMMENDED for all new EPUB Publications.</p>
+								preferred media type is strongly encouraged for all new EPUB Publications.</p>
 						</li>
 
 						<li><strong>Content Type Definition</strong>&#8212;The specification to which the given Core


### PR DESCRIPTION
As raised in #1000 and discussed on the 2018-05-03 telecon, this PR un-deprecates the old javascript and open type media types. The media types are added back to the first column, after the new preferred media types. The following note is also added to the description of the media type column:

> If more than one media type is listed, the first one is the preferred media type. The preferred media type is strongly encouraged for all new EPUB Publications.

I wavered on recommending use, but that could lead to validation as warnings despite the vagueness of "new EPUB Publications", so I've left with our typical non-normative "strongly encouraged" wording.