### PR TITLE
Add note discouraging use of xml:base

### DIFF
--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -523,7 +523,7 @@
 						<p id="confreq-rs-xml-ns"> It MUST be a <a
 								href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#ProcessorConformance"
 								>conformant processor</a> as defined in [[!XML-NAMES]].</p>
-						<p id="confreq-rs-xml-base">It MUST be a conformant application as defined by [[!XMLBase]].</p>
+						<p id="confreq-rs-xml-base">It MUST be a conformant application as defined by [[!XMLBase]]. <span class="note">Note: browsers have removed support for [[!XMLBase]]. Authors should avoid using this feature.</span></p>
 					</dd>
 				</dl>
 

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -523,7 +523,7 @@
 						<p id="confreq-rs-xml-ns"> It MUST be a <a
 								href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#ProcessorConformance"
 								>conformant processor</a> as defined in [[!XML-NAMES]].</p>
-						<p id="confreq-rs-xml-base">It MUST be a conformant application as defined by [[!XMLBase]]. <span class="note">Note: browsers have removed support for [[!XMLBase]]. Authors should avoid using this feature.</span></p>
+						<p id="confreq-rs-xml-base">It MUST be a conformant application as defined by [[!XMLBase]]. <span class="note">Note: browsers have removed support for [[!XMLBase]]. Authors are advised to avoid using this feature.</span></p>
 					</dd>
 				</dl>
 

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -523,7 +523,7 @@
 						<p id="confreq-rs-xml-ns"> It MUST be a <a
 								href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#ProcessorConformance"
 								>conformant processor</a> as defined in [[!XML-NAMES]].</p>
-						<p id="confreq-rs-xml-base">It MUST be a conformant application as defined by [[!XMLBase]]. <span class="note">Note: browsers have removed support for [[!XMLBase]]. Authors are advised to avoid using this feature.</span></p>
+						<p id="confreq-rs-xml-base">It MUST be a conformant application as defined by [[!XMLBase]]. <span class="note">Note: [[HTML]] and [[SVG]] are removing support for [[!XMLBase]]. Authors are advised to avoid using this feature.</span></p>
 					</dd>
 				</dl>
 


### PR DESCRIPTION
Per #1217, add a note advising authors to avoid using XML base. It's been removed from blink and gecko. I have no information on its status in webkit. 