### PR TITLE
Clarify core media types

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -142,9 +142,7 @@
 				<p>The container format is defined in <a href="#sec-ocf"></a>.</p>
 
 				<figure>
-					<figcaption>
-						The following example visually represents the structure of the EPUB format.
-					</figcaption>
+					<figcaption> The following example visually represents the structure of the EPUB format. </figcaption>
 					<object data="images/epub.svg" width="350">
 						<img src="images/epub.png" width="350" alt="" />
 					</object>
@@ -659,19 +657,16 @@
 
 					<p>Formats are typically only included as Core Media Type Resources when it can be shown that they
 						have broad support in web browser cores &#8212; the rendering engines on which EPUB 3 Reading
-						Systems are built. They are like a compact between <a>Authors</a> and Reading Systems to ensure
-						the predictability of rendering of EPUB Publications.</p>
+						Systems are built. They are an agreement between Reading System developers and <a>Authors</a> to
+						ensure the predictability of rendering of EPUB Publications.</p>
 
 					<p>Inclusion as a Core Media Type Resource does not mean that all Reading Systems will support the
-						rendering of a resource, however. Only those Reading Systems that support the type of rendering
-						related to the resource are expected to (e.g., a Reading System with a <a>Viewport</a> has to
-						support image Core Media Type Resources, but a Reading System without a Viewport does not).</p>
-
-					<div class="note">
-						<p>Refer to <a href="https://www.w3.org/TR/epub-rs-33/#sec-rs-conf-general">Conformance
-								Requirements</a> [[EPUB-RS-33]] for more information about which rendering features
-							require support for which Core Media Type Resources.</p>
-					</div>
+						rendering of a resource, however. Only Reading Systems that are capable of rendering the type of
+						resource have to (e.g., a Reading System with a <a>Viewport</a> has to support image Core Media
+						Type Resources, but a Reading System without a Viewport does not). Refer to <a
+							href="https://www.w3.org/TR/epub-rs-33/#sec-rs-conf-general">Conformance Requirements</a>
+						[[EPUB-RS-33]] for more information about which Reading Systems rendering capabilities require
+						support for which Core Media Type Resources.</p>
 
 					<p>Foreign Resources come with no guarantee of rendering support, which is why they require a
 						fallback to a Core Media Type Resource. EPUB Publications are designed to be fully consumable on
@@ -932,9 +927,9 @@
 
 					<ul>
 						<li>
-							<p>intrinsic fallback mechanisms provided by the format (e.g., ability to provide more than
-								one media type or to display an alternate embedded message when a media type cannot be
-								rendered);</p>
+							<p>intrinsic fallback mechanisms provided by the host format (e.g., [[HTML]] elements often
+								provide the ability to reference more than one media type or to display an alternate
+								embedded message when a media type cannot be rendered);</p>
 						</li>
 						<li>
 							<p><a href="#sec-foreign-restrictions-manifest">manifest fallbacks</a>.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -20,23 +20,19 @@
 					name: "Garth Conboy",
 					company: "Google",
 					companyURL: "https://www.google.com"
-				},
-				{
+				}, {
 					name: "Dave Cramer",
 					company: "Hachette Livre",
 					companyURL: "https://www.hachettebookgroup.com",
-				},
-				{
+				}, {
 					name: "Marisa DeMeglio",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
-				},
-				{
+				}, {
 					name: "Matt Garrish",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
-				},
-				{
+				}, {
 					name: "Daniel Weck",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
@@ -142,9 +138,7 @@
 				<p>The container format is defined in <a href="#sec-ocf"></a>.</p>
 
 				<figure>
-					<figcaption>
-						The following example visually represents the structure of the EPUB format.
-					</figcaption>
+					<figcaption> The following example visually represents the structure of the EPUB format. </figcaption>
 					<object data="images/epub.svg" width="350">
 						<img src="images/epub.png" width="350" alt="" />
 					</object>
@@ -657,15 +651,32 @@
 						without fallbacks (<a>Core Media Type Resources</a>) and those that cannot (<a>Foreign
 							Resources</a>).</p>
 
-					<p><a>Authors</a> are free to use both types of resources to construct their EPUB Publications, but
-						need to be aware that some Reading Systems might not render the Foreign Resources they use.</p>
+					<p>Formats are typically only included as Core Media Type Resources when it can be shown that they
+						have broad support in web browser cores &#8212; the rendering engines on which EPUB 3 Reading
+						Systems are built. They are like a compact between Authors and Reading Systems to ensure the
+						predictability of rendering of EPUB Publications.</p>
 
-					<p>As EPUB Publications are designed to be fully consumable on any compliant Reading System, a
-						system of fallbacks is necessary to ensure that the use of Foreign Resources does not impact on
-						the ability of the user to consume the content. This section lists the <a
-							href="#sec-cmt-supported">set of Core Media Type Resources</a> and identifies <a
-							href="#sec-foreign-restrictions">fallback mechanisms</a> that can be used to satisfy the
-						consumability requirement.</p>
+					<p>Inclusion as a Core Media Type Resource does not mean that all Reading Systems will support the
+						rendering of a resource, however, only that those that support the feature are expected to.
+						Refer to <a href="https://www.w3.org/TR/epub-rs-33/#sec-rs-conf-general">Conformance
+							Requirements</a> [[EPUB-RS-33]] for more information about which features require support
+						for which Core Media Type Resources.</p>
+
+					<p>Foreign Resources come with no guarantee of rendering support, which is why they require a
+						fallback to a Core Media Type Resource. EPUB Publications are designed to be fully consumable on
+						any compliant Reading System, so providing a fallback is necessary to ensure that the use of
+						Foreign Resources does not impact on the ability of the user to consume the content.</p>
+
+					<p>This section lists the <a href="#sec-cmt-supported">set of Core Media Type Resources</a> and
+						identifies <a href="#sec-foreign-restrictions">fallback mechanisms</a> that can be used to
+						satisfy the consumability requirement.</p>
+
+					<div class="note">
+						<p>EPUB also exempts some [[HTML]] elements from support requirements (see <a
+								href="#sec-xhtml-fallbacks"></a>). Resources referenced from these elements are neither
+							Core Media Type Resources nor Foreign Resources &#8212; they do not require fallbacks, but
+							they also have no support requirements.</p>
+					</div>
 				</section>
 
 				<section id="sec-cmt-supported">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -20,19 +20,23 @@
 					name: "Garth Conboy",
 					company: "Google",
 					companyURL: "https://www.google.com"
-				}, {
+				},
+				{
 					name: "Dave Cramer",
 					company: "Hachette Livre",
 					companyURL: "https://www.hachettebookgroup.com",
-				}, {
+				},
+				{
 					name: "Marisa DeMeglio",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
-				}, {
+				},
+				{
 					name: "Matt Garrish",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
-				}, {
+				},
+				{
 					name: "Daniel Weck",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org"
@@ -653,14 +657,19 @@
 
 					<p>Formats are typically only included as Core Media Type Resources when it can be shown that they
 						have broad support in web browser cores &#8212; the rendering engines on which EPUB 3 Reading
-						Systems are built. They are like a compact between Authors and Reading Systems to ensure the
-						predictability of rendering of EPUB Publications.</p>
+						Systems are built. They are like a compact between <a>Authors</a> and Reading Systems to ensure
+						the predictability of rendering of EPUB Publications.</p>
 
 					<p>Inclusion as a Core Media Type Resource does not mean that all Reading Systems will support the
-						rendering of a resource, however, only that those that support the feature are expected to.
-						Refer to <a href="https://www.w3.org/TR/epub-rs-33/#sec-rs-conf-general">Conformance
-							Requirements</a> [[EPUB-RS-33]] for more information about which features require support
-						for which Core Media Type Resources.</p>
+						rendering of a resource, however. Only those Reading Systems that support the type of rendering
+						related to the resource are expected to (e.g., a Reading System with a <a>Viewport</a> has to
+						support image Core Media Type Resources, but a Reading System without a Viewport does not).</p>
+
+					<div class="note">
+						<p>Refer to <a href="https://www.w3.org/TR/epub-rs-33/#sec-rs-conf-general">Conformance
+								Requirements</a> [[EPUB-RS-33]] for more information about which rendering features
+							require support for which Core Media Type Resources.</p>
+					</div>
 
 					<p>Foreign Resources come with no guarantee of rendering support, which is why they require a
 						fallback to a Core Media Type Resource. EPUB Publications are designed to be fully consumable on

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -142,7 +142,9 @@
 				<p>The container format is defined in <a href="#sec-ocf"></a>.</p>
 
 				<figure>
-					<figcaption> The following example visually represents the structure of the EPUB format. </figcaption>
+					<figcaption>
+						The following example visually represents the structure of the EPUB format.
+					</figcaption>
 					<object data="images/epub.svg" width="350">
 						<img src="images/epub.png" width="350" alt="" />
 					</object>


### PR DESCRIPTION
Picking up on https://github.com/w3c/publ-epub-revision/pull/1341#issuecomment-707674552, this is my best attempt to expand on the perennially confusing nature of core media types.

Let me know if there's anything you don't agree with, or if any parts need further elaboration.

Feedback is always welcome beyond the reviewer list, too.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-epub-revision/pull/1345.html" title="Last updated on Oct 15, 2020, 11:16 AM UTC (980f1d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-epub-revision/1345/bf93bc8...980f1d5.html" title="Last updated on Oct 15, 2020, 11:16 AM UTC (980f1d5)">Diff</a>