### PR TITLE
Update Reading System Conformance section for MathML

### DIFF
--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -684,12 +684,12 @@
 						<dl class="conformance-list">
 							<dt id="math-pres">Presentation MathML</dt>
 							<dd><p id="confreq-mathml-pres">The <code>math</code> element MUST contain only <a
-										href="https://www.w3.org/TR/2010/REC-MathML3-20101021/chapter3.html"
+										href="https://www.w3.org/TR/REC-MathML/chap3_1.html"
 										>Presentation MathML</a>, with the exception of the <code>annotation-xml</code>
 									element as defined below.</p></dd>
 							<dt id="math-cont">Content MathML</dt>
 							<dd><p id="confreq-mathml-annot-cont"><a
-										href="https://www.w3.org/TR/2010/REC-MathML3-20101021/chapter4.html">Content
+										href="https://www.w3.org/TR/REC-MathML/chap4_1.html">Content
 										MathML</a> MAY be included within MathML markup in XHTML Content Documents, and,
 									when present, MUST occur within an <code>annotation-xml</code> child element of an
 										<code>semantics</code> element.</p><p id="confreq-mathml-annot-cont-attrs">When
@@ -726,10 +726,10 @@
 							supporting MathML embedded in XHTML Content Documents:</p>
 						<ul class="conformance-list">
 							<li><p id="confreq-mathml-rs-behavior">It MUST be an input-compliant renderer for <a
-										href="https://www.w3.org/TR/MathML3/chapter3.html"
+										href="https://www.w3.org/TR/REC-MathML/chap3_1.html"
 										>Presentation MathML</a>, as  defined in the [[!MATHML]] specification.</p></li>
 							<li><p id="confreq-mathml-rs-anno">It MAY support rendering of <a
-										href="https://www.w3.org/TR/MathML3/chapter4.html">Content
+										href="https://www.w3.org/TR/REC-MathML/chap4_1.html">Content
 										MathML</a> found in <code>xml-annotation</code> elements.</p></li>
 							<li><p id="confreq-mathml-rs-render">If it has a <a>Viewport</a>, it MUST support visual
 									rendering of Presentation MathML.</p></li>

--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -723,35 +723,28 @@
 					<section id="sec-xhtml-mathml-rs-conf">
 						<h4>Reading System Conformance</h4>
 						<p>A conformant <a>EPUB Reading System</a> MUST meet all of the following criteria for
-							processing MathML embedded in XHTML Content Documents:</p>
+							supporting MathML embedded in XHTML Content Documents:</p>
 						<ul class="conformance-list">
-							<li><p id="confreq-mathml-rs-behavior">It MUST support processing of <a
-										href="https://www.w3.org/TR/2010/REC-MathML3-20101021/chapter3.html"
-										>Presentation MathML</a> using semantics defined by [[!MATHML]].</p></li>
-							<li><p id="confreq-mathml-rs-anno">It MAY support processing of <a
-										href="https://www.w3.org/TR/2010/REC-MathML3-20101021/chapter4.html">Content
-										MathML</a> found in an <code>xml-annotation</code> element using semantics
-									defined by [[!MATHML]].</p></li>
+							<li><p id="confreq-mathml-rs-behavior">It MUST be an input-compliant renderer for <a
+										href="https://www.w3.org/TR/MathML3/chapter3.html"
+										>Presentation MathML</a>, as  defined in the [[!MATHML]] specification.</p></li>
+							<li><p id="confreq-mathml-rs-anno">It MAY support rendering of <a
+										href="https://www.w3.org/TR/MathML3/chapter4.html">Content
+										MathML</a> found in <code>xml-annotation</code> elements.</p></li>
 							<li><p id="confreq-mathml-rs-render">If it has a <a>Viewport</a>, it MUST support visual
 									rendering of Presentation MathML.</p></li>
 						</ul>
+						<p class="note">
+						EPUB Reading Systems may choose to use third-party libraries 
+						such as MathJax to provide MathML rendering.
+						</p>
 					</section>
 
-					<section id="sec-xhtml-mathml-alt">
-						<h4>Fallback Content</h4>
-						<p>As Reading System support for MathML rendering is inconsistent, <a>Authors</a> are encouraged
-							to provide a fallback image using the <code>altimg</code> attribute on the <code>math</code>
-							element. It is RECOMMENDED that the dimension and alignment attributes
-								(<code>altimg-width</code>, <code>altimg-height</code> and <code>altimg-valign</code>)
-							be used in conjunction with the <code>altimg</code> attribute.</p>
+					
 
-						<div class="note" id="note-mathml-altimg-refprops-pkg">
-							<p>Fallback images have to conform to the constraints for Publication Resources defined in
-									<a href="epub-spec.html#sec-publication-resources">EPUB Publication Conformance</a>
-								[[EPUB32]].</p>
-						</div>
 
-					</section>
+
+
 				</section>
 
 				<section id="sec-xhtml-svg">

--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -684,12 +684,12 @@
 						<dl class="conformance-list">
 							<dt id="math-pres">Presentation MathML</dt>
 							<dd><p id="confreq-mathml-pres">The <code>math</code> element MUST contain only <a
-										href="https://www.w3.org/TR/REC-MathML/chap3_1.html"
+										href="https://www.w3.org/TR/MathML3/chapter3.html"
 										>Presentation MathML</a>, with the exception of the <code>annotation-xml</code>
 									element as defined below.</p></dd>
 							<dt id="math-cont">Content MathML</dt>
 							<dd><p id="confreq-mathml-annot-cont"><a
-										href="https://www.w3.org/TR/REC-MathML/chap4_1.html">Content
+										href="https://www.w3.org/TR/MathML3/chapter4.html">Content
 										MathML</a> MAY be included within MathML markup in XHTML Content Documents, and,
 									when present, MUST occur within an <code>annotation-xml</code> child element of an
 										<code>semantics</code> element.</p><p id="confreq-mathml-annot-cont-attrs">When
@@ -726,10 +726,10 @@
 							supporting MathML embedded in XHTML Content Documents:</p>
 						<ul class="conformance-list">
 							<li><p id="confreq-mathml-rs-behavior">It MUST be an input-compliant renderer for <a
-										href="https://www.w3.org/TR/REC-MathML/chap3_1.html"
+										href="https://www.w3.org/TR/MathML3/chapter3.html"
 										>Presentation MathML</a>, as  defined in the [[!MATHML]] specification.</p></li>
 							<li><p id="confreq-mathml-rs-anno">It MAY support rendering of <a
-										href="https://www.w3.org/TR/REC-MathML/chap4_1.html">Content
+										href="https://www.w3.org/TR/MathML3/chapter4.html">Content
 										MathML</a> found in <code>xml-annotation</code> elements.</p></li>
 							<li><p id="confreq-mathml-rs-render">If it has a <a>Viewport</a>, it MUST support visual
 									rendering of Presentation MathML.</p></li>


### PR DESCRIPTION
This PR:

1. Rewords the reading system conformance requirement for MathML to better express our goals

2. Removes the section on fallback images via `altimg`, as we don't have much evidence that this is widely supported. Describing how to adapt content for non-conforming reading systems is also a tricky business to be in. 

3. Adds a note saying that reading systems may choose to support MathML via third-party libraries such as MathJax

4. Update links to MathML to point to the finished, undated MathML 3 spec rather than an outdated (and dated) version. 