### PR TITLE
Merge fxl sections

### DIFF
--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -273,3 +273,40 @@ table.prefix caption {
     font-size: 90%
 }
 
+
+/* Table zebra style... */
+
+table.zebra {
+    font-size:inherit;
+    font:90%;
+    margin:1em;
+}
+
+table.zebra td {
+    padding-left: 0.3em;
+}
+
+table.zebra th {
+    font-weight: bold;
+    text-align: center;
+    background-color: rgb(0,0,128) !important;
+    font-size: 110%;
+    background: hsl(180, 30%, 50%);
+    color: #fff;
+}
+
+table.zebra th a:link {
+  color: #fff;
+}
+
+table.zebra th a:visited {
+  color: #aaa;
+}
+
+table.zebra tr:nth-child(even) {
+    background-color: hsl(180, 30%, 93%) !important;
+}
+
+table.zebra th{border-bottom:1px solid #bbb;padding:.2em 1em;}
+table.zebra td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1101,7 +1101,7 @@
 
 					<ul>
 						<li>
-							<p><a href="#sec-package-metadata">Metadata</a> — mechanisms to include and/or reference
+							<p><a href="#sec-metadata-assoc">Metadata</a> — mechanisms to include and/or reference
 								metadata applicable to the given Rendition of the <a>EPUB Publication</a>.</p>
 						</li>
 						<li>
@@ -3287,72 +3287,67 @@ Manifest:
 
 			</section>
 
-			<section id="sec-package-metadata">
-				<h3>Package Metadata</h3>
+			<section id="sec-package-metadata-identifiers">
+				<h3>Publication Identifiers</h3>
 
-				<section id="sec-package-metadata-identifiers">
-					<h4>Publication Identifiers</h4>
+				<section id="sec-metadata-elem-identifiers-uid">
+					<h4>Unique Identifier</h4>
 
-					<section id="sec-metadata-elem-identifiers-uid">
-						<h5>Unique Identifier</h5>
+					<p>The <a>Author</a> is responsible for including a primary identifier in the <a>Package
+							Document</a> metadata that is unique to one and only one <a>EPUB Publication</a>. This
+							<a>Unique Identifier</a>, whether chosen or assigned, MUST be stored in the <a
+							href="#sec-opf-dcidentifier"><code>dc:identifier</code> element</a> and be referenced as the
+						Unique Identifier in the <a href="#elemdef-opf-package"><code>package</code> element</a>
+						<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code> attribute</a>.</p>
 
-						<p>The <a>Author</a> is responsible for including a primary identifier in the <a>Package
-								Document</a> metadata that is unique to one and only one <a>EPUB Publication</a>. This
-								<a>Unique Identifier</a>, whether chosen or assigned, MUST be stored in the <a
-								href="#sec-opf-dcidentifier"><code>dc:identifier</code> element</a> and be referenced as
-							the Unique Identifier in the <a href="#elemdef-opf-package"><code>package</code> element</a>
-							<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
-							attribute</a>.</p>
+					<p>Although not static, changes to the Unique Identifier for an EPUB Publication SHOULD be made as
+						infrequently as possible. New identifiers SHOULD NOT be issued when updating metadata, fixing
+						errata or making other minor changes to the EPUB Publication.</p>
+				</section>
 
-						<p>Although not static, changes to the Unique Identifier for an EPUB Publication SHOULD be made
-							as infrequently as possible. New identifiers SHOULD NOT be issued when updating metadata,
-							fixing errata or making other minor changes to the EPUB Publication.</p>
-					</section>
+				<section id="sec-metadata-elem-identifiers-pid">
+					<h4>Release Identifier</h4>
 
-					<section id="sec-metadata-elem-identifiers-pid">
-						<h5>Release Identifier</h5>
+					<p>The <a>Unique Identifier</a> of an <a>EPUB Publication</a> typically SHOULD NOT change with each
+						minor revision to the package or its contents, as Unique Identifiers are intended to have
+						maximal persistence both for referencing and distribution purposes. Each release of an EPUB
+						Publication normally requires that the new version be uniquely identifiable, however, which
+						results in the contradictory need for reliable Unique Identifiers that are changeable.</p>
 
-						<p>The <a>Unique Identifier</a> of an <a>EPUB Publication</a> typically SHOULD NOT change with
-							each minor revision to the package or its contents, as Unique Identifiers are intended to
-							have maximal persistence both for referencing and distribution purposes. Each release of an
-							EPUB Publication normally requires that the new version be uniquely identifiable, however,
-							which results in the contradictory need for reliable Unique Identifiers that are
-							changeable.</p>
+					<p>To redress this problem of identifying minor modifications and releases without changing the
+						Unique Identifier, this specification defines the semantics for a <em>Release Identifier</em>,
+						or means of distinguishing and sequentially ordering EPUB Publications with the same Unique
+						Identifier.</p>
 
-						<p>To redress this problem of identifying minor modifications and releases without changing the
-							Unique Identifier, this specification defines the semantics for a <em>Release
-								Identifier</em>, or means of distinguishing and sequentially ordering EPUB Publications
-							with the same Unique Identifier.</p>
+					<p>The Release Identifier is not an actual property in the package <code>metadata</code> section,
+						but is a value that can be obtained from two other mandatory pieces of metadata: the Unique
+						Identifier and the last modification date of the Rendition. When the taken together, the
+						combined value represents a unique identity that can be used to distinguish any particular
+						version of an EPUB Publication from another.</p>
 
-						<p>The Release Identifier is not an actual property in the package <code>metadata</code>
-							section, but is a value that can be obtained from two other mandatory pieces of metadata:
-							the Unique Identifier and the last modification date of the Rendition. When the taken
-							together, the combined value represents a unique identity that can be used to distinguish
-							any particular version of an EPUB Publication from another.</p>
+					<p id="last-modified-date">To ensure that a Release Identifier can be constructed, each
+							<a>Rendition</a> MUST include exactly one [[!DCTERMS]] <code>modified</code> property
+						containing its last modification date. The value of this property MUST be an [[!XMLSCHEMA-2]]
+						dateTime conformant date of the form:</p>
 
-						<p id="last-modified-date">To ensure that a Release Identifier can be constructed, each
-								<a>Rendition</a> MUST include exactly one [[!DCTERMS]] <code>modified</code> property
-							containing its last modification date. The value of this property MUST be an
-							[[!XMLSCHEMA-2]] dateTime conformant date of the form:</p>
+					<pre class="nohighlight">CCYY-MM-DDThh:mm:ssZ</pre>
 
-						<pre class="nohighlight">CCYY-MM-DDThh:mm:ssZ</pre>
+					<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST be
+						terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
 
-						<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST be
-							terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
+					<p>Additional modified properties MAY be included in the package metadata, but they MUST have a
+						different subject (i.e., they require a <code>refines</code> attribute that references an
+						element or resource).</p>
 
-						<p>Additional modified properties MAY be included in the package metadata, but they MUST have a
-							different subject (i.e., they require a <code>refines</code> attribute that references an
-							element or resource).</p>
+					<p>Although not a part of the package metadata, for referencing and other purposes all string
+						representations of the identifier MUST be constructed using the at sign (<code>@</code>) as the
+						separator (i.e., of the form "id<code>@</code>date"). Whitespace MUST NOT be included when
+						concatenating the strings.</p>
 
-						<p>Although not a part of the package metadata, for referencing and other purposes all string
-							representations of the identifier MUST be constructed using the at sign (<code>@</code>) as
-							the separator (i.e., of the form "id<code>@</code>date"). Whitespace MUST NOT be included
-							when concatenating the strings.</p>
-
-						<aside class="example">
-							<p>The following example shows how a Unique Identifier and modification date are combined to
-								form the Release Identifier.</p>
-							<pre class="nohighlight">&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
+					<aside class="example">
+						<p>The following example shows how a Unique Identifier and modification date are combined to
+							form the Release Identifier.</p>
+						<pre class="nohighlight">&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:identifier id="pub-id"&gt;urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier&gt;
     &lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;
     …
@@ -3362,1000 +3357,354 @@ results in the Package ID:
 
 urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 </pre>
-						</aside>
+					</aside>
 
-						<p>Note that it is possible that the separator character MAY occur in the Unique Identifier, as
-							these identifiers MAY be any string value. The Release Identifier consequently MUST be split
-							on the last instance of the at sign when decomposing it into its component parts.</p>
+					<p>Note that it is possible that the separator character MAY occur in the Unique Identifier, as
+						these identifiers MAY be any string value. The Release Identifier consequently MUST be split on
+						the last instance of the at sign when decomposing it into its component parts.</p>
 
-						<p>The Release Identifier does not supersede the Unique Identifier, but represents the means by
-							which different versions of the same EPUB Publication can be distinguished and identified in
-							distribution channels and by Reading Systems. The sequential, chronological order inherent
-							in the format of the timestamp also places EPUB Publications in order without requiring
-							knowledge of the exact identifier that came before.</p>
+					<p>The Release Identifier does not supersede the Unique Identifier, but represents the means by
+						which different versions of the same EPUB Publication can be distinguished and identified in
+						distribution channels and by Reading Systems. The sequential, chronological order inherent in
+						the format of the timestamp also places EPUB Publications in order without requiring knowledge
+						of the exact identifier that came before.</p>
 
-						<p>The Release Identifier consequently allows a set of EPUB Publications to be inspected to
-							determine if they represent the same version of the same Publication, different versions of
-							a single EPUB Publication, or any combination of differing and similar EPUB
-							Publications.</p>
+					<p>The Release Identifier consequently allows a set of EPUB Publications to be inspected to
+						determine if they represent the same version of the same Publication, different versions of a
+						single EPUB Publication, or any combination of differing and similar EPUB Publications.</p>
 
-						<div class="note">
-							<p>When an <a>EPUB Container</a> includes more than one <a>Rendition</a> of an EPUB
-								Publication, updating the last modified date of the <a>default rendition</a> for each
-								release — even if it has not been updated — will help ensure that the EPUB Publication
-								does not appear to be the same version as an earlier release, as Reading Systems only
-								have to process the default rendition.</p>
-						</div>
-					</section>
+					<div class="note">
+						<p>When an <a>EPUB Container</a> includes more than one <a>Rendition</a> of an EPUB Publication,
+							updating the last modified date of the <a>default rendition</a> for each release — even if
+							it has not been updated — will help ensure that the EPUB Publication does not appear to be
+							the same version as an earlier release, as Reading Systems only have to process the default
+							rendition.</p>
+					</div>
+				</section>
+			</section>
+
+			<section id="sec-metadata-assoc">
+				<h3>Vocabulary Association Mechanisms</h3>
+
+				<section id="sec-metadata-assoc-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>The <code>property</code>, <code>properties</code>, <code>rel</code> and <code>scheme</code>
+						attributes use the <a href="#sec-property-datatype">property data type</a> to represent terms
+						from metadata vocabularies. Similar to a CURIE [[RDFA-CORE]], the property data type represents
+						an IRI [[RFC3987]] in compact form and simplifies the authoring of metadata from standardized
+						vocabularies.</p>
+
+					<p>A property value is an expression that consists of a prefix and a reference, where the prefix —
+						whether literal or implied — is a shorthand mapping of an IRI that typically resolves to a term
+						vocabulary. When the prefix is converted to its IRI representation and combined with the
+						reference, the resulting IRI normally resolves to a fragment within that vocabulary that
+						contains human- and/or machine-readable information about the term.</p>
+
+					<p>To assist Reading Systems in processing property values, this specification defines three
+						mechanisms to establish the IRI a prefix maps to:</p>
+
+					<ul>
+						<li>
+							<p><a href="#sec-metadata-default-vocab">default vocabularies</a> — define the mapping when
+								a property value does not include a prefix;</p>
+						</li>
+						<li>
+							<p><a href="#sec-metadata-reserved-prefixes">reserved prefixes</a> — these mappings are
+								predefined (i.e., all Reading Systems recognize them) and can be used without having to
+								be declared; and</p>
+						</li>
+						<li>
+							<p>the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute — a declarative means of
+								creating new prefix mappings on the root <a href="#sec-package-elem"
+										><code>package</code></a> element.</p>
+						</li>
+					</ul>
+
 				</section>
 
-				<section id="sec-metadata-assoc">
-					<h4>Vocabulary Association Mechanisms</h4>
+				<section id="sec-metadata-default-vocab">
+					<h4>Default Vocabularies</h4>
 
-					<section id="sec-metadata-assoc-intro" class="informative">
-						<h5>Introduction</h5>
+					<p>A default vocabulary is a vocabulary that does not require a prefix to be declared in order to
+						use its terms, and whose terms MUST always be unprefixed.</p>
 
-						<p>The <code>property</code>, <code>properties</code>, <code>rel</code> and <code>scheme</code>
-							attributes use the <a href="#sec-property-datatype">property data type</a> to represent
-							terms from metadata vocabularies. Similar to a CURIE [[RDFA-CORE]], the property data type
-							represents an IRI [[RFC3987]] in compact form and simplifies the authoring of metadata from
-							standardized vocabularies.</p>
+					<p>As the Package Document has multiple unrelated uses for metadata terms, a single default
+						vocabulary is not defined for all attributes. Instead, different default vocabularies are
+						defined for use in attributes that accept a <a href="#sec-property-datatype">property data
+							type</a> as follows:</p>
 
-						<p>A property value is an expression that consists of a prefix and a reference, where the prefix
-							— whether literal or implied — is a shorthand mapping of an IRI that typically resolves to a
-							term vocabulary. When the prefix is converted to its IRI representation and combined with
-							the reference, the resulting IRI normally resolves to a fragment within that vocabulary that
-							contains human- and/or machine-readable information about the term.</p>
+					<ul>
+						<li>
+							<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is defined to be
+								the default vocabulary for the <a href="#elemdef-meta"><code>meta</code></a>
+								<code>property</code> attribute.</p>
+							<p>If the attribute's value does not include a prefix, the following IRI [[!RFC3987]] stem
+								MUST be used to generate the resulting IRI:
+									<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
+						</li>
+						<li>
+							<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is defined to be the default
+								vocabulary for the <a href="#elemdef-opf-link"><code>link</code></a>
+								<code>rel</code> and <code>properties</code> attributes.</p>
+							<p>If any of these attributes' values do not include a prefix, the following IRI
+								[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
+									<code>http://idpf.org/epub/vocab/package/link/#</code></p>
+						</li>
+						<li>
+							<p>The <a href="#app-item-properties-vocab">Manifest Properties Vocabulary</a> is defined to
+								be the default vocabulary for the <a href="#elemdef-package-item"><code>item</code></a>
+								<code>properties</code> attribute.</p>
+							<p>If any of the attribute's values do not include a prefix, the following IRI [[!RFC3987]]
+								stem MUST be used to generate the resulting IRI for them:
+									<code>http://idpf.org/epub/vocab/package/item/#</code></p>
+						</li>
+						<li>
+							<p>The <a href="#app-itemref-properties-vocab">Spine Properties Vocabulary</a> is defined to
+								be the default vocabulary for the <a href="#elemdef-spine-itemref"
+									><code>itemref</code></a>
+								<code>properties</code> attribute.</p>
+							<p>If any of the attribute's values do not include a prefix, the following IRI [[!RFC3987]]
+								stem MUST be used to generate the resulting IRI for them:
+									<code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
+						</li>
+					</ul>
 
-						<p>To assist Reading Systems in processing property values, this specification defines three
-							mechanisms to establish the IRI a prefix maps to:</p>
+					<p>The IRIs associated with these vocabularies MUST NOT be assigned a prefix using the <a
+							href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
 
-						<ul>
-							<li>
-								<p><a href="#sec-metadata-default-vocab">default vocabularies</a> — define the mapping
-									when a property value does not include a prefix;</p>
-							</li>
-							<li>
-								<p><a href="#sec-metadata-reserved-prefixes">reserved prefixes</a> — these mappings are
-									predefined (i.e., all Reading Systems recognize them) and can be used without having
-									to be declared; and</p>
-							</li>
-							<li>
-								<p>the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute — a declarative
-									means of creating new prefix mappings on the root <a href="#sec-package-elem"
-											><code>package</code></a> element.</p>
-							</li>
-						</ul>
+				</section>
 
-					</section>
+				<section id="sec-metadata-reserved-prefixes">
+					<h4>Reserved Prefixes</h4>
 
-					<section id="sec-metadata-default-vocab">
-						<h5>Default Vocabularies</h5>
+					<p>This specification reserves the following set of prefixes that Authors MAY use in package
+						metadata without having to declare.</p>
 
-						<p>A default vocabulary is a vocabulary that does not require a prefix to be declared in order
-							to use its terms, and whose terms MUST always be unprefixed.</p>
+					<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
+						lead to interoperability issues. Validation tools will often reject new prefixes until the tools
+						are updated, for example. Authors are strongly encouraged to declare all prefixes they use to
+						avoid such issues.</p>
 
-						<p>As the Package Document has multiple unrelated uses for metadata terms, a single default
-							vocabulary is not defined for all attributes. Instead, different default vocabularies are
-							defined for use in attributes that accept a <a href="#sec-property-datatype">property data
-								type</a> as follows:</p>
-
-						<ul>
-							<li>
-								<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is defined to
-									be the default vocabulary for the <a href="#elemdef-meta"><code>meta</code></a>
-									<code>property</code> attribute.</p>
-								<p>If the attribute's value does not include a prefix, the following IRI [[!RFC3987]]
-									stem MUST be used to generate the resulting IRI:
-										<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
-							</li>
-							<li>
-								<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is defined to be the
-									default vocabulary for the <a href="#elemdef-opf-link"><code>link</code></a>
-									<code>rel</code> and <code>properties</code> attributes.</p>
-								<p>If any of these attributes' values do not include a prefix, the following IRI
-									[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
-										<code>http://idpf.org/epub/vocab/package/link/#</code></p>
-							</li>
-							<li>
-								<p>The <a href="#app-item-properties-vocab">Manifest Properties Vocabulary</a> is
-									defined to be the default vocabulary for the <a href="#elemdef-package-item"
-											><code>item</code></a>
-									<code>properties</code> attribute.</p>
-								<p>If any of the attribute's values do not include a prefix, the following IRI
-									[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
-										<code>http://idpf.org/epub/vocab/package/item/#</code></p>
-							</li>
-							<li>
-								<p>The <a href="#app-itemref-properties-vocab">Spine Properties Vocabulary</a> is
-									defined to be the default vocabulary for the <a href="#elemdef-spine-itemref"
-											><code>itemref</code></a>
-									<code>properties</code> attribute.</p>
-								<p>If any of the attribute's values do not include a prefix, the following IRI
-									[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
-										<code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
-							</li>
-						</ul>
-
-						<p>The IRIs associated with these vocabularies MUST NOT be assigned a prefix using the <a
-								href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
-
-					</section>
-
-					<section id="sec-metadata-reserved-prefixes">
-						<h5>Reserved Prefixes</h5>
-
-						<p>This specification reserves the following set of prefixes that Authors MAY use in package
-							metadata without having to declare.</p>
-
-						<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
-							lead to interoperability issues. Validation tools will often reject new prefixes until the
-							tools are updated, for example. Authors are strongly encouraged to declare all prefixes they
-							use to avoid such issues.</p>
-
-						<table id="tbl-pkg-reserved-prefixes" class="prefix">
-							<thead>
-								<tr>
-									<th>Prefix</th>
-									<th>IRI</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>a11y</td>
-									<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
-								</tr>
-								<tr>
-									<td>dcterms</td>
-									<td>http://purl.org/dc/terms/</td>
-								</tr>
-								<tr>
-									<td>marc</td>
-									<td>http://id.loc.gov/vocabulary/</td>
-								</tr>
-								<tr>
-									<td>media</td>
-									<td>http://www.idpf.org/epub/vocab/overlays/#</td>
-								</tr>
-								<tr>
-									<td>onix</td>
-									<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
-								</tr>
-								<tr>
-									<td>rendition</td>
-									<td>http://www.idpf.org/vocab/rendition/#</td>
-								</tr>
-								<tr>
-									<td>schema</td>
-									<td>http://schema.org/</td>
-								</tr>
-								<tr>
-									<td>xsd</td>
-									<td>http://www.w3.org/2001/XMLSchema#</td>
-								</tr>
-							</tbody>
-						</table>
-
-						<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"
-									><code>prefix</code> attribute</a>.</p>
-					</section>
-
-					<section id="sec-prefix-attr">
-						<h5>The <code>prefix</code> Attribute</h5>
-
-						<p>The <code>prefix</code> attribute defines additional prefix mappings not <a
-								href="#sec-metadata-reserved-prefixes">reserved</a> by this specification.</p>
-
-						<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
-							prefix-to-IRI mappings of the form:</p>
-
-						<table class="productionset">
-							<caption>(EBNF productions <a
-									href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
-									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
-								(U+0000 to U+007F). </caption>
+					<table id="tbl-pkg-reserved-prefixes" class="prefix">
+						<thead>
 							<tr>
-								<td id="prefix.ebnf.def">
-									<a href="#prefix.ebnf.def">prefixes</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
-										>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
-										href="#prefix.ebnf.mapping">mapping</a> } ; </td>
-								<td> </td>
+								<th>Prefix</th>
+								<th>IRI</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>a11y</td>
+								<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.mapping">
-									<a href="#prefix.ebnf.mapping">mapping</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space"
-										>space</a> , { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
-								<td> </td>
+								<td>dcterms</td>
+								<td>http://purl.org/dc/terms/</td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.prefix">
-									<a href="#prefix.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td> </td>
+								<td>marc</td>
+								<td>http://id.loc.gov/vocabulary/</td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.space">
-									<a href="#prefix.ebnf.space">space</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>#x20 ;</td>
-								<td> </td>
+								<td>media</td>
+								<td>http://www.idpf.org/epub/vocab/overlays/#</td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.whitespace">
-									<a href="#prefix.ebnf.whitespace">whitespace</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>(#x20 | #x9 | #xD | #xA) ;</td>
-								<td> </td>
+								<td>onix</td>
+								<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
 							</tr>
-						</table>
+							<tr>
+								<td>rendition</td>
+								<td>http://www.idpf.org/vocab/rendition/#</td>
+							</tr>
+							<tr>
+								<td>schema</td>
+								<td>http://schema.org/</td>
+							</tr>
+							<tr>
+								<td>xsd</td>
+								<td>http://www.w3.org/2001/XMLSchema#</td>
+							</tr>
+						</tbody>
+					</table>
 
-						<aside class="example">
-							<p>The following example shows prefixes for the Friend of a Friend (<code>foaf</code>) and
-								DBPedia (<code>dbp</code>) vocabularies being declared using the <code>prefix</code>
-								attribute.</p>
-							<pre>&lt;package … 
+					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
+							attribute</a>.</p>
+				</section>
+
+				<section id="sec-prefix-attr">
+					<h4>The <code>prefix</code> Attribute</h4>
+
+					<p>The <code>prefix</code> attribute defines additional prefix mappings not <a
+							href="#sec-metadata-reserved-prefixes">reserved</a> by this specification.</p>
+
+					<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
+						prefix-to-IRI mappings of the form:</p>
+
+					<table class="productionset">
+						<caption>(EBNF productions <a
+								href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
+								>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
+							(U+0000 to U+007F). </caption>
+						<tr>
+							<td id="prefix.ebnf.def">
+								<a href="#prefix.ebnf.def">prefixes</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
+									>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
+									href="#prefix.ebnf.mapping">mapping</a> } ; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.mapping">
+								<a href="#prefix.ebnf.mapping">mapping</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space">space</a>
+								, { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.prefix">
+								<a href="#prefix.ebnf.prefix">prefix</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? xsd:NCName ? ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.space">
+								<a href="#prefix.ebnf.space">space</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>#x20 ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.whitespace">
+								<a href="#prefix.ebnf.whitespace">whitespace</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>(#x20 | #x9 | #xD | #xA) ;</td>
+							<td> </td>
+						</tr>
+					</table>
+
+					<aside class="example">
+						<p>The following example shows prefixes for the Friend of a Friend (<code>foaf</code>) and
+							DBPedia (<code>dbp</code>) vocabularies being declared using the <code>prefix</code>
+							attribute.</p>
+						<pre>&lt;package … 
 	prefix="foaf: http://xmlns.com/foaf/spec/
 		 dbp: http://dbpedia.org/ontology/"&gt;
 	…
 &lt;/package&gt;</pre>
-						</aside>
+					</aside>
 
-						<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix
-							that maps to the <a href="#sec-metadata-default-vocab">default vocabulary</a>.</p>
+					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
+						maps to the <a href="#sec-metadata-default-vocab">default vocabulary</a>.</p>
 
-						<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
-							[[!RDFA-CORE]] processing.</p>
+					<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
+						[[!RDFA-CORE]] processing.</p>
 
-						<p>For future compatibility with alternative serializations of the Package Document, a prefix
-							for the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in
-							the <code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
-								href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
-					</section>
-
-					<section id="sec-property-datatype">
-						<h5>The <code>property</code> Data Type</h5>
-
-						<p>The property data type is a compact means of expressing an IRI [[!RFC3987]] and consists of
-							an OPTIONAL prefix separated from a reference by a colon.</p>
-
-						<table class="productionset">
-							<caption>(EBNF productions <a
-									href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
-									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
-								(U+0000 to U+007F). </caption>
-							<tr>
-								<td id="property.ebnf.property">
-									<a href="#property.ebnf.property">property</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
-										href="#property.ebnf.reference">reference</a>; </td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.prefix">
-									<a href="#property.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.reference">
-									<a href="#property.ebnf.reference">reference</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? irelative-ref ? ;</td>
-								<td>/* as defined in [[!RFC3987]] */<br /></td>
-							</tr>
-						</table>
-
-						<p>The property data type is derived from the CURIE data type defined in [[!RDFA-CORE]], and
-							represents a subset of CURIEs.</p>
-
-						<aside class="example">
-							<p>The following example shows a property value composed of the prefix <code>dcterms</code>
-								and the reference <code>modified</code>.</p>
-							<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
-						</aside>
-
-						<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
-							[[EPUB-RS-33]], this property would expand to the following IRI:</p>
-
-						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
-
-						<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
-								prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
-
-						<p>When a prefix is omitted from a property value, the expressed reference represents a term
-							from the <a href="#sec-metadata-default-vocab">default vocabulary</a> for that
-							attribute.</p>
-
-						<aside class="example">
-							<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
-								manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
-
-							<pre>&lt;item … properties="mathml"/&gt;</pre>
-
-							<p>This property expands to:</p>
-
-							<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
-
-							<p>when the IRI for the vocabulary is concatenated with the reference.</p>
-						</aside>
-
-						<p>An empty string does not represent a valid property value, even though it is valid to the
-							definition above.</p>
-
-					</section>
+					<p>For future compatibility with alternative serializations of the Package Document, a prefix for
+						the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in the
+							<code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
+							href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
 				</section>
 
-				<section id="sec-package-metadata-rendering">
-					<h4>Package Rendering Metadata</h4>
+				<section id="sec-property-datatype">
+					<h4>The <code>property</code> Data Type</h4>
+
+					<p>The property data type is a compact means of expressing an IRI [[!RFC3987]] and consists of an
+						OPTIONAL prefix separated from a reference by a colon.</p>
+
+					<table class="productionset">
+						<caption>(EBNF productions <a
+								href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
+								>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
+							(U+0000 to U+007F). </caption>
+						<tr>
+							<td id="property.ebnf.property">
+								<a href="#property.ebnf.property">property</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
+									href="#property.ebnf.reference">reference</a>; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="property.ebnf.prefix">
+								<a href="#property.ebnf.prefix">prefix</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? xsd:NCName ? ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="property.ebnf.reference">
+								<a href="#property.ebnf.reference">reference</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? irelative-ref ? ;</td>
+							<td>/* as defined in [[!RFC3987]] */<br /></td>
+						</tr>
+					</table>
+
+					<p>The property data type is derived from the CURIE data type defined in [[!RDFA-CORE]], and
+						represents a subset of CURIEs.</p>
+
+					<aside class="example">
+						<p>The following example shows a property value composed of the prefix <code>dcterms</code> and
+							the reference <code>modified</code>.</p>
+						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
+					</aside>
+
+					<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
+						[[EPUB-RS-33]], this property would expand to the following IRI:</p>
+
+					<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
+
+					<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
+							prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
+
+					<p>When a prefix is omitted from a property value, the expressed reference represents a term from
+						the <a href="#sec-metadata-default-vocab">default vocabulary</a> for that attribute.</p>
+
+					<aside class="example">
+						<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
+							manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
+
+						<pre>&lt;item … properties="mathml"/&gt;</pre>
+
+						<p>This property expands to:</p>
+
+						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
+
+						<p>when the IRI for the vocabulary is concatenated with the reference.</p>
+					</aside>
+
+					<p>An empty string does not represent a valid property value, even though it is valid to the
+						definition above.</p>
 
-					<section id="sec-package-metadata-layout-general-intro" class="informative">
-						<h3>Introduction</h3>
-
-						<p>Not all rendering information can be expressed through the underlying technologies that EPUB
-							is built upon. For example, although HTML with CSS provides powerful layout capabilities,
-							those capabilities are limited to the scope of the document being rendered.</p>
-
-						<p>This section defines general-purpose properties that allow Authors to express package-level
-							rendering intentions (i.e., functionality that can only be implemented by the <a>EPUB
-								Reading System</a>). If a Reading System supports the desired rendering, these
-							properties enable the user to be presented the content as the Author optimally designed
-							it.</p>
-
-					</section>
-
-					<section id="rendition-vocab-ref">
-						<h5>Referencing</h5>
-
-						<p>The base IRI for referencing these properties is
-								<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
-
-						<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved
-								for use</a> with the package rendering properties and does not have to be declared in
-							the Package Document.</p>
-					</section>
-
-					<section id="sec-package-metadata-general">
-						<h5>General Properties</h5>
-
-						<section id="flow">
-							<h6>The <code>rendition:flow</code> Property</h6>
-
-							<p>The <code>rendition:flow</code> property specifies the Author preference for how Reading
-								Systems should handle content overflow. </p>
-
-							<section id="layout-property-flow-usage">
-								<h6>Usage</h6>
-
-								<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code>
-										property</a> is specified on a <code>meta</code> element, it indicates the
-									Author's global preference for overflow content handling (i.e., for all spine
-									items). Authors MAY indicate a preference for dynamic pagination or scrolling. For
-									scrolled content, it is also possible to specify whether consecutive <a>EPUB Content
-										Documents</a> are to be rendered as a continuous scrolling view or whether each
-									is to be rendered separately (i.e., with a dynamic page break between each).</p>
-
-								<p id="html-body-page-break-before">Note that when two reflowable EPUB Content Documents
-									occur sequentially in the spine, the default rendering for their [[!HTML]] <a
-										href="https://www.w3.org/TR/html/sections.html#the-body-element"
-											><code>body</code></a> elements is consistent with the <a
-										href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-											><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been
-									set to <code>always</code>. In addition to using the <code>rendition:flow</code>
-									property, Authors MAY override this behavior through an appropriate style sheet
-									declaration, if the Reading System supports such overrides.</p>
-
-								<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
-							</section>
-
-							<section id="layout-property-flow-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:flow</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt id="paginated">paginated</dt>
-									<dd>
-										<p>Dynamically paginate all overflow content.</p>
-									</dd>
-									<dt id="scrolled-continuous">scrolled-continuous</dt>
-									<dd>
-										<p>Render all Content Documents such that overflow content is scrollable, and
-											the EPUB Publication represented by the given <a>Rendition</a> is presented
-											as one continuous scroll from spine item to spine item (except where <a
-												href="#layout-property-flow-overrides">locally overridden</a>).</p>
-										<p>Note that Authors SHOULD NOT create publications in which different resources
-											have different block flow directions, as continuous scrolled rendition in
-											EPUB Reading Systems would be problematic.</p>
-									</dd>
-									<dt id="scrolled-doc">scrolled-doc</dt>
-									<dd>
-										<p>Render all Content Documents such that overflow content is scrollable, and
-											each spine item is presented as a separate scrollable document.</p>
-									</dd>
-									<dt id="auto">auto</dt>
-									<dd>
-										<p>Render overflow content using the Reading System default method or a user
-											preference, whichever is applicable.</p>
-									</dd>
-								</dl>
-							</section>
-
-							<section id="layout-property-flow-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="layout-property-flow-local">Authors MAY specify the following properties locally
-									on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
-									override the <a href="#property-flow-global">global value</a> for the given spine
-									item:</p>
-
-								<dl>
-									<dt id="flow-auto">flow-auto</dt>
-									<dd>Indicates no preference for overflow content handling by the Author.</dd>
-
-									<dt id="flow-paginated">flow-paginated</dt>
-									<dd>Indicates the Author preference is to dynamically paginate content
-										overflow.</dd>
-
-									<dt id="flow-scrolled-continuous">flow-scrolled-continuous</dt>
-									<dd>Indicates the Author preference is to provide a scrolled view for overflow
-										content, and that consecutive spine items with this property are to be rendered
-										as a continuous scroll.</dd>
-
-									<dt id="flow-scrolled-doc">flow-scrolled-doc</dt>
-									<dd>Indicates the Author preference is to provide a scrolled view for overflow
-										content, and each spine item with this property is to be rendered as a separate
-										scrollable document.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-							</section>
-
-							<section id="layout-property-flow-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="property-flow-ex1">
-									<p>The following example demonstrates an Author's intent to have a paginated
-										Rendition with a scrollable table of contents.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:flow"&gt;paginated&lt;/meta&gt;
-&lt;/metadata&gt;
-
-&lt;spine&gt;
-    &lt;itemref idref="toc" properties="rendition:flow-scrolled-doc"/&gt;
-    &lt;itemref idref="c01"/&gt;
-&lt;/spine&gt;</pre>
-								</aside>
-
-							</section>
-
-						</section>
-
-						<section id="align-x-center">
-							<h6>The <code>rendition:align-x-center</code> Property</h6>
-
-							<p>The <code>rendition:align-x-center</code> property specifies that the given spine item
-								should be centered horizontally in the viewport or spread. </p>
-
-							<div class="note">
-								<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title
-									pages), in the absence of reliable centering control within the content rendering.
-									As support for paged media evolves in CSS, however, this property is expected to be
-									deprecated. Authors are encouraged to use CSS solutions when effective.</p>
-							</div>
-
-						</section>
-					</section>
-
-					<section id="sec-package-metadata-fxl">
-						<h5>Fixed-Layout Properties</h5>
-
-						<section id="fxl-intro" class="informative">
-							<h6>Introduction</h6>
-
-							<p>EPUB documents, unlike print books or PDF files, are designed to change. The content
-								flows, or reflows, to fit the screen and to fit the needs of the user. As noted in <a
-									href="epub-overview.html#sec-rendering">Rendering and CSS</a> "content presentation
-								adapts to the user, rather than the user having to adapt to a particular presentation of
-								content." [[EPUB-OVERVIEW-33]]</p>
-
-							<p>But this principle doesn’t work for all types of documents. Sometimes content and design
-								are so intertwined they cannot be separated. Any change in appearance risks changing the
-								meaning, or losing all meaning. <a>Fixed-Layout Documents</a> give <a>Authors</a>
-								greater control over presentation when a reflowable EPUB is not suitable for the
-								content.</p>
-
-							<p>This section defines a set of metadata properties to allow declarative expression of
-								intended rendering behaviors of Fixed-Layout Documents in the context of EPUB 3.</p>
-
-							<div class="note" id="note-mechanisms">
-								<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When
-									fixed-layout content is necessary, the Author's choice of mechanism will depend on
-									many factors including desired degree of precision, file size, accessibility, etc.
-									This section does not attempt to dictate the Author's choice of mechanism.</p>
-							</div>
-
-						</section>
-
-						<section id="layout">
-							<h6>The <code>rendition:layout</code> Property</h6>
-
-							<p>The <code>rendition:layout</code> property specifies whether the given Rendition is
-								reflowable or pre-paginated.</p>
-
-							<section id="layout-usage">
-								<h5>Usage</h5>
-
-								<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code>
-										property</a> is specified on a <code>meta</code> element, it indicates that the
-									paginated or reflowable layout style applies globally for the <a>Rendition</a>
-									(i.e., for all spine items).</p>
-
-								<p>When the property is set to <code>pre-paginated</code> for a spine item, its content
-									dimensions MUST be set as defined in <a href="#sec-fixed-layouts"></a>.</p>
-
-								<p>The <code>rendition:layout</code> property MUST NOT be declared more than once.</p>
-
-							</section>
-
-							<section id="layout-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:layout</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt id="def-layout-reflowable">reflowable</dt>
-									<dd>
-										<p>The given Rendition is not pre-paginated (i.e., Reading Systems apply dynamic
-											pagination when rendering). Default value.</p>
-									</dd>
-									<dt id="def-layout-pre-paginated">pre-paginated</dt>
-									<dd>
-										<p>The given Rendition is pre-paginated (i.e., Reading Systems produce exactly
-											one page per spine <a href="#elemdef-spine-itemref"><code>itemref</code></a>
-											when rendering).</p>
-									</dd>
-								</dl>
-
-								<div class="note" id="uaag">
-									<p>Reading Systems typically restrict or deny the application of user or user agent
-										style sheets to pre-paginated documents, since, as a result of intrinsic
-										properties of such documents, dynamic style changes are highly likely to have
-										unintended consequences. Authors need to take into account the negative impact
-										on usability and accessibility that these restrictions have when choosing to use
-										pre-paginated instead of reflowable content. Refer to <a
-											href="https://www.w3.org/TR/2015/NOTE-UAAG20-20151215/#gl-text-config"
-											>Guideline 1.4 - Provide text configuration</a> [[UAAG20]] for related
-										information.</p>
-								</div>
-
-							</section>
-
-							<section id="layout-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="property-layout-local">Authors MAY specify the following properties locally on
-									spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override
-									the <a href="#property-layout-global">global value</a> for the given spine item:</p>
-
-								<dl>
-									<dt id="layout-pre-paginated">layout-pre-paginated</dt>
-									<dd>Specifies that the given spine item is pre-paginated.</dd>
-
-									<dt id="layout-reflowable">layout-reflowable</dt>
-									<dd>Specifies that the given spine item is reflowable.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-
-							</section>
-
-							<section id="layout-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex1">
-									<p>The following example demonstrates fully fixed-layout content, using
-										[[CSS3-MediaQueries]] to apply different style sheets for three different device
-										categories. Note that the Media Queries only affect the style sheet applied to
-										the document; the size of the content area set in the <code>viewport</code>
-										<code>meta</code> tag is static.</p>
-
-									<h5>Package Document</h5>
-
-									<pre>&lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;</pre>
-
-									<h5>XHTML</h5>
-
-									<pre>&lt;head&gt;
-    &lt;meta name="viewport" content="width=1200, height=900"/&gt;
-	
-    &lt;link rel="stylesheet" href="eink-style.css" media="(max-monochrome: 3)"/&gt;
-    &lt;link rel="stylesheet" href="skinnytablet-style.css" media="((color) and
-        (max-height:600px) and (orientation:landscape), (color) and (max-width:600px)
-        and (orientation:portrait))"/&gt;
-    &lt;link rel="stylesheet" href="fattablet-style.css" media="((color) and
-        (min-height:601px) and (orientation:landscape), (color) and (min-width:601px)
-        and (orientation:portrait)"/&gt;	
-&lt;/head&gt;
-</pre>
-								</aside>
-
-							</section>
-						</section>
-
-						<section id="orientation">
-							<h6>The <code>rendition:orientation</code> Property</h6>
-
-							<p>The <code>rendition:orientation</code> property specifies which orientation the Author
-								intends the given Rendition to be rendered in. </p>
-
-							<section id="orientation-usage">
-								<h5>Usage</h5>
-
-								<p id="property-orientation-global">When the <a href="#orientation"
-											><code>rendition:orientation</code> property</a> is specified on a
-										<code>meta</code> element, it indicates that the intended orientation applies
-									globally for the given Rendition (i.e., for all spine items).</p>
-
-								<p>The <code>rendition:orientation</code> property MUST NOT be declared more than
-									once.</p>
-
-							</section>
-
-							<section id="orientation-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:orientation</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt>landscape</dt>
-									<dd>
-										<p>The given Rendition is intended for landscape rendering.</p>
-									</dd>
-									<dt>portrait</dt>
-									<dd>
-										<p> The given Rendition is intended for portrait rendering.</p>
-									</dd>
-									<dt>auto</dt>
-									<dd>
-										<p>The given Rendition is not orientation constrained. Default value.</p>
-									</dd>
-								</dl>
-							</section>
-
-							<section id="orientation-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="property-orientation-local">Authors MAY specify the following properties locally
-									on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
-									override the <a href="#property-orientation-global">global value</a> for the given
-									spine item:</p>
-
-								<dl>
-									<dt id="orientation-auto">orientation-auto</dt>
-									<dd>Specifies that the Reading System determines the orientation to render the spine
-										item in.</dd>
-
-									<dt id="orientation-landscape">orientation-landscape</dt>
-									<dd>Specifies that the given spine item is to be rendered in landscape
-										orientation.</dd>
-
-									<dt id="orientation-portrait">orientation-portrait</dt>
-									<dd>Specifies that the given spine item is to be rendered in portrait
-										orientation.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-
-							</section>
-
-							<section id="orientation-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex2">
-									<p>The following example demonstrates fully fixed-layout content intended to be
-										rendered without synthetic spreads, and locked to landscape orientation.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;none&lt;/meta&gt;
-    
-    &lt;meta property="rendition:orientation"&gt;landscape&lt;/meta&gt;
-&lt;/metadata&gt;</pre>
-								</aside>
-
-							</section>
-
-						</section>
-
-						<section id="spread">
-							<h6>The <code>rendition:spread</code> Property</h6>
-
-							<p>The <code>rendition:spread</code> property specifies the intended Reading System
-								synthetic spread behavior for the given Rendition.</p>
-
-							<section id="spread-usage">
-								<h6>Usage</h6>
-
-								<p id="property-spread-global">When the <code>rendition:spread</code> property is
-									specified on a <code>meta</code> element, it indicates that the intended
-										<a>Synthetic Spread</a> behavior applies globally for the given Rendition (i.e.,
-									for all spine items).</p>
-
-								<p>The <code>rendition:spread</code> property MUST NOT be declared more than once.</p>
-							</section>
-
-							<section id="spread-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:spread</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt>none</dt>
-									<dd>
-										<p>Do not incorporate spine items in a Synthetic Spread.</p>
-									</dd>
-									<dt>landscape</dt>
-									<dd>
-										<p>Render a Synthetic Spread for spine items only when the device is in
-											landscape orientation.</p>
-									</dd>
-									<dt>portrait (deprecated)</dt>
-									<dd>
-										<p>The use of spreads only in portrait orientation is <a href="#deprecated"
-												>deprecated</a>.</p>
-										<p>Authors are advised to use the value "<code>both</code>" instead, as spreads
-											that are readable in portrait orientation are also readable in
-											landscape.</p>
-									</dd>
-									<dt>both</dt>
-									<dd>
-										<p>Render a Synthetic Spread regardless of device orientation.</p>
-									</dd>
-									<dt>auto</dt>
-									<dd>
-										<p>No explicit Synthetic Spread behavior is defined. Default value.</p>
-									</dd>
-								</dl>
-
-								<div class="note">
-									<p>When Synthetic Spreads are used in the context of HTML and SVG Content Documents,
-										the dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
-											<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"
-												><code>viewBox</code> attribute</a> represents the size of one page in
-										the spread, respectively.</p>
-								</div>
-
-								<div class="note">
-									<p>Refer to <a href="#sec-spine-elem">spine</a> for information about declaration of
-										global flow directionality using the <code>page-progression-direction</code>
-										attribute and that of local page-progression-direction within content
-										documents.</p>
-								</div>
-
-							</section>
-
-							<section id="spread-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="property-spread-local">Authors MAY specify the following properties locally on
-									spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override
-									the <a href="#property-spread-global">global value</a> for the given spine item:</p>
-
-								<dl>
-									<dt id="spread-auto">spread-auto</dt>
-									<dd>Specifies the Reading System determines when to render a synthetic spread for
-										the spine item. </dd>
-
-									<dt id="spread-both">spread-both</dt>
-									<dd>Specifies the Reading System should render a synthetic spread for the spine item
-										in both portrait and landscape orientations. </dd>
-
-									<dt id="spread-landscape">spread-landscape</dt>
-									<dd>Specifies the Reading System should render a synthetic spread for the spine item
-										only when in landscape orientation.</dd>
-
-									<dt id="spread-none">spread-none</dt>
-									<dd>Specifies the Reading System should not render a synthetic spread for the spine
-										item.</dd>
-
-									<dt id="spread-portrait">spread-portrait</dt>
-									<dd>The <code>spread-portrait</code> property is <a href="#deprecated"
-											>deprecated</a>. Refer to its definition in [[!EPUBPublications-301]] for
-										more information.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-							</section>
-
-							<section id="spread-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex3">
-									<p>The following example demonstrates fully fixed-layout content intended to be
-										rendered using synthetic spreads in landscape orientation, and with no spreads
-										in portrait orientation.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;landscape&lt;/meta&gt;
-&lt;/metadata&gt;</pre>
-								</aside>
-
-								<aside class="example" id="fxl-ex4">
-									<p>The following example demonstrates reflowable content with a single fixed-layout
-										title page, where the fixed-layout page is intended for right-hand spread slot
-										if the device renders Synthetic Spreads.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;reflowable&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
-&lt;/metadata&gt;
-
-&lt;spine&gt;
-    &lt;itemref idref="titlepage" properties="page-spread-right rendition:layout-pre-paginated"/&gt;
-&lt;/spine&gt;</pre>
-								</aside>
-
-							</section>
-
-						</section>
-
-						<section id="page-spread">
-							<h6>The <code>rendition:page-spread-*</code> Properties</h6>
-
-							<section id="page-spread-usage">
-								<h6>Usage</h6>
-
-								<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to
-									populate the spread by rendering the next <a>EPUB Content Document</a> in the next
-									available unpopulated viewport, where the next available viewport is determined by
-									the given <a href="#sec-spine-elem">page progression direction</a> or by local
-									declarations within Content Documents. An Author MAY override this automatic
-									population behavior and force a document to be placed in a particular viewport by
-									specifying one of the following properties on its spine <code>itemref</code>
-									element:</p>
-
-								<dl>
-									<dt id="page-spread-center">
-										<code>rendition:page-spread-center</code>
-									</dt>
-									<dd>The <code>rendition:page-spread-center</code> property specifies the forced
-										placement of a Content Document in a <a>Synthetic Spread</a>. </dd>
-
-									<dt id="fxl-page-spread-left">
-										<code>rendition:page-spread-left</code>
-									</dt>
-									<dd>The <code>rendition:page-spread-left</code> property is an alias for the
-												<code><a href="#page-spread-left">page-spread-left</a></code>
-										property.</dd>
-
-									<dt id="fxl-page-spread-right">
-										<code>rendition:page-spread-right</code>
-									</dt>
-									<dd>The <code>rendition:page-spread-right</code> property is an alias for the
-												<code><a href="#page-spread-right">page-spread-right</a></code>
-										property.</dd>
-								</dl>
-
-								<p>The <code>rendition:page-spread-left</code> property indicates that the given spine
-									item is to be rendered in the left-hand slot in the spread, and
-										<code>rendition:page-spread-right</code> that it be rendered in the right-hand
-									slot. The <code>rendition:page-spread-center</code> property indicates to override
-									the synthetic spread mode and render a single viewport positioned at the center of
-									the screen.</p>
-
-								<p>The <code>rendition:page-spread-left</code>, <code>rendition:page-spread-right</code>
-									and <code>rendition:page-spread-center</code> properties apply to both pre-paginated
-									and reflowable content, and they only apply when the Reading System is creating
-									Synthetic Spreads.</p>
-
-								<p>Although Authors often indicate to use a spread in certain device orientations, the
-									content itself does not represent true spreads (i.e., two consecutive pages that
-									have to be rendered side-by-side for readability, such as a two-page map). To
-									indicate that two consecutive pages represent a true spread, Authors SHOULD use the
-										<code>rendition:page-spread-left</code> and
-										<code>rendition:page-spread-right</code> properties on the spine items for the
-									two adjacent EPUB Content Documents, and omit the properties on spine items where
-									one-up or two-up presentation is equally acceptable.</p>
-
-								<p>Only one <code>page-spread-*</code> property can be declared on any given spine
-									item.</p>
-
-								<div class="note" id="note-page-spread-aliases">
-									<p>The <code>rendition:page-spread-left</code> and
-											<code>rendition:page-spread-right</code> properties are aliases for the <a
-											href="#page-spread-left"><code>page-spread-left</code></a> and <a
-											href="#page-spread-right"><code>spread-right</code></a> properties. They
-										allow the use of a single vocabulary for all fixed-layout properties. Authors
-										can use either property set, but older Reading Systems might only recognize the
-										unprefixed versions. The <a href="#app-itemref-properties-vocab">EPUB Spine
-											Properties Vocabulary</a> is no longer being extended for package rendering
-										metadata, so an unprefixed <code>page-spread-center</code> is not available.</p>
-								</div>
-							</section>
-
-							<section id="page-spread-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex5">
-									<p>The following example demonstrates reflowable content with a two-page
-										fixed-layout center plate that is intended to be rendered using synthetic
-										spreads in any device orientation. Note that the author has left spread behavior
-										for the other (reflowable) parts of the <a>Rendition</a> undefined, since the
-										global value of <code>rendition:spread</code> is initialized to
-											<code>auto</code> by default.</p>
-									<pre>&lt;spine page-progression-direction="ltr"&gt;
-    …
-    &lt;itemref idref="center-plate-left"
-             properties="rendition:spread-both rendition:page-spread-left"/&gt;
-    &lt;itemref idref="center-plate-right"
-             properties="rendition:spread-both rendition:page-spread-right"/&gt;
-    …
-&lt;/spine&gt;</pre>
-								</aside>
-
-								<aside class="example" id="fxl-ex6">
-									<p>The following example demonstrates fixed-layout content, where synthetic spreads,
-										when used, have to be disabled for a center plate. Note that the
-											<code>rendition:spread</code> declaration <code>none</code> expression is
-										not needed on the center plate item, as the
-											<code>rendition:page-spread-center</code> property already specifies
-										semantics that dictates that synthetic spreads be disabled.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
-&lt;/metadata&gt;
-&lt;spine&gt;
-    &lt;itemref idref="center-plate" properties="rendition:page-spread-center"/&gt;
-&lt;/spine&gt;</pre>
-								</aside>
-							</section>
-						</section>
-
-						<section id="viewport">
-							<h6>The <code>rendition:viewport</code> Property (Deprecated)</h6>
-
-							<p>The <code>rendition:viewport</code> property allows <a>Authors</a> to express the CSS
-								initial containing block (ICB) [[!CSS21]] for XHTML and SVG Content Documents whose
-									<code>rendition:layout</code> property has been set to
-								<code>pre-paginated</code>.</p>
-
-							<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its definition in
-								[[!EPUBPublications-301]] for more information.</p>
-						</section>
-					</section>
 				</section>
 			</section>
 
@@ -6284,83 +5633,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				</section>
 			</section>
 
-			<section id="sec-fixed-layouts">
-				<h3>Fixed Layouts</h3>
-
-				<section id="sec-fxl-overview" class="informative">
-					<h4>Introduction</h4>
-
-					<p>This section defines rules for the expression and interpretation of dimensional properties of
-							<a>Fixed-Layout Documents</a> — <a>EPUB Content Documents</a> marked as
-							<code>pre-paginated</code> in the <a>Package Document</a>.</p>
-
-					<div class="note">
-						<p>Refer to <a href="#sec-package-metadata-fxl"></a> for information on how to designate that a
-								<a>Rendition</a>, or its individual spine items, are to be rendered in a pre-paginated
-							manner (i.e., with fixed width and height dimensions).</p>
-					</div>
-
-				</section>
-
-				<section id="sec-fxl-content-conf">
-					<h4>Content Conformance</h4>
-
-					<p>A conformant <a>Fixed-Layout Document</a> has to meet the following criteria:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreg-fxl-icb">It MUST specify its <a
-									href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-									containing block</a> [[!CSS2]] as defined in <a href="#sec-fxl-html-svg-dimensions"
-								></a>.</p>
-						</li>
-					</ul>
-				</section>
-
-				<section id="sec-fxl-html-svg-dimensions">
-					<h4>Initial Containing Block Dimensions</h4>
-
-					<section id="sec-fxl-icb-html">
-						<h5>Expressing in HTML</h5>
-
-						<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
-								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-								containing block</a> [[!CSS2]] dimensions MUST be expressed in a <code>viewport</code>
-							<code>meta</code> tag using the syntax defined in [[!CSS-Device-Adapt-1]].</p>
-
-						<aside class="example">
-							<p>The following example shows a <code>viewport</code>
-								<code>meta</code> tag.</p>
-							<pre>
-&lt;head&gt;
-   …
-   &lt;meta name="viewport" content="width=1200, height=600"/&gt;
-   …
-&lt;/head&gt;</pre>
-						</aside>
-					</section>
-
-					<section id="sec-fxl-icb-svg">
-						<h5>Expressing in SVG</h5>
-
-						<p>For SVG <a>Fixed-Layout Documents</a>, the ICB dimensions MUST be expressed using the <a
-								href="http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code>
-								attribute</a> [[!SVG]].</p>
-
-						<aside class="example">
-							<p>The following example shows a <code>viewBox</code> attribute declaration for an SVG
-								Content Document with an aspect ratio of 844 pixels wide by 1200 pixels high.</p>
-							<pre>
-&lt;svg xmlns="http://www.w3.org/2000/svg"
-     version="1.1" 
-     viewBox="0 0 844 1200"&gt;
-   …
-&lt;/svg&gt;</pre>
-						</aside>
-					</section>
-				</section>
-			</section>
-
 			<section id="sec-pls">
 				<h3>Pronunciation Lexicons</h3>
 
@@ -6460,6 +5732,464 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								extension <code class="filename">.pls</code>.</p>
 						</dd>
 					</dl>
+				</section>
+			</section>
+		</section>
+		<section id="sec-fixed-layouts">
+			<h2>Fixed Layouts</h2>
+
+			<section id="fxl-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>EPUB documents, unlike print books or PDF files, are designed to change. The content flows, or
+					reflows, to fit the screen and to fit the needs of the user. As noted in <a
+						href="epub-overview.html#sec-rendering">Rendering and CSS</a> "content presentation adapts to
+					the user, rather than the user having to adapt to a particular presentation of content."
+					[[EPUB-OVERVIEW-33]]</p>
+
+				<p>But this principle doesn’t work for all types of documents. Sometimes content and design are so
+					intertwined they cannot be separated. Any change in appearance risks changing the meaning, or losing
+					all meaning. <a>Fixed-Layout Documents</a> give <a>Authors</a> greater control over presentation
+					when a reflowable EPUB is not suitable for the content.</p>
+
+				<p>This section defines a set of metadata properties to allow declarative expression of intended
+					rendering behaviors of Fixed-Layout Documents in the context of EPUB 3.</p>
+
+				<div class="note" id="note-mechanisms">
+					<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
+						content is necessary, the Author's choice of mechanism will depend on many factors including
+						desired degree of precision, file size, accessibility, etc. This section does not attempt to
+						dictate the Author's choice of mechanism.</p>
+				</div>
+			</section>
+
+			<section id="sec-package-metadata-fxl">
+				<h3>Package Definition</h3>
+
+				<section id="layout">
+					<h4>Layout</h4>
+
+					<p>The <code>rendition:layout</code> property specifies whether the given Rendition is reflowable or
+						pre-paginated.</p>
+
+					<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code> property</a>
+						is specified on a <code>meta</code> element, it indicates that the paginated or reflowable
+						layout style applies globally for the <a>Rendition</a> (i.e., for all spine items).</p>
+
+					<p>The following values are defined for use with the <code>rendition:layout</code> property:</p>
+
+					<dl class="variablelist">
+						<dt id="def-layout-reflowable">reflowable</dt>
+						<dd>
+							<p>The given Rendition is not pre-paginated (i.e., Reading Systems apply dynamic pagination
+								when rendering). Default value.</p>
+						</dd>
+						<dt id="def-layout-pre-paginated">pre-paginated</dt>
+						<dd>
+							<p>The given Rendition is pre-paginated (i.e., Reading Systems produce exactly one page per
+								spine <a href="#elemdef-spine-itemref"><code>itemref</code></a> when rendering).</p>
+						</dd>
+					</dl>
+
+					<div class="note" id="uaag">
+						<p>Reading Systems typically restrict or deny the application of user or user agent style sheets
+							to pre-paginated documents, since, as a result of intrinsic properties of such documents,
+							dynamic style changes are highly likely to have unintended consequences. Authors need to
+							take into account the negative impact on usability and accessibility that these restrictions
+							have when choosing to use pre-paginated instead of reflowable content. Refer to <a
+								href="https://www.w3.org/TR/2015/NOTE-UAAG20-20151215/#gl-text-config">Guideline 1.4 -
+								Provide text configuration</a> [[UAAG20]] for related information.</p>
+					</div>
+
+					<p>When the property is set to <code>pre-paginated</code> for a spine item, its content dimensions
+						MUST be set as defined in <a href="#sec-fixed-layouts"></a>.</p>
+
+					<p>The <code>rendition:layout</code> property MUST NOT be declared more than once.</p>
+
+					<aside class="example" id="fxl-ex1">
+						<p>The following example demonstrates fully fixed-layout content, using [[CSS3-MediaQueries]] to
+							apply different style sheets for three different device categories. Note that the Media
+							Queries only affect the style sheet applied to the document; the size of the content area
+							set in the <code>viewport</code>
+							<code>meta</code> tag is static.</p>
+
+						<h3>Package Document</h3>
+
+						<pre>&lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;</pre>
+
+						<h3>XHTML</h3>
+
+						<pre>&lt;head&gt;
+    &lt;meta name="viewport" content="width=1200, height=900"/&gt;
+	
+    &lt;link rel="stylesheet" href="eink-style.css" media="(max-monochrome: 3)"/&gt;
+    &lt;link rel="stylesheet" href="skinnytablet-style.css" media="((color) and
+        (max-height:600px) and (orientation:landscape), (color) and (max-width:600px)
+        and (orientation:portrait))"/&gt;
+    &lt;link rel="stylesheet" href="fattablet-style.css" media="((color) and
+        (min-height:601px) and (orientation:landscape), (color) and (min-width:601px)
+        and (orientation:portrait)"/&gt;	
+&lt;/head&gt;
+</pre>
+					</aside>
+
+					<section id="layout-overrides">
+						<h5>Spine Overrides</h5>
+
+						<p id="property-layout-local">Authors MAY specify the following properties locally on spine <a
+								href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+								href="#property-layout-global">global value</a> for the given spine item:</p>
+
+						<dl>
+							<dt id="layout-pre-paginated">layout-pre-paginated</dt>
+							<dd>Specifies that the given spine item is pre-paginated.</dd>
+
+							<dt id="layout-reflowable">layout-reflowable</dt>
+							<dd>Specifies that the given spine item is reflowable.</dd>
+						</dl>
+
+						<p>Only one of these overrides is allowed on any given spine item.</p>
+
+					</section>
+				</section>
+
+				<section id="orientation">
+					<h4>Orientaton</h4>
+
+					<p>The <code>rendition:orientation</code> property specifies which orientation the Author intends
+						the given Rendition to be rendered in. </p>
+
+					<p id="property-orientation-global">When the <a href="#orientation"
+								><code>rendition:orientation</code> property</a> is specified on a <code>meta</code>
+						element, it indicates that the intended orientation applies globally for the given Rendition
+						(i.e., for all spine items).</p>
+
+					<p>The following values are defined for use with the <code>rendition:orientation</code>
+						property:</p>
+
+					<dl class="variablelist">
+						<dt>landscape</dt>
+						<dd>
+							<p>The given Rendition is intended for landscape rendering.</p>
+						</dd>
+						<dt>portrait</dt>
+						<dd>
+							<p> The given Rendition is intended for portrait rendering.</p>
+						</dd>
+						<dt>auto</dt>
+						<dd>
+							<p>The given Rendition is not orientation constrained. Default value.</p>
+						</dd>
+					</dl>
+
+					<p>The <code>rendition:orientation</code> property MUST NOT be declared more than once.</p>
+
+					<aside class="example" id="fxl-ex2">
+						<p>The following example demonstrates fully fixed-layout content intended to be rendered without
+							synthetic spreads, and locked to landscape orientation.</p>
+						<pre>&lt;metadata&gt;
+    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
+    &lt;meta property="rendition:spread"&gt;none&lt;/meta&gt;
+    
+    &lt;meta property="rendition:orientation"&gt;landscape&lt;/meta&gt;
+&lt;/metadata&gt;</pre>
+					</aside>
+
+					<section id="orientation-overrides">
+						<h5>Spine Overrides</h5>
+
+						<p id="property-orientation-local">Authors MAY specify the following properties locally on spine
+								<a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+								href="#property-orientation-global">global value</a> for the given spine item:</p>
+
+						<dl>
+							<dt id="orientation-auto">orientation-auto</dt>
+							<dd>Specifies that the Reading System determines the orientation to render the spine item
+								in.</dd>
+
+							<dt id="orientation-landscape">orientation-landscape</dt>
+							<dd>Specifies that the given spine item is to be rendered in landscape orientation.</dd>
+
+							<dt id="orientation-portrait">orientation-portrait</dt>
+							<dd>Specifies that the given spine item is to be rendered in portrait orientation.</dd>
+						</dl>
+
+						<p>Only one of these overrides is allowed on any given spine item.</p>
+
+					</section>
+				</section>
+
+				<section id="spread">
+					<h4>Synthetic Spreads</h4>
+
+					<p>The <code>rendition:spread</code> property specifies the intended Reading System synthetic spread
+						behavior for the given Rendition.</p>
+
+					<p id="property-spread-global">When the <code>rendition:spread</code> property is specified on a
+							<code>meta</code> element, it indicates that the intended <a>Synthetic Spread</a> behavior
+						applies globally for the given Rendition (i.e., for all spine items).</p>
+
+					<p>The following values are defined for use with the <code>rendition:spread</code> property:</p>
+
+					<dl class="variablelist">
+						<dt>none</dt>
+						<dd>
+							<p>Do not incorporate spine items in a Synthetic Spread.</p>
+						</dd>
+						<dt>landscape</dt>
+						<dd>
+							<p>Render a Synthetic Spread for spine items only when the device is in landscape
+								orientation.</p>
+						</dd>
+						<dt>portrait (deprecated)</dt>
+						<dd>
+							<p>The use of spreads only in portrait orientation is <a href="#deprecated"
+								>deprecated</a>.</p>
+							<p>Authors are advised to use the value "<code>both</code>" instead, as spreads that are
+								readable in portrait orientation are also readable in landscape.</p>
+						</dd>
+						<dt>both</dt>
+						<dd>
+							<p>Render a Synthetic Spread regardless of device orientation.</p>
+						</dd>
+						<dt>auto</dt>
+						<dd>
+							<p>No explicit Synthetic Spread behavior is defined. Default value.</p>
+						</dd>
+					</dl>
+
+					<p>The <code>rendition:spread</code> property MUST NOT be declared more than once.</p>
+
+					<div class="note">
+						<p>When Synthetic Spreads are used in the context of HTML and SVG Content Documents, the
+							dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
+								<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"><code>viewBox</code>
+								attribute</a> represents the size of one page in the spread, respectively.</p>
+					</div>
+
+					<div class="note">
+						<p>Refer to <a href="#sec-spine-elem">spine</a> for information about declaration of global flow
+							directionality using the <code>page-progression-direction</code> attribute and that of local
+							page-progression-direction within content documents.</p>
+					</div>
+
+					<aside class="example" id="fxl-ex3">
+						<p>The following example demonstrates fully fixed-layout content intended to be rendered using
+							synthetic spreads in landscape orientation, and with no spreads in portrait orientation.</p>
+						<pre>&lt;metadata&gt;
+    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
+    &lt;meta property="rendition:spread"&gt;landscape&lt;/meta&gt;
+&lt;/metadata&gt;</pre>
+					</aside>
+
+					<aside class="example" id="fxl-ex4">
+						<p>The following example demonstrates reflowable content with a single fixed-layout title page,
+							where the fixed-layout page is intended for right-hand spread slot if the device renders
+							Synthetic Spreads.</p>
+						<pre>&lt;metadata&gt;
+    &lt;meta property="rendition:layout"&gt;reflowable&lt;/meta&gt;
+    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
+&lt;/metadata&gt;
+
+&lt;spine&gt;
+    &lt;itemref idref="titlepage" properties="page-spread-right rendition:layout-pre-paginated"/&gt;
+&lt;/spine&gt;</pre>
+					</aside>
+
+					<section id="spread-overrides">
+						<h5>Spine Overrides</h5>
+
+						<p id="property-spread-local">Authors MAY specify the following properties locally on spine <a
+								href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+								href="#property-spread-global">global value</a> for the given spine item:</p>
+
+						<dl>
+							<dt id="spread-auto">spread-auto</dt>
+							<dd>Specifies the Reading System determines when to render a synthetic spread for the spine
+								item. </dd>
+
+							<dt id="spread-both">spread-both</dt>
+							<dd>Specifies the Reading System should render a synthetic spread for the spine item in both
+								portrait and landscape orientations. </dd>
+
+							<dt id="spread-landscape">spread-landscape</dt>
+							<dd>Specifies the Reading System should render a synthetic spread for the spine item only
+								when in landscape orientation.</dd>
+
+							<dt id="spread-none">spread-none</dt>
+							<dd>Specifies the Reading System should not render a synthetic spread for the spine
+								item.</dd>
+
+							<dt id="spread-portrait">spread-portrait</dt>
+							<dd>The <code>spread-portrait</code> property is <a href="#deprecated">deprecated</a>. Refer
+								to its definition in [[!EPUBPublications-301]] for more information.</dd>
+						</dl>
+
+						<p>Only one of these overrides is allowed on any given spine item.</p>
+					</section>
+				</section>
+
+				<section id="page-spread">
+					<h4>Spread Placement</h4>
+
+					<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to populate the
+						spread by rendering the next <a>EPUB Content Document</a> in the next available unpopulated
+						viewport, where the next available viewport is determined by the given <a href="#sec-spine-elem"
+							>page progression direction</a> or by local declarations within Content Documents. An Author
+						MAY override this automatic population behavior and force a document to be placed in a
+						particular viewport by specifying one of the following properties on its spine
+							<code>itemref</code> element:</p>
+
+					<dl>
+						<dt id="page-spread-center">
+							<code>rendition:page-spread-center</code>
+						</dt>
+						<dd>The <code>rendition:page-spread-center</code> property specifies the forced placement of a
+							Content Document in a <a>Synthetic Spread</a>. </dd>
+
+						<dt id="fxl-page-spread-left">
+							<code>rendition:page-spread-left</code>
+						</dt>
+						<dd>The <code>rendition:page-spread-left</code> property is an alias for the <code><a
+									href="#page-spread-left">page-spread-left</a></code> property.</dd>
+
+						<dt id="fxl-page-spread-right">
+							<code>rendition:page-spread-right</code>
+						</dt>
+						<dd>The <code>rendition:page-spread-right</code> property is an alias for the <code><a
+									href="#page-spread-right">page-spread-right</a></code> property.</dd>
+					</dl>
+
+					<p>The <code>rendition:page-spread-left</code> property indicates that the given spine item is to be
+						rendered in the left-hand slot in the spread, and <code>rendition:page-spread-right</code> that
+						it be rendered in the right-hand slot. The <code>rendition:page-spread-center</code> property
+						indicates to override the synthetic spread mode and render a single viewport positioned at the
+						center of the screen.</p>
+
+					<p>The <code>rendition:page-spread-left</code>, <code>rendition:page-spread-right</code> and
+							<code>rendition:page-spread-center</code> properties apply to both pre-paginated and
+						reflowable content, and they only apply when the Reading System is creating Synthetic
+						Spreads.</p>
+
+					<p>Although Authors often indicate to use a spread in certain device orientations, the content
+						itself does not represent true spreads (i.e., two consecutive pages that have to be rendered
+						side-by-side for readability, such as a two-page map). To indicate that two consecutive pages
+						represent a true spread, Authors SHOULD use the <code>rendition:page-spread-left</code> and
+							<code>rendition:page-spread-right</code> properties on the spine items for the two adjacent
+						EPUB Content Documents, and omit the properties on spine items where one-up or two-up
+						presentation is equally acceptable.</p>
+
+					<p>Only one <code>page-spread-*</code> property can be declared on any given spine item.</p>
+
+					<div class="note" id="note-page-spread-aliases">
+						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
+							properties are aliases for the <a href="#page-spread-left"><code>page-spread-left</code></a>
+							and <a href="#page-spread-right"><code>spread-right</code></a> properties. They allow the
+							use of a single vocabulary for all fixed-layout properties. Authors can use either property
+							set, but older Reading Systems might only recognize the unprefixed versions. The <a
+								href="#app-itemref-properties-vocab">EPUB Spine Properties Vocabulary</a> is no longer
+							being extended for package rendering metadata, so an unprefixed
+								<code>page-spread-center</code> is not available.</p>
+					</div>
+
+					<aside class="example" id="fxl-ex5">
+						<p>The following example demonstrates reflowable content with a two-page fixed-layout center
+							plate that is intended to be rendered using synthetic spreads in any device orientation.
+							Note that the author has left spread behavior for the other (reflowable) parts of the
+								<a>Rendition</a> undefined, since the global value of <code>rendition:spread</code> is
+							initialized to <code>auto</code> by default.</p>
+						<pre>&lt;spine page-progression-direction="ltr"&gt;
+    …
+    &lt;itemref idref="center-plate-left"
+             properties="rendition:spread-both rendition:page-spread-left"/&gt;
+    &lt;itemref idref="center-plate-right"
+             properties="rendition:spread-both rendition:page-spread-right"/&gt;
+    …
+&lt;/spine&gt;</pre>
+					</aside>
+
+					<aside class="example" id="fxl-ex6">
+						<p>The following example demonstrates fixed-layout content, where synthetic spreads, when used,
+							have to be disabled for a center plate. Note that the <code>rendition:spread</code>
+							declaration <code>none</code> expression is not needed on the center plate item, as the
+								<code>rendition:page-spread-center</code> property already specifies semantics that
+							dictates that synthetic spreads be disabled.</p>
+						<pre>&lt;metadata&gt;
+    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
+    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
+&lt;/metadata&gt;
+&lt;spine&gt;
+    &lt;itemref idref="center-plate" properties="rendition:page-spread-center"/&gt;
+&lt;/spine&gt;</pre>
+					</aside>
+				</section>
+
+				<section id="viewport">
+					<h4>Viewport Dimensions (Deprecated)</h4>
+
+					<p>The <code>rendition:viewport</code> property allows <a>Authors</a> to express the CSS initial
+						containing block (ICB) [[!CSS21]] for XHTML and SVG Content Documents whose
+							<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
+
+					<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its definition in
+						[[!EPUBPublications-301]] for more information.</p>
+				</section>
+			</section>
+
+			<section id="sec-fxl-content-dimensions">
+				<h3>Content Document Dimensions</h3>
+
+				<p>This section defines rules for the expression and interpretation of dimensional properties of
+						<a>Fixed-Layout Documents</a> — <a>EPUB Content Documents</a> marked as
+						<code>pre-paginated</code> in the <a>Package Document</a>.</p>
+
+				<div class="note">
+					<p>Refer to <a href="#sec-package-metadata-fxl"></a> for information on how to designate that a
+							<a>Rendition</a>, or its individual spine items, are to be rendered in a pre-paginated
+						manner (i.e., with fixed width and height dimensions).</p>
+				</div>
+
+				<section id="sec-fxl-html-svg-dimensions">
+					<h4>Initial Containing Block</h4>
+
+					<section id="sec-fxl-icb-html">
+						<h5>Expressing in HTML</h5>
+
+						<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
+								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
+								containing block</a> [[!CSS2]] dimensions MUST be expressed in a <code>viewport</code>
+							<code>meta</code> tag using the syntax defined in [[!CSS-Device-Adapt-1]].</p>
+
+						<aside class="example">
+							<p>The following example shows a <code>viewport</code>
+								<code>meta</code> tag.</p>
+							<pre>
+&lt;head&gt;
+   …
+   &lt;meta name="viewport" content="width=1200, height=600"/&gt;
+   …
+&lt;/head&gt;</pre>
+						</aside>
+					</section>
+
+					<section id="sec-fxl-icb-svg">
+						<h5>Expressing in SVG</h5>
+
+						<p>For SVG <a>Fixed-Layout Documents</a>, the ICB dimensions MUST be expressed using the <a
+								href="http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code>
+								attribute</a> [[!SVG]].</p>
+
+						<aside class="example">
+							<p>The following example shows a <code>viewBox</code> attribute declaration for an SVG
+								Content Document with an aspect ratio of 844 pixels wide by 1200 pixels high.</p>
+							<pre>
+&lt;svg xmlns="http://www.w3.org/2000/svg"
+     version="1.1" 
+     viewBox="0 0 844 1200"&gt;
+   …
+&lt;/svg&gt;</pre>
+						</aside>
+					</section>
 				</section>
 			</section>
 		</section>
@@ -8760,6 +8490,8 @@ html.-epub-media-overlay-playing * {
 
 			<div data-include="vocab/link.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 
+			<div data-include="vocab/rendering.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+			
 			<div data-include="vocab/item-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 
 			<div data-include="vocab/itemref-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
@@ -9292,7 +9024,7 @@ EPUB/images/cover.png</pre>
 								</li>
 								<li>
 									<p>
-										<a href="#sec-package-metadata">metadata</a>
+										<a href="#sec-mo-package-metadata">metadata</a>
 									</p>
 									<ul>
 										<li>
@@ -9617,7 +9349,7 @@ EPUB/images/cover.png</pre>
 						</li>
 						<li>
 							<p>
-								<a href="#sec-package-metadata-rendering">layout properties</a>
+								<a href="#sec-rendering-general">layout properties</a>
 							</p>
 							<ul>
 								<li>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -1,0 +1,212 @@
+<section id="app-rendering-vocab">
+	<h3>Package Rendering Vocabulary</h3>
+	
+	<section id="sec-package-metadata-layout-general-intro" class="informative">
+		<h4>Introduction</h4>
+		
+		<p>Not all rendering information can be expressed through the underlying technologies that EPUB is
+			built upon. For example, although HTML with CSS provides powerful layout capabilities, those
+			capabilities are limited to the scope of the document being rendered.</p>
+		
+		<p>This section defines general-purpose properties that allow Authors to express package-level
+			rendering intentions (i.e., functionality that can only be implemented by the <a>EPUB Reading
+				System</a>). If a Reading System supports the desired rendering, these properties enable the
+			user to be presented the content as the Author optimally designed it.</p>
+	</section>
+	
+	<section id="rendition-vocab-ref">
+		<h4>Referencing</h4>
+		
+		<p>The base IRI for referencing these properties is
+			<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
+		
+		<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved for
+			use</a> with the package rendering properties and does not have to be declared in the
+			Package Document.</p>
+	</section>
+	
+	<section id="sec-rendering-general">
+		<h4>General Properties</h4>
+		
+		<section id="flow">
+			<h5>The <code>rendition:flow</code> Property</h5>
+			
+			<p>The <code>rendition:flow</code> property specifies the Author preference for how Reading
+				Systems should handle content overflow. </p>
+			
+				<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code>
+					property</a> is specified on a <code>meta</code> element, it indicates the Author's
+					global preference for overflow content handling (i.e., for all spine items). Authors MAY
+					indicate a preference for dynamic pagination or scrolling. For scrolled content, it is
+					also possible to specify whether consecutive <a>EPUB Content Documents</a> are to be
+					rendered as a continuous scrolling view or whether each is to be rendered separately
+					(i.e., with a dynamic page break between each).</p>
+				
+			<p>The following values are defined for use with the <code>rendition:flow</code>
+				property:</p>
+			
+			<dl class="variablelist">
+				<dt id="paginated">paginated</dt>
+				<dd>
+					<p>Dynamically paginate all overflow content.</p>
+				</dd>
+				<dt id="scrolled-continuous">scrolled-continuous</dt>
+				<dd>
+					<p>Render all Content Documents such that overflow content is scrollable, and the
+						EPUB Publication represented by the given <a>Rendition</a> is presented as one
+						continuous scroll from spine item to spine item (except where <a
+							href="#layout-property-flow-overrides">locally overridden</a>).</p>
+					<p>Note that Authors SHOULD NOT create publications in which different resources
+						have different block flow directions, as continuous scrolled rendition in EPUB
+						Reading Systems would be problematic.</p>
+				</dd>
+				<dt id="scrolled-doc">scrolled-doc</dt>
+				<dd>
+					<p>Render all Content Documents such that overflow content is scrollable, and each
+						spine item is presented as a separate scrollable document.</p>
+				</dd>
+				<dt id="auto">auto</dt>
+				<dd>
+					<p>Render overflow content using the Reading System default method or a user
+						preference, whichever is applicable.</p>
+				</dd>
+			</dl>
+			
+			<p id="html-body-page-break-before">Note that when two reflowable EPUB Content Documents
+					occur sequentially in the spine, the default rendering for their [[!HTML]] <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element"
+						><code>body</code></a> elements is consistent with the <a
+							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
+							><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been set to
+					<code>always</code>. In addition to using the <code>rendition:flow</code> property,
+					Authors MAY override this behavior through an appropriate style sheet declaration, if
+					the Reading System supports such overrides.</p>
+				
+				<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
+			
+			<section id="layout-property-flow-overrides">
+				<h5>Spine Overrides</h5>
+				
+				<p id="layout-property-flow-local">Authors MAY specify the following properties locally on
+					spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
+					<a href="#property-flow-global">global value</a> for the given spine item:</p>
+				
+				<dl>
+					<dt id="flow-auto">flow-auto</dt>
+					<dd>Indicates no preference for overflow content handling by the Author.</dd>
+					
+					<dt id="flow-paginated">flow-paginated</dt>
+					<dd>Indicates the Author preference is to dynamically paginate content overflow.</dd>
+					
+					<dt id="flow-scrolled-continuous">flow-scrolled-continuous</dt>
+					<dd>Indicates the Author preference is to provide a scrolled view for overflow content,
+						and that consecutive spine items with this property are to be rendered as a
+						continuous scroll.</dd>
+					
+					<dt id="flow-scrolled-doc">flow-scrolled-doc</dt>
+					<dd>Indicates the Author preference is to provide a scrolled view for overflow content,
+						and each spine item with this property is to be rendered as a separate scrollable
+						document.</dd>
+				</dl>
+				
+				<p>Only one of these overrides is allowed on any given spine item.</p>
+
+				<aside class="example" id="property-flow-ex1">
+					<p>The following example demonstrates an Author's intent to have a paginated Rendition
+						with a scrollable table of contents.</p>
+					<pre>&lt;metadata&gt;
+    &lt;meta property="rendition:flow"&gt;paginated&lt;/meta&gt;
+&lt;/metadata&gt;
+
+&lt;spine&gt;
+    &lt;itemref idref="toc" properties="rendition:flow-scrolled-doc"/&gt;
+    &lt;itemref idref="c01"/&gt;
+&lt;/spine&gt;</pre>
+				</aside>
+			</section>
+		</section>
+		
+		<section id="align-x-center">
+			<h5>The <code>rendition:align-x-center</code> Property</h5>
+			
+			<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should
+				be centered horizontally in the viewport or spread. </p>
+			
+			<div class="note">
+				<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title
+					pages), in the absence of reliable centering control within the content rendering. As
+					support for paged media evolves in CSS, however, this property is expected to be
+					deprecated. Authors are encouraged to use CSS solutions when effective.</p>
+			</div>
+		</section>
+	</section>
+	<section id="sec-rendering-fxl">
+		<h4>Fixed-Layout Properties</h4>
+		
+		<p>The following properties belong to the Package Rendering Vocabulary. Refer to their respective
+			definitions in <a href="#sec-fixed-layouts"></a> for the details of their use.</p>
+		
+		<table class="zebra">
+			<thead>
+				<tr>
+					<th>Properties</th>
+					<th>Defined in</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>
+						<ul>
+							<li><code>rendition:layout</code></li>
+							<li><code>rendition:layout-pre-paginated</code></li>
+							<li><code>rendition:layout-reflowable</code></li>
+						</ul>
+					</td>
+					<td><a href="#layout"></a></td>
+				</tr>
+				<tr>
+					<td>
+						<ul>
+							<li><code>rendition:orientation</code></li>
+							<li><code>rendition:orientation-auto</code></li>
+							<li><code>rendition:orientation-landscape</code></li>
+							<li><code>rendition:orientation-portrait</code></li>
+						</ul>
+					</td>
+					<td><a href="#orientation"></a></td>
+				</tr>
+				<tr>
+					<td>
+						<ul>
+							<li><code>rendition:spread</code></li>
+							<li><code>rendition:spread-auto</code></li>
+							<li><code>rendition:spread-both</code></li>
+							<li><code>rendition:spread-landscape</code></li>
+							<li><code>rendition:spread-none</code></li>
+							<li><code>rendition:spread-portrait</code></li>
+						</ul>
+					</td>
+					<td><a href="#spread"></a></td>
+				</tr>
+				<tr>
+					<td>
+						<ul>
+							<li><code>rendition:page-spread-center</code></li>
+							<li><code>rendition:page-spread-left</code></li>
+							<li><code>rendition:page-spread-right</code></li>
+						</ul>
+					</td>
+					<td><a href="#page-spread"></a></td>
+				</tr>
+				<tr>
+					<td>
+						<ul>
+							<li><code>rendition:viewport</code></li>
+						</ul>
+					</td>
+					<td><a href="#viewport"></a></td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
+</section>


### PR DESCRIPTION
This is just an experiment related to #1377 at this point. The FXL sections are recombined and only a placeholder section for the fxl properties remains in the vocabulary in the appendix.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1384.html" title="Last updated on Oct 28, 2020, 11:36 PM UTC (038ed2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1384/af19628...038ed2e.html" title="Last updated on Oct 28, 2020, 11:36 PM UTC (038ed2e)">Diff</a>