### PR TITLE
Update links to schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Repository for EPUB 3 Revisions in W3C
 
+# EPUBCheck Needs Your Help!
+
+---
+
+The W3C is raising money to fund further development of EPUBCheck, so that it can support EPUB 3.2. Please [contribute](https://www.w3.org/publishing/epubcheck_fundraising) if you can. Thank you!
+
+---
+
 The next revision of EPUB 3 will be EPUB 3.2, which seeks to update EPUB 3.1 to make a successor that is compatible with [EPUB 3.0.1](http://www.idpf.org/epub/301/spec/epub-publications.html) (i.e., that reverts the package document version number change introduced in 3.1).
 
 Creators of EPUB content are advised __not to implement 3.1__, but to continue to create content compatible with EPUB 3.0.1 until work on EPUB 3.2 is complete.
@@ -18,11 +26,6 @@ To participate in this revision, please join the [EPUB 3 Community Group](https:
 7. [EPUB 3.2 Overview](https://w3c.github.io/publ-epub-revision/epub32/spec/epub-overview.html)
 8. [EPUB 3.2 Changes from 3.0.1](https://w3c.github.io/publ-epub-revision/epub32/spec/epub-changes.html)
 
-### Draft Core Media Types
-
-1. [EPUB 3 CMTs](https://idpf.github.io/epub-cmt/v3/cmt-v3.html)
-
-Located at: https://github.com/IDPF/epub-cmt
 
 ### Draft Vocabularies
 
@@ -57,4 +60,4 @@ Located at: https://github.com/IDPF/epub-registries
 
 ---
 
-For any further help, contact either [Bill McCoy](bmccoy@w3.org) or [Ivan Herman](ivan@w3.org).
+For any further help, contact  [Ivan Herman](ivan@w3.org) or [Dave Cramer](dauwhe@gmail.com).

--- a/epub32/spec/epub-mediaoverlays.html
+++ b/epub32/spec/epub-mediaoverlays.html
@@ -1661,8 +1661,8 @@ html.-epub-media-overlay-playing * {
 			<h1>Media Overlays Schema</h1>
 
 			<p>The schema for Media Overlays is available at <a
-					href="http://www.idpf.org/epub/31/schema/media-overlay-31.nvdl"
-					>http://www.idpf.org/epub/31/schema/media-overlay-31.nvdl</a>.</p>
+					href="https://w3c.github.io/publ-epub-revision/epub32/schema/media-overlay-32.nvdl"
+					>https://w3c.github.io/publ-epub-revision/epub32/schema/media-overlay-32.nvdl</a>.</p>
 
 			<p>Validation using this schema requires a processor that supports [[!NVDL]], [[!RelaxNG-Schema]],
 				[[!ISOSchematron]] and [[!XMLSCHEMA-2]].</p>

--- a/epub32/spec/epub-ocf.html
+++ b/epub32/spec/epub-ocf.html
@@ -1172,8 +1172,8 @@ store destination as source in ocf
 				<h2>Schema for <code>container.xml</code></h2>
 
 				<p>The schema for <code>container.xml</code> files is available at <a
-						href="https://www.idpf.org/epub/31/schema/ocf-container-31.rnc">
-						<code>https://www.idpf.org/epub/31/schema/ocf-container-31.rnc</code></a>.</p>
+						href="https://w3c.github.io/publ-epub-revision/epub32/schema/ocf-container-32.rnc">
+						<code>https://w3c.github.io/publ-epub-revision/epub32/schema/ocf-container-32.rnc</code></a>.</p>
 
 				<p class="issue">We'll need to work on schemas, and provide appropriate links</p>
 

--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -3954,16 +3954,22 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 		<section class="appendix" id="app-package-schema">
 			<h1>Package Document Schema</h1>
 
-			<p>The schema for Package Documents is available at <a
+			<p>A non-normative schema for Package Documents is available at <a
 					href="https://w3c.github.io/publ-epub-revision/epub32/schema/package-32.nvdl"
 					>https://w3c.github.io/publ-epub-revision/epub32/schema/package-32.nvdl</a>.</p>
 
-			<p>Validation using this schema requires a processor that supports [[!NVDL]], [[!RelaxNG-Schema]],
-				[[!ISOSchematron]] and [[!XMLSCHEMA-2]].</p>
+			<p>Validation using this schema requires a processor that supports [[NVDL]], [[RelaxNG-Schema]],
+				[[ISOSchematron]] and [[XMLSCHEMA-2]].</p>
 
 			<div class="note">
 				<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG and
 					ISO Schematron schemas alone.</p>
+			</div>
+			
+			<div class="note">
+				<p>These schemas may be updated and corrected outside of formal revisions of this specification.
+				As a result, they are subject to change at any time.
+				</p>
 			</div>
 
 		</section>


### PR DESCRIPTION
We had lots of links in the docs pointing to the 31 versions of schemas on IDPF servers. I've updated these links. 

I've also added some text saying that the package document schema is non-normative, and is subject to change outside of revisions to this specification.

But it does appear that the container and media overlays schemas are normative...