### PR TITLE
update link vocabulary to add missing fields

### DIFF
--- a/epub32/spec/vocab/link.html
+++ b/epub32/spec/vocab/link.html
@@ -52,6 +52,11 @@
 						</td>
 					</tr>
 					<tr>
+						<th>Extends:</th>
+						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
+								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+					</tr>
+					<tr>
 						<th>Example:</th>
 						<td>
 							<code>&lt;link rel="acquire" href="http://example.org/book/9781448103706"
@@ -99,6 +104,11 @@
 						</td>
 					</tr>
 					<tr>
+						<th>Extends:</th>
+						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
+								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+					</tr>
+					<tr>
 						<th>Example:</th>
 						<td>
 							<code>&lt;link rel="alternate" href="package.json"
@@ -127,6 +137,19 @@
 								href="#attrdef-link-media-type"><code>media-type</code> attribute</a> [[!Packages]]
 							value "<code>application/marcxml+xml</code>".</td>
 					</tr>
+					<tr>
+						<th>Cardinality:</th>
+						<td><code>Zero or one</code></td>
+					</tr>
+					<tr>
+						<th>Extends:</th>
+						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
+								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+					</tr>
+					<tr>
+						<th>Example:</th>
+						<td><code>&lt;link rel="marc21xml-record" href="pub/meta/nor-wood-marc21.xml"/></code></td>
+					</tr>
 				</tbody>
 			</table>
 		</section>
@@ -149,6 +172,19 @@
 								href="#attrdef-link-media-type"><code>media-type</code> attribute</a> [[!Packages]]
 							value "<code>application/mods+xml</code>".</td>
 					</tr>
+					<tr>
+						<th>Cardinality:</th>
+						<td><code>Zero or one</code></td>
+					</tr>
+					<tr>
+						<th>Extends:</th>
+						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
+								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+					</tr>
+					<tr>
+						<th>Example:</th>
+						<td><code>&lt;link rel="mods-record" href="pub/meta/nor-wood-mods.xml"/></code></td>
+					</tr>
 				</tbody>
 			</table>
 		</section>
@@ -170,6 +206,19 @@
 								href="#record"><code>record</code></a> keyword with the <a href="#attrdef-properties"
 								>properties attribute</a> [[!Packages]] value <a href="#onix"
 							><code>onix</code></a>.</td>
+					</tr>
+					<tr>
+						<th>Cardinality:</th>
+						<td><code>Zero or one</code></td>
+					</tr>
+					<tr>
+						<th>Extends:</th>
+						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
+								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+					</tr>
+					<tr>
+						<th>Example:</th>
+						<td><code>&lt;link rel="onix-record" href="pub/meta/nor-wood-onix.xml"/></code></td>
 					</tr>
 				</tbody>
 			</table>
@@ -208,6 +257,11 @@
 						</td>
 					</tr>
 					<tr>
+						<th>Extends:</th>
+						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
+								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+					</tr>
+					<tr>
 						<th>Example:</th>
 						<td>
 							<code>&lt;link rel="record" href="book/52.atom"
@@ -235,6 +289,18 @@
 							linking method. Identification of XML signatures will be addressed in a future version of
 							EPUB.</td>
 					</tr>
+					<tr>
+						<th>Cardinality:</th>
+						<td><code>Zero or more</code></td>
+					</tr>
+					<tr>
+						<th>Extends:</th>
+						<td>All properties.</td>
+					</tr>
+					<tr>
+						<th>Example:</th>
+						<td><code>&lt;link refines="#meta-authority-01" rel="xml-signature" href="../META-INF/signatures.xml#MAI-Signature"/></code></td>
+					</tr>
 				</tbody>
 			</table>
 		</section>
@@ -255,6 +321,19 @@
 						<td>Use of the <code>xmp-record</code> keyword is deprecated. It is replaced by the <a
 								href="#record"><code>record</code></a> keyword with the <a href="#attrdef-properties"
 								>properties attribute</a> value <a href="#xmp"><code>xmp</code></a>.</td>
+					</tr>
+					<tr>
+						<th>Cardinality:</th>
+						<td><code>Zero or one</code></td>
+					</tr>
+					<tr>
+						<th>Extends:</th>
+						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
+								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+					</tr>
+					<tr>
+						<th>Example:</th>
+						<td><code>&lt;link rel="xmp-record" href="pub/meta/nor-wood-xmp.xml"/></code></td>
 					</tr>
 				</tbody>
 			</table>


### PR DESCRIPTION
This PR fixes #1228.

- It adds back the missing Extends field with the restriction on the use of refines.
- It adds that the linked records apply to the EPUB Publication or collection, since these are allowed in collection metadata.
- It adds back the cardinality and examples for the deprecated metadata. Since the vocabularies are now integrated, referencing back to the last version is awkward, plus the other deprecated metadata retain their full info.
