### PR TITLE
Add webp to image core media types

### DIFF
--- a/epub33/common/js/biblio.js
+++ b/epub33/common/js/biblio.js
@@ -387,6 +387,14 @@ var biblio = {
     "US-ASCII": {
       "title": "&quot;Coded Character Set - 7-bit American Standard Code for Information Interchange&quot;, ANSI X3.4, 1986."
     },
+    "WebP-Container": {
+      "title": "WebP Container Specification",
+      "href": "https://developers.google.com/speed/webp/docs/riff_container"
+    },
+    "WebP-LB": {
+      "title": "WebP Lossless Bitstream Specification",
+      "href": "https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification"
+    },
     "W3CProcess": {
       "title": "W3C Process Document",
       "href": "https://www.w3.org/Consortium/Process/"

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10416,9 +10416,11 @@ EPUB/images/cover.png</pre>
 					3.2</a></h3>
 
 				<ul>
-					<li>16-Oct-2020: Added WebP to the image core media types.</li>
+					<li>16-Oct-2020: Added WebP to the image core media types. See <a
+							href="https://github.com/w3c/publ-epub-revision/issues/1344">issue 1344</a>.</li>
 					<li>12-Oct-2020: Added OPUS to the audio core media types with a warning that it is still subject to
-						review depending on support in Mac/iOS.</li>
+						review depending on support in Mac/iOS. See <a
+							href="https://github.com/w3c/publ-epub-revision/issues/645">issue 645</a>.</li>
 					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
 						understanding and access to information. This specification now consolidates the authoring
 						requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -744,6 +744,13 @@
 								</td>
 								<td>SVG documents</td>
 							</tr>
+							<tr>
+								<td id="cmt-webp">
+									<code>image/webp</code>
+								</td>
+								<td> [[!WebP-Container]], [[!WebP-LB]] </td>
+								<td>WebP Images</td>
+							</tr>
 
 
 							<tr>
@@ -10409,6 +10416,7 @@ EPUB/images/cover.png</pre>
 					3.2</a></h3>
 
 				<ul>
+					<li>16-Oct-2020: Added WebP to the image core media types.</li>
 					<li>12-Oct-2020: Added OPUS to the audio core media types with a warning that it is still subject to
 						review depending on support in Mac/iOS.</li>
 					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -898,6 +898,11 @@
 								will monitor support for OPUS in iOS, and may remove OPUS as a core media type if the
 								level of support is inadequate.</p>
 						</div>
+						<div class="issue" data-number="1344">
+							<p>WebP is currently not defined in a stable specification and its media type has not been
+								registered with IANA. Apple also only supports WebP on macOS 11. The working group will
+								continue to monitor these issues.</p>
+						</div>
 					</section>
 
 					<section id="sec-foreign-restrictions">
@@ -7840,9 +7845,15 @@ html.-epub-media-overlay-playing * {
 					<tr>
 						<td>
 							<ul class="flat">
-								<li><code>application/mathml+xml</code></li>
-								<li><code>application/mathml-presentation+xml</code></li>
-								<li><code>application/mathml-content+xml</code></li>
+								<li>
+									<code>application/mathml+xml</code>
+								</li>
+								<li>
+									<code>application/mathml-presentation+xml</code>
+								</li>
+								<li>
+									<code>application/mathml-content+xml</code>
+								</li>
 							</ul>
 						</td>
 						<td>
@@ -7853,7 +7864,9 @@ html.-epub-media-overlay-playing * {
 						</td>
 					</tr>
 					<tr>
-						<td><code>application/svg+xml</code></td>
+						<td>
+							<code>application/svg+xml</code>
+						</td>
 						<td>
 							<code>-//W3C//DTD SVG 1.1//EN</code>
 						</td>
@@ -8948,7 +8961,7 @@ EPUB/images/cover.png</pre>
 					3.2</a></h3>
 
 				<ul>
-					<li>6-Nov-2020: Added WebP to the image core media types. See <a
+					<li>6-Nov-2020: Added WebP to the <a href="#cmt-grp-image">image core media types</a>. See <a
 							href="https://github.com/w3c/publ-epub-revision/issues/1344">issue 1344</a>.</li>
 					<li>6-Nov-2020: A <a href="#app-identifiers-allowed">restricted set of external identifiers</a> are
 						now allowed in publication resources. <a href="#sec-xml-constraints">References to external

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10419,8 +10419,7 @@ EPUB/images/cover.png</pre>
 					<li>16-Oct-2020: Added WebP to the image core media types. See <a
 							href="https://github.com/w3c/publ-epub-revision/issues/1344">issue 1344</a>.</li>
 					<li>12-Oct-2020: Added OPUS to the audio core media types with a warning that it is still subject to
-						review depending on support in Mac/iOS. See <a
-							href="https://github.com/w3c/publ-epub-revision/issues/645">issue 645</a>.</li>
+						review depending on support in Mac/iOS.</li>
 					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
 						understanding and access to information. This specification now consolidates the authoring
 						requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF


### PR DESCRIPTION
I'm not 100% sure on the citing for this. There are a couple of google developer pages for the container and lossless bitstream specifications, so I added both. Are these formal enough references for W3C @iherman? (I don't see what else we could cite, though.)

Partially addresses #1344. Issue of a reliable source specification still to be determined.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1347.html" title="Last updated on Nov 6, 2020, 8:08 PM UTC (d2bef44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1347/706855e...d2bef44.html" title="Last updated on Nov 6, 2020, 8:08 PM UTC (d2bef44)">Diff</a>