### PR TITLE
Update definition of core media types

### DIFF
--- a/epub32/spec/common/js/biblio.js
+++ b/epub32/spec/common/js/biblio.js
@@ -54,10 +54,6 @@ var biblio = {
       "title": "EPUB Content Documents Reserved Prefixes",
       "href": "http://www.idpf.org/epub/vocab/structure/pfx"
     },
-    "CoreMediaTypes": {
-      "title": "EPUB 3 Core Media Types",
-      "href": "https://www.idpf.org/epub/cmt/v3/"
-    },
     "CSSSnapshot": {
       "title": "CSS Snapshot",
       "href": "https://www.w3.org/TR/CSS/"

--- a/epub32/spec/epub-changes.html
+++ b/epub32/spec/epub-changes.html
@@ -87,8 +87,8 @@
 				current versions of HTML, CSS, and SVG, as defined by the W3C. These versions will evolve over time,
 				allowing EPUB to remain up-to-date with the web.</p>
 
-			<p>Another noticeable change is that WOFF 2.0 and SFNT fonts are now core media types. EPUB 3.2 also
-				deprecates some older features, such as <code>bindings</code>, <code>epub:trigger</code>, and
+			<p>Another noticeable change is that WOFF 2.0 and SFNT fonts are now Core Media Type Resources. EPUB 3.2
+				also deprecates some older features, such as <code>bindings</code>, <code>epub:trigger</code>, and
 					<code>epub:switch.</code></p>
 
 		</section>
@@ -145,10 +145,11 @@
 			</section>
 
 			<section id="sec-epub32-cmt">
-				<h2>New Core Media Types</h2>
+				<h2>New Core Media Type Resources</h2>
 
 				<p>EPUB 3.2 adds the <a href="epub-spec.html#cmt-woff2">WOFF 2.0</a> and <a
-						href="epub-spec.html#cmt-sfnt">SFNT</a> font formats as Core Media Types [[EPUB32]].</p>
+						href="epub-spec.html#cmt-sfnt">SFNT</a> font formats as Core Media Type Resources
+					[[EPUB32]].</p>
 			</section>
 
 			<section id="sec-epub32-fallbacks">
@@ -236,8 +237,8 @@
 						<a href="http://www.idpf.org/epub/301/spec/epub-publications.html#sec-bindings-elem">EPUB 3.0.1
 							<code>bindings</code></a>).</p>
 				<p>The [[HTML]] <code>object</code> element's <a href="epub-contentdocs.html#sec-xhtml-fallbacks"
-						>intrinsic fallback mechanism</a> (embedded content) can be used to provide a Core Media Type
-					fallback.</p>
+						>intrinsic fallback mechanism</a> (embedded content) can be used to provide a fallback Core
+					Media Type Resource.</p>
 			</section>
 		</section>
 		<section id="sec-cdoc">

--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -859,7 +859,7 @@
 						Core Media Type Resource.</p>
 
 					<p>The following [[!HTML]] elements can refer to <a href="epub-spec.html#sec-core-media-types"
-							>Foreigh Resources</a> [[!EPUB32]] without having to provide a fallback Core Media Type
+							>Foreign Resources</a> [[!EPUB32]] without having to provide a fallback Core Media Type
 						Resource:</p>
 
 					<ul>

--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -172,9 +172,11 @@
 
 			<section id="sec-xhtml-intro">
 				<h2>Introduction</h2>
+
 				<p>This section defines a profile of [[!HTML]] for creating XHTML Content Documents. An instance of an
 					XML document that conforms to this profile is a <a>Core Media Type Resource</a> and is referred to
 					in this specification as an <a>XHTML Content Document</a>.</p>
+
 				<p>Unless otherwise specified, this specification inherits all definitions of semantics, structure and
 					processing behaviors from the [[!HTML]] specification.</p>
 			</section>
@@ -836,6 +838,7 @@
 
 				<section id="sec-xhtml-fallbacks">
 					<h3>Foreign Resource Restrictions</h3>
+
 					<p id="confreq-resources-cd-fallback">Foreign Resources MAY be referenced from elements that have
 						intrinsic fallback mechanisms, where an intrinsic fallback method is the capability to offer an
 						alternative presentation if the foreign resource is not supported. For example, most [[!HTML]]
@@ -844,6 +847,7 @@
 						allowing embedded HTML content for when a resource cannot be rendered. A <a>Core Media Type
 							Resource</a> or embedded HTML content MUST be provided via the given element's intrinsic
 						fallback mechanism when a Foreign Resource is referenced.</p>
+
 					<p id="confreq-resources-cd-fallback-media">[[!HTML]] <a
 							href="https://www.w3.org/TR/html/dom.html#flow-content">flow content</a> MAY be embedded
 						within the <a
@@ -851,10 +855,13 @@
 								><code>audio</code></a> and <a
 							href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-video-element"
 								><code>video</code></a> elements for rendering in older Reading Systems that do not
-						recognize these elements (e.g., EPUB 2 Reading Systems), but it does not represent a Core Media
-						Type fallback.</p>
-					<p>The following [[!HTML]] elements are exempt from <a href="epub-spec.html#sec-core-media-types"
-							>Core Media Type requirements</a> [[!EPUB32]]:</p>
+						recognize these elements (e.g., EPUB 2 Reading Systems), but it does not represent a fallback
+						Core Media Type Resource.</p>
+
+					<p>The following [[!HTML]] elements can refer to <a href="epub-spec.html#sec-core-media-types"
+							>Foreigh Resources</a> [[!EPUB32]] without having to provide a fallback Core Media Type
+						Resource:</p>
+
 					<ul>
 						<li><p id="confreq-resources-cd-fallback-link"><a
 									href="https://www.w3.org/TR/html/document-metadata.html#the-link-element"
@@ -871,7 +878,7 @@
 					</ul>
 
 					<p>Foreign Resources MAY be referenced from the preceding three elements without the provision of a
-						Core Media Type fallback.</p>
+						fallback Core Media Type Resource.</p>
 
 					<div class="note">
 						<p>Refer to <a href="epub-packages.html#sec-foreign-restrictions-manifest">manifest
@@ -1478,10 +1485,11 @@
 									><code>object</code></a> and <a
 								href="https://www.w3.org/TR/html/semantics-scripting.html#the-canvas-element"
 									><code>canvas</code></a> elements) or, when an intrinsic fallback is not applicable,
-							by using a <a href="epub-packages.html#sec-foreign-restrictions-manifest">manifest-level</a>
-							[[!Packages32]] fallback.</p><p id="confreq-cd-scripted-foreign-resources">Authors MUST
-							ensure that any output scripts generate meets <a href="epub-spec.html#sec-core-media-types"
-								>Core Media Type requirements</a> [[!EPUB32]].</p></dd>
+							by using a <a href="epub-packages.html#sec-foreign-restrictions-manifest">manifest-level
+								fallback</a> [[!Packages32]].</p>
+						<p id="confreq-cd-scripted-foreign-resources">Authors
+							MUST ensure that scripts only generate <a href="epub-spec.html#sec-core-media-types">Core
+								Media Type Resources</a> or fragments thereof [[!EPUB32]].</p></dd>
 				</dl>
 
 				<div class="note">

--- a/epub32/spec/epub-mediaoverlays.html
+++ b/epub32/spec/epub-mediaoverlays.html
@@ -657,8 +657,8 @@
 								<dd>
 									<p>The relative or absolute IRI reference [[!RFC3987]] of an audio file. The audio
 										file MUST be one of the audio formats listed in the <a
-											href="epub-spec.html#sec-core-media-types">Core Media Types</a> [[!EPUB32]]
-										table.</p>
+											href="epub-spec.html#sec-core-media-types">Core Media Type Resources</a>
+										[[!EPUB32]] table.</p>
 								</dd>
 								<dt id="attrdef-smil-clipBegin">
 									<code>clipBegin</code>

--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -1364,9 +1364,9 @@
 						<p id="linked-res-manifest">Linked resources are not <a>Publication Resources</a> and MUST NOT
 							be listed in the <a href="#sec-manifest-elem">manifest</a>. A linked resource MAY be
 							embedded in a Publication Resource that is listed in the manifest, however, in which case it
-							MUST adhere to <a href="epub-spec.html#sec-core-media-types">Core Media Type
-								requirements</a> [[!EPUB32]] (e.g., an <a>EPUB Content Document</a> could contain a
-							metadata record serialized as [[RDFA-CORE]] or [[JSON-LD]]).</p>
+							MUST be a <a href="epub-spec.html#sec-core-media-types">Core Media Type Resource</a>
+							[[!EPUB32]] (e.g., an <a>EPUB Content Document</a> could contain a metadata record
+							serialized as [[RDFA-CORE]] or [[JSON-LD]]).</p>
 
 						<aside class="example">
 							<p>The following example shows a reference to a metadata record embedded in a
@@ -1616,8 +1616,8 @@
 
 						<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[!XML]] that
 							identifies a fallback for the Publication Resource referenced from the <code>item</code>
-							element. Fallbacks MAY be provided for Core Media Type Resources (e.g., to provide a static
-							alternative to a <a>Scripted Content Document</a>). Fallback requirements for Foreign
+							element. Fallbacks MAY be provided for <a>Core Media Type Resources</a> (e.g., to provide a
+							static alternative to a <a>Scripted Content Document</a>). Fallback requirements for Foreign
 							Resources are defined in <a href="#sec-foreign-restrictions-manifest">Manifest
 							Fallbacks</a>.</p>
 
@@ -1706,7 +1706,7 @@
 							<p>The following example shows a <code>manifest</code> that references two <a>Foreign
 									Resources</a>, and therefore uses the <a href="#sec-foreign-restrictions-manifest"
 									>fallback chain mechanism</a> to supply content alternatives. The fallback chain
-								terminates with a Core Media Type.</p>
+								terminates with a <a>Core Media Type Resource</a>.</p>
 							<pre>&lt;manifest&gt;
     &lt;item id="item1" 
           href="chap1_docbook.xml" 

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -76,8 +76,8 @@
 
 			<p>EPUB 3 is modular in nature: it consists of a family of specifications that define the core features and
 				functionality of the standard. This specification represents the primary entry point to standard, but
-				the specifications listed in <a href="#sec-intro-epub-specs">Specifications</a> are all a part of EPUB 3. An
-					<a href="#index">index to key concepts and definitions</a> defined across these specifications is
+				the specifications listed in <a href="#sec-intro-epub-specs">Specifications</a> are all a part of EPUB
+				3. An <a href="#index">index to key concepts and definitions</a> defined across these specifications is
 				provided at the end of this specification.</p>
 
 			<p>The informative [[EPUB3Overview]] provides a general introduction to EPUB 3. A list of technical changes
@@ -89,17 +89,17 @@
 
 			<section id="sec-intro-epub-specs">
 				<h2>Specifications</h2>
-				
+
 				<p>The EPUB 3 standard is modular in nature, with core features and functionality defined across a
 					family of sub-specifications.</p>
-				
+
 				<p>This specification represents the top-most specification in the family. It includes the conformance
 					requirements for both <a>EPUB Publications</a> (the product of the standard) and <a>EPUB Reading
 						Systems</a> (the applications that consume EPUB Publications and present their content to
 					users).</p>
-				
+
 				<p>The other specifications that comprise EPUB 3 are as follows:</p>
-				
+
 				<ul>
 					<li>
 						<p><a href="epub-packages.html">EPUB Packages</a> [[!Packages32]] — defines requirements for
@@ -124,20 +124,20 @@
 							requirements for EPUB Publications.</p>
 					</li>
 				</ul>
-				
+
 				<p>These specifications represent the formal list recognized as belonging to EPUB 3, and that contain
 					functionality referenced as part of the standard. New functionality is also added periodically
 					through the development of extension specifications. Features and functionality defined outside of
 					core revisions to the standard, while not formally recognized in this specification, are nonetheless
 					available for use by <a>Authors</a> and Reading System developers.</p>
 			</section>
-			
+
 			<section id="sec-intro-spec-org" class="informative">
 				<h2>Organization</h2>
-				
+
 				<p>This section reviews the organization of the EPUB specifications through the central product they
 					define: the <a>EPUB Publication</a>.</p>
-				
+
 				<p>An EPUB Publication consists of one or more <a>Renditions</a> of its content, each of which is
 					represented by what is called an <a>EPUB Package</a>. An EPUB Package consists of all the resources
 					needed to render the content. The key file among these is the <a>Package Document</a>, which
@@ -146,25 +146,25 @@
 					content has a fixed layout or can be reflowed). It also provides a complete manifest of resources,
 					and includes a <a>spine</a> that lists the sequence to render documents in as a user progresses
 					through the content.</p>
-				
+
 				<p>An EPUB Package also include another key file called the <a>EPUB Navigation Document</a>. This
 					document provides critical navigation capabilities, such as the table of contents, that allow users
 					to quickly and easily navigate the content.</p>
-				
+
 				<p>The requirements for EPUB Packages are defined in [[Packages32]].</p>
-				
+
 				<p>The EPUB Publication's resources are bundled for distribution in a ZIP-based archive with the file
 					extension <code>.epub</code>. As conformant ZIP archives, EPUB Publications can be unzipped by many
 					software programs, simplifying both their production and consumption.</p>
-				
+
 				<p>The container format not only provides a means of determining that the zipped content represents an
 					EPUB Publication (the <code>mimetype</code> file), but also provides a universally-named directory
 					of informative resources (<code>/META-INF</code>). Key among these resources is the
-					<code>container.xml</code> file, which directs Reading Systems to the available Package
+						<code>container.xml</code> file, which directs Reading Systems to the available Package
 					Documents.</p>
-				
+
 				<p>The container format is defined in [[OCF32]].</p>
-				
+
 				<figure>
 					<figcaption>
 						<p>The following example visually represents the structure of the EPUB format.</p>
@@ -173,31 +173,31 @@
 						<img src="images/epub.png" width="350" alt="" />
 					</object>
 				</figure>
-				
+
 				<p>The structure and containment of an EPUB Publication is only one half of the format, the other half
 					being the content that gets presented to users. This content is built on the Open Web Platform and
 					comes in two flavours: <a data-lt="XHTML Content Document">XHTML</a> and <a
 						data-lt="SVG Content Document">SVG</a>. Called <a>EPUB Content Documents</a>, these documents
 					typically reference many additional resources required for their proper rendering, such as images,
 					audio and video clips, scripts and style sheets.</p>
-				
+
 				<p>Detailed information about the rules and requirements for the production of EPUB Content Documents is
 					provided in [[ContentDocs32]], and accessibility requirements are defined in
 					[[EPUBAccessibility]].</p>
-				
+
 				<p><a>Media Overlay Documents</a> complement EPUB Content Documents. They provide declarative markup for
 					synchronizing the text in EPUB Content Documents with prerecorded audio. The result is the ability
 					to create a read-aloud experience where text is highlighted as it is narrated. Media Overlay
 					Documents are defined in [[MediaOverlays32]].</p>
-				
+
 				<p>While conceptually simple, an EPUB Publication is more than just a collection of HTML pages and
 					dependent assets in a ZIP package as presented here. Additional information about the primary
 					features and functionality that EPUB Publications provide to enhance the reading experience is
 					available from the referenced specifications, and a more general introduction to the features of
 					EPUB 3 is provided in the informative [[EPUB3Overview]].</p>
-				
+
 			</section>
-			
+
 			<section id="sec-terminology">
 				<h2>Terminology</h2>
 
@@ -218,18 +218,11 @@
 							other decoration a <a>EPUB Reading System</a> might inject into the Viewport.</p>
 						<p>In the case of <a>synthetic spreads</a>, the Viewport contains two Content Display Areas.</p>
 					</dd>
-					<dt><dfn id="dfn-core-media-type" data-lt="Core Media Types">Core Media Type</dfn></dt>
-					<dd>
-						<p>A media type [[!RFC2046]] that <a>EPUB Reading Systems</a> have to support. Refer to <a
-								href="#sec-publication-resources"><em>Publication Resources</em></a> for more
-							information.</p>
-					</dd>
 					<dt><dfn id="dfn-core-media-type-resource" data-lt="Core Media Type Resources">Core Media Type
 							Resource</dfn></dt>
 					<dd>
-						<p>A <a>Publication Resource</a> that has a <a>Core Media Type</a> so does not require the
-							provision of a <a href="#sec-foreign-restrictions">fallback</a> (cf. <a>Foreign
-							Resource</a>).</p>
+						<p>A <a>Publication Resource</a> that does not require the provision of a <a
+								href="#sec-foreign-restrictions">fallback</a> (cf. <a>Foreign Resource</a>).</p>
 					</dd>
 					<dt><dfn id="dfn-epub-container" data-lt="EPUB Containers">EPUB Container</dfn></dt>
 					<dd>
@@ -445,7 +438,7 @@
 					<dt id="sec-epub-pub-conformance-all">Publication Resources</dt>
 					<dd>
 						<p id="confreq-manifest">All <a>Publication Resources</a> MUST adhere to the <a
-								href="#sec-publication-resources">constraints for Core Media Types and Foreign
+								href="#sec-publication-resources">constraints for Core Media Type and Foreign
 								Resources</a> and be located as per <a href="#sec-resource-locations">Publication
 								Resource Locations</a>.</p>
 					</dd>
@@ -469,7 +462,6 @@
 							[[!OCF32]].</p>
 						<p id="confreq-rs-epub3-package">It MUST process <a>EPUB Packages</a> as defined in
 							[[!Packages32]].</p>
-						<p id="confreq-rs-epub3-cmt">It MUST support all <a>Core Media Type Resources</a>.</p>
 						<p id="confreq-rs-foreign">It MAY support an arbitrary set of <a>Foreign Resource</a> types, and
 							MUST process fallbacks for unsupported Foreign Resources as defined in <a
 								href="#sec-foreign-restrictions">Foreign Resources</a> if not.</p>
@@ -486,10 +478,10 @@
 								href="epub-contentdocs.html#sec-css-rs-conf">CSS Style Sheets — Reading System
 								Conformance</a> [[!ContentDocs32]].</p>
 						<p id="confreq-rs-epub3-images">If it has a Viewport, it MUST support the <a
-								href="#cmt-grp-image">image Core Media Types</a>.</p>
+								href="#cmt-grp-image">image Core Media Type Resources</a>.</p>
 						<p id="confreq-rs-epub3-mp3-aac">If it has the capability to render pre-recorded audio, it MUST
-							support the <a href="#cmt-grp-audio">audio Core Media Types</a> and SHOULD support Media
-							Overlays [[!MediaOverlays32]].</p>
+							support the <a href="#cmt-grp-audio">audio Core Media Type Resources</a> and SHOULD support
+							Media Overlays [[!MediaOverlays32]].</p>
 						<p id="confreq-rs-epub3-tts">If it supports <a>Text-to-Speech</a> (TTS) rendering, it SHOULD
 							support <a href="epub-contentdocs.html#sec-pls">Pronunciation Lexicons</a>
 							[[!ContentDocs32]], [[!CSS3Speech]] and <a
@@ -552,30 +544,29 @@
 					<h3>Introduction</h3>
 
 					<p>Each <a>Rendition</a> of an <a>EPUB Publication</a> typically consists of many <a>Publication
-							Resources</a>. These resources are divided into two categories: those that <a>EPUB Reading
-							Systems</a> have to support (<a>Core Media Type Resources</a>) and those that they do not
-							(<a>Foreign Resources</a>).</p>
+							Resources</a>. These resources are divided into two categories: those that can be included
+						without fallbacks (<a>Core Media Type Resources</a>) and those that cannot (<a>Foreign
+							Resources</a>).</p>
 
 					<p><a>Authors</a> are free to use both types of resources to construct their EPUB Publications, but
 						need to be aware that some Reading Systems might not render the Foreign Resources they use.</p>
 
 					<p>As EPUB Publications are designed to be fully consumable on any compliant Reading System, a
-						system of fallbacks is therefore necessary to ensure that the use of Foreign Resources does not
-						impact on the ability of the user to consume the content. This section lays out the <a
-							href="#sec-cmt-supported">set of Core Media Types</a> that are supported across Reading
-						Systems and identifies <a href="#sec-foreign-restrictions">fallback mechanisms</a> that can be
-						used to satisfy the consumability requirement.</p>
+						system of fallbacks is necessary to ensure that the use of Foreign Resources does not impact on
+						the ability of the user to consume the content. This section lists the <a
+							href="#sec-cmt-supported">set of Core Media Type Resources</a> and identifies <a
+							href="#sec-foreign-restrictions">fallback mechanisms</a> that can be used to satisfy the
+						consumability requirement.</p>
 
 				</section>
 
 				<section id="sec-cmt-supported">
 					<h3>Supported Media Types</h3>
 
-					<p><a>Publication Resources</a> that conform to a Core Media Type specification are <a>Core Media
-							Type Resources</a> and can be included in an EPUB Publication without fallbacks.</p>
+					<p><a>Publication Resources</a> that conform to the following MIME media type [[!RFC2046]]
+						specifications can be included in an EPUB Publication without fallbacks.</p>
 
-					<p>The following table lists the EPUB 3 Core Media Types. The columns in the table represent the
-						following information:</p>
+					<p>The columns in the following table represent the following information:</p>
 
 					<ul>
 						<li><p><strong>Media Type</strong>&#8212;The MIME media type [[!RFC2046]] used to represent the
@@ -701,10 +692,11 @@
 								<th colspan="3" id="cmt-grp-video" class="tbl-group">Video</th>
 							</tr>
 							<tr>
-								<td colspan="3" id="cmt-vide-note">EPUB 3 does not currently define any video codecs as
-									Core Media Types. Refer to the note in <a href="#note-video-codecs">EPUB
-										Publications — Reading System Conformance</a> for informative recommendations on
-									support for video codecs in EPUB Publications. </td>
+								<td colspan="3" id="cmt-vide-note">EPUB 3 allows any video codecs to be included without
+									fallbacks, although none are technically considered Core Media Type Resources. Refer
+									to the note in <a href="#note-video-codecs">EPUB Publications — Reading System
+										Conformance</a> for informative recommendations on support for video codecs in
+									EPUB Publications. </td>
 							</tr>
 							<tr>
 								<th colspan="3" id="cmt-grp-text" class="tbl-group">Style</th>
@@ -765,8 +757,8 @@
 						a data set with instructions on how to extract it from the EPUB Container).</p>
 
 					<p id="confreq-cmt">When a <a>Foreign Resource</a> is included in the spine or directly rendered in
-						its native format in an EPUB Content Document, a Core Media Type fallback MUST be included.
-						Fallbacks take one of the two following forms:</p>
+						its native format in an EPUB Content Document, a fallback <a>Core Media Type Resource</a> MUST
+						be included. Fallbacks take one of the two following forms:</p>
 
 					<ul>
 						<li>
@@ -840,8 +832,8 @@
 				</div>
 
 				<div class="note">
-					<p>The above rules for Publication Resource locations apply regardless of whether the given resource
-						is a <a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
+					<p>The rules in this section for Publication Resource locations apply regardless of whether the
+						given resource is a <a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
 				</div>
 
 				<div class="note">
@@ -958,7 +950,7 @@
 					</ul>
 				</li>
 				<li id="idx-cmt">
-					<p><a href="#sec-core-media-types">core media types</a></p>
+					<p><a href="#sec-core-media-types">core media type resources</a></p>
 					<ul>
 						<li>
 							<p><a href="#sec-foreign-restrictions">foreign resources</a></p>


### PR DESCRIPTION
This PR addresses the concern raised in #1085 that core media types are defined as requiring support despite the obvious contradictions in support for them.

To fix the problem this PR:

- removes the "Core Media Type" definition , leaving only "Core Media Type Resource"
- remove the requirement to support Core Media Types, as it contradicts more specific resource requirements elsewhere
- clarifies that CMTs are only resources that don't require fallbacks
- revises the video section of the CMT table to state that video are allowed without fallbacks despite none being officially recognized as core media types