### PR TITLE
Fix uses of "attached" for properties

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1977,9 +1977,9 @@
 
 								<p>The [[!DC11]] <code>creator</code> element represents the name of a person,
 									organization, etc. responsible for the creation of the content of the
-										<a>Rendition</a>. The <a href="#role"><code>role</code> property</a> can be
-									attached to the element to indicate the function the creator played in the creation
-									of the content.</p>
+										<a>Rendition</a>. The <a href="#role"><code>role</code> property</a> can be <a
+										href="#subexpression">associated with the element</a> to indicate the function
+									the creator played in the creation of the content.</p>
 
 								<aside class="example">
 									<p>The following example shows how to represent a creator as an author using a <a
@@ -1995,9 +1995,10 @@
 
 								<p>The <code>creator</code> element SHOULD contain the name of the creator as the Author
 									intends it to be displayed to a user. The <a href="#file-as"><code>file-as</code>
-										property</a> MAY be attached to include a normalized form of the name, and the
-										<a href="#alternate-script"><code>alternate-script</code> property</a> to
-									represent a creator's name in another language or script.</p>
+										property</a> MAY be <a href="#subexpression">associated with the element</a> to
+									include a normalized form of the name, and the <a href="#alternate-script"
+											><code>alternate-script</code> property</a> to represent a creator's name in
+									another language or script.</p>
 
 								<aside class="example">
 									<p>The following example shows how a creator name can be included to facilitate
@@ -2080,8 +2081,9 @@
 								<p>Authors MAY identify the system or scheme the element's value is drawn from using the
 										<a href="#authority"><code>authority</code> property</a>.</p>
 
-								<p>When a scheme is identified, a subject code MUST be attached using the <a
-										href="#term"><code>term</code> property</a>.</p>
+								<p>When a scheme is identified, a subject code MUST be <a href="#subexpression"
+										>associated with the element</a> using the <a href="#term"><code>term</code>
+										property</a>.</p>
 
 								<aside class="example">
 									<p>The following example shows a BISAC code and heading.</p>
@@ -2097,8 +2099,8 @@
 &lt;meta refines="#sbj01" property="term">11&lt;/meta></pre>
 								</aside>
 
-								<p>The <code>term</code> property MUST NOT be attached to a <code>subject</code> element
-									that does not specify a scheme.</p>
+								<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
+											<code>subject</code> element</a> that does not specify a scheme.</p>
 
 								<p>The values of the <code>subject</code> element and <code>term</code> property are
 									case sensitive only when the designated scheme requires.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1425,9 +1425,9 @@
 								<code>refines</code>
 							</dt>
 							<dd>
-								<p>Identifies the expression or resource augmented by the element. The value of the
-									attribute must be a relative IRI [[!RFC3987]] referencing the resource or element
-									being described.</p>
+								<p>Establishes an association between the current expression and the element or resource
+									identified by its value. The value of the attribute must be a relative IRI
+									[[!RFC3987]] that references the resource or element being described.</p>
 								<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata
 									being expressed. When omitted, the element defines a <a href="#primary-expression"
 										>primary expression</a>.</p>
@@ -2212,10 +2212,10 @@
 									defines a primary expression.</li>
 
 								<li id="subexpression">A <em>subexpression</em> is one in which the expression defined
-									in the <code>meta</code> element enhances the meaning of the expression or resource
-									referenced in its <code>refines</code> attribute. A subexpression might refine a
-									media clip, for example, by expressing its duration, or refine a creator or
-									contributor expression by defining the role of the person.</li>
+									in the <code>meta</code> element is associated with another expression or resource
+									using the <code>refines</code> attribute to enhance its meaning. A subexpression
+									might refine a media clip, for example, by expressing its duration, or refine a
+									creator or contributor expression by defining the role of the person.</li>
 							</ul>
 
 							<p>Subexpressions are not limited to refining only primary expressions and resources; they


### PR DESCRIPTION
Fixes #1365 - replaces "attached" with "associated with the element" and adds linking to where subexpressions are defined.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1366.html" title="Last updated on Oct 27, 2020, 4:28 PM UTC (26d1569)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1366/18dadfb...26d1569.html" title="Last updated on Oct 27, 2020, 4:28 PM UTC (26d1569)">Diff</a>