### PR TITLE
Add audio/opus to audio core media types

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -24,13 +24,11 @@
 					"name": "George Kerscher",
 					"company": "DAISY Consortium",
 					"companyURL": "http://daisy.org"
-				},
-				{
+				}, {
 					"name": "Charles LaPierre",
 					"company": "Benetech",
 					"companyURL": "http://benetech.org"
-				},
-				{
+				}, {
 					"name": "Avneesh Singh",
 					"company": "DAISY Consortium",
 					"companyURL": "http://daisy.org"
@@ -39,8 +37,7 @@
 					name: "Romain Deltour",
 					company: "DAISY Consortium",
 					companyURL: "http://daisy.org"
-				},
-				{
+				}, {
 					name: "Jean Kaplansky",
 					company: "Invited Expert"
 				}, {
@@ -142,14 +139,25 @@
 				<p>This document uses the following terminology defined in EPUB 3 [[!EPUB3]]:</p>
 
 				<ul>
-					<li><a href="http://www.idpf.org/epub3/latest/#dfn-author">Author</a></li>
-					<li><a href="http://www.idpf.org/epub3/latest/#dfn-epub-content-document">EPUB Content
-						Document</a></li>
-					<li><a href="http://www.idpf.org/epub3/latest/#dfn-epub-publication">EPUB Publication</a></li>
-					<li><a href="http://www.idpf.org/epub3/latest/#dfn-media-overlays-document">Media Overlays
-							Document</a></li>
-					<li><a href="http://www.idpf.org/epub3/latest/#dfn-package-document">Package Document</a></li>
-					<li><a href="http://www.idpf.org/epub3/latest/#dfn-reading-system">Reading System</a></li>
+					<li>
+						<a href="http://www.idpf.org/epub3/latest/#dfn-author">Author</a>
+					</li>
+					<li>
+						<a href="http://www.idpf.org/epub3/latest/#dfn-epub-content-document">EPUB Content Document</a>
+					</li>
+					<li>
+						<a href="http://www.idpf.org/epub3/latest/#dfn-epub-publication">EPUB Publication</a>
+					</li>
+					<li>
+						<a href="http://www.idpf.org/epub3/latest/#dfn-media-overlays-document">Media Overlays
+							Document</a>
+					</li>
+					<li>
+						<a href="http://www.idpf.org/epub3/latest/#dfn-package-document">Package Document</a>
+					</li>
+					<li>
+						<a href="http://www.idpf.org/epub3/latest/#dfn-reading-system">Reading System</a>
+					</li>
 				</ul>
 
 				<p>In addition, it uses the definition of <a href="https://www.w3.org/TR/WCAG20/#atdef">assistive
@@ -272,7 +280,7 @@
 				<h3>Linked Metadata Records</h3>
 
 				<p>Accessibility metadata can also be included in <a
-					href="https://www.w3.org/publishing/epub3/core/#sec-link-elem">linked records</a> [[EPUB3]]
+						href="https://www.w3.org/publishing/epub3/core/#sec-link-elem">linked records</a> [[EPUB3]]
 					(i.e., metadata records referenced from <code>link</code> elements), but the inclusion of such
 					metadata solely in a linked record does not satisfy the discoverability requirements of this
 					document.</p>
@@ -401,8 +409,8 @@
 								mechanisms include <a
 									href="https://www.w3.org/publishing/epub3/core/#sec-foreign-restrictions-manifest"
 									>manifest fallbacks</a> [[!EPUB3]], <a
-									href="https://www.w3.org/publishing/epub3/core/#sec-opf-bindings"
-									>bindings</a> [[!EPUB3]] and content switching via the <a
+									href="https://www.w3.org/publishing/epub3/core/#sec-opf-bindings">bindings</a>
+								[[!EPUB3]] and content switching via the <a
 									href="https://www.w3.org/publishing/epub3/core/#sec-xhtml-content-switch"
 										><code>epub:switch</code> element</a> [[!EPUB3]].</li>
 
@@ -484,8 +492,8 @@
 						</ul>
 
 						<p>In addition, if page numbers are read aloud in a synchronized text-audio playback of the
-							content (e.g., EPUB 3 Media Overlays [[EPUB3]]), Authors MUST identify the page
-							numbers in the markup that controls the playback.</p>
+							content (e.g., EPUB 3 Media Overlays [[EPUB3]]), Authors MUST identify the page numbers in
+							the markup that controls the playback.</p>
 
 						<div class="note">
 							<p>See <a href="techniques/techniques.html#sec-epub-page-markers">Page Markers</a>
@@ -515,8 +523,7 @@
 					<section id="sec-mo-obj">
 						<h5>Objective</h5>
 
-						<p>Structure Media Overlays [[!EPUB3]] to provide more accessible playback
-							experiences.</p>
+						<p>Structure Media Overlays [[!EPUB3]] to provide more accessible playback experiences.</p>
 					</section>
 
 					<section id="sec-mo-understand" class="informative">
@@ -529,10 +536,9 @@
 
 						<p>The most basic <a
 								href="https://www.w3.org/publishing/epub/core/#sec-media-overlays-document-definition"
-								>Media Overlay Documents</a> [[EPUB3]] provide only minimal instructions to
-							Reading Systems, however. They indicate the text to highlight and the audio clip that
-							corresponds to the text. The result is that users only have basic start and stop options
-							available.</p>
+								>Media Overlay Documents</a> [[EPUB3]] provide only minimal instructions to Reading
+							Systems, however. They indicate the text to highlight and the audio clip that corresponds to
+							the text. The result is that users only have basic start and stop options available.</p>
 
 						<p>Authors need to add structure and semantics to media overlay documents to allow Reading
 							Systems to present more usable experiences. With richer markup, a Reading System could
@@ -545,23 +551,21 @@
 					<section id="sec-mo-conf">
 						<h5>Meeting this Objective</h5>
 
-						<p>Media Overlay Documents SHOULD meet the requirements in [[EPUB3]]. It is not
-							necessary to meet any additional requirements beyond those defined in [[EPUB3]] to
-							be conformant with this document.</p>
+						<p>Media Overlay Documents SHOULD meet the requirements in [[EPUB3]]. It is not necessary to
+							meet any additional requirements beyond those defined in [[EPUB3]] to be conformant with
+							this document.</p>
 
 						<p>To improve the usability of Media Overlays, however, Authors are encouraged to ensure their
 							EPUB Publications meet the following criteria:</p>
 
 						<ul>
-							<li>identify all <a
-									href="https://www.w3.org/publishing/epub/core/#sec-skippability"
+							<li>identify all <a href="https://www.w3.org/publishing/epub/core/#sec-skippability"
 									>skippable structures</a> [[EPUB3]] in the Media Overlay Documents;</li>
-							<li>identify all <a
-									href="https://www.w3.org/publishing/epub/core/#sec-escapability"
+							<li>identify all <a href="https://www.w3.org/publishing/epub/core/#sec-escapability"
 									>escapable structures</a> [[EPUB3]] in the Media Overlay Documents;</li>
 							<li>include a Media Overlay Document for the <a
-									href="https://www.w3.org/publishing/epub/core/#sec-nav-doc">EPUB
-									Navigation Document</a> [[EPUB3]].</li>
+									href="https://www.w3.org/publishing/epub/core/#sec-nav-doc">EPUB Navigation
+									Document</a> [[EPUB3]].</li>
 						</ul>
 					</section>
 
@@ -591,21 +595,27 @@
 				<p>The value of the <code>conformsTo</code> property MUST be one of the following URLs:</p>
 
 				<dl>
-					<dt><code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</code></dt>
+					<dt>
+						<code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</code>
+					</dt>
 					<dd>
 						<p>The EPUB Publication meets all <a href="#sec-access-pub">accessibility requirements</a> and
 							achieves <a href="https://www.w3.org/TR/WCAG20/#conformance-reqs">WCAG 2.0 Level A
 								conformance</a> [[!WCAG20]].</p>
 					</dd>
 
-					<dt><code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa</code></dt>
+					<dt>
+						<code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa</code>
+					</dt>
 					<dd>
 						<p>The EPUB Publication meets all <a href="#sec-access-pub">accessibility requirements</a> and
 							achieves <a href="https://www.w3.org/TR/WCAG20/#conformance-reqs">WCAG 2.0 Level AA
 								conformance</a> [[!WCAG20]].</p>
 					</dd>
 
-					<dt><code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa</code></dt>
+					<dt>
+						<code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa</code>
+					</dt>
 					<dd>
 						<p>The EPUB Publication meets all <a href="#sec-access-pub">accessibility requirements</a> and
 							achieves <a href="https://www.w3.org/TR/WCAG20/#conformance-reqs">WCAG 2.0 Level AAA
@@ -857,7 +867,9 @@
 						<table>
 							<tr>
 								<th>Name:</th>
-								<td><code>certifiedBy</code></td>
+								<td>
+									<code>certifiedBy</code>
+								</td>
 							</tr>
 							<tr>
 								<th>Description:</th>
@@ -866,7 +878,9 @@
 							</tr>
 							<tr>
 								<th>Allowed value(s):</th>
-								<td><code>xsd:string</code></td>
+								<td>
+									<code>xsd:string</code>
+								</td>
 							</tr>
 							<tr>
 								<th>Cardinality:</th>
@@ -874,7 +888,9 @@
 							</tr>
 							<tr>
 								<th>Example:</th>
-								<td><pre>&lt;meta property="a11y:certifiedBy">Accessibility Testers Group&lt;/meta></pre></td>
+								<td>
+									<pre>&lt;meta property="a11y:certifiedBy">Accessibility Testers Group&lt;/meta></pre>
+								</td>
 							</tr>
 						</table>
 					</section>
@@ -885,7 +901,9 @@
 						<table>
 							<tr>
 								<th>Name:</th>
-								<td><code>certifierCredential</code></td>
+								<td>
+									<code>certifierCredential</code>
+								</td>
 							</tr>
 							<tr>
 								<th>Description:</th>
@@ -894,7 +912,9 @@
 							</tr>
 							<tr>
 								<th>Allowed value(s):</th>
-								<td><code>xsd:string</code></td>
+								<td>
+									<code>xsd:string</code>
+								</td>
 							</tr>
 							<tr>
 								<th>Cardinality:</th>
@@ -903,7 +923,9 @@
 							</tr>
 							<tr>
 								<th>Example:</th>
-								<td><pre>&lt;meta property="a11y:certifierCredential">DAISY OK&lt;/meta></pre></td>
+								<td>
+									<pre>&lt;meta property="a11y:certifierCredential">DAISY OK&lt;/meta></pre>
+								</td>
 							</tr>
 						</table>
 					</section>
@@ -914,7 +936,9 @@
 						<table>
 							<tr>
 								<th>Name:</th>
-								<td><code>certifierReport</code></td>
+								<td>
+									<code>certifierReport</code>
+								</td>
 							</tr>
 							<tr>
 								<th>Description:</th>
@@ -923,7 +947,9 @@
 							</tr>
 							<tr>
 								<th>Allowed value(s):</th>
-								<td><code>xsd:anyURI</code></td>
+								<td>
+									<code>xsd:anyURI</code>
+								</td>
 							</tr>
 							<tr>
 								<th>Cardinality:</th>
@@ -931,13 +957,40 @@
 							</tr>
 							<tr>
 								<th>Example:</th>
-								<td><pre>&lt;link rel="a11y:certifierReport" href="http://example.com/a11y/reports/9780000000001"/></pre></td>
+								<td>
+									<pre>&lt;link rel="a11y:certifierReport" href="http://example.com/a11y/reports/9780000000001"/></pre>
+								</td>
 							</tr>
 						</table>
 					</section>
 				</section>
 			</section>
 		</section>
-		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+		<section id="change-log">
+			<h2>Change Log</h2>
+
+			<section id="changes-latest">
+				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
+
+				<ul>
+					<li>26-Sept-2020: The revisions made to the Accessibility 1.0 specification as part of publishing it
+						as an ISO standard have been incorporated into the initial draft text.</li>
+				</ul>
+			</section>
+
+			<!--
+				After FPWD:
+				- Uncomment this section and move all pre-FPWD changes above here
+				- Change link/reference in preceding section heading to FPWD
+			
+			<section id="changes-older">
+				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
+				<ul>
+				</ul>
+			</section>
+			-->
+		</section>
+		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
+		></div>
 	</body>
 </html>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -758,9 +758,10 @@
 								<td>
 									<p>OPUS audio using OGG container</p>
 									<div class="issue" data-number="645">
-										<p>The Working Group intends to monitor support for OPUS on Mac/iOS, where it is
-											currently only supported in the latest versions within CAF files. Inclusion
-											as a core media type is subject to change.</p>
+										<p>Although, OPUS/OGG has good support in Android, MacOS, Windows, and Linux,
+											Apple, starting with iOS 11, only supports the OPUS codec in a CAF
+											container. The working group will monitor support for OPUS in iOS, and may
+											remove OPUS as a core media type if the level of support is inadequate.</p>
 									</div>
 								</td>
 							</tr>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -751,6 +751,20 @@
 								<td>AAC LC audio using MP4 container</td>
 							</tr>
 							<tr>
+								<td id="cmt-ogg-opus">
+									<code>audio/opus</code>
+								</td>
+								<td>[[!RFC7845]]</td>
+								<td>
+									<p>OPUS audio using OGG container</p>
+									<div class="issue" data-number="645">
+										<p>The Working Group intends to monitor support for OPUS on Mac/iOS, where
+											it is currently only supported in the latest versions within CAF files.
+											Inclusion as a core media type is subject to change.</p>
+									</div>
+								</td>
+							</tr>
+							<tr>
 								<th colspan="3" id="cmt-grp-video" class="tbl-group">Video</th>
 							</tr>
 							<tr>
@@ -913,7 +927,6 @@
 					<p>Refer to the [[!HTML]] and [[!SVG]] specifications for the intrinsic fallback capabilities their
 						elements provide.</p>
 				</section>
-
 			</section>
 
 			<section id="sec-resource-locations">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -759,15 +759,7 @@
 									<code>audio/opus</code>
 								</td>
 								<td>[[!RFC7845]]</td>
-								<td>
-									<p>OPUS audio using OGG container</p>
-									<div class="issue" data-number="645">
-										<p>Although, OPUS/OGG has good support in Android, MacOS, Windows, and Linux,
-											Apple, starting with iOS 11, only supports the OPUS codec in a CAF
-											container. The working group will monitor support for OPUS in iOS, and may
-											remove OPUS as a core media type if the level of support is inadequate.</p>
-									</div>
-								</td>
+								<td>OPUS audio using OGG container</td>
 							</tr>
 							<tr>
 								<th colspan="3" id="cmt-grp-video" class="tbl-group">Video</th>
@@ -887,6 +879,12 @@
 							</tr>
 						</tbody>
 					</table>
+					<div class="issue" data-number="645">
+						<p>Although, OPUS/OGG has good support in Android, MacOS, Windows, and Linux, Apple, starting
+							with iOS 11, only supports the OPUS codec in a CAF container. The working group will monitor
+							support for OPUS in iOS, and may remove OPUS as a core media type if the level of support is
+							inadequate.</p>
+					</div>
 				</section>
 
 				<section id="sec-foreign-restrictions">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -758,9 +758,9 @@
 								<td>
 									<p>OPUS audio using OGG container</p>
 									<div class="issue" data-number="645">
-										<p>The Working Group intends to monitor support for OPUS on Mac/iOS, where
-											it is currently only supported in the latest versions within CAF files.
-											Inclusion as a core media type is subject to change.</p>
+										<p>The Working Group intends to monitor support for OPUS on Mac/iOS, where it is
+											currently only supported in the latest versions within CAF files. Inclusion
+											as a core media type is subject to change.</p>
 									</div>
 								</td>
 							</tr>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -20,19 +20,23 @@
 					name: "Garth Conboy",
 					company: "Google",
 					companyURL: "https://www.google.com"
-				}, {
+				},
+				{
 					name: "Dave Cramer",
 					company: "Hachette Livre",
 					companyURL: "https://www.hachettebookgroup.com",
-				}, {
+				},
+				{
 					name: "Marisa DeMeglio",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
-				}, {
+				},
+				{
 					name: "Matt Garrish",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
-				}, {
+				},
+				{
 					name: "Daniel Weck",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
@@ -10380,6 +10384,37 @@ EPUB/images/cover.png</pre>
 					</dd>
 				</dl>
 			</section>
+		</section>
+		<section id="change-log">
+			<h2>Change Log</h2>
+
+			<section id="changes-latest">
+				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
+					3.2</a></h3>
+
+				<ul>
+					<li>12-Oct-2020: Added OPUS to the audio core media types with a warning that it is still subject to
+						review depending on support in Mac/iOS.</li>
+					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
+						understanding and access to information. This specification now consolidates the authoring
+						requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF
+						and Media Overlays specifications. A separate document, EPUB Reading Systems 3.3, consolidates
+						the reading system requirements from those documents.</li>
+				</ul>
+			</section>
+
+			<!--
+				After FPWD:
+				- Uncomment this section and move all pre-FPWD changes above here
+				- Change link/reference in preceding section heading to FPWD
+			
+			<section id="changes-older">
+				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
+					3.2</a></h3>
+				<ul>
+				</ul>
+			</section>
+			-->
 		</section>
 		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
 		></div>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -47,7 +47,7 @@
 					branch: "master"
 				},
 				localBiblio: biblio,
-				preProcess:[inlineCustomCSS,fixDefinitionCrossrefs],
+				preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
 				postProcess:[addConformanceLinks]
 			};//]]></script>
 	</head>
@@ -2041,6 +2041,35 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					</section>
 				</section>
 			</section>
+		</section>
+		<section id="change-log">
+			<h2>Change Log</h2>
+
+			<section id="changes-latest">
+				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
+					3.2</a></h3>
+
+				<ul>
+					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
+						understanding and access to information. This specification now consolidates the reading system
+						requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF
+						and Media Overlays specifications. The EPUB 3.3 core specification now focuses only on authoring
+						requirements.</li>
+				</ul>
+			</section>
+
+			<!--
+				After FPWD:
+				- Uncomment this section and move all pre-FPWD changes above here
+				- Change link/reference in preceding section heading to FPWD
+			
+			<section id="changes-older">
+				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
+					3.2</a></h3>
+				<ul>
+				</ul>
+			</section>
+			-->
 		</section>
 		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
 		></div>


### PR DESCRIPTION
Includes a link to issue 645, which we should keep open if we're not fully committed to inclusion yet.

A couple of issues I had with this PR, though:

- I've added audio/opus as the mime type, but I spotted the note about using audio/ogg for Opera. Since this is just the package document declaration, I assume we don't need to account for both.
- From what I've read, Opus is also supported in WebM and MP4 containers, but I assume we're only supporting Ogg since that's all that was discussed.

If I'm assuming wrong on either of these points, please chime in.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-epub-revision/pull/1341.html" title="Last updated on Oct 13, 2020, 12:15 PM UTC (39ac4dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-epub-revision/1341/e8b20f4...39ac4dc.html" title="Last updated on Oct 13, 2020, 12:15 PM UTC (39ac4dc)">Diff</a>