### PR TITLE
Rewrite reading system sections to conformance lists

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -471,7 +471,7 @@
 						<p>Authors MAY include page navigation in reflowable EPUB Publications without statically
 							paginated equivalents.</p>
 
-						<p>A conformant EPUB Publication MUST meet the following criteria when it includes page
+						<p>A conformant EPUB Publication has to meet the following criteria when it includes page
 							navigation:</p>
 
 						<ul>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -20,23 +20,19 @@
 					name: "Garth Conboy",
 					company: "Google",
 					companyURL: "https://www.google.com"
-				},
-				{
+				}, {
 					name: "Dave Cramer",
 					company: "Hachette Livre",
 					companyURL: "https://www.hachettebookgroup.com",
-				},
-				{
+				}, {
 					name: "Marisa DeMeglio",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
-				},
-				{
+				}, {
 					name: "Matt Garrish",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
-				},
-				{
+				}, {
 					name: "Daniel Weck",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
@@ -245,42 +241,55 @@
 				<p>Only the first instance of a term in a section is linked to its definition.</p>
 
 				<dl class="termlist">
-					<dt><dfn id="dfn-author" data-lt="Authors">Author</dfn></dt>
+					<dt>
+						<dfn id="dfn-author" data-lt="Authors">Author</dfn>
+					</dt>
 					<dd>
 						<p>The person(s) or organization responsible for the creation of an <a>EPUB Publication</a>. The
 							Author is not necessarily the creator of the content.</p>
 					</dd>
-					<dt><dfn id="dfn-codec" data-lt="Codecs">Codec</dfn></dt>
+					<dt>
+						<dfn id="dfn-codec" data-lt="Codecs">Codec</dfn>
+					</dt>
 					<dd>
 						<p>Codec refers to content that has intrinsic binary format qualities, such as video and audio
 							media types which are already designed for optimum compression, or which provide optimized
 							streaming capabilities.</p>
 					</dd>
-					<dt><dfn id="dfn-content-display-area">Content Display Area</dfn></dt>
+					<dt>
+						<dfn id="dfn-content-display-area">Content Display Area</dfn>
+					</dt>
 					<dd>
 						<p>The area within the <a>Viewport</a> dedicated to the display of <a>EPUB Content
 							Documents</a>. The Content Display Area excludes any borders, margins, headers, footers or
 							other decoration a <a>EPUB Reading System</a> might inject into the Viewport.</p>
 						<p>In the case of <a>synthetic spreads</a>, the Viewport contains two Content Display Areas.</p>
 					</dd>
-					<dt><dfn id="dfn-core-media-type-resource" data-lt="Core Media Type Resources">Core Media Type
-							Resource</dfn></dt>
+					<dt>
+						<dfn id="dfn-core-media-type-resource" data-lt="Core Media Type Resources">Core Media Type
+							Resource</dfn>
+					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> that does not require the provision of a <a
 								href="#sec-foreign-restrictions">fallback</a> (cf. <a>Foreign Resource</a>).</p>
 					</dd>
-					<dt><dfn id="dfn-default-rendition" data-lt="Default Renditions">Default Rendition</dfn></dt>
+					<dt>
+						<dfn id="dfn-default-rendition" data-lt="Default Renditions">Default Rendition</dfn>
+					</dt>
 					<dd>
 						<p>The <a>Rendition</a> listed in the first <code>rootfile</code> element in the <a
 								href="#sec-container-metainf-container.xml">container.xml</a> file.</p>
 					</dd>
-					<dt><dfn id="dfn-epub-container" data-lt="EPUB Containers">EPUB Container</dfn></dt>
+					<dt>
+						<dfn id="dfn-epub-container" data-lt="EPUB Containers">EPUB Container</dfn>
+					</dt>
 					<dd>
 						<p>The ZIP-based packaging and distribution format for <a>EPUB Publications</a> defined in <a
 								href="#sec-container-zip"></a>.</p>
 					</dd>
-					<dt><dfn id="dfn-epub-content-document" data-lt="EPUB Content Documents">EPUB Content
-						Document</dfn></dt>
+					<dt>
+						<dfn id="dfn-epub-content-document" data-lt="EPUB Content Documents">EPUB Content Document</dfn>
+					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> with an XHTML or SVG media type that contains all or part of
 							the content of an EPUB Publication (i.e., the textual, visual and/or audio content). These
@@ -291,20 +300,26 @@
 								<a>EPUB Publication</a> without the provision of <a href="#sec-foreign-restrictions"
 								>fallbacks</a>.</p>
 					</dd>
-					<dt><dfn id="dfn-epub-navigation-document" data-lt="EPUB Navigation Documents">EPUB Navigation
-							Document</dfn></dt>
+					<dt>
+						<dfn id="dfn-epub-navigation-document" data-lt="EPUB Navigation Documents">EPUB Navigation
+							Document</dfn>
+					</dt>
 					<dd>
 						<p>A specialization of the <a>XHTML Content Document</a> that contains human- and
 							machine-readable global navigation information. The EPUB Navigation Document conforms to the
 							constraints expressed in <a href="#sec-package-nav"></a>.</p>
 					</dd>
-					<dt><dfn id="dfn-epub-package" data-lt="EPUB Packages">EPUB Package</dfn></dt>
+					<dt>
+						<dfn id="dfn-epub-package" data-lt="EPUB Packages">EPUB Package</dfn>
+					</dt>
 					<dd>
 						<p>A logical document entity consisting of a set of interrelated <a
 								data-lt="Publication Resource">resources</a> representing one <a>Rendition</a> of an
 								<a>EPUB Publication</a>, as defined by a <a>Package Document</a>.</p>
 					</dd>
-					<dt><dfn id="dfn-epub-publication" data-lt="EPUB Publications">EPUB Publication</dfn></dt>
+					<dt>
+						<dfn id="dfn-epub-publication" data-lt="EPUB Publications">EPUB Publication</dfn>
+					</dt>
 					<dd>
 						<p>A collection of one or more <a>Renditions</a> that conform to this specification, packaged in
 							an <a>EPUB Container</a>.</p>
@@ -317,13 +332,16 @@
 						<p>A system that processes <a>EPUB Publications</a> for presentation to a user in a manner
 							conformant with this specification.</p>
 					</dd>
-					<dt><dfn id="dfn-file-name" data-lt="File Names">File Name</dfn></dt>
+					<dt>
+						<dfn id="dfn-file-name" data-lt="File Names">File Name</dfn>
+					</dt>
 					<dd>
 						<p>The name of any type of file within an <a>OCF Abstract Container</a>, whether a directory or
 							a file within a directory.</p>
 					</dd>
-					<dt><dfn id="dfn-fixed-layout-document" data-lt="Fixed-Layout Documents">Fixed-Layout
-						Document</dfn></dt>
+					<dt>
+						<dfn id="dfn-fixed-layout-document" data-lt="Fixed-Layout Documents">Fixed-Layout Document</dfn>
+					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> directly referenced from the <a>spine</a> that has been
 							designated <code>pre-paginated</code> in the <a>Package Document</a>, as defined in <a
@@ -331,62 +349,82 @@
 						<p>The dimensions to use for rendering Fixed-Layout Documents are defined in <a
 								href="#sec-fixed-layouts"></a>.</p>
 					</dd>
-					<dt><dfn id="dfn-foreign-resource" data-lt="Foreign Resources">Foreign Resource</dfn></dt>
+					<dt>
+						<dfn id="dfn-foreign-resource" data-lt="Foreign Resources">Foreign Resource</dfn>
+					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> that is not a <a>Core Media Type Resource</a>. Foreign
 							Resources are subject to the fallback requirements defined in <a
 								href="#sec-foreign-restrictions"></a>.</p>
 					</dd>
-					<dt><dfn id="dfn-local-resource" data-lt="Local Resources">Local Resource</dfn></dt>
+					<dt>
+						<dfn id="dfn-local-resource" data-lt="Local Resources">Local Resource</dfn>
+					</dt>
 					<dd>
 						<p>A resource that is located inside the <a>EPUB Container</a>.</p>
 						<p>Refer to <a href="#sec-resource-locations"></a> for media type specific rules for resource
 							locations.</p>
 					</dd>
-					<dt><dfn id="dfn-manifest" data-lt="Manifests">Manifest</dfn></dt>
+					<dt>
+						<dfn id="dfn-manifest" data-lt="Manifests">Manifest</dfn>
+					</dt>
 					<dd>
 						<p>A list of all <a>Publication Resources</a> that constitute the given <a>Rendition</a> of a
 								<a>EPUB Publication</a>.</p>
 						<p>Refer to <a href="#sec-manifest-elem"></a> for more information.</p>
 					</dd>
-					<dt><dfn id="dfn-media-overlay-document" data-lt="Media Overlay Documents">Media Overlay
-							Document</dfn></dt>
+					<dt>
+						<dfn id="dfn-media-overlay-document" data-lt="Media Overlay Documents">Media Overlay
+							Document</dfn>
+					</dt>
 					<dd>
 						<p>An XML document that associates the <a>XHTML Content Document</a> with pre-recorded audio
 							narration in order to provide a synchronized playback experience, as defined in <a
 								href="#sec-media-overlays"></a>.</p>
 					</dd>
-					<dt><dfn id="dfn-package-document" data-lt="Package Documents">Package Document</dfn></dt>
+					<dt>
+						<dfn id="dfn-package-document" data-lt="Package Documents">Package Document</dfn>
+					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> that describes one <a>Rendition</a> of an <a>EPUB
 								Publication</a>, as defined in <a href="#sec-package-doc"></a>. The Package Document
 							carries meta information about the Rendition, provides a manifest of resources and defines
 							the default reading order.</p>
 					</dd>
-					<dt><dfn id="dfn-non-codec" data-lt="Non-Codecs">Non-Codec</dfn></dt>
+					<dt>
+						<dfn id="dfn-non-codec" data-lt="Non-Codecs">Non-Codec</dfn>
+					</dt>
 					<dd>
 						<p>Non-Codec refers to content types that benefit from compression due to the nature of their
 							internal data structure, such as file formats based on character strings (for example, HTML,
 							CSS, etc.).</p>
 					</dd>
-					<dt><dfn id="dfn-ocf-abstract-container" data-lt="OCF Abstract Containers">OCF Abstract
-							Container</dfn></dt>
+					<dt>
+						<dfn id="dfn-ocf-abstract-container" data-lt="OCF Abstract Containers">OCF Abstract
+							Container</dfn>
+					</dt>
 					<dd>
 						<p>The OCF Abstract Container defines a file system model for the contents of the <a>OCF ZIP
 								Container</a>, as defined in <a href="#sec-container-abstract"></a>.</p>
 					</dd>
-					<dt><dfn id="dfn-ocf-processor" data-lt="OCF Processors">OCF Processor</dfn></dt>
+					<dt>
+						<dfn id="dfn-ocf-processor" data-lt="OCF Processors">OCF Processor</dfn>
+					</dt>
 					<dd>
 						<p>A software application that processes <a>OCF ZIP Containers</a> according to the requirements
 							of this specification.</p>
 					</dd>
-					<dt><dfn id="dfn-zip-container" data-lt="OCF ZIP Containers">OCF ZIP Container</dfn></dt>
+					<dt>
+						<dfn id="dfn-zip-container" data-lt="OCF ZIP Containers">OCF ZIP Container</dfn>
+					</dt>
 					<dd>
 						<p>The ZIP-based packaging and distribution format for EPUB Publications, as defined in <a
 								href="#sec-container-zip"></a>.</p>
 						<p>OCF ZIP Container and <a>EPUB Container</a> are synonymous.</p>
 					</dd>
-					<dt><dfn id="dfn-path-name" data-lt="Path Names">Path Name</dfn></dt>
+					<dt>
+						<dfn id="dfn-path-name" data-lt="Path Names">Path Name</dfn>
+					</dt>
 					<dd>
 						<p>For a given directory within the <a href="#sec-container-abstract">OCF Abstract
 							Container</a>, the string holding all directory <a>File Name</a> in the full path
@@ -397,8 +435,9 @@
 							directory File Names, followed by a <code>/</code> character and then the File Name of the
 							file.</p>
 					</dd>
-					<dt><dfn id="dfn-publication-resource" data-lt="Publication Resources">Publication
-						Resource</dfn></dt>
+					<dt>
+						<dfn id="dfn-publication-resource" data-lt="Publication Resources">Publication Resource</dfn>
+					</dt>
 					<dd>
 						<p>A resource that contains content or instructions that contribute to the logic and rendering
 							of at least one <a>Rendition</a> of an <a>EPUB Publication</a>. In the absence of this
@@ -416,53 +455,68 @@
 								href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element"
 								><code>a</code></a> element).</p>
 					</dd>
-					<dt><dfn id="dfn-release-identifier" data-lt="Release Identifiers">Release Identifier</dfn></dt>
+					<dt>
+						<dfn id="dfn-release-identifier" data-lt="Release Identifiers">Release Identifier</dfn>
+					</dt>
 					<dd>
 						<p>The Release Identifier allows any instance of an <a>EPUB Publication</a> to be compared
 							against another to determine if they are identical, different versions, or unrelated.</p>
 						<p>Refer to <a href="#sec-metadata-elem-identifiers-pid"></a> for more information.</p>
 					</dd>
-					<dt><dfn id="dfn-remote-resource" data-lt="Remote Resources">Remote Resource</dfn></dt>
+					<dt>
+						<dfn id="dfn-remote-resource" data-lt="Remote Resources">Remote Resource</dfn>
+					</dt>
 					<dd>
 						<p>A resource that is located outside of the <a>EPUB Container</a>, typically, but not
 							necessarily, online.</p>
 						<p>Refer to <a href="#sec-resource-locations"></a> for media type specific rules for resource
 							locations.</p>
 					</dd>
-					<dt><dfn id="dfn-rendition" data-lt="Renditions">Rendition</dfn></dt>
+					<dt>
+						<dfn id="dfn-rendition" data-lt="Renditions">Rendition</dfn>
+					</dt>
 					<dd>
 						<p>One rendering of the content of an <a>EPUB Publication</a>, as expressed by an <a>EPUB
 								Package</a>.</p>
 					</dd>
-					<dt><dfn id="dfn-root-directory" data-lt="Root Directories">Root Directory</dfn></dt>
+					<dt>
+						<dfn id="dfn-root-directory" data-lt="Root Directories">Root Directory</dfn>
+					</dt>
 					<dd>
 						<p>The root directory represents the base of the <a>OCF Abstract Container</a> file system. This
 							directory is virtual in nature: a <a>EPUB Reading System</a> might or might not generate a
 							physical root directory for the contents of the OCF Abstract Container if the contents are
 							unzipped.</p>
 					</dd>
-					<dt><dfn id="dfn-scripted-content-document" data-lt="Scripted Content Documents">Scripted Content
-							Document</dfn></dt>
+					<dt>
+						<dfn id="dfn-scripted-content-document" data-lt="Scripted Content Documents">Scripted Content
+							Document</dfn>
+					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> that includes scripting or an <a>XHTML Content Document</a>
 							that contains [[!HTML]] <a href="https://www.w3.org/TR/html/sec-forms.html#sec-forms"
 								>forms</a>.</p>
 						<p>Refer to <a href="#sec-scripted-content"></a> for more information.</p>
 					</dd>
-					<dt><dfn id="dfn-spine" data-lt="Spines">Spine</dfn></dt>
+					<dt>
+						<dfn id="dfn-spine" data-lt="Spines">Spine</dfn>
+					</dt>
 					<dd>
 						<p>An ordered list of <a>Publication Resources</a>, <a href="#confreq-spine-itemtypes">typically
 								EPUB Content Documents</a>, representing the default reading order of the given
 								<a>Rendition</a> of an EPUB Publication.</p>
 						<p>Refer to <a href="#sec-spine-elem"></a> for more information.</p>
 					</dd>
-					<dt><dfn id="dfn-svg-content-document" data-lt="SVG Content Documents">SVG Content
-						Document</dfn></dt>
+					<dt>
+						<dfn id="dfn-svg-content-document" data-lt="SVG Content Documents">SVG Content Document</dfn>
+					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> that conforms to the constraints expressed in <a
 								href="#sec-svg"></a>.</p>
 					</dd>
-					<dt><dfn id="dfn-synthetic-spread" data-lt="Synthetic Spreads">Synthetic Spread</dfn></dt>
+					<dt>
+						<dfn id="dfn-synthetic-spread" data-lt="Synthetic Spreads">Synthetic Spread</dfn>
+					</dt>
 					<dd>
 						<p>The rendering of two adjacent pages simultaneously on a device screen.</p>
 					</dd>
@@ -471,13 +525,17 @@
 						<p>The rendering of the textual content of an <a>EPUB Publication</a> as artificial human speech
 							using a synthesized voice.</p>
 					</dd>
-					<dt><dfn id="dfn-top-level-content-document" data-lt="Top-level Content Documents">Top-level Content
-							Document</dfn></dt>
+					<dt>
+						<dfn id="dfn-top-level-content-document" data-lt="Top-level Content Documents">Top-level Content
+							Document</dfn>
+					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> referenced from the <a>spine</a>, whether directly or via a
 								<a href="#sec-foreign-restrictions-manifest">fallback chain</a>.</p>
 					</dd>
-					<dt><dfn id="dfn-unique-identifier" data-lt="Unique Identifiers">Unique Identifier</dfn></dt>
+					<dt>
+						<dfn id="dfn-unique-identifier" data-lt="Unique Identifiers">Unique Identifier</dfn>
+					</dt>
 					<dd>
 						<p>The Unique Identifier is the primary identifier for an <a>EPUB Publication</a>, as identified
 							by the <a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
@@ -485,13 +543,17 @@
 							the same EPUB Publication.</p>
 						<p>Significant revision, abridgement, etc. of the content requires a new Unique Identifier.</p>
 					</dd>
-					<dt><dfn id="dfn-viewport" data-lt="Viewports">Viewport</dfn></dt>
+					<dt>
+						<dfn id="dfn-viewport" data-lt="Viewports">Viewport</dfn>
+					</dt>
 					<dd>
 						<p>The region of an <a>EPUB Reading System</a> in which an <a>EPUB Publication</a> is rendered
 							visually to a user.</p>
 					</dd>
-					<dt><dfn id="dfn-xhtml-content-document" data-lt="XHTML Content Documents">XHTML Content
-							Document</dfn></dt>
+					<dt>
+						<dfn id="dfn-xhtml-content-document" data-lt="XHTML Content Documents">XHTML Content
+							Document</dfn>
+					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> that conforms to the profile of [[!HTML]] defined in <a
 								href="#sec-xhtml"></a>.</p>
@@ -549,7 +611,7 @@
 		<section id="sec-epub-conf">
 			<h2>Conformance Criteria</h2>
 
-			<p>An <a>EPUB Publication</a> MUST meet all of the following criteria:</p>
+			<p>An <a>EPUB Publication</a> has to meet the following criteria:</p>
 
 			<dl class="conformance-list">
 				<dt id="sec-epub-package-conformance">Packages</dt>
@@ -611,7 +673,8 @@
 					<p>The columns in the following table represent the following information:</p>
 
 					<ul>
-						<li><p><strong>Media Type</strong>—The MIME media type [[!RFC2046]] used to represent the given
+						<li>
+							<p><strong>Media Type</strong>—The MIME media type [[!RFC2046]] used to represent the given
 								Publication Resource in the <a href="#sec-manifest-elem">manifest</a>.</p>
 							<p>If more than one media type is listed, the first one is the preferred media type. The
 								preferred media type is strongly encouraged for all new EPUB Publications.</p>
@@ -674,7 +737,8 @@
 							</tr>
 							<tr>
 								<td id="cmt-mp3">
-									<code>audio/mpeg</code></td>
+									<code>audio/mpeg</code>
+								</td>
 								<td> [[!MP3]] </td>
 								<td>MP3 audio</td>
 							</tr>
@@ -718,7 +782,8 @@
 							</tr>
 							<tr>
 								<td id="cmt-sfnt">
-									<code>font/ttf</code><br />
+									<code>font/ttf</code>
+									<br />
 									<code>application/font-sfnt</code>
 								</td>
 								<td>[[!TrueType]] </td>
@@ -726,8 +791,10 @@
 							</tr>
 							<tr>
 								<td id="cmt-otf">
-									<code>font/otf</code><br />
-									<code>application/font-sfnt</code><br />
+									<code>font/otf</code>
+									<br />
+									<code>application/font-sfnt</code>
+									<br />
 									<code>application/vnd.ms-opentype</code>
 								</td>
 								<td>[[!OpenType]]</td>
@@ -736,7 +803,8 @@
 							</tr>
 							<tr>
 								<td id="cmt-woff">
-									<code>font/woff</code><br />
+									<code>font/woff</code>
+									<br />
 									<code>application/font-woff</code>
 								</td>
 								<td> [[!WOFF]] </td>
@@ -766,7 +834,8 @@
 							</tr>
 							<tr>
 								<td id="cmt-js">
-									<code>application/javascript</code><br />
+									<code>application/javascript</code>
+									<br />
 									<code>text/javascript</code>
 								</td>
 								<td> [[!RFC4329]] </td>
@@ -784,7 +853,9 @@
 								<td id="cmt-smil">
 									<code>application/smil+xml</code>
 								</td>
-								<td><a href="#sec-media-overlays">Media Overlays</a></td>
+								<td>
+									<a href="#sec-media-overlays">Media Overlays</a>
+								</td>
 								<td>EPUB Media Overlay documents</td>
 							</tr>
 							<tr>
@@ -903,7 +974,7 @@
 			<section id="sec-xml-constraints">
 				<h3>XML Conformance</h3>
 
-				<p>Any <a>Publication Resource</a> that is an XML-Based Media Type MUST meet the following
+				<p>Any <a>Publication Resource</a> that is an XML-Based Media Type has to meet the following
 					constraints:</p>
 
 				<ul class="conformance-list">
@@ -936,7 +1007,7 @@
 			<section id="sec-package-conformance">
 				<h3>Conformance Criteria</h3>
 
-				<p>A conformant <a>EPUB Package</a> MUST meet all of the following criteria:</p>
+				<p>A conformant <a>EPUB Package</a> has to meet the following criteria:</p>
 
 				<dl class="conformance-list">
 					<dt id="sec-package-conformance-packagedoc">Package Document</dt>
@@ -1030,7 +1101,7 @@
 				<section id="sec-package-content-conf">
 					<h4>Content Conformance</h4>
 
-					<p>A <a>Package Document</a> MUST meet all of the following criteria:</p>
+					<p>A <a>Package Document</a> has to meet the following criteria:</p>
 
 					<dl class="conformance-list">
 						<dt id="confreq-package-docprops">Document Properties</dt>
@@ -1074,7 +1145,9 @@
 						<dl id="elemdef-opf-package" class="elemdef">
 							<dt>Element Name</dt>
 							<dd>
-								<p><code>package</code></p>
+								<p>
+									<code>package</code>
+								</p>
 							</dd>
 							<dt>Usage</dt>
 							<dd>
@@ -1085,34 +1158,51 @@
 								<ul class="nomark">
 									<li>
 										<p>
-											<a href="#attrdef-dir"><code>dir</code></a>
-											<code>[optional]</code></p>
+											<a href="#attrdef-dir">
+												<code>dir</code>
+											</a>
+											<code>[optional]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#attrdef-id"><code>id</code></a>
-											<code>[optional]</code></p>
+											<a href="#attrdef-id">
+												<code>id</code>
+											</a>
+											<code>[optional]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#attrdef-package-prefix"><code>prefix</code></a>
-											<code>[optional]</code></p>
+											<a href="#attrdef-package-prefix">
+												<code>prefix</code>
+											</a>
+											<code>[optional]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-											<code>[optional]</code></p>
+											<a href="#attrdef-xml-lang">
+												<code>xml:lang</code>
+											</a>
+											<code>[optional]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#attrdef-package-unique-identifier"
-												><code>unique-identifier</code></a>
-											<code>[required]</code></p>
+											<a href="#attrdef-package-unique-identifier">
+												<code>unique-identifier</code>
+											</a>
+											<code>[required]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#attrdef-package-version"><code>version</code></a>
-											<code>[required]</code></p>
+											<a href="#attrdef-package-version">
+												<code>version</code>
+											</a>
+											<code>[required]</code>
+										</p>
 									</li>
 								</ul>
 							</dd>
@@ -1122,35 +1212,53 @@
 								<ul class="nomark">
 									<li>
 										<p>
-											<a class="codelink" href="#elemdef-opf-metadata"><code>metadata</code></a>
-											<code>[exactly 1]</code></p>
+											<a class="codelink" href="#elemdef-opf-metadata">
+												<code>metadata</code>
+											</a>
+											<code>[exactly 1]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#elemdef-opf-manifest"><code>manifest</code></a>
-											<code>[exactly 1]</code></p>
+											<a href="#elemdef-opf-manifest">
+												<code>manifest</code>
+											</a>
+											<code>[exactly 1]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#elemdef-opf-spine"><code>spine</code></a>
-											<code>[exactly 1]</code></p>
+											<a href="#elemdef-opf-spine">
+												<code>spine</code>
+											</a>
+											<code>[exactly 1]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#sec-opf2-guide"><code>guide</code></a>
+											<a href="#sec-opf2-guide">
+												<code>guide</code>
+											</a>
 											<code>[0 or 1]</code>
-											<a href="#legacy" class="legacy">(legacy)</a></p>
+											<a href="#legacy" class="legacy">(legacy)</a>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#sec-opf-bindings"><code>bindings</code></a>
+											<a href="#sec-opf-bindings">
+												<code>bindings</code>
+											</a>
 											<code>[0 or 1]</code>
-											<a href="#deprecated" class="deprecated">(deprecated)</a></p>
+											<a href="#deprecated" class="deprecated">(deprecated)</a>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#elemdef-collection"><code>collection</code></a>
-											<code>[0 or more]</code></p>
+											<a href="#elemdef-collection">
+												<code>collection</code>
+											</a>
+											<code>[0 or more]</code>
+										</p>
 									</li>
 								</ul>
 							</dd>
@@ -1179,7 +1287,9 @@
 							two or more elements).</p>
 
 						<dl class="variablelist">
-							<dt id="attrdef-dir"><code>dir</code></dt>
+							<dt id="attrdef-dir">
+								<code>dir</code>
+							</dt>
 							<dd>
 								<p>Specifies the base text direction of the content and attribute values of the carrying
 									element and its descendants.</p>
@@ -1203,7 +1313,9 @@
 											><code>meta</code></a> and <a href="#sec-package-elem"
 										><code>package</code></a>.</p>
 							</dd>
-							<dt id="attrdef-href"><code>href</code></dt>
+							<dt id="attrdef-href">
+								<code>href</code>
+							</dt>
 							<dd>
 								<p>An absolute or relative IRI reference [[!RFC3987]] to a resource.</p>
 								<div class="example">
@@ -1214,7 +1326,9 @@
 								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
 										href="#sec-link-elem"><code>link</code></a>.</p>
 							</dd>
-							<dt id="attrdef-id"><code>id</code></dt>
+							<dt id="attrdef-id">
+								<code>id</code>
+							</dt>
 							<dd>
 								<p>The ID [[!XML]] of the element, which MUST be unique within the document scope.</p>
 								<div class="example">
@@ -1242,7 +1356,9 @@
 										href="#sec-package-elem"><code>package</code></a> and <a href="#sec-spine-elem"
 											><code>spine</code></a>.</p>
 							</dd>
-							<dt id="attrdef-media-type"><code>media-type</code></dt>
+							<dt id="attrdef-media-type">
+								<code>media-type</code>
+							</dt>
 							<dd>
 								<p>A media type [[!RFC2046]] that specifies the type and format of the referenced
 									resource.</p>
@@ -1255,7 +1371,9 @@
 								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
 										href="#sec-link-elem"><code>link</code></a>.</p>
 							</dd>
-							<dt id="attrdef-properties"><code>properties</code></dt>
+							<dt id="attrdef-properties">
+								<code>properties</code>
+							</dt>
 							<dd>
 								<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
 								<p>Refer to each element's definition for the <a href="#sec-metadata-default-vocab"
@@ -1270,7 +1388,9 @@
 										href="#sec-itemref-elem"><code>itemref</code></a> and <a href="#sec-link-elem"
 											><code>link</code></a>.</p>
 							</dd>
-							<dt id="attrdef-refines"><code>refines</code></dt>
+							<dt id="attrdef-refines">
+								<code>refines</code>
+							</dt>
 							<dd>
 								<p>Identifies the expression or resource augmented by the element. The value of the
 									attribute must be a relative IRI [[!RFC3987]] referencing the resource or element
@@ -1281,7 +1401,9 @@
 								<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a
 										href="#sec-meta-elem"><code>meta</code></a>.</p>
 							</dd>
-							<dt id="attrdef-xml-lang"><code>xml:lang</code></dt>
+							<dt id="attrdef-xml-lang">
+								<code>xml:lang</code>
+							</dt>
 							<dd>
 								<p>Specifies the language used in the contents and attribute values of the carrying
 									element and its descendants, as defined in section <a
@@ -1320,7 +1442,9 @@
 							<dl id="elemdef-opf-metadata" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
-									<p><code>metadata</code></p>
+									<p>
+										<code>metadata</code>
+									</p>
 								</dd>
 								<dt>Usage</dt>
 								<dd>
@@ -1337,41 +1461,58 @@
 									<ul class="nomark">
 										<li>
 											<p>
-												<a class="codelink" href="#elemdef-opf-dcidentifier"
-														><code>dc:identifier</code></a>
-												<code>[1 or more]</code></p>
+												<a class="codelink" href="#elemdef-opf-dcidentifier">
+													<code>dc:identifier</code>
+												</a>
+												<code>[1 or more]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#elemdef-opf-dctitle"><code>dc:title</code></a>
-												<code>[1 or more]</code></p>
+												<a href="#elemdef-opf-dctitle">
+													<code>dc:title</code>
+												</a>
+												<code>[1 or more]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#elemdef-opf-dclanguage"><code>dc:language</code></a>
-												<code>[1 or more]</code></p>
+												<a href="#elemdef-opf-dclanguage">
+													<code>dc:language</code>
+												</a>
+												<code>[1 or more]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#sec-opf-dcmes-optional"><code>DCMES Optional
-													Elements</code></a>
-												<code>[0 or more]</code></p>
+												<a href="#sec-opf-dcmes-optional">
+													<code>DCMES Optional Elements</code>
+												</a>
+												<code>[0 or more]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#elemdef-meta"><code>meta</code></a>
-												<code>[1 or more]</code></p>
+												<a href="#elemdef-meta">
+													<code>meta</code>
+												</a>
+												<code>[1 or more]</code>
+											</p>
 										</li>
 										<li>
 											<p>
 												<a href="#sec-opf2-meta">OPF2 <code>meta</code></a>
 												<code>[0 or more]</code>
-												<a href="#legacy" class="legacy">(legacy)</a></p>
+												<a href="#legacy" class="legacy">(legacy)</a>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#elemdef-opf-link"><code>link</code></a>
-												<code>[0 or more]</code></p>
+												<a href="#elemdef-opf-link">
+													<code>link</code>
+												</a>
+												<code>[0 or more]</code>
+											</p>
 										</li>
 									</ul>
 								</dd>
@@ -1450,11 +1591,14 @@
 									<dt>Element Name</dt>
 									<dd>
 										<p>
-											<code>dc:identifier</code></p>
+											<code>dc:identifier</code>
+										</p>
 									</dd>
 									<dt>Namespace</dt>
 									<dd>
-										<p><code>http://purl.org/dc/elements/1.1/</code></p>
+										<p>
+											<code>http://purl.org/dc/elements/1.1/</code>
+										</p>
 									</dd>
 									<dt>Usage</dt>
 									<dd>
@@ -1466,8 +1610,11 @@
 										<ul class="nomark">
 											<li>
 												<p>
-													<a href="#attrdef-id"><code>id</code></a>
-													<code>[optional]</code></p>
+													<a href="#attrdef-id">
+														<code>id</code>
+													</a>
+													<code>[optional]</code>
+												</p>
 											</li>
 										</ul>
 									</dd>
@@ -1555,11 +1702,14 @@
 									<dt>Element Name</dt>
 									<dd>
 										<p>
-											<code>dc:title</code></p>
+											<code>dc:title</code>
+										</p>
 									</dd>
 									<dt>Namespace</dt>
 									<dd>
-										<p><code>http://purl.org/dc/elements/1.1/</code></p>
+										<p>
+											<code>http://purl.org/dc/elements/1.1/</code>
+										</p>
 									</dd>
 									<dt>Usage</dt>
 									<dd>
@@ -1571,18 +1721,27 @@
 										<ul class="nomark">
 											<li>
 												<p>
-													<a href="#attrdef-dir"><code>dir</code></a>
-													<code>[optional]</code></p>
+													<a href="#attrdef-dir">
+														<code>dir</code>
+													</a>
+													<code>[optional]</code>
+												</p>
 											</li>
 											<li>
 												<p>
-													<a href="#attrdef-id"><code>id</code></a>
-													<code>[optional]</code></p>
+													<a href="#attrdef-id">
+														<code>id</code>
+													</a>
+													<code>[optional]</code>
+												</p>
 											</li>
 											<li>
 												<p>
-													<a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-													<code>[optional]</code></p>
+													<a href="#attrdef-xml-lang">
+														<code>xml:lang</code>
+													</a>
+													<code>[optional]</code>
+												</p>
 											</li>
 										</ul>
 									</dd>
@@ -1644,11 +1803,14 @@
 									<dt>Element Name</dt>
 									<dd>
 										<p>
-											<code>dc:language</code></p>
+											<code>dc:language</code>
+										</p>
 									</dd>
 									<dt>Namespace</dt>
 									<dd>
-										<p><code>http://purl.org/dc/elements/1.1/</code></p>
+										<p>
+											<code>http://purl.org/dc/elements/1.1/</code>
+										</p>
 									</dd>
 									<dt>Usage</dt>
 									<dd>
@@ -1658,8 +1820,11 @@
 									<dt>Attributes</dt>
 									<dd>
 										<p>
-											<a href="#attrdef-id"><code>id</code></a>
-											<code>[optional]</code></p>
+											<a href="#attrdef-id">
+												<code>id</code>
+											</a>
+											<code>[optional]</code>
+										</p>
 									</dd>
 									<dt>Content Model</dt>
 									<dd>
@@ -1712,7 +1877,9 @@
 									</dd>
 									<dt>Namespace</dt>
 									<dd>
-										<p><code>http://purl.org/dc/elements/1.1/</code></p>
+										<p>
+											<code>http://purl.org/dc/elements/1.1/</code>
+										</p>
 									</dd>
 									<dt>Usage</dt>
 									<dd>
@@ -1927,7 +2094,8 @@
 								<dt>Element Name</dt>
 								<dd>
 									<p>
-										<code>meta</code></p>
+										<code>meta</code>
+									</p>
 								</dd>
 								<dt>Usage</dt>
 								<dd>
@@ -1939,33 +2107,51 @@
 									<ul class="nomark">
 										<li>
 											<p>
-												<a href="#attrdef-dir"><code>dir</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-dir">
+													<code>dir</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-id"><code>id</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-meta-property"><code>property</code></a>
-												<code>[required]</code></p>
+												<a href="#attrdef-meta-property">
+													<code>property</code>
+												</a>
+												<code>[required]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-refines"><code>refines</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-refines">
+													<code>refines</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-scheme"><code>scheme</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-scheme">
+													<code>scheme</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-xml-lang">
+													<code>xml:lang</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 									</ul>
 								</dd>
@@ -2044,7 +2230,8 @@
 								<dt>Element Name</dt>
 								<dd>
 									<p>
-										<code>link</code></p>
+										<code>link</code>
+									</p>
 								</dd>
 								<dt>Usage</dt>
 								<dd>
@@ -2056,33 +2243,51 @@
 									<ul class="nomark">
 										<li>
 											<p>
-												<a href="#attrdef-href"><code>href</code></a>
-												<code>[required]</code></p>
+												<a href="#attrdef-href">
+													<code>href</code>
+												</a>
+												<code>[required]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-id"><code>id</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-link-media-type"><code>media-type</code></a>
-												<code>[conditionally required]</code></p>
+												<a href="#attrdef-link-media-type">
+													<code>media-type</code>
+												</a>
+												<code>[conditionally required]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-properties"><code>properties</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-properties">
+													<code>properties</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-refines"><code>refines</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-refines">
+													<code>refines</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-link-rel"><code>rel</code></a>
-												<code>[required]</code></p>
+												<a href="#attrdef-link-rel">
+													<code>rel</code>
+												</a>
+												<code>[required]</code>
+											</p>
 										</li>
 									</ul>
 								</dd>
@@ -2226,7 +2431,9 @@
 							<dl id="elemdef-opf-manifest" class="elemdef">
 								<dt>Element name</dt>
 								<dd>
-									<p><code>manifest</code></p>
+									<p>
+										<code>manifest</code>
+									</p>
 								</dd>
 								<dt>Usage</dt>
 								<dd>
@@ -2237,13 +2444,20 @@
 								<dt>Attributes</dt>
 								<dd>
 									<p>
-										<a href="#attrdef-id"><code>id</code></a>
-										<code>[optional]</code></p>
+										<a href="#attrdef-id">
+											<code>id</code>
+										</a>
+										<code>[optional]</code>
+									</p>
 								</dd>
 								<dt>Content Model</dt>
 								<dd>
-									<p><a class="codelink" href="#elemdef-package-item"><code>item</code></a>
-										<code>[1 or more]</code></p>
+									<p>
+										<a class="codelink" href="#elemdef-package-item">
+											<code>item</code>
+										</a>
+										<code>[1 or more]</code>
+									</p>
 								</dd>
 							</dl>
 
@@ -2264,7 +2478,9 @@
 							<dl id="elemdef-package-item" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
-									<p><code>item</code></p>
+									<p>
+										<code>item</code>
+									</p>
 								</dd>
 								<dt>Usage</dt>
 								<dd>
@@ -2276,33 +2492,51 @@
 									<ul class="nomark">
 										<li>
 											<p>
-												<a href="#attrdef-item-fallback"><code>fallback</code></a>
-												<code>[conditionally required]</code></p>
+												<a href="#attrdef-item-fallback">
+													<code>fallback</code>
+												</a>
+												<code>[conditionally required]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-href"><code>href</code></a>
-												<code>[required]</code></p>
+												<a href="#attrdef-href">
+													<code>href</code>
+												</a>
+												<code>[required]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-id"><code>id</code></a>
-												<code>[required]</code></p>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
+												<code>[required]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-item-media-overlay"><code>media-overlay</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-item-media-overlay">
+													<code>media-overlay</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-item-media-type"><code>media-type</code></a>
-												<code>[required]</code></p>
+												<a href="#attrdef-item-media-type">
+													<code>media-type</code>
+												</a>
+												<code>[required]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-properties"><code>properties</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-properties">
+													<code>properties</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 									</ul>
 								</dd>
@@ -2553,7 +2787,9 @@ Manifest:
 							<dl id="elemdef-opf-spine" class="elemdef">
 								<dt>Element name</dt>
 								<dd>
-									<p><code>spine</code></p>
+									<p>
+										<code>spine</code>
+									</p>
 								</dd>
 								<dt>Usage</dt>
 								<dd>
@@ -2566,27 +2802,39 @@ Manifest:
 									<ul class="nomark">
 										<li>
 											<p>
-												<a href="#attrdef-id"><code>id</code></a>
-												<code>[optional]</code></p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-spine-page-progression-direction"
-														><code>page-progression-direction</code></a>
-												<code>[optional]</code></p>
-										</li>
-										<li>
-											<p>
-												<a href="#sec-opf2-ncx"><code>toc</code></a>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
 												<code>[optional]</code>
-												<a href="#legacy" class="legacy">(legacy)</a></p>
+											</p>
+										</li>
+										<li>
+											<p>
+												<a href="#attrdef-spine-page-progression-direction">
+													<code>page-progression-direction</code>
+												</a>
+												<code>[optional]</code>
+											</p>
+										</li>
+										<li>
+											<p>
+												<a href="#sec-opf2-ncx">
+													<code>toc</code>
+												</a>
+												<code>[optional]</code>
+												<a href="#legacy" class="legacy">(legacy)</a>
+											</p>
 										</li>
 									</ul>
 								</dd>
 								<dt>Content Model</dt>
 								<dd>
-									<p><a class="codelink" href="#elemdef-spine-itemref"><code>itemref</code></a>
-										<code>[1 or more]</code></p>
+									<p>
+										<a class="codelink" href="#elemdef-spine-itemref">
+											<code>itemref</code>
+										</a>
+										<code>[1 or more]</code>
+									</p>
 								</dd>
 							</dl>
 
@@ -2647,7 +2895,9 @@ Manifest:
 							<dl id="elemdef-spine-itemref" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
-									<p><code>itemref</code></p>
+									<p>
+										<code>itemref</code>
+									</p>
 								</dd>
 								<dt>Usage</dt>
 								<dd>
@@ -2659,23 +2909,35 @@ Manifest:
 									<ul class="nomark">
 										<li>
 											<p>
-												<a href="#attrdef-id"><code>id</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-itemref-idref"><code>idref</code></a>
-												<code>[required]</code></p>
+												<a href="#attrdef-itemref-idref">
+													<code>idref</code>
+												</a>
+												<code>[required]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-itemref-linear"><code>linear</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-itemref-linear">
+													<code>linear</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-properties"><code>properties</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-properties">
+													<code>properties</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 									</ul>
 								</dd>
@@ -2765,7 +3027,9 @@ Manifest:
 							<dl id="elemdef-collection" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
-									<p><code>collection</code></p>
+									<p>
+										<code>collection</code>
+									</p>
 								</dd>
 								<dt>Usage</dt>
 								<dd>
@@ -2776,23 +3040,35 @@ Manifest:
 									<ul class="nomark">
 										<li>
 											<p>
-												<a href="#attrdef-dir"><code>dir</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-dir">
+													<code>dir</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-id"><code>id</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-collection-role"><code>role</code></a>
-												<code>[required]</code></p>
+												<a href="#attrdef-collection-role">
+													<code>role</code>
+												</a>
+												<code>[required]</code>
+											</p>
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-												<code>[optional]</code></p>
+												<a href="#attrdef-xml-lang">
+													<code>xml:lang</code>
+												</a>
+												<code>[optional]</code>
+											</p>
 										</li>
 									</ul>
 								</dd>
@@ -3242,35 +3518,55 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
 								(U+0000 to U+007F). </caption>
 							<tr>
-								<td id="prefix.ebnf.def"><a href="#prefix.ebnf.def">prefixes</a></td>
-								<td><code>=</code></td>
+								<td id="prefix.ebnf.def">
+									<a href="#prefix.ebnf.def">prefixes</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
 								<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
 										>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
 										href="#prefix.ebnf.mapping">mapping</a> } ; </td>
 								<td> </td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.mapping"><a href="#prefix.ebnf.mapping">mapping</a></td>
-								<td><code>=</code></td>
+								<td id="prefix.ebnf.mapping">
+									<a href="#prefix.ebnf.mapping">mapping</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
 								<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space"
 										>space</a> , { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
 								<td> </td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.prefix"><a href="#prefix.ebnf.prefix">prefix</a></td>
-								<td><code>=</code></td>
+								<td id="prefix.ebnf.prefix">
+									<a href="#prefix.ebnf.prefix">prefix</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
 								<td>? xsd:NCName ? ;</td>
 								<td> </td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.space"><a href="#prefix.ebnf.space">space</a></td>
-								<td><code>=</code></td>
+								<td id="prefix.ebnf.space">
+									<a href="#prefix.ebnf.space">space</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
 								<td>#x20 ;</td>
 								<td> </td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.whitespace"><a href="#prefix.ebnf.whitespace">whitespace</a></td>
-								<td><code>=</code></td>
+								<td id="prefix.ebnf.whitespace">
+									<a href="#prefix.ebnf.whitespace">whitespace</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
 								<td>(#x20 | #x9 | #xD | #xA) ;</td>
 								<td> </td>
 							</tr>
@@ -3311,21 +3607,33 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
 								(U+0000 to U+007F). </caption>
 							<tr>
-								<td id="property.ebnf.property"><a href="#property.ebnf.property">property</a></td>
-								<td><code>=</code></td>
+								<td id="property.ebnf.property">
+									<a href="#property.ebnf.property">property</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
 								<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
 										href="#property.ebnf.reference">reference</a>; </td>
 								<td> </td>
 							</tr>
 							<tr>
-								<td id="property.ebnf.prefix"><a href="#property.ebnf.prefix">prefix</a></td>
-								<td><code>=</code></td>
+								<td id="property.ebnf.prefix">
+									<a href="#property.ebnf.prefix">prefix</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
 								<td>? xsd:NCName ? ;</td>
 								<td> </td>
 							</tr>
 							<tr>
-								<td id="property.ebnf.reference"><a href="#property.ebnf.reference">reference</a></td>
-								<td><code>=</code></td>
+								<td id="property.ebnf.reference">
+									<a href="#property.ebnf.reference">reference</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
 								<td>? irelative-ref ? ;</td>
 								<td>/* as defined in [[!RFC3987]] */<br /></td>
 							</tr>
@@ -3903,16 +4211,22 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 									element:</p>
 
 								<dl>
-									<dt id="page-spread-center"><code>rendition:page-spread-center</code></dt>
+									<dt id="page-spread-center">
+										<code>rendition:page-spread-center</code>
+									</dt>
 									<dd>The <code>rendition:page-spread-center</code> property specifies the forced
 										placement of a Content Document in a <a>Synthetic Spread</a>. </dd>
 
-									<dt id="fxl-page-spread-left"><code>rendition:page-spread-left</code></dt>
+									<dt id="fxl-page-spread-left">
+										<code>rendition:page-spread-left</code>
+									</dt>
 									<dd>The <code>rendition:page-spread-left</code> property is an alias for the
 												<code><a href="#page-spread-left">page-spread-left</a></code>
 										property.</dd>
 
-									<dt id="fxl-page-spread-right"><code>rendition:page-spread-right</code></dt>
+									<dt id="fxl-page-spread-right">
+										<code>rendition:page-spread-right</code>
+									</dt>
 									<dd>The <code>rendition:page-spread-right</code> property is an alias for the
 												<code><a href="#page-spread-right">page-spread-right</a></code>
 										property.</dd>
@@ -4043,7 +4357,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<section id="sec-package-nav-content-conf">
 					<h4>Content Conformance</h4>
 
-					<p>A conformant <a>EPUB Navigation Document</a> MUST meet all of the following criteria:</p>
+					<p>A conformant <a>EPUB Navigation Document</a> has to meet the following criteria:</p>
 
 					<dl class="conformance-list">
 						<dt id="confreq-cd-nav-docprops">Document Properties</dt>
@@ -4074,38 +4388,51 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							<dt>Content Model</dt>
 							<dd>
 								<dl class="variablelist">
-									<dt><a href="https://www.w3.org/TR/html/sections.html#the-nav-element"
-												><code>nav</code></a></dt>
+									<dt>
+										<a href="https://www.w3.org/TR/html/sections.html#the-nav-element">
+											<code>nav</code>
+										</a>
+									</dt>
 									<dd>
 										<p>In this order:</p>
 										<ul class="nomark">
 											<li>
 												<p>
-													<a href="https://www.w3.org/TR/html/dom.html#heading-content"
-															><code>HTML Heading content</code></a>
-													<code>[0 or 1]</code></p>
+													<a href="https://www.w3.org/TR/html/dom.html#heading-content">
+														<code>HTML Heading content</code>
+													</a>
+													<code>[0 or 1]</code>
+												</p>
 											</li>
 											<li>
 												<p>
 													<code>ol</code>
-													<code>[exactly 1]</code></p>
+													<code>[exactly 1]</code>
+												</p>
 											</li>
 										</ul>
 									</dd>
-									<dt><a href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element"
-												><code>ol</code></a></dt>
+									<dt>
+										<a href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element">
+											<code>ol</code>
+										</a>
+									</dt>
 									<dd>
 										<p>In this order:</p>
 										<ul class="nomark">
 											<li>
 												<p>
 													<code>li</code>
-													<code>[1 or more]</code></p>
+													<code>[1 or more]</code>
+												</p>
 											</li>
 										</ul>
 									</dd>
-									<dt><a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element"
-												><code>li</code></a></dt>
+									<dt>
+										<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">
+											<code>li</code>
+										</a>
+									</dt>
 									<dd>
 										<p>In this order:</p>
 										<ul class="nomark">
@@ -4115,7 +4442,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 											<li>
 												<p>
 													<code>ol</code>
-													<code>[conditionally required]</code></p>
+													<code>[conditionally required]</code>
+												</p>
 											</li>
 										</ul>
 									</dd>
@@ -4128,9 +4456,11 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 										<ul class="nomark">
 											<li>
 												<p>
-													<a href="https://www.w3.org/TR/html/dom.html#phrasing-content"
-															><code>HTML Phrasing content</code></a>
-													<code>[1 or more]</code></p>
+													<a href="https://www.w3.org/TR/html/dom.html#phrasing-content">
+														<code>HTML Phrasing content</code>
+													</a>
+													<code>[1 or more]</code>
+												</p>
 											</li>
 										</ul>
 									</dd>
@@ -4251,19 +4581,31 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							<p>This specification defines three types of navigation aid:</p>
 
 							<dl class="variablelist">
-								<dt><a href="#sec-nav-toc"><code>toc</code></a></dt>
+								<dt>
+									<a href="#sec-nav-toc">
+										<code>toc</code>
+									</a>
+								</dt>
 								<dd>
 									<p>Identifies the <code>nav</code> element that contains the table of contents. The
 											<code>toc</code>
 										<code>nav</code> is the only navigation aid that has to be included in the EPUB
 										Navigation Document.</p>
 								</dd>
-								<dt><a href="#sec-nav-pagelist"><code>page-list</code></a></dt>
+								<dt>
+									<a href="#sec-nav-pagelist">
+										<code>page-list</code>
+									</a>
+								</dt>
 								<dd>
 									<p>Identifies the <code>nav</code> element that contains a list of pages for a print
 										or other statically-paginated source for the <a>EPUB Publication</a>.</p>
 								</dd>
-								<dt><a href="#sec-nav-landmarks"><code>landmarks</code></a></dt>
+								<dt>
+									<a href="#sec-nav-landmarks">
+										<code>landmarks</code>
+									</a>
+								</dt>
 								<dd>
 									<p>Identifies the <code>nav</code> element that contains a list of points of
 										interest.</p>
@@ -4492,20 +4834,22 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<section id="sec-xhtml-conf-content">
 					<h4>Content Conformance</h4>
 
-					<p>An <a>XHTML Content Document</a> MUST meet all of the following criteria:</p>
+					<p>An <a>XHTML Content Document</a> has to meet the following criteria:</p>
 
 					<dl class="conformance-list">
 						<dt id="confreq-cd-html-docprops">Document Properties</dt>
-						<dd><p id="confreq-cd-html-docprops-syntax">It MUST be an [[!HTML]] document that conforms to
-								the <a href="https://www.w3.org/TR/html/xhtml.html#xhtml">XHTML</a> syntax.</p><p
-								id="confreq-cd-html-xml">It MUST meet the conformance constraints for XML documents
+						<dd>
+							<p id="confreq-cd-html-docprops-syntax">It MUST be an [[!HTML]] document that conforms to
+								the <a href="https://www.w3.org/TR/html/xhtml.html#xhtml">XHTML</a> syntax.</p>
+							<p id="confreq-cd-html-xml">It MUST meet the conformance constraints for XML documents
 								defined in <a href="#sec-xml-constraints"></a>.</p>
 							<p id="confreq-cd-html-docprops-html">For all document constructs used that are defined by
 								[[!HTML]], it MUST conform to the conformance criteria defined for those constructs in
 								that specification, unless explicitly overridden in <a href="#sec-xhtml-deviations"
-								></a>.</p><p id="confreq-cd-html-docprops-schema">It MAY include extensions to the
-								[[!HTML]] grammar as defined in <a href="#sec-xhtml-extensions"></a>, and MUST conform
-								to all content conformance constraints defined therein.</p>
+								></a>.</p>
+							<p id="confreq-cd-html-docprops-schema">It MAY include extensions to the [[!HTML]] grammar
+								as defined in <a href="#sec-xhtml-extensions"></a>, and MUST conform to all content
+								conformance constraints defined therein.</p>
 							<div class="note">
 								<p>The recommendation that EPUB Publications follow the accessibility requirements in
 									[[EPUBAccessibility-10]] applies to XHTML Content Documents. See <a
@@ -4513,8 +4857,10 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							</div>
 						</dd>
 						<dt id="confreq-cd-html-fileprops">File Properties</dt>
-						<dd><p id="confreq-cd-xhtml-fileprops-name">The XHTML Content Document filename SHOULD use the
-								file extension <code>.xhtml</code></p></dd>
+						<dd>
+							<p id="confreq-cd-xhtml-fileprops-name">The XHTML Content Document filename SHOULD use the
+								file extension <code>.xhtml</code></p>
+						</dd>
 					</dl>
 				</section>
 
@@ -4565,17 +4911,29 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 							<dl class="elemdef" id="attrdef-epub-type">
 								<dt>Attribute Name</dt>
-								<dd><p><code>type</code></p></dd>
+								<dd>
+									<p>
+										<code>type</code>
+									</p>
+								</dd>
 								<dt>Namespace</dt>
-								<dd><p><code>http://www.idpf.org/2007/ops</code></p></dd>
+								<dd>
+									<p>
+										<code>http://www.idpf.org/2007/ops</code>
+									</p>
+								</dd>
 								<dt>Usage</dt>
-								<dd><p><a href="https://www.w3.org/TR/html/dom.html#global-attributes">Global
-											attribute</a>. MAY be specified on all elements.</p></dd>
+								<dd>
+									<p><a href="https://www.w3.org/TR/html/dom.html#global-attributes">Global
+											attribute</a>. MAY be specified on all elements.</p>
+								</dd>
 								<dt>Value</dt>
-								<dd><p>A white space-separated list of <a href="#sec-property-datatype">property</a>
+								<dd>
+									<p>A white space-separated list of <a href="#sec-property-datatype">property</a>
 										values, with restrictions as defined in <a
 											href="#sec-contentdocs-vocab-association"></a>.</p>
-									<p>White space is the set of characters as defined in [[!XML]].</p></dd>
+									<p>White space is the set of characters as defined in [[!XML]].</p>
+								</dd>
 							</dl>
 
 							<p>The <code>epub:type</code> attribute inflects semantics on the element on which it
@@ -4768,20 +5126,32 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 							<dl class="elemdef" id="attrdef-ssml-ph">
 								<dt>Attribute Name</dt>
-								<dd><p><code>ph</code></p></dd>
+								<dd>
+									<p>
+										<code>ph</code>
+									</p>
+								</dd>
 								<dt>Namespace</dt>
-								<dd><p><code>https://www.w3.org/2001/10/synthesis</code></p></dd>
+								<dd>
+									<p>
+										<code>https://www.w3.org/2001/10/synthesis</code>
+									</p>
+								</dd>
 								<dt>Usage</dt>
-								<dd><p><a href="https://www.w3.org/TR/html/dom.html#global-attributes">Global
+								<dd>
+									<p><a href="https://www.w3.org/TR/html/dom.html#global-attributes">Global
 											attribute</a>. MAY be specified on all elements with which a phonetic
 										equivalent can logically be associated (e.g., elements that contain textual
 										information).</p>
 									<p>MUST NOT be specified on a descendant of an element that already carries this
-										attribute.</p></dd>
+										attribute.</p>
+								</dd>
 								<dt>Value</dt>
-								<dd><p>A phonemic/phonetic expression, syntactically valid with respect to <a
+								<dd>
+									<p>A phonemic/phonetic expression, syntactically valid with respect to <a
 											href="#sec-cd-ssml-alphabet-attrib">the phonemic/phonetic alphabet being
-											used</a>.</p></dd>
+											used</a>.</p>
+								</dd>
 							</dl>
 
 							<p>This attribute inherits all the semantics of the [[!SSML]] <code>phoneme</code> element
@@ -4789,12 +5159,14 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 										><code>ph</code></a> attribute, with the following addition:</p>
 
 							<ul class="conformance-list">
-								<li><p id="ssml-ph-concat">When the <code>ssml:ph</code> attribute appears on an element
+								<li>
+									<p id="ssml-ph-concat">When the <code>ssml:ph</code> attribute appears on an element
 										that has text node descendants, the corresponding document text to which the
 										pronunciation applies is the string that results from concatenating the
 										descendant text nodes, in document order. The specified phonetic pronunciation
 										MUST therefore logically match the element's textual data in its entirety (i.e.,
-										not just an isolated part of its content).</p></li>
+										not just an isolated part of its content).</p>
+								</li>
 							</ul>
 						</section>
 
@@ -4807,15 +5179,27 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 							<dl class="elemdef" id="attrdef-ssml-alphabet">
 								<dt>Attribute Name</dt>
-								<dd><p><code>alphabet</code></p></dd>
+								<dd>
+									<p>
+										<code>alphabet</code>
+									</p>
+								</dd>
 								<dt>Namespace</dt>
-								<dd><p><code>https://www.w3.org/2001/10/synthesis</code></p></dd>
+								<dd>
+									<p>
+										<code>https://www.w3.org/2001/10/synthesis</code>
+									</p>
+								</dd>
 								<dt>Usage</dt>
-								<dd><p><a href="https://www.w3.org/TR/html/dom.html#global-attributes">Global
-											attribute</a>. MAY be specified on any element.</p></dd>
+								<dd>
+									<p><a href="https://www.w3.org/TR/html/dom.html#global-attributes">Global
+											attribute</a>. MAY be specified on any element.</p>
+								</dd>
 								<dt>Value</dt>
-								<dd><p>The name of the pronunciation alphabet used in the value of <a
-											href="#attrdef-ssml-ph"><code>ssml:ph</code></a> (inherited).</p></dd>
+								<dd>
+									<p>The name of the pronunciation alphabet used in the value of <a
+											href="#attrdef-ssml-ph"><code>ssml:ph</code></a> (inherited).</p>
+								</dd>
 							</dl>
 
 							<p>This attribute inherits all the semantics of the [[!SSML]] <code>phoneme</code> element
@@ -4823,12 +5207,14 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 										><code>alphabet</code></a> attribute, with the following addition:</p>
 
 							<ul class="conformance-list">
-								<li><p id="ssml-alphabet-inherit">The value of the <code>ssml:alphabet</code> attribute
+								<li>
+									<p id="ssml-alphabet-inherit">The value of the <code>ssml:alphabet</code> attribute
 										is inherited in the document tree. The pronunciation alphabet used in a given
 											<code>ssml:ph</code> attribute value is determined by locating the first
 										occurrence of the <code>ssml:alphabet</code> attribute starting with the element
 										on which the <code>ssml:ph</code> attribute appears, followed by the nearest
-										ancestor element.</p></li>
+										ancestor element.</p>
+								</li>
 							</ul>
 
 							<div class="note">
@@ -4877,9 +5263,15 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 						<ul>
 							<li>
-								<p><code>http://www.w3.org/1999/xhtml</code></p></li>
+								<p>
+									<code>http://www.w3.org/1999/xhtml</code>
+								</p>
+							</li>
 							<li>
-								<p><code>http://www.idpf.org/2007/ops</code></p></li>
+								<p>
+									<code>http://www.idpf.org/2007/ops</code>
+								</p>
+							</li>
 						</ul>
 
 						<p>Custom attributes, and the behaviors associated with them, MUST NOT alter the integrity of an
@@ -4923,25 +5315,31 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 							<dl class="conformance-list">
 								<dt id="math-pres">Presentation MathML</dt>
-								<dd><p id="confreq-mathml-pres">The <code>math</code> element MUST contain only <a
+								<dd>
+									<p id="confreq-mathml-pres">The <code>math</code> element MUST contain only <a
 											href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>,
-										with the exception of the <code>annotation-xml</code> element.</p></dd>
+										with the exception of the <code>annotation-xml</code> element.</p>
+								</dd>
 								<dt id="math-cont">Content MathML</dt>
-								<dd><p id="confreq-mathml-annot-cont"><a
+								<dd>
+									<p id="confreq-mathml-annot-cont"><a
 											href="https://www.w3.org/TR/MathML3/chapter4.html">Content MathML</a> MAY be
 										included within MathML markup in XHTML Content Documents, and, when present,
 										MUST occur within an <code>annotation-xml</code> child element of a
-											<code>semantics</code> element.</p><p id="confreq-mathml-annot-cont-attrs"
-										>When Content MathML is included as per the previous condition, the given
-											<code>annotation-xml</code> element's <code>encoding</code> attribute MUST
-										be set to either of the functionally-equivalent values
-											<code>MathML-Content</code> or <code>application/mathml-content+xml</code>,
-										and its <code>name</code> attribute MUST be set to
-										<code>contentequiv</code>.</p></dd>
+											<code>semantics</code> element.</p>
+									<p id="confreq-mathml-annot-cont-attrs">When Content MathML is included as per the
+										previous condition, the given <code>annotation-xml</code> element's
+											<code>encoding</code> attribute MUST be set to either of the
+										functionally-equivalent values <code>MathML-Content</code> or
+											<code>application/mathml-content+xml</code>, and its <code>name</code>
+										attribute MUST be set to <code>contentequiv</code>.</p>
+								</dd>
 								<dt id="math-deprecated">Deprecated MathML</dt>
-								<dd><p id="confreq-mathml-deprecated">Elements and attributes marked as deprecated in
+								<dd>
+									<p id="confreq-mathml-deprecated">Elements and attributes marked as deprecated in
 										[[!MATHML3]] MUST NOT be included within MathML markup in XHTML Content
-										Documents.</p></dd>
+										Documents.</p>
+								</dd>
 							</dl>
 						</section>
 					</section>
@@ -4972,11 +5370,13 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 						<dl class="variablelist">
 							<dt>Private Use Characters and Embedded Fonts</dt>
-							<dd><p id="confreq-html-unicode-pua">Any included characters that map to a code point within
+							<dd>
+								<p id="confreq-html-unicode-pua">Any included characters that map to a code point within
 									one of the Private Use Area (PUA) ranges as defined in [[!Unicode]] MUST occur
 									within a string that is styled or attributed in a manner that includes a reference
 									to an embedded font [[!CSS-Fonts-3]] that contains an appropriate glyph for that
-									code point.</p></dd>
+									code point.</p>
+							</dd>
 						</dl>
 					</section>
 
@@ -5039,7 +5439,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							use:</p>
 
 						<ul>
-							<li><p>If it is the child of a <a
+							<li>
+								<p>If it is the child of a <a
 										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-picture-element"
 											><code>picture</code> element</a>:</p>
 								<ul>
@@ -5063,18 +5464,27 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								Resources</a> without having to provide a fallback Core Media Type Resource:</p>
 
 						<ul>
-							<li><p id="confreq-resources-cd-fallback-link"><a
+							<li>
+								<p id="confreq-resources-cd-fallback-link"><a
 										href="https://www.w3.org/TR/html/document-metadata.html#the-link-element"
 											><code>link</code></a> — when its <code>rel</code> attribute has <a
-										href="#confreq-cd-pls-assoc">the value "<code>pronunciation</code>"</a></p></li>
-							<li><p id="confreq-resources-cd-fallback-track"><a
-										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-track-element"
-											><code>track</code></a></p></li>
-							<li><p id="confreq-resources-cd-fallback-video"><a
+										href="#confreq-cd-pls-assoc">the value "<code>pronunciation</code>"</a></p>
+							</li>
+							<li>
+								<p id="confreq-resources-cd-fallback-track">
+									<a
+										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-track-element">
+										<code>track</code>
+									</a>
+								</p>
+							</li>
+							<li>
+								<p id="confreq-resources-cd-fallback-video"><a
 										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-video-element"
 											><code>video</code></a> — including any child <a
 										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-source-element"
-											><code>source</code></a> elements</p></li>
+											><code>source</code></a> elements</p>
+							</li>
 						</ul>
 
 						<p>Foreign Resources MAY be referenced from the preceding three elements without the provision
@@ -5127,11 +5537,12 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 				<section id="sec-svg-content-conf">
 					<h4>Content Conformance</h4>
-					<p>An <a>SVG Content Document</a> MUST meet all of the following criteria:</p>
+					<p>An <a>SVG Content Document</a> has to meet the following criteria:</p>
 
 					<dl class="conformance-list">
 						<dt id="confreq-svg-docprops">Document Properties</dt>
-						<dd><p id="confreq-cd-svg-xml">It MUST meet the conformance constraints for XML documents
+						<dd>
+							<p id="confreq-cd-svg-xml">It MUST meet the conformance constraints for XML documents
 								defined in <a href="#sec-xml-constraints"></a>.</p>
 							<p id="confreq-resources-svg-fallback">It MAY include references to <a>Foreign Resources</a>
 								provided a fallback to a <a>Core Media Type Resource</a> is included.</p>
@@ -5147,8 +5558,10 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						</dd>
 
 						<dt id="confreq-svg-fileprops">File Properties</dt>
-						<dd><p id="confreq-svg-fileprops-name">The SVG Content Document filename SHOULD use the file
-								extension <code>.svg</code>.</p></dd>
+						<dd>
+							<p id="confreq-svg-fileprops-name">The SVG Content Document filename SHOULD use the file
+								extension <code>.svg</code>.</p>
+						</dd>
 					</dl>
 				</section>
 
@@ -5159,11 +5572,14 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							href="#sec-xhtml-svg">SVG embedded in XHTML Content Documents</a> as follows:</p>
 
 					<ul class="conformance-list">
-						<li><p id="confreq-svg-foreignObject">The [[!SVG]] <a
+						<li>
+							<p id="confreq-svg-foreignObject">The [[!SVG]] <a
 									href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
 										><code>foreignObject</code></a> element MUST adhere to the following
-								criteria:</p><ul class="conformance-list">
-								<li><p id="confreq-svg-foreignObject-xhtml-content">It MUST contain either [[!HTML]] <a
+								criteria:</p>
+							<ul class="conformance-list">
+								<li>
+									<p id="confreq-svg-foreignObject-xhtml-content">It MUST contain either [[!HTML]] <a
 											href="https://www.w3.org/TR/html/dom.html#flow-content">flow content</a> or
 										exactly one [[!HTML]] <a
 											href="https://www.w3.org/TR/html/sections.html#the-body-element"
@@ -5173,17 +5589,24 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 											href="https://www.w3.org/TR/html/semantics-embedded-content.html#svg"
 											>restrictions on SVG</a> defined in [[HTML]].</p>
 								</li>
-								<li><p id="confreq-svg-foreignObject-xhtml-frag">Its content MUST be a valid document
+								<li>
+									<p id="confreq-svg-foreignObject-xhtml-frag">Its content MUST be a valid document
 										fragment that conforms to the XHTML Content Document model defined in <a
-											href="#sec-xhtml-conf-content"></a>.</p></li>
-								<li><p id="confreq-svg-foreignObject-reqext">Its <code>requiredExtensions</code>
+											href="#sec-xhtml-conf-content"></a>.</p>
+								</li>
+								<li>
+									<p id="confreq-svg-foreignObject-reqext">Its <code>requiredExtensions</code>
 										attribute, if given, MUST be set to
-										"<code>http://www.idpf.org/2007/ops</code>".</p></li>
-							</ul></li>
-						<li><p id="confreq-svg-title">The [[!SVG]] <a
+										"<code>http://www.idpf.org/2007/ops</code>".</p>
+								</li>
+							</ul>
+						</li>
+						<li>
+							<p id="confreq-svg-title">The [[!SVG]] <a
 									href="https://www.w3.org/TR/SVG/struct.html#TitleElement"><code>title</code></a>
 								element MUST contain only valid <a href="#confreq-cd-html-docprops">XHTML Content
-									Document Phrasing content</a>.</p></li>
+									Document Phrasing content</a>.</p>
+						</li>
 					</ul>
 				</section>
 
@@ -5220,29 +5643,39 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<section id="sec-css-content-conf">
 					<h4>Content Conformance</h4>
 
-					<p>A conformant CSS style sheet MUST meet all of the following criteria:</p>
+					<p>A conformant CSS style sheet has to meet the following criteria:</p>
 
 					<ul class="conformance-list">
-						<li><p id="confreq-css-props">It MAY include any CSS properties, with the following
-								exceptions:</p><ul class="conformance-list">
-								<li><p id="confreq-css-props-exc-direction">It MUST NOT use the <a
+						<li>
+							<p id="confreq-css-props">It MAY include any CSS properties, with the following
+								exceptions:</p>
+							<ul class="conformance-list">
+								<li>
+									<p id="confreq-css-props-exc-direction">It MUST NOT use the <a
 											href="https://www.w3.org/TR/css3-writing-modes/#direction"
 												><code>direction</code> property</a> [[!CSS-Writing-Modes-3]]. Use the
 										[[!HTML]] <a href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
-												><code>dir</code> attribute</a> to set the inline base
-									direction.</p></li>
-								<li><p id="confreq-css-props-exc-unicode-bidi">It MUST NOT use the <a
+												><code>dir</code> attribute</a> to set the inline base direction.</p>
+								</li>
+								<li>
+									<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT use the <a
 											href="https://www.w3.org/TR/css3-writing-modes/#unicode-bidi"
 												><code>unicode-bidi</code> property</a> [[!CSS-Writing-Modes-3]]. Use
 										[[!HTML]] <a
 											href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdo-element"
 												><code>bdo</code> elements</a> and <a
 											href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
-												><code>dir</code> attributes</a> to control bidirectionality.</p></li>
-							</ul></li>
-						<li><p id="confreq-css-prefixed">It MAY include the prefixed properties defined in <a
-									href="#sec-css-prefixed"></a>.</p></li>
-						<li><p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p></li>
+												><code>dir</code> attributes</a> to control bidirectionality.</p>
+								</li>
+							</ul>
+						</li>
+						<li>
+							<p id="confreq-css-prefixed">It MAY include the prefixed properties defined in <a
+									href="#sec-css-prefixed"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p>
+						</li>
 					</ul>
 
 					<div class="note">
@@ -5252,10 +5685,12 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							<li>
 								<p>Reading System-induced pagination can interact poorly with style sheets. Pagination
 									is sometimes done using columns, which can result in incorrect values for viewport
-									sizes. Fixed and absolute positioning are particularly problematic.</p></li>
+									sizes. Fixed and absolute positioning are particularly problematic.</p>
+							</li>
 							<li>
 								<p>Some types of screens will render animations and transitions poorly (e.g., those with
-									high latency).</p></li>
+									high latency).</p>
+							</li>
 						</ul>
 					</div>
 				</section>
@@ -5295,82 +5730,190 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							</thead>
 							<tbody>
 								<tr>
-									<td><code>-epub-text-orientation</code></td>
-									<td><code>upright</code></td>
-									<td><code>upright</code></td>
-									<td><code>upright</code></td>
+									<td>
+										<code>-epub-text-orientation</code>
+									</td>
+									<td>
+										<code>upright</code>
+									</td>
+									<td>
+										<code>upright</code>
+									</td>
+									<td>
+										<code>upright</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-orientation</code></td>
-									<td><code>mixed</code></td>
-									<td><code>vertical-right</code><span aria-label="deprecated">*</span></td>
-									<td><code>mixed</code></td>
+									<td>
+										<code>-epub-text-orientation</code>
+									</td>
+									<td>
+										<code>mixed</code>
+									</td>
+									<td>
+										<code>vertical-right</code>
+										<span aria-label="deprecated">*</span>
+									</td>
+									<td>
+										<code>mixed</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-orientation</code></td>
-									<td><code>sideways-right</code></td>
-									<td><code>sideways-right</code></td>
-									<td><code>sideways</code></td>
+									<td>
+										<code>-epub-text-orientation</code>
+									</td>
+									<td>
+										<code>sideways-right</code>
+									</td>
+									<td>
+										<code>sideways-right</code>
+									</td>
+									<td>
+										<code>sideways</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-orientation</code></td>
-									<td><code>sideways-right</code></td>
-									<td><code>rotate-right</code><span aria-label="deprecated">*</span></td>
-									<td><code>sideways</code></td>
+									<td>
+										<code>-epub-text-orientation</code>
+									</td>
+									<td>
+										<code>sideways-right</code>
+									</td>
+									<td>
+										<code>rotate-right</code>
+										<span aria-label="deprecated">*</span>
+									</td>
+									<td>
+										<code>sideways</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-orientation</code></td>
-									<td><code>sideways</code></td>
-									<td><code>rotate-normal</code><span aria-label="deprecated">*</span></td>
-									<td><code>sideways</code></td>
+									<td>
+										<code>-epub-text-orientation</code>
+									</td>
+									<td>
+										<code>sideways</code>
+									</td>
+									<td>
+										<code>rotate-normal</code>
+										<span aria-label="deprecated">*</span>
+									</td>
+									<td>
+										<code>sideways</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-orientation</code></td>
-									<td><code>sideways</code></td>
-									<td><code>sideways</code></td>
-									<td><code>sideways</code></td>
+									<td>
+										<code>-epub-text-orientation</code>
+									</td>
+									<td>
+										<code>sideways</code>
+									</td>
+									<td>
+										<code>sideways</code>
+									</td>
+									<td>
+										<code>sideways</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-orientation</code></td>
-									<td><code>mixed</code></td>
-									<td><code>mixed</code></td>
-									<td><code>mixed</code></td>
+									<td>
+										<code>-epub-text-orientation</code>
+									</td>
+									<td>
+										<code>mixed</code>
+									</td>
+									<td>
+										<code>mixed</code>
+									</td>
+									<td>
+										<code>mixed</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-writing-mode</code></td>
-									<td><code>horizontal-tb</code></td>
-									<td><code>horizontal-tb</code></td>
-									<td><code>horizontal-tb</code></td>
+									<td>
+										<code>-epub-writing-mode</code>
+									</td>
+									<td>
+										<code>horizontal-tb</code>
+									</td>
+									<td>
+										<code>horizontal-tb</code>
+									</td>
+									<td>
+										<code>horizontal-tb</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-writing-mode</code></td>
-									<td><code>vertical-rl</code></td>
-									<td><code>vertical-rl</code></td>
-									<td><code>vertical-rl</code></td>
+									<td>
+										<code>-epub-writing-mode</code>
+									</td>
+									<td>
+										<code>vertical-rl</code>
+									</td>
+									<td>
+										<code>vertical-rl</code>
+									</td>
+									<td>
+										<code>vertical-rl</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-writing-mode</code></td>
-									<td><code>vertical-lr</code></td>
-									<td><code>vertical-lr</code></td>
-									<td><code>vertical-lr</code></td>
+									<td>
+										<code>-epub-writing-mode</code>
+									</td>
+									<td>
+										<code>vertical-lr</code>
+									</td>
+									<td>
+										<code>vertical-lr</code>
+									</td>
+									<td>
+										<code>vertical-lr</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-combine</code><span aria-label="deprecated">*</span></td>
-									<td><code>-epub-text-combine-horizontal: none</code></td>
-									<td><code>none</code></td>
-									<td><code>text-combine-upright: none</code></td>
+									<td>
+										<code>-epub-text-combine</code>
+										<span aria-label="deprecated">*</span>
+									</td>
+									<td>
+										<code>-epub-text-combine-horizontal: none</code>
+									</td>
+									<td>
+										<code>none</code>
+									</td>
+									<td>
+										<code>text-combine-upright: none</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-combine</code><span aria-label="deprecated">*</span></td>
-									<td><code>-epub-text-combine-horizontal: all</code></td>
-									<td><code>horizontal</code></td>
-									<td><code>text-combine-upright: all</code></td>
+									<td>
+										<code>-epub-text-combine</code>
+										<span aria-label="deprecated">*</span>
+									</td>
+									<td>
+										<code>-epub-text-combine-horizontal: all</code>
+									</td>
+									<td>
+										<code>horizontal</code>
+									</td>
+									<td>
+										<code>text-combine-upright: all</code>
+									</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-combine</code><span aria-label="deprecated">*</span></td>
+									<td>
+										<code>-epub-text-combine</code>
+										<span aria-label="deprecated">*</span>
+									</td>
 									<td>Error</td>
-									<td><code>horizontal &lt;number&gt;</code></td>
-									<td><code>text-combine-upright: digits &lt;number&gt;</code></td>
+									<td>
+										<code>horizontal &lt;number&gt;</code>
+									</td>
+									<td>
+										<code>text-combine-upright: digits &lt;number&gt;</code>
+									</td>
 								</tr>
 							</tbody>
 						</table>
@@ -5388,34 +5931,60 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							</thead>
 							<tbody>
 								<tr>
-									<td><code>-epub-hyphens</code></td>
-									<td><code>none | manual | auto</code></td>
+									<td>
+										<code>-epub-hyphens</code>
+									</td>
+									<td>
+										<code>none | manual | auto</code>
+									</td>
 									<td>No Change</td>
 								</tr>
 								<tr>
-									<td><code>-epub-hyphens</code></td>
-									<td><code>all</code></td>
+									<td>
+										<code>-epub-hyphens</code>
+									</td>
+									<td>
+										<code>all</code>
+									</td>
 									<td>Not Supported</td>
 								</tr>
 								<tr>
-									<td><code>-epub-line-break</code></td>
-									<td><code>auto | loose | normal | strict</code></td>
+									<td>
+										<code>-epub-line-break</code>
+									</td>
+									<td>
+										<code>auto | loose | normal | strict</code>
+									</td>
 									<td>No Change</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-align-last</code></td>
-									<td><code>auto | start | end | left | right | center | justify</code></td>
+									<td>
+										<code>-epub-text-align-last</code>
+									</td>
+									<td>
+										<code>auto | start | end | left | right | center | justify</code>
+									</td>
 									<td>No Change</td>
 								</tr>
 								<tr>
-									<td><code>-epub-word-break</code></td>
-									<td><code>normal | keep-all | break-all</code></td>
+									<td>
+										<code>-epub-word-break</code>
+									</td>
+									<td>
+										<code>normal | keep-all | break-all</code>
+									</td>
 									<td>No Change</td>
 								</tr>
 								<tr>
-									<td><code>text-transform</code></td>
-									<td><code>-epub-fullwidth</code></td>
-									<td><code>text-transform: full-width</code></td>
+									<td>
+										<code>text-transform</code>
+									</td>
+									<td>
+										<code>-epub-fullwidth</code>
+									</td>
+									<td>
+										<code>text-transform: full-width</code>
+									</td>
 								</tr>
 							</tbody>
 						</table>
@@ -5433,30 +6002,52 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							</thead>
 							<tbody>
 								<tr>
-									<td><code>-epub-text-emphasis-color</code></td>
-									<td><code>&lt;color&gt;</code></td>
+									<td>
+										<code>-epub-text-emphasis-color</code>
+									</td>
+									<td>
+										<code>&lt;color&gt;</code>
+									</td>
 									<td>No Change</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-emphasis-position </code></td>
-									<td><code>[ over | under ] &amp;&amp; [ right | left ]</code></td>
+									<td>
+										<code>-epub-text-emphasis-position </code>
+									</td>
+									<td>
+										<code>[ over | under ] &amp;&amp; [ right | left ]</code>
+									</td>
 									<td>No Change</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-emphasis-style</code></td>
-									<td><code>none | [ [ filled | open ] || [ dot | circle | double-circle | triangle |
-											sesame ] ] | &lt;string&gt;</code></td>
+									<td>
+										<code>-epub-text-emphasis-style</code>
+									</td>
+									<td>
+										<code>none | [ [ filled | open ] || [ dot | circle | double-circle | triangle |
+											sesame ] ] | &lt;string&gt;</code>
+									</td>
 									<td>No Change</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-underline-position</code></td>
-									<td><code>auto | [ under || [ left | right ] ]</code></td>
+									<td>
+										<code>-epub-text-underline-position</code>
+									</td>
+									<td>
+										<code>auto | [ under || [ left | right ] ]</code>
+									</td>
 									<td>No Change</td>
 								</tr>
 								<tr>
-									<td><code>-epub-text-underline-position</code></td>
-									<td><code>alphabetic</code></td>
-									<td><code>text-underline-position: auto</code></td>
+									<td>
+										<code>-epub-text-underline-position</code>
+									</td>
+									<td>
+										<code>alphabetic</code>
+									</td>
+									<td>
+										<code>text-underline-position: auto</code>
+									</td>
 								</tr>
 							</tbody>
 						</table>
@@ -5485,13 +6076,16 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 					<dl class="variablelist">
 						<dt id="sec-scripted-content-type-spine-level">spine-level</dt>
-						<dd><p>An instance of the [[!HTML]] <a
+						<dd>
+							<p>An instance of the [[!HTML]] <a
 									href="https://www.w3.org/TR/html/semantics-scripting.html#the-script-element"
 										><code>script</code></a> or [[!SVG]] <a
 									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
-								element included in a <a>Top-level Content Document</a>.</p></dd>
+								element included in a <a>Top-level Content Document</a>.</p>
+						</dd>
 						<dt id="sec-scripted-content-type-container-constrained">container-constrained</dt>
-						<dd><p>Either of the following:</p>
+						<dd>
+							<p>Either of the following:</p>
 							<ul>
 								<li>
 									<p>An instance of the [[!HTML]] <a
@@ -5500,7 +6094,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 											Document</a> that is embedded in a parent XHTML Content Document using the
 										[[!HTML]] <a
 											href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-iframe-element"
-												><code>iframe</code></a> element.</p></li>
+												><code>iframe</code></a> element.</p>
+								</li>
 								<li>
 									<p>An instance of the [[!SVG]] <a
 											href="https://www.w3.org/TR/SVG/script.html#ScriptElement"
@@ -5508,7 +6103,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 											Document</a> that is embedded in a parent XHTML Content Document using the
 										[[!HTML]] <a
 											href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-iframe-element"
-												><code>iframe</code></a> element.</p></li>
+												><code>iframe</code></a> element.</p>
+								</li>
 							</ul>
 						</dd>
 					</dl>
@@ -5586,11 +6182,13 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							<li>
 								<p>the code in the <code>script</code> element in the <code>head</code> in
 										<code>scripted01.xhtml</code> is a spine-level script because the document is
-									referenced from the spine;</p></li>
+									referenced from the spine;</p>
+							</li>
 							<li>
 								<p>the code in the <code>script</code> element in <code>scripted02.xhtml</code> is a
 									container-constrained script because the HTML file it occurs in is included in
-										<code>scripted01.xhtml</code> via the <code>iframe</code> element.</p></li>
+										<code>scripted01.xhtml</code> via the <code>iframe</code> element.</p>
+							</li>
 						</ul>
 					</aside>
 				</section>
@@ -5600,25 +6198,32 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 					<dl class="conformance-list">
 						<dt>Container-constrained scripts</dt>
-						<dd><p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
+						<dd>
+							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
 								instructions for modifying the DOM of the parent Content Document or other contents in
 								the EPUB Publication, and MUST NOT contain instructions for manipulating the size of its
-								containing rectangle.</p></dd>
+								containing rectangle.</p>
+						</dd>
 						<dt>Spine-level scripts</dt>
-						<dd><p id="confreq-cd-scripted-spine">EPUB Content Documents that include <a
+						<dd>
+							<p id="confreq-cd-scripted-spine">EPUB Content Documents that include <a
 									href="#sec-scripted-content-type-spine-level">spine-level</a> scripting MUST utilize
 								the <em>progressive enhancement technique</em>, which for the purposes of this
 								specification has the following definition: when the document is rendered by a Reading
 								System without scripting support or with scripting support disabled, the <a>Top-level
 									Content Document</a> MUST retain its integrity, remaining consumable by the user
-								without any information loss or other significant deterioration.</p></dd>
+								without any information loss or other significant deterioration.</p>
+						</dd>
 						<dt>Accessibility</dt>
-						<dd><p id="confreq-cd-scripted-a11y">EPUB Content Documents that <a
+						<dd>
+							<p id="confreq-cd-scripted-a11y">EPUB Content Documents that <a
 									href="#sec-scripted-content-models">include scripting</a> SHOULD employ relevant
 								[[!WAI-ARIA]] accessibility techniques to ensure that the content remains consumable by
-								all users.</p></dd>
+								all users.</p>
+						</dd>
 						<dt id="confreq-cd-scripted-flbk">Fallbacks</dt>
-						<dd><p id="confreq-cd-scripted-fallback">EPUB Content Documents that <a
+						<dd>
+							<p id="confreq-cd-scripted-fallback">EPUB Content Documents that <a
 									href="#sec-scripted-content-models">include scripting</a> MAY provide fallbacks for
 								such content, either by using intrinsic fallback mechanisms (such as those available for
 								the [[!HTML]] <a
@@ -5630,7 +6235,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 									fallback</a>.</p>
 							<p id="confreq-cd-scripted-foreign-resources">Authors MUST ensure that scripts only generate
 									<a href="#sec-core-media-types">Core Media Type Resources</a> or fragments
-								thereof.</p></dd>
+								thereof.</p>
+						</dd>
 					</dl>
 
 					<div class="note">
@@ -5662,14 +6268,15 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<section id="sec-fxl-content-conf">
 					<h4>Content Conformance</h4>
 
-					<p>A conformant <a>Fixed-Layout Document</a> MUST meet all of the following criteria:</p>
+					<p>A conformant <a>Fixed-Layout Document</a> has to meet the following criteria:</p>
 
 					<ul class="conformance-list">
 						<li>
 							<p id="confreg-fxl-icb">It MUST specify its <a
 									href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
 									containing block</a> [[!CSS2]] as defined in <a href="#sec-fxl-html-svg-dimensions"
-								></a>.</p></li>
+								></a>.</p>
+						</li>
 					</ul>
 				</section>
 
@@ -5741,29 +6348,36 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<section id="sec-pls-conf-pub">
 					<h4>EPUB Publication Conformance</h4>
 
-					<p>A conformant <a>Rendition</a> of an <a>EPUB Publication</a> MUST meet all of the following
-						criteria for inclusion of <abbr title="Pronunciation Lexicon Specification">PLS</abbr>
-						documents:</p>
+					<p>A conformant <a>Rendition</a> of an <a>EPUB Publication</a> has to meet the following criteria
+						for inclusion of <abbr title="Pronunciation Lexicon Specification">PLS</abbr> documents:</p>
 
 					<ul class="conformance-list">
-						<li><p id="confreq-cd-pls-xht">PLS Documents MAY be associated with <a>XHTML Content
+						<li>
+							<p id="confreq-cd-pls-xht">PLS Documents MAY be associated with <a>XHTML Content
 									Documents</a>. Each XHTML Content Document MAY contain zero or more PLS document
-								associations.</p></li>
-						<li><p id="confreq-cd-pls-assoc">PLS documents MUST be associated with the <a>XHTML Content
+								associations.</p>
+						</li>
+						<li>
+							<p id="confreq-cd-pls-assoc">PLS documents MUST be associated with the <a>XHTML Content
 									Document</a> to which they apply using the [[!HTML]] <a
 									href="https://www.w3.org/TR/html/document-metadata.html#the-link-element"
 										><code>link</code></a> element with its <code>rel</code> attribute set to
 									"<code>pronunciation</code>" and its <code>type</code> attribute set to the media
-								type "<code>application/pls+xml</code>".</p><p id="confreq-cd-pls-assoc-lang">The
-									<code>link</code> element <code>hreflang</code> attribute SHOULD be specified on
-								each <code>link</code>, and its value MUST match <a
+								type "<code>application/pls+xml</code>".</p>
+							<p id="confreq-cd-pls-assoc-lang">The <code>link</code> element <code>hreflang</code>
+								attribute SHOULD be specified on each <code>link</code>, and its value MUST match <a
 									href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/#S4.1">the
 									language for which the pronunciation lexicon is relevant</a>
-								[[!PRONUNCIATION-LEXICON]] when specified.</p></li>
-						<li><p id="confreq-pls-pub-cont">PLS documents MUST meet the content conformance criteria
-								defined in <a href="#sec-pls-conf-content"></a>.</p></li>
-						<li><p id="confreq-pls-pub-manif">PLS documents MUST be represented and located as defined in <a
-									href="#sec-package-conformance"></a>.</p></li>
+								[[!PRONUNCIATION-LEXICON]] when specified.</p>
+						</li>
+						<li>
+							<p id="confreq-pls-pub-cont">PLS documents MUST meet the content conformance criteria
+								defined in <a href="#sec-pls-conf-content"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-pls-pub-manif">PLS documents MUST be represented and located as defined in <a
+									href="#sec-package-conformance"></a>.</p>
+						</li>
 					</ul>
 
 					<section id="pls-examples">
@@ -5789,21 +6403,25 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<section id="sec-pls-conf-content">
 					<h4>Content Conformance</h4>
 
-					<p>A <abbr title="Pronunciation Lexicon Specification">PLS</abbr> document MUST meet all of the
-						following criteria:</p>
+					<p>A <abbr title="Pronunciation Lexicon Specification">PLS</abbr> document has to meet the following
+						criteria:</p>
 
 					<dl class="conformance-list">
 						<dt id="confreq-cd-pls-docprops">Document Properties</dt>
-						<dd><p id="confreq-cd-pls-xml">It MUST meet the conformance constraints for XML documents
+						<dd>
+							<p id="confreq-cd-pls-xml">It MUST meet the conformance constraints for XML documents
 								defined in <a href="#sec-xml-constraints"></a>.</p>
 							<p id="confreq-cd-pls-docprops-schema">It MUST be valid to the RELAX NG schema for PLS
 								documents available at the URI <a class="uri"
 									href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
 										><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/</code></a>
-								[[!PRONUNCIATION-LEXICON]].</p></dd>
+								[[!PRONUNCIATION-LEXICON]].</p>
+						</dd>
 						<dt id="confreq-cd-pls-fileprops">File Properties</dt>
-						<dd><p id="confreq-cd-pls-fileprops-name">The PLS document filename SHOULD use the file
-								extension <code class="filename">.pls</code>.</p></dd>
+						<dd>
+							<p id="confreq-cd-pls-fileprops-name">The PLS document filename SHOULD use the file
+								extension <code class="filename">.pls</code>.</p>
+						</dd>
 					</dl>
 				</section>
 			</section>
@@ -5842,36 +6460,47 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						direct child of the Root Directory and is used to store the following special files:</p>
 
 					<dl class="variablelist">
-						<dt><code>container.xml</code>
-							<code>[required]</code></dt>
+						<dt>
+							<code>container.xml</code>
+							<code>[required]</code>
+						</dt>
 						<dd>
 							<p>Identifies the <a>Package Documents</a> that define each <a>Rendition</a> of the EPUB
 								Publication.</p>
 						</dd>
-						<dt><code>signatures.xml</code>
+						<dt>
+							<code>signatures.xml</code>
 							<code>[optional]</code>
 						</dt>
 						<dd>
 							<p>Contains digital signatures for various assets.</p>
 						</dd>
-						<dt><code>encryption.xml</code>
-							<code>[optional]</code></dt>
+						<dt>
+							<code>encryption.xml</code>
+							<code>[optional]</code>
+						</dt>
 						<dd>
 							<p>Contains information about the encryption of <a>Publication Resources</a>. This file is
 								mandatory when <a href="#sec-resource-obfuscation">obfuscation</a> is used.</p>
 						</dd>
-						<dt><code>metadata.xml</code>
-							<code>[optional]</code></dt>
+						<dt>
+							<code>metadata.xml</code>
+							<code>[optional]</code>
+						</dt>
 						<dd>
 							<p>Used to store metadata about the <a>OCF ZIP Container</a>.</p>
 						</dd>
-						<dt><code>rights.xml</code>
-							<code>[optional]</code></dt>
+						<dt>
+							<code>rights.xml</code>
+							<code>[optional]</code>
+						</dt>
 						<dd>
 							<p>Used to store information about digital rights.</p>
 						</dd>
-						<dt><code>manifest.xml</code>
-							<code>[optional]</code></dt>
+						<dt>
+							<code>manifest.xml</code>
+							<code>[optional]</code>
+						</dt>
 						<dd>
 							<p>A manifest of container contents as allowed by Open Document Format [[ODF]].</p>
 						</dd>
@@ -5955,7 +6584,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						systems.</p>
 
 					<p>In the context of an <a>OCF Abstract Container</a>, <span id="ocf-fn-cs">File and Path Names are
-							case sensitive</span> and MUST meet all of the following criteria:</p>
+							case sensitive</span> and have to meet the following criteria:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -6193,14 +6822,32 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								whether default or specific encryption is requested:</p>
 
 							<ul class="nomark">
-								<li><code>mimetype</code></li>
-								<li><code>META-INF/container.xml</code></li>
-								<li><code>META-INF/encryption.xml</code></li>
-								<li><code>META-INF/manifest.xml</code></li>
-								<li><code>META-INF/metadata.xml</code></li>
-								<li><code>META-INF/rights.xml</code></li>
-								<li><code>META-INF/signatures.xml</code></li>
-								<li><a><code>Package Document</code></a></li>
+								<li>
+									<code>mimetype</code>
+								</li>
+								<li>
+									<code>META-INF/container.xml</code>
+								</li>
+								<li>
+									<code>META-INF/encryption.xml</code>
+								</li>
+								<li>
+									<code>META-INF/manifest.xml</code>
+								</li>
+								<li>
+									<code>META-INF/metadata.xml</code>
+								</li>
+								<li>
+									<code>META-INF/rights.xml</code>
+								</li>
+								<li>
+									<code>META-INF/signatures.xml</code>
+								</li>
+								<li>
+									<a>
+										<code>Package Document</code>
+									</a>
+								</li>
 							</ul>
 
 							<p>Signed resources MAY subsequently be encrypted using the Decryption Transform for XML
@@ -6272,11 +6919,14 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 									<dt>Element Name</dt>
 									<dd>
 										<p>
-											<code>Compression</code></p>
+											<code>Compression</code>
+										</p>
 									</dd>
 									<dt>Namespace</dt>
 									<dd>
-										<p><code>http://www.idpf.org/2016/encryption#compression</code></p>
+										<p>
+											<code>http://www.idpf.org/2016/encryption#compression</code>
+										</p>
 									</dd>
 									<dt>Usage</dt>
 									<dd>
@@ -6805,7 +7455,7 @@ store destination as source in ocf
 				<section id="sec-overlays-content-conf">
 					<h4>Content Conformance</h4>
 
-					<p>A <a>Media Overlay Document</a> MUST meet all of the following criteria:</p>
+					<p>A <a>Media Overlay Document</a> has to meet the following criteria:</p>
 
 					<dl class="conformance-list">
 						<dt id="confreq-mo-docprops">Document Properties</dt>
@@ -6851,7 +7501,8 @@ store destination as source in ocf
 							<dt>Element Name</dt>
 							<dd>
 								<p>
-									<code>smil</code></p>
+									<code>smil</code>
+								</p>
 							</dd>
 							<dt>Usage</dt>
 							<dd>
@@ -6894,13 +7545,19 @@ store destination as source in ocf
 								<ul class="nomark">
 									<li>
 										<p>
-											<a href="#elemdef-smil-head"><code>head</code></a>
-											<code>[0 or 1]</code></p>
+											<a href="#elemdef-smil-head">
+												<code>head</code>
+											</a>
+											<code>[0 or 1]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#elemdef-smil-body"><code>body</code></a>
-											<code>[exactly 1]</code></p>
+											<a href="#elemdef-smil-body">
+												<code>body</code>
+											</a>
+											<code>[exactly 1]</code>
+										</p>
 									</li>
 								</ul>
 							</dd>
@@ -6917,7 +7574,8 @@ store destination as source in ocf
 							<dt>Element Name</dt>
 							<dd>
 								<p>
-									<code>head</code></p>
+									<code>head</code>
+								</p>
 							</dd>
 							<dt>Usage</dt>
 							<dd>
@@ -6930,8 +7588,12 @@ store destination as source in ocf
 							</dd>
 							<dt>Content Model</dt>
 							<dd>
-								<p><a href="#elemdef-smil-metadata"><code>metadata</code></a>
-									<code>[0 or 1]</code></p>
+								<p>
+									<a href="#elemdef-smil-metadata">
+										<code>metadata</code>
+									</a>
+									<code>[0 or 1]</code>
+								</p>
 							</dd>
 						</dl>
 
@@ -6950,7 +7612,8 @@ store destination as source in ocf
 							<dt>Element Name</dt>
 							<dd>
 								<p>
-									<code>metadata</code></p>
+									<code>metadata</code>
+								</p>
 							</dd>
 							<dt>Usage</dt>
 							<dd>
@@ -6982,7 +7645,8 @@ store destination as source in ocf
 							<dt>Element Name</dt>
 							<dd>
 								<p>
-									<code>body</code></p>
+									<code>body</code>
+								</p>
 							</dd>
 							<dt>Usage</dt>
 							<dd>
@@ -7028,13 +7692,19 @@ store destination as source in ocf
 								<ul class="nomark">
 									<li>
 										<p>
-											<a href="#elemdef-smil-seq"><code>seq</code></a>
-											<code>[0 or more]</code></p>
+											<a href="#elemdef-smil-seq">
+												<code>seq</code>
+											</a>
+											<code>[0 or more]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#elemdef-smil-par"><code>par</code></a>
-											<code>[0 or more]</code></p>
+											<a href="#elemdef-smil-par">
+												<code>par</code>
+											</a>
+											<code>[0 or more]</code>
+										</p>
 									</li>
 								</ul>
 								<p>At least one <code>par</code> or <code>seq</code> is REQUIRED.</p>
@@ -7052,7 +7722,8 @@ store destination as source in ocf
 							<dt>Element Name</dt>
 							<dd>
 								<p>
-									<code>seq</code></p>
+									<code>seq</code>
+								</p>
 							</dd>
 							<dt>Usage</dt>
 							<dd>
@@ -7101,13 +7772,19 @@ store destination as source in ocf
 								<ul class="nomark">
 									<li>
 										<p>
-											<a href="#elemdef-smil-seq"><code>seq</code></a>
-											<code>[0 or more]</code></p>
+											<a href="#elemdef-smil-seq">
+												<code>seq</code>
+											</a>
+											<code>[0 or more]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#elemdef-smil-par"><code>par</code></a>
-											<code>[0 or more]</code></p>
+											<a href="#elemdef-smil-par">
+												<code>par</code>
+											</a>
+											<code>[0 or more]</code>
+										</p>
 									</li>
 								</ul>
 								<p>At least one <code>par</code> or <code>seq</code> is REQUIRED.</p>
@@ -7124,7 +7801,8 @@ store destination as source in ocf
 							<dt>Element Name</dt>
 							<dd>
 								<p>
-									<code>par</code></p>
+									<code>par</code>
+								</p>
 							</dd>
 							<dt>Usage</dt>
 							<dd>
@@ -7162,13 +7840,19 @@ store destination as source in ocf
 								<ul class="nomark">
 									<li>
 										<p>
-											<a href="#elemdef-smil-text"><code>text</code></a>
-											<code>[exactly 1]</code></p>
+											<a href="#elemdef-smil-text">
+												<code>text</code>
+											</a>
+											<code>[exactly 1]</code>
+										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#elemdef-smil-audio"><code>audio</code></a>
-											<code>[0 or 1]</code></p>
+											<a href="#elemdef-smil-audio">
+												<code>audio</code>
+											</a>
+											<code>[0 or 1]</code>
+										</p>
 									</li>
 								</ul>
 								<p>The <a href="#elemdef-smil-audio"><code>audio</code> element</a> is OPTIONAL only if
@@ -7190,7 +7874,8 @@ store destination as source in ocf
 							<dt>Element Name</dt>
 							<dd>
 								<p>
-									<code>text</code></p>
+									<code>text</code>
+								</p>
 							</dd>
 							<dt>Usage</dt>
 							<dd>
@@ -7235,7 +7920,8 @@ store destination as source in ocf
 							<dt>Element Name</dt>
 							<dd>
 								<p>
-									<code>audio</code></p>
+									<code>audio</code>
+								</p>
 							</dd>
 							<dt>Usage</dt>
 							<dd>
@@ -7990,8 +8676,10 @@ html.-epub-media-overlay-playing * {
 					true:</p>
 
 				<ul>
-					<li><p><a>Authors</a> are strongly RECOMMENDED not to use the feature in their <a>EPUB
-								Publications</a>.</p></li>
+					<li>
+						<p><a>Authors</a> are strongly RECOMMENDED not to use the feature in their <a>EPUB
+								Publications</a>.</p>
+					</li>
 					<li>
 						<p><a>Reading Systems</a> MAY support the feature.</p>
 						<p class="note">Developers are advised to consider the unlikelihood of encountering content with
@@ -8011,9 +8699,13 @@ html.-epub-media-overlay-playing * {
 					true:</p>
 
 				<ul>
-					<li><p><a>Authors</a> MAY include the legacy feature for compatibility purposes.</p></li>
-					<li><p><a>Reading Systems</a> MUST NOT support the legacy feature in content that conforms to this
-							version of EPUB.</p></li>
+					<li>
+						<p><a>Authors</a> MAY include the legacy feature for compatibility purposes.</p>
+					</li>
+					<li>
+						<p><a>Reading Systems</a> MUST NOT support the legacy feature in content that conforms to this
+							version of EPUB.</p>
+					</li>
 				</ul>
 
 				<p>Validation tools SHOULD NOT alert Authors about the presence of legacy features in an <a>EPUB
@@ -8362,51 +9054,71 @@ EPUB/images/cover.png</pre>
 						[[EPUBAccessibility-10]]</p>
 					<ul>
 						<li>
-							<p><a href="http://www.idpf.org/epub/latest/accessibility/#sec-access-pub">accessible
-									publications</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/latest/accessibility/#sec-access-pub">accessible
+									publications</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/latest/accessibility/#app-auth-consump">authoring and
-									consumption</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/latest/accessibility/#app-auth-consump">authoring and
+									consumption</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/latest/accessibility/#sec-discovery">discovery
-									metadata</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/latest/accessibility/#sec-discovery">discovery
+									metadata</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/latest/accessibility/#sec-distribution">distribution
-									concerns</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/latest/accessibility/#sec-distribution">distribution
+									concerns</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/latest/accessibility/#sec-opt-pubs">optimized
-									publications</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/latest/accessibility/#sec-opt-pubs">optimized
+									publications</a>
+							</p>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-cmt">
-					<p><a href="#sec-core-media-types">core media type resources</a></p>
+					<p>
+						<a href="#sec-core-media-types">core media type resources</a>
+					</p>
 					<ul>
 						<li>
-							<p><a href="#sec-foreign-restrictions">foreign resources</a></p>
-						</li>
-						<li>
-							<p><a href="#sec-foreign-restrictions-manifest">manifest fallbacks</a>
+							<p>
+								<a href="#sec-foreign-restrictions">foreign resources</a>
 							</p>
 						</li>
 						<li>
-							<p><a href="#sec-core-media-types">supported media types</a></p>
+							<p>
+								<a href="#sec-foreign-restrictions-manifest">manifest fallbacks</a>
+							</p>
+						</li>
+						<li>
+							<p>
+								<a href="#sec-core-media-types">supported media types</a>
+							</p>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-css">
-					<p><a href="#sec-css">CSS style sheets</a>
+					<p>
+						<a href="#sec-css">CSS style sheets</a>
 					</p>
 					<ul>
 						<li>
 							<p><a href="epub-rs.html#confreq-css-rs-support">CSS snapshot support</a> [[EPUB-RS-33]]</p>
 						</li>
 						<li>
-							<p><a href="#sec-css-prefixed">prefixed properties</a></p>
+							<p>
+								<a href="#sec-css-prefixed">prefixed properties</a>
+							</p>
 						</li>
 						<li>
 							<p><a href="epub-rs.html#sec-css-rs-overrides">Reading System overrides</a>
@@ -8415,35 +9127,50 @@ EPUB/images/cover.png</pre>
 					</ul>
 				</li>
 				<li id="idx-navdoc">
-					<p><a href="#sec-package-nav">EPUB Navigation Document</a>
+					<p>
+						<a href="#sec-package-nav">EPUB Navigation Document</a>
 					</p>
 					<ul>
 						<li>
-							<p><a href="#sec-package-nav-def-types-other">custom nav elements</a></p>
+							<p>
+								<a href="#sec-package-nav-def-types-other">custom nav elements</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-package-nav-def-hidden">hidden attribute</a></p>
+							<p>
+								<a href="#sec-package-nav-def-hidden">hidden attribute</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-nav-landmarks">landmarks nav element</a></p>
+							<p>
+								<a href="#sec-nav-landmarks">landmarks nav element</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-package-nav-def-model">nav element restrictions</a></p>
+							<p>
+								<a href="#sec-package-nav-def-model">nav element restrictions</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-nav-pagelist">page-list nav element</a></p>
+							<p>
+								<a href="#sec-nav-pagelist">page-list nav element</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-nav-toc">toc nav element</a></p>
+							<p>
+								<a href="#sec-nav-toc">toc nav element</a>
+							</p>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-fxl">
-					<p><a href="#fxl-intro">fixed layouts</a>
+					<p>
+						<a href="#fxl-intro">fixed layouts</a>
 					</p>
 					<ul>
 						<li>
-							<p><a href="#sec-fxl-html-svg-dimensions">content dimensions</a>
+							<p>
+								<a href="#sec-fxl-html-svg-dimensions">content dimensions</a>
 							</p>
 							<ul>
 								<li>
@@ -8456,25 +9183,39 @@ EPUB/images/cover.png</pre>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-package-metadata-fxl">package metadata</a></p>
+							<p>
+								<a href="#sec-package-metadata-fxl">package metadata</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#layout">rendition:layout property</a></p>
+									<p>
+										<a href="#layout">rendition:layout property</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#orientation">rendition:orientation property</a></p>
+									<p>
+										<a href="#orientation">rendition:orientation property</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#page-spread">rendition:page-spread-center property</a></p>
+									<p>
+										<a href="#page-spread">rendition:page-spread-center property</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#page-spread">rendition:page-spread-left property</a></p>
+									<p>
+										<a href="#page-spread">rendition:page-spread-left property</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#page-spread">rendition:page-spread-right property</a></p>
+									<p>
+										<a href="#page-spread">rendition:page-spread-right property</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#spread">rendition:spread property</a></p>
+									<p>
+										<a href="#spread">rendition:spread property</a>
+									</p>
 								</li>
 							</ul>
 						</li>
@@ -8484,69 +9225,107 @@ EPUB/images/cover.png</pre>
 					</ul>
 				</li>
 				<li id="idx-mo">
-					<p><a href="#sec-media-overlays-document-definition">Media Overlays Documents</a></p>
+					<p>
+						<a href="#sec-media-overlays-document-definition">Media Overlays Documents</a>
+					</p>
 					<ul>
 						<li>
-							<p><a href="#sec-escabaility">escapability</a></p>
+							<p>
+								<a href="#sec-escabaility">escapability</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-nav-doc">navigation document playback</a></p>
+							<p>
+								<a href="#sec-nav-doc">navigation document playback</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-docs-package">packaging</a></p>
+							<p>
+								<a href="#sec-docs-package">packaging</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#sec-package-including">attaching to content documents</a></p>
+									<p>
+										<a href="#sec-package-including">attaching to content documents</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-package-metadata">metadata</a></p>
+									<p>
+										<a href="#sec-package-metadata">metadata</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#active-class">active-class property</a></p>
+											<p>
+												<a href="#active-class">active-class property</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#duration">duration property</a></p>
+											<p>
+												<a href="#duration">duration property</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#narrator">narrator property</a></p>
+											<p>
+												<a href="#narrator">narrator property</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#playback-active-class">playback-active-class property</a></p>
+											<p>
+												<a href="#playback-active-class">playback-active-class property</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-skippability">skippability</a></p>
+							<p>
+								<a href="#sec-skippability">skippability</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-smil-smil-elem">smil element</a></p>
+							<p>
+								<a href="#sec-smil-smil-elem">smil element</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#sec-smil-body-elem">body element</a></p>
+									<p>
+										<a href="#sec-smil-body-elem">body element</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#sec-smil-par-elem">par element</a></p>
+											<p>
+												<a href="#sec-smil-par-elem">par element</a>
+											</p>
 											<ul>
 												<li>
-													<p><a href="#sec-smil-audio-elem">audio element</a></p>
+													<p>
+														<a href="#sec-smil-audio-elem">audio element</a>
+													</p>
 												</li>
 												<li>
-													<p><a href="#sec-smil-text-elem">text element</a></p>
+													<p>
+														<a href="#sec-smil-text-elem">text element</a>
+													</p>
 												</li>
 											</ul>
 										</li>
 										<li>
-											<p><a href="#sec-smil-body-elem">seq element</a></p>
+											<p>
+												<a href="#sec-smil-body-elem">seq element</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 								<li>
-									<p><a href="#sec-smil-head-elem">head element</a></p>
+									<p>
+										<a href="#sec-smil-head-elem">head element</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#sec-smil-metadata-elem">metadata element</a></p>
+											<p>
+												<a href="#sec-smil-metadata-elem">metadata element</a>
+											</p>
 										</li>
 									</ul>
 								</li>
@@ -8556,102 +9335,153 @@ EPUB/images/cover.png</pre>
 							<p><a href="#sec-docs-semantic-inflection">semantic inflection</a> (epub:type)</p>
 						</li>
 						<li>
-							<p><a href="#sec-media-overlays-structure">structure</a></p>
+							<p>
+								<a href="#sec-media-overlays-structure">structure</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-docs-assoc-style">styling</a></p>
+							<p>
+								<a href="#sec-docs-assoc-style">styling</a>
+							</p>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-ocf-abstract">
-					<p><a href="#sec-container-abstract">OCF abstract container</a>
+					<p>
+						<a href="#sec-container-abstract">OCF abstract container</a>
 					</p>
 					<ul>
 						<li>
-							<p><a href="#sec-container-file-and-dir-structure">file and directory structure</a></p>
+							<p>
+								<a href="#sec-container-file-and-dir-structure">file and directory structure</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-container-filenames">file name requirements</a></p>
+							<p>
+								<a href="#sec-container-filenames">file name requirements</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-container-metainf">META-INF directory</a></p>
+							<p>
+								<a href="#sec-container-metainf">META-INF directory</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#sec-container-metainf-container.xml">container.xml file</a></p>
+									<p>
+										<a href="#sec-container-metainf-container.xml">container.xml file</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#elemdef-container-link">link element</a></p>
+											<p>
+												<a href="#elemdef-container-link">link element</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#elemdef-container-rootfile">rootfile element</a></p>
+											<p>
+												<a href="#elemdef-container-rootfile">rootfile element</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 								<li>
-									<p><a href="#sec-container-metainf-encryption.xml">encryption.xml file</a></p>
+									<p>
+										<a href="#sec-container-metainf-encryption.xml">encryption.xml file</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#elemdef-encryption-EncryptedData">EncryptedData element</a></p>
+											<p>
+												<a href="#elemdef-encryption-EncryptedData">EncryptedData element</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#elemdef-encryption-EncryptedKey">EncryptedKey element</a></p>
+											<p>
+												<a href="#elemdef-encryption-EncryptedKey">EncryptedKey element</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#elemdef-encryption-encryption">encryption element</a></p>
+											<p>
+												<a href="#elemdef-encryption-encryption">encryption element</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#encryption-obfuscation">listing obfuscated resources</a></p>
+											<p>
+												<a href="#encryption-obfuscation">listing obfuscated resources</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#sec-enc-compression">order of compression and
-												encryption</a></p>
+											<p>
+												<a href="#sec-enc-compression">order of compression and encryption</a>
+											</p>
 											<ul>
 												<li>
-													<p><a href="#elemdef-enc-Compression">Compression element</a></p>
+													<p>
+														<a href="#elemdef-enc-Compression">Compression element</a>
+													</p>
 												</li>
 											</ul>
 										</li>
 										<li>
-											<p><a href="#encryption-restrictions">restricted files</a></p>
+											<p>
+												<a href="#encryption-restrictions">restricted files</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 								<li>
-									<p><a href="#sec-container-metainf-manifest.xml">manifest.xml file</a></p>
+									<p>
+										<a href="#sec-container-metainf-manifest.xml">manifest.xml file</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-container-metainf-metadata.xml">metadata.xml file</a></p>
+									<p>
+										<a href="#sec-container-metainf-metadata.xml">metadata.xml file</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-container-metainf-rights.xml">rights.xml file</a></p>
+									<p>
+										<a href="#sec-container-metainf-rights.xml">rights.xml file</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-container-metainf-signatures.xml">signatures.xml file</a></p>
+									<p>
+										<a href="#sec-container-metainf-signatures.xml">signatures.xml file</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#sig-container">container signature</a></p>
+											<p>
+												<a href="#sig-container">container signature</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#sig-restrictions">signature restrictions</a></p>
+											<p>
+												<a href="#sig-restrictions">signature restrictions</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-container-iri">relative path references</a></p>
+							<p>
+								<a href="#sec-container-iri">relative path references</a>
+							</p>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-ocf-zip">
-					<p><a href="#sec-container-zip">OCF ZIP container</a>
+					<p>
+						<a href="#sec-container-zip">OCF ZIP container</a>
 					</p>
 					<ul>
 						<li>
-							<p><a href="#sec-container-metainf-encryption.xml">encryption</a></p>
+							<p>
+								<a href="#sec-container-metainf-encryption.xml">encryption</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#encryption-restrictions">restricted files</a></p>
+									<p>
+										<a href="#encryption-restrictions">restricted files</a>
+									</p>
 								</li>
 							</ul>
 							<p></p>
@@ -8663,88 +9493,133 @@ EPUB/images/cover.png</pre>
 							<p><a href="#sec-resource-obfuscation">obfuscation</a> (was font obfuscation)</p>
 							<ul>
 								<li>
-									<p><a href="#obfus-algorithm">algorithm</a></p>
+									<p>
+										<a href="#obfus-algorithm">algorithm</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#obfus-specifying">identifying resources</a></p>
+									<p>
+										<a href="#obfus-specifying">identifying resources</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#obfus-keygen">key</a></p>
+									<p>
+										<a href="#obfus-keygen">key</a>
+									</p>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-zip-container-zipreqs">ZIP requirements</a></p>
+							<p>
+								<a href="#sec-zip-container-zipreqs">ZIP requirements</a>
+							</p>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-pkg">
-					<p><a href="#sec-package-doc">Package Document</a>
+					<p>
+						<a href="#sec-package-doc">Package Document</a>
 					</p>
 					<ul>
 						<li>
-							<p><a href="#sec-collection-elem">collection element</a></p>
+							<p>
+								<a href="#sec-collection-elem">collection element</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#elemdef-collection-link">linking resources</a></p>
+									<p>
+										<a href="#elemdef-collection-link">linking resources</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#elemdef-collection-metadata">metadata</a></p>
+									<p>
+										<a href="#elemdef-collection-metadata">metadata</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#attrdef-collection-role">roles</a></p>
+									<p>
+										<a href="#attrdef-collection-role">roles</a>
+									</p>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-metadata-default-vocab">default vocabularies</a></p>
+							<p>
+								<a href="#sec-metadata-default-vocab">default vocabularies</a>
+							</p>
 						</li>
 						<li>
 							<p><a href="#sec-package-metadata-fxl">fixed layout properties</a> — see also <a
 									href="#idx-fxl">fixed layouts</a></p>
 						</li>
 						<li>
-							<p><a href="#sec-package-metadata-identifiers">identifiers</a></p>
+							<p>
+								<a href="#sec-package-metadata-identifiers">identifiers</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#sec-metadata-elem-identifiers-pid">release identifier</a></p>
+									<p>
+										<a href="#sec-metadata-elem-identifiers-pid">release identifier</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-metadata-elem-identifiers-uid">unique identifier</a></p>
+									<p>
+										<a href="#sec-metadata-elem-identifiers-uid">unique identifier</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#attrdef-package-unique-identifier">unique-identifier attribute</a></p>
+									<p>
+										<a href="#attrdef-package-unique-identifier">unique-identifier attribute</a>
+									</p>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-package-metadata-rendering">layout properties</a></p>
+							<p>
+								<a href="#sec-package-metadata-rendering">layout properties</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#align-x-center">rendition:align-x-center property</a></p>
+									<p>
+										<a href="#align-x-center">rendition:align-x-center property</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#flow">rendition:flow property</a></p>
+									<p>
+										<a href="#flow">rendition:flow property</a>
+									</p>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-metadata-elem">metadata element</a></p>
+							<p>
+								<a href="#sec-metadata-elem">metadata element</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#core-metadata-reqs">core metadata requirements</a></p>
+									<p>
+										<a href="#core-metadata-reqs">core metadata requirements</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-opf-dcidentifier">dc:identifier element</a></p>
+									<p>
+										<a href="#sec-opf-dcidentifier">dc:identifier element</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-opf-dclanguage">dc:language element</a></p>
+									<p>
+										<a href="#sec-opf-dclanguage">dc:language element</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-opf-dctitle">dc:title element</a></p>
+									<p>
+										<a href="#sec-opf-dctitle">dc:title element</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#title-order">importance of order</a></p>
+											<p>
+												<a href="#title-order">importance of order</a>
+											</p>
 										</li>
 									</ul>
 								</li>
@@ -8753,153 +9628,236 @@ EPUB/images/cover.png</pre>
 										modified date)</p>
 								</li>
 								<li>
-									<p><a href="#sec-opf-dcmes-optional">Dublin Core optional elements</a></p>
+									<p>
+										<a href="#sec-opf-dcmes-optional">Dublin Core optional elements</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#sec-opf-dccontributor">contributors</a></p>
+											<p>
+												<a href="#sec-opf-dccontributor">contributors</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#sec-opf-dccreator">creators</a></p>
+											<p>
+												<a href="#sec-opf-dccreator">creators</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#sec-opf-dcdate">publication date</a></p>
+											<p>
+												<a href="#sec-opf-dcdate">publication date</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#sec-opf-dctype">publication types</a></p>
+											<p>
+												<a href="#sec-opf-dctype">publication types</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#sec-opf-dcsubject">subjects</a></p>
+											<p>
+												<a href="#sec-opf-dcsubject">subjects</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 								<li>
-									<p><a href="#sec-link-elem">link element</a></p>
+									<p>
+										<a href="#sec-link-elem">link element</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#attrdef-link-rel">link relationships</a></p>
+											<p>
+												<a href="#attrdef-link-rel">link relationships</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#linked-res-manifest">manifest requirements</a></p>
+											<p>
+												<a href="#linked-res-manifest">manifest requirements</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#sec-linked-records">linked metadata records</a></p>
+											<p>
+												<a href="#sec-linked-records">linked metadata records</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#linked-res-location">resource location</a></p>
+											<p>
+												<a href="#linked-res-location">resource location</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 								<li>
-									<p><a href="#sec-meta-elem">meta element</a></p>
+									<p>
+										<a href="#sec-meta-elem">meta element</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#attrdef-meta-property">expressing properties</a></p>
+											<p>
+												<a href="#attrdef-meta-property">expressing properties</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#attrdef-refines">refines attribute</a></p>
+											<p>
+												<a href="#attrdef-refines">refines attribute</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#attrdef-scheme">value scheme</a></p>
+											<p>
+												<a href="#attrdef-scheme">value scheme</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-manifest-elem">manifest element</a></p>
+							<p>
+								<a href="#sec-manifest-elem">manifest element</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#sec-item-elem">item element</a></p>
+									<p>
+										<a href="#sec-item-elem">item element</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#attrdef-item-fallback">fallbacks</a></p>
+											<p>
+												<a href="#attrdef-item-fallback">fallbacks</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#attrdef-item-media-overlay">media overlay association</a></p>
+											<p>
+												<a href="#attrdef-item-media-overlay">media overlay association</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#attrdef-item-media-type">media type</a></p>
+											<p>
+												<a href="#attrdef-item-media-type">media type</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#attrdef-item-properties">properties</a></p>
+											<p>
+												<a href="#attrdef-item-properties">properties</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#manifest-inclusion">resource inclusion requirements</a></p>
+											<p>
+												<a href="#manifest-inclusion">resource inclusion requirements</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-opf2-ncx">NCX (legacy)</a></p>
+							<p>
+								<a href="#sec-opf2-ncx">NCX (legacy)</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-package-elem">package element</a></p>
+							<p>
+								<a href="#sec-package-elem">package element</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#attrdef-package-version">prefix declarations</a></p>
+									<p>
+										<a href="#attrdef-package-version">prefix declarations</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#attrdef-package-version">version number</a></p>
+									<p>
+										<a href="#attrdef-package-version">version number</a>
+									</p>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-property-datatype">property data type</a></p>
+							<p>
+								<a href="#sec-property-datatype">property data type</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/prefixes/packages/">reserved prefixes</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/prefixes/packages/">reserved prefixes</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-shared-attrs">shared attributes</a></p>
+							<p>
+								<a href="#sec-shared-attrs">shared attributes</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-spine-elem">spine element</a></p>
+							<p>
+								<a href="#sec-spine-elem">spine element</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#sec-itemref-elem">itemref element</a></p>
+									<p>
+										<a href="#sec-itemref-elem">itemref element</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="#attrdef-itemref-linear">linearity</a></p>
+											<p>
+												<a href="#attrdef-itemref-linear">linearity</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="#attrdef-itemref-idref">referencing manifest items</a></p>
+											<p>
+												<a href="#attrdef-itemref-idref">referencing manifest items</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 								<li>
-									<p><a href="#attrdef-spine-page-progression-direction">page progression</a></p>
+									<p>
+										<a href="#attrdef-spine-page-progression-direction">page progression</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#spine-inclusion-req">resource inclusion requirements</a></p>
+									<p>
+										<a href="#spine-inclusion-req">resource inclusion requirements</a>
+									</p>
 								</li>
 							</ul>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-registries">
-					<p><a href="http://www.idpf.org/epub/registries/">registries</a></p>
+					<p>
+						<a href="http://www.idpf.org/epub/registries/">registries</a>
+					</p>
 					<ul>
 						<li>
-							<p><a href="http://www.idpf.org/epub/registries/roles/">Collection Roles</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/registries/roles/">Collection Roles</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/registries/optimizations/">Optimized Publication
-									Standards</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/registries/optimizations/">Optimized Publication
+									Standards</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/registries/types/">Publication Types</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/registries/types/">Publication Types</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/registries/authorities/">Subject Authorities</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/registries/authorities/">Subject Authorities</a>
+							</p>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-remote-res">
-					<p><a href="#sec-resource-locations">remote resources</a></p>
+					<p>
+						<a href="#sec-resource-locations">remote resources</a>
+					</p>
 				</li>
 				<li id="idx-script">
-					<p><a href="#sec-scripted-content">scripting</a>
+					<p>
+						<a href="#sec-scripted-content">scripting</a>
 					</p>
 					<ul>
 						<li>
@@ -8910,24 +9868,36 @@ EPUB/images/cover.png</pre>
 								[[EPUB-RS-33]]</p>
 							<ul>
 								<li>
-									<p><a href="epub-rs.html#app-ers-desc">description</a></p>
+									<p>
+										<a href="epub-rs.html#app-ers-desc">description</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="epub-rs.html#app-ers-hasFeature">hasFeature method</a></p>
+									<p>
+										<a href="epub-rs.html#app-ers-hasFeature">hasFeature method</a>
+									</p>
 									<ul>
 										<li>
-											<p><a href="epub-rs.html#app-ers-hasFeature-desc">description</a></p>
+											<p>
+												<a href="epub-rs.html#app-ers-hasFeature-desc">description</a>
+											</p>
 										</li>
 										<li>
-											<p><a href="epub-rs.html#app-ers-hasFeature-features">features</a></p>
+											<p>
+												<a href="epub-rs.html#app-ers-hasFeature-features">features</a>
+											</p>
 										</li>
 									</ul>
 								</li>
 								<li>
-									<p><a href="epub-rs.html#app-ers-idl">interface definition</a></p>
+									<p>
+										<a href="epub-rs.html#app-ers-idl">interface definition</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="epub-rs.html#app-ers-properties">properties</a></p>
+									<p>
+										<a href="epub-rs.html#app-ers-properties">properties</a>
+									</p>
 								</li>
 							</ul>
 						</li>
@@ -8940,69 +9910,99 @@ EPUB/images/cover.png</pre>
 					</ul>
 				</li>
 				<li id="idx-svg">
-					<p><a href="#sec-svg">SVG Content Documents</a>
+					<p>
+						<a href="#sec-svg">SVG Content Documents</a>
 					</p>
 					<ul>
 						<li>
-							<p><a href="#sec-svg-restrictions">restrictions</a></p>
+							<p>
+								<a href="#sec-svg-restrictions">restrictions</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-svg-semantic-inflection">semantic inflection</a></p>
+							<p>
+								<a href="#sec-svg-semantic-inflection">semantic inflection</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-overview-relations-svg">SVG version conformance</a></p>
+							<p>
+								<a href="#sec-overview-relations-svg">SVG version conformance</a>
+							</p>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-terminology">
-					<p><a href="#sec-terminology">terminology</a></p>
+					<p>
+						<a href="#sec-terminology">terminology</a>
+					</p>
 				</li>
 				<li id="idx-vocabs">
 					<p>vocabularies</p>
 					<ul>
 						<li>
-							<p><a href="http://www.idpf.org/epub/vocab/package/a11y/">Accessibility</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/vocab/package/a11y/">Accessibility</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/vocab/package/link/">Link</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/vocab/package/link/">Link</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/vocab/package/item/">Manifest Properties</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/vocab/package/item/">Manifest Properties</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/vocab/overlays/">Media Overlays</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/vocab/overlays/">Media Overlays</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/vocab/package/meta/">Meta Properties</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/vocab/package/meta/">Meta Properties</a>
+							</p>
 						</li>
 						<li>
 							<p><a href="http://www.idpf.org/vocab/rendition/">Publication Rendering</a> (rendition:
 								properties)</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/vocab/package/itemref/">Spine Properties</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/vocab/package/itemref/">Spine Properties</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="http://www.idpf.org/epub/vocab/structure/">Structural Semantics</a></p>
+							<p>
+								<a href="http://www.idpf.org/epub/vocab/structure/">Structural Semantics</a>
+							</p>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-xhtml">
-					<p><a href="#sec-xhtml">XHTML Content Documents</a>
+					<p>
+						<a href="#sec-xhtml">XHTML Content Documents</a>
 					</p>
 					<ul>
 						<li>
-							<p><a href="#sec-xhtml-custom-attributes">custom attributes</a></p>
+							<p>
+								<a href="#sec-xhtml-custom-attributes">custom attributes</a>
+							</p>
 						</li>
 						<li>
 							<p><a href="#sec-xhtml-deviations-discouraged">discouraged constructs</a> (<code>rp</code>
 								and <code>embed</code>)</p>
 						</li>
 						<li>
-							<p><a href="#sec-xhtml-mathml">embedded MathML</a></p>
+							<p>
+								<a href="#sec-xhtml-mathml">embedded MathML</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-xhtml-svg">embedded SVG</a></p>
+							<p>
+								<a href="#sec-xhtml-svg">embedded SVG</a>
+							</p>
 							<ul>
 								<li>
 									<p><a href="epub-rs.html#sec-xhtml-svg-css">application of CSS styles</a>
@@ -9011,55 +10011,83 @@ EPUB/images/cover.png</pre>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-xhtml-fallbacks">foreign resource restrictions</a></p>
+							<p>
+								<a href="#sec-xhtml-fallbacks">foreign resource restrictions</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-overview-relations-html">HTML version conformance</a></p>
+							<p>
+								<a href="#sec-overview-relations-html">HTML version conformance</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-pls">pronunciation lexicons (PLS)</a></p>
+							<p>
+								<a href="#sec-pls">pronunciation lexicons (PLS)</a>
+							</p>
 						</li>
 						<li>
 							<p><a href="#sec-xhtml-semantic-enrichment">RDFa and microdata</a> (semantic enrichment)</p>
 						</li>
 						<li>
-							<p><a href="#sec-xhtml-semantic-inflection">semantic inflection</a></p>
+							<p>
+								<a href="#sec-xhtml-semantic-inflection">semantic inflection</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#sec-contentdocs-default-vocab">default vocabulary</a></p>
+									<p>
+										<a href="#sec-contentdocs-default-vocab">default vocabulary</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-epub-type-attribute">epub:type attribute</a></p>
+									<p>
+										<a href="#sec-epub-type-attribute">epub:type attribute</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-contentdocs-prefix-attr">prefix declarations</a></p>
+									<p>
+										<a href="#sec-contentdocs-prefix-attr">prefix declarations</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-contentdocs-reserved-prefixes">reserved prefixes</a></p>
+									<p>
+										<a href="#sec-contentdocs-reserved-prefixes">reserved prefixes</a>
+									</p>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-xhtml-ssml-attrib">Speech Synthesis Markup Language (SSML)</a></p>
+							<p>
+								<a href="#sec-xhtml-ssml-attrib">Speech Synthesis Markup Language (SSML)</a>
+							</p>
 							<ul>
 								<li>
-									<p><a href="#sec-cd-ssml-ph-attrib">ssml:ph attribute</a></p>
+									<p>
+										<a href="#sec-cd-ssml-ph-attrib">ssml:ph attribute</a>
+									</p>
 								</li>
 								<li>
-									<p><a href="#sec-cd-ssml-alphabet-attrib">ssml:alphabet attribute</a></p>
+									<p>
+										<a href="#sec-cd-ssml-alphabet-attrib">ssml:alphabet attribute</a>
+									</p>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="#sec-xhtml-svg">SVG</a></p>
+							<p>
+								<a href="#sec-xhtml-svg">SVG</a>
+							</p>
 						</li>
 						<li>
-							<p><a href="#sec-xhtml-deviations-unicode">Unicode restrictions</a></p>
+							<p>
+								<a href="#sec-xhtml-deviations-unicode">Unicode restrictions</a>
+							</p>
 						</li>
 					</ul>
 				</li>
 				<li id="idx-xml">
-					<p><a href="#sec-xml-constraints">XML conformance</a></p>
+					<p>
+						<a href="#sec-xml-constraints">XML conformance</a>
+					</p>
 				</li>
 			</ul>
 		</section>
@@ -9080,11 +10108,15 @@ EPUB/images/cover.png</pre>
 				<dl class="variablelist">
 					<dt>MIME media type name:</dt>
 					<dd>
-						<p><code>application</code></p>
+						<p>
+							<code>application</code>
+						</p>
 					</dd>
 					<dt>MIME subtype name:</dt>
 					<dd>
-						<p><code>oebps-package+xml</code></p>
+						<p>
+							<code>oebps-package+xml</code>
+						</p>
 					</dd>
 					<dt>Required parameters:</dt>
 					<dd>
@@ -9173,7 +10205,9 @@ EPUB/images/cover.png</pre>
 							</dd>
 							<dt>File extension(s):</dt>
 							<dd>
-								<p><code>.opf</code></p>
+								<p>
+									<code>.opf</code>
+								</p>
 							</dd>
 							<dt>Macintosh File Type Code(s):</dt>
 							<dd>
@@ -9218,11 +10252,15 @@ EPUB/images/cover.png</pre>
 				<dl class="variablelist">
 					<dt>MIME media type name:</dt>
 					<dd>
-						<p><code>application</code></p>
+						<p>
+							<code>application</code>
+						</p>
 					</dd>
 					<dt>MIME subtype name:</dt>
 					<dd>
-						<p><code>epub+zip</code></p>
+						<p>
+							<code>epub+zip</code>
+						</p>
 					</dd>
 					<dt>Required parameters:</dt>
 					<dd>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -26,7 +26,15 @@
 					company: "Hachette Livre",
 					companyURL: "https://www.hachettebookgroup.com",
 				}, {
+					name: "Marisa DeMeglio",
+					company: "DAISY Consortium",
+					companyURL: "https://www.daisy.org"
+				}, {
 					name: "Matt Garrish",
+					company: "DAISY Consortium",
+					companyURL: "https://www.daisy.org"
+				}, {
+					name: "Daniel Weck",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
 				}],
@@ -118,7 +126,8 @@
 		<section id="sec-rs-conf-general">
 			<h2>Conformance Requirements</h2>
 
-			<p>An <a>EPUB Reading System</a> MUST meet the following requirements to conform to this specification.</p>
+			<p>An <a>EPUB Reading System</a> is conformant with this specification if it meets the following
+				requirements:</p>
 
 			<dl class="conformance-list">
 				<dt id="sec-epub-rs-conf-epub3">EPUB 3 Processing</dt>
@@ -149,7 +158,7 @@
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-svg">It MUST process <a>SVG Content Documents</a> as defined in <a
-									href="#sec-svg-rs-conf"></a>.</p>
+									href="#sec-svg"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-css">If it has a <a>Viewport</a>, it MUST support visual rendering
@@ -246,7 +255,8 @@
 			<section id="sec-package-rs-conformance">
 				<h3>Basic Conformance</h3>
 
-				<p>An <a>EPUB Reading System</a> MUST meet all of the following criteria:</p>
+				<p>An <a>EPUB Reading System</a> is conformant with this section if meets all of the following
+					criteria:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -281,169 +291,164 @@
 			</section>
 
 			<section id="sec-package-def">
-				<h3>Package Document Definition</h3>
+				<h3>Package Document</h3>
 
 				<section id="metadata">
 					<h4>Metadata</h4>
 
-					<section id="dublin-core">
-						<h5>Dublin Core Metadata</h5>
+					<div class="note">
+						<p>When an element has mandatory text content, that content is referred to as the value of the
+							element in the following requirements.</p>
+					</div>
 
-						<p>In addition to the following element-specific requirements, Reading Systems MUST trim all
-							leading and trailing <a href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]]
-							from Dublin Core element values before processing.</p>
+					<dl class="conformance-list">
+						<dt id="conf-meta-ws">White Space</dt>
+						<dd>
+							<p>Reading Systems MUST trim all leading and trailing <a
+									href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] from Dublin Core
+								element values before processing.</p>
 
-						<section id="dc-identifier">
-							<h6>The <code>identifier</code> element</h6>
+							<p>Unless an individual property explicitly defines a different white space normalization
+								algorithm, Reading Systems MUST trim all leading and trailing <a
+									href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] from
+									<code>meta</code> element values before further processing them.</p>
+						</dd>
 
+						<dt id="dc-identifier">The <code>identifier</code> element</dt>
+						<dd>
 							<p>To determine whether an <code>identifier</code> conforms to an established system or has
 								been granted by an issuing authority, Reading Systems SHOULD check for an <a
 									href="epub-core.html#identifier-type"><code>identifier-type</code> property</a>
 								[[!EPUB-33]].</p>
-						</section>
+						</dd>
 
-						<section id="dc-title">
-							<h6>The <code>title</code> element</h6>
-
+						<dt id="dc-title">The <code>title</code> element</dt>
+						<dd>
 							<p id="title-order"><a>Reading Systems</a> MUST recognize the first <code>title</code>
 								element in document order as the main title of the EPUB Publication (i.e., the primary
 								one to present to users). This specification does not define how to process additional
 									<code>title</code> elements.</p>
-						</section>
+						</dd>
 
-						<section id="dc-creator">
-							<h6>The <code>creator</code> element</h6>
-
+						<dt id="dc-creator">The <code>creator</code> element</dt>
+						<dd>
 							<p>When determining display priority, Reading Systems MUST use the document order of
 									<code>creator</code> elements in the <code>metadata</code> section, where the first
 									<code>creator</code> element encountered is the primary creator. If a Reading System
 								exposes creator metadata to the user, it SHOULD include all the creators listed in the
 									<code>metadata</code> section whenever possible (e.g., when not constrained by
 								display considerations).</p>
-						</section>
-					</section>
+						</dd>
 
-					<section id="meta">
-						<h5>The <code>meta</code> element</h5>
+						<dt id="meta">The <code>meta</code> element</dt>
+						<dd>
+							<p>If a Reading System does not recognize the <code>scheme</code> attribute value, it SHOULD
+								treat the value of the element as a string.</p>
 
-						<p>If a Reading System does not recognize the <code>scheme</code> attribute value, it SHOULD
-							treat the value of the element as a string.</p>
+							<p>Reading Systems SHOULD ignore all <code>meta</code> elements whose <code>property</code>
+								attributes define expressions they do not recognize. A Reading System MUST NOT fail when
+								encountering unknown expressions.</p>
+						</dd>
 
-						<p>Reading Systems SHOULD ignore all <code>meta</code> elements whose <code>property</code>
-							attributes define expressions they do not recognize. A Reading System MUST NOT fail when
-							encountering unknown expressions.</p>
+						<dt id="conf-metadata-link">The <code>link</code> element</dt>
+						<dd>
+							<p>Retrieval of Remote Resources is OPTIONAL.</p>
 
-						<p>Unless an individual property explicitly defines a different white space normalization
-							algorithm, Reading Systems MUST trim all leading and trailing <a
-								href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] from the
-								<code>meta</code> element values before further processing them.</p>
-					</section>
+							<p>Reading System do not have to use or present linked resources, even if they recognize the
+								relationship defined in the <code>rel</code> attribute.</p>
 
-					<section id="link">
-						<h5>The <code>link</code> element</h5>
+							<p id="sec-linked-records">In the case of a <a href="epub-core.html#record">linked metadata
+									record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing the metadata
+								expressed in the Package Document and only use the information expressed in the record.
+								Reading Systems MAY compile metadata from multiple linked records; they do not have to
+								select only one record.</p>
 
-						<p>Retrieval of Remote Resources is OPTIONAL.</p>
+							<p>When it comes to resolving discrepancies and conflicts between metadata expressed in the
+								Package Document and in linked metadata records, Reading Systems MUST use the document
+								order of <code>link</code> elements in the Package Document to establish precedence
+								(i.e., metadata in the first linked record encountered has the highest precedence and
+								metadata in the Package Document the lowest, regardless of whether the <code>link</code>
+								elements occur before, within or after the package metadata elements).</p>
 
-						<p>Reading System do not have to use or present linked resources, even if they recognize the
-							relationship defined in the <code>rel</code> attribute.</p>
-
-						<p id="sec-linked-records">In the case of a <a href="epub-core.html#record">linked metadata
-								record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing the metadata expressed
-							in the Package Document and only use the information expressed in the record. Reading
-							Systems MAY compile metadata from multiple linked records; they do not have to select only
-							one record.</p>
-
-						<p>When it comes to resolving discrepancies and conflicts between metadata expressed in the
-							Package Document and in linked metadata records, Reading Systems MUST use the document order
-							of <code>link</code> elements in the Package Document to establish precedence (i.e.,
-							metadata in the first linked record encountered has the highest precedence and metadata in
-							the Package Document the lowest, regardless of whether the <code>link</code> elements occur
-							before, within or after the package metadata elements).</p>
-
-						<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
-							layout and rendering of the EPUB Publication.</p>
-					</section>
+							<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
+								layout and rendering of the EPUB Publication.</p>
+						</dd>
+					</dl>
 				</section>
 
 				<section id="manifest">
 					<h3>Manifest</h3>
+					<dl class="conformance-list">
+						<dt>The <code>item</code> element</dt>
+						<dd>
+							<p>When an <code>href</code> attribute contains a relative IRI, Reading Systems MUST use the
+								IRI of the Package Document as the base when resolving to an absolute IRI.</p>
 
-					<section id="item">
-						<h4>The <code>item</code> element</h4>
+							<p>Reading Systems MAY optimize the rendering depending on the properties set in the
+									<code>properties</code> attribute (e.g., disable a rendering process or use a
+								fallback). Reading Systems MUST ignore all descriptive metadata properties that they do
+								not recognize.</p>
 
-						<p>When an <code>href</code> attribute contains a relative IRI, Reading Systems MUST use the IRI
-							of the Package Document as the base when resolving to an absolute IRI.</p>
-
-						<p>Reading Systems MAY optimize the rendering depending on the properties set in the
-								<code>properties</code> attribute (e.g., disable a rendering process or use a fallback).
-							Reading Systems MUST ignore all descriptive metadata properties that they do not
-							recognize.</p>
-
-						<p>A Reading System that does not support the Media Type of a given Publication Resource MUST
-							traverse the fallback chain until it has identified at least one supported Publication
-							Resource to use in place of the unsupported resource. If the Reading System supports
-							multiple Publication Resources in the fallback chain, it MAY select the resource to use
-							based on specific <a href="epub-core.html#attrdef-item-properties">properties</a>
-							[[!EPUB-33]] of that resource, otherwise it SHOULD honor the Author's preferred fallback
-							order. If a Reading System does not support any resource in the fallback chain, it MUST
-							alert the reader that content could not be displayed.</p>
-					</section>
-
-					<section id="manifest-fallbacks">
-						<h4>Manifest Fallbacks</h4>
-
-						<p>Reading System MAY choose to utilize fallbacks in order to find the optimal version of a
-							Content Document to render in a given context.</p>
-					</section>
+							<p>A Reading System that does not support the Media Type of a given Publication Resource
+								MUST traverse the fallback chain until it has identified at least one supported
+								Publication Resource to use in place of the unsupported resource. If the Reading System
+								supports multiple Publication Resources in the fallback chain, it MAY select the
+								resource to use based on specific <a href="epub-core.html#attrdef-item-properties"
+									>properties</a> [[!EPUB-33]] of that resource, otherwise it SHOULD honor the
+								Author's preferred fallback order. If a Reading System does not support any resource in
+								the fallback chain, it MUST alert the reader that content could not be displayed.</p>
+						</dd>
+						<dt>Manifest Fallbacks</dt>
+						<dd>
+							<p>Reading System MAY choose to utilize fallbacks in order to find the optimal version of a
+								Content Document to render in a given context.</p>
+						</dd>
+					</dl>
 				</section>
 
 				<section id="spine">
 					<h3>Spine</h3>
 
-					<section id="sec-spine-elem">
-						<h4>The <code>spine</code> element</h4>
+					<dl class="conformance-list">
+						<dt id="sec-spine-elem">The <code>spine</code> element</dt>
+						<dd>
+							<p>Reading Systems MUST provide a means of rendering the Rendition in the order defined in
+								the <code>spine</code>, which includes: 1) recognizing the first primary
+									<code>itemref</code> as the beginning of the default reading order; and, 2)
+								rendering successive primary items in the order given in the <code>spine</code>.</p>
 
-						<p>Reading Systems MUST provide a means of rendering the Rendition in the order defined in the
-								<code>spine</code>, which includes: 1) recognizing the first primary
-								<code>itemref</code> as the beginning of the default reading order; and, 2) rendering
-							successive primary items in the order given in the <code>spine</code>.</p>
+							<p>When the <code>default</code> value is specified, the Reading System can choose the
+								rendering direction. The <code>default</code> value MUST be assumed when the attribute
+								is not specified. In this case, the reading system SHOULD choose a default
+									<code>page-progression-direction</code> value based on the first
+									<code>language</code> element.</p>
 
-						<p>When the <code>default</code> value is specified, the Reading System can choose the rendering
-							direction. The <code>default</code> value MUST be assumed when the attribute is not
-							specified. In this case, the reading system SHOULD choose a default
-								<code>page-progression-direction</code> value based on the first <code>language</code>
-							element.</p>
+							<p>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
+										><code>pre-paginated</code></a> XHTML Content Documents. The
+									<code>page-progression-direction</code> attribute defines the flow direction from
+								one fixed-layout page to the next.</p>
+						</dd>
 
-						<p>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
-									><code>pre-paginated</code></a> XHTML Content Documents. The
-								<code>page-progression-direction</code> attribute defines the flow direction from one
-							fixed-layout page to the next.</p>
-					</section>
+						<dt id="sec-itemref-elem">The <code>itemref</code> element</dt>
+						<dd>
+							<p>When rendering an EPUB Publication, a Reading System MAY either suppress non-linear
+								content so that it does not appear in the default reading order, or ignore the
+									<code>linear</code> attribute in order to provide users access to the entire content
+								of the EPUB Publication. This specification does not mandate which model Reading Systems
+								have to use. A Reading System MAY also provide the option for users to toggle between
+								the two models.</p>
 
-					<section id="sec-itemref-elem">
-						<h4>The <code>itemref</code> element</h4>
-
-						<p>When rendering an EPUB Publication, a Reading System MAY either suppress non-linear content
-							so that it does not appear in the default reading order, or ignore the <code>linear</code>
-							attribute in order to provide users access to the entire content of the EPUB Publication.
-							This specification does not mandate which model Reading Systems have to use. A Reading
-							System MAY also provide the option for users to toggle between the two models.</p>
-
-						<p>Reading Systems MUST ignore all metadata properties expressed in the <code>properties</code>
-							attribute that they do not recognize.</p>
-					</section>
+							<p>Reading Systems MUST ignore all metadata properties expressed in the
+									<code>properties</code> attribute that they do not recognize.</p>
+						</dd>
+					</dl>
 				</section>
 
 				<section id="sec-collections">
 					<h3>Collections</h3>
 
-					<section id="sec-collection-elem">
-						<h4>The <code>collection</code> element</h4>
-
-						<p>In the context of this specification, support for collections in Reading Systems is OPTIONAL.
-							Reading Systems MUST ignore <code>collection</code> elements that define unrecognized
-							roles.</p>
-					</section>
+					<p>In the context of this specification, support for collections in Reading Systems is OPTIONAL.
+						Reading Systems MUST ignore <code>collection</code> elements that define unrecognized roles.</p>
 				</section>
 
 			</section>
@@ -451,48 +456,45 @@
 			<section id="sec-pub-identifiers">
 				<h3>Publication Identifiers</h3>
 
-				<section id="sec-unique-id">
-					<h4>Unique Identifiers</h4>
-
-					<p>Reading Systems MUST NOT depend on the Unique Identifier being unique to one and only one EPUB
-						Publication. Determining whether two EPUB Publications with the same Unique Identifier represent
-						different versions of the same publication (see <a
-							href="epub-core.html#sec-metadata-elem-identifiers-pid">Release Identifier</a>
-						[[!EPUB-33]]), or different publications, might require inspecting other metadata, such as the
-						titles or authors.</p>
-				</section>
+				<dl class="conformance-list">
+					<dt id="sec-unique-id">Unique Identifiers</dt>
+					<dd>
+						<p>Reading Systems MUST NOT depend on the Unique Identifier being unique to one and only one
+							EPUB Publication. Determining whether two EPUB Publications with the same Unique Identifier
+							represent different versions of the same publication (see <a
+								href="epub-core.html#sec-metadata-elem-identifiers-pid">Release Identifier</a>
+							[[!EPUB-33]]), or different publications, might require inspecting other metadata, such as
+							the titles or authors.</p>
+					</dd>
+				</dl>
 			</section>
 
 			<section id="sec-vocab-assoc">
 				<h3>Vocabulary Association Mechanisms</h3>
 
-				<section id="sec-metadata-reserved-prefixes">
-					<h4>Reserved Prefixes</h4>
+				<dl class="conformance-list">
+					<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
+					<dd>
+						<p>Reading Systems MUST resolve all reserved prefixes used in Package Documents using their
+							predefined URIs unless a local <a href="#sec-prefix-attr">prefix</a> is declared. Reading
+							Systems MUST use locally-overriden prefixes in the <code>prefix</code> attribute when
+							encountered.</p>
 
-					<p>Reading Systems MUST resolve all reserved prefixes used in Package Documents using their
-						predefined URIs unless a local <a href="#sec-prefix-attr">prefix</a> is declared. Reading
-						Systems MUST use locally-overriden prefixes in the <code>prefix</code> attribute when
-						encountered.</p>
+						<p>As changes to the reserved prefixes and updates to Reading Systems are not always going
+							happen in synchrony, Reading Systems MUST NOT fail when encountering unrecognized prefixes
+							(i.e., not reserved and not declared using the <code>prefix</code> attribute).</p>
+					</dd>
 
-					<p>As changes to the reserved prefixes and updates to Reading Systems are not always going happen in
-						synchrony, Reading Systems MUST NOT fail when encountering unrecognized prefixes (i.e., not
-						reserved and not declared using the <code>prefix</code> attribute).</p>
-				</section>
+					<dt id="sec-prefix-attr">The <code>prefix</code> attribute</dt>
+					<dd>
+						<p>If the <code>prefix</code> attribute includes a declaration for a <a
+								href="#sec-metadata-reserved-prefixes">predefined prefix</a>, Reading Systems MUST use
+							the URI mapping defined in the <code>prefix</code> attribute, regardless of whether of it
+							maps to the same URI as the predefined prefix.</p>
+					</dd>
 
-				<section id="sec-prefix-attr">
-					<h4>The <code>prefix</code> attribute</h4>
-
-					<p>If the <code>prefix</code> attribute includes a declaration for a <a
-							href="#sec-metadata-reserved-prefixes">predefined prefix</a>, Reading Systems MUST use the
-						URI mapping defined in the <code>prefix</code> attribute, regardless of whether of it maps to
-						the same URI as the predefined prefix.</p>
-				</section>
-
-				<section id="sec-property-datatype">
-					<h4>The <code>property</code> Data Type</h4>
-
-					<section id="sec-property-processing">
-						<h5>Processing</h5>
+					<dt id="sec-property-datatype">The <code>property</code> Data Type</dt>
+					<dd>
 						<p>A Reading System MUST use the following rules to create an IRI [[!RFC3987]] from a
 							property:</p>
 
@@ -511,8 +513,8 @@
 
 						<p>The resulting IRI MUST be valid to [[!RFC3987]]. Reading Systems do not have to resolve this
 							IRI, however.</p>
-					</section>
-				</section>
+					</dd>
+				</dl>
 			</section>
 
 			<section id="sec-package-metadata-rendering">
@@ -730,8 +732,8 @@
 				<section id="sec-package-nav-rs-conf">
 					<h4>General Conformance</h4>
 
-					<p>A conformant <a>EPUB Reading System</a> MUST meet all of the following criteria for processing
-							<a>EPUB Navigation Documents</a>:</p>
+					<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing <a>EPUB
+							Navigation Documents</a>:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -772,25 +774,37 @@
 				<section id="sec-xhtml-conf-rs">
 					<h4>General Conformance</h4>
 
-					<p>A conformant <a>EPUB Reading System</a> MUST meet all of the following criteria for processing
+					<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing
 							<a>XHTML Content Documents</a>:</p>
 
 					<ul class="conformance-list">
-						<li><p id="confreq-html-rs-behavior">Unless explicitly defined by this specification as
+						<li>
+							<p id="confreq-html-rs-behavior">Unless explicitly defined by this specification as
 								overridden, it MUST process XHTML Content Documents using semantics defined by the
 								[[!HTML]] specification and honor any applicable user agent conformance constraints
-								expressed therein.</p></li>
-						<li><p id="confreq-html-rs-behavior-add">It MUST meet all Reading System conformance criteria
-								defined in <a href="#sec-xhtml-extensions"></a>.</p></li>
-						<li><p id="confreq-html-rs-behavior-restr">It MUST recognize and adapt behaviorally to the
-								constraints defined in <a href="#sec-xhtml-deviations"></a>.</p></li>
-						<li><p id="confreq-html-rs-scrpt">It MUST meet the Reading System conformance criteria defined
-								in <a href="#sec-scripted-content-rs-reqs"></a>.</p></li>
-						<li><p id="confreq-html-rs-css">It MUST support visual rendering of XHTML Content Documents as
-								defined in <a href="#sec-css-rs-conf"></a>.</p></li>
-						<li><p id="confreq-html-rs-a11y">It SHOULD recognize embedded ARIA markup and support exposure
+								expressed therein.</p>
+						</li>
+						<li>
+							<p id="confreq-html-rs-behavior-add">It MUST meet all Reading System conformance criteria
+								defined in <a href="#sec-xhtml-extensions"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-html-rs-behavior-restr">It MUST recognize and adapt behaviorally to the
+								constraints defined in <a href="#sec-xhtml-deviations"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-html-rs-scrpt">It MUST meet the Reading System conformance criteria defined
+								in <a href="#sec-scripted-content-rs-reqs"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-html-rs-css">It MUST support visual rendering of XHTML Content Documents as
+								defined in <a href="#sec-css-rs-conf"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-html-rs-a11y">It SHOULD recognize embedded ARIA markup and support exposure
 								of any given ARIA roles, states and properties to platform accessibility APIs
-								[[!WAI-ARIA]].</p></li>
+								[[!WAI-ARIA]].</p>
+						</li>
 					</ul>
 				</section>
 
@@ -800,76 +814,75 @@
 					<section id="sec-xhtml-semantic-inflection">
 						<h5>Semantic Inflection</h5>
 
-						<section id="sec-epub-type-attribute">
-							<h6>The <code>epub:type</code> Attribute</h6>
+						<p>A Reading System has to process the <code>epub:type</code> attribute as follows:</p>
 
-							<p>Reading Systems MUST <a href="#confreq-rs-epubtype-prec">ignore inflected semantics</a>
-								that conflict with the carrying element.</p>
+						<ul class="conformance-list">
+							<li>
+								<p id="confreq-rs-epubtype-beh">It MAY associate behaviors with none, some or all of the
+									terms defined in the <a href="epub-core.html#sec-contentdocs-default-vocab">default
+										vocabulary</a> [[EPUB-33]].</p>
+							</li>
+							<li>
+								<p id="confreq-rs-epubtype-oth">It MAY associate behaviors with terms from other
+									vocabularies.</p>
+							</li>
+							<li>
+								<p id="confreq-rs-epubtype-ign">It MUST ignore terms that it does not recognize.</p>
+							</li>
+							<li>
+								<p id="confreq-rs-epubtype-conflict">It MUST <a href="#confreq-rs-epubtype-prec">ignore
+										inflected semantics</a> that conflict with the carrying element.</p>
+							</li>
+							<li>
+								<p id="confreq-rs-epubtype-head">It MUST ignore semantics expressed on the [[!HTML]] <a
+										href="https://www.w3.org/TR/html/document-metadata.html#the-head-element"
+											><code>head</code></a> element or its descendants.</p>
+							</li>
+						</ul>
 
-							<p>Reading Systems MUST ignore semantics expressed on the [[!HTML]] <a
-									href="https://www.w3.org/TR/html/document-metadata.html#the-head-element"
-										><code>head</code></a> element or its descendants.</p>
-						</section>
-
-						<section id="sec-contentdocs-semantic-inflection-processing-reqs">
-							<h6>Processing Requirements</h6>
-
-							<p>A Reading System MUST process the <code>epub:type</code> attribute as follows:</p>
-
-							<ul class="conformance-list">
-								<li><p id="confreq-rs-epubtype-beh">It MAY associate behaviors with none, some or all of
-										the terms defined in the <a href="epub-core.html#sec-contentdocs-default-vocab"
-											>default vocabulary</a> [[EPUB-33]].</p></li>
-								<li><p id="confreq-rs-epubtype-oth">It MAY associate behaviors with terms from other
-										vocabularies.</p></li>
-								<li><p id="confreq-rs-epubtype-ign">It MUST ignore terms that it does not
-									recognize.</p></li>
-							</ul>
-
-							<p id="confreq-rs-epubtype-prec">When Reading System behavior associated with a given
-									<code>epub:type</code> value conflicts with an element's native behavior, the
-								behavior associated with the element MUST be given precedence.</p>
-						</section>
+						<p id="confreq-rs-epubtype-prec">When Reading System behavior associated with a given
+								<code>epub:type</code> value conflicts with an element's native behavior, the behavior
+							associated with the element MUST be given precedence.</p>
 					</section>
 					<section id="sec-xhtml-semantic-enrichment">
 						<h5>Semantic Enrichment</h5>
 
-						<section id="sec-xhtml-sementic-enrichment-rdfa">
-							<h6>RDFa</h6>
+						<dl class="conformance-list">
+							<dt id="sec-xhtml-sementic-enrichment-rdfa">RDFa</dt>
+							<dd>
+								<p><a>EPUB Reading System</a> support for the <a
+										href="https://www.w3.org/TR/2015/REC-rdfa-core-20150317/#s_model">attribute
+										processing model</a> [[!RDFA-CORE]] is OPTIONAL.</p>
+							</dd>
 
-							<p><a>EPUB Reading System</a> support for the <a
-									href="https://www.w3.org/TR/2015/REC-rdfa-core-20150317/#s_model">attribute
-									processing model</a> [[!RDFA-CORE]] is OPTIONAL.</p>
-						</section>
-
-						<section id="sec-xhtml-sementic-enrichment-microdata">
-							<h6>Microdata</h6>
-
-							<p><a>EPUB Reading System</a> support for the <a
-									href="https://www.w3.org/TR/microdata/#encoding-microdata">attribute processing
-									model</a> is OPTIONAL, as is the <a href="https://www.w3.org/TR/microdata/#json"
-									>conversion to JSON</a> [[!Microdata]].</p>
-						</section>
+							<dt id="sec-xhtml-sementic-enrichment-microdata">Microdata</dt>
+							<dd>
+								<p><a>EPUB Reading System</a> support for the <a
+										href="https://www.w3.org/TR/microdata/#encoding-microdata">attribute processing
+										model</a> is OPTIONAL, as is the <a href="https://www.w3.org/TR/microdata/#json"
+										>conversion to JSON</a> [[!Microdata]].</p>
+							</dd>
+						</dl>
 					</section>
 
 					<section id="sec-xhtml-ssml-attrib">
 						<h5>SSML Attributes</h5>
 
-						<section id="sec-cd-ssml-ph-attrib">
-							<h6>The <code>ssml:ph</code> attribute</h6>
+						<dl class="conformance-list">
+							<dt id="sec-cd-ssml-ph-attrib">The <code>ssml:ph</code> attribute</dt>
+							<dd>
+								<p>Reading Systems that support the SSML Attributes and <a href="epub-core.html#sec-pls"
+										>PLS documents</a> [[!EPUB-33]] MUST honor the defined <a
+										href="#confreq-pls-rs-casc">precedence rules</a> for these two constructs.</p>
+							</dd>
 
-							<p>Reading Systems that support the SSML Attributes and <a href="epub-core.html#sec-pls">PLS
-									documents</a> [[!EPUB-33]] MUST honor the defined <a href="#confreq-pls-rs-casc"
-									>precedence rules</a> for these two constructs.</p>
-						</section>
-
-						<section id="sec-cd-ssml-alphabet-attrib">
-							<h6>The <code>ssml:alphabet</code> attribute</h6>
-
-							<p>Reading Systems that support the <a href="#sec-xhtml-ssml-attrib">SSML Attributes</a>
-								feature of this specification SHOULD support the IPA alphabet [[!IPA]], as expressed by
-								the value "<code>ipa</code>".</p>
-						</section>
+							<dt id="sec-cd-ssml-alphabet-attrib">The <code>ssml:alphabet</code> attribute</dt>
+							<dd>
+								<p>Reading Systems that support the <a href="#sec-xhtml-ssml-attrib">SSML Attributes</a>
+									feature of this specification SHOULD support the IPA alphabet [[!IPA]], as expressed
+									by the value "<code>ipa</code>".</p>
+							</dd>
+						</dl>
 					</section>
 
 					<section id="sec-xhtml-content-switch">
@@ -909,18 +922,24 @@
 					<section id="sec-xhtml-mathml">
 						<h3>MathML</h3>
 
-						<p>A conformant <a>EPUB Reading System</a> MUST meet all of the following criteria for
-							supporting MathML embedded in XHTML Content Documents:</p>
+						<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for supporting
+							MathML embedded in XHTML Content Documents:</p>
 
 						<ul class="conformance-list">
-							<li><p id="confreq-mathml-rs-behavior">It MUST be an input-compliant renderer for <a
+							<li>
+								<p id="confreq-mathml-rs-behavior">It MUST be an input-compliant renderer for <a
 										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
-									defined in the [[!MATHML3]] specification.</p></li>
-							<li><p id="confreq-mathml-rs-anno">It MAY support rendering of <a
+									defined in the [[!MATHML3]] specification.</p>
+							</li>
+							<li>
+								<p id="confreq-mathml-rs-anno">It MAY support rendering of <a
 										href="https://www.w3.org/TR/MathML3/chapter4.html">Content MathML</a> found in
-										<code>annotation-xml</code> elements.</p></li>
-							<li><p id="confreq-mathml-rs-render">If it has a <a>Viewport</a>, it MUST support visual
-									rendering of Presentation MathML.</p></li>
+										<code>annotation-xml</code> elements.</p>
+							</li>
+							<li>
+								<p id="confreq-mathml-rs-render">If it has a <a>Viewport</a>, it MUST support visual
+									rendering of Presentation MathML.</p>
+							</li>
 						</ul>
 						<p class="note"> EPUB Reading Systems may choose to use third-party libraries such as MathJax to
 							provide MathML rendering. </p>
@@ -930,7 +949,7 @@
 						<h5>Embedded SVG</h5>
 
 						<p>Reading Systems MUST process SVG embedded in XHTML Content Documents as defined in <a
-								href="#sec-svg-rs-conf"></a>.</p>
+								href="#sec-svg"></a>.</p>
 
 						<section id="sec-xhtml-svg-css">
 							<h6>Embedded SVG and CSS</h6>
@@ -965,34 +984,39 @@
 			<section id="sec-svg">
 				<h3>SVG Content Documents</h3>
 
-				<section id="sec-svg-rs-conf">
-					<h4>General Conformance</h4>
-					<p>A conformant <a>EPUB Reading System</a> MUST meet all of the following criteria for processing
-						SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content
-						Documents</a>:</p>
+				<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing SVG Content
+					Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content Documents</a>:</p>
 
-					<ul class="conformance-list">
-						<li><p id="confreq-svg-rs-behavior">Unless explicitly defined by this specification as
-								overridden, it MUST process SVG Content Documents using semantics defined by the
-								[[!SVG]] specification and honor any applicable user agent conformance constraints
-								expressed therein.</p></li>
-						<li><p id="confreq-svg-rs-scrpt">It MUST meet the Reading System conformance criteria defined in
-									<a href="#sec-scripted-content-rs-reqs"></a>.</p></li>
-						<li><p id="confreq-svg-rs-css">If it has a <a>Viewport</a>, it MUST support the visual rendering
-								of SVG using CSS as defined in <a href="https://www.w3.org/TR/SVG/styling.html"
-									>Styling</a> [[!SVG]], and it SHOULD support all properties defined in the <a
-									href="https://www.w3.org/TR/SVG/propidx.html">Property Index</a> [[!SVG]]. In the
-								case of embedded SVG, it MUST also conform to the constraints defined in <a
-									href="#sec-xhtml-svg-css"></a>.</p></li>
-						<li><p id="confreq-svg-rs-text">It SHOULD support user selection and searching of text within
-								SVG elements.</p></li>
-						<li><p id="confreq-svg-rs-reqdExt">It MUST recognize the value
-									"<code>http://www.idpf.org/2007/ops</code>" of the <code>requiredExtensions</code>
-								attribute as representing the occurrence of XHTML Content Document fragments (e.g., when
-								the attribute is included on the <code>foreignObject</code> element or children of the
-									<code>switch</code> element).</p></li>
-					</ul>
-				</section>
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-svg-rs-behavior">Unless explicitly defined by this specification as overridden,
+							it MUST process SVG Content Documents using semantics defined by the [[!SVG]] specification
+							and honor any applicable user agent conformance constraints expressed therein.</p>
+					</li>
+					<li>
+						<p id="confreq-svg-rs-scrpt">It MUST meet the Reading System conformance criteria defined in <a
+								href="#sec-scripted-content-rs-reqs"></a>.</p>
+					</li>
+					<li>
+						<p id="confreq-svg-rs-css">If it has a <a>Viewport</a>, it MUST support the visual rendering of
+							SVG using CSS as defined in <a href="https://www.w3.org/TR/SVG/styling.html">Styling</a>
+							[[!SVG]], and it SHOULD support all properties defined in the <a
+								href="https://www.w3.org/TR/SVG/propidx.html">Property Index</a> [[!SVG]]. In the case
+							of embedded SVG, it MUST also conform to the constraints defined in <a
+								href="#sec-xhtml-svg-css"></a>.</p>
+					</li>
+					<li>
+						<p id="confreq-svg-rs-text">It SHOULD support user selection and searching of text within SVG
+							elements.</p>
+					</li>
+					<li>
+						<p id="confreq-svg-rs-reqdExt">It MUST recognize the value
+								"<code>http://www.idpf.org/2007/ops</code>" of the <code>requiredExtensions</code>
+							attribute as representing the occurrence of XHTML Content Document fragments (e.g., when the
+							attribute is included on the <code>foreignObject</code> element or children of the
+								<code>switch</code> element).</p>
+					</li>
+				</ul>
 			</section>
 
 			<section id="sec-css">
@@ -1001,27 +1025,39 @@
 				<section id="sec-css-rs-conf">
 					<h4>General Conformance</h4>
 
-					<p>A conformant <a>EPUB Reading System</a> MUST meet all of the following criteria for processing
-						CSS Style Sheets:</p>
+					<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing CSS
+						Style Sheets:</p>
 
 					<ul class="conformance-list">
-						<li><p id="confreq-css-rs-support">It MUST support the official definition of CSS as described
-								in the [[!CSSSnapshot]].</p></li>
-						<li><p id="confreq-css-rs-modules">It SHOULD support all applicable modules in [[!CSSSnapshot]]
-								that have reached at least <a
-									href="https://www.w3.org/Consortium/Process/#RecsCR">Candidate
-									Recommendation</a> status [[!W3CProcess]] (and are widely implemented).</p></li>
-						<li><p id="confreq-css-rs-fonts">It MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and
-								[[!WOFF2]] font resources referenced from <code>@font-face</code> rules.</p></li>
-						<li><p id="confreq-css-rs-prefixed">It MUST support all prefixed properties defined in <a
+						<li>
+							<p id="confreq-css-rs-support">It MUST support the official definition of CSS as described
+								in the [[!CSSSnapshot]].</p>
+						</li>
+						<li>
+							<p id="confreq-css-rs-modules">It SHOULD support all applicable modules in [[!CSSSnapshot]]
+								that have reached at least <a href="https://www.w3.org/Consortium/Process/#RecsCR"
+									>Candidate Recommendation</a> status [[!W3CProcess]] (and are widely
+								implemented).</p>
+						</li>
+						<li>
+							<p id="confreq-css-rs-fonts">It MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and
+								[[!WOFF2]] font resources referenced from <code>@font-face</code> rules.</p>
+						</li>
+						<li>
+							<p id="confreq-css-rs-prefixed">It MUST support all prefixed properties defined in <a
 									href="epub-core.html#sec-css-prefixed">CSS Style Sheets — Prefixed Properties</a>
-								[[EPUB-33]].</p></li>
-						<li><p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined
+								[[EPUB-33]].</p>
+						</li>
+						<li>
+							<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined
 								above, its user agent style sheet SHOULD support the [[!HTML]] <a
 									href="https://www.w3.org/TR/html/rendering.html#rendering">suggested default
-									rendering</a>.</p></li>
-						<li><p id="confreq-css-rs-overrides">It SHOULD respect Author CSS and user styles as defined in
-									<a href="#sec-css-rs-overrides"></a>.</p></li>
+									rendering</a>.</p>
+						</li>
+						<li>
+							<p id="confreq-css-rs-overrides">It SHOULD respect Author CSS and user styles as defined in
+									<a href="#sec-css-rs-overrides"></a>.</p>
+						</li>
 					</ul>
 
 					<p>Reading System developers are encouraged to implement CSS support at the level of major
@@ -1056,15 +1092,20 @@
 					<p>A Reading System that supports scripting MUST meet the following criteria:</p>
 
 					<ul class="conformance-list">
-						<li><p id="confreq-rs-scripted-reflow-support">It SHOULD support <a
+						<li>
+							<p id="confreq-rs-scripted-reflow-support">It SHOULD support <a
 									href="epub-core.html#sec-scripted-content-type-container-constrained"
 									>container-constrained scripting</a> [[!EPUB-33]] in reflowable EPUB Content
-								Documents.</p></li>
-						<li><p id="confreq-rs-scripted-fxl-support">It SHOULD support <a
+								Documents.</p>
+						</li>
+						<li>
+							<p id="confreq-rs-scripted-fxl-support">It SHOULD support <a
 									href="epub-core.html#sec-scripted-content-type-spine-level">spine-level
 									scripting</a> [[!EPUB-33]] in <a href="#sec-fixed-layouts">fixed-layout
-									documents</a>.</p></li>
-						<li><p id="confreq-rs-scripted-scrolled">It SHOULD support spine-level scripting in reflowable
+									documents</a>.</p>
+						</li>
+						<li>
+							<p id="confreq-rs-scripted-scrolled">It SHOULD support spine-level scripting in reflowable
 								EPUB Content Documents that use the <a href="epub-core.html#flow-scrolled-doc"
 										>"<code>scrolled-doc</code>"</a> or <a
 									href="epub-core.html#flow-scrolled-continuous"
@@ -1072,32 +1113,45 @@
 									<a href="#flow">the <code>rendition:flow</code> property</a>. Similarly, if it
 								supports spine-level scripting in reflowable EPUB Content Documents, it MUST implement
 								the "<code>scrolled-doc</code>" presentation mode and SHOULD implement the
-									"<code>scrolled-continuous</code>" presentation mode.</p></li>
-						<li><p id="confreq-rs-scripted-optional-support">It MAY support scripting in other contexts, but
+									"<code>scrolled-continuous</code>" presentation mode.</p>
+						</li>
+						<li>
+							<p id="confreq-rs-scripted-optional-support">It MAY support scripting in other contexts, but
 								this specification does not address such scripting. As a result, the use of scripting in
-								these contexts might not be consistent across Reading Systems.</p></li>
-						<li><p id="confreq-rs-scripted-ua">It MAY render <a>Scripted Content Documents</a> as an
-								interactive, scripted user agent according to [[!HTML]].</p></li>
-						<li><p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to
+								these contexts might not be consistent across Reading Systems.</p>
+						</li>
+						<li>
+							<p id="confreq-rs-scripted-ua">It MAY render <a>Scripted Content Documents</a> as an
+								interactive, scripted user agent according to [[!HTML]].</p>
+						</li>
+						<li>
+							<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to
 								modify the DOM of the parent Content Document or other contents in the EPUB Publication,
 								and MUST NOT allow it to manipulate the size of its containing rectangle. (Note: Even if
 								a script is not container-constrained, the Reading System MAY impose restrictions on
 								modifications (see also the <a href="#feature-dom-manipulation">dom-manipulation
-									feature</a>).)</p></li>
-						<li><p id="confreq-rs-scripted-limit">It MAY place additional limitations on the capabilities
-								provided to scripts during execution (e.g., limiting networking).</p></li>
-						<li><p id="confreq-rs-scripted-readingsystem-object">It MUST implement the JavaScript
+									feature</a>).)</p>
+						</li>
+						<li>
+							<p id="confreq-rs-scripted-limit">It MAY place additional limitations on the capabilities
+								provided to scripts during execution (e.g., limiting networking).</p>
+						</li>
+						<li>
+							<p id="confreq-rs-scripted-readingsystem-object">It MUST implement the JavaScript
 									<code>navigator</code> extension object <code>epubReadingSystem</code> defined in <a
 									href="#app-epubReadingSystem"></a>. It also MUST support the
 									<code>dom-manipulation</code> and <code>layout-change</code> features defined in <a
 									href="#app-ers-hasFeature-features"></a> in container-constrained scripting
-								contexts.</p></li>
+								contexts.</p>
+						</li>
 					</ul>
 					<p>A Reading System that does not support scripting MUST meet the following criteria:</p>
 					<ul class="conformance-list">
-						<li><p id="confreq-rs-scripted-flbk">It MUST process fallbacks for scripted content as defined
+						<li>
+							<p id="confreq-rs-scripted-flbk">It MUST process fallbacks for scripted content as defined
 								in <a href="epub-core.html#confreq-cd-scripted-flbk">Fallbacks for Scripted Content
-									Documents</a> [[!EPUB-33]].</p></li>
+									Documents</a> [[!EPUB-33]].</p>
+						</li>
 					</ul>
 
 					<div class="note">
@@ -1131,19 +1185,24 @@
 					<ul>
 						<li>
 							<p>an attack against the runtime environment (e.g., stealing files from a user's hard
-								drive);</p></li>
+								drive);</p>
+						</li>
 						<li>
 							<p>an attack against the Reading System itself (e.g., stealing a list of a user's books or
-								causing unexpected behavior);</p></li>
+								causing unexpected behavior);</p>
+						</li>
 						<li>
 							<p>an attack of one Content Document against another (e.g., stealing data that originated in
-								a different document);</p></li>
+								a different document);</p>
+						</li>
 						<li>
 							<p>an attack of an unencrypted script against an encrypted portion of a document (e.g., an
-								injected malicious script extracting protected content);</p></li>
+								injected malicious script extracting protected content);</p>
+						</li>
 						<li>
 							<p>an attack against the local network (e.g., stealing data from a server behind a
-								firewall).</p></li>
+								firewall).</p>
+						</li>
 					</ul>
 
 					<p>The following recommendations are provided as a guide to handling untrusted scripts:</p>
@@ -1175,7 +1234,8 @@
 								data.</p>
 							<p>Reading Systems that allow local storage also need to provide methods for users to
 								inspect, disable, or delete that data. The data needs to be destroyed if the
-								corresponding EPUB Publication is deleted.</p></li>
+								corresponding EPUB Publication is deleted.</p>
+						</li>
 					</ul>
 
 					<p>Note that compliance with these recommendations does not guarantee protection from the possible
@@ -1208,43 +1268,49 @@
 				<section id="sec-fxl-rs-conf">
 					<h4>General Conformance</h4>
 
-					<p>A conformant <a>EPUB Reading System</a> MUST meet all of the following criteria for processing
+					<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing
 							<a>Fixed-Layout Documents</a>:</p>
 
 					<ul class="conformance-list">
-						<li><p id="confreq-fxl-rs-viewport">It SHOULD allocate the full <a>Content Display Area</a> for
-								the document, as defined in <a href="#sec-fxl-viewport"></a>.</p></li>
-						<li><p id="confreq-fxl-rs-html">It MUST use the dimensions expressed in the
+						<li>
+							<p id="confreq-fxl-rs-viewport">It SHOULD allocate the full <a>Content Display Area</a> for
+								the document, as defined in <a href="#sec-fxl-viewport"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-fxl-rs-html">It MUST use the dimensions expressed in the
 									<code>viewport</code>
 								<code>meta</code> tag to render <a>XHTML Content Documents</a>, as defined in <a
-									href="#sec-fxl-icb-html"></a>.</p></li>
-						<li><p id="confreq-fxl-rs-svg">It MUST use the dimensions as defined in <a
+									href="#sec-fxl-html-dimensions"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-fxl-rs-svg">It MUST use the dimensions as defined in <a
 									href="epub-core.html#sec-fxl-icb-svg">Expressing the ICB in SVG</a> [[!EPUB-33]] to
-								render <a>SVG Content Documents</a>.</p></li>
+								render <a>SVG Content Documents</a>.</p>
+						</li>
 					</ul>
+
+					<div class="note">
+						<p>This specification does not define how the <a
+								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
+								containing block</a> [[CSS2]] is placed within the Reading System <a>Content Display
+								Area</a>.</p>
+					</div>
 				</section>
 
-				<section id="sec-fxl-html-svg-dimensions">
-					<h4>Initial Containing Block Dimensions</h4>
+				<section id="sec-fxl-html-dimensions">
+					<h4>HTML Initial Containing Block Dimensions</h4>
 
-					<p>This specification does not define how the <a
-							href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
-							block</a> [[CSS2]] is placed within the Reading System <a>Content Display Area</a>.</p>
+					<p>In this version of this specification, only the width and height expressions as defined in <a
+							href="../core/index.html#sec-fxl-icb-html">Expressing in HTML</a> [[!EPUB-33]] MUST be
+						recognized by <a>Reading Systems</a>.</p>
 
-					<section id="sec-fxl-icb-html">
-						<h5>Expressing in HTML</h5>
-
-						<p>In this version of this specification, only the width and height expressions MUST be
-							recognized by <a>Reading Systems</a>.</p>
-
-						<p>Reading Systems MUST clip XHTML content to the initial containing block (ICB) dimensions
-							declared in the <code>viewport</code>
-							<code>meta</code> tag — content positioned outside of the initial containing block will not
-							be visible. When the ICB aspect ratio does not match the aspect ratio of the Reading System
-								<a>Content Display Area</a>, Reading Systems MAY position the ICB inside the area to
-							accommodate the user interface; in other words, added letter-boxing space MAY appear on
-							either side (or both) of the content.</p>
-					</section>
+					<p>Reading Systems MUST clip XHTML content to the initial containing block (ICB) dimensions declared
+						in the <code>viewport</code>
+						<code>meta</code> tag — content positioned outside of the initial containing block will not be
+						visible. When the ICB aspect ratio does not match the aspect ratio of the Reading System
+							<a>Content Display Area</a>, Reading Systems MAY position the ICB inside the area to
+						accommodate the user interface; in other words, added letter-boxing space MAY appear on either
+						side (or both) of the content.</p>
 				</section>
 
 				<section id="sec-fxl-viewport">
@@ -1268,11 +1334,12 @@
 				<p>Reading Systems with Text-to-Speech (TTS) capabilities SHOULD support <abbr
 						title="Pronunciation Lexicon Specification">PLS</abbr> documents.</p>
 
-				<p>A conformant <a>EPUB Reading System</a> MUST meet all of the following criteria for processing PLS
+				<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing PLS
 					documents:</p>
 
 				<ul class="conformance-list">
-					<li><p id="confreq-pls-rs-sptts">Reading Systems with <a>Text-to-Speech</a> (TTS) capabilities
+					<li>
+						<p id="confreq-pls-rs-sptts">Reading Systems with <a>Text-to-Speech</a> (TTS) capabilities
 							SHOULD support [[!PRONUNCIATION-LEXICON]].</p>
 						<p id="confreq-pls-rs-proc">It MUST process PLS documents as defined in
 							[[!PRONUNCIATION-LEXICON]].</p>
@@ -1290,7 +1357,8 @@
 								Attributes</a>, it MUST let any pronunciation instructions provided via the <a
 								href="#sec-cd-ssml-ph-attrib"><code>ssml:ph</code></a> attribute take precedence in
 							cases where a <code>grapheme</code> element [[!PRONUNCIATION-LEXICON]] matches a text node
-							of an element that carries the <code>ssml:ph</code> attribute [[!SSML]].</p></li>
+							of an element that carries the <code>ssml:ph</code> attribute [[!SSML]].</p>
+					</li>
 				</ul>
 			</section>
 		</section>
@@ -1300,7 +1368,7 @@
 			<section id="ocf-conformance-rs">
 				<h3>Basic Conformance</h3>
 
-				<p>An <a>EPUB Reading System</a> MUST meet all of the following criteria:</p>
+				<p>An <a>EPUB Reading System</a> has to meet the following criteria:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -1348,19 +1416,9 @@
 				<section id="sec-container-metainf">
 					<h4><code>META-INF</code> Directory</h4>
 
-					<section id="sec-container-metainf-inc">
-						<h5>Inclusion</h5>
-
-						<p><a>OCF Processors</a> MUST NOT fail when encountering files in the <code class="filename"
-								>META-INF</code> directory not listed in <a
-								href="epub-core.html#sec-container-metainf-files"></a> [[!EPUB-33]].</p>
-					</section>
-					<section id="sec-container-metainf-files">
-						<h5>Reserved Files</h5>
-
-						<section id="sec-container-metainf-container.xml">
-							<h6>Container File (<code>container.xml</code>)</h6>
-
+					<dl class="conformance-list">
+						<dt id="sec-container-metainf-container.xml">Container File (<code>container.xml</code>)</dt>
+						<dd>
 							<p id="container-default-rendition">An OCF Processor MUST consider the first
 									<code>rootfile</code> element within the <code>rootfiles</code> element to represent
 								the <a>Default Rendition</a> for the contained EPUB Publication. <a>Reading Systems</a>
@@ -1369,64 +1427,68 @@
 
 							<p><a>OCF Processors</a> MUST ignore foreign elements and attributes within a
 									<code>container.xml</code> file.</p>
-						</section>
-					</section>
+						</dd>
+
+						<dt id="sec-container-metainf-inc">Other Files</dt>
+						<dd>
+							<p><a>OCF Processors</a> MUST NOT fail when encountering files in the <code class="filename"
+									>META-INF</code> directory not listed in <a
+									href="epub-core.html#sec-container-metainf-files">Reserved Files</a>
+								[[!EPUB-33]].</p>
+						</dd>
+					</dl>
 				</section>
 			</section>
 
 			<section id="sec-container-zip">
 				<h3>OCF ZIP Container</h3>
 
-				<section id="sec-zip-container-zipreqs">
-					<h4>ZIP File Requirements</h4>
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-zip-mult"><a>OCF Processors</a> MUST treat any OCF files that specify that the
+							ZIP file is split across multiple storage media as being in error.</p>
+					</li>
+					<li>
+						<p id="confreq-zip-comp">OCF Processors MUST treat any OCF Containers that use compression
+							techniques other than Deflate as being in error.</p>
+					</li>
+					<li>
+						<p id="confreq-zip-64">OCF Processors MUST support the ZIP64 extensions defined as "Version
+							1".</p>
+					</li>
+					<li>
+						<p id="confreq-zip-enc">OCF Processors MUST treat OCF ZIP Containers that use ZIP encryption
+							features as being in error.</p>
+					</li>
+					<li>
+						<p id="confreq-zip-preserve">It is not a requirement that OCF Processors preserve information
+							from an OCF ZIP Container through load and save operations that are not defined within the
+							OCF Abstract Container; in particular, an OCF Processor does not have to preserve CRC
+							values, comment fields or fields that hold file system information corresponding to a
+							particular operating system (e.g., <em class="firstterm">External file attributes</em> and
+								<em class="firstterm">Extra field</em>).</p>
+					</li>
+				</ul>
 
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-zip-mult"><a>OCF Processors</a> MUST treat any OCF files that specify that
-								the ZIP file is split across multiple storage media as being in error.</p>
-						</li>
-						<li>
-							<p id="confreq-zip-comp">OCF Processors MUST treat any OCF Containers that use compression
-								techniques other than Deflate as being in error.</p>
-						</li>
-						<li>
-							<p id="confreq-zip-64">OCF Processors MUST support the ZIP64 extensions defined as "Version
-								1".</p>
-						</li>
-						<li>
-							<p id="confreq-zip-enc">OCF Processors MUST treat OCF ZIP Containers that use ZIP encryption
-								features as being in error.</p>
-						</li>
-						<li>
-							<p id="confreq-zip-preserve">It is not a requirement that OCF Processors preserve
-								information from an OCF ZIP Container through load and save operations that are not
-								defined within the OCF Abstract Container; in particular, an OCF Processor does not have
-								to preserve CRC values, comment fields or fields that hold file system information
-								corresponding to a particular operating system (e.g., <em class="firstterm">External
-									file attributes</em> and <em class="firstterm">Extra field</em>).</p>
-						</li>
-					</ul>
+				<p>The following constraints apply to particular fields in the OCF ZIP Container archive:</p>
 
-					<p>The following constraints apply to particular fields in the OCF ZIP Container archive:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-zip-fld-version">OCF Processors MUST treat <code>version needed to
-									extract</code> field values other than <code>10</code>, <code>20</code> or
-									<code>45</code> in the local file header table as being in error.</p>
-						</li>
-						<li>
-							<p id="confreq-zip-fld-comp">OCF Processors MUST treat <code>compression</code> method field
-								values other than <code>0</code> or <code>8</code> in the local file header table as
-								being in error.</p>
-						</li>
-						<li>
-							<p id="confreq-zip-fld-er">OCF Processors MUST treat OCF ZIP Containers with an
-									<code>Archive decryption header</code> or an <code>Archive extra data record</code>
-								as being in error.</p>
-						</li>
-					</ul>
-				</section>
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-zip-fld-version">OCF Processors MUST treat <code>version needed to extract</code>
+							field values other than <code>10</code>, <code>20</code> or <code>45</code> in the local
+							file header table as being in error.</p>
+					</li>
+					<li>
+						<p id="confreq-zip-fld-comp">OCF Processors MUST treat <code>compression</code> method field
+							values other than <code>0</code> or <code>8</code> in the local file header table as being
+							in error.</p>
+					</li>
+					<li>
+						<p id="confreq-zip-fld-er">OCF Processors MUST treat OCF ZIP Containers with an <code>Archive
+								decryption header</code> or an <code>Archive extra data record</code> as being in
+							error.</p>
+					</li>
+				</ul>
 			</section>
 		</section>
 		<section id="mediaoverlays">
@@ -1844,17 +1906,29 @@ partial interface Navigator {
 					</thead>
 					<tbody>
 						<tr>
-							<td id="propdef-name"><code><dfn>name</dfn></code></td>
+							<td id="propdef-name">
+								<code>
+									<dfn>name</dfn>
+								</code>
+							</td>
 							<td>Returns a <code>String</code> value representing the name of the Reading System (e.g.,
 									"<code>iBooks</code>", "<code>Kindle</code>").</td>
 						</tr>
 						<tr>
-							<td id="propdef-version"><code><dfn>version</dfn></code></td>
+							<td id="propdef-version">
+								<code>
+									<dfn>version</dfn>
+								</code>
+							</td>
 							<td>Returns a <code>String</code> value representing the version of the Reading System
 								(e.g., "<code>1.0</code>", "<code>2.1.1</code>").</td>
 						</tr>
 						<tr>
-							<td id="propdef-layoutStyle"><code><dfn>layoutStyle</dfn></code></td>
+							<td id="propdef-layoutStyle">
+								<code>
+									<dfn>layoutStyle</dfn>
+								</code>
+							</td>
 							<td>Use of the <code>layoutStyle</code> property is <a href="epub-core.html#deprecated"
 									>deprecated</a> [[EPUB-33]]. Refer to its definition in [[!EPUBContentDocs-301]] for
 								usage information.</td>
@@ -1914,34 +1988,46 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 							</thead>
 							<tbody>
 								<tr>
-									<td id="feature-dom-manipulation"><code>dom-manipulation</code></td>
+									<td id="feature-dom-manipulation">
+										<code>dom-manipulation</code>
+									</td>
 									<td>Scripts MAY make structural changes to the document’s DOM (applies to <a
 											href="epub-core.html#sec-scripted-content-type-spine-level">spine-level
 											scripting</a> [[!EPUB-33]] only).</td>
 								</tr>
 								<tr>
-									<td id="feature-layout-changes"><code>layout-changes</code></td>
+									<td id="feature-layout-changes">
+										<code>layout-changes</code>
+									</td>
 									<td>Scripts MAY modify attributes and CSS styles that affect content layout (applies
 										to <a href="epub-core.html#sec-scripted-content-type-spine-level">spine-level
 											scripting</a> [[!EPUB-33]] only).</td>
 								</tr>
 								<tr>
-									<td id="feature-touch-events"><code>touch-events</code></td>
+									<td id="feature-touch-events">
+										<code>touch-events</code>
+									</td>
 									<td>The device supports touch events and the Reading System passes touch events to
 										the content.</td>
 								</tr>
 								<tr>
-									<td id="feature-mouse-events"><code>mouse-events</code></td>
+									<td id="feature-mouse-events">
+										<code>mouse-events</code>
+									</td>
 									<td>The device supports mouse events and the Reading System passes mouse events to
 										the content.</td>
 								</tr>
 								<tr>
-									<td id="feature-keyboard-events"><code>keyboard-events</code></td>
+									<td id="feature-keyboard-events">
+										<code>keyboard-events</code>
+									</td>
 									<td>The device supports keyboard events and the Reading System passes keyboard
 										events to the content.</td>
 								</tr>
 								<tr>
-									<td id="feature-spine-scripting"><code>spine-scripting</code></td>
+									<td id="feature-spine-scripting">
+										<code>spine-scripting</code>
+									</td>
 									<td>Indicates whether the Reading System supports <a
 											href="epub-core.html#sec-scripted-content-type-spine-level">spine-level
 											scripting</a> [[!EPUB-33]] (e.g., so a <a


### PR DESCRIPTION
This is another iterative step on turning the reading system specification into a more readable document. It primarily just removes a lot of the excessive sectioning that was copied over from the original pull-out of requirements and replaces them with conformance lists.

A good example of this is the [metadata section](https://raw.githack.com/w3c/publ-epub-revision/rs/cleanup/epub33/rs/#metadata), which used to have subsections for every element and groups of elements.

In the interests of fixing some historical wrongs, it also fixes #903 by rewording the duplicative "XX MUST meet all of the following requirements" introductory paragraphs before the conformance lists (across all three major specifications).

We don't need to normatively assert that normative requirements have to be followed, that stands to reason, so the replacement wording is now simply "XX has to meet the following requirements". This reduces any confusion about why you MUST follow a requirement that is in fact only recommended or optional.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-epub-revision/pull/1340.html" title="Last updated on Oct 11, 2020, 11:25 AM UTC (416c302)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-epub-revision/1340/61ccd48...416c302.html" title="Last updated on Oct 11, 2020, 11:25 AM UTC (416c302)">Diff</a>