### PR TITLE
tweak the prose introducing the properties of the meta vocab

### DIFF
--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -1247,7 +1247,7 @@
 									Publication</a>. A <code>meta</code> element that omits a refines attribute defines
 								a primary expression.</li>
 
-							<li>A <em>subexpression</em> is one in which the expression defined in the <code>meta</code>
+							<li id="subexpression">A <em>subexpression</em> is one in which the expression defined in the <code>meta</code>
 								element enhances the meaning of the expression or resource referenced in its
 									<code>refines</code> attribute. A subexpression might refine a media clip, for
 								example, by expressing its duration, or refine a creator or contributor expression by

--- a/epub32/spec/vocab/meta-property.html
+++ b/epub32/spec/vocab/meta-property.html
@@ -23,11 +23,16 @@
 	<section id="sec-meta-property-values">
 		<h2>Metadata <code>meta</code> Properties</h2>
 
-		<p>These properties MUST reference the expression or resource they augment in the <code><a
-					href="#attrdef-refines">refines</a></code> attribute on their parent <code><a
-					href="#elemdef-meta">meta</a></code> element.</p>
+		<p>The following tables define properties for use in the <a href="#sec-meta-elem"><code>meta</code>
+				element's</a>
+			<code>property</code> attribute.</p>
 
-		<p>The following sections detail the available properties.</p>
+		<p>All the properties defined in this section are used to define <a href="#subexpression">subexpressions</a>:
+				in other words, a <code><a
+					href="#elemdef-meta">meta</a></code> element carrying a property defined in this section MUST
+				have a <code><a
+					href="#attrdef-refines">refines</a></code> attribute referencing a resource or expression being
+				augmented.</p>
 
 		<p>In each property definition, the <strong>Allowed values</strong> field indicates the expected type of value
 			(using [[!XMLSCHEMA-2]] datatypes), the <strong>Cardinality</strong> field indicates the number of times the


### PR DESCRIPTION
Previously the section said:

> Metadata `meta` properties
> These properties MUST…

I found it confusing as cursory readers could misunderstand that it
applies to all `meta` properties. This PR makes it clear that it applies
to the properties defined in the following sections, and aligns the
wording with the other vocabs.

Also, the PR clarifies a bit the language (properties can't "reference
an expression", subexpressions do; properties are not children of `meta`
elements, etc).