### PR TITLE
Various link fixes and new index page

### DIFF
--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -969,7 +969,7 @@
 
 				<ul class="conformance-list">
 					<li><p id="confreq-svg-foreignObject">The [[!SVG]] <a
-								href="https://www.w3.org/TR/SVG/extend.html#ForeignObjectElement"
+								href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
 									><code>foreignObject</code></a> element MUST adhere to the following
 							criteria:</p><ul class="conformance-list">
 							<li><p id="confreq-svg-foreignObject-xhtml-content">It MUST contain either [[!HTML]] <a

--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -1357,7 +1357,7 @@
 					<dd><p>An instance of the [[!HTML]] <a
 								href="https://www.w3.org/TR/html/semantics-scripting.html#the-script-element"
 									><code>script</code></a> or [[!SVG]] <a
-								href="https://www.w3.org/TR/SVG/script.html#ScriptElement"><code>script</code></a>
+								href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 							element included in a <a>Top-level Content Document</a>.</p></dd>
 					<dt id="sec-scripted-content-type-container-constrained">container-constrained</dt>
 					<dd><p>Either of the following:</p>

--- a/epub32/spec/epub-contentdocs.html
+++ b/epub32/spec/epub-contentdocs.html
@@ -732,7 +732,7 @@
 					<h3>Embedded SVG</h3>
 
 					<p><a>XHTML Content Documents</a> support the embedding of <a
-							href="https://www.w3.org/TR/SVG/intro.html#TermSVGDocumentFragment">SVG document
+							href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
 							fragments</a> [[!SVG]] <em>by reference</em> (embedding via reference, for example, from an
 							<code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
 						direct inclusion of the <code>svg</code> element in the XHTML Content Document).</p>

--- a/epub32/spec/snapshot/epub-spec.html
+++ b/epub32/spec/snapshot/epub-spec.html
@@ -1136,9 +1136,9 @@ var[data-type]:hover::before {
 				<p>The container format is defined in [<cite><a class="bibref" href="#bib-ocf32">OCF32</a></cite>].</p>
 
 				<figure id="fig-the-following-example-visually-represents-the-structure-of-the-epub-format">
-					<figcaption>Figure <span class="figno">1</span> <span class="fig-title">
+					<figcaption>Figure <span class="figno">1</span> 
 						<p>The following example visually represents the structure of the EPUB format.</p>
-					</span></figcaption>
+					</figcaption>
 					<object data="images/epub.svg" width="350">
 						<img src="images/epub.png" alt="" width="350">
 					</object>

--- a/epub32/spec/snapshot/index.html
+++ b/epub32/spec/snapshot/index.html
@@ -1,0 +1,483 @@
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US" lang="en-US"><head><meta charset="utf-8"><meta name="generator" content="ReSpec 24.21.1"><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"><style>/* --- ISSUES/NOTES --- */
+.issue-label {
+    text-transform: initial;
+}
+
+.warning > p:first-child { margin-top: 0 }
+.warning {
+    padding: .5em;
+    border-left-width: .5em;
+    border-left-style: solid;
+}
+span.warning { padding: .1em .5em .15em; }
+
+.issue.closed span.issue-number {
+    text-decoration: line-through;
+}
+
+.warning {
+    border-color: #f11;
+    border-width: .2em;
+    border-style: solid;
+    background: #fbe9e9;
+}
+
+.warning-title:before{
+    content: "⚠"; /*U+26A0 WARNING SIGN*/
+    font-size: 3em;
+    float: left;
+    height: 100%;
+    padding-right: .3em;
+    vertical-align: top;
+    margin-top: -0.5em;
+}
+
+li.task-list-item {
+    list-style: none;
+}
+
+input.task-list-item-checkbox {
+    margin: 0 0.35em 0.25em -1.6em;
+    vertical-align: middle;
+}
+
+.issue a.respec-gh-label {
+  padding: 5px;
+  margin: 0 2px 0 2px;
+  font-size: 10px;
+  text-transform: none;
+  text-decoration: none;
+  font-weight: bold;
+  border-radius: 4px;
+  position: relative;
+  bottom: 2px;
+  border: none;
+}
+
+.issue a.respec-label-dark {
+  color: #fff;
+  background-color: #000;
+}
+
+.issue a.respec-label-light {
+  color: #000;
+  background-color: #fff;
+}
+</style>
+		
+		<title>EPUB 3.2 Changes</title>
+		<style id="respec-mainstyle">/*****************************************************************
+ * ReSpec 3 CSS
+ * Robin Berjon - http://berjon.com/
+ *****************************************************************/
+
+@keyframes pop {
+  0% {
+    transform: scale(1, 1);
+  }
+  25% {
+    transform: scale(1.25, 1.25);
+    opacity: 0.75;
+  }
+  100% {
+    transform: scale(1, 1);
+  }
+}
+
+/* Override code highlighter background */
+.hljs {
+  background: transparent !important;
+}
+
+/* --- INLINES --- */
+h1 abbr,
+h2 abbr,
+h3 abbr,
+h4 abbr,
+h5 abbr,
+h6 abbr,
+a abbr {
+  border: none;
+}
+
+dfn {
+  font-weight: bold;
+}
+
+a.internalDFN {
+  color: inherit;
+  border-bottom: 1px solid #99c;
+  text-decoration: none;
+}
+
+a.externalDFN {
+  color: inherit;
+  border-bottom: 1px dotted #ccc;
+  text-decoration: none;
+}
+
+a.bibref {
+  text-decoration: none;
+}
+
+.respec-offending-element:target {
+  animation: pop 0.25s ease-in-out 0s 1;
+}
+
+/* TODO: Remove once https://github.com/w3c/tr-design/pull/176 is merged. */
+.respec-offending-element a[href] {
+  margin: 0;
+}
+
+.respec-offending-element {
+  display: inline-block;
+  position: relative;
+  /* Red squiggly line */
+  background: url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=)
+    bottom repeat-x;
+}
+@supports (text-decoration-style: wavy) {
+  .respec-offending-element {
+    background: none;
+    text-decoration-line: underline;
+    text-decoration-style: wavy;
+    text-decoration-color: red;
+  }
+}
+
+#references :target {
+  background: #eaf3ff;
+  animation: pop 0.4s ease-in-out 0s 1;
+}
+
+cite .bibref {
+  font-style: normal;
+}
+
+code {
+  color: #c83500;
+}
+
+th code {
+  color: inherit;
+}
+
+a[href].orcid {
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
+a[href].orcid > svg {
+    margin-bottom: -2px;
+}
+
+/* --- TOC --- */
+
+.toc a,
+.tof a {
+  text-decoration: none;
+}
+
+a .secno,
+a .figno {
+  color: #000;
+}
+
+ul.tof,
+ol.tof {
+  list-style: none outside none;
+}
+
+.caption {
+  margin-top: 0.5em;
+  font-style: italic;
+}
+
+/* --- TABLE --- */
+
+table.simple {
+  border-spacing: 0;
+  border-collapse: collapse;
+  border-bottom: 3px solid #005a9c;
+}
+
+.simple th {
+  background: #005a9c;
+  color: #fff;
+  padding: 3px 5px;
+  text-align: left;
+}
+
+.simple th[scope="row"] {
+  background: inherit;
+  color: inherit;
+  border-top: 1px solid #ddd;
+}
+
+.simple td {
+  padding: 3px 10px;
+  border-top: 1px solid #ddd;
+}
+
+.simple tr:nth-child(even) {
+  background: #f0f6ff;
+}
+
+/* --- DL --- */
+
+.section dd > p:first-child {
+  margin-top: 0;
+}
+
+.section dd > p:last-child {
+  margin-bottom: 0;
+}
+
+.section dd {
+  margin-bottom: 1em;
+}
+
+.section dl.attrs dd,
+.section dl.eldef dd {
+  margin-bottom: 0;
+}
+
+#issue-summary > ul,
+.respec-dfn-list {
+  column-count: 2;
+}
+
+#issue-summary li,
+.respec-dfn-list li {
+  list-style: none;
+}
+
+details.respec-tests-details {
+  margin-left: 1em;
+  display: inline-block;
+  vertical-align: top;
+}
+
+details.respec-tests-details > * {
+  padding-right: 2em;
+}
+
+details.respec-tests-details[open] {
+  z-index: 999999;
+  position: absolute;
+  border: thin solid #cad3e2;
+  border-radius: 0.3em;
+  background-color: white;
+  padding-bottom: 0.5em;
+}
+
+details.respec-tests-details[open] > summary {
+  border-bottom: thin solid #cad3e2;
+  padding-left: 1em;
+  margin-bottom: 1em;
+  line-height: 2em;
+}
+
+details.respec-tests-details > ul {
+  width: 100%;
+  margin-top: -0.3em;
+}
+
+details.respec-tests-details > li {
+  padding-left: 1em;
+}
+
+a[href].self-link:hover {
+  opacity: 1;
+  text-decoration: none;
+  background-color: transparent;
+}
+
+h2,
+h3,
+h4,
+h5,
+h6 {
+  position: relative;
+}
+
+aside.example .marker > a.self-link {
+  color: inherit;
+}
+
+h2 > a.self-link,
+h3 > a.self-link,
+h4 > a.self-link,
+h5 > a.self-link,
+h6 > a.self-link {
+  border: none;
+  color: inherit;
+  font-size: 83%;
+  height: 2em;
+  left: -1.6em;
+  opacity: 0.5;
+  position: absolute;
+  text-align: center;
+  text-decoration: none;
+  top: 0;
+  transition: opacity 0.2s;
+  width: 2em;
+}
+
+h2 > a.self-link::before,
+h3 > a.self-link::before,
+h4 > a.self-link::before,
+h5 > a.self-link::before,
+h6 > a.self-link::before {
+  content: "§";
+  display: block;
+}
+
+@media (max-width: 767px) {
+  dd {
+    margin-left: 0;
+  }
+
+  /* Don't position self-link in headings off-screen */
+  h2 > a.self-link,
+  h3 > a.self-link,
+  h4 > a.self-link,
+  h5 > a.self-link,
+  h6 > a.self-link {
+    left: auto;
+    top: auto;
+  }
+}
+
+@media print {
+  .removeOnSave {
+    display: none;
+  }
+}
+</style>
+		
+		
+		
+		
+		<link href="common/css/common.css" rel="stylesheet" type="text/css">
+		
+	<link rel="canonical" href="https://www.w3.org/publishing/epub3/index.html"><style>var {
+  position: relative;
+  cursor: pointer;
+  display: inline-block;
+}
+
+var[data-type]::before,
+var[data-type]::after {
+  position: absolute;
+  left: 50%;
+  top: -6px;
+  opacity: 0;
+  transition: opacity 0.4s;
+  pointer-events: none;
+}
+
+/* the triangle or arrow or caret or whatever */
+var[data-type]::before {
+  content: "";
+  transform: translateX(-50%);
+  border-width: 4px 6px 0 6px;
+  border-style: solid;
+  border-color: transparent;
+  border-top-color: #000;
+}
+
+/* actual text */
+var[data-type]::after {
+  content: attr(data-type);
+  transform: translateX(-50%) translateY(-100%);
+  background: #000;
+  text-align: center;
+  /* additional styling */
+  font-family: "Dank Mono", "Fira Code", monospace;
+  font-style: normal;
+  padding: 6px;
+  border-radius: 3px;
+  color: #daca88;
+}
+
+var[data-type]:hover::after,
+var[data-type]:hover::before {
+  opacity: 1;
+}
+</style>
+<meta name="description" content="This is an entry page to the EPUB 3.2 specification documents">
+				<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/cg-final">
+				</head>
+	<body class="h-entry informative toc-inline"><div class="head">
+      <a class="logo" href="https://www.w3.org/"><img alt="W3C" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" height="48"></a>
+      <h1 class="title p-name" id="title">EPUB 3.2</h1>
+      
+      
+        
+     
+      <hr title="Separator for header">
+    </div>
+		<section id="abstract" class="introductory"><h2>What is EPUB?</h2>
+			<p>EPUB® defines a distribution and interchange format for digital publications and documents. The EPUB
+				format provides a means of representing, packaging and encoding structured and semantically enhanced Web
+				content—including HTML, CSS, SVG and other resources—for distribution in a single-file container.</p>
+		</section>
+		<section id="sotd" class="introductory"><h2>About EPUB 3.2</h2><p>EPUB 3.2 is a minor revision of the EPUB 3 specification, which can be considered as a successor to both
+				EPUB 3.0.1 and EPUB 3.1. EPUB 3.1 did not receive wide adoption due to incompatibilities with previous
+				versions, so EPUB 3.2 was developed to be strongly backward-compatible with EPUB 3.0.1, while retaining
+				many of the changes made in EPUB 3.1.</p>
+				<p>On May 8, 2019 the <a
+					href="https://www.w3.org/publishing/groups/epub3-cg/">W3C EPUB 3 Community Group</a> published EPUB
+				3.2 as a Final Community Group Specification.</p>
+
+</section>
+
+
+<nav id="toc"><h2 class="introductory" id="table-of-contents">Links to Specification Documents</h2>
+
+<ol class="toc">
+
+<li><a href="https://w3.org/publishing/epub32/epub-spec.html">EPUB 3.2</a></li>
+				<li><a href="https://w3.org/publishing/epub32/epub-packages.html">EPUB Packages 3.2</a></li>
+				<li><a href="https://w3.org/publishing/epub32/epub-contentdocs.html">EPUB Content Documents 3.2</a></li>
+				<li><a href="https://w3.org/publishing/epub32/epub-ocf.html">EPUB Open Container Format (OCF) 3.2</a></li>
+				<li><a href="https://w3.org/publishing/epub32/epub-mediaoverlays.html">EPUB Media Overlays 3.2</a></li>
+				<li><a href="https://w3.org/publishing/epub32/epub-changes.html">EPUB 3.2 Changes</a></li>
+
+
+
+
+</ol></nav>
+		<section id="sec-organization">
+		
+		
+		
+<h2>EPUB Organization</h2>
+
+<p>EPUB 3.2 is defined by a set of individual specifications. The best starting point for learning about
+				EPUB 3.2 is the <a href="https://w3.org/publishing/epub32/epub-overview.html">EPUB 3 Overview</a>. The
+					<a href="https://www.w3.org/publishing/epub32/epub-spec.html#sec-intro-spec-org">organization of the
+					specification documents</a> is also explained in the EPUB 3.2 specification.</p>
+
+			<p>The <a href="https://www.w3.org/publishing/epub32/epub-changes.html">EPUB 3.2 Changes</a> document
+				identifies the major changes made between EPUB 3.2 and EPUB 3.0.1.</p>
+				
+
+		</section>
+		<section id="participate">
+
+<h2>How to Participate</h2>
+
+<p>The EPUB 3.2 specification is developed by the <a href="https://www.w3.org/publishing/groups/epub3-cg/"
+					>W3C EPUB 3 Community Group</a>. All Working Group activities are conducted in an "open source"
+				manner: the EPUB 3 Community Group <a href="https://github.com/w3c/publ-epub-revision/">project site</a>
+				is publicly accessible and contains a source code repository for specification and related work
+				products.</p>
+
+			<p>All comments on EPUB 3 specifications should be submitted via the <a
+					href="https://github.com/w3c/publ-epub-revision/issues">EPUB 3 issue tracker</a> hosted on GitHub.
+				(NOTE: you must login via a GitHub Account in order to submit an issue.)</p>
+		</section>
+
+<p role="navigation" id="back-to-top"><a href="#title"><abbr title="Back to Top">↑</abbr></a></p><script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>


### PR DESCRIPTION
This PR fixes some bad links to parts of the SVG spec, which were caused by a reorganization of the SVG spec. I've also corrected a validation error generated by ReSpec. 

We also need an index page that users will see if they navigate to w3.org/publishing/epub. The main goal was to provide obvious links to the constituent specs. 