### PR TITLE
Editorial fixes

### DIFF
--- a/epub32/spec/epub-changes.html
+++ b/epub32/spec/epub-changes.html
@@ -43,14 +43,14 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>Describes changes made in the second major revision of the EPUB 3.0 specifications, highlighting key
-				changes and additions.</p>
+			<p>This document describes changes made in the second minor revision of the EPUB® 3 specifications,
+				highlighting key changes and additions.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="sec-introduction">
 			<h1>Introduction</h1>
 
-			<p>EPUB® is an interchange and delivery format for digital publications, based on XML and Web Standards. An
+			<p>EPUB is an interchange and delivery format for digital publications, based on XML and Web Standards. An
 				EPUB Publication can be thought of as a reliable packaging of Web content that represents a digital
 				book, magazine, or other type of publication, and that can be distributed for online and offline
 				consumption. </p>
@@ -65,54 +65,13 @@
 				<h2>Note about EPUB 3.1</h2>
 
 				<p>EPUB 3.2 can be considered as a successor to both EPUB 3.0.1 and EPUB 3.1. While reverting certain
-					incompatible changes to EPUB 3.0.1 that EPUB 3.1 introduced, it also retains most of the rest of the
-					revisions that were made to EPUB 3.1.</p>
+					incompatible changes to EPUB 3.0.1 that were introduced in EPUB 3.1, it also retains most of the
+					rest of the updates made during the 3.1 revision.</p>
 
 				<p>Since EPUB 3.1 did not receive widespread adoption, the community group has decided to retain a list
 					of all changes made during the EPUB 3.1 revision that are still reflected in EPUB 3.2. This decision
 					was made to simplify comprehension of what has changed since EPUB 3.0.1 (i.e., readers do not have
 					to review EPUB 3.1 before being able to determine how this new version updates EPUB 3.0.1).</p>
-			</section>
-
-			<section id="sec-diff-intro-history">
-				<h2>EPUB Revision History</h2>
-
-				<section>
-					<h3>OEB, OCF and EPUB 2: 1999—2010</h3>
-
-					<p>EPUB had its roots in the interchange format known as the Open EBook Publication Structure
-						(OEBPS). OEBPS 1.0 was approved in 1999 by the Open eBook Forum, an organization that later
-						became the International Digital Publishing Forum (IDPF). Subsequent revisions 1.1 and 1.2 were
-						approved by the IDPF in 2001 and 2002 respectively.</p>
-
-					<p> It was realized that a need existed for a format standard that could be used for delivery as
-						well as interchange, and work began in late 2005 on a single-file container format for OEPBS,
-						which was approved by the IDPF as the OEBPS Container Format (OCF) in 2006. Work on a 2.0
-						revision of OEBPS began in parallel which was approved as the renamed EPUB 2.0 in October, 2007,
-						consisting of a triumvirate of specifications: Open Package Format (OPF), Open Publication
-						Format (OPF) together with OCF. EPUB 2.0.1, a maintenance update to the 2.0 specification set
-						primarily intended clarify and correct errata in the specifications, was approved in September,
-						2010. [[OPF2]] [[OPS2]] [[OCF2]]</p>
-
-				</section>
-				<section>
-					<h3>EPUB 3.0–3.0.1: 2010–2014</h3>
-
-					<p>Work on a major revision of the EPUB specifications began in 2010, with the goal of aligning EPUB
-						more closely with HTML, and in the process bringing new, native multimedia features,
-						sophisticated CSS layout rendering and font embedding, scripted interactivity, enhanced global
-						language support, and improved accessibility. A new specification, EPUB Media Overlays was also
-						introduced, enabling text and audio synchronization in EPUB Publications. To better align the
-						specification names with the standard, the Open Package Format specification was renamed EPUB
-						Publications and the Open Publication Format specification was renamed EPUB Content Documents.
-						The EPUB 3.0 specifications were approved in October, 2011. [[Publications30]] [[ContentDocs30]]
-						[[OCF30]] [[MediaOverlays30]]</p>
-
-					<p>The EPUB 3.0.1 revision was undertaken in 2013-14. Although introducing mostly minor fixes and
-						updates, it did see the integration of Fixed Layout Documents, which give Authors greater
-						control over presentation when a reflowable EPUB is not suitable for the content.
-						[[Publications301]] [[ContentDocs301]] [[OCF301]] [[MediaOverlays301]]</p>
-				</section>
 			</section>
 		</section>
 		<section id="sec-reorg">
@@ -120,7 +79,7 @@
 
 			<p>To simplify reading and referencing of the EPUB standard, a major reorganization of the specifications
 				was undertaken. Foremost among the changes, a new umbrella <a href="epub-spec.html#sec-overview">EPUB
-					3.2 specification</a> was introduced as the primary point of entry. EPUB Publication and Reading
+					specification</a> was introduced as the primary point of entry. EPUB Publication and Reading
 				System requirements that were formerly defined in [[Publications301]] were moved to this new top-level
 				specification, as was the section on <a href="epub-spec.html#sec-publication-resources">Publication
 					Resources</a>. All <a href="epub-spec.html#sec-terminology">common terminology</a> were collected
@@ -168,8 +127,7 @@
 				<h2>New Core Media Types</h2>
 
 				<p>EPUB 3.2 adds the <a href="epub-spec.html#cmt-woff2">WOFF 2.0</a> and <a
-					href="epub-spec.html#cmt-sfnt">SFNT</a> font formats as Core Media Types
-					[[EPUB32]].</p>
+						href="epub-spec.html#cmt-sfnt">SFNT</a> font formats as Core Media Types [[EPUB32]].</p>
 			</section>
 
 			<section id="sec-epub32-fallbacks">

--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -62,24 +62,18 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>EPUB Content Documents 3.2 specifies a usage of HTML, SVG and CSS optimized for representation of
-				structured, composable, and accessible documents.</p>
+			<p>This specification defines profiles of HTML, SVG, and CSS for use in the context of <a
+					data-lt="EPUB Publication">EPUB® Publications</a>.</p>
+			<p>This specification is one of a <a href="epub-spec.html#sec-epub-specs">family of specifications</a> that
+				compose [[EPUB32]], an interchange and delivery format for digital publications based on XML and Web
+				Standards. It is meant to be read and understood in concert with the other specifications that make up
+				EPUB 3.</p>
+			<p>Refer to [[EPUB32Changes]] for more information on the differences between this specification and its
+				predecessor.</p>
 		</section>
 		<section id="sotd"></section>
-		<section id="sec-overview">
-			<h1>Overview</h1>
-
-			<section id="sec-overview-purpose-and-scope" class="informative">
-				<h2>Purpose and Scope</h2>
-				<p>This specification, EPUB Content Documents 3.2, defines profiles of HTML, SVG, and CSS for use in the
-					context of <a data-lt="EPUB Publication">EPUB® Publications</a>.</p>
-				<p>This specification is one of a <a href="epub-spec.html#sec-epub-specs">family of specifications</a>
-					that compose [[EPUB32]], an interchange and delivery format for digital publications based on XML
-					and Web Standards. It is meant to be read and understood in concert with the other specifications
-					that make up EPUB 3.2.</p>
-				<p>Refer to [[EPUB32Changes]] for more information on the differences between this specification and its
-					predecessor.</p>
-			</section>
+		<section id="sec-introduction">
+			<h1>Introduction</h1>
 
 			<section id="sec-overview-relations" class="informative">
 				<h2>Relationship to Other Specifications</h2>
@@ -130,14 +124,14 @@
 
 				<section id="sec-overview-relations-css">
 					<h3>Relationship to CSS</h3>
-					<p>EPUB 3.2 supports CSS as defined by the CSS Working Group Snapshot [[CSSSnapshot]]. EPUB 3.2 also
+					<p>EPUB 3 supports CSS as defined by the CSS Working Group Snapshot [[CSSSnapshot]]. EPUB 3 also
 						maintains some prefixed CSS properties, to ensure consistent support for global languages.</p>
 				</section>
 			</section>
 
 			<section id="sec-terminology">
 				<h2>Terminology</h2>
-				<p>Terms with meanings specific to EPUB 3.2 are capitalized in this document (e.g., "Author", "Reading
+				<p>Terms with meanings specific to EPUB 3 are capitalized in this document (e.g., "Author", "Reading
 					System"). A complete list of these <a href="epub-spec.html#sec-terminology">terms and
 						definitions</a> is provided in [[!EPUB32]].</p>
 				<p>Only the first instance of a term in a section is linked to its definition.</p>
@@ -240,14 +234,14 @@
 			<section id="sec-xhtml-extensions">
 				<h2>HTML Extensions</h2>
 
-				<p>This section defines EPUB 3.2 <a>XHTML Content Document</a> extensions to the underlying [[!HTML]]
+				<p>This section defines EPUB 3 <a>XHTML Content Document</a> extensions to the underlying [[!HTML]]
 					document model.</p>
 
 				<div class="note">
 					<p>Although [[HTML]] allows user agents to support <a
 							href="https://www.w3.org/TR/html5/infrastructure.html#extensibility-0">vendor-neutral
 							extensions</a>, unless such extensions are listed in this section they are not supported
-						features of EPUB 3.2.</p>
+						features of EPUB 3.</p>
 				</div>
 
 				<section id="sec-xhtml-semantic-inflection">
@@ -448,7 +442,7 @@
 							Attributes as defined below.</p>
 
 						<div class="note">
-							<p>For more information on EPUB 3.2 features related to synthetic speech, refer to <a
+							<p>For more information on EPUB 3 features related to synthetic speech, refer to <a
 									href="epub-overview.html#sec-tts">Text-to-speech</a> [[EPUB32Overview]].</p>
 						</div>
 
@@ -592,7 +586,7 @@
 			<section id="sec-xhtml-deviations">
 				<h2>HTML Deviations and Constraints</h2>
 				<p>This section defines deviations from, and constraints on, the underlying [[!HTML]] document model
-					applicable to EPUB 3.2 <a>XHTML Content Documents</a>.</p>
+					applicable to EPUB 3 <a>XHTML Content Documents</a>.</p>
 
 				<section id="sec-xhtml-mathml">
 					<h3>Embedded MathML</h3>
@@ -757,8 +751,8 @@
 								href="https://www.w3.org/TR/html/textlevel-semantics.html#the-rp-element"
 									><code>rp</code></a> element is intended to provide a fallback for older version
 								<a>Reading Systems</a> that do not recognize ruby markup (i.e., a parenthesis display
-							around <code>ruby</code> markup). As EPUB 3.2 Reading Systems are ruby-aware, and can
-							provide fallbacks, the use of <code>rp</code> elements is discouraged.</p>
+							around <code>ruby</code> markup). As EPUB 3 Reading Systems are ruby-aware, and can provide
+							fallbacks, the use of <code>rp</code> elements is discouraged.</p>
 					</section>
 
 					<section id="sec-xhtml-deviations-embed">
@@ -1719,7 +1713,7 @@
 					Documents</a>.</p>
 
 				<div class="note">
-					<p>For more information on EPUB 3.2 features related to synthetic speech, refer to <a
+					<p>For more information on EPUB 3 features related to synthetic speech, refer to <a
 							href="epub-overview.html#sec-tts">Text-to-speech</a> [[EPUB32Overview]].</p>
 				</div>
 

--- a/epub32/spec/epub-mediaoverlays.html
+++ b/epub32/spec/epub-mediaoverlays.html
@@ -46,38 +46,29 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>EPUB Media Overlays 3.2 specifies a usage of SMIL, the Package Document, CSS Style Sheets, and EPUB
-				Content Documents for representation of audio synchronized with the EPUB Content Document.</p>
+			<p>This specification defines a usage of [[SMIL]] (Synchronized Multimedia Integration Language), the <a
+					class="glossterm" href="epub-spec.html#gloss-package-document">Package Document</a>, CSS Style
+				Sheets, and <a class="glossterm" href="epub-spec.html#gloss-content-document-epub">EPUB® Content
+					Documents</a> for representation of audio synchronized with the EPUB Content Document.</p>
+
+			<p>The text and audio synchronization enabled by Media Overlays provides enhanced accessibility for any user
+				who has difficulty following the text of a traditional book. Media Overlays also provide a continuous
+				listening experience for readers who are unable to read the text for any reason, something that
+				traditional audio embedding techniques cannot offer. They are even useful for purposes not traditionally
+				considered accessibility concerns (e.g., for language learning or reading of commercial audio
+				books).</p>
+
+			<p>This specification is one of a <a href="epub-spec.html#sec-epub-specs">family of specifications</a> that
+				compose [[EPUB32]], an interchange and delivery format for digital publications based on XML and Web
+				Standards. It is meant to be read and understood in concert with the other specifications that make up
+				EPUB 3.1.</p>
+
+			<p>Refer to [[EPUB32Changes]] for more information on the differences between this specification and its
+				predecessor.</p>
 		</section>
 		<section id="sotd"></section>
-		<section id="sec-overview">
-			<h1>Overview</h1>
-
-			<section id="sec-overview-purpose-and-scope" class="informative">
-				<h2>Purpose and Scope</h2>
-
-				<p>This specification, EPUB Media Overlays 3.2, defines a usage of [[SMIL]] (Synchronized Multimedia
-					Integration Language), the <a class="glossterm" href="epub-spec.html#gloss-package-document">Package
-						Document</a>, CSS Style Sheets, and <a class="glossterm"
-						href="epub-spec.html#gloss-content-document-epub">EPUB® Content Documents</a> for representation
-					of audio synchronized with the EPUB Content Document.</p>
-
-				<p>The text and audio synchronization enabled by Media Overlays provides enhanced accessibility for any
-					user who has difficulty following the text of a traditional book. Media Overlays also provide a
-					continuous listening experience for readers who are unable to read the text for any reason,
-					something that traditional audio embedding techniques cannot offer. They are even useful for
-					purposes not traditionally considered accessibility concerns (e.g., for language learning or reading
-					of commercial audio books).</p>
-
-				<p>This specification is one of a <a href="epub-spec.html#sec-epub-specs">family of specifications</a>
-					that compose [[EPUB32]], an interchange and delivery format for digital publications based on XML
-					and Web Standards. It is meant to be read and understood in concert with the other specifications
-					that make up EPUB 3.1.</p>
-
-				<p>Refer to [[EPUB32Changes]] for more information on the differences between this specification and its
-					predecessor.</p>
-
-			</section>
+		<section id="sec-introduction">
+			<h1>Introduction</h1>
 
 			<section id="sec-overview-relationship" class="informative">
 				<h2>Relationship to Other Specifications</h2>
@@ -96,7 +87,7 @@
 			<section id="sec-terminology">
 				<h2>Terminology</h2>
 
-				<p>Terms with meanings specific to EPUB 3.2 are capitalized in this document (e.g., "Author", "Reading
+				<p>Terms with meanings specific to EPUB 3 are capitalized in this document (e.g., "Author", "Reading
 					System"). A complete list of these <a href="epub-spec.html#sec-terminology">terms and
 						definitions</a> is provided in [[!EPUB32]].</p>
 
@@ -137,10 +128,10 @@
 				<h2>Introduction</h2>
 
 				<p>Synchronized audio narration is found in mainstream ebooks, educational tools and ebooks formatted
-					for persons with print disabilities. In EPUB 3.2, these types of books are created using Media
-					Overlay Documents to describe the timing for the pre-recorded audio narration and how it relates to
-					the EPUB Content Document markup. The file format for Media Overlays is defined as a subset of
-					[[SMIL]], a W3C recommendation for representing synchronized multimedia information in XML.</p>
+					for persons with print disabilities. In EPUB 3, these types of books are created using Media Overlay
+					Documents to describe the timing for the pre-recorded audio narration and how it relates to the EPUB
+					Content Document markup. The file format for Media Overlays is defined as a subset of [[SMIL]], a
+					W3C recommendation for representing synchronized multimedia information in XML.</p>
 
 				<p>The Media Overlays feature is designed to be transparent to <a class="glossterm"
 						href="epub-spec.html#gloss-epub-reading-system">EPUB Reading Systems</a> that do not support the

--- a/epub32/spec/epub-ocf.html
+++ b/epub32/spec/epub-ocf.html
@@ -53,42 +53,34 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This specification, EPUB Open Container Format (OCF) 3.2, defines a file format and processing model for
-				encapsulating a set of related resources into a single-file container.</p>
+			<p>This specification defines a file format and processing model for encapsulating the set of related
+				resources that comprise an <a class="glossterm" href="epub-spec.html#gloss-epub-publication">EPUB®
+					Publication</a> into a single-file container, the <a class="glossterm"
+					href="epub-spec.html#gloss-container">EPUB Container</a>.</p>
+
+			<p>This specification defines the rules for structuring the file collection in the abstract (the "<a
+					href="#sec-container-abstract">abstract container</a>") and the rules for the representation of this
+				abstract container within a ZIP archive (the "<a href="#sec-container-zip">ZIP container</a>"). The
+				rules for ZIP containers build upon the ZIP technologies used by [[ODF]]. OCF also defines a standard
+				method for obfuscating embedded resources, such as fonts, for those EPUB Publications that require this
+				functionality.</p>
+
+			<p>This specification is one of a <a href="epub-spec.html#sec-epub-specs">family of specifications</a> that
+				compose EPUB 3 [[EPUB32]], an interchange and delivery format for digital publications based on XML and
+				Web Standards. It is meant to be read and understood in concert with the other specifications that make
+				up EPUB 3.</p>
+
+			<p>Refer to [[EPUB32Changes]] for more information on the differences between this specification and its
+				predecessor.</p>
 		</section>
 		<section id="sotd"></section>
-		<section id="sec-overview">
-			<h1>Overview</h1>
-
-			<section id="sec-overview-purpose-and-scope" class="informative">
-				<h2>Purpose and Scope</h2>
-
-				<p>This specification, EPUB Open Container Format (OCF) 3.2, defines a file format and processing model
-					for encapsulating the set of related resources that comprise an <a class="glossterm"
-						href="epub-spec.html#gloss-epub-publication">EPUB® Publication</a> into a single-file container,
-					the <a class="glossterm" href="epub-spec.html#gloss-container">EPUB Container</a>.</p>
-
-				<p>This specification defines the rules for structuring the file collection in the abstract (the "<a
-						href="#sec-container-abstract">abstract container</a>") and the rules for the representation of
-					this abstract container within a ZIP archive (the "<a href="#sec-container-zip">ZIP container</a>").
-					The rules for ZIP containers build upon the ZIP technologies used by [[ODF]]. OCF also defines a
-					standard method for obfuscating embedded resources, such as fonts, for those EPUB Publications that
-					require this functionality.</p>
-
-				<p>This specification is one of a <a href="epub-spec.html#sec-epub-specs">family of specifications</a>
-					that compose [[EPUB32]], an interchange and delivery format for digital publications based on XML
-					and Web Standards. It is meant to be read and understood in concert with the other specifications
-					that make up EPUB 3.2.</p>
-
-				<p>Refer to [[EPUB32Changes]] for more information on the differences between this specification and its
-					predecessor.</p>
-
-			</section>
+		<section id="sec-introduction">
+			<h1>Introduction</h1>
 
 			<section id="sec-terminology">
 				<h2>Terminology</h2>
 
-				<p>Terms with meanings specific to EPUB 3.2 are capitalized in this document (e.g., "Author", "Reading
+				<p>Terms with meanings specific to EPUB 3 are capitalized in this document (e.g., "Author", "Reading
 					System"). A complete list of these <a href="epub-spec.html#sec-terminology">terms and
 						definitions</a> is provided in [[!EPUB32]].</p>
 

--- a/epub32/spec/epub-overview.html
+++ b/epub32/spec/epub-overview.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>EPUB 3.2 Overview</title>
+		<title>EPUB 3 Overview</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c-common" class="remove"></script>
 		<script src="../../common/js/biblio.js" class="remove"></script>
 		<script src="../../common/js/dfn-crossref.js" class="remove"></script>
@@ -68,26 +68,15 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This document serves as the overall introduction to EPUB 3.2, describing the other EPUB 3.2 documents and
-				reviewing cross-cutting concerns including accessibility, metadata, and global language support.</p>
+			<p>This document provides a starting point for content authors and software developers wishing to understand
+				the EPUB® 3 specifications. It consists entirely of informative overview material that describes the
+				features available in EPUB 3</p>
+
+			<p>The current version of EPUB 3 is defined in [[EPUB32]], the second minor revision of the standard.
+				Another informative document, EPUB 3.2 Changes [[EPUB32Changes]], describes changes from the last
+				version.</p>
 		</section>
 		<section id="sotd"></section>
-		<section id="sec-intro">
-			<h1>Introduction</h1>
-
-			<section id="sec-intro-overview">
-				<h2>Overview</h2>
-
-				<p>This document provides a starting point for content authors and software developers wishing to
-					understand the EPUB® 3.2 specifications. It consists entirely of informative overview material that
-					describes the features available in EPUB 3.2</p>
-
-				<p>Another informative document, EPUB 3.2 Changes from EPUB 3.0.1 [[EPUB32Changes]], describes changes in
-					EPUB 3.2 from the last version.</p>
-
-			</section>
-
-		</section>
 		<section id="sec-features">
 			<h1>Features</h1>
 
@@ -158,8 +147,8 @@
 					<h3>Navigation Document</h3>
 
 					<p>Each Rendition of an EPUB Publication contains a special XHTML Content Document called the
-							<a>EPUB Navigation Document</a>, which uses the [[HTML]] <code>nav</code> element to
-						define human- and machine-readable navigation information.</p>
+							<a>EPUB Navigation Document</a>, which uses the [[HTML]] <code>nav</code> element to define
+						human- and machine-readable navigation information.</p>
 
 					<p>The Navigation Document replaces the EPUB 2 NCX document [[OPS2]]. The Navigation Document, while
 						maintaining the baseline accessibility and navigation support and features of the NCX,
@@ -229,7 +218,7 @@
 					forms require the ability to create page-precise layouts in order to be represented
 					meaningfully.</p>
 
-				<p>EPUB 3.2 includes metadata that allows the creation of <a
+				<p>EPUB 3 includes metadata that allows the creation of <a
 						href="epub-packages.html#sec-package-metadata-fxl">fixed-layout XHTML Content Documents</a>
 					[[Packages32]], in addition to existing capabilities for fixed layouts in SVG. This metadata enables
 					the <a href="epub-contentdocs.html#sec-fxl-html-svg-dimensions">dimensions of the page</a>
@@ -263,22 +252,22 @@
 					throughout the evolution of the EPUB standard.</p>
 
 				<p>EPUB Content Documents can reference CSS Style Sheets, allowing Authors to define the desired
-					rendering properties. EPUB 3.2 follows support for CSS as defined in the [[CSSSnapshot]].</p>
+					rendering properties. EPUB 3 follows support for CSS as defined in the [[CSSSnapshot]].</p>
 
-				<p>EPUB 3.2 also supports CSS styles that enable both horizontal and vertical layout and both
-					left-to-right and right-to-left writing. Refer to <a href="#sec-gls-css">CSS</a> in the Global
-					Language Support section for more information.</p>
+				<p>EPUB 3 also supports CSS styles that enable both horizontal and vertical layout and bo left-to-right
+					and right-to-left writing. Refer to <a href="#sec-gls-css">CSS</a> in the Global Language Support
+					section for more information.</p>
 			</section>
 
 			<section id="sec-multimedia">
 				<h2>Multimedia</h2>
 
-				<p>EPUB 3.2 supports audio and video embedded in <a>XHTML Content Documents</a> via the [[HTML]]
+				<p>EPUB 3 supports audio and video embedded in <a>XHTML Content Documents</a> via the [[HTML]]
 						<code>audio</code> and <code>video</code> elements, inheriting all the functionality and
 					features these elements provide. For more information on audio and video formats, refer to
 					[[EPUB32]].</p>
 
-				<p>Another key multimedia feature in EPUB 3.2 is the inclusion of <a>Media Overlay Documents</a>
+				<p>Another key multimedia feature in EPUB 3 is the inclusion of <a>Media Overlay Documents</a>
 					[[MediaOverlays32]]. When pre-recorded narration is available for a Rendition of an EPUB
 					Publication, Media Overlays provide the ability to synchronize that audio with the text of a Content
 					Document (see also <a href="#sec-access-overlays">Aural Renditions and Media Overlays</a>).</p>
@@ -288,14 +277,14 @@
 			<section id="sec-fonts">
 				<h2>Fonts</h2>
 
-				<p>EPUB 3.2 supports two closely-related font formats — OpenType [[OpenType]] and WOFF [[WOFF]]
-					[[WOFF2]] — to accommodate both traditional publishing workflows and emerging Web-based workflows.
-					Word processing programs used to create EPUB Publications are likely to have access only to a
-					collection of installed OpenType fonts, for example, whereas Web-archival EPUB generators will
-					likely only have access to WOFF resources (which cannot be converted to OpenType without
-					undesirable, and potentially unlicensed, stripping of WOFF metadata).</p>
+				<p>EPUB 3 supports two closely-related font formats — OpenType [[OpenType]] and WOFF [[WOFF]] [[WOFF2]]
+					— to accommodate both traditional publishing workflows and emerging Web-based workflows. Word
+					processing programs used to create EPUB Publications are likely to have access only to a collection
+					of installed OpenType fonts, for example, whereas Web-archival EPUB generators will likely only have
+					access to WOFF resources (which cannot be converted to OpenType without undesirable, and potentially
+					unlicensed, stripping of WOFF metadata).</p>
 
-				<p>EPUB 3.2 also supports both obfuscated and regular font resources for both OpenType and WOFF font
+				<p>EPUB 3 also supports both obfuscated and regular font resources for both OpenType and WOFF font
 					formats. Support for obfuscated font resources is required to accommodate font licensing
 					restrictions for many commercially-available fonts.</p>
 
@@ -328,7 +317,7 @@
 			<section id="sec-tts">
 				<h2>Text-to-speech</h2>
 
-				<p>EPUB 3.2 provides the following text-to-speech (TTS) facilities for controlling aspects of speech
+				<p>EPUB 3 provides the following text-to-speech (TTS) facilities for controlling aspects of speech
 					synthesis, such as pronunciation, prosody and voice characteristics:</p>
 
 				<dl class="labels">
@@ -375,8 +364,8 @@
 			<section id="sec-gls-metadata">
 				<h2>Metadata</h2>
 
-				<p>EPUB 3.2 supports alternate representations of all text metadata items in the package metadata
-					section to improve global distribution of EPUB Publications. The <a
+				<p>EPUB 3 supports alternate representations of all text metadata items in the package metadata section
+					to improve global distribution of EPUB Publications. The <a
 						href="epub-packages.html#attrdef-opf-alt-rep"><code>opf:alt-rep</code> attribute</a>
 					[[Packages32]] provides the ability to include and identify alternate script renderings of
 					language-specific metadata.</p>
@@ -412,8 +401,8 @@
 			<section id="sec-gls-css">
 				<h2>CSS</h2>
 
-				<p>EPUB 3.2's support for CSS3 modules enables typography for many different languages and cultures.
-					Some specific enhancements include:</p>
+				<p>EPUB 3's support for CSS3 modules enables typography for many different languages and cultures. Some
+					specific enhancements include:</p>
 
 				<ul>
 					<li>
@@ -437,13 +426,13 @@
 			<section id="sec-gls-fonts">
 				<h2>Fonts</h2>
 
-				<p>EPUB 3.2 does not require that Reading Systems come with any particular set of built-in system fonts.
+				<p>EPUB 3 does not require that Reading Systems come with any particular set of built-in system fonts.
 					As occurs in Web contexts, users in a particular locale might have installed fonts that omit
 					characters required for other locales, and Reading Systems might utilize intrinsic fonts or font
 					engines that do not utilize operating system installed fonts. As a result, the text content of an
 					EPUB Publication might not natively render as intended on all Reading Systems.</p>
 
-				<p>To address this problem, EPUB 3.2 supports the embedding of fonts to facilitate the rendering of text
+				<p>To address this problem, EPUB 3 supports the embedding of fonts to facilitate the rendering of text
 					content, and this practice is advised in order to ensure content is rendered as intended.</p>
 
 				<p>Support for embedded fonts also ensures that characters and glyphs unique to an EPUB Publication can
@@ -454,7 +443,7 @@
 			<section id="sec-gls-tts">
 				<h2>Text-to-speech</h2>
 
-				<p>EPUB 3.2's support for PLS documents and SSML attributes increases the pronunciation control that
+				<p>EPUB 3's support for PLS documents and SSML attributes increases the pronunciation control that
 					Authors have over the rendering of any natural language in text-to-speech-enabled Reading Systems.
 					Refer to <a href="#sec-tts">Text-to-speech</a> in the Features section for more information on these
 					capabilities.</p>
@@ -475,11 +464,11 @@
 		<section id="sec-accessibility">
 			<h1>Accessibility</h1>
 
-			<p>A major goal of EPUB is to facilitate content accessibility, and a variety of features in EPUB 3.2
-				support this requirement. This section reviews these features, detailing some established best practices
-				for ensuring that EPUB Publications are accessible where applicable.</p>
+			<p>A major goal of EPUB is to facilitate content accessibility, and a variety of features in EPUB 3 support
+				this requirement. This section reviews these features, detailing some established best practices for
+				ensuring that EPUB Publications are accessible where applicable.</p>
 
-			<p>EPUB 3.2 also includes an Accessibility specification [[EPUBAccessibility]] that leverages the extensive
+			<p>EPUB 3 also includes an Accessibility specification [[EPUBAccessibility]] that leverages the extensive
 				work done to make Web content accessible in [[WCAG20]]. The specification defines requirements for the
 				production of EPUB Publications that can be accessed by a wide range of users. It is accompanied by a
 				techniques document that outlines best practices for meeting the requirements.</p>
@@ -492,16 +481,16 @@
 			<section id="sec-access-nav">
 				<h2>Navigation</h2>
 
-				<p>EPUB 3.2 improves on NCX documents with the addition of <a>EPUB Navigation Documents</a>. As noted in
+				<p>EPUB 3 improves on NCX documents with the addition of <a>EPUB Navigation Documents</a>. As noted in
 						<a href="#sec-nav-nav-doc">Navigation Document</a> above, the navigation features represent a
 					more universal and flexible navigation system.</p>
 
 				<p>The Navigation Document can also be reused in the body of an EPUB Publication by including it in the
 						<code>spine</code>. To avoid the situation in highly structured documents where it might not be
 					desirable to display the complete table of contents to users in the body, the display level can be
-					modified using the [[HTML]] <code>hidden</code> attribute. This attribute is ignored by
-					Reading Systems when they render the table of contents outside the <code>spine</code> (e.g., in
-					their own specialized views), which avoids minimizing the information that is available.</p>
+					modified using the [[HTML]] <code>hidden</code> attribute. This attribute is ignored by Reading
+					Systems when they render the table of contents outside the <code>spine</code> (e.g., in their own
+					specialized views), which avoids minimizing the information that is available.</p>
 
 				<p>Authors are also encouraged to supply additional <code>nav</code> elements if their EPUB Publications
 					contain non-structural points of interest, such as figures, tables, etc. in order to further enhance
@@ -521,8 +510,8 @@
 					support the inclusion of ARIA role and state attributes and events, enhancing the ability of
 					Assistive Technologies to interact with the content.</p>
 
-				<p>EPUB 3.2 includes the <code>epub:type</code> attribute, which is meant to be functionally equivalent
-					to the W3C Role Attribute [[Role-Attribute]]. This attribute allows any element in an XHTML Content
+				<p>EPUB 3 includes the <code>epub:type</code> attribute, which is meant to be functionally equivalent to
+					the W3C Role Attribute [[Role-Attribute]]. This attribute allows any element in an XHTML Content
 					Document to include additional information about its purpose and meaning within the work, using
 					controlled vocabularies and terms. Refer to <a
 						href="epub-contentdocs.html#sec-xhtml-semantic-inflection">XHTML Semantic Inflection</a>
@@ -577,7 +566,7 @@
 				<p>Publication- and content-level fallbacks are defined in <a
 						href="epub-spec.html#sec-foreign-restrictions">Foreign Resources</a> [[EPUB32]]. These fallback
 					mechanisms enable the inclusion of Foreign Resources in an EPUB Publication and ensure compatibility
-					of EPUB 3.2 content across Reading Systems with varying capabilities (e.g., they allow the inclusion
+					of EPUB 3 content across Reading Systems with varying capabilities (e.g., they allow the inclusion
 					of multiple video formats, and the inclusion of XHTML fallbacks to SVG Content Documents for EPUB 2
 					Reading Systems).</p>
 
@@ -593,7 +582,7 @@
 			<section id="sec-access-scripting">
 				<h2>Scripting</h2>
 
-				<p>EPUB 3.2 adopts a progressive enhancement approach for scripted content, whereby scripting has to not
+				<p>EPUB 3 adopts a progressive enhancement approach for scripted content, whereby scripting has to not
 					interfere with the integrity of the document (i.e., not result in information loss when scripting is
 					not available). Consequently, although documents that do employ scripting <a
 						href="epub-contentdocs.html#sec-scripted-content">can provide fallbacks</a> [[ContentDocs32]] to
@@ -603,6 +592,72 @@
 					provided in [[WAI-ARIA]], and reserve the use of scripting for situations in which interactivity is
 					critical to the user experience.</p>
 
+			</section>
+		</section>
+		<section id="sec-revision-history">
+			<h2>EPUB Revision History</h2>
+
+			<section id="epub2">
+				<h3>OEB, OCF and EPUB 2: 1999—2010</h3>
+
+				<p>EPUB has its roots in the interchange format known as the Open EBook Publication Structure (OEBPS).
+					OEBPS 1.0 was approved in 1999 by the Open eBook Forum, an organization that later became the
+					International Digital Publishing Forum (IDPF). Subsequent revisions 1.1 and 1.2 were approved by the
+					IDPF in 2001 and 2002 respectively.</p>
+
+				<p>It was realized that a need existed for a format standard that could be used for delivery as well as
+					interchange, and work began in late 2005 on a single-file container format for OEPBS, which was
+					approved by the IDPF as the OEBPS Container Format (OCF) in 2006. Work on a 2.0 revision of OEBPS
+					began in parallel which was approved as the renamed EPUB 2.0 in October, 2007, consisting of a
+					triumvirate of specifications: Open Package Format (OPF), Open Publication Format (OPF) together
+					with OCF. EPUB 2.0.1, a maintenance update to the 2.0 specification set primarily intended clarify
+					and correct errata in the specifications, was approved in September, 2010. [[OPF2]] [[OPS2]]
+					[[OCF2]]</p>
+
+			</section>
+			<section id="epub30">
+				<h3>EPUB 3.0: 2010</h3>
+
+				<p>Work on a major revision of the EPUB specifications began in 2010, with the goal of aligning EPUB
+					more closely with HTML, and in the process bringing new, native multimedia features, sophisticated
+					CSS layout rendering and font embedding, scripted interactivity, enhanced global language support,
+					and improved accessibility. A new specification, EPUB Media Overlays was also introduced, enabling
+					text and audio synchronization in EPUB Publications. To better align the specification names with
+					the standard, the Open Package Format specification was renamed EPUB Publications and the Open
+					Publication Format specification was renamed EPUB Content Documents. The EPUB 3.0 specifications
+					were approved in October, 2011. [[Publications30]] [[ContentDocs30]] [[OCF30]] [[MediaOverlays30]]
+					[[EPUB3Changes]]</p>
+			</section>
+
+			<section id="epub301">
+				<h3>EPUB 3.0.1: 2014</h3>
+				<p>The EPUB 3.0.1 revision was undertaken in 2013-14. Although introducing mostly minor fixes and
+					updates, it did see the integration of Fixed Layout Documents, which give Authors greater control
+					over presentation when a reflowable EPUB is not suitable for the content. [[Publications301]]
+					[[ContentDocs301]] [[OCF301]] [[MediaOverlays301]] [[EPUB301Changes]]</p>
+			</section>
+
+			<section id="epub31">
+				<h3>EPUB 3.1: 2017</h3>
+				<p>EPUB 3.1 was the first minor revision of EPUB 3. The goal of this revision was to better align EPUB 3
+					with current Web standards. References to important standards were made undated, meaning that
+					whenever they are updated they are legal to use in EPUB 3 content (e.g., the latest version of HTML
+					is always valid to use; a revision of EPUB is not needed). The use of CSS was also clarified, and
+					the use of EPUB-specific properties reduced.</p>
+				<p>Many EPUB-specific features were also removed from the standard, in particular content switching,
+					triggers, and bindings. This change necessitated a new Package Document version number.[[EPUB31]]
+					[[Packages31]] [[ContentDocs31]] [[OCF31]] [[MediaOverlays31]] [[EPUB31Changes]]</p>
+			</section>
+
+			<section id="epub32">
+				<h3>EPUB 3.2: 2018</h3>
+				<p>EPUB 3.2 was undertaken shortly after EPUB 3.1 in order to restore compatibility of content to EPUB
+					3. The change of version number introduced in EPUB 3.1 meant that authors, vendors and reading
+					system developers would have to produce, distribute and consume two versions of EPUB content, but
+					the costs of this change outweighed the benefits of the new version. EPUB 3.2 instead keeps all the
+					best parts of EPUB 3.1, but returns and deprecates the removed elements so that a new version number
+					is not necessary in the Package Document. [[EPUB32]] [[Packages32]] [[ContentDocs32]] [[OCF32]]
+					[[MediaOverlays32]] [[EPUB32Changes]]</p>
 			</section>
 		</section>
 	</body>

--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -58,38 +58,31 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>EPUB Packages 3.2 defines package semantics and conformance requirements.</p>
+			<p>This specification defines semantics and conformance requirements for an <a data-lt="EPUB Package">EPUB®
+					Package</a>. Each Package represents one <a>Rendition</a> of an <a>EPUB Publication</a>, and is
+				defined by a <a>Package Document</a> that describes the content of the Rendition and sets the
+				requirements for how <a>Publication Resources</a> are associated.</p>
+
+			<p>This specification also defines the <a>EPUB Navigation Document</a>, a machine- and human-readable
+				specialization of an <a>EPUB Content Document</a> that provides navigation aids such as the table of
+				contents.</p>
+
+			<p>This specification is one of a <a href="epub-spec.html#sec-epub-specs">family of specifications</a> that
+				compose [[EPUB32]], an interchange and delivery format for digital publications based on XML and Web
+				Standards. It is meant to be read and understood in concert with the other specifications that make up
+				EPUB 3</p>
+
+			<p>Refer to [[EPUB32Changes]] for more information on the differences between this specification and its
+				predecessor.</p>
 		</section>
 		<section id="sotd"></section>
-		<section id="sec-overview">
-			<h1>Overview</h1>
-
-			<section id="sec-overview-purpose-and-scope" class="informative">
-				<h2>Purpose and Scope</h2>
-
-				<p>This specification, EPUB Packages 3.2, defines semantics and conformance requirements for an <a
-						data-lt="EPUB Package">EPUB® Package</a>. Each Package represents one <a>Rendition</a> of an
-						<a>EPUB Publication</a>, and is defined by a <a>Package Document</a> that describes the content
-					of the Rendition and sets the requirements for how <a>Publication Resources</a> are associated.</p>
-
-				<p>This specification also defines the <a>EPUB Navigation Document</a>, a machine- and human-readable
-					specialization of an <a>EPUB Content Document</a> that provides navigation aids such as the table of
-					contents.</p>
-
-				<p>This specification is one of a <a href="epub-spec.html#sec-epub-specs">family of specifications</a>
-					that compose [[EPUB32]], an interchange and delivery format for digital publications based on XML
-					and Web Standards. It is meant to be read and understood in concert with the other specifications
-					that make up EPUB 3.2</p>
-
-				<p>Refer to [[EPUB32Changes]] for more information on the differences between this specification and its
-					predecessor.</p>
-
-			</section>
+		<section id="sec-introduction">
+			<h1>Introduction</h1>
 
 			<section id="sec-terminology">
 				<h2>Terminology</h2>
 
-				<p>Terms with meanings specific to EPUB 3.2 are capitalized in this document (e.g., "Author", "Reading
+				<p>Terms with meanings specific to EPUB 3 are capitalized in this document (e.g., "Author", "Reading
 					System"). A complete list of these <a href="epub-spec.html#sec-terminology">terms and
 						definitions</a> is provided in [[!EPUB32]].</p>
 
@@ -2452,8 +2445,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						</li>
 						<li>
 							<p>The <a href="http://www.idpf.org/epub/vocab/package/link/">EPUB Metadata Link
-									Vocabulary</a> [[!LinkVocab]] is defined to be the default vocabulary for the
-								<a href="#elemdef-opf-link"><code>link</code></a>
+									Vocabulary</a> [[!LinkVocab]] is defined to be the default vocabulary for the <a
+									href="#elemdef-opf-link"><code>link</code></a>
 								<code>rel</code> and <code>properties</code> attributes.</p>
 							<p>If any of these attributes' values do not include a prefix, the following IRI
 								[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -60,43 +60,34 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>EPUB 3.2 is an interchange and delivery format for digital publications based on XML and Web
-				Standards.</p>
+			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The
+				EPUB format provides a means of representing, packaging and encoding structured and semantically
+				enhanced Web content — including HTML, CSS, SVG and other resources — for distribution in a
+				single-file container. This specification represents the second major revision of the standard</p>
+			
+			<p>EPUB 3 has been widely adopted as the format for digital books (ebooks), and this revision continues
+				to increase the format's capabilities in order to better support a wider range of publication
+				requirements, including complex layouts, rich media and interactivity, and global typography
+				features. The expectation is that the EPUB 3 format will be utilized for a broad range of content,
+				including books, magazines and educational, professional and scientific publications.</p>
+			
+			<p>EPUB 3 is modular in nature: it consists of a family of specifications that define the core features
+				and functionality of the standard. This specification represents the primary entry point to
+				standard, but the specifications listed in <a href="#sec-epub-specs">Specifications</a> are all a
+				part of EPUB 3. An <a href="#index">index to key concepts and definitions</a> defined across these
+				specifications is provided at the end of this specification.</p>
+			
+			<p>The informative [[EPUB32Overview]] provides a general introduction to EPUB 3. A list of technical
+				changes from the previous revision is also available in the informative [[EPUB32Changes]].</p>
 		</section>
 		<section id="sotd"></section>
-		<section id="sec-overview">
-			<h1>Overview</h1>
-
-			<section id="sec-purpose-scope" class="informative">
-				<h2>Purpose and Scope</h2>
-
-				<p>This specification, EPUB 3.2, defines a distribution and interchange format for digital publications
-					and documents. The EPUB® format provides a means of representing, packaging and encoding structured
-					and semantically enhanced Web content — including HTML, CSS, SVG and other resources — for
-					distribution in a single-file container.</p>
-
-				<p>EPUB has been widely adopted as the format for digital books (ebooks), and EPUB 3.2 continues to
-					increase the format's capabilities in order to better support a wider range of publication
-					requirements, including complex layouts, rich media and interactivity, and global typography
-					features. The expectation is that the EPUB 3.2 format will be utilized for a broad range of content,
-					including books, magazines and educational, professional and scientific publications.</p>
-
-				<p>EPUB 3.2 is modular in nature: it consists of a family of specifications that define the core
-					features and functionality of the standard. This specification represents the primary entry point to
-					standard, but the specifications listed in <a href="#sec-epub-specs">Specifications</a> are all a
-					part of EPUB 3.2. An <a href="#index">index to key concepts and definitions</a> defined across these
-					specifications is provided at the end of this specification.</p>
-
-				<p>The informative [[EPUB32Overview]] provides a general introduction to EPUB 3.2. A list of technical
-					changes from EPUB 3.1, the previous version of the standard, is also available in the informative
-					[[EPUB32Changes]].</p>
-
-			</section>
+		<section id="sec-introduction">
+			<h1>Introduction</h1>
 
 			<section id="sec-terminology">
 				<h2>Terminology</h2>
 
-				<p>The following terms are specific to EPUB 3.2. They are capitalized wherever used.</p>
+				<p>The following terms are specific to EPUB 3. They are capitalized wherever used.</p>
 
 				<p>Only the first instance of a term in a section is linked to its definition.</p>
 
@@ -314,7 +305,7 @@
 			<section id="sec-epub-specs">
 				<h2>Specifications</h2>
 
-				<p>The EPUB 3.2 standard is modular in nature, with core features and functionality defined across a
+				<p>The EPUB 3 standard is modular in nature, with core features and functionality defined across a
 					family of sub-specifications.</p>
 
 				<p>This specification represents the top-most specification in the family. It includes the conformance
@@ -322,23 +313,23 @@
 						Systems</a> (the applications that consume EPUB Publications and present their content to
 					users).</p>
 
-				<p>The other specifications that comprise EPUB 3.2 are as follows:</p>
+				<p>The other specifications that comprise EPUB 3 are as follows:</p>
 
 				<ul>
 					<li>
-						<p><a href="epub-packages.html">EPUB Packages 3.2</a> [[!Packages32]] — defines requirements for
+						<p><a href="epub-packages.html">EPUB Packages</a> [[!Packages32]] — defines requirements for
 							each <a>Rendition</a> of the content.</p>
 					</li>
 					<li>
-						<p><a href="epub-contentdocs.html">EPUB Content Documents 3.2</a> [[!ContentDocs32]] — defines
+						<p><a href="epub-contentdocs.html">EPUB Content Documents</a> [[!ContentDocs32]] — defines
 							profiles of XHTML, SVG and CSS for use in the context of EPUB Publications.</p>
 					</li>
 					<li>
-						<p><a href="epub-mediaoverlays.html">EPUB Media Overlays 3.2</a> [[!MediaOverlays32]] — defines
-							a format and a processing model for synchronization of text and audio.</p>
+						<p><a href="epub-mediaoverlays.html">EPUB Media Overlays</a> [[!MediaOverlays32]] — defines a
+							format and a processing model for synchronization of text and audio.</p>
 					</li>
 					<li>
-						<p><a href="epub-ocf.html">EPUB Open Container Format (OCF) 3.2</a> [[!OCF32]] — defines a file
+						<p><a href="epub-ocf.html">EPUB Open Container Format (OCF)</a> [[!OCF32]] — defines a file
 							format and processing model for encapsulating a set of related resources into a single-file
 							(ZIP) <a>EPUB Container</a>.</p>
 					</li>
@@ -349,7 +340,7 @@
 					</li>
 				</ul>
 
-				<p>These specifications represent the formal list recognized as belonging to EPUB 3.2, and that contain
+				<p>These specifications represent the formal list recognized as belonging to EPUB 3, and that contain
 					functionality referenced as part of the standard. New functionality is also added periodically
 					through the development of extension specifications. Features and functionality defined outside of
 					core revisions to the standard, while not formally recognized in this specification, are nonetheless
@@ -418,7 +409,7 @@
 					dependent assets in a ZIP package as presented here. Additional information about the primary
 					features and functionality that EPUB Publications provide to enhance the reading experience is
 					available from the referenced specifications, and a more general introduction to the features of
-					EPUB 3.2 is provided in the informative [[EPUB32Overview]].</p>
+					EPUB 3 is provided in the informative [[EPUB32Overview]].</p>
 
 			</section>
 
@@ -463,7 +454,7 @@
 				<p>An <a>EPUB Reading System</a> MUST meet all of the following criteria:</p>
 
 				<dl class="conformance-list">
-					<dt id="sec-epub-rs-conf-epub3">EPUB 3.2 Processing</dt>
+					<dt id="sec-epub-rs-conf-epub3">EPUB 3 Processing</dt>
 					<dd>
 						<p id="confreq-rs-epub3-ocf">It MUST process the <a>EPUB Container</a> as defined in
 							[[!OCF32]].</p>
@@ -940,7 +931,7 @@
 		</section>
 		<section id="index" class="index informative">
 			<h1>Index</h1>
-			<p>This index identifies where key concepts are defined in EPUB 3.2, including element, attribute and
+			<p>This index identifies where key concepts are defined in EPUB 3, including element, attribute and
 				property definitions.</p>
 			<ul>
 				<li id="idx-a11y">


### PR DESCRIPTION
This PR was initially going to address the issue I raised in #1045 about referring to EPUB 3 as the standard, but as I was going through I noticed a couple of other areas that could also be improved. So, in addition, to some text tweaking around version numbers, this PR also introduces the following changes:

- It moves the brief revision history of EPUB that had been in the changes document to the overview. The overview is the better location to talk generally about what we're tweaking as we go. The changes document is a reference to the specific changes made in one particular revision.

- It takes the "purpose and scope" sections and makes them the abstracts for each specification. These were always our version of an abstract in IDPF, and the current abstracts are mostly just ripoffs of the first sentence from the purpose and scope section.
