### PR TITLE
Replace mapping table with pointer to reserved prefix section

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -510,42 +510,8 @@
 				<section id="sec-shorthands-prefixes">
 					<h4>Prefixes</h4>
 
-					<p>For convenience, the following <a href="#sec-metadata-reserved-prefixes">reserved prefix
-							mappings</a> are used in this specification.</p>
-
-					<table class="mapping">
-						<tr>
-							<th>prefix</th>
-							<th>URI</th>
-						</tr>
-
-						<tr>
-							<td>
-								<code>dcterms</code>
-							</td>
-							<td>
-								<code>http://purl.org/dc/terms/</code>
-							</td>
-						</tr>
-
-						<tr>
-							<td>
-								<code>opf</code>
-							</td>
-							<td>
-								<code>http://www.idpf.org/2007/opf</code>
-							</td>
-						</tr>
-
-						<tr>
-							<td>
-								<code>rendition</code>
-							</td>
-							<td>
-								<code>http://www.idpf.org/vocab/rendition/#</code>
-							</td>
-						</tr>
-					</table>
+					<p>In <a>Package Document</a> metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
+							prefixes</a> are used without declaration.</p>
 				</section>
 
 				<section id="sec-shorthands-ns">
@@ -561,12 +527,20 @@
 							<th>URI</th>
 						</tr>
 						<tr>
-							<td><code>epub</code></td>
-							<td><code>http://www.idpf.org/2007/ops</code></td>
+							<td>
+								<code>epub</code>
+							</td>
+							<td>
+								<code>http://www.idpf.org/2007/ops</code>
+							</td>
 						</tr>
 						<tr>
-							<td><code>ssml</code></td>
-							<td><code>https://www.w3.org/2001/10/synthesis</code></td>
+							<td>
+								<code>ssml</code>
+							</td>
+							<td>
+								<code>https://www.w3.org/2001/10/synthesis</code>
+							</td>
 						</tr>
 					</table>
 				</section>


### PR DESCRIPTION
Fixes #1308 

This is just an editorial fix. We don't need to duplicate the list of reserved property prefixes in declaring the shorthands we're using. That was only necessary when we were maintaining the list separately.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-epub-revision/pull/1335.html" title="Last updated on Oct 6, 2020, 5:10 PM UTC (445bf12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-epub-revision/1335/2784496...445bf12.html" title="Last updated on Oct 6, 2020, 5:10 PM UTC (445bf12)">Diff</a>