### PR TITLE
remove the deprecated label from display-seq

### DIFF
--- a/epub32/spec/vocab/meta-property.html
+++ b/epub32/spec/vocab/meta-property.html
@@ -27,13 +27,11 @@
 				element's</a>
 			<code>property</code> attribute.</p>
 
-		<p>Unless indicated otherwise in its “Extends” field, 
-		the properties defined in this section are used to define <a href="#subexpression">subexpressions</a>:
-				in other words, a <code><a
-					href="#elemdef-meta">meta</a></code> element carrying a property defined in this section MUST
-				have a <code><a
+		<p>Unless indicated otherwise in its “Extends” field, the properties defined in this section are used to define
+				<a href="#subexpression">subexpressions</a>: in other words, a <code><a href="#elemdef-meta"
+				>meta</a></code> element carrying a property defined in this section MUST have a <code><a
 					href="#attrdef-refines">refines</a></code> attribute referencing a resource or expression being
-				augmented.</p>
+			augmented.</p>
 
 		<p>In each property definition, the <strong>Allowed values</strong> field indicates the expected type of value
 			(using [[!XMLSCHEMA-2]] datatypes), the <strong>Cardinality</strong> field indicates the number of times the
@@ -206,7 +204,7 @@
     …
 &lt;/metadata></pre>
 			</aside>
-			
+
 		</section>
 
 		<section id="sec-collection-type">
@@ -226,8 +224,8 @@
 							<p>The <code>collection-type</code> property indicates the form or nature of a
 								collection.</p>
 							<p>When the <code>collection-type</code> value is drawn from a code list or other formal
-								enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
-								be attached to identify its source.</p>
+								enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD be
+								attached to identify its source.</p>
 							<p>When a scheme is not specified, Reading Systems SHOULD recognize the following collection
 								type values:</p>
 							<dl>
@@ -285,7 +283,7 @@
 		</section>
 
 		<section id="sec-display-seq">
-			<h3>display-seq (Deprecated)</h3>
+			<h3>display-seq</h3>
 
 			<table id="display-seq">
 				<tbody>
@@ -299,12 +297,10 @@
 						<th>Description:</th>
 						<td>
 							<p>The <code>display-seq</code> property indicates the numeric position in which to display
-								the current property relative to identical metadata properties (e.g., to indicate the
-								order in which to render multiple <code>title</code>s).</p>
-							<p><strong>Use of the <code>display-seq</code> property is deprecated.</strong> Precedence
-								is given to elements in a set based on their appearance in document order in the EPUB
-								Package Document (i.e., the first element in document order has the highest
-								priority).</p>
+								the current property relative to identical metadata properties.</p>
+							<p>This property only applies where precedence rules have not already been defined (e.g.,
+								precedence is given to <a href="#sec-opf-dccreator">creators</a> based on their
+								appearance in document order).</p>
 						</td>
 					</tr>
 					<tr>
@@ -424,11 +420,11 @@
     …
 &lt;/metadata></pre>
 			</aside>
-			
-						
+
+
 			<aside class="example">
-				<p>The following example uses a decimal-separated value for <code>group-position</code>,
-				in this case volume 98, issue 4 of a periodical.</p>
+				<p>The following example uses a decimal-separated value for <code>group-position</code>, in this case
+					volume 98, issue 4 of a periodical.</p>
 				<pre>&lt;metadata&gt;
     …
     &lt;meta property="belongs-to-collection" id="cygnus-x-1">Physical Review D&lt;/meta>
@@ -436,9 +432,9 @@
     &lt;meta refines="#cygnus-x-1" property="group-position">98.4&lt;/meta>
     …
 &lt;/metadata></pre>
-			</aside>			
-			
-			
+			</aside>
+
+
 		</section>
 
 		<section id="sec-identifier-type">
@@ -458,8 +454,8 @@
 							<p>The <code>identifier-type</code> property indicates the form or nature of an
 									<code>identifier</code>.</p>
 							<p>When the <code>identifier-type</code> value is drawn from a code list or other formal
-								enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
-								be attached to identify its source.</p>
+								enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD be
+								attached to identify its source.</p>
 						</td>
 					</tr>
 					<tr>
@@ -553,8 +549,8 @@
 									<code>creator</code> or <code>contributor</code> (e.g., that the person is the
 								author or editor of a work).</p>
 							<p>When the <code>role</code> value is drawn from a code list or other formal enumeration,
-								the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD be attached
-								to identify its source.</p>
+								the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD be attached to
+								identify its source.</p>
 						</td>
 					</tr>
 					<tr>
@@ -634,9 +630,8 @@
 					</tr>
 				</tbody>
 			</table>
-			<p class="note">
-			See [[EPUBAccessibilityTechniques]] for information on how to provide accessible page navigation.
-			</p>
+			<p class="note"> See [[EPUBAccessibilityTechniques]] for information on how to provide accessible page
+				navigation. </p>
 			<aside class="example">
 				<p>The following example shows the ISBN identifier for an EPUB Publication together with the source ISBN
 					identifier for the print work it was derived from.</p>
@@ -719,9 +714,9 @@
 							<p>The <code>title-type</code> property indicates the form or nature of a
 								<code>title</code>.</p>
 							<p>When the <code>title-type</code> value is drawn from a code list or other formal
-								enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
-								be attached to identify its source. When a scheme is not specified, Reading Systems
-									<span class="rfc2119">should</span> recognize the following title type values:
+								enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD be
+								attached to identify its source. When a scheme is not specified, Reading Systems <span
+									class="rfc2119">should</span> recognize the following title type values:
 									<code>main</code>, <code>subtitle</code>, <code class="value">short</code>,
 									<code>collection</code>, <code class="value">edition</code> and
 									<code>expanded</code>. </p>


### PR DESCRIPTION
This PR is a proposed fix for #1242:

- it removes the deprecated label from `display-seq`
- it rewords the definition to explain that it only applies in the absence of existing precedence rules
