### PR TITLE
Describe how fonts become a core media type

### DIFF
--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -1093,6 +1093,7 @@
 							have reached at least <a href="https://www.w3.org/2015/Process-20150901/#candidate-rec"
 								>Candidate Recommendation</a> status [[!W3CProcess]] (and are widely
 						implemented).</p></li>
+						<li><p id="confreq-css-rs-fonts">It MUST support [[TrueType]], [[OpenType]], [[WOFF]] and [[WOFF2]] font resources referenced from <code>@font-face</code> rules.</p></li>
 					<li><p id="confreq-css-rs-prefixed">It MUST support all prefixed properties defined in <a
 								href="#sec-css-prefixed">CSS Style Sheets — Prefixed Properties</a>.</p></li>
 					<li><p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above,

--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -1093,7 +1093,7 @@
 							have reached at least <a href="https://www.w3.org/2015/Process-20150901/#candidate-rec"
 								>Candidate Recommendation</a> status [[!W3CProcess]] (and are widely
 						implemented).</p></li>
-						<li><p id="confreq-css-rs-fonts">It MUST support [[TrueType]], [[OpenType]], [[WOFF]] and [[WOFF2]] font resources referenced from <code>@font-face</code> rules.</p></li>
+						<li><p id="confreq-css-rs-fonts">It MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and [[!WOFF2]] font resources referenced from <code>@font-face</code> rules.</p></li>
 					<li><p id="confreq-css-rs-prefixed">It MUST support all prefixed properties defined in <a
 								href="#sec-css-prefixed">CSS Style Sheets — Prefixed Properties</a>.</p></li>
 					<li><p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above,


### PR DESCRIPTION
See #1158. This adds text to describe that reading systems with a viewport must support the font core media types via `@font-face`.