### PR TITLE
Fix some small OCF errors

### DIFF
--- a/epub32/spec/epub-ocf.html
+++ b/epub32/spec/epub-ocf.html
@@ -371,6 +371,9 @@
 								<p>REVERSE SOLIDUS: <code>\</code> (<code>U+005C</code>)</p>
 							</li>
 							<li>
+								<p>VERTICAL LINE: <code>\</code> (<code>U+007C</code>)</p>
+							</li>
+							<li>
 								<p>DEL (<code>U+007F</code>)</p>
 							</li>
 							<li>
@@ -910,7 +913,7 @@
 					</li>
 					<li>
 						<p id="confreq-zip-mult">OCF ZIP Containers MUST NOT use the features in the ZIP application
-							note [[!ZIP]] that allow ZIP files to be split across multiple storage media. <a
+							note [[!ZIP]] that allow ZIP files to be spanned across multiple storage media, or split into multiple files. <a
 								href="#dfn-ocf-processor">OCF Processors</a> MUST treat any OCF files that specify that
 							the ZIP file is split across multiple storage media as being in error.</p>
 					</li>


### PR DESCRIPTION
This fixes #1202 and #1204, forbidding the vertical line character in filenames (already an error in EPUBCheck), and disallowing OCF ZIP containers split across multiple files. 