### PR TITLE
EPUB OCF 3.2 sections A-E editorial fixes

### DIFF
--- a/epub32/spec/acknowledgements.html
+++ b/epub32/spec/acknowledgements.html
@@ -7,20 +7,20 @@
 	<p>The EPUB 3.2 revision was led by: </p>
 
 	<ul>
-		<li>Rachel Comerford (Macmillan Higher Education) Chair</li>
-		<li>Dave Cramer (Hachette Livre) Chair</li>
+		<li>Rachel Comerford (Macmillan Higher Education), Chair</li>
+		<li>Dave Cramer (Hachette Livre), Chair</li>
 	</ul>
 
-	<p>In addition to the editors, this version of EPUB would not have been possible without the significant
+	<p>In addition to the editors, this version of EPUB would not have been possible without significant
 		contributions from:</p>
 	
 	<ul>
-		<li>Conboy, Garth (Google)</li>
-		<li>Murata, Makoto (JEPA EPUB Study Group)</li>
+		<li>Garth Conboy (Google)</li>
+		<li>Makoto Murata (JEPA EPUB Study Group)</li>
 	</ul>
 
 	<p class="issue">Acknowledgements to be completed before release.</p>
 
-	<p>Special thanks goes to the former members of the International Digital Publishing Forum, particularly Markus
+	<p>Special thanks go to the former members of the International Digital Publishing Forum, particularly Markus
 		Gylling and Bill McCoy, without whom EPUB would not have become a reality.</p>
 </section>

--- a/epub32/spec/epub-ocf.html
+++ b/epub32/spec/epub-ocf.html
@@ -1159,9 +1159,9 @@ store destination as source in ocf
 			<section id="app-schema-container">
 				<h2>Schema for <code>container.xml</code></h2>
 
-				<p>The schema for <code>container.xml</code> files is available at <a class="uri"
-						href="http://www.idpf.org/epub/31/schema/ocf-container-31.rnc"
-							><code>http://www.idpf.org/epub/31/schema/ocf-container-31.rnc</code></a>.</p>
+				<p>The schema for <code>container.xml</code> files is available at
+					<a href="https://www.idpf.org/epub/31/schema/ocf-container-31.rnc">
+					<code>https://www.idpf.org/epub/31/schema/ocf-container-31.rnc</code></a>.</p>
 
 				<p class="issue">We'll need to work on schemas, and provide appropriate links</p>
 
@@ -1186,36 +1186,47 @@ store destination as source in ocf
 
 		</section>
 		<section class="appendix informative" id="example">
-			<h1>Example</h1>
-			<p>The following example demonstrates the use of this OCF format to contain a signed and encrypted EPUB
-				Publication within an <a>OCF ZIP Container</a>.</p> Ordered list of files in the OCF ZIP Container
-			<pre>
-mimetype
+			<h1>Examples</h1>
+			<p>The following examples demonstrate the use of the OCF format to contain a signed and encrypted EPUB Publication within an <a>OCF ZIP Container</a>.</p>
+
+			<aside class="example">
+				<p>Ordered list of files in the OCF ZIP Container</p>
+<pre>mimetype
 META-INF/container.xml
 META-INF/signatures.xml
 META-INF/encryption.xml
-EPUB/As You Like It.opf
+EPUB/As_You_Like_It.opf
 EPUB/book.html
 EPUB/nav.html
 EPUB/images/cover.png</pre>
-			The contents of the <code>mimetype</code> file <code>application/epub+zip</code> The contents of the
-				<code>META-INF/container.xml</code> file
-			<pre>&lt;?xml version="1.0"?&gt;
+			</aside>
+
+			<aside class="example">
+				<p>The contents of the <code>mimetype</code> file</p>
+<pre>application/epub+zip</pre>
+			</aside>
+
+			<aside class="example">
+				<p>The contents of the <code>META-INF/container.xml</code> file</p>
+<pre>&lt;?xml version="1.0"?&gt;
 &lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
     &lt;rootfiles&gt;
         &lt;rootfile full-path="EPUB/As_You_Like_It.opf"
-            media-type="application/oebps-package+xml" /&gt;
+            media-type="application/oebps-package+xml"/&gt;
     &lt;/rootfiles&gt;
 &lt;/container&gt;</pre>
-			The contents of the <code>META-INF/signatures.xml</code> file
-			<pre>&lt;signatures xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
+			</aside>
+
+			<aside class="example">
+				<p>The contents of the <code>META-INF/signatures.xml</code> file</p>
+<pre>&lt;signatures xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
     &lt;Signature Id="AsYouLikeItSignature" xmlns="http://www.w3.org/2000/09/xmldsig#"&gt;
         
-        &lt;!-- 
+        &lt;!--
              SignedInfo is the information that is actually signed.
-             In this case the SHA-1 algorithm is used to sign the 
+             In this case, the SHA-1 algorithm is used to sign the 
              canonical form of the XML documents enumerated in the
-             Object element below
+             Object element below.
         --&gt;
         &lt;SignedInfo&gt;
             &lt;CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
@@ -1226,13 +1237,15 @@ EPUB/images/cover.png</pre>
             &lt;/Reference&gt;
         &lt;/SignedInfo&gt;
         
-        &lt;!-- 
-             The signed value of the digest above using the DSA 
+        &lt;!--
+             The signed value of the digest above, using the DSA 
              algorithm
         --&gt;
         &lt;SignatureValue&gt;…&lt;/SignatureValue&gt;
         
-        &lt;!-- The key to use to validate the signature --&gt;
+        &lt;!--
+             The key used to validate the signature
+        --&gt;
         &lt;KeyInfo&gt;
             &lt;KeyValue&gt;
                 &lt;DSAKeyValue&gt;
@@ -1244,14 +1257,14 @@ EPUB/images/cover.png</pre>
             &lt;/KeyValue&gt;
         &lt;/KeyInfo&gt;
         
-        &lt;!-- 
-             The list documents to sign. Note that the canonical 
-             form of XML documents is signed while the binary form
-             of the other documents is used
+        &lt;!--
+             The list of resources to sign (note that the canonical
+             form of XML documents is signed, while the binary form
+             of all other resources is used)
         --&gt;
         &lt;Object&gt;
             &lt;Manifest Id="AsYouLikeIt"&gt;
-                &lt;Reference URI="EPUB/As You Like It.opf"&gt;
+                &lt;Reference URI="EPUB/As_You_Like_It.opf"&gt;
                     &lt;Transforms&gt;
                         &lt;Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
                     &lt;/Transforms&gt;
@@ -1270,17 +1283,20 @@ EPUB/images/cover.png</pre>
                     &lt;DigestValue&gt;&lt;/DigestValue&gt;
                 &lt;/Reference&gt;
             &lt;/Manifest&gt;
-        &lt;/Object&gt;        
+        &lt;/Object&gt;
     &lt;/Signature&gt;
 &lt;/signatures&gt;</pre>
-			The contents of the <code>META-INF/encryption.xml</code> file
-			<pre>&lt;?xml version="1.0"?&gt;
+			</aside>
+
+			<aside class="example">
+				<p>The contents of the <code>META-INF/encryption.xml</code> file</p>
+<pre>&lt;?xml version="1.0"?&gt;
 &lt;encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
     xmlns:enc="http://www.w3.org/2001/04/xmlenc#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"&gt;
 
     &lt;!--
-         The RSA encrypted AES-128 symmetric key used to encrypt
-         the data
+         The RSA-encrypted AES-128 symmetric key used to encrypt
+         data enumerated in EncryptedData blocks below
     --&gt;
     &lt;enc:EncryptedKey Id="EK"&gt;
         &lt;enc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
@@ -1292,10 +1308,10 @@ EPUB/images/cover.png</pre>
         &lt;/enc:CipherData&gt;
     &lt;/enc:EncryptedKey&gt;
 
-    &lt;!-- 
-         Each EncryptedData block identifies a single document
+    &lt;!--
+         Each EncryptedData block identifies a single resource
          that has been encrypted using the AES-128 algorithm.
-         The data remains stored in its encrypted form in the
+         The data remains stored, in its encrypted form, in the
          original file within the container.
     --&gt;
     &lt;enc:EncryptedData Id="ED1"&gt;
@@ -1317,18 +1333,19 @@ EPUB/images/cover.png</pre>
             &lt;enc:CipherReference URI="EPUB/images/cover.png"/&gt;
         &lt;/enc:CipherData&gt;
     &lt;/enc:EncryptedData&gt;
-
 &lt;/encryption&gt;</pre>
-			The contents of the <code>EPUB/As You Like It.opf</code> file
-			<pre>&lt;?xml version="1.0"?&gt;
-&lt;package version="3.0" 
+			</aside>
+
+			<aside class="example">
+				<p>The contents of the <code>EPUB/As_You_Like_It.opf</code> file</p>
+<pre>&lt;?xml version="1.0"?&gt;
+&lt;package version="3.0"
          xml:lang="en"
-         xmlns="http://www.idpf.org/2007/opf" 
+         xmlns="http://www.idpf.org/2007/opf"
          unique-identifier="pub-id"&gt;
     
     &lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-        &lt;dc:identifier 
-              id="pub-id"&gt;urn:uuid:B9B412F2-CAAD-4A44-B91F-A375068478A0&lt;/dc:identifier&gt;
+        &lt;dc:identifier id="pub-id"&gt;urn:uuid:B9B412F2-CAAD-4A44-B91F-A375068478A0&lt;/dc:identifier&gt;
         
         &lt;dc:language&gt;en&lt;/dc:language&gt;
         
@@ -1344,12 +1361,11 @@ EPUB/images/cover.png</pre>
         
         &lt;meta property="dcterms:dateCopyrighted"&gt;9999-01-01&lt;/meta&gt;
         
-        &lt;dc:identifier 
-              id="isbn13"&gt;urn:isbn:9780741014559&lt;/dc:identifier&gt;
+        &lt;dc:identifier id="isbn13"&gt;urn:isbn:9780741014559&lt;/dc:identifier&gt;
         
         &lt;dc:identifier id="isbn10"&gt;0-7410-1455-6&lt;/dc:identifier&gt;
         
-        &lt;link rel="xml-signature" 
+        &lt;link rel="xml-signature"
               href="../META-INF/signatures.xml#AsYouLikeItSignature"/&gt;
     &lt;/metadata&gt;
     
@@ -1369,16 +1385,17 @@ EPUB/images/cover.png</pre>
     &lt;spine&gt;
         &lt;itemref idref="r4915"/&gt;
     &lt;/spine&gt;
-&lt;/package&gt;
-</pre>
+&lt;/package&gt;</pre>
+			</aside>
 		</section>
+
 		<section class="appendix informative" id="app-media-type">
 			<h1>The <code>application/epub+zip</code> Media Type</h1>
 
 			<p>This appendix registers the media type <code>application/epub+zip</code> for the EPUB Open Container
 				Format (OCF).</p>
 
-			<p>An OCF file is a container technology based on the ZIP archive format. It is used to encapsulate the
+			<p>An <a>OCF ZIP Container</a>, or <a>EPUB Container</a>, file is a container technology based on the [[!ZIP]] archive format. It is used to encapsulate the
 				Renditions of EPUB Publications. OCF and its related standards are maintained and defined by the World
 				Wide Web Consortium (W3C).</p>
 
@@ -1401,24 +1418,20 @@ EPUB/images/cover.png</pre>
 				</dd>
 				<dt>Encoding considerations:</dt>
 				<dd>
-					<p>OCF files are binary files in ZIP (<a class="uri"
-							href="http://www.iana.org/assignments/media-types/application/zip"
-								><code>http://www.iana.org/assignments/media-types/application/zip</code></a>)
-						format.</p>
+					<p>OCF ZIP Container files are binary files encoded in the <a class="media-type" href="https://www.iana.org/assignments/media-types/application/zip">
+						<code>application/zip</code></a> media type.</p>
 				</dd>
 				<dt>Security considerations:</dt>
 				<dd>
-					<p>All processors that read OCF files should rigorously check the size and validity of data
+					<p>All processors that read OCF ZIP Container files should rigorously check the size and validity of data
 						retrieved.</p>
-					<p>In addition, because of the various content types that can be embedded in OCF files, it is
-						possible that <code>application/epub+zip</code> may describe content that has security
-						implications beyond those described here. However, only in the case where the processor
+					<p>In addition, because of the various content types that can be embedded in OCF ZIP Container files,
+						<code>application/epub+zip</code> may describe content that poses security
+						implications beyond those noted here. However, only in cases where the processor
 						recognizes and processes the additional content, or where further processing of that content is
-						dispatched to other processors, would security issues potentially arise. And in that case, they
+						dispatched to other processors, would security issues potentially arise. In such cases, matters of security
 						would fall outside the domain of this registration document.</p>
-					<p>Security considerations that apply to <a class="media-type"
-							href="http://www.iana.org/assignments/media-types/application/zip"
-								><code>application/zip</code></a> also apply to OCF files.</p>
+					<p>Security considerations that apply to <code>application/zip</code> also apply to OCF ZIP Container files.</p>
 				</dd>
 				<dt>Interoperability considerations:</dt>
 				<dd>
@@ -1427,53 +1440,28 @@ EPUB/images/cover.png</pre>
 				<dt>Published specification:</dt>
 				<dd>
 					<p>This media type registration is for the EPUB Open Container Format (OCF), as described by the
-						EPUB Open Container Format (OCF) 3.2 specification located at <a class="uri"
-							href="http://w3c.github.io/publ-epub-revision/epub32/spec/epub-ocf.html"
-								><code>http://w3c.github.io/publ-epub-revision/epub32/spec/epub-ocf.html</code></a>.</p>
-					<p>The EPUB OCF 3.2 specification supersedes <a href="https://tools.ietf.org/html/rfc4839">RFC
-							4839</a> as well as the Open Container Format 2.0.1 specification, which is located at <a
-							class="uri" href="http://www.idpf.org/doc_library/epub/OCF_2.0.1_draft.doc"
-								><code>http://www.idpf.org/doc_library/epub/OCF_2.0.1_draft.doc</code></a> and which
-						also uses the <code class="media-type">application/epub+zip</code> media type.</p>
+						EPUB Open Container Format (OCF) 3.2 specification located at
+						<a href="https://w3c.github.io/publ-epub-revision/epub32/spec/epub-ocf.html"><code>https://w3c.github.io/publ-epub-revision/epub32/spec/epub-ocf.html</code></a>.</p>
+					<p>The EPUB OCF 3.2 specification supersedes both <a href="https://tools.ietf.org/html/rfc4839">RFC
+						4839</a> and the Open Container Format 2.0.1 specification, which is located at <a href="https://www.idpf.org/doc_library/epub/OCF_2.0.1_draft.doc"><code>https://www.idpf.org/doc_library/epub/OCF_2.0.1_draft.doc</code></a>,
+						and which also uses the <code>application/epub+zip</code> media type.</p>
 				</dd>
-				<dt>Applications which use this media type:</dt>
+				<dt>Applications that use this media type:</dt>
 				<dd>
 					<p>This media type is in wide use for the distribution of ebooks in the EPUB format. The following
 						list of applications is not exhaustive.</p>
 					<ul>
-						<li>
-							<p>Adobe Digital Editions</p>
-						</li>
-						<li>
-							<p>Aldiko</p>
-						</li>
-						<li>
-							<p>Azardi</p>
-						</li>
-						<li>
-							<p>Apple iBooks</p>
-						</li>
-						<li>
-							<p>Barnes &amp; Noble Nook</p>
-						</li>
-						<li>
-							<p>Bluefire Reader</p>
-						</li>
-						<li>
-							<p>Calibre</p>
-						</li>
-						<li>
-							<p>Google Play Books</p>
-						</li>
-						<li>
-							<p>Kobo</p>
-						</li>
-						<li>
-							<p>Microsoft Edge</p>
-						</li>
-						<li>
-							<p>Readium</p>
-						</li>
+						<li>Adobe Digital Editions</li>
+						<li>Aldiko</li>
+						<li>Azardi</li>
+						<li>Apple iBooks</li>
+						<li>Barnes &amp; Noble NOOK</li>
+						<li>Bluefire Reader</li>
+						<li>Calibre</li>
+						<li>Google Play Books</li>
+						<li>Kobo</li>
+						<li>Microsoft Edge</li>
+						<li>Readium</li>
 					</ul>
 				</dd>
 				<dt>Additional information:</dt>
@@ -1486,19 +1474,18 @@ EPUB/images/cover.png</pre>
 						</dd>
 						<dt>File extension(s):</dt>
 						<dd>
-							<p>OCF files are most often identified with the extension <code>.epub</code>.</p>
+							<p>OCF ZIP Container files are most often identified with the extension <code>.epub</code>.</p>
 						</dd>
-						<dt>Macintosh File Type Code(s):</dt>
+						<dt>Macintosh file type code(s):</dt>
 						<dd>
 							<p>ZIP</p>
 						</dd>
-						<dt>Fragment Identifiers:</dt>
+						<dt>Fragment identifiers:</dt>
 						<dd>
-							<p>A registry of linking schemes is maintained at <a class="uri"
-									href="http://www.idpf.org/epub/linking/"
-										><code>http://www.idpf.org/epub/linking/</code></a>. Some of these schemes
-								define custom fragment identifiers that resolve to <code>application/epub+zip</code> and
-									<code>application/oebps-package+xml</code> documents.</p>
+							<p>A registry of linking schemes is maintained at
+								<a href="https://www.idpf.org/epub/linking/"><code>https://www.idpf.org/epub/linking/</code></a>.
+								Some of these schemes define custom fragment identifiers that resolve to
+								<code>application/epub+zip</code> and <code>application/oebps-package+xml</code> documents.</p>
 						</dd>
 					</dl>
 				</dd>
@@ -1510,10 +1497,10 @@ EPUB/images/cover.png</pre>
 				<dd>
 					<p>COMMON</p>
 				</dd>
-				<dt>Author/Change controller:</dt>
+				<dt>Author/change controller:</dt>
 				<dd>
-					<p>The published specification is a work product of the World Wide Web Consortium’s EPUB 3 Community
-						Group. W3C has change control over this specification.</p>
+					<p>The published specification is a work product of the World Wide Web Consortium (W3C)’s EPUB 3 Community
+						Group. The W3C has change control over this specification.</p>
 				</dd>
 			</dl>
 


### PR DESCRIPTION
Implemented several editorial changes across appendix sections. Also fixed a few broken references in the technical examples, and applied uniform styles throughout. Some remaining questions:

- "Issue 1:" What are appropriate links for the schema section? What other content/copy still needs authoring?
- Do example implementations of the `application/epub+zip` media type need trademarks? I noticed EPUB uses it in the intro; unsure about "Apple iBooks", "Microsoft Edge", etc.
- "Issue 2:" List of general acknowledgments is still TK, correct?

I'm happy to revert any of my changes.

Thanks, and let me know how I can help further.