### PR TITLE
Clarify references to white space

### DIFF
--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -797,8 +797,9 @@
 								parsing the identifier. This specification does not require or endorse the use of any
 								particular scheme for identifiers.</p>
 
-							<p>Reading Systems MUST trim all leading and trailing white space from the element value, as
-								defined by the XML specification [[!XML]], before processing the value.</p>
+							<p>Reading Systems MUST trim all leading and trailing <a
+									href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] from the element
+								value before processing the value.</p>
 
 							<p>This specification imposes no additional restrictions or the requirements of the
 								identifier except that it MUST be at least one character in length after white space has
@@ -892,8 +893,9 @@
 
 							<p>The title for each <a>Rendition</a> MAY differ.</p>
 
-							<p>Reading Systems MUST trim all leading and trailing white space from the element value, as
-								defined by the XML specification [[!XML]], before processing the value.</p>
+							<p>Reading Systems MUST trim all leading and trailing <a
+									href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] before processing
+								the value.</p>
 
 							<p>This specification imposes no additional restrictions or requirements on the title except
 								that it MUST be at least one character in length after white space has been trimmed.</p>
@@ -953,8 +955,9 @@
 
 							<p>Languages for each <a>Rendition</a> MAY differ.</p>
 
-							<p>Reading Systems MUST trim all leading and trailing white space from the element value, as
-								defined by the XML specification [[!XML]], before processing the value.</p>
+							<p>Reading Systems MUST trim all leading and trailing <a
+									href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] before processing
+								the value.</p>
 
 						</section>
 
@@ -1022,8 +1025,9 @@
 
 							<p>The OPTIONAL [[!DC11]] metadata for each <a>Rendition</a> MAY differ.</p>
 
-							<p>Reading Systems MUST trim all leading and trailing white space from the element value, as
-								defined by the XML specification [[!XML]], before processing the value.</p>
+							<p>Reading Systems MUST trim all leading and trailing <a
+									href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] before processing
+								the value.</p>
 
 							<p> The value of all OPTIONAL [[!DC11]] elements MUST be at least one character in length
 								after white space has been trimmed.</p>
@@ -1308,9 +1312,9 @@
 							encountering unknown expressions.</p>
 
 						<p>Unless an individual property explicitly defines a different white space normalization
-							algorithm, Reading Systems MUST trim all leading and trailing white space from the
-								<code>meta</code> element values, as defined by the XML specification [[!XML]], before
-							further processing them.</p>
+							algorithm, Reading Systems MUST trim all leading and trailing <a
+								href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] from the
+								<code>meta</code> element values before further processing them.</p>
 
 						<p>Every <code>meta</code> element MUST express a value that is at least one character in length
 							after white space normalization.</p>


### PR DESCRIPTION
This PR fixes #1213 to remove the ambiguity about what the reference to the XML specification is referring to.