### PR TITLE
Clarify package version attribute value

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1292,7 +1292,14 @@
 
 						<p id="attrdef-package-version">The <code>version</code> attribute specifies the EPUB
 							specification version to which the given EPUB Package conforms. The attribute MUST have the
-							value "<code>3.0</code>" to indicate compliance with this version of the specification.</p>
+							value "<code>3.0</code>" to indicate conformance with EPUB 3.</p>
+
+						<div class="note">
+							<p>Updates to this specification do not represent new versions of EPUB 3 (i.e., each new 3.X
+								specification is a continuation of the EPUB 3 format). The working group is committed to
+								ensuring that changes do not invalidate existing content, allowing the
+									<code>version</code> atribute value to remain unchanged.</p>
+						</div>
 
 						<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an
 							IDREF [[!XML]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1298,7 +1298,7 @@
 							<p>Updates to this specification do not represent new versions of EPUB 3 (i.e., each new 3.X
 								specification is a continuation of the EPUB 3 format). The working group is committed to
 								ensuring that changes do not invalidate existing content, allowing the
-									<code>version</code> atribute value to remain unchanged.</p>
+									<code>version</code> attribute value to remain unchanged.</p>
 						</div>
 
 						<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1297,7 +1297,7 @@
 						<div class="note">
 							<p>Updates to this specification do not represent new versions of EPUB 3 (i.e., each new 3.X
 								specification is a continuation of the EPUB 3 format). The working group is committed to
-								ensuring that changes do not invalidate existing content, allowing the
+								minimizing any changes that would invalidate existing content, allowing the
 									<code>version</code> attribute value to remain unchanged.</p>
 						</div>
 


### PR DESCRIPTION
Fixes #1349.

In addition to the change I mentioned in 1349, this PR also adds a note clarifying that new revisions are not new versions and that  we don't intend to modify the number, as this seems to always be a point of concern/confusion.

Comments on the approach welcome, as usual.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1350.html" title="Last updated on Oct 22, 2020, 3:20 PM UTC (ffe27c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1350/a4dc3ea...ffe27c9.html" title="Last updated on Oct 22, 2020, 3:20 PM UTC (ffe27c9)">Diff</a>