### PR TITLE
Update conformance titles

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -83,9 +83,9 @@
 
 				<ul>
 					<li>
-						<p><a href="epub-rs.html">EPUB 3 Reading Systems</a> [[!EPUB-RS-33]] — defines the processing
-							requirements for <a>EPUB Reading Systems</a> — the applications that consume EPUB
-							Publications and present their content to users.</p>
+						<p><a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3 Reading Systems</a> [[!EPUB-RS-33]] —
+							defines the processing requirements for <a>EPUB Reading Systems</a> — the applications that
+							consume EPUB Publications and present their content to users.</p>
 					</li>
 					<li>
 						<p><a href="http://www.idpf.org/epub/latest/accessibility">EPUB Accessibility</a>
@@ -142,9 +142,7 @@
 				<p>The container format is defined in <a href="#sec-ocf"></a>.</p>
 
 				<figure>
-					<figcaption>
-						The following example visually represents the structure of the EPUB format.
-					</figcaption>
+					<figcaption> The following example visually represents the structure of the EPUB format. </figcaption>
 					<object data="images/epub.svg" width="350">
 						<img src="images/epub.png" width="350" alt="" />
 					</object>
@@ -759,9 +757,9 @@
 							<tr>
 								<td colspan="3" id="cmt-vide-note">EPUB 3 allows any video codecs to be included without
 									fallbacks, although none are technically considered Core Media Type Resources. Refer
-									to the note in <a href="epub-rs.html#note-video-codecs">Conformance — General
-										Requirements</a> [[EPUB-RS-33]] for informative recommendations on support for
-									video codecs in EPUB Publications. </td>
+									to the note in <a href="https://www.w3.org/TR/epub-rs-33/#note-video-codecs"
+										>Conformance — General Requirements</a> [[EPUB-RS-33]] for informative
+									recommendations on support for video codecs in EPUB Publications. </td>
 							</tr>
 							<tr>
 								<th colspan="3" id="cmt-grp-text" class="tbl-group">Style</th>
@@ -781,8 +779,8 @@
 							<tr>
 								<td colspan="3" id="cmt-font-note"> EPUB 3 allows any font resource to be included
 									without a fallback, as CSS already defines fallback rules for fonts. Refer to the <a
-										href="epub-rs.html#confreq-css-rs-fonts">Reading System support requirements for
-										fonts</a> [[!EPUB-RS-33]] for more information.</td>
+										href="https://www.w3.org/TR/epub-rs-33/#confreq-css-rs-fonts">Reading System
+										support requirements for fonts</a> [[!EPUB-RS-33]] for more information.</td>
 							</tr>
 							<tr>
 								<td id="cmt-sfnt">
@@ -3657,8 +3655,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
 						</aside>
 
-						<p>After <a href="epub-rs.html#sec-property-processing">processing</a> [[EPUB-RS-33]], this
-							property would expand to the following IRI:</p>
+						<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
+							[[EPUB-RS-33]], this property would expand to the following IRI:</p>
 
 						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
 
@@ -6124,9 +6122,9 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 					<p>Which context a script is used in determines the rights and restrictions that a Reading System
 						places on it. Refer to <a href="#sec-scripted-content-content-reqs"></a> and <a
-							href="epub-rs.html#sec-scripted-content-rs-reqs">Scripting — General Conformance</a>
-						[[EPUB-RS-33]] for some specific requirements that have to be adhered to (not all Reading
-						Systems will provide the same scripting functionality).</p>
+							href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">Scripting
+							Conformance</a> [[EPUB-RS-33]] for some specific requirements that have to be adhered to
+						(not all Reading Systems will provide the same scripting functionality).</p>
 
 					<h5>Example</h5>
 
@@ -8267,8 +8265,9 @@ store destination as source in ocf
 
 					<p> The <code>epub:type</code> attribute facilitates Reading System behavior appropriate for the
 						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
-							>skippability and escapability</a> and <a href="epub-rs.html#note-table-reading-mode">table
-							reading mode</a> [[EPUB-RS-33]].</p>
+							>skippability and escapability</a> and <a
+							href="https://www.w3.org/TR/epub-rs-33/#note-table-reading-mode">table reading mode</a>
+						[[EPUB-RS-33]].</p>
 
 					<aside class="example">
 						<p>The following example shows the semantic markup for a Media Overlay containing a figure.</p>
@@ -8645,9 +8644,10 @@ html.-epub-media-overlay-playing * {
 				<p>The <a>EPUB Navigation Document</a> is an <a>XHTML Content Document</a> and can therefore be
 					associated with an audio Media Overlay. Unlike traditional XHTML Content Documents, however,
 						<a>Reading Systems</a> have to present the EPUB Navigation Document to users even when it is not
-					included in the <a>spine</a> (see <a href="epub-rs.html#sec-package-nav-rs-conf">Navigation Document
-						— General Conformance</a> [[EPUB-RS-33]]). As a result, the method in which an associated Media
-					Overlay behaves can change depending on the context:</p>
+					included in the <a>spine</a> (see <a
+						href="https://www.w3.org/TR/epub-rs-33/#sec-package-nav-rs-conf">Navigation Document
+						Conformance</a> [[EPUB-RS-33]]). As a result, the method in which an associated Media Overlay
+					behaves can change depending on the context:</p>
 
 				<ul>
 					<li>
@@ -9122,7 +9122,8 @@ EPUB/images/cover.png</pre>
 					</p>
 					<ul>
 						<li>
-							<p><a href="epub-rs.html#confreq-css-rs-support">CSS snapshot support</a> [[EPUB-RS-33]]</p>
+							<p><a href="https://www.w3.org/TR/epub-rs-33/#confreq-css-rs-support">CSS snapshot
+									support</a> [[EPUB-RS-33]]</p>
 						</li>
 						<li>
 							<p>
@@ -9130,8 +9131,8 @@ EPUB/images/cover.png</pre>
 							</p>
 						</li>
 						<li>
-							<p><a href="epub-rs.html#sec-css-rs-overrides">Reading System overrides</a>
-								[[EPUB-RS-33]]</p>
+							<p><a href="https://www.w3.org/TR/epub-rs-33/#sec-css-rs-overrides">Reading System
+									overrides</a> [[EPUB-RS-33]]</p>
 						</li>
 					</ul>
 				</li>
@@ -9229,7 +9230,8 @@ EPUB/images/cover.png</pre>
 							</ul>
 						</li>
 						<li>
-							<p><a href="epub-rs.html#sec-fxl-viewport">viewport rendering</a> [[EPUB-RS-33]]</p>
+							<p><a href="https://www.w3.org/TR/epub-rs-33/#sec-fxl-viewport">viewport rendering</a>
+								[[EPUB-RS-33]]</p>
 						</li>
 					</ul>
 				</li>
@@ -9873,48 +9875,53 @@ EPUB/images/cover.png</pre>
 							<p><a href="#sec-scripted-context">contexts</a> (container-constrained and spine-level)</p>
 						</li>
 						<li>
-							<p><a href="epub-rs.html#app-epubReadingSystem">epubReadingSystem object</a>
-								[[EPUB-RS-33]]</p>
+							<p><a href="https://www.w3.org/TR/epub-rs-33/#app-epubReadingSystem">epubReadingSystem
+									object</a> [[EPUB-RS-33]]</p>
 							<ul>
 								<li>
 									<p>
-										<a href="epub-rs.html#app-ers-desc">description</a>
+										<a href="https://www.w3.org/TR/epub-rs-33/#app-ers-desc">description</a>
 									</p>
 								</li>
 								<li>
 									<p>
-										<a href="epub-rs.html#app-ers-hasFeature">hasFeature method</a>
+										<a href="https://www.w3.org/TR/epub-rs-33/#app-ers-hasFeature">hasFeature
+											method</a>
 									</p>
 									<ul>
 										<li>
 											<p>
-												<a href="epub-rs.html#app-ers-hasFeature-desc">description</a>
+												<a href="https://www.w3.org/TR/epub-rs-33/#app-ers-hasFeature-desc"
+													>description</a>
 											</p>
 										</li>
 										<li>
 											<p>
-												<a href="epub-rs.html#app-ers-hasFeature-features">features</a>
+												<a href="https://www.w3.org/TR/epub-rs-33/#app-ers-hasFeature-features"
+													>features</a>
 											</p>
 										</li>
 									</ul>
 								</li>
 								<li>
 									<p>
-										<a href="epub-rs.html#app-ers-idl">interface definition</a>
+										<a href="https://www.w3.org/TR/epub-rs-33/#app-ers-idl">interface definition</a>
 									</p>
 								</li>
 								<li>
 									<p>
-										<a href="epub-rs.html#app-ers-properties">properties</a>
+										<a href="https://www.w3.org/TR/epub-rs-33/#app-ers-properties">properties</a>
 									</p>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p><a href="epub-rs.html#sec-scripted-content-events">event model</a> [[EPUB-RS-33]]</p>
+							<p><a href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-events">event model</a>
+								[[EPUB-RS-33]]</p>
 						</li>
 						<li>
-							<p><a href="epub-rs.html#sec-scripted-content-security">security</a> [[EPUB-RS-33]]</p>
+							<p><a href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-security">security</a>
+								[[EPUB-RS-33]]</p>
 						</li>
 					</ul>
 				</li>
@@ -10014,8 +10021,8 @@ EPUB/images/cover.png</pre>
 							</p>
 							<ul>
 								<li>
-									<p><a href="epub-rs.html#sec-xhtml-svg-css">application of CSS styles</a>
-										[[EPUB-RS-33]]</p>
+									<p><a href="https://www.w3.org/TR/epub-rs-33/#sec-xhtml-svg-css">application of CSS
+											styles</a> [[EPUB-RS-33]]</p>
 								</li>
 							</ul>
 						</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -68,9 +68,9 @@
 				<h3>Overview</h3>
 
 				<p>The EPUB 3 standard is separated into two distinct concerns: the authoring of <a>EPUB
-						Publications</a> is defined in the <a href="epub-core.html">core specification</a> [[EPUB-33]],
-					while this specification details the rendering requirements for them in <a>EPUB Reading
-					Systems</a>.</p>
+						Publications</a> is defined in the <a href="https://www.w3.org/TR/epub-33/">core
+						specification</a> [[EPUB-33]], while this specification details the rendering requirements for
+					them in <a>EPUB Reading Systems</a>.</p>
 
 				<p>An EPUB Reading System can take many forms. It might have a visual display area for rendering the
 					content to users, for example, or it might only provide audio playback of the content. As a result,
@@ -144,12 +144,12 @@
 						<li>
 							<p id="confreq-rs-foreign">It MAY support an arbitrary set of <a>Foreign Resource</a> types,
 								and MUST process fallbacks for unsupported Foreign Resources as defined in <a
-									href="epub-core.html#sec-foreign-restrictions">Foreign Resources</a> [[!EPUB-33]] if
-								not.</p>
+									href="https://www.w3.org/TR/epub-33/#sec-foreign-restrictions">Foreign Resources</a>
+								[[!EPUB-33]] if not.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-remote">It SHOULD support <a>remote resources</a>, as defined in <a
-									href="epub-core.html#sec-resource-locations">Resource Locations</a>
+									href="https://www.w3.org/TR/epub-33/#sec-resource-locations">Resource Locations</a>
 								[[!EPUB-33]].</p>
 						</li>
 						<li>
@@ -166,19 +166,19 @@
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-images">If it has a Viewport, it MUST support the <a
-									href="epub-core.html#cmt-grp-image">image Core Media Type Resources</a>
-								[[!EPUB-33]].</p>
+									href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type
+									Resources</a> [[!EPUB-33]].</p>
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-mp3-aac">If it has the capability to render pre-recorded audio, it
-								MUST support the <a href="epub-core.html#cmt-grp-audio">audio Core Media Type
-									Resources</a> [[!EPUB-33]] and SHOULD support Media Overlays [[!EPUB-33]].</p>
+								MUST support the <a href="https://www.w3.org/TR/epub-33/#cmt-grp-audio">audio Core Media
+									Type Resources</a> [[!EPUB-33]] and SHOULD support Media Overlays [[!EPUB-33]].</p>
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-tts">If it supports <a>Text-to-Speech</a> (TTS) rendering, it SHOULD
 								support <a href="#sec-pls-conf-rs">Pronunciation Lexicons</a>, [[!CSS3Speech]] and <a
-									href="epub-core.html#sec-xhtml-ssml-attrib">SSML attributes</a> [[!EPUB-33]] in
-									<a>XHTML Content Documents</a>.</p>
+									href="https://www.w3.org/TR/epub-33/#sec-xhtml-ssml-attrib">SSML attributes</a>
+								[[!EPUB-33]] in <a>XHTML Content Documents</a>.</p>
 						</li>
 					</ul>
 					<p class="note" id="note-video-codecs">It is recommended that Reading Systems support at least one
@@ -253,7 +253,7 @@
 			<h2>Package Processing</h2>
 
 			<section id="sec-package-rs-conformance">
-				<h3>Basic Conformance</h3>
+				<h3>Package Conformance</h3>
 
 				<p>An <a>EPUB Reading System</a> is conformant with this section if meets all of the following
 					criteria:</p>
@@ -261,8 +261,9 @@
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-rendition-rs-package">It MUST honor all presentation logic expressed through the
-								<a href="epub-core.html#sec-package-def">Package Document</a> [[!EPUB-33]] (e.g., the
-							reading order, fallback chains, page progression direction and fixed layouts).</p>
+								<a href="https://www.w3.org/TR/epub-33/#sec-package-def">Package Document</a>
+							[[!EPUB-33]] (e.g., the reading order, fallback chains, page progression direction and fixed
+							layouts).</p>
 					</li>
 					<li>
 						<p id="confreq-rs-package-def">It MUST process the Package Document in conformance with all
@@ -284,8 +285,9 @@
 					<li>
 						<p id="confreq-rendition-rs-manifest">It MUST NOT use any resources not listed in the Package
 							Document in the processing of the Package (e.g., <a
-								href="epub-core.html#sec-container-metainf"><code>META-INF</code> files</a> [[EPUB-33]]
-							or resources specific to other Renditions of the EPUB Publication).</p>
+								href="https://www.w3.org/TR/epub-33/#sec-container-metainf"><code>META-INF</code>
+								files</a> [[EPUB-33]] or resources specific to other Renditions of the EPUB
+							Publication).</p>
 					</li>
 				</ul>
 			</section>
@@ -318,8 +320,8 @@
 						<dd>
 							<p>To determine whether an <code>identifier</code> conforms to an established system or has
 								been granted by an issuing authority, Reading Systems SHOULD check for an <a
-									href="epub-core.html#identifier-type"><code>identifier-type</code> property</a>
-								[[!EPUB-33]].</p>
+									href="https://www.w3.org/TR/epub-33/#identifier-type"><code>identifier-type</code>
+									property</a> [[!EPUB-33]].</p>
 						</dd>
 
 						<dt id="dc-title">The <code>title</code> element</dt>
@@ -357,11 +359,11 @@
 							<p>Reading System do not have to use or present linked resources, even if they recognize the
 								relationship defined in the <code>rel</code> attribute.</p>
 
-							<p id="sec-linked-records">In the case of a <a href="epub-core.html#record">linked metadata
-									record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing the metadata
-								expressed in the Package Document and only use the information expressed in the record.
-								Reading Systems MAY compile metadata from multiple linked records; they do not have to
-								select only one record.</p>
+							<p id="sec-linked-records">In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
+									>linked metadata record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing
+								the metadata expressed in the Package Document and only use the information expressed in
+								the record. Reading Systems MAY compile metadata from multiple linked records; they do
+								not have to select only one record.</p>
 
 							<p>When it comes to resolving discrepancies and conflicts between metadata expressed in the
 								Package Document and in linked metadata records, Reading Systems MUST use the document
@@ -393,10 +395,11 @@
 								MUST traverse the fallback chain until it has identified at least one supported
 								Publication Resource to use in place of the unsupported resource. If the Reading System
 								supports multiple Publication Resources in the fallback chain, it MAY select the
-								resource to use based on specific <a href="epub-core.html#attrdef-item-properties"
-									>properties</a> [[!EPUB-33]] of that resource, otherwise it SHOULD honor the
-								Author's preferred fallback order. If a Reading System does not support any resource in
-								the fallback chain, it MUST alert the reader that content could not be displayed.</p>
+								resource to use based on specific <a
+									href="https://www.w3.org/TR/epub-33/#attrdef-item-properties">properties</a>
+								[[!EPUB-33]] of that resource, otherwise it SHOULD honor the Author's preferred fallback
+								order. If a Reading System does not support any resource in the fallback chain, it MUST
+								alert the reader that content could not be displayed.</p>
 						</dd>
 						<dt>Manifest Fallbacks</dt>
 						<dd>
@@ -462,9 +465,9 @@
 						<p>Reading Systems MUST NOT depend on the Unique Identifier being unique to one and only one
 							EPUB Publication. Determining whether two EPUB Publications with the same Unique Identifier
 							represent different versions of the same publication (see <a
-								href="epub-core.html#sec-metadata-elem-identifiers-pid">Release Identifier</a>
-							[[!EPUB-33]]), or different publications, might require inspecting other metadata, such as
-							the titles or authors.</p>
+								href="https://www.w3.org/TR/epub-33/#sec-metadata-elem-identifiers-pid">Release
+								Identifier</a> [[!EPUB-33]]), or different publications, might require inspecting other
+							metadata, such as the titles or authors.</p>
 					</dd>
 				</dl>
 			</section>
@@ -501,8 +504,9 @@
 						<ul>
 							<li>
 								<p>If the property consists only of a reference, the IRI is obtained by concatenating
-									the IRI stem associated with the <a href="epub-core.html#sec-metadata-default-vocab"
-										>default vocabulary</a> [[!EPUB-33]] to the reference.</p>
+									the IRI stem associated with the <a
+										href="https://www.w3.org/TR/epub-33/#sec-metadata-default-vocab">default
+										vocabulary</a> [[!EPUB-33]] to the reference.</p>
 							</li>
 							<li>
 								<p>If the property consists of a prefix and reference, the IRI is obtained by
@@ -532,8 +536,8 @@
 
 						<p>The default value <code>auto</code> MUST be assumed by Reading Systems as the global value if
 							no <code>meta</code> element carrying this property occurs in the <a
-								href="epub-core.html#elemdef-opf-metadata"><code>metadata</code> section</a>
-							[[!EPUB-33]]. Reading Systems MAY support only this default value.</p>
+								href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code>
+								section</a> [[!EPUB-33]]. Reading Systems MAY support only this default value.</p>
 
 						<p>If a Reading Systems supports the <a href="#layout"><code>rendition:layout</code></a>
 							property, it MUST ignore the <code>rendition:flow</code> property when it has been set on a
@@ -553,8 +557,8 @@
 								<p>The Reading System SHOULD render all Content Documents such that overflow content is
 									scrollable, and the EPUB Publication represented by the given <a>Rendition</a>
 									SHOULD be presented as one continuous scroll from spine item to spine item (except
-									where <a href="epub-core.html#layout-property-flow-overrides">locally overridden</a>
-									[[!EPUB-33]]).</p>
+									where <a href="https://www.w3.org/TR/epub-33/#layout-property-flow-overrides"
+										>locally overridden</a> [[!EPUB-33]]).</p>
 							</dd>
 							<dt id="scrolled-doc">scrolled-doc</dt>
 							<dd>
@@ -571,7 +575,7 @@
 
 						<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction is
 							defined relative to the block flow direction of the root element of the XHTML Content
-							Document referenced by the <a href="epub-core.html#elemdef-spine-itemref"
+							Document referenced by the <a href="https://www.w3.org/TR/epub-33/#elemdef-spine-itemref"
 									><code>itemref</code> element</a> [[!EPUB-33]]. The scroll direction is vertical if
 							the block flow direction is downward (top-to-bottom). It is horizontal if the block flow
 							direction of the root element is rightward (left-to-right) or leftward (right-to-left).</p>
@@ -602,8 +606,8 @@
 
 						<p>The default value <code>reflowable</code> MUST be assumed by <a>EPUB Reading Systems</a> as
 							the global value if no <code>meta</code> element carrying this property occurs in the <a
-								href="epub-core.html#elemdef-opf-metadata"><code>metadata</code> section</a>
-							[[!EPUB-33]].</p>
+								href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code>
+								section</a> [[!EPUB-33]].</p>
 
 						<p>When the <code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading
 							Systems MUST NOT include space between the adjacent content slots when rendering
@@ -620,8 +624,8 @@
 							<dt id="def-layout-pre-paginated">pre-paginated</dt>
 							<dd>
 								<p>Reading Systems MUST produce exactly one page per spine <a
-										href="epub-core.html#elemdef-spine-itemref"><code>itemref</code></a>
-									[[!EPUB-33]] when rendering.</p>
+										href="https://www.w3.org/TR/epub-33/#elemdef-spine-itemref"
+										><code>itemref</code></a> [[!EPUB-33]] when rendering.</p>
 							</dd>
 						</dl>
 					</section>
@@ -706,7 +710,7 @@
 						<p>When a <a href="#def-layout-reflowable">reflowable</a> spine item follows a <a
 								href="#def-layout-pre-paginated">pre-paginated</a> one, the reflowable one SHOULD start
 							on the next page (as defined by the <a
-								href="epub-core.html#attrdef-spine-page-progression-direction"
+								href="https://www.w3.org/TR/epub-33/#attrdef-spine-page-progression-direction"
 									><code>page-progression-direction</code></a> [[EPUB-33]]) when it lacks a
 								<code>rendition:page-spread-*</code> property value. If the reflowable spine item has a
 								<code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by
@@ -730,7 +734,7 @@
 				<h3>Navigation Document</h3>
 
 				<section id="sec-package-nav-rs-conf">
-					<h4>General Conformance</h4>
+					<h4>Navigation Document Conformance</h4>
 
 					<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing <a>EPUB
 							Navigation Documents</a>:</p>
@@ -738,9 +742,9 @@
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-nav-access">When requested by a user, it MUST provide access to the links and
-								link labels in <a href="epub-core.html#sec-package-nav-def-types">the <code>nav</code>
-									elements</a> [[!EPUB-33]] of the EPUB Navigation Document in a fashion that allows
-								the user to activate the links.</p>
+								link labels in <a href="https://www.w3.org/TR/epub-33/#sec-package-nav-def-types">the
+										<code>nav</code> elements</a> [[!EPUB-33]] of the EPUB Navigation Document in a
+								fashion that allows the user to activate the links.</p>
 						</li>
 						<li>
 							<p id="confreq-nav-activation">When a link is activated, it MUST relocate the application's
@@ -772,7 +776,7 @@
 				<h3>XHTML Content Documents</h3>
 
 				<section id="sec-xhtml-conf-rs">
-					<h4>General Conformance</h4>
+					<h4>XHTML Conformance</h4>
 
 					<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing
 							<a>XHTML Content Documents</a>:</p>
@@ -819,7 +823,8 @@
 						<ul class="conformance-list">
 							<li>
 								<p id="confreq-rs-epubtype-beh">It MAY associate behaviors with none, some or all of the
-									terms defined in the <a href="epub-core.html#sec-contentdocs-default-vocab">default
+									terms defined in the <a
+										href="https://www.w3.org/TR/epub-33/#sec-contentdocs-default-vocab">default
 										vocabulary</a> [[EPUB-33]].</p>
 							</li>
 							<li>
@@ -871,9 +876,10 @@
 						<dl class="conformance-list">
 							<dt id="sec-cd-ssml-ph-attrib">The <code>ssml:ph</code> attribute</dt>
 							<dd>
-								<p>Reading Systems that support the SSML Attributes and <a href="epub-core.html#sec-pls"
-										>PLS documents</a> [[!EPUB-33]] MUST honor the defined <a
-										href="#confreq-pls-rs-casc">precedence rules</a> for these two constructs.</p>
+								<p>Reading Systems that support the SSML Attributes and <a
+										href="https://www.w3.org/TR/epub-33/#sec-pls">PLS documents</a> [[!EPUB-33]]
+									MUST honor the defined <a href="#confreq-pls-rs-casc">precedence rules</a> for these
+									two constructs.</p>
 							</dd>
 
 							<dt id="sec-cd-ssml-alphabet-attrib">The <code>ssml:alphabet</code> attribute</dt>
@@ -888,17 +894,17 @@
 					<section id="sec-xhtml-content-switch">
 						<h5>Content Switching (Deprecated)</h5>
 
-						<p>Use of the <code>switch</code> element is <a href="epub-core.html#deprecated">deprecated</a>
-							[[EPUB-33]]. Refer to its definition in [[!EPUBContentDocs-301]] for implementation
-							information.</p>
+						<p>Use of the <code>switch</code> element is <a href="https://www.w3.org/TR/epub-33/#deprecated"
+								>deprecated</a> [[EPUB-33]]. Refer to its definition in [[!EPUBContentDocs-301]] for
+							implementation information.</p>
 					</section>
 
 					<section id="sec-xhtml-epub-trigger">
 						<h5>The <code>epub:trigger</code> Element (Deprecated)</h5>
 
-						<p>Use of the <code>trigger</code> element is <a href="epub-core.html#deprecated">deprecated</a>
-							[[EPUB-33]]. Refer to its definition in [[!EPUBContentDocs-301]] for implementation
-							information.</p>
+						<p>Use of the <code>trigger</code> element is <a
+								href="https://www.w3.org/TR/epub-33/#deprecated">deprecated</a> [[EPUB-33]]. Refer to
+							its definition in [[!EPUBContentDocs-301]] for implementation information.</p>
 					</section>
 
 					<section id="sec-xhtml-custom-attributes">
@@ -1023,7 +1029,7 @@
 				<h3>CSS Style Sheets</h3>
 
 				<section id="sec-css-rs-conf">
-					<h4>General Conformance</h4>
+					<h4>CSS Conformance</h4>
 
 					<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing CSS
 						Style Sheets:</p>
@@ -1045,8 +1051,8 @@
 						</li>
 						<li>
 							<p id="confreq-css-rs-prefixed">It MUST support all prefixed properties defined in <a
-									href="epub-core.html#sec-css-prefixed">CSS Style Sheets — Prefixed Properties</a>
-								[[EPUB-33]].</p>
+									href="https://www.w3.org/TR/epub-33/#sec-css-prefixed">CSS Style Sheets — Prefixed
+									Properties</a> [[EPUB-33]].</p>
 						</li>
 						<li>
 							<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined
@@ -1088,29 +1094,31 @@
 				<h3>Scripting</h3>
 
 				<section id="sec-scripted-content-rs-reqs">
-					<h4>General Conformance</h4>
+					<h4>Scripting Conformance</h4>
+
 					<p>A Reading System that supports scripting MUST meet the following criteria:</p>
 
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-rs-scripted-reflow-support">It SHOULD support <a
-									href="epub-core.html#sec-scripted-content-type-container-constrained"
+									href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-container-constrained"
 									>container-constrained scripting</a> [[!EPUB-33]] in reflowable EPUB Content
 								Documents.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-scripted-fxl-support">It SHOULD support <a
-									href="epub-core.html#sec-scripted-content-type-spine-level">spine-level
-									scripting</a> [[!EPUB-33]] in <a href="#sec-fixed-layouts">fixed-layout
+									href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-spine-level"
+									>spine-level scripting</a> [[!EPUB-33]] in <a href="#sec-fixed-layouts">fixed-layout
 									documents</a>.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-scripted-scrolled">It SHOULD support spine-level scripting in reflowable
-								EPUB Content Documents that use the <a href="epub-core.html#flow-scrolled-doc"
-										>"<code>scrolled-doc</code>"</a> or <a
-									href="epub-core.html#flow-scrolled-continuous"
-									>"<code>scrolled-continuous</code>"</a> [[!EPUB-33]] presentation modes defined by
-									<a href="#flow">the <code>rendition:flow</code> property</a>. Similarly, if it
+								EPUB Content Documents that use the <a
+									href="https://www.w3.org/TR/epub-33/#flow-scrolled-doc"
+									>"<code>scrolled-doc</code>"</a> or <a
+									href="https://www.w3.org/TR/epub-33/#flow-scrolled-continuous"
+										>"<code>scrolled-continuous</code>"</a> [[!EPUB-33]] presentation modes defined
+								by <a href="#flow">the <code>rendition:flow</code> property</a>. Similarly, if it
 								supports spine-level scripting in reflowable EPUB Content Documents, it MUST implement
 								the "<code>scrolled-doc</code>" presentation mode and SHOULD implement the
 									"<code>scrolled-continuous</code>" presentation mode.</p>
@@ -1149,8 +1157,8 @@
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-rs-scripted-flbk">It MUST process fallbacks for scripted content as defined
-								in <a href="epub-core.html#confreq-cd-scripted-flbk">Fallbacks for Scripted Content
-									Documents</a> [[!EPUB-33]].</p>
+								in <a href="https://www.w3.org/TR/epub-33/#confreq-cd-scripted-flbk">Fallbacks for
+									Scripted Content Documents</a> [[!EPUB-33]].</p>
 						</li>
 					</ul>
 
@@ -1159,7 +1167,7 @@
 							capabilities and/or provides a different rendering and user experience (e.g., by disabling
 							pagination).</p>
 						<p>Authors choosing to restrict the usage of scripting to the <a
-								href="epub-core.html#sec-scripted-content-type-container-constrained"
+								href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-container-constrained"
 								>container-constrained model</a> [[!EPUB-33]] will ensure a more consistent user
 							experience between scripted and non-scripted content (e.g., consistent pagination
 							behavior).</p>
@@ -1266,7 +1274,7 @@
 				<h3>Fixed Layouts</h3>
 
 				<section id="sec-fxl-rs-conf">
-					<h4>General Conformance</h4>
+					<h4>Fixed Layout Conformance</h4>
 
 					<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing
 							<a>Fixed-Layout Documents</a>:</p>
@@ -1284,8 +1292,8 @@
 						</li>
 						<li>
 							<p id="confreq-fxl-rs-svg">It MUST use the dimensions as defined in <a
-									href="epub-core.html#sec-fxl-icb-svg">Expressing the ICB in SVG</a> [[!EPUB-33]] to
-								render <a>SVG Content Documents</a>.</p>
+									href="https://www.w3.org/TR/epub-33/#sec-fxl-icb-svg">Expressing the ICB in SVG</a>
+								[[!EPUB-33]] to render <a>SVG Content Documents</a>.</p>
 						</li>
 					</ul>
 
@@ -1366,7 +1374,7 @@
 			<h2>Open Container Format Processing</h2>
 
 			<section id="ocf-conformance-rs">
-				<h3>Basic Conformance</h3>
+				<h3>OCF Conformance</h3>
 
 				<p>An <a>EPUB Reading System</a> has to meet the following criteria:</p>
 
@@ -1382,8 +1390,8 @@
 					</li>
 					<li>
 						<p id="confreq-ocf-fobfus">If it has a <a>Viewport</a>, it MUST support deobfuscation of
-							resources as defined in <a href="epub-core.html#sec-resource-obfuscation"><em>Resource
-									Obfuscation</em></a> [[!EPUB-33]].</p>
+							resources as defined in <a href="https://www.w3.org/TR/epub-33/#sec-resource-obfuscation"
+									><em>Resource Obfuscation</em></a> [[!EPUB-33]].</p>
 					</li>
 				</ul>
 
@@ -1445,7 +1453,7 @@
 						<dd>
 							<p><a>Reading Systems</a> MUST NOT fail when encountering files in the <code
 									class="filename">META-INF</code> directory not listed in <a
-									href="epub-core.html#sec-container-metainf-files">Reserved Files</a>
+									href="https://www.w3.org/TR/epub-33/#sec-container-metainf-files">Reserved Files</a>
 								[[!EPUB-33]].</p>
 						</dd>
 					</dl>
@@ -1507,7 +1515,7 @@
 			<h2>Media Overlays Processing</h2>
 
 			<section id="sec-overlays-rs-conf">
-				<h2>General Conformance</h2>
+				<h2>Media Overlays Conformance</h2>
 
 				<p><a>EPUB Reading System</a> support for Media Overlays is OPTIONAL. A Reading System that supports
 					Media Overlays MUST meet the following criteria:</p>
@@ -1536,9 +1544,9 @@
 					<li>
 						<p id="confreq-rs-mo-ignore">It MUST ignore both the <code>media-overlay</code> attribute on
 								<a>Manifest</a>
-							<a href="epub-core.html#elemdef-package-item"><code>item</code> elements</a> and the
-							manifest <code>item</code> elements where the <code>media-type</code> attribute value equals
-								<code>application/smil+xml</code>.</p>
+							<a href="https://www.w3.org/TR/epub-33/#elemdef-package-item"><code>item</code> elements</a>
+							and the manifest <code>item</code> elements where the <code>media-type</code> attribute
+							value equals <code>application/smil+xml</code>.</p>
 					</li>
 				</ul>
 			</section>
@@ -1551,9 +1559,9 @@
 
 					<p>When an <a>EPUB Reading System</a> loads a <a>Package Document</a>, it MUST refer to the
 							<a>Manifest</a>
-						<a href="epub-core.html#elemdef-package-item"><code>item</code> elements'</a> [[!EPUB-33]]
-							<code>media-overlay</code> attributes to discover the corresponding Media Overlays for
-							<a>EPUB Content Documents</a>. Playback MUST start at the Media Overlay element which
+						<a href="https://www.w3.org/TR/epub-33/#elemdef-package-item"><code>item</code> elements'</a>
+						[[!EPUB-33]] <code>media-overlay</code> attributes to discover the corresponding Media Overlays
+						for <a>EPUB Content Documents</a>. Playback MUST start at the Media Overlay element which
 						corresponds to the desired EPUB Content Document starting point. Note that the start of an EPUB
 						Content Document MAY correspond to an element at the start or in the middle of a Media Overlay.
 						When the Media Overlay Document has finished playing, the Reading System SHOULD load the next
@@ -1568,12 +1576,13 @@
 						<h3>Timing and Synchronization</h3>
 
 						<p>Reading Systems MUST render immediate children of the <a
-								href="epub-core.html#elemdef-smil-body"><code>body</code> element</a> [[!EPUB-33]] in a
-							sequence. A <a href="epub-core.html#elemdef-smil-seq"><code>seq</code> element's</a>
-							[[!EPUB-33]] children MUST be rendered in sequence, and playback completes when the last
-							child has finished playing. A <a href="epub-core.html#elemdef-smil-par"><code>par</code>
-								element's</a> [[!EPUB-33]] children MUST be rendered in parallel (with each starting at
-							the same time), and playback completes when all the children have finished playing. When the
+								href="https://www.w3.org/TR/epub-33/#elemdef-smil-body"><code>body</code> element</a>
+							[[!EPUB-33]] in a sequence. A <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-seq"
+									><code>seq</code> element's</a> [[!EPUB-33]] children MUST be rendered in sequence,
+							and playback completes when the last child has finished playing. A <a
+								href="https://www.w3.org/TR/epub-33/#elemdef-smil-par"><code>par</code> element's</a>
+							[[!EPUB-33]] children MUST be rendered in parallel (with each starting at the same time),
+							and playback completes when all the children have finished playing. When the
 								<code>body</code> element's last child has finished playing, playback of the Media
 							Overlay Document is done.</p>
 
@@ -1582,13 +1591,14 @@
 					<section id="sec-rsconf-rendering-audio">
 						<h5>Rendering Audio</h5>
 
-						<p>When presented with a Media Overlay <a href="epub-core.html#elemdef-smil-audio"
-									><code>audio</code> element</a> [[!EPUB-33]], Reading Systems MUST play the audio
-							resource referenced by the <code>src</code> attribute, starting at the clip offset time
-							given by the <a href="epub-core.html#attrdef-smil-clipBegin"><code>clipBegin</code>
+						<p>When presented with a Media Overlay <a
+								href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"><code>audio</code> element</a>
+							[[!EPUB-33]], Reading Systems MUST play the audio resource referenced by the
+								<code>src</code> attribute, starting at the clip offset time given by the <a
+								href="https://www.w3.org/TR/epub-33/#attrdef-smil-clipBegin"><code>clipBegin</code>
 								attribute</a> [[!EPUB-33]] and ending at the clip offset time given by the <a
-								href="epub-core.html#attrdef-smil-clipEnd"><code>clipEnd</code> attribute</a>
-							[[!EPUB-33]]. The following rules MUST be observed:</p>
+								href="https://www.w3.org/TR/epub-33/#attrdef-smil-clipEnd"><code>clipEnd</code>
+								attribute</a> [[!EPUB-33]]. The following rules MUST be observed:</p>
 
 						<ul>
 							<li>
@@ -1614,16 +1624,18 @@
 					<section id="sec-rsconf-rendering-text">
 						<h5>Rendering EPUB Content Document Elements</h5>
 
-						<p>When presented with a Media Overlay <a href="epub-core.html#elemdef-smil-text"
-									><code>text</code> element</a> [[!EPUB-33]], Reading Systems SHOULD ensure the EPUB
-							Content Document element referenced by the <code>src</code> attribute is visible in the
-								<a>Viewport</a>. During Media Overlays playback, Reading Systems with a Viewport SHOULD
-							add the class names given by the metadata properties <a href="epub-core.html#active-class"
-									><code>active-class</code></a> and <a href="epub-core.html#playback-active-class"
+						<p>When presented with a Media Overlay <a
+								href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"><code>text</code> element</a>
+							[[!EPUB-33]], Reading Systems SHOULD ensure the EPUB Content Document element referenced by
+							the <code>src</code> attribute is visible in the <a>Viewport</a>. During Media Overlays
+							playback, Reading Systems with a Viewport SHOULD add the class names given by the metadata
+							properties <a href="https://www.w3.org/TR/epub-33/#active-class"
+								><code>active-class</code></a> and <a
+								href="https://www.w3.org/TR/epub-33/#playback-active-class"
 									><code>playback-active-class</code></a> [[!EPUB-33]] to the appropriate elements in
 							the EPUB Content Document. Conversely, the class names SHOULD be removed when the playback
-							state changes, as described in <a href="epub-core.html#sec-docs-assoc-style">Associating
-								Style Information</a> [[!EPUB-33]].</p>
+							state changes, as described in <a href="https://www.w3.org/TR/epub-33/#sec-docs-assoc-style"
+								>Associating Style Information</a> [[!EPUB-33]].</p>
 
 						<p>The <code>active-class</code> and <code>playback-active-class</code> metadata properties are
 							OPTIONAL, and if omitted, Reading System behavior is implementation-specific.</p>
@@ -1655,8 +1667,8 @@
 							<p>A Media Overlay Document can be associated directly with a Navigation Document in order
 								to provide synchronized playback of its contents, regardless of whether the <a>XHTML
 									Content Document</a> in which it resides is included in the <a>spine</a>. See <a
-									href="epub-core.html#sec-nav-doc"><em>EPUB Navigation Document</em></a> [[!EPUB-33]]
-								for more information.</p>
+									href="https://www.w3.org/TR/epub-33/#sec-nav-doc"><em>EPUB Navigation
+									Document</em></a> [[!EPUB-33]] for more information.</p>
 						</div>
 
 						<div class="note" id="note-table-reading-mode">
@@ -1684,9 +1696,9 @@
 								href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-audio-element"
 									><code>audio</code></a> elements within the associated EPUB Content Document. That
 							is to say, the rules apply to only those elements pointed to by <a
-								href="epub-core.html#elemdef-smil-text"><code>text</code> elements</a> [[!EPUB-33]]
-							within the Media Overlay (i.e., via the <code>src</code> attribute). Embedded media that is
-							not referenced by Media Overlay elements is not subject to these rules.</p>
+								href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"><code>text</code> elements</a>
+							[[!EPUB-33]] within the Media Overlay (i.e., via the <code>src</code> attribute). Embedded
+							media that is not referenced by Media Overlay elements is not subject to these rules.</p>
 
 						<ul>
 							<li>
@@ -1729,9 +1741,9 @@
 								<p>When an EPUB Content Document element becomes active, the CSS Style Sheet visual
 									highlighting rules apply regardless of the content type referred to by that
 									element's <code>src</code> attribute (e.g., the CSS class name defined by the <a
-										href="epub-core.html#active-class"><code>active-class</code> metadata
-										property</a> [[!EPUB-33]] SHOULD be applied to visible video and audio player
-									controls within the host EPUB Content Document).</p>
+										href="https://www.w3.org/TR/epub-33/#active-class"><code>active-class</code>
+										metadata property</a> [[!EPUB-33]] SHOULD be applied to visible video and audio
+									player controls within the host EPUB Content Document).</p>
 							</li>
 							<li>
 								<p>In addition to the default behavior of Media Overlay activation for textual fragments
@@ -1741,10 +1753,11 @@
 								<ul>
 									<li>
 										<p>When a Media Overlay <code>text</code> element has no <a
-												href="epub-core.html#elemdef-smil-audio"><code>audio</code></a>
-											[[!EPUB-33]] sibling within its <a href="epub-core.html#elemdef-smil-par"
-													><code>par</code></a> [[!EPUB-33]] parent container, the referenced
-											EPUB Content Document audio or video media MUST play until it ends, at which
+												href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"
+													><code>audio</code></a> [[!EPUB-33]] sibling within its <a
+												href="https://www.w3.org/TR/epub-33/#elemdef-smil-par"
+												><code>par</code></a> [[!EPUB-33]] parent container, the referenced EPUB
+											Content Document audio or video media MUST play until it ends, at which
 											point the <code>text</code> element's lifespan terminates. In this case, the
 											implicit duration of the <code>text</code> element (and by inference, of the
 											parent <code>par</code> container) is that of the referenced audio or video
@@ -1794,8 +1807,9 @@
 					<section id="sec-text-to-speech">
 						<h5>Text-to-Speech</h5>
 
-						<p>When a Media Overlay <a href="epub-core.html#elemdef-smil-text"><code>text</code> element</a>
-							[[!EPUB-33]] with no <a href="epub-core.html#elemdef-smil-audio"><code>audio</code></a>
+						<p>When a Media Overlay <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"
+									><code>text</code> element</a> [[!EPUB-33]] with no <a
+								href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"><code>audio</code></a>
 							[[!EPUB-33]] sibling element references text within the target <a>EPUB Content Document</a>,
 							Reading Systems capable of <a>Text-to-Speech</a> (TTS) SHOULD render the referenced text
 							using TTS.</p>
@@ -1821,8 +1835,9 @@
 						<h5>Skippability</h5>
 
 						<p>Reading Systems SHOULD use the semantic information provided by Media Overlay elements' <a
-								href="epub-core.html#sec-docs-semantic-inflection"><code>epub:type</code> attribute</a>
-							[[!EPUB-33]] to determine when to offer users the option of skippable features.</p>
+								href="https://www.w3.org/TR/epub-33/#sec-docs-semantic-inflection"
+									><code>epub:type</code> attribute</a> [[!EPUB-33]] to determine when to offer users
+							the option of skippable features.</p>
 					</section>
 
 					<section id="sec-escabaility">
@@ -1830,9 +1845,9 @@
 
 						<p>Reading Systems SHOULD allow escaping of nested structures. Reading Systems MUST determine
 							the start of nested structures by the value of the <a
-								href="epub-core.html#sec-docs-semantic-inflection"><code>epub:type</code> attribute</a>
-							[[!EPUB-33]] and SHOULD offer users the option to skip playback of that structure and resume
-							with whatever content comes after it.</p>
+								href="https://www.w3.org/TR/epub-33/#sec-docs-semantic-inflection"
+									><code>epub:type</code> attribute</a> [[!EPUB-33]] and SHOULD offer users the option
+							to skip playback of that structure and resume with whatever content comes after it.</p>
 					</section>
 				</section>
 			</section>
@@ -1884,8 +1899,8 @@ partial interface Navigator {
 
 				<p>Reading Systems MUST expose the <code>epubReadingSystem</code> object on the <code>navigator</code>
 					object of all loaded Scripted Content Documents, including any nested <a
-						href="epub-core.html#sec-scripted-content-type-container-constrained">container-constrained
-						scripting contexts</a> [[!EPUB-33]]. Reading Systems MUST ensure that the
+						href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-container-constrained"
+						>container-constrained scripting contexts</a> [[!EPUB-33]]. Reading Systems MUST ensure that the
 						<code>epubReadingSystem</code> object is available no later than when the <a
 						href="https://www.w3.org/TR/html/syntax.html#the-end"><code>DOMContentLoaded</code> event is
 						triggered</a> [[!HTML]].</p>
@@ -1937,9 +1952,9 @@ partial interface Navigator {
 									<dfn>layoutStyle</dfn>
 								</code>
 							</td>
-							<td>Use of the <code>layoutStyle</code> property is <a href="epub-core.html#deprecated"
-									>deprecated</a> [[EPUB-33]]. Refer to its definition in [[!EPUBContentDocs-301]] for
-								usage information.</td>
+							<td>Use of the <code>layoutStyle</code> property is <a
+									href="https://www.w3.org/TR/epub-33/#deprecated">deprecated</a> [[EPUB-33]]. Refer
+								to its definition in [[!EPUBContentDocs-301]] for usage information.</td>
 						</tr>
 					</tbody>
 				</table>
@@ -2000,16 +2015,17 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 										<code>dom-manipulation</code>
 									</td>
 									<td>Scripts MAY make structural changes to the document’s DOM (applies to <a
-											href="epub-core.html#sec-scripted-content-type-spine-level">spine-level
-											scripting</a> [[!EPUB-33]] only).</td>
+											href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-spine-level"
+											>spine-level scripting</a> [[!EPUB-33]] only).</td>
 								</tr>
 								<tr>
 									<td id="feature-layout-changes">
 										<code>layout-changes</code>
 									</td>
 									<td>Scripts MAY modify attributes and CSS styles that affect content layout (applies
-										to <a href="epub-core.html#sec-scripted-content-type-spine-level">spine-level
-											scripting</a> [[!EPUB-33]] only).</td>
+										to <a
+											href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-spine-level"
+											>spine-level scripting</a> [[!EPUB-33]] only).</td>
 								</tr>
 								<tr>
 									<td id="feature-touch-events">
@@ -2037,9 +2053,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 										<code>spine-scripting</code>
 									</td>
 									<td>Indicates whether the Reading System supports <a
-											href="epub-core.html#sec-scripted-content-type-spine-level">spine-level
-											scripting</a> [[!EPUB-33]] (e.g., so a <a
-											href="epub-core.html#sec-scripted-content-type-container-constrained"
+											href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-spine-level"
+											>spine-level scripting</a> [[!EPUB-33]] (e.g., so a <a
+											href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-container-constrained"
 											>container-constrained script</a> [[EPUB-33]] can determine whether any
 										actions that depend on scripting support in a <a>Top-level Content Document</a>
 										have any chance of success before attempting them).</td>


### PR DESCRIPTION
Looking at https://github.com/w3c/publ-epub-revision/pull/1345#issuecomment-708831539, it appears that we lost "CSS Style Sheets -- Reading System Conformance" as the title of the link (partly due to the separation of requirements, and partly due to letting respec generate the titles from the section headers).

All I've done to fix this issue is update all the "General/Basic Conformance" headings to mention what specifically they're related to. So, in this case, the bullet now reads:

> If it has a Viewport, it MUST support visual rendering of XHTML Content Documents as defined in § 4.3.1 CSS Conformance.

Which is much closer to what it used to say.

I've also fixed the cross-linking between documents, as I noticed there were relative links using the old directory structure. The links now all use TR paths, although these also won't work until we publish FPWDs of the documents.

[Reading Systems preview](https://raw.githack.com/w3c/publ-epub-revision/editorial/fix-generic-titles/epub33/rs/)
[Reading Systems diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fpubl-epub-revision%2Fepub33%2Frs%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fpubl-epub-revision%2Feditorial%2Ffix-generic-titles%2Fepub33%2Frs%2Findex.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/publ-epub-revision/pull/1346.html" title="Last updated on Oct 15, 2020, 12:59 PM UTC (14c2760)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/publ-epub-revision/1346/49d6df9...14c2760.html" title="Last updated on Oct 15, 2020, 12:59 PM UTC (14c2760)">Diff</a>