### PR TITLE
dc:language is not inherited by publication resources

### DIFF
--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -888,7 +888,8 @@
 							<h5>The <code>language</code> Element</h5>
 
 							<p>The [[!DC11]] <code>language</code> element specifies the language of the content of the
-								given <a>Rendition</a>.</p>
+								given <a>Rendition</a>. 
+								This value is not inherited by the individual resources of the Rendition.</p>
 
 							<dl id="elemdef-opf-dclanguage" class="elemdef">
 								<dt>Element Name</dt>


### PR DESCRIPTION
Per CG resolution and #1078 