### PR TITLE
Update epub-changes.html

### DIFF
--- a/epub32/spec/epub-changes.html
+++ b/epub32/spec/epub-changes.html
@@ -208,7 +208,7 @@
 					<li>The <a href="epub-packages.html#viewport"><code>rendition:viewport</code></a> property is
 						deprecated.</li>
 					<li>The <a href="epub-packages.html#sec-display-seq"><code>display-seq</code></a> and <a
-							href="epub-packages.html#sec-meta-auth"><code>meta-auth</code></a> properties in the are
+							href="epub-packages.html#sec-meta-auth"><code>meta-auth</code></a> properties are
 						deprecated. For display sequence, precedence now follows document order. </li>
 					<li>The <a href="epub-packages.html#sec-authority"><code>authority</code></a> and <a
 							href="epub-packages.html#sec-term"><code>term</code></a> properties have been added for use


### PR DESCRIPTION
The display-seq and meta-auth properties *in the are* deprecated. For display sequence, precedence now follows document order.