### PR TITLE
define img fallback requirements

### DIFF
--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -112,11 +112,11 @@
 				<section id="sec-overview-relations-svg">
 					<h3>Relationship to SVG</h3>
 					<p>This specification does not reference a specific version of [[SVG]], but instead uses an undated
-						reference. Whenever there is any ambiguity in this reference, the latest recommended specification is the authoritative reference.</p>
-					<p>This approach ensures that EPUB
-						will always keep pace with changes to the SVG standard. Authors and Reading System developers
-						will need to keep track of changes to the SVG standard, and ensure that their processes and
-						systems are kept up to date.</p>
+						reference. Whenever there is any ambiguity in this reference, the latest recommended
+						specification is the authoritative reference.</p>
+					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. Authors
+						and Reading System developers will need to keep track of changes to the SVG standard, and ensure
+						that their processes and systems are kept up to date.</p>
 
 					<div class="caution">
 						<p>As SVG evolves, it is possible that features that were valid in previous versions could
@@ -847,6 +847,23 @@
 						recognize these elements (e.g., EPUB 2 Reading Systems), but it does not represent a fallback
 						Core Media Type Resource.</p>
 
+					<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that can be associated with
+						to the [[!HTML]] <a
+							href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-img-element"
+								><code>img</code> element</a>, the following fallback conditions apply to its use:</p>
+
+					<ul>
+						<li>A Core Media Type Resource MUST be specified in its <code>src</code> attribute when it is
+							the child of a <a
+								href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-picture-element"
+									><code>picture</code> element</a>.</li>
+						<li>A Core Media Type Resource MUST be specified in its <code>src</code> attribute when it
+							specifies a <code>srcset</code> attribute.</li>
+						<li>A <a href="epub-packages.html#sec-foreign-restrictions-manifest">manifest fallback</a>
+							[[Packages32]] MUST be specified in all other cases when a Foreign Resource is referenced
+							from its <code>src</code> attribute.</li>
+					</ul>
+
 					<p>The following [[!HTML]] elements can refer to <a href="epub-spec.html#sec-core-media-types"
 							>Foreign Resources</a> [[!EPUB32]] without having to provide a fallback Core Media Type
 						Resource:</p>
@@ -874,9 +891,7 @@
 								fallbacks</a> [[Packages32]] for the provision of fallbacks for elements without
 							intrinsic mechanisms, such as the [[HTML]] <a
 								href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-iframe-element"
-									><code>iframe</code></a> and <a
-								href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-img-element"
-									><code>img</code></a> elements.</p>
+									><code>iframe</code></a>.</p>
 					</div>
 				</section>
 
@@ -1094,7 +1109,8 @@
 							have reached at least <a href="https://www.w3.org/2015/Process-20150901/#candidate-rec"
 								>Candidate Recommendation</a> status [[!W3CProcess]] (and are widely
 						implemented).</p></li>
-						<li><p id="confreq-css-rs-fonts">It MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and [[!WOFF2]] font resources referenced from <code>@font-face</code> rules.</p></li>
+					<li><p id="confreq-css-rs-fonts">It MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and
+							[[!WOFF2]] font resources referenced from <code>@font-face</code> rules.</p></li>
 					<li><p id="confreq-css-rs-prefixed">It MUST support all prefixed properties defined in <a
 								href="#sec-css-prefixed">CSS Style Sheets — Prefixed Properties</a>.</p></li>
 					<li><p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above,


### PR DESCRIPTION
This PR addresses the resolutions from the CG call on 2019-03-07 for use of fallbacks:

- a core media type fallback is required in img when used inside of picture
- a core media type is required when img has a srcset attribute
- a manifest fallback is required otherwise when it references a foreign resource