### PR TITLE
update core media type requirements for picture and img

### DIFF
--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -853,15 +853,24 @@
 								><code>img</code> element</a>, the following fallback conditions apply to its use:</p>
 
 					<ul>
-						<li>A Core Media Type Resource MUST be specified in its <code>src</code> attribute when it is
-							the child of a <a
-								href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-picture-element"
-									><code>picture</code> element</a>.</li>
-						<li>A Core Media Type Resource MUST be specified in its <code>src</code> attribute when it
-							specifies a <code>srcset</code> attribute.</li>
-						<li>A <a href="epub-packages.html#sec-foreign-restrictions-manifest">manifest fallback</a>
-							[[Packages32]] MUST be specified in all other cases when a Foreign Resource is referenced
-							from its <code>src</code> attribute.</li>
+						<li><p>If it is the child of a <a
+									href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-picture-element"
+										><code>picture</code> element</a>:</p>
+							<ul>
+								<li>it MUST reference Core Media Type Resources from its <code>src</code> and
+										<code>srcset</code> attributes, when those attributes are specified;</li>
+								<li>any child <a
+										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-source-element"
+											><code>source</code> elements</a> also MUST reference Core Media Type
+									Resources from their <code>src</code> and <code>srcset</code> attributes unless the
+									element specifies that it references a Foreign Resource media type in its
+										<code>type</code> attribute.</li>
+							</ul>
+						</li>
+						<li>Otherwise, it MAY reference Foreign Resources in its <code>src</code> and
+								<code>srcset</code> attributes provided a <a
+								href="epub-packages.html#sec-foreign-restrictions-manifest">manifest fallback</a>
+							[[Packages32]] is defined.</li>
 					</ul>
 
 					<p>The following [[!HTML]] elements can refer to <a href="epub-spec.html#sec-core-media-types"

--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -858,19 +858,18 @@
 										><code>picture</code> element</a>:</p>
 							<ul>
 								<li>it MUST reference Core Media Type Resources from its <code>src</code> and
-										<code>srcset</code> attributes, when those attributes are specified;</li>
-								<li>any child <a
+										<code>srcset</code> attributes, when those attributes are specified; and</li>
+								<li>each sibling <a
 										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-source-element"
-											><code>source</code> elements</a> also MUST reference Core Media Type
-									Resources from their <code>src</code> and <code>srcset</code> attributes unless the
-									element specifies that it references a Foreign Resource media type in its
-										<code>type</code> attribute.</li>
+											><code>source</code> element</a> MUST reference a Core Media Type Resource
+									from its <code>src</code> and <code>srcset</code> attributes unless it specifies a
+									media type in its <code>type</code> attribute that is not a Core Media Type.</li>
 							</ul>
 						</li>
 						<li>Otherwise, it MAY reference Foreign Resources in its <code>src</code> and
-								<code>srcset</code> attributes provided a <a
-								href="epub-packages.html#sec-foreign-restrictions-manifest">manifest fallback</a>
-							[[Packages32]] is defined.</li>
+								<code>srcset</code> attributes provided <a
+								href="epub-packages.html#sec-foreign-restrictions-manifest">manifest fallbacks</a>
+							[[Packages32]] are defined.</li>
 					</ul>
 
 					<p>The following [[!HTML]] elements can refer to <a href="epub-spec.html#sec-core-media-types"


### PR DESCRIPTION
This PR fixes #1237 (again) as described in https://github.com/w3c/publ-epub-revision/issues/1237#issuecomment-472822055:

- when inside a `picture` the only time foreign resources can be referenced is from a `source` element that explicitly identifies that it references a foreign media type in its `type` attribute
- otherwise, the `img` element requires a core media type fallback whenever its `src` or `srcset` attributes reference foreign resources.

@rdeltour please verify that I have this right, and that the spec prose reflects your proposal.