### PR TITLE
Clarify what being a core media type means for fonts

### DIFF
--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -669,6 +669,13 @@
 								<th colspan="3" id="cmt-grp-font" class="tbl-group">Fonts</th>
 							</tr>
 							<tr>
+								<td colspan="3" id="cmt-font-note">
+								EPUB 3 allows any font resource to be included 
+								without a fallback, as CSS already defines fallback 
+								rules for fonts. Refer to EPUB Content Documents 
+								for <a href="epub-contentdocs.html#confreq-css-rs-fonts">support requirements</a> in EPUB Publications.
+								</td>
+							<tr>
 								<td id="cmt-sfnt">
 									<code>font/ttf</code><br />
 									<code>application/font-sfnt</code>

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -675,6 +675,7 @@
 								rules for fonts. Refer to EPUB Content Documents 
 								for <a href="epub-contentdocs.html#confreq-css-rs-fonts">support requirements</a> in EPUB Publications.
 								</td>
+							</tr>
 							<tr>
 								<td id="cmt-sfnt">
 									<code>font/ttf</code><br />


### PR DESCRIPTION
Per #1158, add a note to the CMT table saying that CSS already handles fallback for fonts, and pointing to the reading system conformance requirement. 