### PR TITLE
Fix linking errors

### DIFF
--- a/epub32/spec/epub-changes.html
+++ b/epub32/spec/epub-changes.html
@@ -405,8 +405,6 @@
 					for conditional display of content (cf. <a
 						href="http://www.idpf.org/epub/301/spec/epub-contentdocs.html#sec-xhtml-content-switch">EPUB
 						3.0.1 <code>switch</code> element</a>).</p>
-				<p>Authors are instead directed to the existing guidance on the use of the <a
-						href="epub-contentdocs.html#sec-xhtml-mathml-alt">MathML <code>altimg</code> attribute</a>.</p>
 			</section>
 
 			<section id="sec-cdoc-trigger">

--- a/epub32/spec/epub-spec.html
+++ b/epub32/spec/epub-spec.html
@@ -1406,12 +1406,6 @@
 								</li>
 								<li>
 									<p><a href="epub-packages.html#sec-opf-dcidentifier">dc:identifier element</a></p>
-									<ul>
-										<li>
-											<p><a href="epub-packages.html#attrdef-identifier-scheme">identifier
-													schemes</a></p>
-										</li>
-									</ul>
 								</li>
 								<li>
 									<p><a href="epub-packages.html#sec-opf-dclanguage">dc:language element</a></p>


### PR DESCRIPTION
There were two bad links in EPUB 3.2, which happened as we edited text out from under the target of the links. See #1268. 