### PR TITLE
SVG fixed layout clarifications

### DIFF
--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -112,11 +112,11 @@
 				<section id="sec-overview-relations-svg">
 					<h3>Relationship to SVG</h3>
 					<p>This specification does not reference a specific version of [[SVG]], but instead uses an undated
-						reference. Whenever there is any ambiguity in this reference, the latest recommended specification is the authoritative reference.</p>
-					<p>This approach ensures that EPUB
-						will always keep pace with changes to the SVG standard. Authors and Reading System developers
-						will need to keep track of changes to the SVG standard, and ensure that their processes and
-						systems are kept up to date.</p>
+						reference. Whenever there is any ambiguity in this reference, the latest recommended
+						specification is the authoritative reference.</p>
+					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. Authors
+						and Reading System developers will need to keep track of changes to the SVG standard, and ensure
+						that their processes and systems are kept up to date.</p>
 
 					<div class="caution">
 						<p>As SVG evolves, it is possible that features that were valid in previous versions could
@@ -1094,7 +1094,8 @@
 							have reached at least <a href="https://www.w3.org/2015/Process-20150901/#candidate-rec"
 								>Candidate Recommendation</a> status [[!W3CProcess]] (and are widely
 						implemented).</p></li>
-						<li><p id="confreq-css-rs-fonts">It MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and [[!WOFF2]] font resources referenced from <code>@font-face</code> rules.</p></li>
+					<li><p id="confreq-css-rs-fonts">It MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and
+							[[!WOFF2]] font resources referenced from <code>@font-face</code> rules.</p></li>
 					<li><p id="confreq-css-rs-prefixed">It MUST support all prefixed properties defined in <a
 								href="#sec-css-prefixed">CSS Style Sheets — Prefixed Properties</a>.</p></li>
 					<li><p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above,
@@ -1637,8 +1638,11 @@
 
 			<section id="sec-fxl-overview" class="informative">
 				<h2>Introduction</h2>
-				<p>This section defines rules for the expression and interpretation of dimensional properties of <a>EPUB
-						Content Documents</a> marked as <code>pre-paginated</code> in the <a>Package Document</a>.</p>
+
+				<p>This section defines rules for the expression and interpretation of dimensional properties of
+						<a>Fixed-Layout Documents</a> — <a>EPUB Content Documents</a> marked as
+						<code>pre-paginated</code> in the <a>Package Document</a>.</p>
+
 				<p>This specification does not define how the <a
 						href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
 						block</a> [[CSS2]] will be placed within the Reading System <a>Content Display Area</a>.</p>
@@ -1681,6 +1685,7 @@
 
 			<section id="sec-fxl-viewport">
 				<h2>Viewport Rendering</h2>
+
 				<p>When rendering <a>Fixed-Layout Documents</a>, the default intent is that the <a>Content Display
 						Area</a> SHOULD occupy as much of the available <a>Viewport</a> area as possible. <a>Reading
 						Systems</a> SHOULD NOT inject additional content such as border, margins, headers or footers
@@ -1698,7 +1703,8 @@
 
 				<section id="sec-fxl-icb-html">
 					<h3>Expressing in HTML</h3>
-					<p>For <a>XHTML Content Documents</a>, the <a
+
+					<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
 							href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
 							block</a> [[!CSS2]] dimensions MUST be expressed in a <code>viewport</code>
 						<code>meta</code> tag using the syntax defined in [[!CSS-Device-Adapt-1]]. In this version of
@@ -1728,23 +1734,10 @@
 
 				<section id="sec-fxl-icb-svg">
 					<h3>Expressing in SVG</h3>
-					<p>For <a>SVG Content Documents</a>, the root <code>svg</code> element MUST include one or both
-						of:</p>
-					<ul>
-						<li>
-							<p>the <a href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
-									><code>viewBox</code></a> attribute;</p></li>
-						<li>
-							<p>the <a href="https://www.w3.org/TR/SVG/struct.html#SVGElementHeightAttribute"
-										><code>height</code></a> and <a
-									href="https://www.w3.org/TR/SVG/struct.html#SVGElementWidthAttribute"
-										><code>width</code></a> (and OPTIONAL <a
-									href="https://www.w3.org/TR/SVG/struct.html#SVGElementXAttribute"><code>x</code></a>
-								and <a href="https://www.w3.org/TR/SVG/struct.html#SVGElementYAttribute"
-									><code>y</code></a>) attributes.</p></li>
-					</ul>
-					<p>It is RECOMMENDED to use only the <code>viewBox</code> attribute to ensure proper rescaling of
-						the SVG Content Document, as needed.</p>
+
+					<p>For SVG <a>Fixed-Layout Documents</a>, the ICB dimensions MUST be expressed using the <a
+							href="http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code>
+							attribute</a> [[!SVG]].</p>
 
 					<aside class="example">
 						<p>The following example shows a <code>viewBox</code> attribute declaration for an SVG Content
@@ -1756,33 +1749,6 @@
    …
 &lt;/svg&gt;</pre>
 					</aside>
-
-
-					<p>If only the [[!SVG]] <a href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
-								><code>viewBox</code></a> attribute is present, the coordinate system it defines is
-						mapped to the <a>Viewport</a>, keeping the aspect ratio, thereby establishing the <a
-							href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
-							block</a> (ICB) in pixels [[!CSS2]]. The result of this mapping is typically the bounds of
-						the Viewport.</p>
-					<p>If only the <a href="https://www.w3.org/TR/SVG/struct.html#SVGElementXAttribute"
-							><code>x</code></a>, <a href="https://www.w3.org/TR/SVG/struct.html#SVGElementYAttribute"
-								><code>y</code></a>, <a
-							href="https://www.w3.org/TR/SVG/struct.html#SVGElementHeightAttribute"
-							><code>height</code></a> and <a
-							href="https://www.w3.org/TR/SVG/struct.html#SVGElementWidthAttribute"><code>width</code></a>
-						attributes are present, they SHOULD be defined in pixel values (establishing the ICB). Note that
-						if the pixel values defined by <code>x</code>, <code>y</code>, <code>height</code> and
-							<code>width</code> attributes exceed the Viewport's pixel values, the graphic will be
-						clipped on the Viewport boundaries (i.e., the graphics will not be rescaled).</p>
-					<p>If the coordinate system is defined by the <code>viewBox</code> and the
-							<code>width</code>/<code>height</code> values, the coordinate system defined by the
-							<code>viewBox</code> is mapped on the boundaries as described in the previous item.</p>
-
-					<div class="note">
-						<p>See [[SVG]] for more details on the interplay between <code>viewBox</code> and the
-								<code>width</code>/<code>height</code> values.</p>
-					</div>
-
 				</section>
 			</section>
 		</section>


### PR DESCRIPTION
This PR actually addresses two items that were resolved on the 2019-03-07 call:

- as raised in #1239, it changes the terminology links from "XHTML/SVG Content Documents" to "XHTML/SVG _Fixed-Layout_ Documents" to reduce any confusion that these rules apply to all content documents.
- as raised in #1236, it reverts the SVG ICB dimensions section to "MUST" use the viewBox attribute (noting that additional discussions about this next week may further change the section)