### PR TITLE
switch svg and css2 to undated references

### DIFF
--- a/epub32/spec/common/js/biblio.js
+++ b/epub32/spec/common/js/biblio.js
@@ -58,6 +58,12 @@ var biblio = {
       "title": "CSS Snapshot",
       "href": "https://www.w3.org/TR/CSS/"
     },
+    "CSS2": {
+      "title": "CSS 2",
+      "href": "https://www.w3.org/TR/CSS2/",
+      "status": "W3C Recommendation",
+      "publisher": "W3C"
+    },
     "CSS-Text-3-20160119": {
       "title": "CSS Text Level 3 (20160119)",
       "href": "https://drafts.csswg.org/date/2016-01-19T17:23:23/css-text/",
@@ -321,6 +327,11 @@ var biblio = {
       "title": "EPUB Spine Properties Vocabulary",
       "href": "http://www.idpf.org/epub/vocab/package/itemref"
     },
+    "SVG": {
+        "title": "SVG",
+        "href": "https://www.w3.org/TR/SVG/",
+        "publisher": "W3C"
+    },
     "SWF": {
       "title": "SWF File Format Specification</link> Version 19",
       "href": "http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/swf/pdf/swf-file-format-spec.pdf",
@@ -342,10 +353,6 @@ var biblio = {
     },
     "US-ASCII": {
       "title": "&quot;Coded Character Set - 7-bit American Standard Code for Information Interchange&quot;, ANSI X3.4, 1986."
-    },
-    "WEBIDL": {
-      "title": "WebIDL",
-      "href": "https://www.w3.org/TR/WebIDL/"
     },
     "W3CProcess": {
       "title": "World Wide Web Consortium Process Document",

--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -111,7 +111,7 @@
 
 				<section id="sec-overview-relations-svg">
 					<h3>Relationship to SVG</h3>
-					<p>This specification does not reference a specific version of [[SVG2]], but instead uses an undated
+					<p>This specification does not reference a specific version of [[SVG]], but instead uses an undated
 						reference that will always point to the latest recommendation. This approach ensures that EPUB
 						will always keep pace with changes to the SVG standard. Authors and Reading System developers
 						will need to keep track of changes to the SVG standard, and ensure that their processes and
@@ -751,7 +751,7 @@
 					<h3>Embedded SVG</h3>
 					<p><a>XHTML Content Documents</a> support the embedding of <a
 							href="https://www.w3.org/TR/SVG/intro.html#TermSVGDocumentFragment">SVG document
-							fragments</a> [[!SVG2]] <em>by reference</em> (embedding via reference, for example, from an
+							fragments</a> [[!SVG]] <em>by reference</em> (embedding via reference, for example, from an
 							<code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
 						direct inclusion of the <code>svg</code> element in the XHTML Content Document).</p>
 					<p>The content conformance constraints for SVG embedded in XHTML Content Documents are the same as
@@ -895,7 +895,7 @@
 			<h1>SVG Content Documents</h1>
 
 			<div class="caution">
-				<p>Some features of [[!SVG2]] are not fully supported in <a>Reading Systems</a>, or supported across all
+				<p>Some features of [[!SVG]] are not fully supported in <a>Reading Systems</a>, or supported across all
 					platforms on which Reading Systems run. When utilizing such features, <a>Authors</a> need to
 					consider the inherent risks in terms of the potential impact on interoperability and document
 					longevity.</p>
@@ -906,7 +906,7 @@
 			<section id="sec-svg-intro" class="informative">
 				<h2>Introduction</h2>
 
-				<p>The Scalable Vector Graphics (SVG) specification [[SVG2]] defines a format for representing final-form
+				<p>The Scalable Vector Graphics (SVG) specification [[SVG]] defines a format for representing final-form
 					vector graphics and text.</p>
 
 				<p>Although an EPUB Publication typically uses <a href="#sec-xhtml">XHTML Content Documents</a> as the
@@ -915,7 +915,7 @@
 					such as when final-form page images are the only suitable representation of the content (e.g., for
 					cover art or in the context of manga or comic books).</p>
 
-				<p>This section defines a profile for [[SVG2]] documents. An instance of an XML document that conforms to
+				<p>This section defines a profile for [[SVG]] documents. An instance of an XML document that conforms to
 					this profile is a <a>Core Media Type Resource</a> and is referred to in this specification as an
 						<a>SVG Content Document</a>.</p>
 
@@ -939,7 +939,7 @@
 							provided a fallback to a <a>Core Media Type Resource</a> is included.</p>
 						<p id="confreq-cd-svg-docprops-schema">It MUST be an <a
 								href="https://www.w3.org/TR/SVG/intro.html#TermSVGDocumentFragment">SVG document
-								fragment</a> [[!SVG2]], and conform to all content conformance constraints expressed in
+								fragment</a> [[!SVG]], and conform to all content conformance constraints expressed in
 								<a href="#sec-svg-restrictions">Restrictions on SVG</a>.</p>
 						<div class="note">
 							<p>The recommendation that EPUB Publications follow the accessibility requirements in
@@ -961,7 +961,7 @@
 						href="#sec-xhtml-svg">SVG embedded in XHTML Content Documents</a> as follows:</p>
 
 				<ul class="conformance-list">
-					<li><p id="confreq-svg-foreignObject">The [[!SVG2]] <a
+					<li><p id="confreq-svg-foreignObject">The [[!SVG]] <a
 								href="https://www.w3.org/TR/SVG/extend.html#ForeignObjectElement"
 									><code>foreignObject</code></a> element MUST adhere to the following
 							criteria:</p><ul class="conformance-list">
@@ -977,7 +977,7 @@
 							<li><p id="confreq-svg-foreignObject-reqext">Its <code>requiredExtensions</code> attribute,
 									if given, MUST be set to "<code>http://www.idpf.org/2007/ops</code>".</p></li>
 						</ul></li>
-					<li><p id="confreq-svg-title">The [[!SVG2]] <a
+					<li><p id="confreq-svg-title">The [[!SVG]] <a
 								href="https://www.w3.org/TR/SVG/struct.html#TitleElement"><code>title</code></a> element
 							MUST contain only valid <a href="#confreq-cd-html-docprops">XHTML Content Document Phrasing
 								content</a>.</p></li>
@@ -992,15 +992,15 @@
 
 				<ul class="conformance-list">
 					<li><p id="confreq-svg-rs-behavior">Unless explicitly defined by this specification as overridden,
-							it MUST process SVG Content Documents using semantics defined by the [[!SVG2]] specification
+							it MUST process SVG Content Documents using semantics defined by the [[!SVG]] specification
 							and honor any applicable user agent conformance constraints expressed therein.</p></li>
 					<li><p id="confreq-svg-rs-scrpt">It MUST meet the Reading System conformance criteria defined in <a
 								href="#sec-scripted-content-rs-reqs">Scripted Content Documents — Reading System
 								Conformance</a>.</p></li>
 					<li><p id="confreq-svg-rs-css">If it has a <a>Viewport</a>, it MUST support the visual rendering of
 							SVG using CSS as defined in <a href="https://www.w3.org/TR/SVG/styling.html">Styling</a>
-							[[!SVG2]], and it SHOULD support all properties defined in the <a
-								href="https://www.w3.org/TR/SVG/propidx.html">Property Index</a> [[!SVG2]]. In the case
+							[[!SVG]], and it SHOULD support all properties defined in the <a
+								href="https://www.w3.org/TR/SVG/propidx.html">Property Index</a> [[!SVG]]. In the case
 							of embedded SVG, it MUST also conform to the constraints defined in <a
 								href="#sec-xhtml-svg-css">Embedded SVG and CSS</a>.</p></li>
 					<li><p id="confreq-svg-rs-text">It SHOULD support user selection and searching of text within SVG
@@ -1331,7 +1331,7 @@
 			<section id="sec-scripted-context">
 				<h2>Scripting Contexts</h2>
 				<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in the
-					respective underlying specifications ([[!HTML]] and [[!SVG2]]). When an EPUB Content Document
+					respective underlying specifications ([[!HTML]] and [[!SVG]]). When an EPUB Content Document
 					contains scripting, it is referred to in this specification as a <a>Scripted Content Document</a>.
 					This label also applies to <a>XHTML Content Documents</a> when they contain instances of [[!HTML]]
 						<a href="https://www.w3.org/TR/html/sec-forms.html#sec-forms">forms</a>.</p>
@@ -1342,7 +1342,7 @@
 					<dt id="sec-scripted-content-type-spine-level">spine-level</dt>
 					<dd><p>An instance of the [[!HTML]] <a
 								href="https://www.w3.org/TR/html/semantics-scripting.html#the-script-element"
-									><code>script</code></a> or [[!SVG2]] <a
+									><code>script</code></a> or [[!SVG]] <a
 								href="https://www.w3.org/TR/SVG/script.html#ScriptElement"><code>script</code></a>
 							element included in a <a>Top-level Content Document</a>.</p></dd>
 					<dt id="sec-scripted-content-type-container-constrained">container-constrained</dt>
@@ -1357,7 +1357,7 @@
 										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-iframe-element"
 											><code>iframe</code></a> element.</p></li>
 							<li>
-								<p>An instance of the [[!SVG2]] <a
+								<p>An instance of the [[!SVG]] <a
 										href="https://www.w3.org/TR/SVG/script.html#ScriptElement"
 										><code>script</code></a> element included in an <a>SVG Content Document</a> that
 									is embedded in a parent XHTML Content Document using the [[!HTML]] <a
@@ -1756,7 +1756,7 @@
 					</aside>
 
 
-					<p>If only the [[!SVG2]] <a href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
+					<p>If only the [[!SVG]] <a href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
 								><code>viewBox</code></a> attribute is present, the coordinate system it defines is
 						mapped to the <a>Viewport</a>, keeping the aspect ratio, thereby establishing the <a
 							href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
@@ -1777,7 +1777,7 @@
 							<code>viewBox</code> is mapped on the boundaries as described in the previous item.</p>
 
 					<div class="note">
-						<p>See [[SVG2]] for more details on the interplay between <code>viewBox</code> and the
+						<p>See [[SVG]] for more details on the interplay between <code>viewBox</code> and the
 								<code>width</code>/<code>height</code> values.</p>
 					</div>
 

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -762,7 +762,7 @@
 							>spine <code>itemref</code> elements</a> [[!Packages32]] or directly rendered in their
 						native format in EPUB Content Documents (e.g., via [[!HTML]] <a
 							href="https://www.w3.org/TR/html/dom.html#embedded-content">embedded content</a> and
-						[[!SVG2]] <a href="https://www.w3.org/TR/SVG/struct.html#ImageElement"><code>image</code></a> and
+						[[!SVG]] <a href="https://www.w3.org/TR/SVG/struct.html#ImageElement"><code>image</code></a> and
 							<a href="https://www.w3.org/TR/SVG/extend.html#ForeignObjectElement"
 								><code>foreignObject</code></a> elements).</p>
 
@@ -795,7 +795,7 @@
 							href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-img-element"
 								><code>img</code></a> element).</p>
 
-					<p>Refer to the [[!HTML]] and [[!SVG2]] specifications for the intrinsic fallback capabilities their
+					<p>Refer to the [[!HTML]] and [[!SVG]] specifications for the intrinsic fallback capabilities their
 						elements provide.</p>
 
 				</section>
@@ -819,7 +819,7 @@
 					</li>
 					<li>
 						<p id="sec-resource-locations-script">Resources retrieved by scripts MAY be located outside the
-							EPUB Container, but the [[!HTML]] and [[!SVG2]] <code>script</code> elements MUST NOT
+							EPUB Container, but the [[!HTML]] and [[!SVG]] <code>script</code> elements MUST NOT
 							reference <a>Remote Resources</a> to ensure availability at runtime (i.e., from their
 								<code>src</code> or <code>href</code> attributes, respectively).</p>
 					</li>


### PR DESCRIPTION
Adds entries to the local biblio file to create undated references for SVG and CSS2 to match the one we already have for HTML. This moves us back to the way we intended them for 3.1 - as not dated or numbered to any specific revision.