### PR TITLE
Alternative conformance configuration

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7332,6 +7332,8 @@ store destination as source in ocf
 				<section id="sec-overlay-req">
 					<h4>Media Overlay Document Requirements</h4>
 
+					<p>A <a>Media Overlay Document</a> has to meet the following requirements:</p>
+
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-mo-docprops-schema">It MUST be valid to the Media Overlays schema as defined

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3248,7 +3248,7 @@ Manifest:
 				</section>
 
 				<section id="sec-package-enc">
-					<h4>Package Document Encoding</h4>
+					<h4>Package Document File Properties</h4>
 
 					<p id="confreq-package-fileprops-name">The Package Document filename SHOULD use the file extension
 							<code class="filename">.opf</code>.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7300,19 +7300,6 @@ store destination as source in ocf
 		<section id="sec-media-overlays">
 			<h2>Media Overlays</h2>
 
-			<p id="confreq-mo-docprops-schema">It MUST be valid to the Media Overlays schema as defined in <a
-					href="#app-schema-overlays"></a> and conform to all content conformance constraints expressed in <a
-					href="#sec-overlays-def"></a>.</p>
-			<p id="confreq-mo-docprops-structure">It MUST be authored to reflect the structure of the <a>EPUB Content
-					Document</a> with which it is associated, as stated in <a href="#sec-media-overlays-structure"
-				></a>.</p>
-			<p id="confreq-mo-docprops-references">It MAY refer to more than one EPUB Content Document, but an EPUB
-				Content Document MUST NOT be referenced by more than one Media Overlay Document.</p>
-			<p id="confreq-mo-docprops-semantics">It SHOULD use semantic markup where appropriate, as described in <a
-					href="#sec-docs-semantic-inflection"></a>.</p>
-			<p id="confreq-mo-fileprops-name">The Media Overlay Document filename SHOULD use the file extension <code
-					class="filename">.smil</code>.</p>
-
 			<section id="sec-overlays-introduction" class="informative">
 				<h4>Introduction</h4>
 
@@ -7339,499 +7326,537 @@ store destination as source in ocf
 					the EPUB Content Document.</p>
 			</section>
 
-			<section id="sec-overlays-def">
-				<h3>Media Overlay Document Definition</h3>
+			<section id="sec-overlay-docs">
+				<h3>Media Overlay Documents</h3>
 
-				<p>All elements [[!XML]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
-					namespace [[!XML-NAMES]] unless otherwise specified.</p>
+				<section id="sec-overlay-req">
+					<h4>Media Overlay Document Requirements</h4>
 
-				<section id="sec-smil-smil-elem">
-					<h5>The <code>smil</code> Element</h5>
-
-					<p>The <code>smil</code> element is the root element of all Media Overlay Documents.</p>
-
-					<dl class="elemdef" id="elemdef-smil">
-						<dt>Element Name</dt>
-						<dd>
-							<p>
-								<code>smil</code>
-							</p>
-						</dd>
-						<dt>Usage</dt>
-						<dd>
-							<p>The <code>smil</code> element is the root element of the Media Overlay Document.</p>
-						</dd>
-						<dt>Attributes</dt>
-						<dd>
-							<dl>
-								<dt>
-									<code>version</code>
-									<code>[required]</code>
-								</dt>
-								<dd>
-									<p>Specifies the version number of the [[!SMIL3]] specification to which the Media
-										Overlay adheres.</p>
-									<p>This attribute MUST have the value "<code>3.0</code>".</p>
-								</dd>
-								<dt>
-									<code>id</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>The ID [[!XML]] of the element, which MUST be unique within the document
-										scope.</p>
-								</dd>
-								<dt id="attrdef-smil-prefix">
-									<code>epub:prefix</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>Declares additional metadata vocabulary prefixes.</p>
-									<p>Refer to <a href="#sec-docs-semantic-inflection"></a> for more information.</p>
-								</dd>
-							</dl>
-						</dd>
-						<dt>Content Model</dt>
-						<dd>
-							<p>In this order:</p>
-							<ul class="nomark">
-								<li>
-									<p>
-										<a href="#elemdef-smil-head">
-											<code>head</code>
-										</a>
-										<code>[0 or 1]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#elemdef-smil-body">
-											<code>body</code>
-										</a>
-										<code>[exactly 1]</code>
-									</p>
-								</li>
-							</ul>
-						</dd>
-					</dl>
+					<ul class="conformance-list">
+						<li>
+							<p id="confreq-mo-docprops-schema">It MUST be valid to the Media Overlays schema as defined
+								in <a href="#app-schema-overlays"></a> and conform to all content conformance
+								constraints expressed in <a href="#sec-overlays-def"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-mo-docprops-references">It MAY refer to more than one EPUB Content Document,
+								but an EPUB Content Document MUST NOT be referenced by more than one Media Overlay
+								Document.</p>
+						</li>
+						<li>
+							<p id="confreq-mo-docprops-semantics">It SHOULD use <a href="#sec-docs-semantic-inflection"
+									>semantic markup</a> where appropriate.</p>
+						</li>
+						<li>
+							<p id="confreq-mo-fileprops-name">It SHOULD use the file extension <code class="filename"
+									>.smil</code>.</p>
+						</li>
+					</ul>
 				</section>
 
-				<section id="sec-smil-head-elem">
-					<h5>The <code>head</code> Element</h5>
+				<section id="sec-overlays-def">
+					<h3>Media Overlay Document Definition</h3>
 
-					<p>The <code>head</code> element is the container for metadata in the Media Overlay Document.</p>
+					<p>All elements [[!XML]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
+						namespace [[!XML-NAMES]] unless otherwise specified.</p>
 
-					<dl class="elemdef" id="elemdef-smil-head">
-						<dt>Element Name</dt>
-						<dd>
-							<p>
-								<code>head</code>
-							</p>
-						</dd>
-						<dt>Usage</dt>
-						<dd>
-							<p>The <code>head</code> element is the OPTIONAL first child of the <a href="#elemdef-smil"
-										><code>smil</code></a> element.</p>
-						</dd>
-						<dt>Attributes</dt>
-						<dd>
-							<p>None</p>
-						</dd>
-						<dt>Content Model</dt>
-						<dd>
-							<p>
-								<a href="#elemdef-smil-metadata">
+					<section id="sec-smil-smil-elem">
+						<h5>The <code>smil</code> Element</h5>
+
+						<p>The <code>smil</code> element is the root element of all Media Overlay Documents.</p>
+
+						<dl class="elemdef" id="elemdef-smil">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>smil</code>
+								</p>
+							</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>The <code>smil</code> element is the root element of the Media Overlay Document.</p>
+							</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<dl>
+									<dt>
+										<code>version</code>
+										<code>[required]</code>
+									</dt>
+									<dd>
+										<p>Specifies the version number of the [[!SMIL3]] specification to which the
+											Media Overlay adheres.</p>
+										<p>This attribute MUST have the value "<code>3.0</code>".</p>
+									</dd>
+									<dt>
+										<code>id</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+											scope.</p>
+									</dd>
+									<dt id="attrdef-smil-prefix">
+										<code>epub:prefix</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>Declares additional metadata vocabulary prefixes.</p>
+										<p>Refer to <a href="#sec-docs-semantic-inflection"></a> for more
+											information.</p>
+									</dd>
+								</dl>
+							</dd>
+							<dt>Content Model</dt>
+							<dd>
+								<p>In this order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#elemdef-smil-head">
+												<code>head</code>
+											</a>
+											<code>[0 or 1]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#elemdef-smil-body">
+												<code>body</code>
+											</a>
+											<code>[exactly 1]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
+						</dl>
+					</section>
+
+					<section id="sec-smil-head-elem">
+						<h5>The <code>head</code> Element</h5>
+
+						<p>The <code>head</code> element is the container for metadata in the Media Overlay
+							Document.</p>
+
+						<dl class="elemdef" id="elemdef-smil-head">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>head</code>
+								</p>
+							</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>The <code>head</code> element is the OPTIONAL first child of the <a
+										href="#elemdef-smil"><code>smil</code></a> element.</p>
+							</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<p>None</p>
+							</dd>
+							<dt>Content Model</dt>
+							<dd>
+								<p>
+									<a href="#elemdef-smil-metadata">
+										<code>metadata</code>
+									</a>
+									<code>[0 or 1]</code>
+								</p>
+							</dd>
+						</dl>
+
+						<p>As this specification does not define any metadata properties that have to occur in the Media
+							Overlay Document, the <code>head</code> element is OPTIONAL.</p>
+					</section>
+
+					<section id="sec-smil-metadata-elem">
+						<h5>The <code>metadata</code> Element</h5>
+
+						<p>The <code>metadata</code> element represents metadata for the Media Overlay Document. The
+								<code>metadata</code> element is an extension point that allows the inclusion of
+							metadata from any metainformation structuring language.</p>
+
+						<dl class="elemdef" id="elemdef-smil-metadata">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
 									<code>metadata</code>
-								</a>
-								<code>[0 or 1]</code>
-							</p>
-						</dd>
-					</dl>
+								</p>
+							</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>As a child of the <a href="#elemdef-smil-head"><code>head</code></a> element.</p>
+							</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<p>None</p>
+							</dd>
+							<dt>Content Model</dt>
+							<dd>
+								<p><code>[0 or more]</code> elements from any namespace</p>
+							</dd>
+						</dl>
 
-					<p>As this specification does not define any metadata properties that have to occur in the Media
-						Overlay Document, the <code>head</code> element is OPTIONAL.</p>
-				</section>
+						<p>This specification defines no metadata properties that MUST occur in the Media Overlay
+							Document; the <code>metadata</code> element is provided for custom metadata
+							requirements.</p>
+					</section>
 
-				<section id="sec-smil-metadata-elem">
-					<h5>The <code>metadata</code> Element</h5>
+					<section id="sec-smil-body-elem">
+						<h5>The <code>body</code> Element</h5>
 
-					<p>The <code>metadata</code> element represents metadata for the Media Overlay Document. The
-							<code>metadata</code> element is an extension point that allows the inclusion of metadata
-						from any metainformation structuring language.</p>
+						<p>The <code>body</code> element is the starting point for the presentation contained in the
+							Media Overlay Document. It contains the main sequence of <code>par</code> and
+								<code>seq</code> elements.</p>
 
-					<dl class="elemdef" id="elemdef-smil-metadata">
-						<dt>Element Name</dt>
-						<dd>
-							<p>
-								<code>metadata</code>
-							</p>
-						</dd>
-						<dt>Usage</dt>
-						<dd>
-							<p>As a child of the <a href="#elemdef-smil-head"><code>head</code></a> element.</p>
-						</dd>
-						<dt>Attributes</dt>
-						<dd>
-							<p>None</p>
-						</dd>
-						<dt>Content Model</dt>
-						<dd>
-							<p><code>[0 or more]</code> elements from any namespace</p>
-						</dd>
-					</dl>
+						<dl class="elemdef" id="elemdef-smil-body">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>body</code>
+								</p>
+							</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>The <code>body</code> element is the REQUIRED second child of the <a
+										href="#elemdef-smil"><code>smil</code></a> element.</p>
+							</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<dl>
+									<dt id="addrdef-smil-body-type">
+										<code>epub:type</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>An expression of the structural semantics of the corresponding element in the
+												<a>EPUB Content Document</a>.</p>
+										<p>The value is a white space separated list of <a href="#sec-property-datatype"
+												>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"
+											></a> for more information.</p>
+									</dd>
+									<dt>
+										<code>id</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+											scope.</p>
+									</dd>
+									<dt id="attrdef-body-textref">
+										<code>epub:textref</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
+											Document, including a fragment identifier that references the specific
+											element as per the [[!XPTRSH]].</p>
+									</dd>
+								</dl>
+							</dd>
+							<dt>Content Model</dt>
+							<dd>
+								<p>In any order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#elemdef-smil-seq">
+												<code>seq</code>
+											</a>
+											<code>[0 or more]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#elemdef-smil-par">
+												<code>par</code>
+											</a>
+											<code>[0 or more]</code>
+										</p>
+									</li>
+								</ul>
+								<p>At least one <code>par</code> or <code>seq</code> is REQUIRED.</p>
+							</dd>
+						</dl>
+					</section>
 
-					<p>This specification defines no metadata properties that MUST occur in the Media Overlay Document;
-						the <code>metadata</code> element is provided for custom metadata requirements.</p>
-				</section>
+					<section id="sec-smil-seq-elem">
+						<h5>The <code>seq</code> Element</h5>
 
-				<section id="sec-smil-body-elem">
-					<h5>The <code>body</code> Element</h5>
+						<p>The <code>seq</code> element contains media objects which are to be rendered
+							sequentially.</p>
 
-					<p>The <code>body</code> element is the starting point for the presentation contained in the Media
-						Overlay Document. It contains the main sequence of <code>par</code> and <code>seq</code>
-						elements.</p>
+						<dl class="elemdef" id="elemdef-smil-seq">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>seq</code>
+								</p>
+							</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>One or more <code>seq</code> elements MAY occur as children of the <a
+										href="#elemdef-smil-body"><code>body</code> element</a> and of the <a
+										href="#elemdef-smil-seq"><code>seq</code> element</a>.</p>
+							</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<dl>
+									<dt>
+										<code>epub:type</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>An expression of the structural semantics of the corresponding element in the
+												<a>EPUB Content Document</a>.</p>
+										<p>The value is a white space separated list of <a href="#sec-property-datatype"
+												>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"
+											></a> for more information.</p>
+									</dd>
+									<dt>
+										<code>id</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+											scope.</p>
+									</dd>
+									<dt id="attrdef-seq-textref">
+										<code>epub:textref</code>
+										<code>[required]</code>
+									</dt>
+									<dd>
+										<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
+											Document, including a fragment identifier that references the specific
+											element as per the [[!XPTRSH]].</p>
+										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
+											information.</p>
+									</dd>
+								</dl>
+							</dd>
+							<dt>Content Model</dt>
+							<dd>
+								<p>In any order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#elemdef-smil-seq">
+												<code>seq</code>
+											</a>
+											<code>[0 or more]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#elemdef-smil-par">
+												<code>par</code>
+											</a>
+											<code>[0 or more]</code>
+										</p>
+									</li>
+								</ul>
+								<p>At least one <code>par</code> or <code>seq</code> is REQUIRED.</p>
+							</dd>
+						</dl>
+					</section>
 
-					<dl class="elemdef" id="elemdef-smil-body">
-						<dt>Element Name</dt>
-						<dd>
-							<p>
-								<code>body</code>
-							</p>
-						</dd>
-						<dt>Usage</dt>
-						<dd>
-							<p>The <code>body</code> element is the REQUIRED second child of the <a href="#elemdef-smil"
-										><code>smil</code></a> element.</p>
-						</dd>
-						<dt>Attributes</dt>
-						<dd>
-							<dl>
-								<dt id="addrdef-smil-body-type">
-									<code>epub:type</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>An expression of the structural semantics of the corresponding element in the
-											<a>EPUB Content Document</a>.</p>
-									<p>The value is a white space separated list of <a href="#sec-property-datatype"
-											>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"></a>
-										for more information.</p>
-								</dd>
-								<dt>
-									<code>id</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>The ID [[!XML]] of the element, which MUST be unique within the document
-										scope.</p>
-								</dd>
-								<dt id="attrdef-body-textref">
-									<code>epub:textref</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
-										Document, including a fragment identifier that references the specific element
-										as per the [[!XPTRSH]].</p>
-								</dd>
-							</dl>
-						</dd>
-						<dt>Content Model</dt>
-						<dd>
-							<p>In any order:</p>
-							<ul class="nomark">
-								<li>
-									<p>
-										<a href="#elemdef-smil-seq">
-											<code>seq</code>
-										</a>
-										<code>[0 or more]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#elemdef-smil-par">
-											<code>par</code>
-										</a>
-										<code>[0 or more]</code>
-									</p>
-								</li>
-							</ul>
-							<p>At least one <code>par</code> or <code>seq</code> is REQUIRED.</p>
-						</dd>
-					</dl>
-				</section>
+					<section id="sec-smil-par-elem">
+						<h5>The <code>par</code> Element</h5>
 
-				<section id="sec-smil-seq-elem">
-					<h5>The <code>seq</code> Element</h5>
+						<p>The <code>par</code> element contains media objects which are to be rendered in parallel.</p>
 
-					<p>The <code>seq</code> element contains media objects which are to be rendered sequentially.</p>
+						<dl class="elemdef" id="elemdef-smil-par">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>par</code>
+								</p>
+							</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>One or more <code>par</code> elements MAY occur as children of the <a
+										href="#elemdef-smil-body"><code>body</code></a> and <a href="#elemdef-smil-seq"
+											><code>seq</code></a> elements.</p>
+							</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<dl>
+									<dt>
+										<code>epub:type</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>An expression of the structural semantics of the corresponding element in the
+												<a>EPUB Content Document</a>.</p>
+										<p>The value is a white space separated list of <a href="#sec-property-datatype"
+												>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"
+											></a> for more information.</p>
+									</dd>
+									<dt>
+										<code>id</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+											scope.</p>
+									</dd>
+								</dl>
+							</dd>
+							<dt>Content Model</dt>
+							<dd>
+								<p>In any order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#elemdef-smil-text">
+												<code>text</code>
+											</a>
+											<code>[exactly 1]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#elemdef-smil-audio">
+												<code>audio</code>
+											</a>
+											<code>[0 or 1]</code>
+										</p>
+									</li>
+								</ul>
+								<p>The <a href="#elemdef-smil-audio"><code>audio</code> element</a> is OPTIONAL only if
+									its sibling <a href="#elemdef-smil-text"><code>text</code> element</a> refers to
+									audio or video media (see <a href="#sec-audio-video"></a>), or to textual content
+									intended for rendering via <a>Text-to-Speech</a> (TTS).</p>
+							</dd>
+						</dl>
+					</section>
 
-					<dl class="elemdef" id="elemdef-smil-seq">
-						<dt>Element Name</dt>
-						<dd>
-							<p>
-								<code>seq</code>
-							</p>
-						</dd>
-						<dt>Usage</dt>
-						<dd>
-							<p>One or more <code>seq</code> elements MAY occur as children of the <a
-									href="#elemdef-smil-body"><code>body</code> element</a> and of the <a
-									href="#elemdef-smil-seq"><code>seq</code> element</a>.</p>
-						</dd>
-						<dt>Attributes</dt>
-						<dd>
-							<dl>
-								<dt>
-									<code>epub:type</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>An expression of the structural semantics of the corresponding element in the
-											<a>EPUB Content Document</a>.</p>
-									<p>The value is a white space separated list of <a href="#sec-property-datatype"
-											>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"></a>
-										for more information.</p>
-								</dd>
-								<dt>
-									<code>id</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>The ID [[!XML]] of the element, which MUST be unique within the document
-										scope.</p>
-								</dd>
-								<dt id="attrdef-seq-textref">
-									<code>epub:textref</code>
-									<code>[required]</code>
-								</dt>
-								<dd>
-									<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
-										Document, including a fragment identifier that references the specific element
-										as per the [[!XPTRSH]].</p>
-									<p>Refer to <a href="#sec-media-overlays-structure"></a> for more information.</p>
-								</dd>
-							</dl>
-						</dd>
-						<dt>Content Model</dt>
-						<dd>
-							<p>In any order:</p>
-							<ul class="nomark">
-								<li>
-									<p>
-										<a href="#elemdef-smil-seq">
-											<code>seq</code>
-										</a>
-										<code>[0 or more]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#elemdef-smil-par">
-											<code>par</code>
-										</a>
-										<code>[0 or more]</code>
-									</p>
-								</li>
-							</ul>
-							<p>At least one <code>par</code> or <code>seq</code> is REQUIRED.</p>
-						</dd>
-					</dl>
-				</section>
+					<section id="sec-smil-text-elem">
+						<h5>The <code>text</code> Element</h5>
 
-				<section id="sec-smil-par-elem">
-					<h5>The <code>par</code> Element</h5>
+						<p>The <code>text</code> element references an element in the <a>EPUB Content Document</a>. A
+								<code>text</code> element typically refers to a textual element, but can also refer to
+							other EPUB Content Document media elements (see <a href="#sec-audio-video"></a>).</p>
 
-					<p>The <code>par</code> element contains media objects which are to be rendered in parallel.</p>
+						<dl class="elemdef" id="elemdef-smil-text">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>text</code>
+								</p>
+							</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>As a REQUIRED child of the <a href="#elemdef-smil-par"><code>par</code></a>
+									element.</p>
+							</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<dl>
+									<dt>
+										<code>src</code>
+										<code>[required]</code>
+									</dt>
+									<dd>
+										<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
+											Document, including a fragment identifier that references the specific
+											element as per the [[!XPTRSH]].</p>
+									</dd>
+									<dt>
+										<code>id</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+											scope.</p>
+									</dd>
+								</dl>
+							</dd>
+							<dt>Content Model</dt>
+							<dd>
+								<p>Empty</p>
+							</dd>
+						</dl>
+					</section>
 
-					<dl class="elemdef" id="elemdef-smil-par">
-						<dt>Element Name</dt>
-						<dd>
-							<p>
-								<code>par</code>
-							</p>
-						</dd>
-						<dt>Usage</dt>
-						<dd>
-							<p>One or more <code>par</code> elements MAY occur as children of the <a
-									href="#elemdef-smil-body"><code>body</code></a> and <a href="#elemdef-smil-seq"
-										><code>seq</code></a> elements.</p>
-						</dd>
-						<dt>Attributes</dt>
-						<dd>
-							<dl>
-								<dt>
-									<code>epub:type</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>An expression of the structural semantics of the corresponding element in the
-											<a>EPUB Content Document</a>.</p>
-									<p>The value is a white space separated list of <a href="#sec-property-datatype"
-											>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"></a>
-										for more information.</p>
-								</dd>
-								<dt>
-									<code>id</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>The ID [[!XML]] of the element, which MUST be unique within the document
-										scope.</p>
-								</dd>
-							</dl>
-						</dd>
-						<dt>Content Model</dt>
-						<dd>
-							<p>In any order:</p>
-							<ul class="nomark">
-								<li>
-									<p>
-										<a href="#elemdef-smil-text">
-											<code>text</code>
-										</a>
-										<code>[exactly 1]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#elemdef-smil-audio">
-											<code>audio</code>
-										</a>
-										<code>[0 or 1]</code>
-									</p>
-								</li>
-							</ul>
-							<p>The <a href="#elemdef-smil-audio"><code>audio</code> element</a> is OPTIONAL only if its
-								sibling <a href="#elemdef-smil-text"><code>text</code> element</a> refers to audio or
-								video media (see <a href="#sec-audio-video"></a>), or to textual content intended for
-								rendering via <a>Text-to-Speech</a> (TTS).</p>
-						</dd>
-					</dl>
-				</section>
+					<section id="sec-smil-audio-elem">
+						<h5>The <code>audio</code> Element</h5>
 
-				<section id="sec-smil-text-elem">
-					<h5>The <code>text</code> Element</h5>
+						<p>The <code>audio</code> element represents a clip of audio media.</p>
 
-					<p>The <code>text</code> element references an element in the <a>EPUB Content Document</a>. A
-							<code>text</code> element typically refers to a textual element, but can also refer to other
-						EPUB Content Document media elements (see <a href="#sec-audio-video"></a>).</p>
-
-					<dl class="elemdef" id="elemdef-smil-text">
-						<dt>Element Name</dt>
-						<dd>
-							<p>
-								<code>text</code>
-							</p>
-						</dd>
-						<dt>Usage</dt>
-						<dd>
-							<p>As a REQUIRED child of the <a href="#elemdef-smil-par"><code>par</code></a> element.</p>
-						</dd>
-						<dt>Attributes</dt>
-						<dd>
-							<dl>
-								<dt>
-									<code>src</code>
-									<code>[required]</code>
-								</dt>
-								<dd>
-									<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
-										Document, including a fragment identifier that references the specific element
-										as per the [[!XPTRSH]].</p>
-								</dd>
-								<dt>
-									<code>id</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>The ID [[!XML]] of the element, which MUST be unique within the document
-										scope.</p>
-								</dd>
-							</dl>
-						</dd>
-						<dt>Content Model</dt>
-						<dd>
-							<p>Empty</p>
-						</dd>
-					</dl>
-				</section>
-
-				<section id="sec-smil-audio-elem">
-					<h5>The <code>audio</code> Element</h5>
-
-					<p>The <code>audio</code> element represents a clip of audio media.</p>
-
-					<dl class="elemdef" id="elemdef-smil-audio">
-						<dt>Element Name</dt>
-						<dd>
-							<p>
-								<code>audio</code>
-							</p>
-						</dd>
-						<dt>Usage</dt>
-						<dd>
-							<p>A REQUIRED child of the <a href="#elemdef-smil-par"><code>par</code> element</a> unless
-								its sibling <a href="#elemdef-smil-text"><code>text</code> element</a> refers to audio
-								or video media, or to textual content intended for rendering via <a>Text-to-Speech</a>
-								(TTS), in which case it is OPTIONAL (see <a href="#sec-audio-video"></a>).</p>
-						</dd>
-						<dt>Attributes</dt>
-						<dd>
-							<dl>
-								<dt>
-									<code>id</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>The ID [[!XML]] of the element, which MUST be unique within the document
-										scope.</p>
-								</dd>
-								<dt>
-									<code>src</code>
-									<code>[required]</code>
-								</dt>
-								<dd>
-									<p>The relative or absolute IRI reference [[!RFC3987]] of an audio file. The audio
-										file MUST be one of the audio formats listed in the <a
-											href="#sec-core-media-types">Core Media Type Resources</a> table.</p>
-								</dd>
-								<dt id="attrdef-smil-clipBegin">
-									<code>clipBegin</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>A clock value that specifies the offset into the physical media corresponding to
-										the start point of an audio clip.</p>
-									<p>MUST be a [[!SMIL3]] <a href="https://www.w3.org/TR/SMIL/smil-timing.html#q22"
-											>clock value</a>.</p>
-									<p>See <a href="#app-clock-examples"></a>.</p>
-								</dd>
-								<dt id="attrdef-smil-clipEnd">
-									<code>clipEnd</code>
-									<code>[optional]</code>
-								</dt>
-								<dd>
-									<p>A clock value that specifies the offset into the physical media corresponding to
-										the end point of an audio clip.</p>
-									<p>MUST be a [[!SMIL3]] <a href="https://www.w3.org/TR/SMIL/smil-timing.html#q22"
-											>clock value</a>.</p>
-									<p>See <a href="#app-clock-examples"></a>.</p>
-									<p>The chronological offset of the terminating position MUST be after the starting
-										offset specified in the <code>clipBegin</code> attribute.</p>
-								</dd>
-							</dl>
-						</dd>
-						<dt>Content Model</dt>
-						<dd>
-							<p>Empty</p>
-						</dd>
-					</dl>
+						<dl class="elemdef" id="elemdef-smil-audio">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>audio</code>
+								</p>
+							</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>A REQUIRED child of the <a href="#elemdef-smil-par"><code>par</code> element</a>
+									unless its sibling <a href="#elemdef-smil-text"><code>text</code> element</a> refers
+									to audio or video media, or to textual content intended for rendering via
+										<a>Text-to-Speech</a> (TTS), in which case it is OPTIONAL (see <a
+										href="#sec-audio-video"></a>).</p>
+							</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<dl>
+									<dt>
+										<code>id</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+											scope.</p>
+									</dd>
+									<dt>
+										<code>src</code>
+										<code>[required]</code>
+									</dt>
+									<dd>
+										<p>The relative or absolute IRI reference [[!RFC3987]] of an audio file. The
+											audio file MUST be one of the audio formats listed in the <a
+												href="#sec-core-media-types">Core Media Type Resources</a> table.</p>
+									</dd>
+									<dt id="attrdef-smil-clipBegin">
+										<code>clipBegin</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>A clock value that specifies the offset into the physical media corresponding
+											to the start point of an audio clip.</p>
+										<p>MUST be a [[!SMIL3]] <a
+												href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">clock
+											value</a>.</p>
+										<p>See <a href="#app-clock-examples"></a>.</p>
+									</dd>
+									<dt id="attrdef-smil-clipEnd">
+										<code>clipEnd</code>
+										<code>[optional]</code>
+									</dt>
+									<dd>
+										<p>A clock value that specifies the offset into the physical media corresponding
+											to the end point of an audio clip.</p>
+										<p>MUST be a [[!SMIL3]] <a
+												href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">clock
+											value</a>.</p>
+										<p>See <a href="#app-clock-examples"></a>.</p>
+										<p>The chronological offset of the terminating position MUST be after the
+											starting offset specified in the <code>clipBegin</code> attribute.</p>
+									</dd>
+								</dl>
+							</dd>
+							<dt>Content Model</dt>
+							<dd>
+								<p>Empty</p>
+							</dd>
+						</dl>
+					</section>
 				</section>
 			</section>
 
-			<section id="sec-overlay-docs">
+			<section id="sec-overlay-doc-create">
 				<h3>Creating Media Overlays</h3>
 
 				<section id="sec-docs-intro" class="informative">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -54,6 +54,26 @@
 				postProcess:[addConformanceLinks]
 			};//]]>
       </script>
+		<style>
+			dd > ul.conformance-list,
+			li > ul.conformance-list {
+				margin-left: 2rem;
+			}
+			
+			dl.conformance-list > dt {
+				font-size: 105%;
+				color: rgb(0, 90, 156);
+			}
+			
+			dl.conformance-list > dd > dl.conformance-list > dt {
+				font-size: 100%;
+				color: rgb(0, 0, 0);
+			}
+			
+			dl.conformance-list > dd > dl.conformance-list > dd > dl.conformance-list > dt {
+				font-style: italic !important;
+				font-size: 95%;
+			}</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -616,7 +636,271 @@
 				<dt id="sec-epub-package-conformance">Packages</dt>
 				<dd>
 					<p id="confreq-renditions">It MUST include one or more <a>EPUB Packages</a>, each of which MUST
-						conform to the requirements defined in <a href="#sec-packages"></a>.</p>
+						conform to the following requirements:</p>
+
+					<dl class="conformance-list" id="sec-package-conformance">
+
+						<dt id="sec-package-conformance-packagedoc">Package Document</dt>
+						<dd>
+							<p id="confreq-package">It MUST contain exactly one <a>Package Document</a>, which MUST
+								conform to the following requirements:</p>
+
+							<dl class="conformance-list" id="sec-package-content-conf">
+								<dt id="confreq-package-docprops">Document Properties</dt>
+								<dd>
+									<p id="confreq-package-xml"> It MUST meet the conformance constraints for XML
+										documents defined in <a href="#sec-xml-constraints"></a>. </p>
+									<p id="confreq-package-docprops-schema">It MUST conform to all content conformance
+										constraints expressed in <a href="#sec-package-def"></a>.</p>
+									<p class="note">Some of the content conformance constraints can be checked by
+										validating content documents against the schemas provided in <a
+											href="#app-package-schema"></a>.</p>
+								</dd>
+								<dt id="confreq-package-fileprops">File Properties</dt>
+								<dd>
+									<p id="confreq-package-fileprops-name">The Package Document filename SHOULD use the
+										file extension <code class="filename">.opf</code>.</p>
+								</dd>
+							</dl>
+
+							<p id="media-type">Package Documents have the MIME media type
+									<code>application/oebps-package+xml</code> [[!RFC4839]].</p>
+						</dd>
+						<dt id="sec-epub-rendition-content-conformance-all">Publication Resources</dt>
+						<dd>
+							<p id="confreq-rendition-manifest">All <a>Publication Resources</a> associated with the
+								Package MUST be listed in the Package Document (as defined in <a
+									href="#sec-manifest-elem"></a>).</p>
+						</dd>
+						<dt id="sec-package-conformance-nav">EPUB Navigation Document</dt>
+						<dd>
+							<p id="confreq-nav-occur">It MUST contain exactly one <a>EPUB Navigation Document</a>, which
+								MUST conform to the following requirements:</p>
+
+							<ul class="conformance-list" id="sec-package-nav-content-conf">
+								<li>
+									<p id="confreq-cd-nav-docprops-parent">It MUST conform to the content conformance
+										constraints defined in <a href="#sec-xhtml-conf-content">XHTML Content
+											Documents</a>.</p>
+								</li>
+								<li>
+									<p id="confreq-cd-nav-docprops-schema">It MUST conform to the content conformance
+										constraints specific to EPUB Navigation Documents defined in <a
+											href="#sec-package-nav-def"></a>.</p>
+								</li>
+								<li>
+									<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, it MAY
+										be included in the <a href="#sec-spine-elem">spine</a>.</p>
+								</li>
+							</ul>
+						</dd>
+						<dt id="sec-package-conformance-contentdocs">Content Documents</dt>
+						<dd>
+							<p id="confreq-cd">It MUST contain one or more <a>EPUB Content Documents</a>, each of which
+								MUST conform to the corresponding sets of requirements:</p>
+
+							<dl class="conformance-list">
+								<dt id="sec-xhtml-conf-content">XHTML Content Documents</dt>
+								<dd>
+									<p>An <a>XHTML Content Document</a> has to meet the following criteria:</p>
+
+									<dl class="conformance-list">
+										<dt id="confreq-cd-html-docprops">Document Properties</dt>
+										<dd>
+											<p id="confreq-cd-html-docprops-syntax">It MUST be an [[!HTML]] document
+												that conforms to the <a
+													href="https://www.w3.org/TR/html/xhtml.html#xhtml">XHTML</a>
+												syntax.</p>
+											<p id="confreq-cd-html-xml">It MUST meet the conformance constraints for XML
+												documents defined in <a href="#sec-xml-constraints"></a>.</p>
+											<p id="confreq-cd-html-docprops-html">For all document constructs used that
+												are defined by [[!HTML]], it MUST conform to the conformance criteria
+												defined for those constructs in that specification, unless explicitly
+												overridden in <a href="#sec-xhtml-deviations"></a>.</p>
+											<p id="confreq-cd-html-docprops-schema">It MAY include extensions to the
+												[[!HTML]] grammar as defined in <a href="#sec-xhtml-extensions"></a>,
+												and MUST conform to all content conformance constraints defined
+												therein.</p>
+											<div class="note">
+												<p>The recommendation that EPUB Publications follow the accessibility
+													requirements in [[EPUBAccessibility-10]] applies to XHTML Content
+													Documents. See <a href="#sec-epub-a11y">Accessibility</a>.</p>
+											</div>
+										</dd>
+										<dt id="confreq-cd-html-fileprops">File Properties</dt>
+										<dd>
+											<p id="confreq-cd-xhtml-fileprops-name">The XHTML Content Document filename
+												SHOULD use the file extension <code>.xhtml</code></p>
+										</dd>
+									</dl>
+								</dd>
+
+								<dt id="sec-svg-content-conf">SVG Content Documents</dt>
+								<dd>
+									<p>An <a>SVG Content Document</a> has to meet the following criteria:</p>
+
+									<dl class="conformance-list">
+										<dt id="confreq-svg-docprops">Document Properties</dt>
+										<dd>
+											<p id="confreq-cd-svg-xml">It MUST meet the conformance constraints for XML
+												documents defined in <a href="#sec-xml-constraints"></a>.</p>
+											<p id="confreq-resources-svg-fallback">It MAY include references to
+													<a>Foreign Resources</a> provided a fallback to a <a>Core Media Type
+													Resource</a> is included.</p>
+											<p id="confreq-cd-svg-docprops-schema">It MUST be an <a
+													href="https://www.w3.org/TR/SVG/intro.html#TermSVGDocumentFragment"
+													>SVG document fragment</a> [[!SVG]], and conform to all content
+												conformance constraints expressed in <a href="#sec-svg-restrictions"
+												></a>.</p>
+											<div class="note">
+												<p>The recommendation that EPUB Publications follow the accessibility
+													requirements in [[EPUBAccessibility-10]] applies to SVG Content
+													Documents. See <a href="#sec-epub-a11y">Accessibility</a>.</p>
+											</div>
+										</dd>
+
+										<dt id="confreq-svg-fileprops">File Properties</dt>
+										<dd>
+											<p id="confreq-svg-fileprops-name">The SVG Content Document filename SHOULD
+												use the file extension <code>.svg</code>.</p>
+										</dd>
+									</dl>
+								</dd>
+							</dl>
+						</dd>
+						<dt id="sec-package-conformance-css">CSS Style Sheets</dt>
+						<dd>
+							<p id="confreq-css">It MAY contain zero or more CSS Style Sheets, each of which MUST conform
+								to the following requirements:</p>
+
+							<ul class="conformance-list">
+								<li>
+									<p id="confreq-css-props">It MAY include any CSS properties, with the following
+										exceptions:</p>
+									<ul class="conformance-list">
+										<li>
+											<p id="confreq-css-props-exc-direction">It MUST NOT use the <a
+													href="https://www.w3.org/TR/css3-writing-modes/#direction"
+														><code>direction</code> property</a> [[!CSS-Writing-Modes-3]].
+												Use the [[!HTML]] <a
+													href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
+														><code>dir</code> attribute</a> to set the inline base
+												direction.</p>
+										</li>
+										<li>
+											<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT use the <a
+													href="https://www.w3.org/TR/css3-writing-modes/#unicode-bidi"
+														><code>unicode-bidi</code> property</a>
+												[[!CSS-Writing-Modes-3]]. Use [[!HTML]] <a
+													href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdo-element"
+														><code>bdo</code> elements</a> and <a
+													href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
+														><code>dir</code> attributes</a> to control
+												bidirectionality.</p>
+										</li>
+									</ul>
+								</li>
+								<li>
+									<p id="confreq-css-prefixed">It MAY include the prefixed properties defined in <a
+											href="#sec-css-prefixed"></a>.</p>
+								</li>
+								<li>
+									<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p>
+								</li>
+							</ul>
+						</dd>
+						<dt id="sec-package-conformance-pls">Pronunciation Lexicons</dt>
+						<dd>
+							<p id="confreq-pls">It MAY contain zero or more PLS Documents, each of which MUST conform to
+								the following requirements:</p>
+
+							<dl class="conformance-list">
+								<dt id="confreq-cd-pls-docprops">Document Properties</dt>
+								<dd>
+									<ul class="conformance-list">
+										<li>
+											<p id="confreq-cd-pls-xml">It MUST meet the conformance constraints for XML
+												documents defined in <a href="#sec-xml-constraints"></a>.</p>
+										</li>
+										<li>
+											<p id="confreq-cd-pls-docprops-schema">It MUST be valid to the RELAX NG
+												schema for PLS documents available at the URI <a class="uri"
+													href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
+														><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/</code></a>
+												[[!PRONUNCIATION-LEXICON]].</p>
+										</li>
+										<li>
+											<p class="confreq-cd-pls-xhtml">It MUST be linked to the applicable XHTML
+												Content Documents as defined in <a href="#sec-pls"></a>.</p>
+										</li>
+									</ul>
+								</dd>
+								<dt id="confreq-cd-pls-fileprops">File Properties</dt>
+								<dd>
+									<p id="confreq-cd-pls-fileprops-name">It SHOULD use the file extension <code
+											class="filename">.pls</code>.</p>
+								</dd>
+							</dl>
+						</dd>
+						<dt id="sec-package-conformance-media-overlays">Media Overlay Documents</dt>
+						<dd>
+							<p id="confreq-mo">It MAY contain zero or more <a>Media Overlay Documents</a>, each of which
+								has to conform to the following requirements:</p>
+
+							<dl class="conformance-list" id="sec-overlays-content-conf">
+								<dt id="confreq-mo-docprops">Document Properties</dt>
+								<dd>
+									<ul class="conformance-list">
+										<li>
+											<p id="confreq-mo-xml"> It MUST meet the conformance constraints for XML
+												documents defined in <a href="#sec-xml-constraints"></a>.</p>
+										</li>
+										<li>
+											<p id="confreq-mo-docprops-schema">It MUST be valid to the Media Overlays
+												schema as defined in <a href="#app-schema-overlays"></a> and conform to
+												all content conformance constraints expressed in <a
+													href="#sec-overlays-def"></a>.</p>
+										</li>
+										<li>
+											<p id="confreq-mo-docprops-structure">It MUST be authored to reflect the
+												structure of the <a>EPUB Content Document</a> with which it is
+												associated, as stated in <a href="#sec-media-overlays-structure"
+												></a>.</p>
+										</li>
+										<li>
+											<p id="confreq-mo-docprops-references">It MAY refer to more than one EPUB
+												Content Document, but an EPUB Content Document MUST NOT be referenced by
+												more than one Media Overlay Document.</p>
+										</li>
+										<li>
+											<p id="confreq-mo-docprops-embed">It MUST adhere to the requirements for <a
+													href="#sec-audio-video">Embedded Media</a>.</p>
+										</li>
+										<li>
+											<p id="confreq-mo-docprops-semantics">It SHOULD use semantic markup where
+												appropriate, as described in <a href="#sec-docs-semantic-inflection"
+												></a>.</p>
+										</li>
+										<li>
+											<p id="confreq-mo-docprops-package">It MUST be packaged with the <a>EPUB
+													Publication</a> as shown in <a href="#sec-docs-package"></a>.</p>
+										</li>
+									</ul>
+								</dd>
+								<dt id="confreq-mo-fileprops">File Properties</dt>
+								<dd>
+									<p id="confreq-mo-fileprops-name">The Media Overlay Document filename SHOULD use the
+										file extension <code class="filename">.smil</code>.</p>
+								</dd>
+							</dl>
+						</dd>
+						<dt id="sec-package-conformance-additional">Additional Resources</dt>
+						<dd>
+							<p id="confreq-additional">It MAY contain zero or more <a>Publication Resources</a> in
+								addition to those listed above, each of which MUST adhere to the requirements in <a
+									href="#sec-epub-pub-conformance-all">Publication Resources</a>.</p>
+						</dd>
+					</dl>
 				</dd>
 				<dt id="sec-epub-a11y">Accessibility</dt>
 				<dd>
@@ -631,12 +915,21 @@
 				</dd>
 				<dt id="sec-epub-pub-conformance-container">Container</dt>
 				<dd>
-					<p id="confreq-ocf">It MUST be packaged in a <a>EPUB Container</a> as defined in <a href="#sec-ocf"
-						></a>.</p>
+					<p id="confreq-ocf">It MUST be packaged in a <a>EPUB Container</a> that meets the following
+						requirements:</p>
+
+					<ul class="conformance-list" id="sec-ocf-conformance">
+						<li>
+							<p id="confreq-ocf-content-abstr">It MUST meet the conformance constraints for the OCF
+								Abstract Container defined in <a href="#sec-container-abstract"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-ocf-content-zip">It MUST meet the conformance constraints for the OCF ZIP
+								Container defined in <a href="#sec-container-zip"></a>.</p>
+						</li>
+					</ul>
 				</dd>
 			</dl>
-
-
 		</section>
 		<section id="sec-publication-resources">
 			<h2>Publication Resources</h2>
@@ -1034,58 +1327,6 @@
 		<section id="sec-packages">
 			<h2>EPUB Packages</h2>
 
-			<section id="sec-package-conformance">
-				<h3>Conformance Criteria</h3>
-
-				<p>A conformant <a>EPUB Package</a> has to meet the following criteria:</p>
-
-				<dl class="conformance-list">
-					<dt id="sec-package-conformance-packagedoc">Package Document</dt>
-					<dd>
-						<p id="confreq-package">It MUST contain exactly one <a>Package Document</a>, which MUST conform
-							to the content requirements defined in <a href="#sec-package-content-conf"></a>.</p>
-					</dd>
-					<dt id="sec-epub-rendition-content-conformance-all">Publication Resources</dt>
-					<dd>
-						<p id="confreq-rendition-manifest">All <a>Publication Resources</a> associated with the Package
-							MUST be listed in the Package Document (as defined in <a href="#sec-manifest-elem"
-							></a>).</p>
-					</dd>
-					<dt id="sec-package-conformance-nav">EPUB Navigation Document</dt>
-					<dd>
-						<p id="confreq-nav-occur">It MUST contain exactly one <a>EPUB Navigation Document</a>, which
-							MUST conform to the content requirements defined in <a href="#sec-package-nav-content-conf"
-							></a>.</p>
-					</dd>
-					<dt id="sec-package-conformance-contentdocs">Content Documents</dt>
-					<dd>
-						<p id="confreq-cd">It MUST contain one or more <a>EPUB Content Documents</a>, each of which MUST
-							conform to the content requirements defined in <a href="#sec-contentdocs"></a>.</p>
-					</dd>
-					<dt id="sec-package-conformance-css">CSS Style Sheets</dt>
-					<dd>
-						<p id="confreq-css">It MAY contain zero or more CSS Style Sheets, each of which MUST conform to
-							the content requirements defined in <a href="#sec-css-content-conf"></a>.</p>
-					</dd>
-					<dt id="sec-package-conformance-pls">Pronunciation Lexicons</dt>
-					<dd>
-						<p id="confreq-pls">It MAY contain zero or more PLS Documents, each of which MUST conform to the
-							content requirements defined in <a href="#sec-pls-conf-content"></a>.</p>
-					</dd>
-					<dt id="sec-package-conformance-media-overlays">Media Overlay Documents</dt>
-					<dd>
-						<p id="confreq-mo">It MAY contain zero or more <a>Media Overlay Documents</a>, each of which
-							MUST conform to the content requirements defined in <a href="#sec-media-overlays"></a>.</p>
-					</dd>
-					<dt id="sec-package-conformance-additional">Additional Resources</dt>
-					<dd>
-						<p id="confreq-additional">It MAY contain zero or more <a>Publication Resources</a> in addition
-							to those listed above, each of which MUST adhere to the requirements in <a
-								href="#sec-epub-pub-conformance-all">Publication Resources</a>.</p>
-					</dd>
-				</dl>
-			</section>
-
 			<section id="sec-package-doc">
 				<h3>Package Document</h3>
 
@@ -1126,33 +1367,6 @@
 						</li>
 					</ul>
 
-				</section>
-
-				<section id="sec-package-content-conf">
-					<h4>Content Conformance</h4>
-
-					<p>A <a>Package Document</a> has to meet the following criteria:</p>
-
-					<dl class="conformance-list">
-						<dt id="confreq-package-docprops">Document Properties</dt>
-						<dd>
-							<p id="confreq-package-xml"> It MUST meet the conformance constraints for XML documents
-								defined in <a href="#sec-xml-constraints"></a>. </p>
-							<p id="confreq-package-docprops-schema">It MUST conform to all content conformance
-								constraints expressed in <a href="#sec-package-def"></a>.</p>
-							<p class="note">Some of the content conformance constraints can be checked by validating
-								content documents against the schemas provided in <a href="#app-package-schema"
-								></a>.</p>
-						</dd>
-						<dt id="confreq-package-fileprops">File Properties</dt>
-						<dd>
-							<p id="confreq-package-fileprops-name">The Package Document filename SHOULD use the file
-								extension <code class="filename">.opf</code>.</p>
-						</dd>
-					</dl>
-
-					<p id="media-type">Package Documents have the MIME media type
-							<code>application/oebps-package+xml</code> [[!RFC4839]].</p>
 				</section>
 
 				<section id="sec-package-def">
@@ -4391,26 +4605,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 				</section>
 
-				<section id="sec-package-nav-content-conf">
-					<h4>Content Conformance</h4>
-
-					<p>A conformant <a>EPUB Navigation Document</a> has to meet the following criteria:</p>
-
-					<dl class="conformance-list">
-						<dt id="confreq-cd-nav-docprops">Document Properties</dt>
-						<dd>
-							<p id="confreq-cd-nav-docprops-parent">It MUST conform to the content conformance
-								constraints for <a>XHTML Content Documents</a> defined in <a
-									href="#sec-xhtml-conf-content"></a>.</p>
-							<p id="confreq-cd-nav-docprops-schema">It MUST conform to the content conformance
-								constraints specific to EPUB Navigation Documents defined in <a
-									href="#sec-package-nav-def"></a>.</p>
-							<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, it MAY be
-								included in the <a href="#sec-spine-elem">spine</a>.</p>
-						</dd>
-					</dl>
-				</section>
-
 				<section id="sec-package-nav-def">
 					<h4>EPUB Navigation Document Definition</h4>
 
@@ -4868,39 +5062,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						and processing behaviors from the [[!HTML]] specification.</p>
 				</section>
 
-				<section id="sec-xhtml-conf-content">
-					<h4>Content Conformance</h4>
-
-					<p>An <a>XHTML Content Document</a> has to meet the following criteria:</p>
-
-					<dl class="conformance-list">
-						<dt id="confreq-cd-html-docprops">Document Properties</dt>
-						<dd>
-							<p id="confreq-cd-html-docprops-syntax">It MUST be an [[!HTML]] document that conforms to
-								the <a href="https://www.w3.org/TR/html/xhtml.html#xhtml">XHTML</a> syntax.</p>
-							<p id="confreq-cd-html-xml">It MUST meet the conformance constraints for XML documents
-								defined in <a href="#sec-xml-constraints"></a>.</p>
-							<p id="confreq-cd-html-docprops-html">For all document constructs used that are defined by
-								[[!HTML]], it MUST conform to the conformance criteria defined for those constructs in
-								that specification, unless explicitly overridden in <a href="#sec-xhtml-deviations"
-								></a>.</p>
-							<p id="confreq-cd-html-docprops-schema">It MAY include extensions to the [[!HTML]] grammar
-								as defined in <a href="#sec-xhtml-extensions"></a>, and MUST conform to all content
-								conformance constraints defined therein.</p>
-							<div class="note">
-								<p>The recommendation that EPUB Publications follow the accessibility requirements in
-									[[EPUBAccessibility-10]] applies to XHTML Content Documents. See <a
-										href="#sec-epub-a11y">Accessibility</a>.</p>
-							</div>
-						</dd>
-						<dt id="confreq-cd-html-fileprops">File Properties</dt>
-						<dd>
-							<p id="confreq-cd-xhtml-fileprops-name">The XHTML Content Document filename SHOULD use the
-								file extension <code>.xhtml</code></p>
-						</dd>
-					</dl>
-				</section>
-
 				<section id="sec-xhtml-extensions">
 					<h4>HTML Extensions</h4>
 
@@ -5326,59 +5487,46 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					<section id="sec-xhtml-mathml">
 						<h5>Embedded MathML</h5>
 
-						<section id="sec-xhtml-mathml-intro" class="informative">
-							<h6>Introduction</h6>
+						<p>XHTML Content Documents support embedded [[MATHML3]]. Occurrences of MathML markup MUST
+							conform to the constraints expressed in the MathML specification [[!MATHML3]], with the
+							following additional restrictions:</p>
 
-							<p>XHTML Content Documents support embedded [[MATHML3]] but limit its usage to a restricted
-								subset of the full MathML markup language.</p>
+						<dl class="conformance-list">
+							<dt id="math-pres">Presentation MathML</dt>
+							<dd>
+								<p id="confreq-mathml-pres">The <code>math</code> element MUST contain only <a
+										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, with
+									the exception of the <code>annotation-xml</code> element.</p>
+							</dd>
+							<dt id="math-cont">Content MathML</dt>
+							<dd>
+								<p id="confreq-mathml-annot-cont"><a href="https://www.w3.org/TR/MathML3/chapter4.html"
+										>Content MathML</a> MAY be included within MathML markup in XHTML Content
+									Documents, and, when present, MUST occur within an <code>annotation-xml</code> child
+									element of a <code>semantics</code> element.</p>
+								<p id="confreq-mathml-annot-cont-attrs">When Content MathML is included as per the
+									previous condition, the given <code>annotation-xml</code> element's
+										<code>encoding</code> attribute MUST be set to either of the
+									functionally-equivalent values <code>MathML-Content</code> or
+										<code>application/mathml-content+xml</code>, and its <code>name</code> attribute
+									MUST be set to <code>contentequiv</code>.</p>
+							</dd>
+							<dt id="math-deprecated">Deprecated MathML</dt>
+							<dd>
+								<p id="confreq-mathml-deprecated">Elements and attributes marked as deprecated in
+									[[!MATHML3]] MUST NOT be included within MathML markup in XHTML Content
+									Documents.</p>
+							</dd>
+						</dl>
 
-							<p>This subset is designed to ease the implementation burden on Reading Systems and to
-								promote accessibility, while retaining compatibility with [[HTML]] user agents.</p>
+						<p>This subset is designed to ease the implementation burden on Reading Systems and to promote
+							accessibility, while retaining compatibility with [[HTML]] user agents.</p>
 
-							<div class="note">
-								<p>The <a href="#mathml"><code>mathml</code> property</a> of the <a>manifest</a>
-									<code>item</code> element indicates that an XHTML Content Document contains embedded
-									MathML.</p>
-							</div>
-
-						</section>
-
-						<section id="sec-xhtml-mathml-conf-content">
-							<h6>Content Conformance</h6>
-
-							<p>Any occurrence of MathML markup in XHTML Content Documents MUST conform to the
-								constraints expressed in the MathML specification [[!MATHML3]], with the following
-								additional restrictions:</p>
-
-							<dl class="conformance-list">
-								<dt id="math-pres">Presentation MathML</dt>
-								<dd>
-									<p id="confreq-mathml-pres">The <code>math</code> element MUST contain only <a
-											href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>,
-										with the exception of the <code>annotation-xml</code> element.</p>
-								</dd>
-								<dt id="math-cont">Content MathML</dt>
-								<dd>
-									<p id="confreq-mathml-annot-cont"><a
-											href="https://www.w3.org/TR/MathML3/chapter4.html">Content MathML</a> MAY be
-										included within MathML markup in XHTML Content Documents, and, when present,
-										MUST occur within an <code>annotation-xml</code> child element of a
-											<code>semantics</code> element.</p>
-									<p id="confreq-mathml-annot-cont-attrs">When Content MathML is included as per the
-										previous condition, the given <code>annotation-xml</code> element's
-											<code>encoding</code> attribute MUST be set to either of the
-										functionally-equivalent values <code>MathML-Content</code> or
-											<code>application/mathml-content+xml</code>, and its <code>name</code>
-										attribute MUST be set to <code>contentequiv</code>.</p>
-								</dd>
-								<dt id="math-deprecated">Deprecated MathML</dt>
-								<dd>
-									<p id="confreq-mathml-deprecated">Elements and attributes marked as deprecated in
-										[[!MATHML3]] MUST NOT be included within MathML markup in XHTML Content
-										Documents.</p>
-								</dd>
-							</dl>
-						</section>
+						<div class="note">
+							<p>The <a href="#mathml"><code>mathml</code> property</a> of the <a>manifest</a>
+								<code>item</code> element indicates that an XHTML Content Document contains embedded
+								MathML.</p>
+						</div>
 					</section>
 
 					<section id="sec-xhtml-svg">
@@ -5569,37 +5717,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								href="#sec-xhtml-svg"></a> for the conformance requirements for SVG embedded in XHTML
 							Content Documents.</p>
 					</div>
-
-				</section>
-
-				<section id="sec-svg-content-conf">
-					<h4>Content Conformance</h4>
-					<p>An <a>SVG Content Document</a> has to meet the following criteria:</p>
-
-					<dl class="conformance-list">
-						<dt id="confreq-svg-docprops">Document Properties</dt>
-						<dd>
-							<p id="confreq-cd-svg-xml">It MUST meet the conformance constraints for XML documents
-								defined in <a href="#sec-xml-constraints"></a>.</p>
-							<p id="confreq-resources-svg-fallback">It MAY include references to <a>Foreign Resources</a>
-								provided a fallback to a <a>Core Media Type Resource</a> is included.</p>
-							<p id="confreq-cd-svg-docprops-schema">It MUST be an <a
-									href="https://www.w3.org/TR/SVG/intro.html#TermSVGDocumentFragment">SVG document
-									fragment</a> [[!SVG]], and conform to all content conformance constraints expressed
-								in <a href="#sec-svg-restrictions"></a>.</p>
-							<div class="note">
-								<p>The recommendation that EPUB Publications follow the accessibility requirements in
-									[[EPUBAccessibility-10]] applies to SVG Content Documents. See <a
-										href="#sec-epub-a11y">Accessibility</a>.</p>
-							</div>
-						</dd>
-
-						<dt id="confreq-svg-fileprops">File Properties</dt>
-						<dd>
-							<p id="confreq-svg-fileprops-name">The SVG Content Document filename SHOULD use the file
-								extension <code>.svg</code>.</p>
-						</dd>
-					</dl>
 				</section>
 
 				<section id="sec-svg-restrictions">
@@ -5629,7 +5746,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								<li>
 									<p id="confreq-svg-foreignObject-xhtml-frag">Its content MUST be a valid document
 										fragment that conforms to the XHTML Content Document model defined in <a
-											href="#sec-xhtml-conf-content"></a>.</p>
+											href="#sec-xhtml-conf-content">XHTML Content Documents</a>.</p>
 								</li>
 								<li>
 									<p id="confreq-svg-foreignObject-reqext">Its <code>requiredExtensions</code>
@@ -5675,45 +5792,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						longer recommends the use of prefixed properties, this specification has to maintain some
 						prefixed properties to avoid breaking existing content. But with the minor exceptions defined in
 						this section, EPUB defers to the W3C to define CSS.</p>
-				</section>
-
-				<section id="sec-css-content-conf">
-					<h4>Content Conformance</h4>
-
-					<p>A conformant CSS style sheet has to meet the following criteria:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-css-props">It MAY include any CSS properties, with the following
-								exceptions:</p>
-							<ul class="conformance-list">
-								<li>
-									<p id="confreq-css-props-exc-direction">It MUST NOT use the <a
-											href="https://www.w3.org/TR/css3-writing-modes/#direction"
-												><code>direction</code> property</a> [[!CSS-Writing-Modes-3]]. Use the
-										[[!HTML]] <a href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
-												><code>dir</code> attribute</a> to set the inline base direction.</p>
-								</li>
-								<li>
-									<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT use the <a
-											href="https://www.w3.org/TR/css3-writing-modes/#unicode-bidi"
-												><code>unicode-bidi</code> property</a> [[!CSS-Writing-Modes-3]]. Use
-										[[!HTML]] <a
-											href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdo-element"
-												><code>bdo</code> elements</a> and <a
-											href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
-												><code>dir</code> attributes</a> to control bidirectionality.</p>
-								</li>
-							</ul>
-						</li>
-						<li>
-							<p id="confreq-css-prefixed">It MAY include the prefixed properties defined in <a
-									href="#sec-css-prefixed"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p>
-						</li>
-					</ul>
 
 					<div class="note">
 						<p>Keep in mind that some <a>Reading Systems</a> will not support all desired features of CSS.
@@ -6108,6 +6186,12 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						instances of [[!HTML]] <a href="https://www.w3.org/TR/html/sec-forms.html#sec-forms"
 						>forms</a>.</p>
 
+					<div class="note">
+						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
+							<code>item</code> element indicates that an EPUB Content Document is a <a>Scripted Content
+								Document</a>.</p>
+					</div>
+
 					<p id="sec-scripted-content-models">This specification defines two contexts in which scripts MAY
 						appear:</p>
 
@@ -6230,99 +6314,73 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					</aside>
 				</section>
 
-				<section id="sec-scripted-content-content-reqs">
-					<h4>Content Conformance</h4>
+				<section id="sec-scripted-container-constrained">
+					<h4>Container-Constrained Scripts</h4>
 
-					<dl class="conformance-list">
-						<dt>Container-constrained scripts</dt>
-						<dd>
-							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
-								instructions for modifying the DOM of the parent Content Document or other contents in
-								the EPUB Publication, and MUST NOT contain instructions for manipulating the size of its
-								containing rectangle.</p>
-						</dd>
-						<dt>Spine-level scripts</dt>
-						<dd>
-							<p id="confreq-cd-scripted-spine">EPUB Content Documents that include <a
-									href="#sec-scripted-content-type-spine-level">spine-level</a> scripting MUST utilize
-								the <em>progressive enhancement technique</em>, which for the purposes of this
-								specification has the following definition: when the document is rendered by a Reading
-								System without scripting support or with scripting support disabled, the <a>Top-level
-									Content Document</a> MUST retain its integrity, remaining consumable by the user
-								without any information loss or other significant deterioration.</p>
-						</dd>
-						<dt>Accessibility</dt>
-						<dd>
-							<p id="confreq-cd-scripted-a11y">EPUB Content Documents that <a
-									href="#sec-scripted-content-models">include scripting</a> SHOULD employ relevant
-								[[!WAI-ARIA]] accessibility techniques to ensure that the content remains consumable by
-								all users.</p>
-						</dd>
-						<dt id="confreq-cd-scripted-flbk">Fallbacks</dt>
-						<dd>
-							<p id="confreq-cd-scripted-fallback">EPUB Content Documents that <a
-									href="#sec-scripted-content-models">include scripting</a> MAY provide fallbacks for
-								such content, either by using intrinsic fallback mechanisms (such as those available for
-								the [[!HTML]] <a
-									href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-object-element"
-										><code>object</code></a> and <a
-									href="https://www.w3.org/TR/html/semantics-scripting.html#the-canvas-element"
-										><code>canvas</code></a> elements) or, when an intrinsic fallback is not
-								applicable, by using a <a href="#sec-foreign-restrictions-manifest">manifest-level
-									fallback</a>.</p>
-							<p id="confreq-cd-scripted-foreign-resources">Authors MUST ensure that scripts only generate
-									<a href="#sec-core-media-types">Core Media Type Resources</a> or fragments
-								thereof.</p>
-						</dd>
-					</dl>
+					<p id="confreq-cd-scripted-container">A <a href="sec-scripted-type-container-constrained"
+							>container-constrained script</a> MUST NOT contain instructions for modifying the DOM of the
+						parent Content Document or other contents in the EPUB Publication, and MUST NOT contain
+						instructions for manipulating the size of its containing rectangle.</p>
+				</section>
 
-					<div class="note">
-						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
-							<code>item</code> element indicates that an EPUB Content Document is a <a>Scripted Content
-								Document</a>.</p>
-					</div>
+				<section id="sec-scripted-spine">
+					<h4>Spine-Level Scripts</h4>
+
+					<p id="confreq-cd-scripted-spine">EPUB Content Documents that include <a
+							href="#sec-scripted-content-type-spine-level">spine-level scripting</a> MUST utilize the
+							<em>progressive enhancement technique</em>, which for the purposes of this specification has
+						the following definition: when the document is rendered by a Reading System without scripting
+						support or with scripting support disabled, the <a>Top-level Content Document</a> MUST retain
+						its integrity, remaining consumable by the user without any information loss or other
+						significant deterioration.</p>
+				</section>
+
+				<section id="sec-scripted-a11y">
+					<h4>Scripting Accessibility</h4>
+
+					<p id="confreq-cd-scripted-a11y">EPUB Content Documents that <a href="#sec-scripted-content-models"
+							>include scripting</a> SHOULD employ relevant [[!WAI-ARIA]] accessibility techniques to
+						ensure that the content remains consumable by all users.</p>
+				</section>
+
+				<section id="sec-scripted-fallbacks">
+					<h4 id="confreq-cd-scripted-flbk">Scripting Fallbacks</h4>
+
+					<p id="confreq-cd-scripted-fallback">EPUB Content Documents that <a
+							href="#sec-scripted-content-models">include scripting</a> MAY provide fallbacks for such
+						content, either by using intrinsic fallback mechanisms (such as those available for the
+						[[!HTML]] <a
+							href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-object-element"
+								><code>object</code></a> and <a
+							href="https://www.w3.org/TR/html/semantics-scripting.html#the-canvas-element"
+								><code>canvas</code></a> elements) or, when an intrinsic fallback is not applicable, by
+						using a <a href="#sec-foreign-restrictions-manifest">manifest-level fallback</a>.</p>
+					<p id="confreq-cd-scripted-foreign-resources">Authors MUST ensure that scripts only generate <a
+							href="#sec-core-media-types">Core Media Type Resources</a> or fragments thereof.</p>
 				</section>
 			</section>
 
 			<section id="sec-fixed-layouts">
 				<h3>Fixed Layouts</h3>
 
-				<section id="sec-fxl-overview" class="informative">
-					<h4>Introduction</h4>
+				<p><a>Fixed-Layout Documents</a> are <a>EPUB Content Documents</a> marked as <code>pre-paginated</code>
+					in the <a>Package Document</a>.</p>
 
-					<p>This section defines rules for the expression and interpretation of dimensional properties of
-							<a>Fixed-Layout Documents</a> — <a>EPUB Content Documents</a> marked as
-							<code>pre-paginated</code> in the <a>Package Document</a>.</p>
+				<div class="note">
+					<p>Refer to <a href="#sec-package-metadata-fxl"></a> for information on how to designate that a
+							<a>Rendition</a>, or its individual spine items, are to be rendered in a pre-paginated
+						manner (i.e., with fixed width and height dimensions).</p>
+				</div>
 
-					<div class="note">
-						<p>Refer to <a href="#sec-package-metadata-fxl"></a> for information on how to designate that a
-								<a>Rendition</a>, or its individual spine items, are to be rendered in a pre-paginated
-							manner (i.e., with fixed width and height dimensions).</p>
-					</div>
 
-				</section>
+				<p id="confreg-fxl-icb">Fixed-Layout Documents MUST specify their <a
+						href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
+						block</a> [[!CSS2]] as defined in <a href="#sec-fixed-layouts"></a>. The manner in which initial
+					containg block is specified differs depending on the type of EPUB Content Document.</p>
 
-				<section id="sec-fxl-content-conf">
-					<h4>Content Conformance</h4>
-
-					<p>A conformant <a>Fixed-Layout Document</a> has to meet the following criteria:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreg-fxl-icb">It MUST specify its <a
-									href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-									containing block</a> [[!CSS2]] as defined in <a href="#sec-fxl-html-svg-dimensions"
-								></a>.</p>
-						</li>
-					</ul>
-				</section>
-
-				<section id="sec-fxl-html-svg-dimensions">
-					<h4>Initial Containing Block Dimensions</h4>
-
-					<section id="sec-fxl-icb-html">
-						<h5>Expressing in HTML</h5>
-
+				<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
+					<dt id="sec-fxl-icb-html">Expressing in XHTML</dt>
+					<dd>
 						<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
 								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
 								containing block</a> [[!CSS2]] dimensions MUST be expressed in a <code>viewport</code>
@@ -6338,11 +6396,10 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
    …
 &lt;/head&gt;</pre>
 						</aside>
-					</section>
+					</dd>
 
-					<section id="sec-fxl-icb-svg">
-						<h5>Expressing in SVG</h5>
-
+					<dt id="sec-fxl-icb-svg">Expressing in SVG</dt>
+					<dd>
 						<p>For SVG <a>Fixed-Layout Documents</a>, the ICB dimensions MUST be expressed using the <a
 								href="http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code>
 								attribute</a> [[!SVG]].</p>
@@ -6357,74 +6414,35 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
    …
 &lt;/svg&gt;</pre>
 						</aside>
-					</section>
-				</section>
+					</dd>
+				</dl>
 			</section>
 
 			<section id="sec-pls">
 				<h3>Pronunciation Lexicons</h3>
 
-				<section id="sec-pls-intro" class="informative">
-					<h4>Introduction</h4>
+				<p>The W3C Pronunciation Lexicon Specification (PLS) [[PRONUNCIATION-LEXICON]] defines syntax and
+					semantics for XML-based pronunciation lexicons to be used by Automatic Speech Recognition and
+						<a>Text-to-Speech</a> (TTS) engines.</p>
 
-					<p>The W3C Pronunciation Lexicon Specification (PLS) [[PRONUNCIATION-LEXICON]] defines syntax and
-						semantics for XML-based pronunciation lexicons to be used by Automatic Speech Recognition and
-							<a>Text-to-Speech</a> (TTS) engines.</p>
+				<p id="confreq-cd-pls-xht">A PLS Document MAY be associated with <a>XHTML Content Documents</a>. Each
+					XHTML Content Document MAY contain zero or more PLS document associations.</p>
 
-					<p>The following sections define conformance criteria for PLS documents when included in <a>EPUB
-							Publications</a>, and rules for associating PLS documents with <a>XHTML Content
-							Documents</a>.</p>
+				<p id="confreq-cd-pls-assoc">A PLS Document MUST be associated with the <a>XHTML Content Document</a> to
+					which it applies using the [[!HTML]] <a
+						href="https://www.w3.org/TR/html/document-metadata.html#the-link-element"><code>link</code></a>
+					element with its <code>rel</code> attribute set to "<code>pronunciation</code>" and its
+						<code>type</code> attribute set to the media type "<code>application/pls+xml</code>".</p>
 
-					<div class="note">
-						<p>For more information on EPUB 3 features related to synthetic speech, refer to <a
-								href="epub-overview.html#sec-tts">Text-to-speech</a> [[EPUB-OVERVIEW-33]].</p>
-					</div>
+				<p id="confreq-cd-pls-assoc-lang">The <code>link</code> element <code>hreflang</code> attribute SHOULD
+					be specified on each <code>link</code>, and its value MUST match <a
+						href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/#S4.1">the language for
+						which the pronunciation lexicon is relevant</a> [[!PRONUNCIATION-LEXICON]] when specified.</p>
 
-				</section>
-
-				<section id="sec-pls-conf-pub">
-					<h4>EPUB Publication Conformance</h4>
-
-					<p>A conformant <a>Rendition</a> of an <a>EPUB Publication</a> has to meet the following criteria
-						for inclusion of <abbr title="Pronunciation Lexicon Specification">PLS</abbr> documents:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-cd-pls-xht">PLS Documents MAY be associated with <a>XHTML Content
-									Documents</a>. Each XHTML Content Document MAY contain zero or more PLS document
-								associations.</p>
-						</li>
-						<li>
-							<p id="confreq-cd-pls-assoc">PLS documents MUST be associated with the <a>XHTML Content
-									Document</a> to which they apply using the [[!HTML]] <a
-									href="https://www.w3.org/TR/html/document-metadata.html#the-link-element"
-										><code>link</code></a> element with its <code>rel</code> attribute set to
-									"<code>pronunciation</code>" and its <code>type</code> attribute set to the media
-								type "<code>application/pls+xml</code>".</p>
-							<p id="confreq-cd-pls-assoc-lang">The <code>link</code> element <code>hreflang</code>
-								attribute SHOULD be specified on each <code>link</code>, and its value MUST match <a
-									href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/#S4.1">the
-									language for which the pronunciation lexicon is relevant</a>
-								[[!PRONUNCIATION-LEXICON]] when specified.</p>
-						</li>
-						<li>
-							<p id="confreq-pls-pub-cont">PLS documents MUST meet the content conformance criteria
-								defined in <a href="#sec-pls-conf-content"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-pls-pub-manif">PLS documents MUST be represented and located as defined in <a
-									href="#sec-package-conformance"></a>.</p>
-						</li>
-					</ul>
-
-					<section id="pls-examples">
-						<h5>Examples</h5>
-
-						<aside class="example">
-							<p>The following example shows two <abbr title="Pronunciation Lexicon Specification"
-									>PLS</abbr> documents (one for Chinese and one for Mongolian) associated with an
-								XHTML Content Document.</p>
-							<pre>
+				<aside class="example">
+					<p>The following example shows two <abbr title="Pronunciation Lexicon Specification">PLS</abbr>
+						documents (one for Chinese and one for Mongolian) associated with an XHTML Content Document.</p>
+					<pre>
 &lt;html … &gt;    
     &lt;head&gt;
         …
@@ -6433,54 +6451,16 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
     &lt;/head&gt;        
     …
 &lt;/html&gt;</pre>
-						</aside>
-					</section>
-				</section>
+				</aside>
 
-				<section id="sec-pls-conf-content">
-					<h4>Content Conformance</h4>
-
-					<p>A <abbr title="Pronunciation Lexicon Specification">PLS</abbr> document has to meet the following
-						criteria:</p>
-
-					<dl class="conformance-list">
-						<dt id="confreq-cd-pls-docprops">Document Properties</dt>
-						<dd>
-							<p id="confreq-cd-pls-xml">It MUST meet the conformance constraints for XML documents
-								defined in <a href="#sec-xml-constraints"></a>.</p>
-							<p id="confreq-cd-pls-docprops-schema">It MUST be valid to the RELAX NG schema for PLS
-								documents available at the URI <a class="uri"
-									href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
-										><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/</code></a>
-								[[!PRONUNCIATION-LEXICON]].</p>
-						</dd>
-						<dt id="confreq-cd-pls-fileprops">File Properties</dt>
-						<dd>
-							<p id="confreq-cd-pls-fileprops-name">The PLS document filename SHOULD use the file
-								extension <code class="filename">.pls</code>.</p>
-						</dd>
-					</dl>
-				</section>
+				<div class="note">
+					<p>For more information on EPUB 3 features related to synthetic speech, refer to <a
+							href="epub-overview.html#sec-tts">Text-to-speech</a> [[EPUB-OVERVIEW-33]].</p>
+				</div>
 			</section>
 		</section>
 		<section id="sec-ocf">
 			<h2>Open Container Format</h2>
-
-			<section id="sec-ocf-conformance">
-				<h3>OCF Conformance</h3>
-
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-ocf-content-abstr">An OCF Abstract Container MUST meet the conformance
-							constraints defined in <a href="#sec-container-abstract"></a>.</p>
-					</li>
-					<li>
-						<p id="confreq-ocf-content-zip">An OCF ZIP Container MUST meet the conformance constraints
-							defined in <a href="#sec-container-zip"></a>.</p>
-					</li>
-				</ul>
-
-			</section>
 
 			<section id="sec-container-abstract">
 				<h3>OCF Abstract Container</h3>
@@ -7459,569 +7439,521 @@ store destination as source in ocf
 		<section id="sec-media-overlays">
 			<h2>Media Overlays</h2>
 
-			<section id="sec-media-overlays-document-definition">
+			<section id="sec-overlays-introduction" class="informative">
+				<h4>Introduction</h4>
+
+				<p>Synchronized audio narration is found in mainstream ebooks, educational tools and ebooks formatted
+					for persons with print disabilities. In EPUB 3, these types of books are created using Media Overlay
+					Documents to describe the timing for the pre-recorded audio narration and how it relates to the EPUB
+					Content Document markup. The file format for Media Overlays is defined as a subset of [[SMIL3]], a
+					W3C recommendation for representing synchronized multimedia information in XML.</p>
+
+				<p>The text and audio synchronization enabled by Media Overlays provides enhanced accessibility for any
+					user who has difficulty following the text of a traditional book. Media Overlays also provide a
+					continuous listening experience for readers who are unable to read the text for any reason,
+					something that traditional audio embedding techniques cannot offer. They are even useful for
+					purposes not traditionally considered accessibility concerns (e.g., for language learning or reading
+					of commercial audio books).</p>
+
+				<p>The Media Overlays feature is designed to be transparent to <a>EPUB Reading Systems</a> that do not
+					support the feature. The inclusion of Media Overlays in an EPUB Publication has no impact on the
+					ability of Media Overlay-unaware Reading Systems to render the EPUB Publication as though the Media
+					Overlays are not present.</p>
+
+				<p>Although future versions of this specification might incorporate support for video media (e.g.,
+					synchronized text/sign-language books), this version supports only synchronizing audio media with
+					the EPUB Content Document.</p>
+			</section>
+
+			<section id="sec-overlays-def">
 				<h3>Media Overlay Document Definition</h3>
 
-				<section id="sec-overlays-introduction" class="informative">
-					<h4>Introduction</h4>
+				<p>All elements [[!XML]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
+					namespace [[!XML-NAMES]] unless otherwise specified.</p>
 
-					<p>Synchronized audio narration is found in mainstream ebooks, educational tools and ebooks
-						formatted for persons with print disabilities. In EPUB 3, these types of books are created using
-						Media Overlay Documents to describe the timing for the pre-recorded audio narration and how it
-						relates to the EPUB Content Document markup. The file format for Media Overlays is defined as a
-						subset of [[SMIL3]], a W3C recommendation for representing synchronized multimedia information
-						in XML.</p>
+				<section id="sec-smil-smil-elem">
+					<h5>The <code>smil</code> Element</h5>
 
-					<p>The text and audio synchronization enabled by Media Overlays provides enhanced accessibility for
-						any user who has difficulty following the text of a traditional book. Media Overlays also
-						provide a continuous listening experience for readers who are unable to read the text for any
-						reason, something that traditional audio embedding techniques cannot offer. They are even useful
-						for purposes not traditionally considered accessibility concerns (e.g., for language learning or
-						reading of commercial audio books).</p>
+					<p>The <code>smil</code> element is the root element of all Media Overlay Documents.</p>
 
-					<p>The Media Overlays feature is designed to be transparent to <a>EPUB Reading Systems</a> that do
-						not support the feature. The inclusion of Media Overlays in an EPUB Publication has no impact on
-						the ability of Media Overlay-unaware Reading Systems to render the EPUB Publication as though
-						the Media Overlays are not present.</p>
-
-					<p>Although future versions of this specification might incorporate support for video media (e.g.,
-						synchronized text/sign-language books), this version supports only synchronizing audio media
-						with the EPUB Content Document.</p>
-				</section>
-
-				<section id="sec-overlays-content-conf">
-					<h4>Content Conformance</h4>
-
-					<p>A <a>Media Overlay Document</a> has to meet the following criteria:</p>
-
-					<dl class="conformance-list">
-						<dt id="confreq-mo-docprops">Document Properties</dt>
+					<dl class="elemdef" id="elemdef-smil">
+						<dt>Element Name</dt>
 						<dd>
-							<p id="confreq-mo-xml"> It MUST meet the conformance constraints for XML documents defined
-								in <a href="#sec-xml-constraints"></a>.</p>
-							<p id="confreq-mo-docprops-schema">It MUST be valid to the Media Overlays schema as defined
-								in <a href="#app-schema-overlays"></a> and conform to all content conformance
-								constraints expressed in <a href="#sec-overlays-def"></a>.</p>
-							<p id="confreq-mo-docprops-structure">It MUST be authored to reflect the structure of the
-									<a>EPUB Content Document</a> with which it is associated, as stated in <a
-									href="#sec-media-overlays-structure"></a>.</p>
-							<p id="confreq-mo-docprops-references">It MAY refer to more than one EPUB Content Document,
-								but an EPUB Content Document MUST NOT be referenced by more than one Media Overlay
-								Document.</p>
-							<p id="confreq-mo-docprops-embed">It MUST adhere to the requirements for <a
-									href="#sec-audio-video">Embedded Media</a>.</p>
-							<p id="confreq-mo-docprops-semantics">It SHOULD use semantic markup where appropriate, as
-								described in <a href="#sec-docs-semantic-inflection"></a>.</p>
-							<p id="confreq-mo-docprops-package">It MUST be packaged with the <a>EPUB Publication</a> as
-								shown in <a href="#sec-docs-package"></a>.</p>
+							<p>
+								<code>smil</code>
+							</p>
 						</dd>
-						<dt id="confreq-mo-fileprops">File Properties</dt>
+						<dt>Usage</dt>
 						<dd>
-							<p id="confreq-mo-fileprops-name">The Media Overlay Document filename SHOULD use the file
-								extension <code class="filename">.smil</code>.</p>
+							<p>The <code>smil</code> element is the root element of the Media Overlay Document.</p>
+						</dd>
+						<dt>Attributes</dt>
+						<dd>
+							<dl>
+								<dt>
+									<code>version</code>
+									<code>[required]</code>
+								</dt>
+								<dd>
+									<p>Specifies the version number of the [[!SMIL3]] specification to which the Media
+										Overlay adheres.</p>
+									<p>This attribute MUST have the value "<code>3.0</code>".</p>
+								</dd>
+								<dt>
+									<code>id</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										scope.</p>
+								</dd>
+								<dt id="attrdef-smil-prefix">
+									<code>epub:prefix</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>Declares additional metadata vocabulary prefixes.</p>
+									<p>Refer to <a href="#sec-docs-semantic-inflection"></a> for more information.</p>
+								</dd>
+							</dl>
+						</dd>
+						<dt>Content Model</dt>
+						<dd>
+							<p>In this order:</p>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#elemdef-smil-head">
+											<code>head</code>
+										</a>
+										<code>[0 or 1]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-smil-body">
+											<code>body</code>
+										</a>
+										<code>[exactly 1]</code>
+									</p>
+								</li>
+							</ul>
 						</dd>
 					</dl>
 				</section>
 
-				<section id="sec-overlays-def">
-					<h4>Media Overlay Document Definition</h4>
+				<section id="sec-smil-head-elem">
+					<h5>The <code>head</code> Element</h5>
 
-					<p>All elements [[!XML]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
-						namespace [[!XML-NAMES]] unless otherwise specified.</p>
+					<p>The <code>head</code> element is the container for metadata in the Media Overlay Document.</p>
 
-					<section id="sec-smil-smil-elem">
-						<h5>The <code>smil</code> Element</h5>
-
-						<p>The <code>smil</code> element is the root element of all Media Overlay Documents.</p>
-
-						<dl class="elemdef" id="elemdef-smil">
-							<dt>Element Name</dt>
-							<dd>
-								<p>
-									<code>smil</code>
-								</p>
-							</dd>
-							<dt>Usage</dt>
-							<dd>
-								<p>The <code>smil</code> element is the root element of the Media Overlay Document.</p>
-							</dd>
-							<dt>Attributes</dt>
-							<dd>
-								<dl>
-									<dt>
-										<code>version</code>
-										<code>[required]</code>
-									</dt>
-									<dd>
-										<p>Specifies the version number of the [[!SMIL3]] specification to which the
-											Media Overlay adheres.</p>
-										<p>This attribute MUST have the value "<code>3.0</code>".</p>
-									</dd>
-									<dt>
-										<code>id</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
-											scope.</p>
-									</dd>
-									<dt id="attrdef-smil-prefix">
-										<code>epub:prefix</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>Declares additional metadata vocabulary prefixes.</p>
-										<p>Refer to <a href="#sec-docs-semantic-inflection"></a> for more
-											information.</p>
-									</dd>
-								</dl>
-							</dd>
-							<dt>Content Model</dt>
-							<dd>
-								<p>In this order:</p>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#elemdef-smil-head">
-												<code>head</code>
-											</a>
-											<code>[0 or 1]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#elemdef-smil-body">
-												<code>body</code>
-											</a>
-											<code>[exactly 1]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-						</dl>
-					</section>
-
-					<section id="sec-smil-head-elem">
-						<h5>The <code>head</code> Element</h5>
-
-						<p>The <code>head</code> element is the container for metadata in the Media Overlay
-							Document.</p>
-
-						<dl class="elemdef" id="elemdef-smil-head">
-							<dt>Element Name</dt>
-							<dd>
-								<p>
-									<code>head</code>
-								</p>
-							</dd>
-							<dt>Usage</dt>
-							<dd>
-								<p>The <code>head</code> element is the OPTIONAL first child of the <a
-										href="#elemdef-smil"><code>smil</code></a> element.</p>
-							</dd>
-							<dt>Attributes</dt>
-							<dd>
-								<p>None</p>
-							</dd>
-							<dt>Content Model</dt>
-							<dd>
-								<p>
-									<a href="#elemdef-smil-metadata">
-										<code>metadata</code>
-									</a>
-									<code>[0 or 1]</code>
-								</p>
-							</dd>
-						</dl>
-
-						<p>As this specification does not define any metadata properties that have to occur in the Media
-							Overlay Document, the <code>head</code> element is OPTIONAL.</p>
-					</section>
-
-					<section id="sec-smil-metadata-elem">
-						<h5>The <code>metadata</code> Element</h5>
-
-						<p>The <code>metadata</code> element represents metadata for the Media Overlay Document. The
-								<code>metadata</code> element is an extension point that allows the inclusion of
-							metadata from any metainformation structuring language.</p>
-
-						<dl class="elemdef" id="elemdef-smil-metadata">
-							<dt>Element Name</dt>
-							<dd>
-								<p>
+					<dl class="elemdef" id="elemdef-smil-head">
+						<dt>Element Name</dt>
+						<dd>
+							<p>
+								<code>head</code>
+							</p>
+						</dd>
+						<dt>Usage</dt>
+						<dd>
+							<p>The <code>head</code> element is the OPTIONAL first child of the <a href="#elemdef-smil"
+										><code>smil</code></a> element.</p>
+						</dd>
+						<dt>Attributes</dt>
+						<dd>
+							<p>None</p>
+						</dd>
+						<dt>Content Model</dt>
+						<dd>
+							<p>
+								<a href="#elemdef-smil-metadata">
 									<code>metadata</code>
-								</p>
-							</dd>
-							<dt>Usage</dt>
-							<dd>
-								<p>As a child of the <a href="#elemdef-smil-head"><code>head</code></a> element.</p>
-							</dd>
-							<dt>Attributes</dt>
-							<dd>
-								<p>None</p>
-							</dd>
-							<dt>Content Model</dt>
-							<dd>
-								<p><code>[0 or more]</code> elements from any namespace</p>
-							</dd>
-						</dl>
+								</a>
+								<code>[0 or 1]</code>
+							</p>
+						</dd>
+					</dl>
 
-						<p>This specification defines no metadata properties that MUST occur in the Media Overlay
-							Document; the <code>metadata</code> element is provided for custom metadata
-							requirements.</p>
-					</section>
+					<p>As this specification does not define any metadata properties that have to occur in the Media
+						Overlay Document, the <code>head</code> element is OPTIONAL.</p>
+				</section>
 
-					<section id="sec-smil-body-elem">
-						<h5>The <code>body</code> Element</h5>
+				<section id="sec-smil-metadata-elem">
+					<h5>The <code>metadata</code> Element</h5>
 
-						<p>The <code>body</code> element is the starting point for the presentation contained in the
-							Media Overlay Document. It contains the main sequence of <code>par</code> and
-								<code>seq</code> elements.</p>
+					<p>The <code>metadata</code> element represents metadata for the Media Overlay Document. The
+							<code>metadata</code> element is an extension point that allows the inclusion of metadata
+						from any metainformation structuring language.</p>
 
-						<dl class="elemdef" id="elemdef-smil-body">
-							<dt>Element Name</dt>
-							<dd>
-								<p>
-									<code>body</code>
-								</p>
-							</dd>
-							<dt>Usage</dt>
-							<dd>
-								<p>The <code>body</code> element is the REQUIRED second child of the <a
-										href="#elemdef-smil"><code>smil</code></a> element.</p>
-							</dd>
-							<dt>Attributes</dt>
-							<dd>
-								<dl>
-									<dt id="addrdef-smil-body-type">
-										<code>epub:type</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>An expression of the structural semantics of the corresponding element in the
-												<a>EPUB Content Document</a>.</p>
-										<p>The value is a white space separated list of <a href="#sec-property-datatype"
-												>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"
-											></a> for more information.</p>
-									</dd>
-									<dt>
-										<code>id</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
-											scope.</p>
-									</dd>
-									<dt id="attrdef-body-textref">
-										<code>epub:textref</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
-											Document, including a fragment identifier that references the specific
-											element as per the [[!XPTRSH]].</p>
-									</dd>
-								</dl>
-							</dd>
-							<dt>Content Model</dt>
-							<dd>
-								<p>In any order:</p>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#elemdef-smil-seq">
-												<code>seq</code>
-											</a>
-											<code>[0 or more]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#elemdef-smil-par">
-												<code>par</code>
-											</a>
-											<code>[0 or more]</code>
-										</p>
-									</li>
-								</ul>
-								<p>At least one <code>par</code> or <code>seq</code> is REQUIRED.</p>
-							</dd>
-						</dl>
-					</section>
+					<dl class="elemdef" id="elemdef-smil-metadata">
+						<dt>Element Name</dt>
+						<dd>
+							<p>
+								<code>metadata</code>
+							</p>
+						</dd>
+						<dt>Usage</dt>
+						<dd>
+							<p>As a child of the <a href="#elemdef-smil-head"><code>head</code></a> element.</p>
+						</dd>
+						<dt>Attributes</dt>
+						<dd>
+							<p>None</p>
+						</dd>
+						<dt>Content Model</dt>
+						<dd>
+							<p><code>[0 or more]</code> elements from any namespace</p>
+						</dd>
+					</dl>
 
-					<section id="sec-smil-seq-elem">
-						<h5>The <code>seq</code> Element</h5>
+					<p>This specification defines no metadata properties that MUST occur in the Media Overlay Document;
+						the <code>metadata</code> element is provided for custom metadata requirements.</p>
+				</section>
 
-						<p>The <code>seq</code> element contains media objects which are to be rendered
-							sequentially.</p>
+				<section id="sec-smil-body-elem">
+					<h5>The <code>body</code> Element</h5>
 
-						<dl class="elemdef" id="elemdef-smil-seq">
-							<dt>Element Name</dt>
-							<dd>
-								<p>
-									<code>seq</code>
-								</p>
-							</dd>
-							<dt>Usage</dt>
-							<dd>
-								<p>One or more <code>seq</code> elements MAY occur as children of the <a
-										href="#elemdef-smil-body"><code>body</code> element</a> and of the <a
-										href="#elemdef-smil-seq"><code>seq</code> element</a>.</p>
-							</dd>
-							<dt>Attributes</dt>
-							<dd>
-								<dl>
-									<dt>
-										<code>epub:type</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>An expression of the structural semantics of the corresponding element in the
-												<a>EPUB Content Document</a>.</p>
-										<p>The value is a white space separated list of <a href="#sec-property-datatype"
-												>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"
-											></a> for more information.</p>
-									</dd>
-									<dt>
-										<code>id</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
-											scope.</p>
-									</dd>
-									<dt id="attrdef-seq-textref">
-										<code>epub:textref</code>
-										<code>[required]</code>
-									</dt>
-									<dd>
-										<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
-											Document, including a fragment identifier that references the specific
-											element as per the [[!XPTRSH]].</p>
-										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
-											information.</p>
-									</dd>
-								</dl>
-							</dd>
-							<dt>Content Model</dt>
-							<dd>
-								<p>In any order:</p>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#elemdef-smil-seq">
-												<code>seq</code>
-											</a>
-											<code>[0 or more]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#elemdef-smil-par">
-												<code>par</code>
-											</a>
-											<code>[0 or more]</code>
-										</p>
-									</li>
-								</ul>
-								<p>At least one <code>par</code> or <code>seq</code> is REQUIRED.</p>
-							</dd>
-						</dl>
-					</section>
+					<p>The <code>body</code> element is the starting point for the presentation contained in the Media
+						Overlay Document. It contains the main sequence of <code>par</code> and <code>seq</code>
+						elements.</p>
 
-					<section id="sec-smil-par-elem">
-						<h5>The <code>par</code> Element</h5>
+					<dl class="elemdef" id="elemdef-smil-body">
+						<dt>Element Name</dt>
+						<dd>
+							<p>
+								<code>body</code>
+							</p>
+						</dd>
+						<dt>Usage</dt>
+						<dd>
+							<p>The <code>body</code> element is the REQUIRED second child of the <a href="#elemdef-smil"
+										><code>smil</code></a> element.</p>
+						</dd>
+						<dt>Attributes</dt>
+						<dd>
+							<dl>
+								<dt id="addrdef-smil-body-type">
+									<code>epub:type</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>An expression of the structural semantics of the corresponding element in the
+											<a>EPUB Content Document</a>.</p>
+									<p>The value is a white space separated list of <a href="#sec-property-datatype"
+											>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"></a>
+										for more information.</p>
+								</dd>
+								<dt>
+									<code>id</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										scope.</p>
+								</dd>
+								<dt id="attrdef-body-textref">
+									<code>epub:textref</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
+										Document, including a fragment identifier that references the specific element
+										as per the [[!XPTRSH]].</p>
+								</dd>
+							</dl>
+						</dd>
+						<dt>Content Model</dt>
+						<dd>
+							<p>In any order:</p>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#elemdef-smil-seq">
+											<code>seq</code>
+										</a>
+										<code>[0 or more]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-smil-par">
+											<code>par</code>
+										</a>
+										<code>[0 or more]</code>
+									</p>
+								</li>
+							</ul>
+							<p>At least one <code>par</code> or <code>seq</code> is REQUIRED.</p>
+						</dd>
+					</dl>
+				</section>
 
-						<p>The <code>par</code> element contains media objects which are to be rendered in parallel.</p>
+				<section id="sec-smil-seq-elem">
+					<h5>The <code>seq</code> Element</h5>
 
-						<dl class="elemdef" id="elemdef-smil-par">
-							<dt>Element Name</dt>
-							<dd>
-								<p>
-									<code>par</code>
-								</p>
-							</dd>
-							<dt>Usage</dt>
-							<dd>
-								<p>One or more <code>par</code> elements MAY occur as children of the <a
-										href="#elemdef-smil-body"><code>body</code></a> and <a href="#elemdef-smil-seq"
-											><code>seq</code></a> elements.</p>
-							</dd>
-							<dt>Attributes</dt>
-							<dd>
-								<dl>
-									<dt>
-										<code>epub:type</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>An expression of the structural semantics of the corresponding element in the
-												<a>EPUB Content Document</a>.</p>
-										<p>The value is a white space separated list of <a href="#sec-property-datatype"
-												>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"
-											></a> for more information.</p>
-									</dd>
-									<dt>
-										<code>id</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
-											scope.</p>
-									</dd>
-								</dl>
-							</dd>
-							<dt>Content Model</dt>
-							<dd>
-								<p>In any order:</p>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#elemdef-smil-text">
-												<code>text</code>
-											</a>
-											<code>[exactly 1]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#elemdef-smil-audio">
-												<code>audio</code>
-											</a>
-											<code>[0 or 1]</code>
-										</p>
-									</li>
-								</ul>
-								<p>The <a href="#elemdef-smil-audio"><code>audio</code> element</a> is OPTIONAL only if
-									its sibling <a href="#elemdef-smil-text"><code>text</code> element</a> refers to
-									audio or video media (see <a href="#sec-audio-video"></a>), or to textual content
-									intended for rendering via <a>Text-to-Speech</a> (TTS).</p>
-							</dd>
-						</dl>
-					</section>
+					<p>The <code>seq</code> element contains media objects which are to be rendered sequentially.</p>
 
-					<section id="sec-smil-text-elem">
-						<h5>The <code>text</code> Element</h5>
+					<dl class="elemdef" id="elemdef-smil-seq">
+						<dt>Element Name</dt>
+						<dd>
+							<p>
+								<code>seq</code>
+							</p>
+						</dd>
+						<dt>Usage</dt>
+						<dd>
+							<p>One or more <code>seq</code> elements MAY occur as children of the <a
+									href="#elemdef-smil-body"><code>body</code> element</a> and of the <a
+									href="#elemdef-smil-seq"><code>seq</code> element</a>.</p>
+						</dd>
+						<dt>Attributes</dt>
+						<dd>
+							<dl>
+								<dt>
+									<code>epub:type</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>An expression of the structural semantics of the corresponding element in the
+											<a>EPUB Content Document</a>.</p>
+									<p>The value is a white space separated list of <a href="#sec-property-datatype"
+											>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"></a>
+										for more information.</p>
+								</dd>
+								<dt>
+									<code>id</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										scope.</p>
+								</dd>
+								<dt id="attrdef-seq-textref">
+									<code>epub:textref</code>
+									<code>[required]</code>
+								</dt>
+								<dd>
+									<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
+										Document, including a fragment identifier that references the specific element
+										as per the [[!XPTRSH]].</p>
+									<p>Refer to <a href="#sec-media-overlays-structure"></a> for more information.</p>
+								</dd>
+							</dl>
+						</dd>
+						<dt>Content Model</dt>
+						<dd>
+							<p>In any order:</p>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#elemdef-smil-seq">
+											<code>seq</code>
+										</a>
+										<code>[0 or more]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-smil-par">
+											<code>par</code>
+										</a>
+										<code>[0 or more]</code>
+									</p>
+								</li>
+							</ul>
+							<p>At least one <code>par</code> or <code>seq</code> is REQUIRED.</p>
+						</dd>
+					</dl>
+				</section>
 
-						<p>The <code>text</code> element references an element in the <a>EPUB Content Document</a>. A
-								<code>text</code> element typically refers to a textual element, but can also refer to
-							other EPUB Content Document media elements (see <a href="#sec-audio-video"></a>).</p>
+				<section id="sec-smil-par-elem">
+					<h5>The <code>par</code> Element</h5>
 
-						<dl class="elemdef" id="elemdef-smil-text">
-							<dt>Element Name</dt>
-							<dd>
-								<p>
-									<code>text</code>
-								</p>
-							</dd>
-							<dt>Usage</dt>
-							<dd>
-								<p>As a REQUIRED child of the <a href="#elemdef-smil-par"><code>par</code></a>
-									element.</p>
-							</dd>
-							<dt>Attributes</dt>
-							<dd>
-								<dl>
-									<dt>
-										<code>src</code>
-										<code>[required]</code>
-									</dt>
-									<dd>
-										<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
-											Document, including a fragment identifier that references the specific
-											element as per the [[!XPTRSH]].</p>
-									</dd>
-									<dt>
-										<code>id</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
-											scope.</p>
-									</dd>
-								</dl>
-							</dd>
-							<dt>Content Model</dt>
-							<dd>
-								<p>Empty</p>
-							</dd>
-						</dl>
-					</section>
+					<p>The <code>par</code> element contains media objects which are to be rendered in parallel.</p>
 
-					<section id="sec-smil-audio-elem">
-						<h5>The <code>audio</code> Element</h5>
+					<dl class="elemdef" id="elemdef-smil-par">
+						<dt>Element Name</dt>
+						<dd>
+							<p>
+								<code>par</code>
+							</p>
+						</dd>
+						<dt>Usage</dt>
+						<dd>
+							<p>One or more <code>par</code> elements MAY occur as children of the <a
+									href="#elemdef-smil-body"><code>body</code></a> and <a href="#elemdef-smil-seq"
+										><code>seq</code></a> elements.</p>
+						</dd>
+						<dt>Attributes</dt>
+						<dd>
+							<dl>
+								<dt>
+									<code>epub:type</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>An expression of the structural semantics of the corresponding element in the
+											<a>EPUB Content Document</a>.</p>
+									<p>The value is a white space separated list of <a href="#sec-property-datatype"
+											>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"></a>
+										for more information.</p>
+								</dd>
+								<dt>
+									<code>id</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										scope.</p>
+								</dd>
+							</dl>
+						</dd>
+						<dt>Content Model</dt>
+						<dd>
+							<p>In any order:</p>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#elemdef-smil-text">
+											<code>text</code>
+										</a>
+										<code>[exactly 1]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-smil-audio">
+											<code>audio</code>
+										</a>
+										<code>[0 or 1]</code>
+									</p>
+								</li>
+							</ul>
+							<p>The <a href="#elemdef-smil-audio"><code>audio</code> element</a> is OPTIONAL only if its
+								sibling <a href="#elemdef-smil-text"><code>text</code> element</a> refers to audio or
+								video media (see <a href="#sec-audio-video"></a>), or to textual content intended for
+								rendering via <a>Text-to-Speech</a> (TTS).</p>
+						</dd>
+					</dl>
+				</section>
 
-						<p>The <code>audio</code> element represents a clip of audio media.</p>
+				<section id="sec-smil-text-elem">
+					<h5>The <code>text</code> Element</h5>
 
-						<dl class="elemdef" id="elemdef-smil-audio">
-							<dt>Element Name</dt>
-							<dd>
-								<p>
-									<code>audio</code>
-								</p>
-							</dd>
-							<dt>Usage</dt>
-							<dd>
-								<p>A REQUIRED child of the <a href="#elemdef-smil-par"><code>par</code> element</a>
-									unless its sibling <a href="#elemdef-smil-text"><code>text</code> element</a> refers
-									to audio or video media, or to textual content intended for rendering via
-										<a>Text-to-Speech</a> (TTS), in which case it is OPTIONAL (see <a
-										href="#sec-audio-video"></a>).</p>
-							</dd>
-							<dt>Attributes</dt>
-							<dd>
-								<dl>
-									<dt>
-										<code>id</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
-											scope.</p>
-									</dd>
-									<dt>
-										<code>src</code>
-										<code>[required]</code>
-									</dt>
-									<dd>
-										<p>The relative or absolute IRI reference [[!RFC3987]] of an audio file. The
-											audio file MUST be one of the audio formats listed in the <a
-												href="#sec-core-media-types">Core Media Type Resources</a> table.</p>
-									</dd>
-									<dt id="attrdef-smil-clipBegin">
-										<code>clipBegin</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>A clock value that specifies the offset into the physical media corresponding
-											to the start point of an audio clip.</p>
-										<p>MUST be a [[!SMIL3]] <a
-												href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">clock
-											value</a>.</p>
-										<p>See <a href="#app-clock-examples"></a>.</p>
-									</dd>
-									<dt id="attrdef-smil-clipEnd">
-										<code>clipEnd</code>
-										<code>[optional]</code>
-									</dt>
-									<dd>
-										<p>A clock value that specifies the offset into the physical media corresponding
-											to the end point of an audio clip.</p>
-										<p>MUST be a [[!SMIL3]] <a
-												href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">clock
-											value</a>.</p>
-										<p>See <a href="#app-clock-examples"></a>.</p>
-										<p>The chronological offset of the terminating position MUST be after the
-											starting offset specified in the <code>clipBegin</code> attribute.</p>
-									</dd>
-								</dl>
-							</dd>
-							<dt>Content Model</dt>
-							<dd>
-								<p>Empty</p>
-							</dd>
-						</dl>
-					</section>
+					<p>The <code>text</code> element references an element in the <a>EPUB Content Document</a>. A
+							<code>text</code> element typically refers to a textual element, but can also refer to other
+						EPUB Content Document media elements (see <a href="#sec-audio-video"></a>).</p>
+
+					<dl class="elemdef" id="elemdef-smil-text">
+						<dt>Element Name</dt>
+						<dd>
+							<p>
+								<code>text</code>
+							</p>
+						</dd>
+						<dt>Usage</dt>
+						<dd>
+							<p>As a REQUIRED child of the <a href="#elemdef-smil-par"><code>par</code></a> element.</p>
+						</dd>
+						<dt>Attributes</dt>
+						<dd>
+							<dl>
+								<dt>
+									<code>src</code>
+									<code>[required]</code>
+								</dt>
+								<dd>
+									<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
+										Document, including a fragment identifier that references the specific element
+										as per the [[!XPTRSH]].</p>
+								</dd>
+								<dt>
+									<code>id</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										scope.</p>
+								</dd>
+							</dl>
+						</dd>
+						<dt>Content Model</dt>
+						<dd>
+							<p>Empty</p>
+						</dd>
+					</dl>
+				</section>
+
+				<section id="sec-smil-audio-elem">
+					<h5>The <code>audio</code> Element</h5>
+
+					<p>The <code>audio</code> element represents a clip of audio media.</p>
+
+					<dl class="elemdef" id="elemdef-smil-audio">
+						<dt>Element Name</dt>
+						<dd>
+							<p>
+								<code>audio</code>
+							</p>
+						</dd>
+						<dt>Usage</dt>
+						<dd>
+							<p>A REQUIRED child of the <a href="#elemdef-smil-par"><code>par</code> element</a> unless
+								its sibling <a href="#elemdef-smil-text"><code>text</code> element</a> refers to audio
+								or video media, or to textual content intended for rendering via <a>Text-to-Speech</a>
+								(TTS), in which case it is OPTIONAL (see <a href="#sec-audio-video"></a>).</p>
+						</dd>
+						<dt>Attributes</dt>
+						<dd>
+							<dl>
+								<dt>
+									<code>id</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										scope.</p>
+								</dd>
+								<dt>
+									<code>src</code>
+									<code>[required]</code>
+								</dt>
+								<dd>
+									<p>The relative or absolute IRI reference [[!RFC3987]] of an audio file. The audio
+										file MUST be one of the audio formats listed in the <a
+											href="#sec-core-media-types">Core Media Type Resources</a> table.</p>
+								</dd>
+								<dt id="attrdef-smil-clipBegin">
+									<code>clipBegin</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>A clock value that specifies the offset into the physical media corresponding to
+										the start point of an audio clip.</p>
+									<p>MUST be a [[!SMIL3]] <a href="https://www.w3.org/TR/SMIL/smil-timing.html#q22"
+											>clock value</a>.</p>
+									<p>See <a href="#app-clock-examples"></a>.</p>
+								</dd>
+								<dt id="attrdef-smil-clipEnd">
+									<code>clipEnd</code>
+									<code>[optional]</code>
+								</dt>
+								<dd>
+									<p>A clock value that specifies the offset into the physical media corresponding to
+										the end point of an audio clip.</p>
+									<p>MUST be a [[!SMIL3]] <a href="https://www.w3.org/TR/SMIL/smil-timing.html#q22"
+											>clock value</a>.</p>
+									<p>See <a href="#app-clock-examples"></a>.</p>
+									<p>The chronological offset of the terminating position MUST be after the starting
+										offset specified in the <code>clipBegin</code> attribute.</p>
+								</dd>
+							</dl>
+						</dd>
+						<dt>Content Model</dt>
+						<dd>
+							<p>Empty</p>
+						</dd>
+					</dl>
 				</section>
 			</section>
 
@@ -9267,7 +9199,7 @@ EPUB/images/cover.png</pre>
 				</li>
 				<li id="idx-mo">
 					<p>
-						<a href="#sec-media-overlays-document-definition">Media Overlays Documents</a>
+						<a href="#sec-media-overlays">Media Overlays Documents</a>
 					</p>
 					<ul>
 						<li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3247,7 +3247,7 @@ Manifest:
 					</section>
 				</section>
 
-				<section id="sec-package-enc">
+				<section id="sec-package-file">
 					<h4>Package Document File Properties</h4>
 
 					<p id="confreq-package-fileprops-name">The Package Document filename SHOULD use the file extension

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -627,705 +627,449 @@
 				</section>
 			</section>
 		</section>
-		<section id="sec-epub-conf">
-			<h2>Conformance Criteria</h2>
+		<section id="sec-publications">
+			<h2>EPUB Publications</h2>
 
-			<p>An <a>EPUB Publication</a> has to meet the following criteria:</p>
+			<section id="sec-epub-conf">
+				<h3>Conformance Criteria</h3>
 
-			<dl class="conformance-list">
-				<dt id="sec-epub-package-conformance">Packages</dt>
-				<dd>
-					<p id="confreq-renditions">It MUST include one or more <a>EPUB Packages</a>, each of which MUST
-						conform to the following requirements:</p>
+				<p>The basic requirements for an EPUB Publication are that:</p>
 
-					<dl class="conformance-list" id="sec-package-conformance">
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-packages">It MUST include one or more <a href="#sec-packages">EPUB
+							Packages</a>.</p>
+					</li>
+					<li>
+						<p id="confreq-a11y">It SHOULD conform to the accessibility requirements defined in
+							[[!EPUBAccessibility-10]].</p>
+					</li>
+					<li>
+						<p id="confreq-ocf">It MUST be packaged in an <a href="#sec-ocf">OCF Container</a>.</p>
+					</li>
+				</ul>
 
-						<dt id="sec-package-conformance-packagedoc">Package Document</dt>
-						<dd>
-							<p id="confreq-package">It MUST contain exactly one <a>Package Document</a>, which MUST
-								conform to the following requirements:</p>
+				<p>Specific conformance details are covered in the rest of this specification.</p>
+			</section>
 
-							<dl class="conformance-list" id="sec-package-content-conf">
-								<dt id="confreq-package-docprops">Document Properties</dt>
-								<dd>
-									<p id="confreq-package-xml"> It MUST meet the conformance constraints for XML
-										documents defined in <a href="#sec-xml-constraints"></a>. </p>
-									<p id="confreq-package-docprops-schema">It MUST conform to all content conformance
-										constraints expressed in <a href="#sec-package-def"></a>.</p>
-									<p class="note">Some of the content conformance constraints can be checked by
-										validating content documents against the schemas provided in <a
-											href="#app-package-schema"></a>.</p>
-								</dd>
-								<dt id="confreq-package-fileprops">File Properties</dt>
-								<dd>
-									<p id="confreq-package-fileprops-name">The Package Document filename SHOULD use the
-										file extension <code class="filename">.opf</code>.</p>
-								</dd>
-							</dl>
+			<section id="sec-publication-resources">
+				<h3>Publication Resources</h3>
 
-							<p id="media-type">Package Documents have the MIME media type
-									<code>application/oebps-package+xml</code> [[!RFC4839]].</p>
-						</dd>
-						<dt id="sec-epub-rendition-content-conformance-all">Publication Resources</dt>
-						<dd>
-							<p id="confreq-rendition-manifest">All <a>Publication Resources</a> associated with the
-								Package MUST be listed in the Package Document (as defined in <a
-									href="#sec-manifest-elem"></a>).</p>
-						</dd>
-						<dt id="sec-package-conformance-nav">EPUB Navigation Document</dt>
-						<dd>
-							<p id="confreq-nav-occur">It MUST contain exactly one <a>EPUB Navigation Document</a>, which
-								MUST conform to the following requirements:</p>
+				<section id="sec-core-media-types">
+					<h4>Core Media Types</h4>
 
-							<ul class="conformance-list" id="sec-package-nav-content-conf">
-								<li>
-									<p id="confreq-cd-nav-docprops-parent">It MUST conform to the content conformance
-										constraints defined in <a href="#sec-xhtml-conf-content">XHTML Content
-											Documents</a>.</p>
-								</li>
-								<li>
-									<p id="confreq-cd-nav-docprops-schema">It MUST conform to the content conformance
-										constraints specific to EPUB Navigation Documents defined in <a
-											href="#sec-package-nav-def"></a>.</p>
-								</li>
-								<li>
-									<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, it MAY
-										be included in the <a href="#sec-spine-elem">spine</a>.</p>
-								</li>
-							</ul>
-						</dd>
-						<dt id="sec-package-conformance-contentdocs">Content Documents</dt>
-						<dd>
-							<p id="confreq-cd">It MUST contain one or more <a>EPUB Content Documents</a>, each of which
-								MUST conform to the corresponding sets of requirements:</p>
+					<section id="sec-cmt-intro">
+						<h5>Introduction</h5>
 
-							<dl class="conformance-list">
-								<dt id="sec-xhtml-conf-content">XHTML Content Documents</dt>
-								<dd>
-									<p>An <a>XHTML Content Document</a> has to meet the following criteria:</p>
+						<p>Each <a>Rendition</a> of an <a>EPUB Publication</a> typically consists of many <a>Publication
+								Resources</a>. These resources are divided into two categories: those that can be
+							included without fallbacks (<a>Core Media Type Resources</a>) and those that cannot
+								(<a>Foreign Resources</a>).</p>
 
-									<dl class="conformance-list">
-										<dt id="confreq-cd-html-docprops">Document Properties</dt>
-										<dd>
-											<p id="confreq-cd-html-docprops-syntax">It MUST be an [[!HTML]] document
-												that conforms to the <a
-													href="https://www.w3.org/TR/html/xhtml.html#xhtml">XHTML</a>
-												syntax.</p>
-											<p id="confreq-cd-html-xml">It MUST meet the conformance constraints for XML
-												documents defined in <a href="#sec-xml-constraints"></a>.</p>
-											<p id="confreq-cd-html-docprops-html">For all document constructs used that
-												are defined by [[!HTML]], it MUST conform to the conformance criteria
-												defined for those constructs in that specification, unless explicitly
-												overridden in <a href="#sec-xhtml-deviations"></a>.</p>
-											<p id="confreq-cd-html-docprops-schema">It MAY include extensions to the
-												[[!HTML]] grammar as defined in <a href="#sec-xhtml-extensions"></a>,
-												and MUST conform to all content conformance constraints defined
-												therein.</p>
-											<div class="note">
-												<p>The recommendation that EPUB Publications follow the accessibility
-													requirements in [[EPUBAccessibility-10]] applies to XHTML Content
-													Documents. See <a href="#sec-epub-a11y">Accessibility</a>.</p>
-											</div>
-										</dd>
-										<dt id="confreq-cd-html-fileprops">File Properties</dt>
-										<dd>
-											<p id="confreq-cd-xhtml-fileprops-name">The XHTML Content Document filename
-												SHOULD use the file extension <code>.xhtml</code></p>
-										</dd>
-									</dl>
-								</dd>
+						<p>Formats are typically only included as Core Media Type Resources when it can be shown that
+							they have broad support in web browser cores &#8212; the rendering engines on which EPUB 3
+							Reading Systems are built. They are an agreement between Reading System developers and
+								<a>Authors</a> to ensure the predictability of rendering of EPUB Publications.</p>
 
-								<dt id="sec-svg-content-conf">SVG Content Documents</dt>
-								<dd>
-									<p>An <a>SVG Content Document</a> has to meet the following criteria:</p>
+						<p>Inclusion as a Core Media Type Resource does not mean that all Reading Systems will support
+							the rendering of a resource, however. Only Reading Systems that are capable of rendering the
+							type of resource have to (e.g., a Reading System with a <a>Viewport</a> has to support image
+							Core Media Type Resources, but a Reading System without a Viewport does not). Refer to <a
+								href="https://www.w3.org/TR/epub-rs-33/#sec-rs-conf-general">Conformance
+								Requirements</a> [[EPUB-RS-33]] for more information about which Reading Systems
+							rendering capabilities require support for which Core Media Type Resources.</p>
 
-									<dl class="conformance-list">
-										<dt id="confreq-svg-docprops">Document Properties</dt>
-										<dd>
-											<p id="confreq-cd-svg-xml">It MUST meet the conformance constraints for XML
-												documents defined in <a href="#sec-xml-constraints"></a>.</p>
-											<p id="confreq-resources-svg-fallback">It MAY include references to
-													<a>Foreign Resources</a> provided a fallback to a <a>Core Media Type
-													Resource</a> is included.</p>
-											<p id="confreq-cd-svg-docprops-schema">It MUST be an <a
-													href="https://www.w3.org/TR/SVG/intro.html#TermSVGDocumentFragment"
-													>SVG document fragment</a> [[!SVG]], and conform to all content
-												conformance constraints expressed in <a href="#sec-svg-restrictions"
-												></a>.</p>
-											<div class="note">
-												<p>The recommendation that EPUB Publications follow the accessibility
-													requirements in [[EPUBAccessibility-10]] applies to SVG Content
-													Documents. See <a href="#sec-epub-a11y">Accessibility</a>.</p>
-											</div>
-										</dd>
+						<p>Foreign Resources come with no guarantee of rendering support, which is why they require a
+							fallback to a Core Media Type Resource. EPUB Publications are designed to be fully
+							consumable on any compliant Reading System, so providing a fallback is necessary to ensure
+							that the use of Foreign Resources does not impact on the ability of the user to consume the
+							content.</p>
 
-										<dt id="confreq-svg-fileprops">File Properties</dt>
-										<dd>
-											<p id="confreq-svg-fileprops-name">The SVG Content Document filename SHOULD
-												use the file extension <code>.svg</code>.</p>
-										</dd>
-									</dl>
-								</dd>
-							</dl>
-						</dd>
-						<dt id="sec-package-conformance-css">CSS Style Sheets</dt>
-						<dd>
-							<p id="confreq-css">It MAY contain zero or more CSS Style Sheets, each of which MUST conform
-								to the following requirements:</p>
+						<p>This section lists the <a href="#sec-cmt-supported">set of Core Media Type Resources</a> and
+							identifies <a href="#sec-foreign-restrictions">fallback mechanisms</a> that can be used to
+							satisfy the consumability requirement.</p>
 
-							<ul class="conformance-list">
-								<li>
-									<p id="confreq-css-props">It MAY include any CSS properties, with the following
-										exceptions:</p>
-									<ul class="conformance-list">
-										<li>
-											<p id="confreq-css-props-exc-direction">It MUST NOT use the <a
-													href="https://www.w3.org/TR/css3-writing-modes/#direction"
-														><code>direction</code> property</a> [[!CSS-Writing-Modes-3]].
-												Use the [[!HTML]] <a
-													href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
-														><code>dir</code> attribute</a> to set the inline base
-												direction.</p>
-										</li>
-										<li>
-											<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT use the <a
-													href="https://www.w3.org/TR/css3-writing-modes/#unicode-bidi"
-														><code>unicode-bidi</code> property</a>
-												[[!CSS-Writing-Modes-3]]. Use [[!HTML]] <a
-													href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdo-element"
-														><code>bdo</code> elements</a> and <a
-													href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
-														><code>dir</code> attributes</a> to control
-												bidirectionality.</p>
-										</li>
-									</ul>
-								</li>
-								<li>
-									<p id="confreq-css-prefixed">It MAY include the prefixed properties defined in <a
-											href="#sec-css-prefixed"></a>.</p>
-								</li>
-								<li>
-									<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p>
-								</li>
-							</ul>
-						</dd>
-						<dt id="sec-package-conformance-pls">Pronunciation Lexicons</dt>
-						<dd>
-							<p id="confreq-pls">It MAY contain zero or more PLS Documents, each of which MUST conform to
-								the following requirements:</p>
+						<div class="note">
+							<p>EPUB also exempts some [[HTML]] elements from support requirements (see <a
+									href="#sec-xhtml-fallbacks"></a>). Resources referenced from these elements are
+								neither Core Media Type Resources nor Foreign Resources &#8212; they do not require
+								fallbacks, but they also have no support requirements.</p>
+						</div>
+					</section>
 
-							<dl class="conformance-list">
-								<dt id="confreq-cd-pls-docprops">Document Properties</dt>
-								<dd>
-									<ul class="conformance-list">
-										<li>
-											<p id="confreq-cd-pls-xml">It MUST meet the conformance constraints for XML
-												documents defined in <a href="#sec-xml-constraints"></a>.</p>
-										</li>
-										<li>
-											<p id="confreq-cd-pls-docprops-schema">It MUST be valid to the RELAX NG
-												schema for PLS documents available at the URI <a class="uri"
-													href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
-														><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/</code></a>
-												[[!PRONUNCIATION-LEXICON]].</p>
-										</li>
-										<li>
-											<p class="confreq-cd-pls-xhtml">It MUST be linked to the applicable XHTML
-												Content Documents as defined in <a href="#sec-pls"></a>.</p>
-										</li>
-									</ul>
-								</dd>
-								<dt id="confreq-cd-pls-fileprops">File Properties</dt>
-								<dd>
-									<p id="confreq-cd-pls-fileprops-name">It SHOULD use the file extension <code
-											class="filename">.pls</code>.</p>
-								</dd>
-							</dl>
-						</dd>
-						<dt id="sec-package-conformance-media-overlays">Media Overlay Documents</dt>
-						<dd>
-							<p id="confreq-mo">It MAY contain zero or more <a>Media Overlay Documents</a>, each of which
-								has to conform to the following requirements:</p>
+					<section id="sec-cmt-supported">
+						<h5>Supported Media Types</h5>
 
-							<dl class="conformance-list" id="sec-overlays-content-conf">
-								<dt id="confreq-mo-docprops">Document Properties</dt>
-								<dd>
-									<ul class="conformance-list">
-										<li>
-											<p id="confreq-mo-xml"> It MUST meet the conformance constraints for XML
-												documents defined in <a href="#sec-xml-constraints"></a>.</p>
-										</li>
-										<li>
-											<p id="confreq-mo-docprops-schema">It MUST be valid to the Media Overlays
-												schema as defined in <a href="#app-schema-overlays"></a> and conform to
-												all content conformance constraints expressed in <a
-													href="#sec-overlays-def"></a>.</p>
-										</li>
-										<li>
-											<p id="confreq-mo-docprops-structure">It MUST be authored to reflect the
-												structure of the <a>EPUB Content Document</a> with which it is
-												associated, as stated in <a href="#sec-media-overlays-structure"
-												></a>.</p>
-										</li>
-										<li>
-											<p id="confreq-mo-docprops-references">It MAY refer to more than one EPUB
-												Content Document, but an EPUB Content Document MUST NOT be referenced by
-												more than one Media Overlay Document.</p>
-										</li>
-										<li>
-											<p id="confreq-mo-docprops-embed">It MUST adhere to the requirements for <a
-													href="#sec-audio-video">Embedded Media</a>.</p>
-										</li>
-										<li>
-											<p id="confreq-mo-docprops-semantics">It SHOULD use semantic markup where
-												appropriate, as described in <a href="#sec-docs-semantic-inflection"
-												></a>.</p>
-										</li>
-										<li>
-											<p id="confreq-mo-docprops-package">It MUST be packaged with the <a>EPUB
-													Publication</a> as shown in <a href="#sec-docs-package"></a>.</p>
-										</li>
-									</ul>
-								</dd>
-								<dt id="confreq-mo-fileprops">File Properties</dt>
-								<dd>
-									<p id="confreq-mo-fileprops-name">The Media Overlay Document filename SHOULD use the
-										file extension <code class="filename">.smil</code>.</p>
-								</dd>
-							</dl>
-						</dd>
-						<dt id="sec-package-conformance-additional">Additional Resources</dt>
-						<dd>
-							<p id="confreq-additional">It MAY contain zero or more <a>Publication Resources</a> in
-								addition to those listed above, each of which MUST adhere to the requirements in <a
-									href="#sec-epub-pub-conformance-all">Publication Resources</a>.</p>
-						</dd>
-					</dl>
-				</dd>
-				<dt id="sec-epub-a11y">Accessibility</dt>
-				<dd>
-					<p id="confreq-a11y">It SHOULD conform to the accessibility requirements defined in
-						[[!EPUBAccessibility-10]].</p>
-				</dd>
-				<dt id="sec-epub-pub-conformance-all">Publication Resources</dt>
-				<dd>
-					<p id="confreq-manifest">All <a>Publication Resources</a> MUST adhere to the <a
-							href="#sec-publication-resources">constraints for Core Media Type and Foreign Resources</a>
-						and be located as per <a href="#sec-resource-locations"></a>.</p>
-				</dd>
-				<dt id="sec-epub-pub-conformance-container">Container</dt>
-				<dd>
-					<p id="confreq-ocf">It MUST be packaged in a <a>EPUB Container</a> that meets the following
-						requirements:</p>
+						<p><a>Publication Resources</a> that conform to the following MIME media type [[!RFC2046]]
+							specifications can be included in an EPUB Publication without fallbacks.</p>
 
-					<ul class="conformance-list" id="sec-ocf-conformance">
+						<p>The columns in the following table represent the following information:</p>
+
+						<ul>
+							<li>
+								<p><strong>Media Type</strong>—The MIME media type [[!RFC2046]] used to represent the
+									given Publication Resource in the <a href="#sec-manifest-elem">manifest</a>.</p>
+								<p>If more than one media type is listed, the first one is the preferred media type. The
+									preferred media type is strongly encouraged for all new EPUB Publications.</p>
+							</li>
+
+							<li><strong>Content Type Definition</strong>—The specification to which the given Core Media
+								Type Resource has to conform.</li>
+
+							<li><strong>Applies to</strong>—The Publication Resource type(s) that the Media Type and
+								Content Type Definition applies to.</li>
+						</ul>
+
+						<table id="tbl-core-media-types">
+							<thead>
+								<tr>
+									<th id="tbl-cmt-string">Media Type</th>
+									<th id="tbl-cmt-def">Content Type Definition</th>
+									<th id="tbl-cmt-appl">Applies to</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
+								</tr>
+								<tr>
+									<td id="cmt-gif">
+										<code>image/gif</code>
+									</td>
+									<td> [[!GIF]] </td>
+									<td>GIF Images</td>
+								</tr>
+
+								<tr>
+									<td id="cmt-jpeg">
+										<code>image/jpeg</code>
+									</td>
+									<td> [[!JPEG]] </td>
+									<td>JPEG Images</td>
+								</tr>
+								<tr>
+									<td id="cmt-png">
+										<code>image/png</code>
+									</td>
+									<td> [[!PNG]] </td>
+									<td>PNG Images</td>
+								</tr>
+								<tr>
+									<td id="cmt-svg">
+										<code>image/svg+xml</code>
+									</td>
+									<td>
+										<a href="#sec-svg">SVG Content Documents</a>
+									</td>
+									<td>SVG documents</td>
+								</tr>
+
+
+								<tr>
+									<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>
+								</tr>
+								<tr>
+									<td id="cmt-mp3">
+										<code>audio/mpeg</code>
+									</td>
+									<td> [[!MP3]] </td>
+									<td>MP3 audio</td>
+								</tr>
+								<tr>
+									<td id="cmt-mp4-aac">
+										<code>audio/mp4</code>
+									</td>
+									<td> [[!MPEG4-Audio]], [[!MP4]] </td>
+									<td>AAC LC audio using MP4 container</td>
+								</tr>
+								<tr>
+									<td id="cmt-ogg-opus">
+										<code>audio/opus</code>
+									</td>
+									<td>[[!RFC7845]]</td>
+									<td>OPUS audio using OGG container</td>
+								</tr>
+								<tr>
+									<th colspan="3" id="cmt-grp-video" class="tbl-group">Video</th>
+								</tr>
+								<tr>
+									<td colspan="3" id="cmt-vide-note">EPUB 3 allows any video codecs to be included
+										without fallbacks, although none are technically considered Core Media Type
+										Resources. Refer to the note in <a
+											href="https://www.w3.org/TR/epub-rs-33/#note-video-codecs">Conformance —
+											General Requirements</a> [[EPUB-RS-33]] for informative recommendations on
+										support for video codecs in EPUB Publications. </td>
+								</tr>
+								<tr>
+									<th colspan="3" id="cmt-grp-text" class="tbl-group">Style</th>
+								</tr>
+								<tr>
+									<td id="cmt-css">
+										<code>text/css</code>
+									</td>
+									<td>
+										<a href="#sec-css">CSS Style Sheets</a>
+									</td>
+									<td>CSS Style Sheets.</td>
+								</tr>
+								<tr>
+									<th colspan="3" id="cmt-grp-font" class="tbl-group">Fonts</th>
+								</tr>
+								<tr>
+									<td colspan="3" id="cmt-font-note"> EPUB 3 allows any font resource to be included
+										without a fallback, as CSS already defines fallback rules for fonts. Refer to
+										the <a href="https://www.w3.org/TR/epub-rs-33/#confreq-css-rs-fonts">Reading
+											System support requirements for fonts</a> [[!EPUB-RS-33]] for more
+										information.</td>
+								</tr>
+								<tr>
+									<td id="cmt-sfnt">
+										<code>font/ttf</code>
+										<br />
+										<code>application/font-sfnt</code>
+									</td>
+									<td>[[!TrueType]] </td>
+									<td>TrueType fonts</td>
+								</tr>
+								<tr>
+									<td id="cmt-otf">
+										<code>font/otf</code>
+										<br />
+										<code>application/font-sfnt</code>
+										<br />
+										<code>application/vnd.ms-opentype</code>
+									</td>
+									<td>[[!OpenType]]</td>
+									<td>OpenType fonts</td>
+
+								</tr>
+								<tr>
+									<td id="cmt-woff">
+										<code>font/woff</code>
+										<br />
+										<code>application/font-woff</code>
+									</td>
+									<td> [[!WOFF]] </td>
+									<td>WOFF fonts</td>
+								</tr>
+								<tr>
+									<td id="cmt-woff2">
+										<code>font/woff2</code>
+									</td>
+									<td> [[!WOFF2]] </td>
+									<td>WOFF2 fonts</td>
+								</tr>
+								<tr>
+									<th colspan="3" id="cmt-grp-other" class="tbl-group">Other</th>
+								</tr>
+
+								<tr>
+									<td id="cmt-xhtml">
+										<code>application/xhtml+xml</code>
+									</td>
+									<td>
+										<a href="#sec-xhtml">XHTML Content Documents</a>
+									</td>
+									<td><a>XHTML Content Documents</a> that use the <a
+											href="https://www.w3.org/TR/html/xhtml.html#xhtml">XHTML syntax</a>
+										[[!HTML]]. </td>
+								</tr>
+								<tr>
+									<td id="cmt-js">
+										<code>application/javascript</code>
+										<br />
+										<code>text/javascript</code>
+									</td>
+									<td> [[!RFC4329]] </td>
+									<td>Scripts.</td>
+								</tr>
+								<tr>
+									<td id="cmt-ncx">
+										<code>application/x-dtbncx+xml</code>
+									</td>
+									<td> [[!OPF-201]] </td>
+									<td>The <a href="#legacy">legacy</a> NCX.</td>
+								</tr>
+
+								<tr>
+									<td id="cmt-smil">
+										<code>application/smil+xml</code>
+									</td>
+									<td>
+										<a href="#sec-media-overlays">Media Overlays</a>
+									</td>
+									<td>EPUB Media Overlay documents</td>
+								</tr>
+								<tr>
+									<td id="cmt-pls">
+										<code>application/pls+xml</code>
+									</td>
+									<td> [[!PRONUNCIATION-LEXICON]] </td>
+									<td><a>Text-to-Speech</a> (TTS) Pronunciation lexicons</td>
+								</tr>
+							</tbody>
+						</table>
+						<div class="issue" data-number="645">
+							<p>Although, OPUS/OGG has good support in Android, MacOS, Windows, and Linux, Apple,
+								starting with iOS 11, only supports the OPUS codec in a CAF container. The working group
+								will monitor support for OPUS in iOS, and may remove OPUS as a core media type if the
+								level of support is inadequate.</p>
+						</div>
+					</section>
+
+					<section id="sec-foreign-restrictions">
+						<h5>Foreign Resources</h5>
+
+						<p id="confreq-foreign-no-fallback">Foreign Resources MAY be included in an EPUB Publication
+							without a fallback provided they are not referenced from <a href="#sec-itemref-elem">spine
+									<code>itemref</code> elements</a> or directly rendered in their native format in
+							EPUB Content Documents (e.g., via [[!HTML]] <a
+								href="https://www.w3.org/TR/html/dom.html#embedded-content">embedded content</a> and
+							[[!SVG]] <a href="https://www.w3.org/TR/SVG/struct.html#ImageElement"><code>image</code></a>
+							and <a href="https://www.w3.org/TR/SVG/extend.html#ForeignObjectElement"
+									><code>foreignObject</code></a> elements).</p>
+
+						<p class="note">This exception allows Authors to include resources in the <a>EPUB Container</a>
+							that are not for use by EPUB Reading Systems. The primary case for this exception is to
+							allow data files to travel with an EPUB Publication, whether for use by scripts in its
+							constituent EPUB Content Documents or for use by external applications (e.g., a scientific
+							journal might include a data set with instructions on how to extract it from the EPUB
+							Container).</p>
+
+						<p id="confreq-cmt">When a <a>Foreign Resource</a> is included in the spine or directly rendered
+							in its native format in an EPUB Content Document, a fallback <a>Core Media Type Resource</a>
+							MUST be included. Fallbacks take one of the two following forms:</p>
+
+						<ul>
+							<li>
+								<p>intrinsic fallback mechanisms provided by the host format (e.g., [[HTML]] elements
+									often provide the ability to reference more than one media type or to display an
+									alternate embedded message when a media type cannot be rendered);</p>
+							</li>
+							<li>
+								<p><a href="#sec-foreign-restrictions-manifest">manifest fallbacks</a>.</p>
+							</li>
+						</ul>
+
+						<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback chains
+							to Core Media Type Resources. They are used to create fallbacks for Foreign Resources in the
+								<a href="#sec-spine-elem">spine</a> and when intrinsic fallback capabilities are not
+							available (e.g., for the [[!HTML]] <a
+								href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-img-element"
+									><code>img</code></a> element).</p>
+
+						<p>Refer to the [[!HTML]] and [[!SVG]] specifications for the intrinsic fallback capabilities
+							their elements provide.</p>
+					</section>
+				</section>
+
+				<section id="sec-resource-locations">
+					<h4>Resource Locations</h4>
+
+					<p>All <a>Publication Resources</a> MUST be <a href="#sec-container-iri">located in the EPUB
+							Container</a>, with the following exceptions:</p>
+
+					<ul class="conformance-list">
 						<li>
-							<p id="confreq-ocf-content-abstr">It MUST meet the conformance constraints for the OCF
-								Abstract Container defined in <a href="#sec-container-abstract"></a>.</p>
+							<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a> MAY be
+								located outside the EPUB Container.</p>
 						</li>
 						<li>
-							<p id="confreq-ocf-content-zip">It MUST meet the conformance constraints for the OCF ZIP
-								Container defined in <a href="#sec-container-zip"></a>.</p>
+							<p id="sec-resource-locations-video"><a href="#cmt-grp-video">Video resources</a> MAY be
+								located outside the EPUB Container.</p>
+						</li>
+						<li>
+							<p id="sec-resource-locations-script">Resources retrieved by scripts MAY be located outside
+								the EPUB Container.</p>
+						</li>
+						<li>
+							<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a> MAY be
+								located outside the EPUB Container.</p>
 						</li>
 					</ul>
-				</dd>
-			</dl>
-		</section>
-		<section id="sec-publication-resources">
-			<h2>Publication Resources</h2>
 
-			<section id="sec-core-media-types">
-				<h3>Core Media Types</h3>
+					<aside class="example">
+						<p>The following example shows a reference to an audio file in an <a>XHTML Content Document</a>
+							that is located inside the EPUB Container.</p>
+						<pre>&lt;audio src="audio/ch01.mp4" controls="controls"/&gt;</pre>
+					</aside>
 
-				<section id="sec-cmt-intro">
-					<h4>Introduction</h4>
-
-					<p>Each <a>Rendition</a> of an <a>EPUB Publication</a> typically consists of many <a>Publication
-							Resources</a>. These resources are divided into two categories: those that can be included
-						without fallbacks (<a>Core Media Type Resources</a>) and those that cannot (<a>Foreign
-							Resources</a>).</p>
-
-					<p>Formats are typically only included as Core Media Type Resources when it can be shown that they
-						have broad support in web browser cores &#8212; the rendering engines on which EPUB 3 Reading
-						Systems are built. They are an agreement between Reading System developers and <a>Authors</a> to
-						ensure the predictability of rendering of EPUB Publications.</p>
-
-					<p>Inclusion as a Core Media Type Resource does not mean that all Reading Systems will support the
-						rendering of a resource, however. Only Reading Systems that are capable of rendering the type of
-						resource have to (e.g., a Reading System with a <a>Viewport</a> has to support image Core Media
-						Type Resources, but a Reading System without a Viewport does not). Refer to <a
-							href="https://www.w3.org/TR/epub-rs-33/#sec-rs-conf-general">Conformance Requirements</a>
-						[[EPUB-RS-33]] for more information about which Reading Systems rendering capabilities require
-						support for which Core Media Type Resources.</p>
-
-					<p>Foreign Resources come with no guarantee of rendering support, which is why they require a
-						fallback to a Core Media Type Resource. EPUB Publications are designed to be fully consumable on
-						any compliant Reading System, so providing a fallback is necessary to ensure that the use of
-						Foreign Resources does not impact on the ability of the user to consume the content.</p>
-
-					<p>This section lists the <a href="#sec-cmt-supported">set of Core Media Type Resources</a> and
-						identifies <a href="#sec-foreign-restrictions">fallback mechanisms</a> that can be used to
-						satisfy the consumability requirement.</p>
+					<aside class="example">
+						<p>The following example shows a reference to an audio file in an XHTML Content Document that is
+							located outside the EPUB Container.</p>
+						<pre>&lt;audio src="http://www.example.com/book/audio/ch01.mp4" controls="controls"/&gt;</pre>
+					</aside>
 
 					<div class="note">
-						<p>EPUB also exempts some [[HTML]] elements from support requirements (see <a
-								href="#sec-xhtml-fallbacks"></a>). Resources referenced from these elements are neither
-							Core Media Type Resources nor Foreign Resources &#8212; they do not require fallbacks, but
-							they also have no support requirements.</p>
+						<p>Authors are encouraged to locate audio, video and script resources inside the EPUB Container
+							whenever feasible to allow users access to the entire presentation regardless of
+							connectivity status.</p>
 					</div>
+
+					<div class="note">
+						<p>The rules in this section for Publication Resource locations apply regardless of whether the
+							given resource is a <a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
+					</div>
+
+					<div class="note">
+						<p>The inclusion of Remote Resources in an <a>EPUB Publication</a> is indicated via the <a
+								href="#remote-resources"><code>remote-resources</code> property</a> on the
+								<a>manifest</a>
+							<a href="#sec-item-elem"><code>item</code> element</a>.</p>
+					</div>
+
 				</section>
 
-				<section id="sec-cmt-supported">
-					<h4>Supported Media Types</h4>
+				<section id="sec-xml-constraints">
+					<h4>XML Conformance</h4>
 
-					<p><a>Publication Resources</a> that conform to the following MIME media type [[!RFC2046]]
-						specifications can be included in an EPUB Publication without fallbacks.</p>
+					<p>Any <a>Publication Resource</a> that is an XML-Based Media Type has to meet the following
+						constraints:</p>
 
-					<p>The columns in the following table represent the following information:</p>
-
-					<ul>
+					<ul class="conformance-list">
 						<li>
-							<p><strong>Media Type</strong>—The MIME media type [[!RFC2046]] used to represent the given
-								Publication Resource in the <a href="#sec-manifest-elem">manifest</a>.</p>
-							<p>If more than one media type is listed, the first one is the preferred media type. The
-								preferred media type is strongly encouraged for all new EPUB Publications.</p>
-						</li>
-
-						<li><strong>Content Type Definition</strong>—The specification to which the given Core Media
-							Type Resource has to conform.</li>
-
-						<li><strong>Applies to</strong>—The Publication Resource type(s) that the Media Type and Content
-							Type Definition applies to.</li>
-					</ul>
-
-					<table id="tbl-core-media-types">
-						<thead>
-							<tr>
-								<th id="tbl-cmt-string">Media Type</th>
-								<th id="tbl-cmt-def">Content Type Definition</th>
-								<th id="tbl-cmt-appl">Applies to</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
-							</tr>
-							<tr>
-								<td id="cmt-gif">
-									<code>image/gif</code>
-								</td>
-								<td> [[!GIF]] </td>
-								<td>GIF Images</td>
-							</tr>
-
-							<tr>
-								<td id="cmt-jpeg">
-									<code>image/jpeg</code>
-								</td>
-								<td> [[!JPEG]] </td>
-								<td>JPEG Images</td>
-							</tr>
-							<tr>
-								<td id="cmt-png">
-									<code>image/png</code>
-								</td>
-								<td> [[!PNG]] </td>
-								<td>PNG Images</td>
-							</tr>
-							<tr>
-								<td id="cmt-svg">
-									<code>image/svg+xml</code>
-								</td>
-								<td>
-									<a href="#sec-svg">SVG Content Documents</a>
-								</td>
-								<td>SVG documents</td>
-							</tr>
-
-
-							<tr>
-								<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>
-							</tr>
-							<tr>
-								<td id="cmt-mp3">
-									<code>audio/mpeg</code>
-								</td>
-								<td> [[!MP3]] </td>
-								<td>MP3 audio</td>
-							</tr>
-							<tr>
-								<td id="cmt-mp4-aac">
-									<code>audio/mp4</code>
-								</td>
-								<td> [[!MPEG4-Audio]], [[!MP4]] </td>
-								<td>AAC LC audio using MP4 container</td>
-							</tr>
-							<tr>
-								<td id="cmt-ogg-opus">
-									<code>audio/opus</code>
-								</td>
-								<td>[[!RFC7845]]</td>
-								<td>OPUS audio using OGG container</td>
-							</tr>
-							<tr>
-								<th colspan="3" id="cmt-grp-video" class="tbl-group">Video</th>
-							</tr>
-							<tr>
-								<td colspan="3" id="cmt-vide-note">EPUB 3 allows any video codecs to be included without
-									fallbacks, although none are technically considered Core Media Type Resources. Refer
-									to the note in <a href="https://www.w3.org/TR/epub-rs-33/#note-video-codecs"
-										>Conformance — General Requirements</a> [[EPUB-RS-33]] for informative
-									recommendations on support for video codecs in EPUB Publications. </td>
-							</tr>
-							<tr>
-								<th colspan="3" id="cmt-grp-text" class="tbl-group">Style</th>
-							</tr>
-							<tr>
-								<td id="cmt-css">
-									<code>text/css</code>
-								</td>
-								<td>
-									<a href="#sec-css">CSS Style Sheets</a>
-								</td>
-								<td>CSS Style Sheets.</td>
-							</tr>
-							<tr>
-								<th colspan="3" id="cmt-grp-font" class="tbl-group">Fonts</th>
-							</tr>
-							<tr>
-								<td colspan="3" id="cmt-font-note"> EPUB 3 allows any font resource to be included
-									without a fallback, as CSS already defines fallback rules for fonts. Refer to the <a
-										href="https://www.w3.org/TR/epub-rs-33/#confreq-css-rs-fonts">Reading System
-										support requirements for fonts</a> [[!EPUB-RS-33]] for more information.</td>
-							</tr>
-							<tr>
-								<td id="cmt-sfnt">
-									<code>font/ttf</code>
-									<br />
-									<code>application/font-sfnt</code>
-								</td>
-								<td>[[!TrueType]] </td>
-								<td>TrueType fonts</td>
-							</tr>
-							<tr>
-								<td id="cmt-otf">
-									<code>font/otf</code>
-									<br />
-									<code>application/font-sfnt</code>
-									<br />
-									<code>application/vnd.ms-opentype</code>
-								</td>
-								<td>[[!OpenType]]</td>
-								<td>OpenType fonts</td>
-
-							</tr>
-							<tr>
-								<td id="cmt-woff">
-									<code>font/woff</code>
-									<br />
-									<code>application/font-woff</code>
-								</td>
-								<td> [[!WOFF]] </td>
-								<td>WOFF fonts</td>
-							</tr>
-							<tr>
-								<td id="cmt-woff2">
-									<code>font/woff2</code>
-								</td>
-								<td> [[!WOFF2]] </td>
-								<td>WOFF2 fonts</td>
-							</tr>
-							<tr>
-								<th colspan="3" id="cmt-grp-other" class="tbl-group">Other</th>
-							</tr>
-
-							<tr>
-								<td id="cmt-xhtml">
-									<code>application/xhtml+xml</code>
-								</td>
-								<td>
-									<a href="#sec-xhtml">XHTML Content Documents</a>
-								</td>
-								<td><a>XHTML Content Documents</a> that use the <a
-										href="https://www.w3.org/TR/html/xhtml.html#xhtml">XHTML syntax</a> [[!HTML]].
-								</td>
-							</tr>
-							<tr>
-								<td id="cmt-js">
-									<code>application/javascript</code>
-									<br />
-									<code>text/javascript</code>
-								</td>
-								<td> [[!RFC4329]] </td>
-								<td>Scripts.</td>
-							</tr>
-							<tr>
-								<td id="cmt-ncx">
-									<code>application/x-dtbncx+xml</code>
-								</td>
-								<td> [[!OPF-201]] </td>
-								<td>The <a href="#legacy">legacy</a> NCX.</td>
-							</tr>
-
-							<tr>
-								<td id="cmt-smil">
-									<code>application/smil+xml</code>
-								</td>
-								<td>
-									<a href="#sec-media-overlays">Media Overlays</a>
-								</td>
-								<td>EPUB Media Overlay documents</td>
-							</tr>
-							<tr>
-								<td id="cmt-pls">
-									<code>application/pls+xml</code>
-								</td>
-								<td> [[!PRONUNCIATION-LEXICON]] </td>
-								<td><a>Text-to-Speech</a> (TTS) Pronunciation lexicons</td>
-							</tr>
-						</tbody>
-					</table>
-					<div class="issue" data-number="645">
-						<p>Although, OPUS/OGG has good support in Android, MacOS, Windows, and Linux, Apple, starting
-							with iOS 11, only supports the OPUS codec in a CAF container. The working group will monitor
-							support for OPUS in iOS, and may remove OPUS as a core media type if the level of support is
-							inadequate.</p>
-					</div>
-				</section>
-
-				<section id="sec-foreign-restrictions">
-					<h4>Foreign Resources</h4>
-
-					<p id="confreq-foreign-no-fallback">Foreign Resources MAY be included in an EPUB Publication without
-						a fallback provided they are not referenced from <a href="#sec-itemref-elem">spine
-								<code>itemref</code> elements</a> or directly rendered in their native format in EPUB
-						Content Documents (e.g., via [[!HTML]] <a
-							href="https://www.w3.org/TR/html/dom.html#embedded-content">embedded content</a> and
-						[[!SVG]] <a href="https://www.w3.org/TR/SVG/struct.html#ImageElement"><code>image</code></a> and
-							<a href="https://www.w3.org/TR/SVG/extend.html#ForeignObjectElement"
-								><code>foreignObject</code></a> elements).</p>
-
-					<p class="note">This exception allows Authors to include resources in the <a>EPUB Container</a> that
-						are not for use by EPUB Reading Systems. The primary case for this exception is to allow data
-						files to travel with an EPUB Publication, whether for use by scripts in its constituent EPUB
-						Content Documents or for use by external applications (e.g., a scientific journal might include
-						a data set with instructions on how to extract it from the EPUB Container).</p>
-
-					<p id="confreq-cmt">When a <a>Foreign Resource</a> is included in the spine or directly rendered in
-						its native format in an EPUB Content Document, a fallback <a>Core Media Type Resource</a> MUST
-						be included. Fallbacks take one of the two following forms:</p>
-
-					<ul>
-						<li>
-							<p>intrinsic fallback mechanisms provided by the host format (e.g., [[HTML]] elements often
-								provide the ability to reference more than one media type or to display an alternate
-								embedded message when a media type cannot be rendered);</p>
+							<p id="confreq-xml-wellformed"> It MUST be a conformant XML 1.0 Document as defined in <a
+									href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#Conformance">Conformance of
+									Documents</a> [[!XML-NAMES]].</p>
 						</li>
 						<li>
-							<p><a href="#sec-foreign-restrictions-manifest">manifest fallbacks</a>.</p>
+							<p id="confreq-xml-extmarkupdecl">
+								<a href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">External
+									identifiers</a> MUST NOT appear in the document type declaration [[!XML]].</p>
+						</li>
+						<li>
+							<p id="confreq-xml-xinc"> It MUST NOT make use of XInclude [[!XInclude]].</p>
+						</li>
+						<li>
+							<p id="confreq-xml-enc"> It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p>
 						</li>
 					</ul>
 
-					<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback chains to
-						Core Media Type Resources. They are used to create fallbacks for Foreign Resources in the <a
-							href="#sec-spine-elem">spine</a> and when intrinsic fallback capabilities are not available
-						(e.g., for the [[!HTML]] <a
-							href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-img-element"
-								><code>img</code></a> element).</p>
+					<p>The above constraints apply regardless of whether the given Publication Resource is a <a>Core
+							Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
 
-					<p>Refer to the [[!HTML]] and [[!SVG]] specifications for the intrinsic fallback capabilities their
-						elements provide.</p>
 				</section>
-			</section>
-
-			<section id="sec-resource-locations">
-				<h3>Resource Locations</h3>
-
-				<p>All <a>Publication Resources</a> MUST be <a href="#sec-container-iri">located in the EPUB
-						Container</a>, with the following exceptions:</p>
-
-				<ul class="conformance-list">
-					<li>
-						<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a> MAY be located
-							outside the EPUB Container.</p>
-					</li>
-					<li>
-						<p id="sec-resource-locations-video"><a href="#cmt-grp-video">Video resources</a> MAY be located
-							outside the EPUB Container.</p>
-					</li>
-					<li>
-						<p id="sec-resource-locations-script">Resources retrieved by scripts MAY be located outside the
-							EPUB Container.</p>
-					</li>
-					<li>
-						<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a> MAY be located
-							outside the EPUB Container.</p>
-					</li>
-				</ul>
-
-				<aside class="example">
-					<p>The following example shows a reference to an audio file in an <a>XHTML Content Document</a> that
-						is located inside the EPUB Container.</p>
-					<pre>&lt;audio src="audio/ch01.mp4" controls="controls"/&gt;</pre>
-				</aside>
-
-				<aside class="example">
-					<p>The following example shows a reference to an audio file in an XHTML Content Document that is
-						located outside the EPUB Container.</p>
-					<pre>&lt;audio src="http://www.example.com/book/audio/ch01.mp4" controls="controls"/&gt;</pre>
-				</aside>
-
-				<div class="note">
-					<p>Authors are encouraged to locate audio, video and script resources inside the EPUB Container
-						whenever feasible to allow users access to the entire presentation regardless of connectivity
-						status.</p>
-				</div>
-
-				<div class="note">
-					<p>The rules in this section for Publication Resource locations apply regardless of whether the
-						given resource is a <a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
-				</div>
-
-				<div class="note">
-					<p>The inclusion of Remote Resources in an <a>EPUB Publication</a> is indicated via the <a
-							href="#remote-resources"><code>remote-resources</code> property</a> on the <a>manifest</a>
-						<a href="#sec-item-elem"><code>item</code> element</a>.</p>
-				</div>
-
-			</section>
-
-			<section id="sec-xml-constraints">
-				<h3>XML Conformance</h3>
-
-				<p>Any <a>Publication Resource</a> that is an XML-Based Media Type has to meet the following
-					constraints:</p>
-
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-xml-wellformed"> It MUST be a conformant XML 1.0 Document as defined in <a
-								href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#Conformance">Conformance of
-								Documents</a> [[!XML-NAMES]].</p>
-					</li>
-					<li>
-						<p id="confreq-xml-extmarkupdecl">
-							<a href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">External
-								identifiers</a> MUST NOT appear in the document type declaration [[!XML]].</p>
-					</li>
-					<li>
-						<p id="confreq-xml-xinc"> It MUST NOT make use of XInclude [[!XInclude]].</p>
-					</li>
-					<li>
-						<p id="confreq-xml-enc"> It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p>
-					</li>
-				</ul>
-
-				<p>The above constraints apply regardless of whether the given Publication Resource is a <a>Core Media
-						Type Resource</a> or a <a>Foreign Resource</a>.</p>
-
 			</section>
 		</section>
 		<section id="sec-packages">
 			<h2>EPUB Packages</h2>
+
+			<section id="sec-package-construction">
+				<h3>Package Construction</h3>
+
+				<p>An EPUB Package has the following requirements:</p>
+
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-package">It MUST contain exactly one <a>Package Document</a>, including all
+							content requirements defined in <a href="#sec-package-doc"></a>.</p>
+					</li>
+					<li>
+						<p id="confreq-nav">It MUST contain exactly one <a href="#sec-nav-doc">EPUB Navigation
+								Document</a>.</p>
+					</li>
+				</ul>
+			</section>
 
 			<section id="sec-package-doc">
 				<h3>Package Document</h3>
@@ -1366,7 +1110,6 @@
 								rendering.</p>
 						</li>
 					</ul>
-
 				</section>
 
 				<section id="sec-package-def">
@@ -2712,13 +2455,15 @@
 								</dd>
 							</dl>
 
+							<p id="confreq-rendition-manifest">All <a>Publication Resources</a> associated with the
+								Package MUST be listed in the <code>manifest</code>.</p>
+
 							<div class="note">
 								<p>This specification supports internationalized resource naming, so elements and
 									attributes that reference Publication Resources accept IRIs as their value. For
 									compatibility with older Reading Systems that only accept URIs, resource names need
 									to be restricted to the ASCII character set.</p>
 							</div>
-
 						</section>
 
 						<section id="sec-item-elem">
@@ -3089,7 +2834,10 @@ Manifest:
 								</dd>
 							</dl>
 
-							<p id="spine-inclusion-req">All <a>Publication Resources</a> that are hyperlinked to from
+							<p id="confreq-pub-resource">The <code>spine</code> MUST include at least one <a>Publication
+									Resource</a>.</p>
+
+							<p id="spine-inclusion-req">All Publication Resources that are hyperlinked to from
 								Publication Resources in the <code>spine</code> MUST themselves be listed in the
 									<code>spine</code>, where hyperlinking is defined to be any linking mechanism that
 								requires the user to navigate away from the current resource. Common hyperlinking
@@ -3499,6 +3247,15 @@ Manifest:
 					</section>
 				</section>
 
+				<section id="sec-package-enc">
+					<h4>Package Document Encoding</h4>
+
+					<p id="confreq-package-fileprops-name">The Package Document filename SHOULD use the file extension
+							<code class="filename">.opf</code>.</p>
+
+					<p id="media-type">Package Documents have the MIME media type
+							<code>application/oebps-package+xml</code> [[!RFC4839]].</p>
+				</section>
 			</section>
 
 			<section id="sec-package-metadata">
@@ -4602,7 +4359,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						included in the <a>spine</a>. The use of <a href="#confreq-cd-scripted-spine">progressive
 							enhancement</a> techniques for scripting and styling of the navigation document will help
 						ensure the content will retain its integrity when rendered in a non-browser context.</p>
-
 				</section>
 
 				<section id="sec-package-nav-def">
@@ -4790,6 +4546,9 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 &lt;/nav&gt;
 </pre>
 						</aside>
+
+						<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, the EPUB
+							Navigation Document MAY be included in the <a href="#sec-spine-elem">spine</a>.</p>
 
 						<p id="confreq-nav-ol-style">In the context of this specification, the default display style of
 							list items within <code>nav</code> elements is equivalent to the <a
@@ -5060,6 +4819,38 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 					<p>Unless otherwise specified, this specification inherits all definitions of semantics, structure
 						and processing behaviors from the [[!HTML]] specification.</p>
+				</section>
+
+				<section id="sec-xhtml-req">
+					<h4>XHTML Requirements</h4>
+
+					<p>An XHTML Content Document has to meet the following basic requirements:</p>
+
+					<ul class="conformance-list">
+						<li>
+							<p id="confreq-cd-html-docprops-syntax">It MUST be an [[!HTML]] document that conforms to
+								the <a href="https://www.w3.org/TR/html/xhtml.html#xhtml">XHTML</a> syntax.</p>
+						</li>
+						<li>
+							<p id="confreq-cd-html-docprops-html">It MUST conform to the conformance criteria for all
+								document constructs defined by [[!HTML]] unless explicitly overridden in <a
+									href="#sec-xhtml-deviations"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-cd-html-docprops-schema">It MAY include extensions to the [[!HTML]] grammar
+								as defined in <a href="#sec-xhtml-extensions"></a>, and MUST conform to all content
+								conformance constraints defined therein.</p>
+						</li>
+						<li>
+							<p id="confreq-cd-xhtml-fileprops-name">It SHOULD use the file extension
+								<code>.xhtml</code></p>
+						</li>
+					</ul>
+					<div class="note">
+						<p>The recommendation that EPUB Publications follow the accessibility requirements in
+							[[EPUBAccessibility-10]] applies to XHTML Content Documents. See <a href="#sec-epub-a11y"
+								>Accessibility</a>.</p>
+					</div>
 				</section>
 
 				<section id="sec-xhtml-extensions">
@@ -5719,6 +5510,30 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					</div>
 				</section>
 
+				<section id="sec-svg-req">
+					<h4>SVG Requirements</h4>
+
+					<p>An SVG Content Document has to meet the following requirements:</p>
+
+					<ul>
+						<li>
+							<p id="confreq-cd-svg-docprops-schema">It MUST be an <a
+									href="https://www.w3.org/TR/SVG/intro.html#TermSVGDocumentFragment">SVG document
+									fragment</a> [[!SVG]], and conform to all content conformance constraints expressed
+								in <a href="#sec-svg-restrictions"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-svg-fileprops-name">It SHOULD use the file extension <code>.svg</code>.</p>
+						</li>
+					</ul>
+
+					<div class="note">
+						<p>The recommendation that EPUB Publications follow the accessibility requirements in
+							[[EPUBAccessibility-10]] applies to SVG Content Documents. See <a href="#sec-epub-a11y"
+								>Accessibility</a>.</p>
+					</div>
+				</section>
+
 				<section id="sec-svg-restrictions">
 					<h4>Restrictions on SVG</h4>
 
@@ -5766,10 +5581,12 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 				<section id="sec-svg-semantic-inflection">
 					<h4>Semantic Inflection</h4>
+
 					<p>The syntax and semantics defined in <a href="#sec-xhtml-semantic-inflection"></a> are inherited
 						for use of the <a href="#attrdef-epub-type"><code>epub:type</code></a> and <a
 							href="#sec-contentdocs-prefix-attr"><code>epub:prefix</code></a> attributes in <a>SVG
 							Content Documents</a>.</p>
+
 					<p>The use of the <code>epub:prefix</code> attribute is only valid on the root <code>svg</code>
 						element in SVG Content Documents. Prefixes used in <a href="#sec-xhtml-svg">embedded SVG</a>
 						MUST be declared on the [[!HTML]] root <a
@@ -5808,6 +5625,45 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							</li>
 						</ul>
 					</div>
+				</section>
+
+				<section id="sec-css-req">
+					<h4>CSS Requirements</h4>
+
+					<p>A CSS style sheets has to meet the following requirements:</p>
+
+					<ul class="conformance-list">
+						<li>
+							<p id="confreq-css-props">It MAY include any CSS properties, with the following
+								exceptions:</p>
+							<ul class="conformance-list">
+								<li>
+									<p id="confreq-css-props-exc-direction">It MUST NOT use the <a
+											href="https://www.w3.org/TR/css3-writing-modes/#direction"
+												><code>direction</code> property</a> [[!CSS-Writing-Modes-3]]. Use the
+										[[!HTML]] <a href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
+												><code>dir</code> attribute</a> to set the inline base direction.</p>
+								</li>
+								<li>
+									<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT use the <a
+											href="https://www.w3.org/TR/css3-writing-modes/#unicode-bidi"
+												><code>unicode-bidi</code> property</a> [[!CSS-Writing-Modes-3]]. Use
+										[[!HTML]] <a
+											href="https://www.w3.org/TR/html/textlevel-semantics.html#the-bdo-element"
+												><code>bdo</code> elements</a> and <a
+											href="https://www.w3.org/TR/html/dom.html#the-dir-attribute"
+												><code>dir</code> attributes</a> to control bidirectionality.</p>
+								</li>
+							</ul>
+						</li>
+						<li>
+							<p id="confreq-css-prefixed">It MAY include the prefixed properties defined in <a
+									href="#sec-css-prefixed"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p>
+						</li>
+					</ul>
 				</section>
 
 				<section id="sec-css-prefixed">
@@ -6372,11 +6228,9 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						manner (i.e., with fixed width and height dimensions).</p>
 				</div>
 
-
-				<p id="confreg-fxl-icb">Fixed-Layout Documents MUST specify their <a
+				<p id="confreg-fxl-icb">Fixed-Layout Documents specify their <a
 						href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
-						block</a> [[!CSS2]] as defined in <a href="#sec-fixed-layouts"></a>. The manner in which initial
-					containg block is specified differs depending on the type of EPUB Content Document.</p>
+						block</a> [[!CSS2]] in the manner applicable to their format:</p>
 
 				<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
 					<dt id="sec-fxl-icb-html">Expressing in XHTML</dt>
@@ -6425,6 +6279,11 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					semantics for XML-based pronunciation lexicons to be used by Automatic Speech Recognition and
 						<a>Text-to-Speech</a> (TTS) engines.</p>
 
+				<p id="confreq-cd-pls-docprops-schema">PLS Documents MUST be valid to the RELAX NG schema available at
+					the URI <a class="uri" href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
+							><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/</code></a>
+					[[!PRONUNCIATION-LEXICON]].</p>
+
 				<p id="confreq-cd-pls-xht">A PLS Document MAY be associated with <a>XHTML Content Documents</a>. Each
 					XHTML Content Document MAY contain zero or more PLS document associations.</p>
 
@@ -6452,6 +6311,9 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
     …
 &lt;/html&gt;</pre>
 				</aside>
+
+				<p id="confreq-cd-pls-fileprops-name">PLS Documents SHOULD use the file extension <code class="filename"
+						>.pls</code>.</p>
 
 				<div class="note">
 					<p>For more information on EPUB 3 features related to synthetic speech, refer to <a
@@ -7438,6 +7300,19 @@ store destination as source in ocf
 		</section>
 		<section id="sec-media-overlays">
 			<h2>Media Overlays</h2>
+
+			<p id="confreq-mo-docprops-schema">It MUST be valid to the Media Overlays schema as defined in <a
+					href="#app-schema-overlays"></a> and conform to all content conformance constraints expressed in <a
+					href="#sec-overlays-def"></a>.</p>
+			<p id="confreq-mo-docprops-structure">It MUST be authored to reflect the structure of the <a>EPUB Content
+					Document</a> with which it is associated, as stated in <a href="#sec-media-overlays-structure"
+				></a>.</p>
+			<p id="confreq-mo-docprops-references">It MAY refer to more than one EPUB Content Document, but an EPUB
+				Content Document MUST NOT be referenced by more than one Media Overlay Document.</p>
+			<p id="confreq-mo-docprops-semantics">It SHOULD use semantic markup where appropriate, as described in <a
+					href="#sec-docs-semantic-inflection"></a>.</p>
+			<p id="confreq-mo-fileprops-name">The Media Overlay Document filename SHOULD use the file extension <code
+					class="filename">.smil</code>.</p>
 
 			<section id="sec-overlays-introduction" class="informative">
 				<h4>Introduction</h4>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2959,8 +2959,8 @@ Manifest:
 									href="#sec-foreign-restrictions-manifest">fallback chain</a>.</p>
 
 							<div class="note">
-								<p>Although EPUB Publications <a href="#confreq-nav-occur">have to include</a> an
-										<a>EPUB Navigation Document</a>, it is not mandatory to include it in the
+								<p>Although EPUB Publications <a href="#confreq-nav">have to include</a> an <a>EPUB
+										Navigation Document</a>, it is not mandatory to include it in the
 										<code>spine</code>.</p>
 							</div>
 
@@ -4336,10 +4336,9 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<section id="sec-package-nav-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>The EPUB Navigation Document is a <a href="#sec-package-conformance-nav">mandatory component</a>
-						of an <a>EPUB Package</a>. It allows <a>Authors</a> to include a human- and machine-readable
-						global navigation layer, thereby ensuring increased usability and accessibility for the
-						user.</p>
+					<p>The EPUB Navigation Document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
+							Package</a>. It allows <a>Authors</a> to include a human- and machine-readable global
+						navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
 
 					<p>The EPUB Navigation Document is an <a>XHTML Content Document</a>, but with additional
 						restrictions on its structure to facilitate the machine-processing of its contents. [[HTML]] <a
@@ -4848,7 +4847,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					</ul>
 					<div class="note">
 						<p>The recommendation that EPUB Publications follow the accessibility requirements in
-							[[EPUBAccessibility-10]] applies to XHTML Content Documents. See <a href="#sec-epub-a11y"
+							[[EPUBAccessibility-10]] applies to XHTML Content Documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -5529,7 +5528,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 					<div class="note">
 						<p>The recommendation that EPUB Publications follow the accessibility requirements in
-							[[EPUBAccessibility-10]] applies to SVG Content Documents. See <a href="#sec-epub-a11y"
+							[[EPUBAccessibility-10]] applies to SVG Content Documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -5561,7 +5560,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								<li>
 									<p id="confreq-svg-foreignObject-xhtml-frag">Its content MUST be a valid document
 										fragment that conforms to the XHTML Content Document model defined in <a
-											href="#sec-xhtml-conf-content">XHTML Content Documents</a>.</p>
+											href="#sec-xhtml-req"></a>.</p>
 								</li>
 								<li>
 									<p id="confreq-svg-foreignObject-reqext">Its <code>requiredExtensions</code>
@@ -5573,8 +5572,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						<li>
 							<p id="confreq-svg-title">The [[!SVG]] <a
 									href="https://www.w3.org/TR/SVG/struct.html#TitleElement"><code>title</code></a>
-								element MUST contain only valid <a href="#confreq-cd-html-docprops">XHTML Content
-									Document Phrasing content</a>.</p>
+								element MUST contain only valid <a href="#sec-xhtml-req">XHTML Content Document Phrasing
+									content</a>.</p>
 						</li>
 					</ul>
 				</section>
@@ -6091,8 +6090,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						difference to the executing context.</p>
 
 					<p>Which context a script is used in determines the rights and restrictions that a Reading System
-						places on it. Refer to <a href="#sec-scripted-content-content-reqs"></a> and <a
-							href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">Scripting
+						places on it. Refer to <a href="sec-scripted-container-constrained">the following sections</a>
+						and <a href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">Scripting
 							Conformance</a> [[EPUB-RS-33]] for some specific requirements that have to be adhered to
 						(not all Reading Systems will provide the same scripting functionality).</p>
 


### PR DESCRIPTION
Here's a second possibility for dealing with all the conformance sections:

- it adds a new "EPUB Publications" section after the introduction that incorporates publication conformance and publication resources (it's kind of odd now that we've merged everything not to have such a section)
- only the three key conformance statements are listed: at least one package, accessibility conformance and ocf (there is no need to say that a publication has to contain resources, as that's required elsewhere, if not patently obvious). Everything else follows from the rest of the specification.
- the package requirements are similarly minimized since we don't need to list the various resources that you may include but are not required to (specific requirements like at least one resource in the spine are already covered)
- after that, I've tried to reduce the need for conformance sections for each technology, but it's not possible in all cases. But where we have to note requirements, I've tried to strip any redundant bullets

Maybe this is a happier medium, as it avoids the need for a huge conformance criteria section, but still identifies the core requirements while keeping technology-specific requirements where you expect/need to find them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1391.html" title="Last updated on Nov 1, 2020, 11:55 PM UTC (e18ae7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1391/af19628...e18ae7f.html" title="Last updated on Nov 1, 2020, 11:55 PM UTC (e18ae7f)">Diff</a>