### PR TITLE
One correction of incorrect information, and several grammar and readability changes.

### DIFF
--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -73,7 +73,7 @@
 			<p>This specification is one of a <a href="epub-spec.html#sec-intro-epub-specs">family of specifications</a>
 				that compose [[EPUB32]], an interchange and delivery format for digital publications based on XML and
 				Web Standards. It is meant to be read and understood in concert with the other specifications that make
-				up EPUB 3</p>
+				up EPUB 3</p>.
 
 			<p>Refer to [[EPUB32Changes]] for more information on the differences between this specification and its
 				predecessor.</p>
@@ -215,7 +215,7 @@
 					</li>
 					<li>
 						<p id="confreq-rendition-rs-manifest">It MUST NOT use any resources not listed in the Package
-							Document in the processing of the Package (e.g., <code>META-INF</code> files [[!OCF32]] and
+							Document in the processing of the Package (e.g., <code>META-INF</code> files ([[!OCF32]]) or
 							resources specific to other Renditions of the EPUB Publication).</p>
 					</li>
 				</ul>
@@ -242,8 +242,8 @@
 							metadata applicable to the given Rendition of the <a>EPUB Publication</a>.</p>
 					</li>
 					<li>
-						<p>A <a href="#sec-manifest-elem">manifest</a> — identifies (via IRI) and describes (via MIME
-							media type) the set of resources that collectively compose the given Rendition.</p>
+						<p>A <a href="#sec-manifest-elem">manifest</a> — identifies (via IRI [[RFC3987]]) and describes (via MIME
+							media type [[RFC4839]]) the set of resources that collectively compose the given Rendition.</p>
 					</li>
 					<li>
 						<p>A <a href="#sec-spine-elem">spine</a> — an ordered sequence of ID references to top-level
@@ -274,7 +274,7 @@
 						<p id="confreq-package-xml"> It MUST meet the conformance constraints for XML documents defined
 							in <a href="epub-spec.html#sec-xml-constraints">XML Conformance</a> [[!EPUB32]]. </p>
 						<p id="confreq-package-docprops-schema">It MUST be valid to the Package Document schema, as
-							defined in <a href="#app-package-schema">Appendix B, <em>Package Document Schema</em></a>,
+							defined in <a href="#app-package-schema">Appendix A, <em>Package Document Schema</em></a>,
 							and conform to all content conformance constraints expressed in <a href="#sec-package-def"
 								>Package Document Definition</a>.</p>
 					</dd>
@@ -302,9 +302,9 @@
 							Reading System conformance constraints expressed in <a href="#sec-package-def">Package
 								Document Definition</a>.</p>
 						<p id="confreq-rs-epub3-presentational-meta">It SHOULD process rendering metadata, as expressed
-							in <a href="#sec-package-metadata-rendering">Package Rendering Metadata</a></p>
+							in <a href="#sec-package-metadata-rendering">Package Rendering Metadata</a>.</p>
 						<p id="confreq-rs-epub3-fxl-meta">It MUST process fixed layout metadata, as expressed in <a
-								href="#sec-package-metadata-fxl">Fixed-Layout Properties</a></p>
+								href="#sec-package-metadata-fxl">Fixed-Layout Properties</a>.</p>
 						<p id="confreq-rs-epub3-fxl-conflicts">It MUST ignore proprietary metadata properties that
 							pertain to layout expressions if they conflict behaviorally with the property semantics
 							defined in <a href="#sec-package-metadata-fxl">Fixed-Layout Properties</a>.</p>
@@ -326,8 +326,7 @@
 					<h3>The <code>package</code> Element</h3>
 
 					<p>The <code>package</code> element is the root element of the <a>Package Document</a> and defines
-						various aspects of the <a>EPUB Package</a> (see <a href="#sec-package-intro">the
-							introduction</a> for a general overview).</p>
+						various aspects of the <a>EPUB Package</a> (see the <a href="#sec-package-intro">introduction</a> for a general overview).</p>
 
 					<dl id="elemdef-opf-package" class="elemdef">
 						<dt>Element Name</dt>
@@ -1259,7 +1258,7 @@
 							be used to refine the meaning of other subexpressions, thereby creating chains of
 							information.</p>
 
-						<p class="note">All of the [DCMES] elements represent primary expressions, and permit refinement
+						<p class="note">All of the DCMES [[!DC11]] elements represent primary expressions, and permit refinement
 							by meta element subexpressions.</p>
 
 						<p>This specification <a href="#sec-metadata-default-vocab">reserves</a> the <a


### PR DESCRIPTION
1. Fixed the link text for an incorrect appendix name.
1. Made punctuation consistent in lists (if one bullet ends with a period, then all should).
1. Added missing periods.
1. Replaced a broken link to [DCMES] with the informative reference to DC11.
1. Rephrased a parenthetical for readability and grammar.
1. Added some informative references on the first uses of IRI and MIME.
1. Changed link text from "the introduction" to "introduction" to match common practice.