### PR TITLE
Update prose about relationship to html to reflect change of standard

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -184,11 +184,11 @@
 
 					<p>The [[HTML]] standard is continuously evolving &#8212; there are no longer versioned releases of
 						it. That standard, in turn, references various technologies that continue to evolve, such as
-						MathML, SVG, CSS and JavaScript.</p>
+						MathML, SVG, CSS, and JavaScript.</p>
 
 					<p>The benefit of this approach for EPUB is that EPUB Publications always keep pace with changes to
-						the web without the need for new revisions. Authors, however, will need to keep track of the
-						various changes to HTML, and the technologies it references, and ensure that their processes are
+						the Web without the need for new revisions. Authors, however, will need to keep track of the
+						various changes to HTML and the technologies it references, and ensure that their processes are
 						kept up to date.</p>
 
 					<div class="warning">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -181,23 +181,27 @@
 
 				<section id="sec-overview-relations-html">
 					<h4>Relationship to HTML</h4>
-					<p>This specification does not reference a specific version of W3C [[HTML]], but instead uses an
-						undated reference that will always point to the latest recommendation. This approach ensures
-						that EPUB will always keep pace with changes to the HTML standard. Authors will need to keep
-						track of changes to HTML, and ensure that their processes are kept up to date.</p>
 
-					<div class="caution">
+					<p>The [[HTML]] standard is continuously evolving &#8212; there are no longer versioned releases of
+						it. That standard, in turn, references various technologies that continue to evolve, such as
+						MathML, SVG, CSS and JavaScript.</p>
+
+					<p>The benefit of this approach for EPUB is that EPUB Publications always keep pace with changes to
+						the web without the need for new revisions. Authors, however, will need to keep track of the
+						various changes to HTML, and the technologies it references, and ensure that their processes are
+						kept up to date.</p>
+
+					<div class="warning">
 						<p>As HTML evolves, it is possible that features that were valid in previous versions could
-							become obsolete or be removed. It is anticipated that the W3C will make any such changes
-							carefully to ensure minimal disruption for Authors, but in the case of a
-							backwards-incompatible revision the use of an undated reference could be revisited.</p>
+							become obsolete or be removed. In general, however, features are typically only removed if
+							serious issues with them arise (e.g., lack of support in browsers, security issues).</p>
 					</div>
 
 					<p>The <a href="#sec-xhtml">XHTML profile defined by this specification</a> inherits all definitions
-						of semantics, structure and processing behaviors from [[HTML]] unless otherwise specified.</p>
+						of semantics, structure and processing behaviors from HTML unless otherwise specified.</p>
 
 					<p>In addition, this specification <a href="#sec-xhtml-extensions">defines a set of extensions</a>
-						to the W3C HTML document model that <a>Authors</a> can include in <a>XHTML Content
+						to the [[HTML]] document model that <a>Authors</a> can include in <a>XHTML Content
 						Documents</a>.</p>
 				</section>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -61,8 +61,8 @@
 				format provides a means of representing, packaging and encoding structured and semantically enhanced Web
 				content — including HTML, CSS, SVG and other resources — for distribution in a single-file
 				container.</p>
-			<p>This specification defines the conformance requirements for EPUB® 3 Reading Systems — the user agents that
-				render EPUB Publications.</p>
+			<p>This specification defines the conformance requirements for EPUB® 3 Reading Systems — the user agents
+				that render EPUB Publications.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="sec-introduction">
@@ -100,11 +100,12 @@
 				<section id="rel">
 					<h4>Relationship to HTML</h4>
 
-					<p>This specification does not reference a specific version of W3C [[HTML]], but instead uses an
-						undated reference that will always point to the latest recommendation. This approach ensures
-						that EPUB will always keep pace with changes to the HTML standard. Reading System developers
-						will need to keep track of changes to HTML, and ensure that their systems are kept up to
-						date.</p>
+					<p>The [[HTML]] standard is continuously evolving &#8212; there are no longer versioned releases of
+						it. That standard, in turn, references various technologies that continue to evolve, such as
+						MathML, SVG, CSS and JavaScript.</p>
+
+					<p>Reading System developers will need to keep track of the changes to HTML, and the technologies it
+						references, and ensure that their systems are kept up to date.</p>
 
 					<p>This specification does not require <a>EPUB Reading Systems</a> to support scripting, HTML forms
 						or the HTML DOM. Reading Systems conformant with this specification are only expected to be able

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -102,7 +102,7 @@
 
 					<p>The [[HTML]] standard is continuously evolving &#8212; there are no longer versioned releases of
 						it. That standard, in turn, references various technologies that continue to evolve, such as
-						MathML, SVG, CSS and JavaScript.</p>
+						MathML, SVG, CSS, and JavaScript.</p>
 
 					<p>Reading System developers will need to keep track of the changes to HTML, and the technologies it
 						references, and ensure that their systems are kept up to date.</p>


### PR DESCRIPTION
This PR fixes #1351 as follows:

- removes the references to W3C HTML and versioning from the core and RS relationship sections
- mentions that the underlying technologies that HTML reference are also subject to change (MathML, SVG, CSS, JavaScript)

I discovered how we ended up with the MathML reference we have. "MathML" is already taken for referring to 1.0 and I can't override it in the biblio file (redefining gets ignored). "MathML3" uses the path for the latest MathML 3 version (/TR/MathML3) but specifically references 3.0 second edition because it's the current REC.

Looking at the HTML reference, it now goes to the draft spec for 3.0 third edition, so technically we have the right reference if that's how it's published.

What happens if there is a MathML 4, however, is beyond me, short of our coming up with some unique shorthand so we could make an even more generic reference to /TR/MathML and go back to what we were doing in IDPF.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1363.html" title="Last updated on Oct 26, 2020, 4:52 PM UTC (2bdac90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1363/18dadfb...2bdac90.html" title="Last updated on Oct 26, 2020, 4:52 PM UTC (2bdac90)">Diff</a>