### PR TITLE
Revised restriction on external identifiers

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1016,12 +1016,11 @@
 					<li>
 						<p id="confreq-xml-identifiers">It MAY only include a <a
 								href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-doctype">document type
-								declaration</a> that references the <a
-								href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-pubid">public identifier</a> and
-								<a href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-sysid">system identifier</a>
-							for a format referenced in <a href="#app-identifiers-allowed"></a>, or that omits <a
+								declaration</a> that references an <a
 								href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">external
-								identifiers</a> [[!XML]].</p>
+								identifier</a> appropriate for its media type &#8212; as defined in <a
+								href="#app-identifiers-allowed"></a> &#8212; or that omits external identifiers
+							[[!XML]].</p>
 					</li>
 					<li>
 						<p id="confreq-xml-entities">It MUST NOT declare external <a
@@ -8767,20 +8766,27 @@ html.-epub-media-overlay-playing * {
 		<section id="app-identifiers-allowed" class="appendix">
 			<h2>Allowed External Identifiers</h2>
 
-			<p>The following table lists the public and system identifiers <a href="#confreq-xml-identifiers">allowed in
-					document type declarations</a>.</p>
+			<p>The following table lists the <a aria-label="public identifiers"
+					href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-pubid">public </a> and <a
+					href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-sysid">system identifiers</a> [[!XML]] allowed
+				in <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-doctype">document type declarations</a>.
+				[[!XML]]</p>
+
+			<p>These external identifiers MAY be used only in <a>Publication Resources</a> with the listed media types
+				specified in their <a href="#sec-manifest-elem">manifest</a> declarations. (Refer to <a
+					href="#confreq-xml-identifiers"></a> for more information.)</p>
 
 			<table>
 				<thead>
 					<tr>
-						<th>Format</th>
+						<th>Media Type</th>
 						<th>Public Identifier</th>
 						<th>System Identifier</th>
 					</tr>
 				</thead>
 				<tbody>
 					<tr>
-						<td>SVG 1.1</td>
+						<td>application/svg+xml</td>
 						<td>
 							<code>-//W3C//DTD SVG 1.1//EN</code>
 						</td>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7821,7 +7821,7 @@ html.-epub-media-overlay-playing * {
 
 			<p>These external identifiers MAY be used only in <a>Publication Resources</a> with the listed media types
 				specified in their <a href="#sec-manifest-elem">manifest</a> declarations. (Refer to <a
-					href="#confreq-xml-identifiers"></a> for more information.)</p>
+					href="#sec-xml-constraints"></a> for more information.)</p>
 
 			<table>
 				<thead>
@@ -7930,7 +7930,6 @@ html.-epub-media-overlay-playing * {
 				<aside class="example" id="ex.epubtype.note">
 					<p>The following example shows how a preamble could be marked up with the <code>epub:type</code>
 						attribute on its containing [[!HTML]] <code>section</code> element.</p>
-
 					<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
     …
@@ -7944,7 +7943,6 @@ html.-epub-media-overlay-playing * {
 				<aside class="example" id="ex.epubtype.gloss">
 					<p>The following example shows the <code>epub:type</code> attribute used to add glossary semantics
 						on an [[!HTML]] definition list.</p>
-
 					<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
     …
@@ -7958,7 +7956,6 @@ html.-epub-media-overlay-playing * {
 				<aside class="example" id="ex.epubtype.pg">
 					<p>The following example shows the <code>epub:type</code> attribute used to add pagebreak
 						semantics.</p>
-
 					<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
    …
@@ -8926,11 +8923,15 @@ EPUB/images/cover.png</pre>
 					3.2</a></h3>
 
 				<ul>
-					<li>5-Nov-2020: Generalized the restriction on custom attribute namespace URIs to exclude all of
-						idpf.org and w3.org. See <a href="https://github.com/w3c/epub-specs/issues/1388">issue
-						1388</a>.</li>
-					<li>12-Oct-2020: Added OPUS to the audio core media types with a warning that it is still subject to
-						review depending on support in Mac/iOS. See <a
+					<li>6-Nov-2020: A <a href="#app-identifiers-allowed">restricted set of external identifiers</a> are
+						now allowed in publication resources. <a href="#sec-xml-constraints">References to external
+							entities</a> from the internal DTD subset remain restricted, however. See <a
+							href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
+					<li>5-Nov-2020: Generalized the restriction on <a href="#sec-xhtml-custom-attributes">custom
+							attribute namespace URIs</a> to exclude all of idpf.org and w3.org. See <a
+							href="https://github.com/w3c/epub-specs/issues/1388">issue 1388</a>.</li>
+					<li>12-Oct-2020: Added OPUS to the <a href="#cmt-grp-audio">audio core media types</a> with a
+						warning that it is still subject to review depending on support in Mac/iOS. See <a
 							href="https://github.com/w3c/epub-specs/issues/645">issue 645</a>.</li>
 					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
 						understanding and access to information. This specification now consolidates the authoring

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1014,9 +1014,20 @@
 								Documents</a> [[!XML-NAMES]].</p>
 					</li>
 					<li>
-						<p id="confreq-xml-extmarkupdecl">
-							<a href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">External
-								identifiers</a> MUST NOT appear in the document type declaration [[!XML]].</p>
+						<p id="confreq-xml-identifiers">It MAY only include a <a
+								href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-doctype">document type
+								declaration</a> that references the <a
+								href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-pubid">public identifier</a> and
+								<a href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-sysid">system identifier</a>
+							for a format referenced in <a href="#app-identifiers-allowed"></a>, or that omits <a
+								href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">external
+								identifiers</a> [[!XML]].</p>
+					</li>
+					<li>
+						<p id="confreq-xml-entities">It MUST NOT declare external <a
+								href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-parsedent">parsed entities</a> or
+							external <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-PE">parameter entities</a>
+							in an internal DTD subset [[!XML]].</p>
 					</li>
 					<li>
 						<p id="confreq-xml-xinc"> It MUST NOT make use of XInclude [[!XInclude]].</p>
@@ -8752,6 +8763,33 @@ html.-epub-media-overlay-playing * {
 					alert Authors if a legacy feature does not conform to its definition or otherwise breaks a usage
 					requirement.</p>
 			</section>
+		</section>
+		<section id="app-identifiers-allowed" class="appendix">
+			<h2>Allowed External Identifiers</h2>
+
+			<p>The following table lists the public and system identifiers <a href="#confreq-xml-identifiers">allowed in
+					document type declarations</a>.</p>
+
+			<table>
+				<thead>
+					<tr>
+						<th>Format</th>
+						<th>Public Identifier</th>
+						<th>System Identifier</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>SVG 1.1</td>
+						<td>
+							<code>-//W3C//DTD SVG 1.1//EN</code>
+						</td>
+						<td>
+							<code>http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd</code>
+						</td>
+					</tr>
+				</tbody>
+			</table>
 		</section>
 		<section id="app-vocabs" class="appendix">
 			<h2>Vocabularies</h2>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7856,25 +7856,34 @@ html.-epub-media-overlay-playing * {
 		</section>
 		<section id="app-semantic-inflection">
 			<h2>Semantic Inflection</h2>
+
 			<section id="sec-semantic-inflection-intro">
-				<h3>Introduction</h3> <p>Semantic inflection is the process of attaching additional meaning about the
-					specific purpose and/or nature an element plays. The <a href="#sec-epub-type-attribute"
-							><code>epub:type</code> attribute</a> is used to express domain-specific semantics in
-						<a>EPUB Content Documents</a> and <a>Media Overlay Documents</a>, with the inflection(s) it
-					carries complementing the underlying vocabulary.</p> <p>The applied semantics are intended to refine
-					the meaning of their containing elements; they are not provided to override their nature (e.g., the
-					attribute can be used to indicate a [[HTML]] <code>section</code> is a chapter in a work, but is not
-					designed to turn <code>p</code> elements into list items to avoid proper list structures).</p>
-					<p>Semantic metadata is intended to enrich content for use in publishing workflows and for
+				<h3>Introduction</h3>
+
+				<p>Semantic inflection is the process of attaching additional meaning about the specific purpose and/or
+					nature an element plays. The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a>
+					is used to express domain-specific semantics in <a>EPUB Content Documents</a> and <a>Media Overlay
+						Documents</a>, with the inflection(s) it carries complementing the underlying vocabulary.</p>
+
+				<p>The applied semantics are intended to refine the meaning of their containing elements; they are not
+					provided to override their nature (e.g., the attribute can be used to indicate a [[HTML]]
+						<code>section</code> is a chapter in a work, but is not designed to turn <code>p</code> elements
+					into list items to avoid proper list structures).</p>
+
+				<p>Semantic metadata is intended to enrich content for use in publishing workflows and for
 					author-defined purposes. It also allows Reading Systems to learn more about the structure and
 					content of a document (e.g., to enable <a href="#sec-behaviors-skip-escape">skippability and
-						escapability</a> in Media Ovelays).</p> <p>This specification defines a method for semantic
-					inflection using <em>the attribute axis</em>: instead of adding new elements, the
-						<code>epub:type</code> attribute can be appended to existing elements to inflect the desired
-					semantics.</p>
+						escapability</a> in Media Ovelays).</p>
+
+				<p>This specification defines a method for semantic inflection using <em>the attribute axis</em>:
+					instead of adding new elements, the <code>epub:type</code> attribute can be appended to existing
+					elements to inflect the desired semantics.</p>
 			</section>
+
 			<section id="sec-epub-type-attribute">
-				<h3>The <code>epub:type</code> Attribute</h3> <dl class="elemdef" id="attrdef-epub-type">
+				<h3>The <code>epub:type</code> Attribute</h3>
+
+				<dl class="elemdef" id="attrdef-epub-type">
 					<dt>Attribute Name</dt>
 					<dd>
 						<p>
@@ -7898,22 +7907,30 @@ html.-epub-media-overlay-playing * {
 							restrictions as defined in <a href="#sec-vocab-assoc"></a>.</p>
 						<p>White space is the set of characters as defined in [[!XML]].</p>
 					</dd>
-				</dl> <p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its
-					value is one or more white space-separated terms stemming from external vocabularies associated with
-					the document instance.</p> <p>The inflected semantic MUST express a subclass of the semantic of the
-					carrying element. In the case of semantically neutral elements, such as the [[!HTML]] <a
+				</dl>
+
+				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
+					is one or more white space-separated terms stemming from external vocabularies associated with the
+					document instance.</p>
+
+				<p>The inflected semantic MUST express a subclass of the semantic of the carrying element. In the case
+					of semantically neutral elements, such as the [[!HTML]] <a
 						href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"><code>div</code></a> and
 						<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element"
 						><code>span</code></a> elements, the inflected semantic MUST NOT attach a meaning that is
 					already conveyed by an existing element (e.g., that a <code>div</code> represents a paragraph or
-					section).</p> <p>The <a href="#sec-default-vocab">default vocabulary</a> for the
-						<code>epub:type</code> attribute is the <a href="#structure-vocab">Structural Semantics
-						Vocabulary</a>. Unprefixed terms that are not part of the this vocabulary MAY be included, but
-					their use is discouraged. The use of <a href="#sec-prefix-attr">prefixes</a> is the preferred method
-					for adding custom semantics. Refer to <a href="#sec-vocab-assoc"></a> for more information.</p>
-					<aside class="example" id="ex.epubtype.note">
+					section).</p>
+
+				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
+					the <a href="#structure-vocab">Structural Semantics Vocabulary</a>. Unprefixed terms that are not
+					part of the this vocabulary MAY be included, but their use is discouraged. The use of <a
+						href="#sec-prefix-attr">prefixes</a> is the preferred method for adding custom semantics. Refer
+					to <a href="#sec-vocab-assoc"></a> for more information.</p>
+
+				<aside class="example" id="ex.epubtype.note">
 					<p>The following example shows how a preamble could be marked up with the <code>epub:type</code>
 						attribute on its containing [[!HTML]] <code>section</code> element.</p>
+
 					<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
     …
@@ -7922,9 +7939,12 @@ html.-epub-media-overlay-playing * {
     &lt;/section&gt;
     …
 &lt;/html&gt;</pre>
-				</aside> <aside class="example" id="ex.epubtype.gloss">
+				</aside>
+
+				<aside class="example" id="ex.epubtype.gloss">
 					<p>The following example shows the <code>epub:type</code> attribute used to add glossary semantics
 						on an [[!HTML]] definition list.</p>
+
 					<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
     …
@@ -7933,9 +7953,12 @@ html.-epub-media-overlay-playing * {
     &lt;/dl&gt;        
     …
 &lt;/html&gt;</pre>
-				</aside> <aside class="example" id="ex.epubtype.pg">
+				</aside>
+
+				<aside class="example" id="ex.epubtype.pg">
 					<p>The following example shows the <code>epub:type</code> attribute used to add pagebreak
 						semantics.</p>
+
 					<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
    …
@@ -7943,7 +7966,8 @@ html.-epub-media-overlay-playing * {
    … 
 &lt;/html&gt;</pre>
 				</aside>
-			</section> >>>>>>> remotes/origin/master </section>
+			</section>
+		</section>
 		<section id="app-vocabs" class="appendix">
 			<h2>Vocabularies</h2>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1023,10 +1023,9 @@
 							[[!XML]].</p>
 					</li>
 					<li>
-						<p id="confreq-xml-entities">It MUST NOT declare external <a
-								href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-parsedent">parsed entities</a> or
-							external <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-PE">parameter entities</a>
-							in an internal DTD subset [[!XML]].</p>
+						<p id="confreq-xml-entities"><a
+								href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">External
+								identifiers</a> MUST NOT appear in the internal DTD subset [[!XML]].</p>
 					</li>
 					<li>
 						<p id="confreq-xml-xinc"> It MUST NOT make use of XInclude [[!XInclude]].</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1023,9 +1023,9 @@
 							[[!XML]].</p>
 					</li>
 					<li>
-						<p id="confreq-xml-entities"><a
-								href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">External
-								identifiers</a> MUST NOT appear in the internal DTD subset [[!XML]].</p>
+						<p id="confreq-xml-entities">It MUST NOT contain <a
+								href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-extent">external entity</a>
+							declarations in the internal DTD subset [[!XML]].</p>
 					</li>
 					<li>
 						<p id="confreq-xml-xinc"> It MUST NOT make use of XInclude [[!XInclude]].</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -237,6 +237,11 @@
 									non-validating processor</a> [[!XML]].</p>
 						</li>
 						<li>
+							<p id="confreq-rs-xml-extid">It MUST NOT resolve <a
+									href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">external
+									identifiers</a> [[!XML]].</p>
+						</li>
+						<li>
 							<p id="confreq-rs-xml-ns"> It MUST be a <a
 									href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#ProcessorConformance"
 									>conformant processor</a> as defined in [[!XML-NAMES]].</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2087,6 +2087,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					3.2</a></h3>
 
 				<ul>
+					<li>6-Nov-2020: Reading systems are now required to <a href="#confreq-rs-xml-extid">not resolve
+							external identifiers</a> in doctype declarations. See <a
+							href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
 					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
 						understanding and access to information. This specification now consolidates the reading system
 						requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF


### PR DESCRIPTION
Without getting into whether we should list other allowed doctypes, is there at least the possibility for agreement on this approach to updating the restriction @iherman @murata2makoto?

Fixes #1338.

[Reading Systems preview](https://raw.githack.com/w3c/epub-specs/fix/issue-1338/epub33/rs/)
[Reading Systems diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Frs%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-1338%2Fepub33%2Frs%2Findex.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1368.html" title="Last updated on Nov 6, 2020, 5:25 PM UTC (2f80ee4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1368/378a906...2f80ee4.html" title="Last updated on Nov 6, 2020, 5:25 PM UTC (2f80ee4)">Diff</a>