### PR TITLE
Rewrite Introduction to EPUB Navigation Documents

### DIFF
--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -3472,7 +3472,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					as well as allowing Reading Systems to generate navigational interfaces.</p>
 
 				<p>But the EPUB Navigation Document is not exclusively for machine processing. Because it is 
-					an XHTML Content Document, it can be part of the linear reading order, avoiding the
+					an XHTML Content Document, it can be part of the linear reading order, 
 					avoiding the need for duplicate tables of contents.
 					Content which is only destined for machine processing, such as <a href="#sec-nav-pagelist">page lists</a>, 
 					can be hidden from visual rendering with the <a href="#sec-package-nav-def-hidden">hidden</a> attribute.</p>

--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -3474,18 +3474,16 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<p>But the EPUB Navigation Document is not exclusively for machine processing. Because it is 
 					an XHTML Content Document, it can be part of the linear reading order, avoiding the
 					avoiding the need for duplicate tables of contents.
-					Content which is only destined for machine processing, such as page lists, 
+					Content which is only destined for machine processing, such as <a href="#sec-nav-pagelist">page lists</a>, 
 					can be hidden from visual rendering with the <a href="#sec-package-nav-def-hidden">hidden</a> attribute.</p>
 
-				<p>When designing an EPUB Navigation Document for such dual use, however, be aware that machine
-					extraction of the content can result in loss of formatting control. Scripting, styling and other
-					HTML formatting can be stripped by a Reading System as it generates a custom control, such as the
-					table of contents, from the markup. If such formatting and functionality is used, then the EPUB
-					Navigation Document also needs to be included in the linear reading order. Another design
-					consideration is to use <a href="epub-contentdocs.html#confreq-cd-scripted-spine">progressive
-						enhancement</a> [[ContentDocs32]] techniques for scripting and styling of the navigation
-					document, such that that the content will retain its integrity when rendered in a non-browser
-					context.</p>
+				<p>Note that Reading Systems may strip scripting, styling, and HTML formatting 
+					as they generate navigational interfaces from information found in the 
+					EPUB Navigation Document. If such formatting and functionality is needed, 
+					then the EPUB Navigation Document also needs to be included in the <a>spine</a>. 
+					Authors should also use <a href="epub-contentdocs.html#confreq-cd-scripted-spine">progressive enhancement</a>
+					 [[ContentDocs32]] techniques for scripting and styling of the navigation document, 
+					 so that that the content will retain its integrity when rendered in a non-browser context.</p>
 
 			</section>
 

--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -3460,32 +3460,22 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<h2>Introduction</h2>
 
 				<p>The EPUB Navigation Document is a <a href="#sec-package-conformance-nav">mandatory component</a> of
-					an <a>EPUB Package</a>. It provides the <a>Author</a> with a mechanism to include a human- and
+					an <a>EPUB Package</a>. It allows <a>Authors</a> to include a human- and
 					machine-readable global navigation layer, thereby ensuring increased usability and accessibility for
 					the user.</p>
 
-				<p>The EPUB Navigation Document is an adaptation of an <a>XHTML Content Document</a> and is, <a
-						href="#confreq-cd-nav-docprops-parent">by definition</a>, a valid XHTML Content Document
-					instance. All Content and Reading System conformance requirements that apply to XHTML Content
-					Documents also apply to the EPUB Navigation Document.</p>
+				<p>The EPUB Navigation Document is an <a>XHTML Content Document</a>,
+				 	but with additional restrictions on its structure to facilitate the machine-processing of its contents.
+					[[HTML]] <a
+					href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code></a> elements 
+					contain the specialized navigational information, which remains human-readable 
+					as well as allowing Reading Systems to generate navigational interfaces.</p>
 
-				<p>The navigation features of this adaptation are expressed through specializations of the [[HTML]] <a
-						href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code></a> element.
-					Each <code>nav</code> element in an EPUB Navigation Document represents a data island — an embedded
-					source of specialized information within the general markup — from which Reading Systems can
-					retrieve navigational information. Unlike typical XML data islands, however, the information within
-					the <code>nav</code> element remains human readable as an [[HTML]] document.</p>
-
-				<p>To facilitate machine readability, the content model of <code>nav</code> elements in EPUB Navigation
-					Documents is restricted relative to what is allowed in general XHTML Content Documents.</p>
-
-				<p>Note that the EPUB Navigation Document is not exclusively for machine processing. Formulating the
-					document as an XHTML Content Document enables its reuse in the linear reading order, avoiding the
-					creation of additional tables of contents (i.e., it can also be added to the <a
-						href="#elemdef-opf-spine">spine</a>). The visual display of components defined in the EPUB
-					Navigation Document can be controlled using the <a href="#sec-package-nav-def-hidden">hidden</a>
-					attribute, which has no effect outside of spine rendering (i.e., hiding a component from rendering
-					in the spine does not hide it from Reading System presentation in a custom control).</p>
+				<p>But the EPUB Navigation Document is not exclusively for machine processing. Because it is 
+					an XHTML Content Document, it can be part of the linear reading order, avoiding the
+					avoiding the need for duplicate tables of contents.
+					Content which is only destined for machine processing, such as page lists, 
+					can be hidden from visual rendering with the <a href="#sec-package-nav-def-hidden">hidden</a> attribute.</p>
 
 				<p>When designing an EPUB Navigation Document for such dual use, however, be aware that machine
 					extraction of the content can result in loss of formatting control. Scripting, styling and other


### PR DESCRIPTION
@bigbluehat was assigned to review this section of the spec, and as a newcomer to the world of EPUB found some of the terminology potentially confusing. I’ve attempted to rewrite this, avoiding terms such as “data islands” which were more common in much older EPUB specs. 

 