### PR TITLE
clarify reference to SVG per #1219

### DIFF
--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -112,7 +112,8 @@
 				<section id="sec-overview-relations-svg">
 					<h3>Relationship to SVG</h3>
 					<p>This specification does not reference a specific version of [[SVG]], but instead uses an undated
-						reference that will always point to the latest recommendation. This approach ensures that EPUB
+						reference. Whenever there is any ambiguity in this reference, the latest recommended specification is the authoritative reference.</p>
+					<p>This approach ensures that EPUB
 						will always keep pace with changes to the SVG standard. Authors and Reading System developers
 						will need to keep track of changes to the SVG standard, and ensure that their processes and
 						systems are kept up to date.</p>


### PR DESCRIPTION
This basically adopts [Matt's language](https://github.com/w3c/publ-epub-revision/issues/1219#issuecomment-459922406) in #1219 while changing as little as possible from what's already there, which I hope partially addresses Makoto's comment. 