### PR TITLE
Remove redundant media overlays support bullet

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1440,10 +1440,6 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-rs-mo-package-def">It MUST process the Media Overlay Document in conformance with
-							all Reading System conformance constraints expressed in <a
-								href="epub-core.html#sec-overlays-def">Media Overlay Document Definition</a>
-							[[!EPUB-33]].</p>
 						<p id="confreq-rs-xhtml-svg">It MUST support <a>XHTML Content Documents</a>, and it MAY support
 								<a>SVG Content Documents</a>.</p>
 						<p id="confreq-rs-render">It MUST render Media Overlay elements as described in <a


### PR DESCRIPTION
Fixes #1331 

This also falls into the editorial category. Removing the bullet doesn't affect anything, not only because there weren't any reading system requirements in the definition, but the bullet two down from it already references the section where how to render the elements is covered.