### PR TITLE
clarify "other" navs can reference remote resources

### DIFF
--- a/epub32/spec/epub-packages.html
+++ b/epub32/spec/epub-packages.html
@@ -773,8 +773,8 @@
 							<p>Whenever a Rendition is modified, it MUST include a new last modified date.</p>
 
 							<p>To determine whether an <code>identifier</code> conforms to an established system or has
-								been granted by an issuing authority, Reading Systems SHOULD check for an
-									<a href="#identifier-type"><code>identifier-type</code> property</a>.</p>
+								been granted by an issuing authority, Reading Systems SHOULD check for an <a
+									href="#identifier-type"><code>identifier-type</code> property</a>.</p>
 
 							<aside class="example">
 								<p>The following example shows how an identifier can be additionally marked as a <a
@@ -1060,8 +1060,8 @@
 &lt;/metadata></pre>
 							</aside>
 
-							<p>The <code>creator</code> element SHOULD contain the name of the creator as the Author 
-							intends it to be displayed to a user. The <a href="#file-as"><code>file-as</code>
+							<p>The <code>creator</code> element SHOULD contain the name of the creator as the Author
+								intends it to be displayed to a user. The <a href="#file-as"><code>file-as</code>
 									property</a> MAY be attached to include a normalized form of the name, and the <a
 									href="#alternate-script"><code>alternate-script</code> property</a> to represent a
 								creator's name in another language or script.</p>
@@ -3662,10 +3662,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 										or fragment therein.</p>
 								</li>
 								<li>
-									<p id="confreq-nav-a-href-other">For all other <code>nav</code> types, it MAY
-										reference any resource, regardless of whether it is a Publication Resource, or
-										whether it is <a data-lt="Local Resource">Local</a> or <a>Remote
-										Resource</a>.</p>
+									<p id="confreq-nav-a-href-other">For all other <code>nav</code> types, it MAY also
+										reference <a>Remote Resources</a>.</p>
 								</li>
 							</ul>
 						</li>


### PR DESCRIPTION
The 3.1 revision clarified that nav element can [reference remote resources](https://github.com/w3c/publ-epub-revision/issues/594) so long as they aren't one of the three epub-defined lists (toc, landmarks, page-list).

Unfortunately, we ended up with the following overly-liberal sounding statement:

> For all other nav types, [the href attribute] MAY reference any resource, regardless of whether it is a Publication Resource, or whether it is Local or Remote Resource.

As noted https://github.com/w3c/epubcheck/issues/890, this sounds contradictory to the requirement that all linked resources have to be in the spine. This PR fixes the statement with the following alternative wording:

> For all other <code>nav</code> types, it MAY also reference <a>Remote Resources</a>.
