### PR TITLE
add note that html further restricts foreignObject

### DIFF
--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -361,8 +361,9 @@
 							<h5>Default Vocabulary</h5>
 
 							<p>The default vocabulary for Content Documents is defined to be the [[!EPUB-SSV]].
-								Unprefixed terms that are not part of the [[!EPUB-SSV]] MAY be included, but their use is discouraged. 
-								The use of prefixes is the preferred method for adding custom semantics.</p>
+								Unprefixed terms that are not part of the [[!EPUB-SSV]] MAY be included, but their use
+								is discouraged. The use of prefixes is the preferred method for adding custom
+								semantics.</p>
 						</section>
 
 						<section id="sec-contentdocs-reserved-prefixes">
@@ -741,14 +742,17 @@
 
 				<section id="sec-xhtml-svg">
 					<h3>Embedded SVG</h3>
+
 					<p><a>XHTML Content Documents</a> support the embedding of <a
 							href="https://www.w3.org/TR/SVG/intro.html#TermSVGDocumentFragment">SVG document
 							fragments</a> [[!SVG]] <em>by reference</em> (embedding via reference, for example, from an
 							<code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
 						direct inclusion of the <code>svg</code> element in the XHTML Content Document).</p>
+
 					<p>The content conformance constraints for SVG embedded in XHTML Content Documents are the same as
 						defined for <a>SVG Content Documents</a> in <a href="#sec-svg-restrictions">Restrictions on
 							SVG</a>.</p>
+
 					<p>Reading Systems MUST process SVG embedded in XHTML Content Documents as defined in <a
 							href="#sec-svg-rs-conf">SVG Content Documents — Reading System Conformance</a>.</p>
 
@@ -961,7 +965,12 @@
 										href="https://www.w3.org/TR/html/dom.html#flow-content">flow content</a> or
 									exactly one [[!HTML]] <a
 										href="https://www.w3.org/TR/html/sections.html#the-body-element"
-											><code>body</code> element</a>.</p></li>
+											><code>body</code> element</a>.</p>
+								<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
+										<code>body</code> element is not permitted per the <a
+										href="https://www.w3.org/TR/html/semantics-embedded-content.html#svg"
+										>restrictions on SVG</a> defined in [[HTML]].</p>
+							</li>
 							<li><p id="confreq-svg-foreignObject-xhtml-frag">Its content MUST be a valid document
 									fragment that conforms to the XHTML Content Document model defined in <a
 										href="#sec-xhtml-conf-content">XHTML Content Documents — Content


### PR DESCRIPTION
This PR fixes #1210 by adding a note to the bullet for SVG Content Documents where foreignObject is restricted to a body element or flow content to make clear that the HTML specification has an even tighter restriction for embedded SVGs.