### PR TITLE
Re-org of vocabularies and mechanisms

### DIFF
--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -273,3 +273,40 @@ table.prefix caption {
     font-size: 90%
 }
 
+
+/* Table zebra style... */
+
+table.zebra {
+    font-size:inherit;
+    font:90%;
+    margin:1em;
+}
+
+table.zebra td {
+    padding-left: 0.3em;
+}
+
+table.zebra th {
+    font-weight: bold;
+    text-align: center;
+    background-color: rgb(0,0,128) !important;
+    font-size: 110%;
+    background: hsl(180, 30%, 50%);
+    color: #fff;
+}
+
+table.zebra th a:link {
+  color: #fff;
+}
+
+table.zebra th a:visited {
+  color: #aaa;
+}
+
+table.zebra tr:nth-child(even) {
+    background-color: hsl(180, 30%, 93%) !important;
+}
+
+table.zebra th{border-bottom:1px solid #bbb;padding:.2em 1em;}
+table.zebra td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2194,8 +2194,8 @@
 								></a>.</p>
 
 							<aside class="example">
-								<p>The following example shows various property declarations using reserved
-									prefixes.</p>
+								<p>The following example shows various property declarations using <a
+										href="#sec-reserved-prefixes">reserved prefixes</a>.</p>
 
 								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     …
@@ -2211,6 +2211,12 @@
 								that the element's value is drawn from. The value of the attribute MUST be a <a
 									href="#sec-property-datatype"><var>property</var> data type value</a> that resolves
 								to the resource that defines the scheme.</p>
+
+							<aside class="example">
+								<p>The following example shows the <code>scheme</code> attribute used to indicate the
+									value of the <code>meta</code> tag is drawn from ONIX code list 5.</p>
+								<pre>&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta></pre>
+							</aside>
 
 							<p>Every <code>meta</code> element MUST express a value that is at least one character in
 								length after white space normalization.</p>
@@ -3898,8 +3904,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					<section id="sec-xhtml-semantic-inflection">
 						<h5>Semantic Inflection</h5>
 
-						<p>The <a href="sec-epub-type"><code>epub:type</code> attribute</a> MAY be used in <a>XHTML
-								Content Documents</a> to express structural semantics.</p>
+						<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> MAY be used in
+								<a>XHTML Content Documents</a> to express structural semantics.</p>
 
 						<p>As the [[!HTML]] <a href="https://www.w3.org/TR/html/document-metadata.html#the-head-element"
 									><code>head</code> element</a> contains metadata for the document, structural
@@ -4377,7 +4383,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						<li>
 							<p id="confreq-svg-semantic-inflection">It MAY include the <a href="attrdef-epub-type"
 										><code>epub:type</code></a> attribute for <a href="#app-semantic-inflection"
-									>semantic inflection</a>.</p>
+									>semantic inflection</a>, and use all applicable <a href="#sec-vocab-assoc"
+									>vocabulary association mechanisms</a> for that attribute.</p>
 						</li>
 						<li>
 							<p id="confreq-svg-fileprops-name">It SHOULD use the file extension <code>.svg</code>.</p>
@@ -4933,7 +4940,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						difference to the executing context.</p>
 
 					<p>Which context a script is used in determines the rights and restrictions that a Reading System
-						places on it. Refer to <a href="sec-scripted-container-constrained">the following sections</a>
+						places on it. Refer to <a href="#sec-scripted-container-constrained">the following sections</a>
 						and <a href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">Scripting
 							Conformance</a> [[EPUB-RS-33]] for some specific requirements that have to be adhered to
 						(not all Reading Systems will provide the same scripting functionality).</p>
@@ -5015,7 +5022,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<section id="sec-scripted-container-constrained">
 					<h4>Container-Constrained Scripts</h4>
 
-					<p id="confreq-cd-scripted-container">A <a href="sec-scripted-type-container-constrained"
+					<p id="confreq-cd-scripted-container">A <a href="#sec-scripted-content-type-container-constrained"
 							>container-constrained script</a> MUST NOT contain instructions for modifying the DOM of the
 						parent Content Document or other contents in the EPUB Publication, and MUST NOT contain
 						instructions for manipulating the size of its containing rectangle.</p>
@@ -7390,6 +7397,9 @@ store destination as source in ocf
     &lt;/body&gt;
 &lt;/smil&gt;</pre>
 					</aside>
+
+					<p>Media Overlays MAY use the applicable <a href="#sec-vocab-assoc">vocabulary association
+							mechanisms</a> for the <code>epub:type</code> attribute to define additinal semantics.</p>
 				</section>
 
 				<section id="sec-docs-assoc-style">
@@ -7821,25 +7831,23 @@ html.-epub-media-overlay-playing * {
 				<h3>Introduction</h3>
 
 				<p>Semantic inflection is the process of attaching additional meaning about the specific purpose and/or
-					nature an element plays in an <a>XHTML Content Document</a>. The <a href="#sec-epub-type-attribute"
-							><code>epub:type</code> attribute</a> is used to express domain-specific semantics in XHTML
-					Content Documents, with the inflection(s) it carries complementing the underlying [[HTML]]
-					vocabulary.</p>
+					nature an element plays. The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a>
+					is used to express domain-specific semantics in <a>EPUB Content Documents</a> and <a>Media Ovelay
+						Documents</a>, with the inflection(s) it carries complementing the underlying vocabulary.</p>
 
 				<p>The applied semantics are intended to refine the meaning of their containing elements; they are not
-					provided to override their nature (e.g., the attribute can be used to indicate a
+					provided to override their nature (e.g., the attribute can be used to indicate a [[HTML]]
 						<code>section</code> is a chapter in a work, but is not designed to turn <code>p</code> elements
 					into list items to avoid proper list structures).</p>
 
 				<p>Semantic metadata is intended to enrich content for use in publishing workflows and for
-					author-defined purposes. While it also allows Reading Systems to learn more about the structure and
-					content of a document, no specific behaviors are defined for the semantics by this specification.
-					Any such behaviors are Reading System-dependent.</p>
+					author-defined purposes. It also allows Reading Systems to learn more about the structure and
+					content of a document (e.g., to enable <a href="#sec-behaviors-skip-escape">skippability and
+						escapability</a> in Media Ovelays).</p>
 
 				<p>This specification defines a method for semantic inflection using <em>the attribute axis</em>:
 					instead of adding new elements, the <code>epub:type</code> attribute can be appended to existing
-					elements to inflect the desired semantics. A mechanism to identify external vocabularies that
-					provide controlled values for the attributes is also defined.</p>
+					elements to inflect the desired semantics.</p>
 			</section>
 
 			<section id="sec-epub-type-attribute">
@@ -7887,7 +7895,7 @@ html.-epub-media-overlay-playing * {
 					the <a href="#structure-vocab">Structural Semantics Vocabulary</a>. Unprefixed terms that are not
 					part of the this vocabulary MAY be included, but their use is discouraged. The use of <a
 						href="#sec-prefix-attr">prefixes</a> is the preferred method for adding custom semantics. Refer
-					to <a href="#app-semantic-inflection"></a> for more information.</p>
+					to <a href="#sec-vocab-assoc"></a> for more information.</p>
 
 				<aside class="example" id="ex.epubtype.note">
 					<p>The following example shows how a preamble could be marked up with the <code>epub:type</code>
@@ -7941,11 +7949,11 @@ html.-epub-media-overlay-playing * {
 
 					<p>EPUB defines a formal method of referencing terms and properties defined in metadata and semantic
 						vocabularies using the <a href="#sec-property-datatype"><var>property</var> data type</a>. The
-							<code>epub:type</code> attribute is used in <a>EPUB Content Documents</a> and <a>Media
-							Overlay Documents</a> to add <a href="#app-semantic-inflection">semantic inflections</a>,
-						for example, while the <code>property</code> and <code>rel</code> attributes define properties
-						and relationships in the <a>Package Document</a>. All of these attributes require a
-							<var>property</var> data type as their value.</p>
+							<code>epub:type</code> attribute uses this data type in <a>EPUB Content Documents</a> and
+							<a>Media Overlay Documents</a> to add <a href="#app-semantic-inflection">semantic
+							inflections</a>, for example, while the <code>property</code> and <code>rel</code>
+						attributes use the data type to define properties and relationships in the <a>Package
+							Document</a>.</p>
 
 					<p>A <var>property</var> value is similar to a CURIE [[RDFA-CORE]] &#8212; it represents an IRI
 						[[RFC3987]] in compact form. The expression consists of a prefix and a reference, where the
@@ -7954,7 +7962,7 @@ html.-epub-media-overlay-playing * {
 						the reference, the resulting IRI normally resolves to a fragment within that vocabulary that
 						contains human- and/or machine-readable information about the term.</p>
 
-					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> value
+					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> data type
 						also defines a <a href="#sec-default-vocab">default vocabulary</a>. Terms and properties
 						referenced from the default vocabularies do not include a prefix as the mapping <a>Reading
 							Systems</a> use to map to a IRI is predefined.</p>
@@ -8152,9 +8160,8 @@ html.-epub-media-overlay-playing * {
 &lt;/package></pre>
 					</aside>
 
-					<p>The <code>prefix</code> attribute MUST be declared in the namespace
-							<code>http://www.idpf.org/2007/ops</code> when declared in <a>EPUB Content Documents</a> and
-							<a>Media Overlay Documents</a>.</p>
+					<p>The attribute MUST be declared in the namespace <code>http://www.idpf.org/2007/ops</code> when
+						declared in <a>EPUB Content Documents</a> and <a>Media Overlay Documents</a>.</p>
 
 					<aside class="example">
 						<p>The following example shows the <code>prefix</code> attribute declared in an <a>XHTML Content
@@ -8197,7 +8204,7 @@ html.-epub-media-overlay-playing * {
 					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
 							attribute</a>.</p>
 
-					<p>The reserved prefixes availabe for use depends is context-dependent:</p>
+					<p>The reserved prefixes availabe for use is context dependent:</p>
 
 					<dl class="conformance-list">
 						<dt>Package Document</dt>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1050,358 +1050,6 @@
 
 				</section>
 			</section>
-
-			<section id="sec-epub-semantics" class="appendix">
-				<h2>Publication Semantics</h2>
-
-				<section id="sec-package-semantic-enrich">
-					<h4>Semantic Enrichment</h4>
-
-					<p>The <code>property</code>, <code>properties</code>, <code>rel</code> and <code>scheme</code>
-						attributes use the <a href="#sec-property-datatype">property data type</a> to represent terms
-						from metadata vocabularies.</p>
-				</section>
-
-				<section id="sec-pub-semantic-inflection">
-					<h3>Semantic Inflection</h3>
-
-					<p>Semantic inflection is the process of attaching additional meaning about the specific purpose
-						and/or nature an element plays in an <a>XHTML Content Document</a>. The <a
-							href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is used to express
-						domain-specific semantics in XHTML Content Documents, with the inflection(s) it carries
-						complementing the underlying [[HTML]] vocabulary.</p>
-
-					<p>The applied semantics are intended to refine the meaning of their containing elements; they are
-						not provided to override their nature (e.g., the attribute can be used to indicate a
-							<code>section</code> is a chapter in a work, but is not designed to turn <code>p</code>
-						elements into list items to avoid proper list structures).</p>
-
-					<p>Semantic metadata is intended to enrich content for use in publishing workflows and for
-						author-defined purposes. While it also allows Reading Systems to learn more about the structure
-						and content of a document, no specific behaviors are defined for the semantics by this
-						specification. Any such behaviors are Reading System-dependent.</p>
-
-					<p>This specification defines a method for semantic inflection using <em>the attribute axis</em>:
-						instead of adding new elements, the <code>epub:type</code> attribute can be appended to existing
-						elements to inflect the desired semantics. A mechanism to identify external vocabularies that
-						provide controlled values for the attributes is also defined.</p>
-				</section>
-
-				<section id="sec-vocab-assoc">
-					<h3>Vocabulary Association Mechanisms</h3>
-
-					<section id="sec-vocab-assoc-intro">
-						<h4>Introduction</h4>
-
-						<p>Similar to a CURIE [[RDFA-CORE]], the property data type represents an IRI [[RFC3987]] in
-							compact form and simplifies the authoring of metadata from standardized vocabularies.</p>
-
-						<p>A property value is an expression that consists of a prefix and a reference, where the prefix
-							— whether literal or implied — is a shorthand mapping of an IRI that typically resolves to a
-							term vocabulary. When the prefix is converted to its IRI representation and combined with
-							the reference, the resulting IRI normally resolves to a fragment within that vocabulary that
-							contains human- and/or machine-readable information about the term.</p>
-
-						<p>To assist Reading Systems in processing property values, this specification defines three
-							mechanisms to establish the IRI a prefix maps to:</p>
-
-						<ul>
-							<li>
-								<p><a href="#sec-default-vocab">default vocabularies</a> — define the mapping when a
-									property or term does not include a prefix;</p>
-							</li>
-							<li>
-								<p><a href="#sec-metadata-reserved-prefixes">reserved prefixes</a> — these mappings are
-									predefined (i.e., all Reading Systems recognize them) and can be used without having
-									to be declared; and</p>
-							</li>
-							<li>
-								<p>the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute — a declarative
-									means of creating new prefix mappings on the root <a href="#sec-package-elem"
-											><code>package</code></a> element.</p>
-							</li>
-						</ul>
-					</section>
-
-					<section id="sec-default-vocab">
-						<h5>Default Vocabularies</h5>
-
-						<p>A default vocabulary is a vocabulary that does not require a prefix to be declared in order
-							to use its terms, and whose terms MUST always be unprefixed.</p>
-
-						<p>The IRIs associated with these vocabularies MUST NOT be assigned a prefix using the <a
-								href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
-
-						<div class="note">
-							<p>Refer to the definition of each attribute that allows semantic enrichment or inflection
-								for more information about its default vocabulary.</p>
-						</div>
-					</section>
-
-					<section id="sec-reserved-prefixes">
-						<h4>Reserved Prefixes</h4>
-
-						<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"
-									><code>prefix</code> attribute</a>.</p>
-
-						<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
-							lead to interoperability issues. Validation tools will often reject new prefixes until the
-							tools are updated, for example. Authors are strongly encouraged to declare all prefixes they
-							use to avoid such issues.</p>
-
-						<p id="sec-metadata-reserved-prefixes">This specification reserves the following set of prefixes
-							that Authors MAY use in package metadata without having to declare.</p>
-
-						<table id="tbl-pkg-reserved-prefixes" class="prefix">
-							<thead>
-								<tr>
-									<th>Prefix</th>
-									<th>IRI</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>a11y</td>
-									<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
-								</tr>
-								<tr>
-									<td>dcterms</td>
-									<td>http://purl.org/dc/terms/</td>
-								</tr>
-								<tr>
-									<td>marc</td>
-									<td>http://id.loc.gov/vocabulary/</td>
-								</tr>
-								<tr>
-									<td>media</td>
-									<td>http://www.idpf.org/epub/vocab/overlays/#</td>
-								</tr>
-								<tr>
-									<td>onix</td>
-									<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
-								</tr>
-								<tr>
-									<td>rendition</td>
-									<td>http://www.idpf.org/vocab/rendition/#</td>
-								</tr>
-								<tr>
-									<td>schema</td>
-									<td>http://schema.org/</td>
-								</tr>
-								<tr>
-									<td>xsd</td>
-									<td>http://www.w3.org/2001/XMLSchema#</td>
-								</tr>
-							</tbody>
-						</table>
-
-						<p id="sec-content-reserved-prefixes">Authors MAY use the following reserved prefixes in the
-								<code>epub:type</code> attribute without having to declare them.</p>
-
-						<table id="tbl-reserved-prefixes" class="prefix">
-							<thead>
-								<tr>
-									<th>Prefix</th>
-									<th>IRI</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>msv</td>
-									<td>http://www.idpf.org/epub/vocab/structure/magazine/#</td>
-								</tr>
-								<tr>
-									<td>prism</td>
-									<td>http://www.prismstandard.org/specifications/3.0/PRISM_CV_Spec_3.0.htm#</td>
-								</tr>
-							</tbody>
-						</table>
-					</section>
-
-					<section id="sec-prefix-attr">
-						<h4>The <code>prefix</code> Attribute</h4>
-
-						<p>The <code>prefix</code> attribute defines additional prefix mappings not <a
-								href="#sec-metadata-reserved-prefixes">reserved</a> by this specification.</p>
-
-						<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
-							prefix-to-IRI mappings of the form:</p>
-
-						<table class="productionset">
-							<caption>(EBNF productions <a
-									href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
-									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
-								(U+0000 to U+007F). </caption>
-							<tr>
-								<td id="prefix.ebnf.def">
-									<a href="#prefix.ebnf.def">prefixes</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
-										>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
-										href="#prefix.ebnf.mapping">mapping</a> } ; </td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.mapping">
-									<a href="#prefix.ebnf.mapping">mapping</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space"
-										>space</a> , { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.prefix">
-									<a href="#prefix.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.space">
-									<a href="#prefix.ebnf.space">space</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>#x20 ;</td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.whitespace">
-									<a href="#prefix.ebnf.whitespace">whitespace</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>(#x20 | #x9 | #xD | #xA) ;</td>
-								<td> </td>
-							</tr>
-						</table>
-
-						<aside class="example">
-							<p>The following example shows prefixes for the Friend of a Friend (<code>foaf</code>) and
-								DBPedia (<code>dbp</code>) vocabularies being declared using the <code>prefix</code>
-								attribute.</p>
-							<pre>&lt;package … 
-	prefix="foaf: http://xmlns.com/foaf/spec/
-		 dbp: http://dbpedia.org/ontology/"&gt;
-	…
-&lt;/package&gt;</pre>
-						</aside>
-
-						<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix
-							that maps to the <a href="#sec-default-vocab">default vocabulary</a>.</p>
-
-						<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
-							[[!RDFA-CORE]] processing.</p>
-
-						<p>For future compatibility with alternative serializations of the Package Document, a prefix
-							for the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in
-							the <code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
-								href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
-
-						<p>Although the <code>prefix</code> attribute is not namespaced when used in the <a>Package
-								Document</a>, a namespace declaration and prefix are required for <a>EPUB Content
-								Documents</a> and <a>Media Overlay Documents</a>. For these documents, the attribute is
-							defined to be in the namespace <code>http://www.idpf.org/2007/ops</code> and MUST only be
-							attached to the root element.</p>
-
-						<p>Note that for <a href="#sec-xhtml-svg">embedded SVG</a>, prefixes MUST be declared on the
-							[[!HTML]] root <a href="https://www.w3.org/TR/html/semantics.html#the-html-element"
-									><code>html</code> element</a>.</p>
-					</section>
-
-					<section id="sec-property-datatype">
-						<h4>The <code>property</code> Data Type</h4>
-
-						<p>The property data type is a compact means of expressing an IRI [[!RFC3987]] and consists of
-							an OPTIONAL prefix separated from a reference by a colon.</p>
-
-						<table class="productionset">
-							<caption>(EBNF productions <a
-									href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
-									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
-								(U+0000 to U+007F). </caption>
-							<tr>
-								<td id="property.ebnf.property">
-									<a href="#property.ebnf.property">property</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
-										href="#property.ebnf.reference">reference</a>; </td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.prefix">
-									<a href="#property.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.reference">
-									<a href="#property.ebnf.reference">reference</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? irelative-ref ? ;</td>
-								<td>/* as defined in [[!RFC3987]] */<br /></td>
-							</tr>
-						</table>
-
-						<p>The property data type is derived from the CURIE data type defined in [[!RDFA-CORE]], and
-							represents a subset of CURIEs.</p>
-
-						<aside class="example">
-							<p>The following example shows a property value composed of the prefix <code>dcterms</code>
-								and the reference <code>modified</code>.</p>
-							<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
-						</aside>
-
-						<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
-							[[EPUB-RS-33]], this property would expand to the following IRI:</p>
-
-						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
-
-						<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
-								prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
-
-						<p>When a prefix is omitted from a property value, the expressed reference represents a term
-							from the <a href="#sec-default-vocab">default vocabulary</a> for that attribute.</p>
-
-						<aside class="example">
-							<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
-								manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
-
-							<pre>&lt;item … properties="mathml"/&gt;</pre>
-
-							<p>This property expands to:</p>
-
-							<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
-
-							<p>when the IRI for the vocabulary is concatenated with the reference.</p>
-						</aside>
-
-						<p>An empty string does not represent a valid property value, even though it is valid to the
-							definition above.</p>
-					</section>
-				</section>
-			</section>
 		</section>
 		<section id="sec-packages">
 			<h2>EPUB Packages</h2>
@@ -2509,9 +2157,9 @@
 
 							<p id="attrdef-meta-property">Each <code>meta</code> element defines a metadata expression.
 								The <code>property</code> attribute takes a <a href="#sec-property-datatype"
-									>property</a> data type value that defines the statement being made in the
-								expression, and the text content of the element represents the assertion. (Refer to <a
-									href="#sec-package-semantic-enrich"></a> for more information.)</p>
+										><var>property</var> data type value</a> that defines the statement being made
+								in the expression, and the text content of the element represents the assertion. (Refer
+								to <a href="#sec-vocab-assoc"></a> for more information.)</p>
 
 							<p>This specification defines two types of metadata expressions that can be defined using
 								the <code>meta</code> element:</p>
@@ -2542,8 +2190,8 @@
 								the following IRI [[!RFC3987]] stem MUST be used to generate the resulting IRI:
 									<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
 
-							<p>Authors MAY add terms from other vocabularies as defined in <a
-									href="#sec-package-semantic-enrich"></a>.</p>
+							<p>Authors MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+								></a>.</p>
 
 							<aside class="example">
 								<p>The following example shows various property declarations using reserved
@@ -2561,8 +2209,8 @@
 
 							<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme
 								that the element's value is drawn from. The value of the attribute MUST be a <a
-									href="#sec-property-datatype">property</a> data type that resolves to the resource
-								that defines the scheme.</p>
+									href="#sec-property-datatype"><var>property</var> data type value</a> that resolves
+								to the resource that defines the scheme.</p>
 
 							<p>Every <code>meta</code> element MUST express a value that is at least one character in
 								length after white space normalization.</p>
@@ -2716,7 +2364,7 @@
 								resulting IRI for them: <code>http://idpf.org/epub/vocab/package/link/#</code></p>
 
 							<p><a>Authors</a> MAY add relationships and properties from other vocabularies as defined in
-									<a href="#sec-package-semantic-enrich"></a>.</p>
+									<a href="#sec-vocab-assoc"></a>.</p>
 
 							<aside class="example">
 								<p>The following example shows the <code>link</code> element used to associate an
@@ -2929,8 +2577,8 @@
 								prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the resulting IRI
 								for them: <code>http://idpf.org/epub/vocab/package/item/#</code></p>
 
-							<p>Authors MAY add terms from other vocabularies as defined in <a
-									href="#sec-package-semantic-enrich"></a>.</p>
+							<p>Authors MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+								></a>.</p>
 
 							<p>Authors MUST declare all applicable descriptive metadata properties for each Publication
 								Resource in this attribute.</p>
@@ -3346,8 +2994,8 @@ Manifest:
 								include a prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the
 								resulting IRI for them: <code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
 
-							<p>Authors MAY add terms from other vocabularies as defined in <a
-									href="#sec-package-semantic-enrich"></a>.</p>
+							<p>Authors MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+								></a>.</p>
 
 							<p>All applicable descriptive metadata properties defined in the <a
 									href="#app-itemref-properties-vocab">Spine Properties Vocabulary</a> SHOULD be
@@ -4247,101 +3895,19 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							are not supported features of EPUB 3.</p>
 					</div>
 
-					<section id="sec-epub-type-attribute">
-						<h5>The <code>epub:type</code> Attribute</h5>
+					<section id="sec-xhtml-semantic-inflection">
+						<h5>Semantic Inflection</h5>
 
-						<dl class="elemdef" id="attrdef-epub-type">
-							<dt>Attribute Name</dt>
-							<dd>
-								<p>
-									<code>type</code>
-								</p>
-							</dd>
-							<dt>Namespace</dt>
-							<dd>
-								<p>
-									<code>http://www.idpf.org/2007/ops</code>
-								</p>
-							</dd>
-							<dt>Usage</dt>
-							<dd>
-								<p><a href="https://www.w3.org/TR/html/dom.html#global-attributes">Global attribute</a>.
-									MAY be specified on all elements.</p>
-							</dd>
-							<dt>Value</dt>
-							<dd>
-								<p>A white space-separated list of <a href="#sec-property-datatype">property</a> values,
-									with restrictions as defined in <a href="#sec-vocab-assoc"></a>.</p>
-								<p>White space is the set of characters as defined in [[!XML]].</p>
-							</dd>
-						</dl>
-
-						<p>The <code>epub:type</code> attribute <a href="#sec-pub-semantic-inflection">inflects
-								semantics</a> on the element on which it appears. Its value is one or more white
-							space-separated terms stemming from external vocabularies associated with the document
-							instance.</p>
-
-						<p>The inflected semantic MUST express a subclass of the semantic of the carrying element. In
-							the case of semantically neutral elements, such as the [[!HTML]] <a
-								href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"
-								><code>div</code></a> and <a
-								href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element"
-									><code>span</code></a> elements, the inflected semantic MUST NOT attach a meaning
-							that is already conveyed by an existing element (e.g., that a <code>div</code> represents a
-							paragraph or section).</p>
+						<p>The <a href="sec-epub-type"><code>epub:type</code> attribute</a> MAY be used in <a>XHTML
+								Content Documents</a> to express structural semantics.</p>
 
 						<p>As the [[!HTML]] <a href="https://www.w3.org/TR/html/document-metadata.html#the-head-element"
 									><code>head</code> element</a> contains metadata for the document, structural
 							semantics expressed on this element or any descendant of it have no meaning.</p>
-
-						<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code>
-							attribute is the <a href="#structure-vocab">Structural Semantics Vocabulary</a>. Unprefixed
-							terms that are not part of the this vocabulary MAY be included, but their use is
-							discouraged. The use of <a href="#sec-prefix-attr">prefixes</a> is the preferred method for
-							adding custom semantics. Refer to <a href="#sec-pub-semantic-inflection"></a> for more
-							information.</p>
-
-						<aside class="example" id="ex.epubtype.note">
-							<p>The following example shows how a preamble could be marked up with the
-									<code>epub:type</code> attribute on its containing [[!HTML]] <code>section</code>
-								element.</p>
-							<pre>
-&lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
-    …
-    &lt;section epub:type="preamble"&gt;
-        …    
-    &lt;/section&gt;
-    …
-&lt;/html&gt;</pre>
-						</aside>
-
-						<aside class="example" id="ex.epubtype.gloss">
-							<p>The following example shows the <code>epub:type</code> attribute used to add glossary
-								semantics on an [[!HTML]] definition list.</p>
-							<pre>
-&lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
-    …
-    &lt;dl epub:type="glossary"&gt;
-        …    
-    &lt;/dl&gt;        
-    …
-&lt;/html&gt;</pre>
-						</aside>
-
-						<aside class="example" id="ex.epubtype.pg">
-							<p>The following example shows the <code>epub:type</code> attribute used to add pagebreak
-								semantics.</p>
-							<pre>
-&lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
-   …
-  &lt;p&gt; … &lt;span epub:type="pagebreak" id="p234"/&gt; … &lt;/p&gt;    
-   … 
-&lt;/html&gt;</pre>
-						</aside>
 					</section>
 
-					<section id="sec-xhtml-sementic-enrichment-rdfa">
-						<h6>RDFa</h6>
+					<section id="sec-xhtml-rdfa">
+						<h5>RDFa</h5>
 
 						<p>The [[!RDFA-CORE]] specification defines a set of attributes that can be used in <a>XHTML
 								Content Documents</a> to semantically enrich the content.</p>
@@ -4353,8 +3919,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							attributes are used. This modified content model is valid in XHTML Content Documents.</p>
 					</section>
 
-					<section id="sec-xhtml-sementic-enrichment-microdata">
-						<h6>Microdata</h6>
+					<section id="sec-xhtml-microdata">
+						<h5>Microdata</h5>
 
 						<p>The [[!Microdata]] specification defines a set of attributes that can be used in <a>XHTML
 								Content Documents</a> to semantically enrich the content.</p>
@@ -4810,7 +4376,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						</li>
 						<li>
 							<p id="confreq-svg-semantic-inflection">It MAY include the <a href="attrdef-epub-type"
-										><code>epub:type</code></a> attribute for <a href="#sec-pub-semantic-inflection"
+										><code>epub:type</code></a> attribute for <a href="#app-semantic-inflection"
 									>semantic inflection</a>.</p>
 						</li>
 						<li>
@@ -7789,7 +7355,7 @@ store destination as source in ocf
 				<section id="sec-docs-semantic-inflection">
 					<h4>Semantic Inflection</h4>
 
-					<p>In order to express <a href="#sec-pub-semantic-inflection">semantic inflections</a>, the <a
+					<p>In order to express <a href="#app-semantic-inflection">semantic inflections</a>, the <a
 							href="#attrdef-epub-type"><code>epub:type</code> attribute</a> MAY be attached to Media
 						Overlay <a href="#elemdef-smil-par"><code>par</code></a>, <a href="#elemdef-smil-seq"
 								><code>seq</code></a>, and <a href="#elemdef-smil-body"><code>body</code></a>
@@ -8192,7 +7758,7 @@ html.-epub-media-overlay-playing * {
 				</div>
 			</section>
 		</section>
-		<section id="sec-overview-unsupported" class="appendix">
+		<section id="app-overview-unsupported" class="appendix">
 			<h2>Unsupported Features</h2>
 
 			<p>This specification and its siblings contain certain features that are no longer recommended for use or
@@ -8246,8 +7812,468 @@ html.-epub-media-overlay-playing * {
 					requirement.</p>
 			</section>
 		</section>
-		<section id="sec-vocabs" class="appendix">
-			<h3>Vocabularies</h3>
+		<section id="app-semantic-inflection">
+			<h2>Semantic Inflection</h2>
+
+			<section id="sec-semantic-inflection-intro">
+				<h3>Introduction</h3>
+
+				<p>Semantic inflection is the process of attaching additional meaning about the specific purpose and/or
+					nature an element plays in an <a>XHTML Content Document</a>. The <a href="#sec-epub-type-attribute"
+							><code>epub:type</code> attribute</a> is used to express domain-specific semantics in XHTML
+					Content Documents, with the inflection(s) it carries complementing the underlying [[HTML]]
+					vocabulary.</p>
+
+				<p>The applied semantics are intended to refine the meaning of their containing elements; they are not
+					provided to override their nature (e.g., the attribute can be used to indicate a
+						<code>section</code> is a chapter in a work, but is not designed to turn <code>p</code> elements
+					into list items to avoid proper list structures).</p>
+
+				<p>Semantic metadata is intended to enrich content for use in publishing workflows and for
+					author-defined purposes. While it also allows Reading Systems to learn more about the structure and
+					content of a document, no specific behaviors are defined for the semantics by this specification.
+					Any such behaviors are Reading System-dependent.</p>
+
+				<p>This specification defines a method for semantic inflection using <em>the attribute axis</em>:
+					instead of adding new elements, the <code>epub:type</code> attribute can be appended to existing
+					elements to inflect the desired semantics. A mechanism to identify external vocabularies that
+					provide controlled values for the attributes is also defined.</p>
+			</section>
+
+			<section id="sec-epub-type-attribute">
+				<h3>The <code>epub:type</code> Attribute</h3>
+
+				<dl class="elemdef" id="attrdef-epub-type">
+					<dt>Attribute Name</dt>
+					<dd>
+						<p>
+							<code>type</code>
+						</p>
+					</dd>
+					<dt>Namespace</dt>
+					<dd>
+						<p>
+							<code>http://www.idpf.org/2007/ops</code>
+						</p>
+					</dd>
+					<dt>Usage</dt>
+					<dd>
+						<p><a href="https://www.w3.org/TR/html/dom.html#global-attributes">Global attribute</a>. MAY be
+							specified on all elements.</p>
+					</dd>
+					<dt>Value</dt>
+					<dd>
+						<p>A white space-separated list of <a href="#sec-property-datatype">property</a> values, with
+							restrictions as defined in <a href="#sec-vocab-assoc"></a>.</p>
+						<p>White space is the set of characters as defined in [[!XML]].</p>
+					</dd>
+				</dl>
+
+				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
+					is one or more white space-separated terms stemming from external vocabularies associated with the
+					document instance.</p>
+
+				<p>The inflected semantic MUST express a subclass of the semantic of the carrying element. In the case
+					of semantically neutral elements, such as the [[!HTML]] <a
+						href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"><code>div</code></a> and
+						<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element"
+						><code>span</code></a> elements, the inflected semantic MUST NOT attach a meaning that is
+					already conveyed by an existing element (e.g., that a <code>div</code> represents a paragraph or
+					section).</p>
+
+				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
+					the <a href="#structure-vocab">Structural Semantics Vocabulary</a>. Unprefixed terms that are not
+					part of the this vocabulary MAY be included, but their use is discouraged. The use of <a
+						href="#sec-prefix-attr">prefixes</a> is the preferred method for adding custom semantics. Refer
+					to <a href="#app-semantic-inflection"></a> for more information.</p>
+
+				<aside class="example" id="ex.epubtype.note">
+					<p>The following example shows how a preamble could be marked up with the <code>epub:type</code>
+						attribute on its containing [[!HTML]] <code>section</code> element.</p>
+					<pre>
+&lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+    …
+    &lt;section epub:type="preamble"&gt;
+        …    
+    &lt;/section&gt;
+    …
+&lt;/html&gt;</pre>
+				</aside>
+
+				<aside class="example" id="ex.epubtype.gloss">
+					<p>The following example shows the <code>epub:type</code> attribute used to add glossary semantics
+						on an [[!HTML]] definition list.</p>
+					<pre>
+&lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+    …
+    &lt;dl epub:type="glossary"&gt;
+        …    
+    &lt;/dl&gt;        
+    …
+&lt;/html&gt;</pre>
+				</aside>
+
+				<aside class="example" id="ex.epubtype.pg">
+					<p>The following example shows the <code>epub:type</code> attribute used to add pagebreak
+						semantics.</p>
+					<pre>
+&lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+   …
+  &lt;p&gt; … &lt;span epub:type="pagebreak" id="p234"/&gt; … &lt;/p&gt;    
+   … 
+&lt;/html&gt;</pre>
+				</aside>
+			</section>
+		</section>
+		<section id="app-vocabs" class="appendix">
+			<h2>Vocabularies</h2>
+
+			<p>This appendix defines a general set of mechanisms by which attributes in this specification can reference
+				terms from vocabularies, as well as EPUB-specific vocabularies that are used with the attributes.</p>
+
+			<section id="sec-vocab-assoc">
+				<h3>Vocabulary Association Mechanisms</h3>
+
+				<section id="sec-vocab-assoc-intro">
+					<h4>Introduction</h4>
+
+					<p>EPUB defines a formal method of referencing terms and properties defined in metadata and semantic
+						vocabularies using the <a href="#sec-property-datatype"><var>property</var> data type</a>. The
+							<code>epub:type</code> attribute is used in <a>EPUB Content Documents</a> and <a>Media
+							Overlay Documents</a> to add <a href="#app-semantic-inflection">semantic inflections</a>,
+						for example, while the <code>property</code> and <code>rel</code> attributes define properties
+						and relationships in the <a>Package Document</a>. All of these attributes require a
+							<var>property</var> data type as their value.</p>
+
+					<p>A <var>property</var> value is similar to a CURIE [[RDFA-CORE]] &#8212; it represents an IRI
+						[[RFC3987]] in compact form. The expression consists of a prefix and a reference, where the
+						prefix — whether literal or implied — is a shorthand mapping of an IRI that typically resolves
+						to a term vocabulary. When the prefix is converted to its IRI representation and combined with
+						the reference, the resulting IRI normally resolves to a fragment within that vocabulary that
+						contains human- and/or machine-readable information about the term.</p>
+
+					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> value
+						also defines a <a href="#sec-default-vocab">default vocabulary</a>. Terms and properties
+						referenced from the default vocabularies do not include a prefix as the mapping <a>Reading
+							Systems</a> use to map to a IRI is predefined.</p>
+
+					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
+						terms and properties, authors only need to declare a <a href="#sec-prefix-attr">prefix</a>. In
+						another authoring convenience, this specification also <a href="#sec-metadata-reserved-prefixes"
+							>reserves prefixes</a> for many commonly-used publishing vocabularies (i.e., they do not
+						have to be declared).</p>
+
+					<p>Additional details on the <var>property</var> data type and vocabulary association mechanism are
+						provided in the following sections.</p>
+				</section>
+
+				<section id="sec-property-datatype">
+					<h4>The <var>property</var> Data Type</h4>
+
+					<p>The <var>property</var> data type is a compact means of expressing an IRI [[!RFC3987]] and
+						consists of an OPTIONAL prefix separated from a reference by a colon.</p>
+
+					<table class="productionset">
+						<caption>(EBNF productions <a
+								href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
+								>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
+							(U+0000 to U+007F). </caption>
+						<tr>
+							<td id="property.ebnf.property">
+								<a href="#property.ebnf.property">property</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
+									href="#property.ebnf.reference">reference</a>; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="property.ebnf.prefix">
+								<a href="#property.ebnf.prefix">prefix</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? xsd:NCName ? ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="property.ebnf.reference">
+								<a href="#property.ebnf.reference">reference</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? irelative-ref ? ;</td>
+							<td>/* as defined in [[!RFC3987]] */<br /></td>
+						</tr>
+					</table>
+
+					<p>The <var>property</var> data type is derived from the CURIE data type defined in [[!RDFA-CORE]],
+						and represents a subset of CURIEs.</p>
+
+					<aside class="example">
+						<p>The following example shows a <var>property</var> value composed of the prefix
+								<code>dcterms</code> and the reference <code>modified</code>.</p>
+						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
+					</aside>
+
+					<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
+						[[EPUB-RS-33]], this property would expand to the following IRI:</p>
+
+					<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
+
+					<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
+							prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
+
+					<p>When a prefix is omitted from a <var>property</var> value, the expressed reference represents a
+						term from the <a href="#sec-default-vocab">default vocabulary</a> for that attribute.</p>
+
+					<aside class="example">
+						<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
+							manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
+
+						<pre>&lt;item … properties="mathml"/&gt;</pre>
+
+						<p>This property expands to:</p>
+
+						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
+
+						<p>when the IRI for the vocabulary is concatenated with the reference.</p>
+					</aside>
+
+					<p>An empty string does not represent a valid <var>property</var> value, even though it is valid to
+						the definition above.</p>
+				</section>
+
+				<section id="sec-default-vocab">
+					<h5>Default Vocabularies</h5>
+
+					<p>A default vocabulary is one that does not require a <a href="#sec-prefix-attr">prefix</a> to be
+						declared in order to use its terms and properties where a <a href="#sec-property-datatype"
+								><var>property</var> value</a> is expected. Terms and properties from a default
+						vocabulary MUST always be unprefixed.</p>
+
+					<p>The IRIs associated with these vocabularies MUST NOT be assigned a prefix using the <a
+							href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
+
+					<div class="note">
+						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"
+									><var>property</var> data type</a> for more information about its default
+							vocabulary.</p>
+					</div>
+				</section>
+
+				<section id="sec-prefix-attr">
+					<h4>The <code>prefix</code> Attribute</h4>
+
+					<p>The <code>prefix</code> attribute defines prefix mappings for use in <a
+							href="#sec-property-datatype"><var>property</var> values</a>.</p>
+
+					<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
+						prefix-to-IRI mappings of the form:</p>
+
+					<table class="productionset">
+						<caption>(EBNF productions <a
+								href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
+								>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
+							(U+0000 to U+007F). </caption>
+						<tr>
+							<td id="prefix.ebnf.def">
+								<a href="#prefix.ebnf.def">prefixes</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
+									>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
+									href="#prefix.ebnf.mapping">mapping</a> } ; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.mapping">
+								<a href="#prefix.ebnf.mapping">mapping</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space">space</a>
+								, { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.prefix">
+								<a href="#prefix.ebnf.prefix">prefix</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? xsd:NCName ? ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.space">
+								<a href="#prefix.ebnf.space">space</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>#x20 ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.whitespace">
+								<a href="#prefix.ebnf.whitespace">whitespace</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>(#x20 | #x9 | #xD | #xA) ;</td>
+							<td> </td>
+						</tr>
+					</table>
+
+					<p>The <code>prefix</code> attribute MUST only be attached to the root element of the respective
+						format.</p>
+
+					<p>The attribute is not namespaced when used in the <a>Package Document</a>.</p>
+
+					<aside class="example">
+						<p>The following example shows prefixes for the Friend of a Friend (<code>foaf</code>) and
+							DBPedia (<code>dbp</code>) vocabularies being declared in the Package Document.</p>
+						<pre>&lt;package … 
+         prefix="foaf: http://xmlns.com/foaf/spec/
+         dbp: http://dbpedia.org/ontology/">
+   …
+&lt;/package></pre>
+					</aside>
+
+					<p>The <code>prefix</code> attribute MUST be declared in the namespace
+							<code>http://www.idpf.org/2007/ops</code> when declared in <a>EPUB Content Documents</a> and
+							<a>Media Overlay Documents</a>.</p>
+
+					<aside class="example">
+						<p>The following example shows the <code>prefix</code> attribute declared in an <a>XHTML Content
+								Document</a>.</p>
+						<pre>&lt;html …
+      xmlns:epub="http://www.idpf.org/2007/ops"
+      epub:prefix="z3998: https://www.daisy.org/z3998/2012/vocab/structure/">
+   …
+&lt;/html></pre>
+					</aside>
+
+					<p>Note that for <a href="#sec-xhtml-svg">embedded SVG</a>, prefixes MUST be declared on the
+						[[!HTML]] root <a href="https://www.w3.org/TR/html/semantics.html#the-html-element"
+								><code>html</code> element</a>.</p>
+
+					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
+						maps to the <a href="#sec-default-vocab">default vocabulary</a>.</p>
+
+					<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
+						[[!RDFA-CORE]] processing.</p>
+
+					<p>For future compatibility with alternative serializations of the Package Document, a prefix for
+						the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in the
+							<code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
+							href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
+				</section>
+
+				<section id="sec-reserved-prefixes">
+					<h4>Reserved Prefixes</h4>
+
+					<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
+						lead to interoperability issues. Validation tools will often reject new prefixes until the tools
+						are updated, for example. Authors are strongly encouraged to declare all prefixes they use to
+						avoid such issues.</p>
+
+					<p><a>Authors</a> MAY use reserved prefixes in attributes that expect a <a
+							href="#sec-property-datatype"><var>property</var> value</a> without declaring them in a <a
+							href="#sec-prefix-attr"><code>prefix</code> attribute</a>.</p>
+
+					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
+							attribute</a>.</p>
+
+					<p>The reserved prefixes availabe for use depends is context-dependent:</p>
+
+					<dl class="conformance-list">
+						<dt>Package Document</dt>
+						<dd id="sec-metadata-reserved-prefixes">
+							<p>Authors MAY use the following prefixes in <a>Package Document</a> attributes without
+								having to declare them.</p>
+
+							<table id="tbl-pkg-reserved-prefixes" class="prefix">
+								<thead>
+									<tr>
+										<th>Prefix</th>
+										<th>IRI</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>a11y</td>
+										<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
+									</tr>
+									<tr>
+										<td>dcterms</td>
+										<td>http://purl.org/dc/terms/</td>
+									</tr>
+									<tr>
+										<td>marc</td>
+										<td>http://id.loc.gov/vocabulary/</td>
+									</tr>
+									<tr>
+										<td>media</td>
+										<td>http://www.idpf.org/epub/vocab/overlays/#</td>
+									</tr>
+									<tr>
+										<td>onix</td>
+										<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
+									</tr>
+									<tr>
+										<td>rendition</td>
+										<td>http://www.idpf.org/vocab/rendition/#</td>
+									</tr>
+									<tr>
+										<td>schema</td>
+										<td>http://schema.org/</td>
+									</tr>
+									<tr>
+										<td>xsd</td>
+										<td>http://www.w3.org/2001/XMLSchema#</td>
+									</tr>
+								</tbody>
+							</table>
+						</dd>
+
+						<dt id="sec-content-reserved-prefixes">Semantic Inflection</dt>
+						<dd>
+							<p>Authors MAY use the following reserved prefixes in the <a href="#app-semantic-inflection"
+										><code>epub:type</code> attribute</a> without having to declare them.</p>
+
+							<table id="tbl-reserved-prefixes" class="prefix">
+								<thead>
+									<tr>
+										<th>Prefix</th>
+										<th>IRI</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>msv</td>
+										<td>http://www.idpf.org/epub/vocab/structure/magazine/#</td>
+									</tr>
+									<tr>
+										<td>prism</td>
+										<td>http://www.prismstandard.org/specifications/3.0/PRISM_CV_Spec_3.0.htm#</td>
+									</tr>
+								</tbody>
+							</table>
+						</dd>
+					</dl>
+				</section>
+			</section>
 
 			<div data-include="vocab/meta-property.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 
@@ -8332,7 +8358,7 @@ html.-epub-media-overlay-playing * {
 				</div>
 			</section>
 		</section>
-		<section id="ocf-example" class="appendix informative">
+		<section id="app-ocf-example" class="appendix informative">
 			<h2>OCF Example</h2>
 
 			<p>The following example demonstrates the use of the OCF format to contain a signed and encrypted EPUB

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3686,9 +3686,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								no nested sublists).</p>
 
 							<p>The destinations of the <code>page-list</code> references MAY be identified in their
-								respective EPUB Content Documents using the <a
-									href="http://www.idpf.org/epub/vocab/structure#pagebreak"><code>pagebreak</code>
-									term</a> [[!EPUB-SSV]].</p>
+								respective EPUB Content Documents using the <a href="#pagebreak"><code>pagebreak</code>
+									term</a>.</p>
 						</section>
 
 						<section id="sec-nav-landmarks">
@@ -3707,7 +3706,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 							<aside class="example">
 								<p>The following example shows a <code>landmarks</code>
-									<code>nav</code> element with structural semantics drawn from the [[EPUB-SSV]].</p>
+									<code>nav</code> element with structural semantics drawn from <a
+										href="#structure-vocab"></a>.</p>
 								<pre>&lt;nav epub:type="landmarks"&gt;
     &lt;h2&gt;Guide&lt;/h2&gt;
     &lt;ol&gt;
@@ -7599,8 +7599,9 @@ html.-epub-media-overlay-playing * {
 &lt;/html&gt;</pre>
 					</aside>
 
-					<p>The following non-exhaustive list represents terms from the [[!EPUB-SSV]] for which Reading
-						Systems might offer the option of skippability:</p>
+					<p>The following non-exhaustive list represents terms from the <a href="#structure-vocab">Strucural
+							Semantics Vocbulary</a> for which Reading Systems might offer the option of
+						skippability:</p>
 
 					<ul>
 						<li>
@@ -7701,8 +7702,9 @@ html.-epub-media-overlay-playing * {
 &lt;/smil&gt;</pre>
 					</aside>
 
-					<p>The following non-exhaustive list represents terms from the [[!EPUB-SSV]] for which Reading
-						Systems might offer the option of escapability:</p>
+					<p>The following non-exhaustive list represents terms from the <a href="#structure-vocab">Structural
+							Semantics Vocabulary</a> for which Reading Systems might offer the option of
+						escapability:</p>
 
 					<ul>
 						<li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1050,6 +1050,366 @@
 
 				</section>
 			</section>
+
+			<section id="app-epub-semantics" class="appendix">
+				<h2>Publication Semantics</h2>
+
+				<section id="sec-package-semantic-enrich">
+					<h4>Semantic Enrichment</h4>
+
+					<p>The <code>property</code>, <code>properties</code>, <code>rel</code> and <code>scheme</code>
+						attributes use the <a href="#sec-property-datatype">property data type</a> to represent terms
+						from metadata vocabularies.</p>
+				</section>
+
+				<section id="sec-pub-semantic-inflection">
+					<h3>Semantic Inflection</h3>
+
+					<p>Semantic inflection is the process of attaching additional meaning about the specific purpose
+						and/or nature an element plays in an <a>XHTML Content Document</a>. The <a
+							href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is used to express
+						domain-specific semantics in XHTML Content Documents, with the inflection(s) it carries
+						complementing the underlying [[HTML]] vocabulary.</p>
+
+					<p>The applied semantics are intended to refine the meaning of their containing elements; they are
+						not provided to override their nature (e.g., the attribute can be used to indicate a
+							<code>section</code> is a chapter in a work, but is not designed to turn <code>p</code>
+						elements into list items to avoid proper list structures).</p>
+
+					<p>Semantic metadata is intended to enrich content for use in publishing workflows and for
+						author-defined purposes. While it also allows Reading Systems to learn more about the structure
+						and content of a document, no specific behaviors are defined for the semantics by this
+						specification. Any such behaviors are Reading System-dependent.</p>
+
+					<p>This specification defines a method for semantic inflection using <em>the attribute axis</em>:
+						instead of adding new elements, the <code>epub:type</code> attribute can be appended to existing
+						elements to inflect the desired semantics. A mechanism to identify external vocabularies that
+						provide controlled values for the attributes is also defined.</p>
+				</section>
+
+				<section id="sec-vocab-assoc">
+					<h3>Vocabulary Association Mechanisms</h3>
+
+					<section id="sec-vocab-assoc-intro">
+						<h4>Introduction</h4>
+
+						<p>Similar to a CURIE [[RDFA-CORE]], the property data type represents an IRI [[RFC3987]] in
+							compact form and simplifies the authoring of metadata from standardized vocabularies.</p>
+
+						<p>A property value is an expression that consists of a prefix and a reference, where the prefix
+							— whether literal or implied — is a shorthand mapping of an IRI that typically resolves to a
+							term vocabulary. When the prefix is converted to its IRI representation and combined with
+							the reference, the resulting IRI normally resolves to a fragment within that vocabulary that
+							contains human- and/or machine-readable information about the term.</p>
+
+						<p>To assist Reading Systems in processing property values, this specification defines three
+							mechanisms to establish the IRI a prefix maps to:</p>
+
+						<ul>
+							<li>
+								<p><a href="#sec-metadata-default-vocab">default vocabularies</a> — define the mapping
+									when a property value does not include a prefix;</p>
+							</li>
+							<li>
+								<p><a href="#sec-metadata-reserved-prefixes">reserved prefixes</a> — these mappings are
+									predefined (i.e., all Reading Systems recognize them) and can be used without having
+									to be declared; and</p>
+							</li>
+							<li>
+								<p>the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute — a declarative
+									means of creating new prefix mappings on the root <a href="#sec-package-elem"
+											><code>package</code></a> element.</p>
+							</li>
+						</ul>
+					</section>
+
+					<section id="sec-default-vocab">
+						<h5>Default Vocabularies</h5>
+
+						<p>A default vocabulary is a vocabulary that does not require a prefix to be declared in order
+							to use its terms, and whose terms MUST always be unprefixed.</p>
+
+						<p>The IRIs associated with these vocabularies MUST NOT be assigned a prefix using the <a
+								href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
+
+						<div class="note">
+							<p>Refer to the definition of each attribute that allows semantic enrichment or inflection
+								for more information about its default vocabulary.</p>
+						</div>
+					</section>
+
+					<section id="sec-reserved-prefixes">
+						<h4>Reserved Prefixes</h4>
+
+						<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"
+									><code>prefix</code> attribute</a>.</p>
+
+						<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
+							lead to interoperability issues. Validation tools will often reject new prefixes until the
+							tools are updated, for example. Authors are strongly encouraged to declare all prefixes they
+							use to avoid such issues.</p>
+
+						<p>This specification reserves the following set of prefixes that Authors MAY use in package
+							metadata without having to declare.</p>
+
+						<table id="tbl-pkg-reserved-prefixes" class="prefix">
+							<thead>
+								<tr>
+									<th>Prefix</th>
+									<th>IRI</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>a11y</td>
+									<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
+								</tr>
+								<tr>
+									<td>dcterms</td>
+									<td>http://purl.org/dc/terms/</td>
+								</tr>
+								<tr>
+									<td>marc</td>
+									<td>http://id.loc.gov/vocabulary/</td>
+								</tr>
+								<tr>
+									<td>media</td>
+									<td>http://www.idpf.org/epub/vocab/overlays/#</td>
+								</tr>
+								<tr>
+									<td>onix</td>
+									<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
+								</tr>
+								<tr>
+									<td>rendition</td>
+									<td>http://www.idpf.org/vocab/rendition/#</td>
+								</tr>
+								<tr>
+									<td>schema</td>
+									<td>http://schema.org/</td>
+								</tr>
+								<tr>
+									<td>xsd</td>
+									<td>http://www.w3.org/2001/XMLSchema#</td>
+								</tr>
+							</tbody>
+						</table>
+
+						<p>Authors MAY use the following reserved prefixes in the <code>epub:type</code> attribute
+							without having to declare them.</p>
+
+						<table id="tbl-reserved-prefixes" class="prefix">
+							<thead>
+								<tr>
+									<th>Prefix</th>
+									<th>IRI</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>msv</td>
+									<td>http://www.idpf.org/epub/vocab/structure/magazine/#</td>
+								</tr>
+								<tr>
+									<td>prism</td>
+									<td>http://www.prismstandard.org/specifications/3.0/PRISM_CV_Spec_3.0.htm#</td>
+								</tr>
+							</tbody>
+						</table>
+					</section>
+
+					<section id="sec-prefix-attr">
+						<h4>The <code>prefix</code> Attribute</h4>
+
+						<p>The <code>prefix</code> attribute defines additional prefix mappings not <a
+								href="#sec-metadata-reserved-prefixes">reserved</a> by this specification.</p>
+
+						<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
+							prefix-to-IRI mappings of the form:</p>
+
+						<table class="productionset">
+							<caption>(EBNF productions <a
+									href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
+									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
+								(U+0000 to U+007F). </caption>
+							<tr>
+								<td id="prefix.ebnf.def">
+									<a href="#prefix.ebnf.def">prefixes</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
+										>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
+										href="#prefix.ebnf.mapping">mapping</a> } ; </td>
+								<td> </td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.mapping">
+									<a href="#prefix.ebnf.mapping">mapping</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space"
+										>space</a> , { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
+								<td> </td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.prefix">
+									<a href="#prefix.ebnf.prefix">prefix</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>? xsd:NCName ? ;</td>
+								<td> </td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.space">
+									<a href="#prefix.ebnf.space">space</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>#x20 ;</td>
+								<td> </td>
+							</tr>
+							<tr>
+								<td id="prefix.ebnf.whitespace">
+									<a href="#prefix.ebnf.whitespace">whitespace</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>(#x20 | #x9 | #xD | #xA) ;</td>
+								<td> </td>
+							</tr>
+						</table>
+
+						<aside class="example">
+							<p>The following example shows prefixes for the Friend of a Friend (<code>foaf</code>) and
+								DBPedia (<code>dbp</code>) vocabularies being declared using the <code>prefix</code>
+								attribute.</p>
+							<pre>&lt;package … 
+	prefix="foaf: http://xmlns.com/foaf/spec/
+		 dbp: http://dbpedia.org/ontology/"&gt;
+	…
+&lt;/package&gt;</pre>
+						</aside>
+
+						<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix
+							that maps to the <a href="#sec-metadata-default-vocab">default vocabulary</a>.</p>
+
+						<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
+							[[!RDFA-CORE]] processing.</p>
+
+						<p>For future compatibility with alternative serializations of the Package Document, a prefix
+							for the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in
+							the <code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
+								href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
+
+						<p>Although the <code>prefix</code> attribute is not namespaced when used in the <a>Package
+								Document</a>, a namespace declaration and prefix are required to be valid in <a>EPUB
+								Content Documents</a> and <a>Media Overlay Documents</a>. For these documents, the
+							attribute is defined to be in the namespace <code>http://www.idpf.org/2007/ops</code> when
+							used in and has the following restrictions:</p>
+
+						<ul>
+							<li>
+								<p>It is only valid on the [[!HTML]] root <code>html</code> element in EPUB Content
+									Documents.</p>
+							</li>
+							<li>
+								<p>It is only valid on the [[!SMIL]] root <code>smil</code> element in Media Overlay
+									Documents.</p>
+							</li>
+						</ul>
+					</section>
+
+					<section id="sec-property-datatype">
+						<h4>The <code>property</code> Data Type</h4>
+
+						<p>The property data type is a compact means of expressing an IRI [[!RFC3987]] and consists of
+							an OPTIONAL prefix separated from a reference by a colon.</p>
+
+						<table class="productionset">
+							<caption>(EBNF productions <a
+									href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
+									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
+								(U+0000 to U+007F). </caption>
+							<tr>
+								<td id="property.ebnf.property">
+									<a href="#property.ebnf.property">property</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
+										href="#property.ebnf.reference">reference</a>; </td>
+								<td> </td>
+							</tr>
+							<tr>
+								<td id="property.ebnf.prefix">
+									<a href="#property.ebnf.prefix">prefix</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>? xsd:NCName ? ;</td>
+								<td> </td>
+							</tr>
+							<tr>
+								<td id="property.ebnf.reference">
+									<a href="#property.ebnf.reference">reference</a>
+								</td>
+								<td>
+									<code>=</code>
+								</td>
+								<td>? irelative-ref ? ;</td>
+								<td>/* as defined in [[!RFC3987]] */<br /></td>
+							</tr>
+						</table>
+
+						<p>The property data type is derived from the CURIE data type defined in [[!RDFA-CORE]], and
+							represents a subset of CURIEs.</p>
+
+						<aside class="example">
+							<p>The following example shows a property value composed of the prefix <code>dcterms</code>
+								and the reference <code>modified</code>.</p>
+							<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
+						</aside>
+
+						<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
+							[[EPUB-RS-33]], this property would expand to the following IRI:</p>
+
+						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
+
+						<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
+								prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
+
+						<p>When a prefix is omitted from a property value, the expressed reference represents a term
+							from the <a href="#sec-metadata-default-vocab">default vocabulary</a> for that
+							attribute.</p>
+
+						<aside class="example">
+							<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
+								manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
+
+							<pre>&lt;item … properties="mathml"/&gt;</pre>
+
+							<p>This property expands to:</p>
+
+							<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
+
+							<p>when the IRI for the vocabulary is concatenated with the reference.</p>
+						</aside>
+
+						<p>An empty string does not represent a valid property value, even though it is valid to the
+							definition above.</p>
+					</section>
+				</section>
+			</section>
 		</section>
 		<section id="sec-packages">
 			<h2>EPUB Packages</h2>
@@ -2184,16 +2544,19 @@
 							<p class="note">All of the DCMES [[!DC11]] elements represent primary expressions, and
 								permit refinement by meta element subexpressions.</p>
 
-							<p>This specification <a href="#sec-metadata-default-vocab">reserves</a> the <a
-									href="#app-meta-property-vocab">Meta Properties Vocabulary</a> for use with the
-									<code>property</code> attribute. Terms from other vocabularies MAY be used provided
-								they have a <a href="#sec-prefix-attr">prefix</a> (refer to <a
-									href="#sec-metadata-reserved-prefixes"></a> for a list of prefixes that do not have
-								to be declared).</p>
+							<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a
+									href="#sec-default-vocab">default vocabulary</a> for use with the
+									<code>property</code> attribute. If the attribute's value does not include a prefix,
+								the following IRI [[!RFC3987]] stem MUST be used to generate the resulting IRI:
+									<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
+
+							<p>Authors MAY add terms from other vocabularies as defined in <a
+									href="#sec-package-semantic-enrich"></a>.</p>
 
 							<aside class="example">
 								<p>The following example shows various property declarations using reserved
 									prefixes.</p>
+
 								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     …
     &lt;meta property="dcterms:modified"&gt;2016-02-29T12:34:56Z&lt;/meta&gt;
@@ -2354,15 +2717,14 @@
       properties="xmp"/&gt;</pre>
 							</aside>
 
-							<p>The list of <a href="#sec-metadata-default-vocab">reserved</a> relationships and
-								properties recognized by this specification is defined in the <a href="#app-link-vocab"
-									>EPUB Metadata Link Vocabulary</a>.</p>
+							<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a
+									href="#sec-default-vocab">default vocabulary</a> for the <code>rel</code> and
+									<code>properties</code> attributes. If any of these attributes' values do not
+								include a prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the
+								resulting IRI for them: <code>http://idpf.org/epub/vocab/package/link/#</code></p>
 
-							<p><a>Authors</a> MAY add relationships and properties from other vocabularies via the <a
-									href="#attrdef-package-prefix">metadata extensibility mechanism</a> defined in this
-								specification. Authors also MAY create new values by defining their own <a
-									href="#sec-prefix-attr">prefixes</a>. Refer to <a href="#sec-metadata-assoc"></a>
-								for more information.</p>
+							<p><a>Authors</a> MAY add relationships and properties from other vocabularies as defined in
+									<a href="#sec-package-semantic-enrich"></a>.</p>
 
 							<aside class="example">
 								<p>The following example shows the <code>link</code> element used to associate an
@@ -2569,12 +2931,14 @@
 									Document</a>). Fallback requirements for Foreign Resources are defined in <a
 									href="#sec-foreign-restrictions-manifest"></a>.</p>
 
-							<p id="attrdef-item-properties">This specification <a href="#sec-metadata-default-vocab"
-									>reserves</a> the <a href="#app-item-properties-vocab">EPUB Manifest Properties
-									Vocabulary</a> for use with the <code>properties</code> attribute. Terms from other
-								vocabularies MAY be used provided they have a <a href="#sec-prefix-attr">prefix</a>
-								(refer to <a href="#sec-metadata-reserved-prefixes"></a> for a list of prefixes that do
-								not have to be declared).</p>
+							<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
+									Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
+									<code>properties</code> attribute. If any of the attribute's values do not include a
+								prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the resulting IRI
+								for them: <code>http://idpf.org/epub/vocab/package/item/#</code></p>
+
+							<p>Authors MAY add terms from other vocabularies as defined in <a
+									href="#sec-package-semantic-enrich"></a>.</p>
 
 							<p>Authors MUST declare all applicable descriptive metadata properties for each Publication
 								Resource in this attribute.</p>
@@ -2984,12 +3348,14 @@ Manifest:
 							<p>Authors MUST provide a means of accessing all non-linear content (e.g., hyperlinks in the
 								content or from the <a href="#sec-package-nav">EPUB Navigation Document</a>).</p>
 
-							<p id="attrdef-itemref-properties">This specification <a href="#sec-metadata-default-vocab"
-									>reserves</a> the <a href="#app-itemref-properties-vocab">EPUB Spine Properties
-									Vocabulary</a> for use with the <code>properties</code> attribute. Terms from any
-								other vocabulary MAY be used provided they have a <a href="#sec-prefix-attr">prefix</a>
-								(refer to <a href="#sec-metadata-reserved-prefixes">Reserved Prefixes</a> for a list of
-								prefixes that do not have to be declared).</p>
+							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
+									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>
+								for the <code>properties</code> attribute. If any of the attribute's values do not
+								include a prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the
+								resulting IRI for them: <code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
+
+							<p>Authors MAY add terms from other vocabularies as defined in <a
+									href="#sec-package-semantic-enrich"></a>.</p>
 
 							<p>All applicable descriptive metadata properties defined in the <a
 									href="#app-itemref-properties-vocab">Spine Properties Vocabulary</a> SHOULD be
@@ -3919,10 +4285,10 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							</dd>
 						</dl>
 
-						<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears.
-							Its value is one or more white space-separated terms stemming from external vocabularies
-							associated with the document instance, as defined in <a
-								href="#sec-contentdocs-vocab-association"></a>.</p>
+						<p>The <code>epub:type</code> attribute <a href="#sec-pub-semantic-inflection">inflects
+								semantics</a> on the element on which it appears. Its value is one or more white
+							space-separated terms stemming from external vocabularies associated with the document
+							instance.</p>
 
 						<p>The inflected semantic MUST express a subclass of the semantic of the carrying element. In
 							the case of semantically neutral elements, such as the [[!HTML]] <a
@@ -3937,7 +4303,12 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 									><code>head</code> element</a> contains metadata for the document, structural
 							semantics expressed on this element or any descendant of it have no meaning.</p>
 
-						<h4>Examples</h4>
+						<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code>
+							attribute is the <a href="#structure-vocab">Structural Semantics Vocabulary</a>. Unprefixed
+							terms that are not part of the this vocabulary MAY be included, but their use is
+							discouraged. The use of <a href="#attrdef-prefix">prefixes</a> is the preferred method for
+							adding custom semantics. Refer to <a href="#sec-semantic-inflection"></a> for more
+							information.</p>
 
 						<aside class="example" id="ex.epubtype.note">
 							<p>The following example shows how a preamble could be marked up with the
@@ -3978,41 +4349,31 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						</aside>
 					</section>
 
-					<section id="sec-xhtml-semantic-enrichment">
-						<h5>Semantic Enrichment</h5>
+					<section id="sec-xhtml-sementic-enrichment-rdfa">
+						<h6>RDFa</h6>
 
-						<section id="sec-xhtml-semantic-enrichment-intro" class="informative">
-							<h6>Introduction</h6>
+						<p>The [[!RDFA-CORE]] specification defines a set of attributes that can be used in <a>XHTML
+								Content Documents</a> to semantically enrich the content.</p>
 
-							<p>Unlike <a href="#sec-xhtml-semantic-inflection">semantic inflection</a>, which is about
-								refining the structures within the markup, semantic enrichment enables the layering of
-								meaning into the content in order to facilitate machine processing.</p>
+						<p>The use of [[!RDFA-CORE]] attributes MUST conform to the requirements defined in
+							[[!HTML-RDFA]].</p>
 
-							<p>The [[Microdata]] and [[RDFA-CORE]] specifications both define sets of attributes that
-								can be used in <a>XHTML Content Documents</a> to semantically enrich the content.</p>
-						</section>
+						<p>The [[!RDFA-CORE]] specification defines changes to the [[!HTML]] content model when RDFa
+							attributes are used. This modified content model is valid in XHTML Content Documents.</p>
+					</section>
 
-						<section id="sec-xhtml-sementic-enrichment-rdfa">
-							<h6>RDFa</h6>
+					<section id="sec-xhtml-sementic-enrichment-microdata">
+						<h6>Microdata</h6>
 
-							<p>The use of [[!RDFA-CORE]] attributes is allowed in <a>XHTML Content Documents</a>, but
-								any usage MUST conform to the requirements defined in [[!HTML-RDFA]].</p>
+						<p>The [[!Microdata]] specification defines a set of attributes that can be used in <a>XHTML
+								Content Documents</a> to semantically enrich the content.</p>
 
-							<p>The [[!RDFA-CORE]] specification defines changes to the [[!HTML]] content model when RDFa
-								attributes are used. This modified content model is valid in XHTML Content
-								Documents.</p>
-						</section>
+						<p>The use of [[!Microdata]] attributes MUST conform to the requirements defined in that
+							specification.</p>
 
-						<section id="sec-xhtml-sementic-enrichment-microdata">
-							<h6>Microdata</h6>
-
-							<p>The use of [[!Microdata]] attributes is allowed in <a>XHTML Content Documents</a>, but
-								any usage MUST conform to the requirements defined in that specification.</p>
-
-							<p>The [[!Microdata]] specification defines changes to the [[!HTML]] content model when
-								Microdata attributes are used. This modified content model is valid in XHTML Content
-								Documents.</p>
-						</section>
+						<p>The [[!Microdata]] specification defines changes to the [[!HTML]] content model when
+							Microdata attributes are used. This modified content model is valid in XHTML Content
+							Documents.</p>
 					</section>
 
 					<section id="sec-xhtml-ssml-attrib">
@@ -7052,14 +7413,11 @@ store destination as source in ocf
 				<section id="sec-docs-semantic-inflection">
 					<h4>Semantic Inflection</h4>
 
-					<p>In order to express semantic inflections, the <a href="#attrdef-epub-type"><code>epub:type</code>
-							attribute</a> MAY be attached to Media Overlay <a href="#elemdef-smil-par"
-							><code>par</code></a>, <a href="#elemdef-smil-seq"><code>seq</code></a>, and <a
-							href="#elemdef-smil-body"><code>body</code></a> elements.</p>
-
-					<p>Values for the Media Overlay <code>epub:type</code> attribute are constrained identically to the
-							<code>epub:type</code> attribute in <a>EPUB Content Documents</a>. Refer to <a
-							href="#sec-xhtml-semantic-inflection"></a> for details.</p>
+					<p>In order to express <a href="#sec-pub-semantic-inflection">semantic inflections</a>, the <a
+							href="#attrdef-epub-type"><code>epub:type</code> attribute</a> MAY be attached to Media
+						Overlay <a href="#elemdef-smil-par"><code>par</code></a>, <a href="#elemdef-smil-seq"
+								><code>seq</code></a>, and <a href="#elemdef-smil-body"><code>body</code></a>
+						elements.</p>
 
 					<p> The <code>epub:type</code> attribute facilitates Reading System behavior appropriate for the
 						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
@@ -7090,15 +7448,6 @@ store destination as source in ocf
     &lt;/body&gt;
 &lt;/smil&gt;</pre>
 					</aside>
-
-					<p>This specification adopts the vocabulary association mechanisms defined in <a
-							href="#sec-contentdocs-vocab-association"></a> unmodified. Terms from the <a
-							href="#sec-contentdocs-default-vocab">default vocabulary</a> MUST be used unprefixed in
-						Overlay Documents.</p>
-
-					<p>Media Overlays MAY use additional vocabularies by defining them in the <a
-							href="#attrdef-smil-prefix"><code>epub:prefix</code> attribute</a> on the root
-							<code>smil</code> element.</p>
 				</section>
 
 				<section id="sec-docs-assoc-style">
@@ -7521,445 +7870,20 @@ html.-epub-media-overlay-playing * {
 					requirement.</p>
 			</section>
 		</section>
-		<section id="app-epub-semantics" class="appendix">
-			<h2>EPUB Semantics</h2>
+		<section id="sec-vocabs" class="appendix">
+			<h3>Vocabularies</h3>
 
-			<section id="sec-package-semantic-enrich">
-				<h4>Semantic Enrichment</h4>
+			<div data-include="vocab/meta-property.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 
-				<section id="sec-metadata-assoc-intro" class="informative">
-					<h5>Introduction</h5>
+			<div data-include="vocab/link.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 
-					<p>The <code>property</code>, <code>properties</code>, <code>rel</code> and <code>scheme</code>
-						attributes use the <a href="#sec-property-datatype">property data type</a> to represent terms
-						from metadata vocabularies.</p>
-				</section>
+			<div data-include="vocab/item-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 
-				<section id="sec-metadata-default-vocab">
-					<h5>Default Vocabularies</h5>
+			<div data-include="vocab/itemref-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 
-					<p>As the Package Document has multiple unrelated uses for metadata terms, a single default
-						vocabulary is not defined for all attributes. Instead, different default vocabularies are
-						defined for use in attributes that accept a <a href="#sec-property-datatype">property data
-							type</a> as follows:</p>
-					<ul>
-						<li>
-							<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is defined to be
-								the default vocabulary for the <a href="#elemdef-meta"><code>meta</code></a>
-								<code>property</code> attribute.</p>
-							<p>If the attribute's value does not include a prefix, the following IRI [[!RFC3987]] stem
-								MUST be used to generate the resulting IRI:
-									<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
-						</li>
-						<li>
-							<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is defined to be the default
-								vocabulary for the <a href="#elemdef-opf-link"><code>link</code></a>
-								<code>rel</code> and <code>properties</code> attributes.</p>
-							<p>If any of these attributes' values do not include a prefix, the following IRI
-								[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
-									<code>http://idpf.org/epub/vocab/package/link/#</code></p>
-						</li>
-						<li>
-							<p>The <a href="#app-item-properties-vocab">Manifest Properties Vocabulary</a> is defined to
-								be the default vocabulary for the <a href="#elemdef-package-item"><code>item</code></a>
-								<code>properties</code> attribute.</p>
-							<p>If any of the attribute's values do not include a prefix, the following IRI [[!RFC3987]]
-								stem MUST be used to generate the resulting IRI for them:
-									<code>http://idpf.org/epub/vocab/package/item/#</code></p>
-						</li>
-						<li>
-							<p>The <a href="#app-itemref-properties-vocab">Spine Properties Vocabulary</a> is defined to
-								be the default vocabulary for the <a href="#elemdef-spine-itemref"
-									><code>itemref</code></a>
-								<code>properties</code> attribute.</p>
-							<p>If any of the attribute's values do not include a prefix, the following IRI [[!RFC3987]]
-								stem MUST be used to generate the resulting IRI for them:
-									<code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
-						</li>
-					</ul>
-				</section>
+			<div data-include="vocab/overlays.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 
-				<section id="sec-metadata-reserved-prefixes">
-					<h5>Reserved Prefixes</h5>
-
-					<p>This specification reserves the following set of prefixes that Authors MAY use in package
-						metadata without having to declare.</p>
-
-					<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
-						lead to interoperability issues. Validation tools will often reject new prefixes until the tools
-						are updated, for example. Authors are strongly encouraged to declare all prefixes they use to
-						avoid such issues.</p>
-
-					<table id="tbl-pkg-reserved-prefixes" class="prefix">
-						<thead>
-							<tr>
-								<th>Prefix</th>
-								<th>IRI</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>a11y</td>
-								<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
-							</tr>
-							<tr>
-								<td>dcterms</td>
-								<td>http://purl.org/dc/terms/</td>
-							</tr>
-							<tr>
-								<td>marc</td>
-								<td>http://id.loc.gov/vocabulary/</td>
-							</tr>
-							<tr>
-								<td>media</td>
-								<td>http://www.idpf.org/epub/vocab/overlays/#</td>
-							</tr>
-							<tr>
-								<td>onix</td>
-								<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
-							</tr>
-							<tr>
-								<td>rendition</td>
-								<td>http://www.idpf.org/vocab/rendition/#</td>
-							</tr>
-							<tr>
-								<td>schema</td>
-								<td>http://schema.org/</td>
-							</tr>
-							<tr>
-								<td>xsd</td>
-								<td>http://www.w3.org/2001/XMLSchema#</td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-			</section>
-
-			<section id="sec-xhtml-semantic-inflection">
-				<h3>Semantic Inflection</h3>
-
-				<section id="sec-xhtml-semantic-inflection-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>Semantic inflection is the process of attaching additional meaning about the specific purpose
-						and/or nature an element plays in an <a>XHTML Content Document</a>. The <a
-							href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is used to express
-						domain-specific semantics in XHTML Content Documents, with the inflection(s) it carries
-						complementing the underlying [[HTML]] vocabulary.</p>
-
-					<p>The applied semantics are intended to refine the meaning of their containing elements; they are
-						not provided to override their nature (e.g., the attribute can be used to indicate a
-							<code>section</code> is a chapter in a work, but is not designed to turn <code>p</code>
-						elements into list items to avoid proper list structures).</p>
-
-					<p>Semantic metadata is intended to enrich content for use in publishing workflows and for
-						author-defined purposes. While it also allows Reading Systems to learn more about the structure
-						and content of a document, no specific behaviors are defined for the semantics by this
-						specification. Any such behaviors are Reading System-dependent.</p>
-
-					<p>This specification defines a method for semantic inflection using <em>the attribute axis</em>:
-						instead of adding new elements, the <code>epub:type</code> attribute can be appended to existing
-						elements to inflect the desired semantics. A mechanism to identify external vocabularies that
-						provide controlled values for the attributes is also defined.</p>
-				</section>
-
-				<section id="sec-inflection-default-vocabs">
-					<h5>Default Vocabularies</h5>
-
-					<p>The default vocabulary for EPUB Content Documents and Media Overlay Documents is defined to be
-						the [[!EPUB-SSV]]. Unprefixed terms that are not part of the [[!EPUB-SSV]] MAY be included, but
-						their use is discouraged. The use of prefixes is the preferred method for adding custom
-						semantics.</p>
-				</section>
-
-				<section id="sec-contentdocs-reserved-prefixes">
-					<h5>Reserved Prefixes</h5>
-
-					<p>Authors MAY use the following reserved prefixes in the <code>epub:type</code> attribute without
-						having to declare them.</p>
-
-					<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
-						lead to interoperability issues. Validation tools will often reject new prefixes until the tools
-						are updated, for example. Authors are strongly encouraged to declare all prefixes they use to
-						avoid such issues.</p>
-
-					<table id="tbl-reserved-prefixes" class="prefix">
-						<thead>
-							<tr>
-								<th>Prefix</th>
-								<th>IRI</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td>msv</td>
-								<td>http://www.idpf.org/epub/vocab/structure/magazine/#</td>
-							</tr>
-							<tr>
-								<td>prism</td>
-								<td>http://www.prismstandard.org/specifications/3.0/PRISM_CV_Spec_3.0.htm#</td>
-							</tr>
-						</tbody>
-					</table>
-				</section>
-
-				<section id="sec-contentdocs-prefix-attr">
-					<h6>The <code>prefix</code> Attribute</h6>
-
-					<p>The <code>prefix</code> attribute is defined to be in the namespace
-							<code>http://www.idpf.org/2007/ops</code> when used in EPUB Content Documents and Media
-						Overlay Documents.</p>
-
-					<p>The <code>prefix</code> attribute is only valid on the [[!HTML]] root <code>html</code> element
-						in EPUB Content Documents.</p>
-
-					<p>The <code>prefix</code> attribute is only valid on the [[!SMIL]] root <code>smil</code> element
-						in Media Overlay Documents.</p>
-				</section>
-			</section>
-
-			<section id="sec-vocab-assoc">
-				<h3>Vocabulary Association Mechanisms</h3>
-				
-				<section id="sec-vocab-assoc-intro">
-					<h4>Introduction</h4>
-					
-					<p>Similar to a CURIE [[RDFA-CORE]], the property data type represents an IRI [[RFC3987]] in compact
-						form and simplifies the authoring of metadata from standardized vocabularies.</p>
-					
-					<p>A property value is an expression that consists of a prefix and a reference, where the prefix —
-						whether literal or implied — is a shorthand mapping of an IRI that typically resolves to a term
-						vocabulary. When the prefix is converted to its IRI representation and combined with the
-						reference, the resulting IRI normally resolves to a fragment within that vocabulary that
-						contains human- and/or machine-readable information about the term.</p>
-					
-					<p>To assist Reading Systems in processing property values, this specification defines three
-						mechanisms to establish the IRI a prefix maps to:</p>
-					
-					<ul>
-						<li>
-							<p><a href="#sec-metadata-default-vocab">default vocabularies</a> — define the mapping when
-								a property value does not include a prefix;</p>
-						</li>
-						<li>
-							<p><a href="#sec-metadata-reserved-prefixes">reserved prefixes</a> — these mappings are
-								predefined (i.e., all Reading Systems recognize them) and can be used without having to
-								be declared; and</p>
-						</li>
-						<li>
-							<p>the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute — a declarative means of
-								creating new prefix mappings on the root <a href="#sec-package-elem"
-									><code>package</code></a> element.</p>
-						</li>
-					</ul>
-				</section>
-				
-				<section id="sec-vocab-assoc-default-vocab">
-					<h5>Default Vocabularies</h5>
-					
-					<p>A default vocabulary is a vocabulary that does not require a prefix to be declared in order to
-						use its terms, and whose terms MUST always be unprefixed.</p>
-					
-					<p>The IRIs associated with these vocabularies MUST NOT be assigned a prefix using the <a
-						href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
-				</section>
-				
-				<section id="sec-vocab-assoc-reserved-prefixes">
-					<h4>Reserved Prefixes</h4>
-					
-					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
-						attribute</a>.</p>
-				</section>
-				
-				<section id="sec-prefix-attr">
-					<h4>The <code>prefix</code> Attribute</h4>
-					
-					<p>The <code>prefix</code> attribute defines additional prefix mappings not <a
-						href="#sec-metadata-reserved-prefixes">reserved</a> by this specification.</p>
-					
-					<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
-						prefix-to-IRI mappings of the form:</p>
-					
-					<table class="productionset">
-						<caption>(EBNF productions <a
-							href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
-							>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
-							(U+0000 to U+007F). </caption>
-						<tr>
-							<td id="prefix.ebnf.def">
-								<a href="#prefix.ebnf.def">prefixes</a>
-							</td>
-							<td>
-								<code>=</code>
-							</td>
-							<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
-								>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
-									href="#prefix.ebnf.mapping">mapping</a> } ; </td>
-							<td> </td>
-						</tr>
-						<tr>
-							<td id="prefix.ebnf.mapping">
-								<a href="#prefix.ebnf.mapping">mapping</a>
-							</td>
-							<td>
-								<code>=</code>
-							</td>
-							<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space">space</a>
-								, { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
-							<td> </td>
-						</tr>
-						<tr>
-							<td id="prefix.ebnf.prefix">
-								<a href="#prefix.ebnf.prefix">prefix</a>
-							</td>
-							<td>
-								<code>=</code>
-							</td>
-							<td>? xsd:NCName ? ;</td>
-							<td> </td>
-						</tr>
-						<tr>
-							<td id="prefix.ebnf.space">
-								<a href="#prefix.ebnf.space">space</a>
-							</td>
-							<td>
-								<code>=</code>
-							</td>
-							<td>#x20 ;</td>
-							<td> </td>
-						</tr>
-						<tr>
-							<td id="prefix.ebnf.whitespace">
-								<a href="#prefix.ebnf.whitespace">whitespace</a>
-							</td>
-							<td>
-								<code>=</code>
-							</td>
-							<td>(#x20 | #x9 | #xD | #xA) ;</td>
-							<td> </td>
-						</tr>
-					</table>
-					
-					<aside class="example">
-						<p>The following example shows prefixes for the Friend of a Friend (<code>foaf</code>) and
-							DBPedia (<code>dbp</code>) vocabularies being declared using the <code>prefix</code>
-							attribute.</p>
-						<pre>&lt;package … 
-	prefix="foaf: http://xmlns.com/foaf/spec/
-		 dbp: http://dbpedia.org/ontology/"&gt;
-	…
-&lt;/package&gt;</pre>
-					</aside>
-					
-					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
-						maps to the <a href="#sec-metadata-default-vocab">default vocabulary</a>.</p>
-					
-					<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
-						[[!RDFA-CORE]] processing.</p>
-					
-					<p>For future compatibility with alternative serializations of the Package Document, a prefix for
-						the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in the
-						<code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
-							href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
-				</section>
-				
-				<section id="sec-property-datatype">
-					<h4>The <code>property</code> Data Type</h4>
-					
-					<p>The property data type is a compact means of expressing an IRI [[!RFC3987]] and consists of an
-						OPTIONAL prefix separated from a reference by a colon.</p>
-					
-					<table class="productionset">
-						<caption>(EBNF productions <a
-							href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
-							>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
-							(U+0000 to U+007F). </caption>
-						<tr>
-							<td id="property.ebnf.property">
-								<a href="#property.ebnf.property">property</a>
-							</td>
-							<td>
-								<code>=</code>
-							</td>
-							<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
-								href="#property.ebnf.reference">reference</a>; </td>
-							<td> </td>
-						</tr>
-						<tr>
-							<td id="property.ebnf.prefix">
-								<a href="#property.ebnf.prefix">prefix</a>
-							</td>
-							<td>
-								<code>=</code>
-							</td>
-							<td>? xsd:NCName ? ;</td>
-							<td> </td>
-						</tr>
-						<tr>
-							<td id="property.ebnf.reference">
-								<a href="#property.ebnf.reference">reference</a>
-							</td>
-							<td>
-								<code>=</code>
-							</td>
-							<td>? irelative-ref ? ;</td>
-							<td>/* as defined in [[!RFC3987]] */<br /></td>
-						</tr>
-					</table>
-					
-					<p>The property data type is derived from the CURIE data type defined in [[!RDFA-CORE]], and
-						represents a subset of CURIEs.</p>
-					
-					<aside class="example">
-						<p>The following example shows a property value composed of the prefix <code>dcterms</code> and
-							the reference <code>modified</code>.</p>
-						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
-					</aside>
-					
-					<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
-						[[EPUB-RS-33]], this property would expand to the following IRI:</p>
-					
-					<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
-					
-					<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
-						prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
-					
-					<p>When a prefix is omitted from a property value, the expressed reference represents a term from
-						the <a href="#sec-metadata-default-vocab">default vocabulary</a> for that attribute.</p>
-					
-					<aside class="example">
-						<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
-							manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
-						
-						<pre>&lt;item … properties="mathml"/&gt;</pre>
-						
-						<p>This property expands to:</p>
-						
-						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
-						
-						<p>when the IRI for the vocabulary is concatenated with the reference.</p>
-					</aside>
-					
-					<p>An empty string does not represent a valid property value, even though it is valid to the
-						definition above.</p>
-				</section>
-			</section>
-			
-			<section id="sec-vocabs">
-				<h3>Vocabularies</h3>
-				
-				<div data-include="vocab/meta-property.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-				
-				<div data-include="vocab/link.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-				
-				<div data-include="vocab/item-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-				
-				<div data-include="vocab/itemref-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-				
-				<div data-include="vocab/overlays.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-				
-				<div data-include="vocab/structure.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-			</section>
+			<div data-include="vocab/structure.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 		</section>
 		<section id="app-schemas" class="appendix">
 			<h2>Schemas</h2>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1101,7 +1101,7 @@
 
 					<ul>
 						<li>
-							<p><a href="#sec-package-metadata">Metadata</a> — mechanisms to include and/or reference
+							<p><a href="#sec-metadata-assoc">Metadata</a> — mechanisms to include and/or reference
 								metadata applicable to the given Rendition of the <a>EPUB Publication</a>.</p>
 						</li>
 						<li>
@@ -3287,72 +3287,67 @@ Manifest:
 
 			</section>
 
-			<section id="sec-package-metadata">
-				<h3>Package Metadata</h3>
+			<section id="sec-package-metadata-identifiers">
+				<h3>Publication Identifiers</h3>
 
-				<section id="sec-package-metadata-identifiers">
-					<h4>Publication Identifiers</h4>
+				<section id="sec-metadata-elem-identifiers-uid">
+					<h4>Unique Identifier</h4>
 
-					<section id="sec-metadata-elem-identifiers-uid">
-						<h5>Unique Identifier</h5>
+					<p>The <a>Author</a> is responsible for including a primary identifier in the <a>Package
+							Document</a> metadata that is unique to one and only one <a>EPUB Publication</a>. This
+							<a>Unique Identifier</a>, whether chosen or assigned, MUST be stored in the <a
+							href="#sec-opf-dcidentifier"><code>dc:identifier</code> element</a> and be referenced as the
+						Unique Identifier in the <a href="#elemdef-opf-package"><code>package</code> element</a>
+						<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code> attribute</a>.</p>
 
-						<p>The <a>Author</a> is responsible for including a primary identifier in the <a>Package
-								Document</a> metadata that is unique to one and only one <a>EPUB Publication</a>. This
-								<a>Unique Identifier</a>, whether chosen or assigned, MUST be stored in the <a
-								href="#sec-opf-dcidentifier"><code>dc:identifier</code> element</a> and be referenced as
-							the Unique Identifier in the <a href="#elemdef-opf-package"><code>package</code> element</a>
-							<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
-							attribute</a>.</p>
+					<p>Although not static, changes to the Unique Identifier for an EPUB Publication SHOULD be made as
+						infrequently as possible. New identifiers SHOULD NOT be issued when updating metadata, fixing
+						errata or making other minor changes to the EPUB Publication.</p>
+				</section>
 
-						<p>Although not static, changes to the Unique Identifier for an EPUB Publication SHOULD be made
-							as infrequently as possible. New identifiers SHOULD NOT be issued when updating metadata,
-							fixing errata or making other minor changes to the EPUB Publication.</p>
-					</section>
+				<section id="sec-metadata-elem-identifiers-pid">
+					<h4>Release Identifier</h4>
 
-					<section id="sec-metadata-elem-identifiers-pid">
-						<h5>Release Identifier</h5>
+					<p>The <a>Unique Identifier</a> of an <a>EPUB Publication</a> typically SHOULD NOT change with each
+						minor revision to the package or its contents, as Unique Identifiers are intended to have
+						maximal persistence both for referencing and distribution purposes. Each release of an EPUB
+						Publication normally requires that the new version be uniquely identifiable, however, which
+						results in the contradictory need for reliable Unique Identifiers that are changeable.</p>
 
-						<p>The <a>Unique Identifier</a> of an <a>EPUB Publication</a> typically SHOULD NOT change with
-							each minor revision to the package or its contents, as Unique Identifiers are intended to
-							have maximal persistence both for referencing and distribution purposes. Each release of an
-							EPUB Publication normally requires that the new version be uniquely identifiable, however,
-							which results in the contradictory need for reliable Unique Identifiers that are
-							changeable.</p>
+					<p>To redress this problem of identifying minor modifications and releases without changing the
+						Unique Identifier, this specification defines the semantics for a <em>Release Identifier</em>,
+						or means of distinguishing and sequentially ordering EPUB Publications with the same Unique
+						Identifier.</p>
 
-						<p>To redress this problem of identifying minor modifications and releases without changing the
-							Unique Identifier, this specification defines the semantics for a <em>Release
-								Identifier</em>, or means of distinguishing and sequentially ordering EPUB Publications
-							with the same Unique Identifier.</p>
+					<p>The Release Identifier is not an actual property in the package <code>metadata</code> section,
+						but is a value that can be obtained from two other mandatory pieces of metadata: the Unique
+						Identifier and the last modification date of the Rendition. When the taken together, the
+						combined value represents a unique identity that can be used to distinguish any particular
+						version of an EPUB Publication from another.</p>
 
-						<p>The Release Identifier is not an actual property in the package <code>metadata</code>
-							section, but is a value that can be obtained from two other mandatory pieces of metadata:
-							the Unique Identifier and the last modification date of the Rendition. When the taken
-							together, the combined value represents a unique identity that can be used to distinguish
-							any particular version of an EPUB Publication from another.</p>
+					<p id="last-modified-date">To ensure that a Release Identifier can be constructed, each
+							<a>Rendition</a> MUST include exactly one [[!DCTERMS]] <code>modified</code> property
+						containing its last modification date. The value of this property MUST be an [[!XMLSCHEMA-2]]
+						dateTime conformant date of the form:</p>
 
-						<p id="last-modified-date">To ensure that a Release Identifier can be constructed, each
-								<a>Rendition</a> MUST include exactly one [[!DCTERMS]] <code>modified</code> property
-							containing its last modification date. The value of this property MUST be an
-							[[!XMLSCHEMA-2]] dateTime conformant date of the form:</p>
+					<pre class="nohighlight">CCYY-MM-DDThh:mm:ssZ</pre>
 
-						<pre class="nohighlight">CCYY-MM-DDThh:mm:ssZ</pre>
+					<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST be
+						terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
 
-						<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST be
-							terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
+					<p>Additional modified properties MAY be included in the package metadata, but they MUST have a
+						different subject (i.e., they require a <code>refines</code> attribute that references an
+						element or resource).</p>
 
-						<p>Additional modified properties MAY be included in the package metadata, but they MUST have a
-							different subject (i.e., they require a <code>refines</code> attribute that references an
-							element or resource).</p>
+					<p>Although not a part of the package metadata, for referencing and other purposes all string
+						representations of the identifier MUST be constructed using the at sign (<code>@</code>) as the
+						separator (i.e., of the form "id<code>@</code>date"). Whitespace MUST NOT be included when
+						concatenating the strings.</p>
 
-						<p>Although not a part of the package metadata, for referencing and other purposes all string
-							representations of the identifier MUST be constructed using the at sign (<code>@</code>) as
-							the separator (i.e., of the form "id<code>@</code>date"). Whitespace MUST NOT be included
-							when concatenating the strings.</p>
-
-						<aside class="example">
-							<p>The following example shows how a Unique Identifier and modification date are combined to
-								form the Release Identifier.</p>
-							<pre class="nohighlight">&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
+					<aside class="example">
+						<p>The following example shows how a Unique Identifier and modification date are combined to
+							form the Release Identifier.</p>
+						<pre class="nohighlight">&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:identifier id="pub-id"&gt;urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier&gt;
     &lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;
     …
@@ -3362,1000 +3357,354 @@ results in the Package ID:
 
 urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 </pre>
-						</aside>
+					</aside>
 
-						<p>Note that it is possible that the separator character MAY occur in the Unique Identifier, as
-							these identifiers MAY be any string value. The Release Identifier consequently MUST be split
-							on the last instance of the at sign when decomposing it into its component parts.</p>
+					<p>Note that it is possible that the separator character MAY occur in the Unique Identifier, as
+						these identifiers MAY be any string value. The Release Identifier consequently MUST be split on
+						the last instance of the at sign when decomposing it into its component parts.</p>
 
-						<p>The Release Identifier does not supersede the Unique Identifier, but represents the means by
-							which different versions of the same EPUB Publication can be distinguished and identified in
-							distribution channels and by Reading Systems. The sequential, chronological order inherent
-							in the format of the timestamp also places EPUB Publications in order without requiring
-							knowledge of the exact identifier that came before.</p>
+					<p>The Release Identifier does not supersede the Unique Identifier, but represents the means by
+						which different versions of the same EPUB Publication can be distinguished and identified in
+						distribution channels and by Reading Systems. The sequential, chronological order inherent in
+						the format of the timestamp also places EPUB Publications in order without requiring knowledge
+						of the exact identifier that came before.</p>
 
-						<p>The Release Identifier consequently allows a set of EPUB Publications to be inspected to
-							determine if they represent the same version of the same Publication, different versions of
-							a single EPUB Publication, or any combination of differing and similar EPUB
-							Publications.</p>
+					<p>The Release Identifier consequently allows a set of EPUB Publications to be inspected to
+						determine if they represent the same version of the same Publication, different versions of a
+						single EPUB Publication, or any combination of differing and similar EPUB Publications.</p>
 
-						<div class="note">
-							<p>When an <a>EPUB Container</a> includes more than one <a>Rendition</a> of an EPUB
-								Publication, updating the last modified date of the <a>default rendition</a> for each
-								release — even if it has not been updated — will help ensure that the EPUB Publication
-								does not appear to be the same version as an earlier release, as Reading Systems only
-								have to process the default rendition.</p>
-						</div>
-					</section>
+					<div class="note">
+						<p>When an <a>EPUB Container</a> includes more than one <a>Rendition</a> of an EPUB Publication,
+							updating the last modified date of the <a>default rendition</a> for each release — even if
+							it has not been updated — will help ensure that the EPUB Publication does not appear to be
+							the same version as an earlier release, as Reading Systems only have to process the default
+							rendition.</p>
+					</div>
+				</section>
+			</section>
+
+			<section id="sec-metadata-assoc">
+				<h3>Vocabulary Association Mechanisms</h3>
+
+				<section id="sec-metadata-assoc-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>The <code>property</code>, <code>properties</code>, <code>rel</code> and <code>scheme</code>
+						attributes use the <a href="#sec-property-datatype">property data type</a> to represent terms
+						from metadata vocabularies. Similar to a CURIE [[RDFA-CORE]], the property data type represents
+						an IRI [[RFC3987]] in compact form and simplifies the authoring of metadata from standardized
+						vocabularies.</p>
+
+					<p>A property value is an expression that consists of a prefix and a reference, where the prefix —
+						whether literal or implied — is a shorthand mapping of an IRI that typically resolves to a term
+						vocabulary. When the prefix is converted to its IRI representation and combined with the
+						reference, the resulting IRI normally resolves to a fragment within that vocabulary that
+						contains human- and/or machine-readable information about the term.</p>
+
+					<p>To assist Reading Systems in processing property values, this specification defines three
+						mechanisms to establish the IRI a prefix maps to:</p>
+
+					<ul>
+						<li>
+							<p><a href="#sec-metadata-default-vocab">default vocabularies</a> — define the mapping when
+								a property value does not include a prefix;</p>
+						</li>
+						<li>
+							<p><a href="#sec-metadata-reserved-prefixes">reserved prefixes</a> — these mappings are
+								predefined (i.e., all Reading Systems recognize them) and can be used without having to
+								be declared; and</p>
+						</li>
+						<li>
+							<p>the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute — a declarative means of
+								creating new prefix mappings on the root <a href="#sec-package-elem"
+										><code>package</code></a> element.</p>
+						</li>
+					</ul>
+
 				</section>
 
-				<section id="sec-metadata-assoc">
-					<h4>Vocabulary Association Mechanisms</h4>
+				<section id="sec-metadata-default-vocab">
+					<h4>Default Vocabularies</h4>
 
-					<section id="sec-metadata-assoc-intro" class="informative">
-						<h5>Introduction</h5>
+					<p>A default vocabulary is a vocabulary that does not require a prefix to be declared in order to
+						use its terms, and whose terms MUST always be unprefixed.</p>
 
-						<p>The <code>property</code>, <code>properties</code>, <code>rel</code> and <code>scheme</code>
-							attributes use the <a href="#sec-property-datatype">property data type</a> to represent
-							terms from metadata vocabularies. Similar to a CURIE [[RDFA-CORE]], the property data type
-							represents an IRI [[RFC3987]] in compact form and simplifies the authoring of metadata from
-							standardized vocabularies.</p>
+					<p>As the Package Document has multiple unrelated uses for metadata terms, a single default
+						vocabulary is not defined for all attributes. Instead, different default vocabularies are
+						defined for use in attributes that accept a <a href="#sec-property-datatype">property data
+							type</a> as follows:</p>
 
-						<p>A property value is an expression that consists of a prefix and a reference, where the prefix
-							— whether literal or implied — is a shorthand mapping of an IRI that typically resolves to a
-							term vocabulary. When the prefix is converted to its IRI representation and combined with
-							the reference, the resulting IRI normally resolves to a fragment within that vocabulary that
-							contains human- and/or machine-readable information about the term.</p>
+					<ul>
+						<li>
+							<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is defined to be
+								the default vocabulary for the <a href="#elemdef-meta"><code>meta</code></a>
+								<code>property</code> attribute.</p>
+							<p>If the attribute's value does not include a prefix, the following IRI [[!RFC3987]] stem
+								MUST be used to generate the resulting IRI:
+									<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
+						</li>
+						<li>
+							<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is defined to be the default
+								vocabulary for the <a href="#elemdef-opf-link"><code>link</code></a>
+								<code>rel</code> and <code>properties</code> attributes.</p>
+							<p>If any of these attributes' values do not include a prefix, the following IRI
+								[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
+									<code>http://idpf.org/epub/vocab/package/link/#</code></p>
+						</li>
+						<li>
+							<p>The <a href="#app-item-properties-vocab">Manifest Properties Vocabulary</a> is defined to
+								be the default vocabulary for the <a href="#elemdef-package-item"><code>item</code></a>
+								<code>properties</code> attribute.</p>
+							<p>If any of the attribute's values do not include a prefix, the following IRI [[!RFC3987]]
+								stem MUST be used to generate the resulting IRI for them:
+									<code>http://idpf.org/epub/vocab/package/item/#</code></p>
+						</li>
+						<li>
+							<p>The <a href="#app-itemref-properties-vocab">Spine Properties Vocabulary</a> is defined to
+								be the default vocabulary for the <a href="#elemdef-spine-itemref"
+									><code>itemref</code></a>
+								<code>properties</code> attribute.</p>
+							<p>If any of the attribute's values do not include a prefix, the following IRI [[!RFC3987]]
+								stem MUST be used to generate the resulting IRI for them:
+									<code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
+						</li>
+					</ul>
 
-						<p>To assist Reading Systems in processing property values, this specification defines three
-							mechanisms to establish the IRI a prefix maps to:</p>
+					<p>The IRIs associated with these vocabularies MUST NOT be assigned a prefix using the <a
+							href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
 
-						<ul>
-							<li>
-								<p><a href="#sec-metadata-default-vocab">default vocabularies</a> — define the mapping
-									when a property value does not include a prefix;</p>
-							</li>
-							<li>
-								<p><a href="#sec-metadata-reserved-prefixes">reserved prefixes</a> — these mappings are
-									predefined (i.e., all Reading Systems recognize them) and can be used without having
-									to be declared; and</p>
-							</li>
-							<li>
-								<p>the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute — a declarative
-									means of creating new prefix mappings on the root <a href="#sec-package-elem"
-											><code>package</code></a> element.</p>
-							</li>
-						</ul>
+				</section>
 
-					</section>
+				<section id="sec-metadata-reserved-prefixes">
+					<h4>Reserved Prefixes</h4>
 
-					<section id="sec-metadata-default-vocab">
-						<h5>Default Vocabularies</h5>
+					<p>This specification reserves the following set of prefixes that Authors MAY use in package
+						metadata without having to declare.</p>
 
-						<p>A default vocabulary is a vocabulary that does not require a prefix to be declared in order
-							to use its terms, and whose terms MUST always be unprefixed.</p>
+					<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
+						lead to interoperability issues. Validation tools will often reject new prefixes until the tools
+						are updated, for example. Authors are strongly encouraged to declare all prefixes they use to
+						avoid such issues.</p>
 
-						<p>As the Package Document has multiple unrelated uses for metadata terms, a single default
-							vocabulary is not defined for all attributes. Instead, different default vocabularies are
-							defined for use in attributes that accept a <a href="#sec-property-datatype">property data
-								type</a> as follows:</p>
-
-						<ul>
-							<li>
-								<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is defined to
-									be the default vocabulary for the <a href="#elemdef-meta"><code>meta</code></a>
-									<code>property</code> attribute.</p>
-								<p>If the attribute's value does not include a prefix, the following IRI [[!RFC3987]]
-									stem MUST be used to generate the resulting IRI:
-										<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
-							</li>
-							<li>
-								<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is defined to be the
-									default vocabulary for the <a href="#elemdef-opf-link"><code>link</code></a>
-									<code>rel</code> and <code>properties</code> attributes.</p>
-								<p>If any of these attributes' values do not include a prefix, the following IRI
-									[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
-										<code>http://idpf.org/epub/vocab/package/link/#</code></p>
-							</li>
-							<li>
-								<p>The <a href="#app-item-properties-vocab">Manifest Properties Vocabulary</a> is
-									defined to be the default vocabulary for the <a href="#elemdef-package-item"
-											><code>item</code></a>
-									<code>properties</code> attribute.</p>
-								<p>If any of the attribute's values do not include a prefix, the following IRI
-									[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
-										<code>http://idpf.org/epub/vocab/package/item/#</code></p>
-							</li>
-							<li>
-								<p>The <a href="#app-itemref-properties-vocab">Spine Properties Vocabulary</a> is
-									defined to be the default vocabulary for the <a href="#elemdef-spine-itemref"
-											><code>itemref</code></a>
-									<code>properties</code> attribute.</p>
-								<p>If any of the attribute's values do not include a prefix, the following IRI
-									[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
-										<code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
-							</li>
-						</ul>
-
-						<p>The IRIs associated with these vocabularies MUST NOT be assigned a prefix using the <a
-								href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
-
-					</section>
-
-					<section id="sec-metadata-reserved-prefixes">
-						<h5>Reserved Prefixes</h5>
-
-						<p>This specification reserves the following set of prefixes that Authors MAY use in package
-							metadata without having to declare.</p>
-
-						<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
-							lead to interoperability issues. Validation tools will often reject new prefixes until the
-							tools are updated, for example. Authors are strongly encouraged to declare all prefixes they
-							use to avoid such issues.</p>
-
-						<table id="tbl-pkg-reserved-prefixes" class="prefix">
-							<thead>
-								<tr>
-									<th>Prefix</th>
-									<th>IRI</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>a11y</td>
-									<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
-								</tr>
-								<tr>
-									<td>dcterms</td>
-									<td>http://purl.org/dc/terms/</td>
-								</tr>
-								<tr>
-									<td>marc</td>
-									<td>http://id.loc.gov/vocabulary/</td>
-								</tr>
-								<tr>
-									<td>media</td>
-									<td>http://www.idpf.org/epub/vocab/overlays/#</td>
-								</tr>
-								<tr>
-									<td>onix</td>
-									<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
-								</tr>
-								<tr>
-									<td>rendition</td>
-									<td>http://www.idpf.org/vocab/rendition/#</td>
-								</tr>
-								<tr>
-									<td>schema</td>
-									<td>http://schema.org/</td>
-								</tr>
-								<tr>
-									<td>xsd</td>
-									<td>http://www.w3.org/2001/XMLSchema#</td>
-								</tr>
-							</tbody>
-						</table>
-
-						<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"
-									><code>prefix</code> attribute</a>.</p>
-					</section>
-
-					<section id="sec-prefix-attr">
-						<h5>The <code>prefix</code> Attribute</h5>
-
-						<p>The <code>prefix</code> attribute defines additional prefix mappings not <a
-								href="#sec-metadata-reserved-prefixes">reserved</a> by this specification.</p>
-
-						<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
-							prefix-to-IRI mappings of the form:</p>
-
-						<table class="productionset">
-							<caption>(EBNF productions <a
-									href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
-									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
-								(U+0000 to U+007F). </caption>
+					<table id="tbl-pkg-reserved-prefixes" class="prefix">
+						<thead>
 							<tr>
-								<td id="prefix.ebnf.def">
-									<a href="#prefix.ebnf.def">prefixes</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
-										>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
-										href="#prefix.ebnf.mapping">mapping</a> } ; </td>
-								<td> </td>
+								<th>Prefix</th>
+								<th>IRI</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>a11y</td>
+								<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.mapping">
-									<a href="#prefix.ebnf.mapping">mapping</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space"
-										>space</a> , { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
-								<td> </td>
+								<td>dcterms</td>
+								<td>http://purl.org/dc/terms/</td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.prefix">
-									<a href="#prefix.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td> </td>
+								<td>marc</td>
+								<td>http://id.loc.gov/vocabulary/</td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.space">
-									<a href="#prefix.ebnf.space">space</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>#x20 ;</td>
-								<td> </td>
+								<td>media</td>
+								<td>http://www.idpf.org/epub/vocab/overlays/#</td>
 							</tr>
 							<tr>
-								<td id="prefix.ebnf.whitespace">
-									<a href="#prefix.ebnf.whitespace">whitespace</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>(#x20 | #x9 | #xD | #xA) ;</td>
-								<td> </td>
+								<td>onix</td>
+								<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
 							</tr>
-						</table>
+							<tr>
+								<td>rendition</td>
+								<td>http://www.idpf.org/vocab/rendition/#</td>
+							</tr>
+							<tr>
+								<td>schema</td>
+								<td>http://schema.org/</td>
+							</tr>
+							<tr>
+								<td>xsd</td>
+								<td>http://www.w3.org/2001/XMLSchema#</td>
+							</tr>
+						</tbody>
+					</table>
 
-						<aside class="example">
-							<p>The following example shows prefixes for the Friend of a Friend (<code>foaf</code>) and
-								DBPedia (<code>dbp</code>) vocabularies being declared using the <code>prefix</code>
-								attribute.</p>
-							<pre>&lt;package … 
+					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
+							attribute</a>.</p>
+				</section>
+
+				<section id="sec-prefix-attr">
+					<h4>The <code>prefix</code> Attribute</h4>
+
+					<p>The <code>prefix</code> attribute defines additional prefix mappings not <a
+							href="#sec-metadata-reserved-prefixes">reserved</a> by this specification.</p>
+
+					<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
+						prefix-to-IRI mappings of the form:</p>
+
+					<table class="productionset">
+						<caption>(EBNF productions <a
+								href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
+								>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
+							(U+0000 to U+007F). </caption>
+						<tr>
+							<td id="prefix.ebnf.def">
+								<a href="#prefix.ebnf.def">prefixes</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
+									>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
+									href="#prefix.ebnf.mapping">mapping</a> } ; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.mapping">
+								<a href="#prefix.ebnf.mapping">mapping</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space">space</a>
+								, { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.prefix">
+								<a href="#prefix.ebnf.prefix">prefix</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? xsd:NCName ? ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.space">
+								<a href="#prefix.ebnf.space">space</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>#x20 ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.whitespace">
+								<a href="#prefix.ebnf.whitespace">whitespace</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>(#x20 | #x9 | #xD | #xA) ;</td>
+							<td> </td>
+						</tr>
+					</table>
+
+					<aside class="example">
+						<p>The following example shows prefixes for the Friend of a Friend (<code>foaf</code>) and
+							DBPedia (<code>dbp</code>) vocabularies being declared using the <code>prefix</code>
+							attribute.</p>
+						<pre>&lt;package … 
 	prefix="foaf: http://xmlns.com/foaf/spec/
 		 dbp: http://dbpedia.org/ontology/"&gt;
 	…
 &lt;/package&gt;</pre>
-						</aside>
+					</aside>
 
-						<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix
-							that maps to the <a href="#sec-metadata-default-vocab">default vocabulary</a>.</p>
+					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
+						maps to the <a href="#sec-metadata-default-vocab">default vocabulary</a>.</p>
 
-						<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
-							[[!RDFA-CORE]] processing.</p>
+					<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
+						[[!RDFA-CORE]] processing.</p>
 
-						<p>For future compatibility with alternative serializations of the Package Document, a prefix
-							for the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in
-							the <code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
-								href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
-					</section>
-
-					<section id="sec-property-datatype">
-						<h5>The <code>property</code> Data Type</h5>
-
-						<p>The property data type is a compact means of expressing an IRI [[!RFC3987]] and consists of
-							an OPTIONAL prefix separated from a reference by a colon.</p>
-
-						<table class="productionset">
-							<caption>(EBNF productions <a
-									href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
-									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
-								(U+0000 to U+007F). </caption>
-							<tr>
-								<td id="property.ebnf.property">
-									<a href="#property.ebnf.property">property</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
-										href="#property.ebnf.reference">reference</a>; </td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.prefix">
-									<a href="#property.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.reference">
-									<a href="#property.ebnf.reference">reference</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? irelative-ref ? ;</td>
-								<td>/* as defined in [[!RFC3987]] */<br /></td>
-							</tr>
-						</table>
-
-						<p>The property data type is derived from the CURIE data type defined in [[!RDFA-CORE]], and
-							represents a subset of CURIEs.</p>
-
-						<aside class="example">
-							<p>The following example shows a property value composed of the prefix <code>dcterms</code>
-								and the reference <code>modified</code>.</p>
-							<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
-						</aside>
-
-						<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
-							[[EPUB-RS-33]], this property would expand to the following IRI:</p>
-
-						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
-
-						<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
-								prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
-
-						<p>When a prefix is omitted from a property value, the expressed reference represents a term
-							from the <a href="#sec-metadata-default-vocab">default vocabulary</a> for that
-							attribute.</p>
-
-						<aside class="example">
-							<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
-								manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
-
-							<pre>&lt;item … properties="mathml"/&gt;</pre>
-
-							<p>This property expands to:</p>
-
-							<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
-
-							<p>when the IRI for the vocabulary is concatenated with the reference.</p>
-						</aside>
-
-						<p>An empty string does not represent a valid property value, even though it is valid to the
-							definition above.</p>
-
-					</section>
+					<p>For future compatibility with alternative serializations of the Package Document, a prefix for
+						the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in the
+							<code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
+							href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
 				</section>
 
-				<section id="sec-package-metadata-rendering">
-					<h4>Package Rendering Metadata</h4>
+				<section id="sec-property-datatype">
+					<h4>The <code>property</code> Data Type</h4>
+
+					<p>The property data type is a compact means of expressing an IRI [[!RFC3987]] and consists of an
+						OPTIONAL prefix separated from a reference by a colon.</p>
+
+					<table class="productionset">
+						<caption>(EBNF productions <a
+								href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
+								>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
+							(U+0000 to U+007F). </caption>
+						<tr>
+							<td id="property.ebnf.property">
+								<a href="#property.ebnf.property">property</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
+									href="#property.ebnf.reference">reference</a>; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="property.ebnf.prefix">
+								<a href="#property.ebnf.prefix">prefix</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? xsd:NCName ? ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="property.ebnf.reference">
+								<a href="#property.ebnf.reference">reference</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? irelative-ref ? ;</td>
+							<td>/* as defined in [[!RFC3987]] */<br /></td>
+						</tr>
+					</table>
+
+					<p>The property data type is derived from the CURIE data type defined in [[!RDFA-CORE]], and
+						represents a subset of CURIEs.</p>
+
+					<aside class="example">
+						<p>The following example shows a property value composed of the prefix <code>dcterms</code> and
+							the reference <code>modified</code>.</p>
+						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
+					</aside>
+
+					<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
+						[[EPUB-RS-33]], this property would expand to the following IRI:</p>
+
+					<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
+
+					<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
+							prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
+
+					<p>When a prefix is omitted from a property value, the expressed reference represents a term from
+						the <a href="#sec-metadata-default-vocab">default vocabulary</a> for that attribute.</p>
+
+					<aside class="example">
+						<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
+							manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
+
+						<pre>&lt;item … properties="mathml"/&gt;</pre>
+
+						<p>This property expands to:</p>
+
+						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
+
+						<p>when the IRI for the vocabulary is concatenated with the reference.</p>
+					</aside>
+
+					<p>An empty string does not represent a valid property value, even though it is valid to the
+						definition above.</p>
 
-					<section id="sec-package-metadata-layout-general-intro" class="informative">
-						<h3>Introduction</h3>
-
-						<p>Not all rendering information can be expressed through the underlying technologies that EPUB
-							is built upon. For example, although HTML with CSS provides powerful layout capabilities,
-							those capabilities are limited to the scope of the document being rendered.</p>
-
-						<p>This section defines general-purpose properties that allow Authors to express package-level
-							rendering intentions (i.e., functionality that can only be implemented by the <a>EPUB
-								Reading System</a>). If a Reading System supports the desired rendering, these
-							properties enable the user to be presented the content as the Author optimally designed
-							it.</p>
-
-					</section>
-
-					<section id="rendition-vocab-ref">
-						<h5>Referencing</h5>
-
-						<p>The base IRI for referencing these properties is
-								<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
-
-						<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved
-								for use</a> with the package rendering properties and does not have to be declared in
-							the Package Document.</p>
-					</section>
-
-					<section id="sec-package-metadata-general">
-						<h5>General Properties</h5>
-
-						<section id="flow">
-							<h6>The <code>rendition:flow</code> Property</h6>
-
-							<p>The <code>rendition:flow</code> property specifies the Author preference for how Reading
-								Systems should handle content overflow. </p>
-
-							<section id="layout-property-flow-usage">
-								<h6>Usage</h6>
-
-								<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code>
-										property</a> is specified on a <code>meta</code> element, it indicates the
-									Author's global preference for overflow content handling (i.e., for all spine
-									items). Authors MAY indicate a preference for dynamic pagination or scrolling. For
-									scrolled content, it is also possible to specify whether consecutive <a>EPUB Content
-										Documents</a> are to be rendered as a continuous scrolling view or whether each
-									is to be rendered separately (i.e., with a dynamic page break between each).</p>
-
-								<p id="html-body-page-break-before">Note that when two reflowable EPUB Content Documents
-									occur sequentially in the spine, the default rendering for their [[!HTML]] <a
-										href="https://www.w3.org/TR/html/sections.html#the-body-element"
-											><code>body</code></a> elements is consistent with the <a
-										href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-											><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been
-									set to <code>always</code>. In addition to using the <code>rendition:flow</code>
-									property, Authors MAY override this behavior through an appropriate style sheet
-									declaration, if the Reading System supports such overrides.</p>
-
-								<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
-							</section>
-
-							<section id="layout-property-flow-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:flow</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt id="paginated">paginated</dt>
-									<dd>
-										<p>Dynamically paginate all overflow content.</p>
-									</dd>
-									<dt id="scrolled-continuous">scrolled-continuous</dt>
-									<dd>
-										<p>Render all Content Documents such that overflow content is scrollable, and
-											the EPUB Publication represented by the given <a>Rendition</a> is presented
-											as one continuous scroll from spine item to spine item (except where <a
-												href="#layout-property-flow-overrides">locally overridden</a>).</p>
-										<p>Note that Authors SHOULD NOT create publications in which different resources
-											have different block flow directions, as continuous scrolled rendition in
-											EPUB Reading Systems would be problematic.</p>
-									</dd>
-									<dt id="scrolled-doc">scrolled-doc</dt>
-									<dd>
-										<p>Render all Content Documents such that overflow content is scrollable, and
-											each spine item is presented as a separate scrollable document.</p>
-									</dd>
-									<dt id="auto">auto</dt>
-									<dd>
-										<p>Render overflow content using the Reading System default method or a user
-											preference, whichever is applicable.</p>
-									</dd>
-								</dl>
-							</section>
-
-							<section id="layout-property-flow-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="layout-property-flow-local">Authors MAY specify the following properties locally
-									on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
-									override the <a href="#property-flow-global">global value</a> for the given spine
-									item:</p>
-
-								<dl>
-									<dt id="flow-auto">flow-auto</dt>
-									<dd>Indicates no preference for overflow content handling by the Author.</dd>
-
-									<dt id="flow-paginated">flow-paginated</dt>
-									<dd>Indicates the Author preference is to dynamically paginate content
-										overflow.</dd>
-
-									<dt id="flow-scrolled-continuous">flow-scrolled-continuous</dt>
-									<dd>Indicates the Author preference is to provide a scrolled view for overflow
-										content, and that consecutive spine items with this property are to be rendered
-										as a continuous scroll.</dd>
-
-									<dt id="flow-scrolled-doc">flow-scrolled-doc</dt>
-									<dd>Indicates the Author preference is to provide a scrolled view for overflow
-										content, and each spine item with this property is to be rendered as a separate
-										scrollable document.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-							</section>
-
-							<section id="layout-property-flow-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="property-flow-ex1">
-									<p>The following example demonstrates an Author's intent to have a paginated
-										Rendition with a scrollable table of contents.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:flow"&gt;paginated&lt;/meta&gt;
-&lt;/metadata&gt;
-
-&lt;spine&gt;
-    &lt;itemref idref="toc" properties="rendition:flow-scrolled-doc"/&gt;
-    &lt;itemref idref="c01"/&gt;
-&lt;/spine&gt;</pre>
-								</aside>
-
-							</section>
-
-						</section>
-
-						<section id="align-x-center">
-							<h6>The <code>rendition:align-x-center</code> Property</h6>
-
-							<p>The <code>rendition:align-x-center</code> property specifies that the given spine item
-								should be centered horizontally in the viewport or spread. </p>
-
-							<div class="note">
-								<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title
-									pages), in the absence of reliable centering control within the content rendering.
-									As support for paged media evolves in CSS, however, this property is expected to be
-									deprecated. Authors are encouraged to use CSS solutions when effective.</p>
-							</div>
-
-						</section>
-					</section>
-
-					<section id="sec-package-metadata-fxl">
-						<h5>Fixed-Layout Properties</h5>
-
-						<section id="fxl-intro" class="informative">
-							<h6>Introduction</h6>
-
-							<p>EPUB documents, unlike print books or PDF files, are designed to change. The content
-								flows, or reflows, to fit the screen and to fit the needs of the user. As noted in <a
-									href="epub-overview.html#sec-rendering">Rendering and CSS</a> "content presentation
-								adapts to the user, rather than the user having to adapt to a particular presentation of
-								content." [[EPUB-OVERVIEW-33]]</p>
-
-							<p>But this principle doesn’t work for all types of documents. Sometimes content and design
-								are so intertwined they cannot be separated. Any change in appearance risks changing the
-								meaning, or losing all meaning. <a>Fixed-Layout Documents</a> give <a>Authors</a>
-								greater control over presentation when a reflowable EPUB is not suitable for the
-								content.</p>
-
-							<p>This section defines a set of metadata properties to allow declarative expression of
-								intended rendering behaviors of Fixed-Layout Documents in the context of EPUB 3.</p>
-
-							<div class="note" id="note-mechanisms">
-								<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When
-									fixed-layout content is necessary, the Author's choice of mechanism will depend on
-									many factors including desired degree of precision, file size, accessibility, etc.
-									This section does not attempt to dictate the Author's choice of mechanism.</p>
-							</div>
-
-						</section>
-
-						<section id="layout">
-							<h6>The <code>rendition:layout</code> Property</h6>
-
-							<p>The <code>rendition:layout</code> property specifies whether the given Rendition is
-								reflowable or pre-paginated.</p>
-
-							<section id="layout-usage">
-								<h5>Usage</h5>
-
-								<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code>
-										property</a> is specified on a <code>meta</code> element, it indicates that the
-									paginated or reflowable layout style applies globally for the <a>Rendition</a>
-									(i.e., for all spine items).</p>
-
-								<p>When the property is set to <code>pre-paginated</code> for a spine item, its content
-									dimensions MUST be set as defined in <a href="#sec-fixed-layouts"></a>.</p>
-
-								<p>The <code>rendition:layout</code> property MUST NOT be declared more than once.</p>
-
-							</section>
-
-							<section id="layout-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:layout</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt id="def-layout-reflowable">reflowable</dt>
-									<dd>
-										<p>The given Rendition is not pre-paginated (i.e., Reading Systems apply dynamic
-											pagination when rendering). Default value.</p>
-									</dd>
-									<dt id="def-layout-pre-paginated">pre-paginated</dt>
-									<dd>
-										<p>The given Rendition is pre-paginated (i.e., Reading Systems produce exactly
-											one page per spine <a href="#elemdef-spine-itemref"><code>itemref</code></a>
-											when rendering).</p>
-									</dd>
-								</dl>
-
-								<div class="note" id="uaag">
-									<p>Reading Systems typically restrict or deny the application of user or user agent
-										style sheets to pre-paginated documents, since, as a result of intrinsic
-										properties of such documents, dynamic style changes are highly likely to have
-										unintended consequences. Authors need to take into account the negative impact
-										on usability and accessibility that these restrictions have when choosing to use
-										pre-paginated instead of reflowable content. Refer to <a
-											href="https://www.w3.org/TR/2015/NOTE-UAAG20-20151215/#gl-text-config"
-											>Guideline 1.4 - Provide text configuration</a> [[UAAG20]] for related
-										information.</p>
-								</div>
-
-							</section>
-
-							<section id="layout-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="property-layout-local">Authors MAY specify the following properties locally on
-									spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override
-									the <a href="#property-layout-global">global value</a> for the given spine item:</p>
-
-								<dl>
-									<dt id="layout-pre-paginated">layout-pre-paginated</dt>
-									<dd>Specifies that the given spine item is pre-paginated.</dd>
-
-									<dt id="layout-reflowable">layout-reflowable</dt>
-									<dd>Specifies that the given spine item is reflowable.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-
-							</section>
-
-							<section id="layout-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex1">
-									<p>The following example demonstrates fully fixed-layout content, using
-										[[CSS3-MediaQueries]] to apply different style sheets for three different device
-										categories. Note that the Media Queries only affect the style sheet applied to
-										the document; the size of the content area set in the <code>viewport</code>
-										<code>meta</code> tag is static.</p>
-
-									<h5>Package Document</h5>
-
-									<pre>&lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;</pre>
-
-									<h5>XHTML</h5>
-
-									<pre>&lt;head&gt;
-    &lt;meta name="viewport" content="width=1200, height=900"/&gt;
-	
-    &lt;link rel="stylesheet" href="eink-style.css" media="(max-monochrome: 3)"/&gt;
-    &lt;link rel="stylesheet" href="skinnytablet-style.css" media="((color) and
-        (max-height:600px) and (orientation:landscape), (color) and (max-width:600px)
-        and (orientation:portrait))"/&gt;
-    &lt;link rel="stylesheet" href="fattablet-style.css" media="((color) and
-        (min-height:601px) and (orientation:landscape), (color) and (min-width:601px)
-        and (orientation:portrait)"/&gt;	
-&lt;/head&gt;
-</pre>
-								</aside>
-
-							</section>
-						</section>
-
-						<section id="orientation">
-							<h6>The <code>rendition:orientation</code> Property</h6>
-
-							<p>The <code>rendition:orientation</code> property specifies which orientation the Author
-								intends the given Rendition to be rendered in. </p>
-
-							<section id="orientation-usage">
-								<h5>Usage</h5>
-
-								<p id="property-orientation-global">When the <a href="#orientation"
-											><code>rendition:orientation</code> property</a> is specified on a
-										<code>meta</code> element, it indicates that the intended orientation applies
-									globally for the given Rendition (i.e., for all spine items).</p>
-
-								<p>The <code>rendition:orientation</code> property MUST NOT be declared more than
-									once.</p>
-
-							</section>
-
-							<section id="orientation-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:orientation</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt>landscape</dt>
-									<dd>
-										<p>The given Rendition is intended for landscape rendering.</p>
-									</dd>
-									<dt>portrait</dt>
-									<dd>
-										<p> The given Rendition is intended for portrait rendering.</p>
-									</dd>
-									<dt>auto</dt>
-									<dd>
-										<p>The given Rendition is not orientation constrained. Default value.</p>
-									</dd>
-								</dl>
-							</section>
-
-							<section id="orientation-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="property-orientation-local">Authors MAY specify the following properties locally
-									on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
-									override the <a href="#property-orientation-global">global value</a> for the given
-									spine item:</p>
-
-								<dl>
-									<dt id="orientation-auto">orientation-auto</dt>
-									<dd>Specifies that the Reading System determines the orientation to render the spine
-										item in.</dd>
-
-									<dt id="orientation-landscape">orientation-landscape</dt>
-									<dd>Specifies that the given spine item is to be rendered in landscape
-										orientation.</dd>
-
-									<dt id="orientation-portrait">orientation-portrait</dt>
-									<dd>Specifies that the given spine item is to be rendered in portrait
-										orientation.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-
-							</section>
-
-							<section id="orientation-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex2">
-									<p>The following example demonstrates fully fixed-layout content intended to be
-										rendered without synthetic spreads, and locked to landscape orientation.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;none&lt;/meta&gt;
-    
-    &lt;meta property="rendition:orientation"&gt;landscape&lt;/meta&gt;
-&lt;/metadata&gt;</pre>
-								</aside>
-
-							</section>
-
-						</section>
-
-						<section id="spread">
-							<h6>The <code>rendition:spread</code> Property</h6>
-
-							<p>The <code>rendition:spread</code> property specifies the intended Reading System
-								synthetic spread behavior for the given Rendition.</p>
-
-							<section id="spread-usage">
-								<h6>Usage</h6>
-
-								<p id="property-spread-global">When the <code>rendition:spread</code> property is
-									specified on a <code>meta</code> element, it indicates that the intended
-										<a>Synthetic Spread</a> behavior applies globally for the given Rendition (i.e.,
-									for all spine items).</p>
-
-								<p>The <code>rendition:spread</code> property MUST NOT be declared more than once.</p>
-							</section>
-
-							<section id="spread-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:spread</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt>none</dt>
-									<dd>
-										<p>Do not incorporate spine items in a Synthetic Spread.</p>
-									</dd>
-									<dt>landscape</dt>
-									<dd>
-										<p>Render a Synthetic Spread for spine items only when the device is in
-											landscape orientation.</p>
-									</dd>
-									<dt>portrait (deprecated)</dt>
-									<dd>
-										<p>The use of spreads only in portrait orientation is <a href="#deprecated"
-												>deprecated</a>.</p>
-										<p>Authors are advised to use the value "<code>both</code>" instead, as spreads
-											that are readable in portrait orientation are also readable in
-											landscape.</p>
-									</dd>
-									<dt>both</dt>
-									<dd>
-										<p>Render a Synthetic Spread regardless of device orientation.</p>
-									</dd>
-									<dt>auto</dt>
-									<dd>
-										<p>No explicit Synthetic Spread behavior is defined. Default value.</p>
-									</dd>
-								</dl>
-
-								<div class="note">
-									<p>When Synthetic Spreads are used in the context of HTML and SVG Content Documents,
-										the dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
-											<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"
-												><code>viewBox</code> attribute</a> represents the size of one page in
-										the spread, respectively.</p>
-								</div>
-
-								<div class="note">
-									<p>Refer to <a href="#sec-spine-elem">spine</a> for information about declaration of
-										global flow directionality using the <code>page-progression-direction</code>
-										attribute and that of local page-progression-direction within content
-										documents.</p>
-								</div>
-
-							</section>
-
-							<section id="spread-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="property-spread-local">Authors MAY specify the following properties locally on
-									spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override
-									the <a href="#property-spread-global">global value</a> for the given spine item:</p>
-
-								<dl>
-									<dt id="spread-auto">spread-auto</dt>
-									<dd>Specifies the Reading System determines when to render a synthetic spread for
-										the spine item. </dd>
-
-									<dt id="spread-both">spread-both</dt>
-									<dd>Specifies the Reading System should render a synthetic spread for the spine item
-										in both portrait and landscape orientations. </dd>
-
-									<dt id="spread-landscape">spread-landscape</dt>
-									<dd>Specifies the Reading System should render a synthetic spread for the spine item
-										only when in landscape orientation.</dd>
-
-									<dt id="spread-none">spread-none</dt>
-									<dd>Specifies the Reading System should not render a synthetic spread for the spine
-										item.</dd>
-
-									<dt id="spread-portrait">spread-portrait</dt>
-									<dd>The <code>spread-portrait</code> property is <a href="#deprecated"
-											>deprecated</a>. Refer to its definition in [[!EPUBPublications-301]] for
-										more information.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-							</section>
-
-							<section id="spread-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex3">
-									<p>The following example demonstrates fully fixed-layout content intended to be
-										rendered using synthetic spreads in landscape orientation, and with no spreads
-										in portrait orientation.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;landscape&lt;/meta&gt;
-&lt;/metadata&gt;</pre>
-								</aside>
-
-								<aside class="example" id="fxl-ex4">
-									<p>The following example demonstrates reflowable content with a single fixed-layout
-										title page, where the fixed-layout page is intended for right-hand spread slot
-										if the device renders Synthetic Spreads.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;reflowable&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
-&lt;/metadata&gt;
-
-&lt;spine&gt;
-    &lt;itemref idref="titlepage" properties="page-spread-right rendition:layout-pre-paginated"/&gt;
-&lt;/spine&gt;</pre>
-								</aside>
-
-							</section>
-
-						</section>
-
-						<section id="page-spread">
-							<h6>The <code>rendition:page-spread-*</code> Properties</h6>
-
-							<section id="page-spread-usage">
-								<h6>Usage</h6>
-
-								<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to
-									populate the spread by rendering the next <a>EPUB Content Document</a> in the next
-									available unpopulated viewport, where the next available viewport is determined by
-									the given <a href="#sec-spine-elem">page progression direction</a> or by local
-									declarations within Content Documents. An Author MAY override this automatic
-									population behavior and force a document to be placed in a particular viewport by
-									specifying one of the following properties on its spine <code>itemref</code>
-									element:</p>
-
-								<dl>
-									<dt id="page-spread-center">
-										<code>rendition:page-spread-center</code>
-									</dt>
-									<dd>The <code>rendition:page-spread-center</code> property specifies the forced
-										placement of a Content Document in a <a>Synthetic Spread</a>. </dd>
-
-									<dt id="fxl-page-spread-left">
-										<code>rendition:page-spread-left</code>
-									</dt>
-									<dd>The <code>rendition:page-spread-left</code> property is an alias for the
-												<code><a href="#page-spread-left">page-spread-left</a></code>
-										property.</dd>
-
-									<dt id="fxl-page-spread-right">
-										<code>rendition:page-spread-right</code>
-									</dt>
-									<dd>The <code>rendition:page-spread-right</code> property is an alias for the
-												<code><a href="#page-spread-right">page-spread-right</a></code>
-										property.</dd>
-								</dl>
-
-								<p>The <code>rendition:page-spread-left</code> property indicates that the given spine
-									item is to be rendered in the left-hand slot in the spread, and
-										<code>rendition:page-spread-right</code> that it be rendered in the right-hand
-									slot. The <code>rendition:page-spread-center</code> property indicates to override
-									the synthetic spread mode and render a single viewport positioned at the center of
-									the screen.</p>
-
-								<p>The <code>rendition:page-spread-left</code>, <code>rendition:page-spread-right</code>
-									and <code>rendition:page-spread-center</code> properties apply to both pre-paginated
-									and reflowable content, and they only apply when the Reading System is creating
-									Synthetic Spreads.</p>
-
-								<p>Although Authors often indicate to use a spread in certain device orientations, the
-									content itself does not represent true spreads (i.e., two consecutive pages that
-									have to be rendered side-by-side for readability, such as a two-page map). To
-									indicate that two consecutive pages represent a true spread, Authors SHOULD use the
-										<code>rendition:page-spread-left</code> and
-										<code>rendition:page-spread-right</code> properties on the spine items for the
-									two adjacent EPUB Content Documents, and omit the properties on spine items where
-									one-up or two-up presentation is equally acceptable.</p>
-
-								<p>Only one <code>page-spread-*</code> property can be declared on any given spine
-									item.</p>
-
-								<div class="note" id="note-page-spread-aliases">
-									<p>The <code>rendition:page-spread-left</code> and
-											<code>rendition:page-spread-right</code> properties are aliases for the <a
-											href="#page-spread-left"><code>page-spread-left</code></a> and <a
-											href="#page-spread-right"><code>spread-right</code></a> properties. They
-										allow the use of a single vocabulary for all fixed-layout properties. Authors
-										can use either property set, but older Reading Systems might only recognize the
-										unprefixed versions. The <a href="#app-itemref-properties-vocab">EPUB Spine
-											Properties Vocabulary</a> is no longer being extended for package rendering
-										metadata, so an unprefixed <code>page-spread-center</code> is not available.</p>
-								</div>
-							</section>
-
-							<section id="page-spread-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex5">
-									<p>The following example demonstrates reflowable content with a two-page
-										fixed-layout center plate that is intended to be rendered using synthetic
-										spreads in any device orientation. Note that the author has left spread behavior
-										for the other (reflowable) parts of the <a>Rendition</a> undefined, since the
-										global value of <code>rendition:spread</code> is initialized to
-											<code>auto</code> by default.</p>
-									<pre>&lt;spine page-progression-direction="ltr"&gt;
-    …
-    &lt;itemref idref="center-plate-left"
-             properties="rendition:spread-both rendition:page-spread-left"/&gt;
-    &lt;itemref idref="center-plate-right"
-             properties="rendition:spread-both rendition:page-spread-right"/&gt;
-    …
-&lt;/spine&gt;</pre>
-								</aside>
-
-								<aside class="example" id="fxl-ex6">
-									<p>The following example demonstrates fixed-layout content, where synthetic spreads,
-										when used, have to be disabled for a center plate. Note that the
-											<code>rendition:spread</code> declaration <code>none</code> expression is
-										not needed on the center plate item, as the
-											<code>rendition:page-spread-center</code> property already specifies
-										semantics that dictates that synthetic spreads be disabled.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
-&lt;/metadata&gt;
-&lt;spine&gt;
-    &lt;itemref idref="center-plate" properties="rendition:page-spread-center"/&gt;
-&lt;/spine&gt;</pre>
-								</aside>
-							</section>
-						</section>
-
-						<section id="viewport">
-							<h6>The <code>rendition:viewport</code> Property (Deprecated)</h6>
-
-							<p>The <code>rendition:viewport</code> property allows <a>Authors</a> to express the CSS
-								initial containing block (ICB) [[!CSS21]] for XHTML and SVG Content Documents whose
-									<code>rendition:layout</code> property has been set to
-								<code>pre-paginated</code>.</p>
-
-							<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its definition in
-								[[!EPUBPublications-301]] for more information.</p>
-						</section>
-					</section>
 				</section>
 			</section>
 
@@ -6284,83 +5633,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				</section>
 			</section>
 
-			<section id="sec-fixed-layouts">
-				<h3>Fixed Layouts</h3>
-
-				<section id="sec-fxl-overview" class="informative">
-					<h4>Introduction</h4>
-
-					<p>This section defines rules for the expression and interpretation of dimensional properties of
-							<a>Fixed-Layout Documents</a> — <a>EPUB Content Documents</a> marked as
-							<code>pre-paginated</code> in the <a>Package Document</a>.</p>
-
-					<div class="note">
-						<p>Refer to <a href="#sec-package-metadata-fxl"></a> for information on how to designate that a
-								<a>Rendition</a>, or its individual spine items, are to be rendered in a pre-paginated
-							manner (i.e., with fixed width and height dimensions).</p>
-					</div>
-
-				</section>
-
-				<section id="sec-fxl-content-conf">
-					<h4>Content Conformance</h4>
-
-					<p>A conformant <a>Fixed-Layout Document</a> has to meet the following criteria:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreg-fxl-icb">It MUST specify its <a
-									href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-									containing block</a> [[!CSS2]] as defined in <a href="#sec-fxl-html-svg-dimensions"
-								></a>.</p>
-						</li>
-					</ul>
-				</section>
-
-				<section id="sec-fxl-html-svg-dimensions">
-					<h4>Initial Containing Block Dimensions</h4>
-
-					<section id="sec-fxl-icb-html">
-						<h5>Expressing in HTML</h5>
-
-						<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
-								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-								containing block</a> [[!CSS2]] dimensions MUST be expressed in a <code>viewport</code>
-							<code>meta</code> tag using the syntax defined in [[!CSS-Device-Adapt-1]].</p>
-
-						<aside class="example">
-							<p>The following example shows a <code>viewport</code>
-								<code>meta</code> tag.</p>
-							<pre>
-&lt;head&gt;
-   …
-   &lt;meta name="viewport" content="width=1200, height=600"/&gt;
-   …
-&lt;/head&gt;</pre>
-						</aside>
-					</section>
-
-					<section id="sec-fxl-icb-svg">
-						<h5>Expressing in SVG</h5>
-
-						<p>For SVG <a>Fixed-Layout Documents</a>, the ICB dimensions MUST be expressed using the <a
-								href="http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code>
-								attribute</a> [[!SVG]].</p>
-
-						<aside class="example">
-							<p>The following example shows a <code>viewBox</code> attribute declaration for an SVG
-								Content Document with an aspect ratio of 844 pixels wide by 1200 pixels high.</p>
-							<pre>
-&lt;svg xmlns="http://www.w3.org/2000/svg"
-     version="1.1" 
-     viewBox="0 0 844 1200"&gt;
-   …
-&lt;/svg&gt;</pre>
-						</aside>
-					</section>
-				</section>
-			</section>
-
 			<section id="sec-pls">
 				<h3>Pronunciation Lexicons</h3>
 
@@ -6460,6 +5732,464 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								extension <code class="filename">.pls</code>.</p>
 						</dd>
 					</dl>
+				</section>
+			</section>
+		</section>
+		<section id="sec-fixed-layouts">
+			<h2>Fixed Layouts</h2>
+
+			<section id="fxl-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>EPUB documents, unlike print books or PDF files, are designed to change. The content flows, or
+					reflows, to fit the screen and to fit the needs of the user. As noted in <a
+						href="epub-overview.html#sec-rendering">Rendering and CSS</a> "content presentation adapts to
+					the user, rather than the user having to adapt to a particular presentation of content."
+					[[EPUB-OVERVIEW-33]]</p>
+
+				<p>But this principle doesn’t work for all types of documents. Sometimes content and design are so
+					intertwined they cannot be separated. Any change in appearance risks changing the meaning, or losing
+					all meaning. <a>Fixed-Layout Documents</a> give <a>Authors</a> greater control over presentation
+					when a reflowable EPUB is not suitable for the content.</p>
+
+				<p>This section defines a set of metadata properties to allow declarative expression of intended
+					rendering behaviors of Fixed-Layout Documents in the context of EPUB 3.</p>
+
+				<div class="note" id="note-mechanisms">
+					<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
+						content is necessary, the Author's choice of mechanism will depend on many factors including
+						desired degree of precision, file size, accessibility, etc. This section does not attempt to
+						dictate the Author's choice of mechanism.</p>
+				</div>
+			</section>
+
+			<section id="sec-package-metadata-fxl">
+				<h3>Package Definition</h3>
+
+				<section id="layout">
+					<h4>Layout</h4>
+
+					<p>The <code>rendition:layout</code> property specifies whether the given Rendition is reflowable or
+						pre-paginated.</p>
+
+					<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code> property</a>
+						is specified on a <code>meta</code> element, it indicates that the paginated or reflowable
+						layout style applies globally for the <a>Rendition</a> (i.e., for all spine items).</p>
+
+					<p>The following values are defined for use with the <code>rendition:layout</code> property:</p>
+
+					<dl class="variablelist">
+						<dt id="def-layout-reflowable">reflowable</dt>
+						<dd>
+							<p>The given Rendition is not pre-paginated (i.e., Reading Systems apply dynamic pagination
+								when rendering). Default value.</p>
+						</dd>
+						<dt id="def-layout-pre-paginated">pre-paginated</dt>
+						<dd>
+							<p>The given Rendition is pre-paginated (i.e., Reading Systems produce exactly one page per
+								spine <a href="#elemdef-spine-itemref"><code>itemref</code></a> when rendering).</p>
+						</dd>
+					</dl>
+
+					<div class="note" id="uaag">
+						<p>Reading Systems typically restrict or deny the application of user or user agent style sheets
+							to pre-paginated documents, since, as a result of intrinsic properties of such documents,
+							dynamic style changes are highly likely to have unintended consequences. Authors need to
+							take into account the negative impact on usability and accessibility that these restrictions
+							have when choosing to use pre-paginated instead of reflowable content. Refer to <a
+								href="https://www.w3.org/TR/2015/NOTE-UAAG20-20151215/#gl-text-config">Guideline 1.4 -
+								Provide text configuration</a> [[UAAG20]] for related information.</p>
+					</div>
+
+					<p>When the property is set to <code>pre-paginated</code> for a spine item, its content dimensions
+						MUST be set as defined in <a href="#sec-fixed-layouts"></a>.</p>
+
+					<p>The <code>rendition:layout</code> property MUST NOT be declared more than once.</p>
+
+					<aside class="example" id="fxl-ex1">
+						<p>The following example demonstrates fully fixed-layout content, using [[CSS3-MediaQueries]] to
+							apply different style sheets for three different device categories. Note that the Media
+							Queries only affect the style sheet applied to the document; the size of the content area
+							set in the <code>viewport</code>
+							<code>meta</code> tag is static.</p>
+
+						<h3>Package Document</h3>
+
+						<pre>&lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;</pre>
+
+						<h3>XHTML</h3>
+
+						<pre>&lt;head&gt;
+    &lt;meta name="viewport" content="width=1200, height=900"/&gt;
+	
+    &lt;link rel="stylesheet" href="eink-style.css" media="(max-monochrome: 3)"/&gt;
+    &lt;link rel="stylesheet" href="skinnytablet-style.css" media="((color) and
+        (max-height:600px) and (orientation:landscape), (color) and (max-width:600px)
+        and (orientation:portrait))"/&gt;
+    &lt;link rel="stylesheet" href="fattablet-style.css" media="((color) and
+        (min-height:601px) and (orientation:landscape), (color) and (min-width:601px)
+        and (orientation:portrait)"/&gt;	
+&lt;/head&gt;
+</pre>
+					</aside>
+
+					<section id="layout-overrides">
+						<h5>Spine Overrides</h5>
+
+						<p id="property-layout-local">Authors MAY specify the following properties locally on spine <a
+								href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+								href="#property-layout-global">global value</a> for the given spine item:</p>
+
+						<dl>
+							<dt id="layout-pre-paginated">layout-pre-paginated</dt>
+							<dd>Specifies that the given spine item is pre-paginated.</dd>
+
+							<dt id="layout-reflowable">layout-reflowable</dt>
+							<dd>Specifies that the given spine item is reflowable.</dd>
+						</dl>
+
+						<p>Only one of these overrides is allowed on any given spine item.</p>
+
+					</section>
+				</section>
+
+				<section id="orientation">
+					<h4>Orientaton</h4>
+
+					<p>The <code>rendition:orientation</code> property specifies which orientation the Author intends
+						the given Rendition to be rendered in. </p>
+
+					<p id="property-orientation-global">When the <a href="#orientation"
+								><code>rendition:orientation</code> property</a> is specified on a <code>meta</code>
+						element, it indicates that the intended orientation applies globally for the given Rendition
+						(i.e., for all spine items).</p>
+
+					<p>The following values are defined for use with the <code>rendition:orientation</code>
+						property:</p>
+
+					<dl class="variablelist">
+						<dt>landscape</dt>
+						<dd>
+							<p>The given Rendition is intended for landscape rendering.</p>
+						</dd>
+						<dt>portrait</dt>
+						<dd>
+							<p> The given Rendition is intended for portrait rendering.</p>
+						</dd>
+						<dt>auto</dt>
+						<dd>
+							<p>The given Rendition is not orientation constrained. Default value.</p>
+						</dd>
+					</dl>
+
+					<p>The <code>rendition:orientation</code> property MUST NOT be declared more than once.</p>
+
+					<aside class="example" id="fxl-ex2">
+						<p>The following example demonstrates fully fixed-layout content intended to be rendered without
+							synthetic spreads, and locked to landscape orientation.</p>
+						<pre>&lt;metadata&gt;
+    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
+    &lt;meta property="rendition:spread"&gt;none&lt;/meta&gt;
+    
+    &lt;meta property="rendition:orientation"&gt;landscape&lt;/meta&gt;
+&lt;/metadata&gt;</pre>
+					</aside>
+
+					<section id="orientation-overrides">
+						<h5>Spine Overrides</h5>
+
+						<p id="property-orientation-local">Authors MAY specify the following properties locally on spine
+								<a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+								href="#property-orientation-global">global value</a> for the given spine item:</p>
+
+						<dl>
+							<dt id="orientation-auto">orientation-auto</dt>
+							<dd>Specifies that the Reading System determines the orientation to render the spine item
+								in.</dd>
+
+							<dt id="orientation-landscape">orientation-landscape</dt>
+							<dd>Specifies that the given spine item is to be rendered in landscape orientation.</dd>
+
+							<dt id="orientation-portrait">orientation-portrait</dt>
+							<dd>Specifies that the given spine item is to be rendered in portrait orientation.</dd>
+						</dl>
+
+						<p>Only one of these overrides is allowed on any given spine item.</p>
+
+					</section>
+				</section>
+
+				<section id="spread">
+					<h4>Synthetic Spreads</h4>
+
+					<p>The <code>rendition:spread</code> property specifies the intended Reading System synthetic spread
+						behavior for the given Rendition.</p>
+
+					<p id="property-spread-global">When the <code>rendition:spread</code> property is specified on a
+							<code>meta</code> element, it indicates that the intended <a>Synthetic Spread</a> behavior
+						applies globally for the given Rendition (i.e., for all spine items).</p>
+
+					<p>The following values are defined for use with the <code>rendition:spread</code> property:</p>
+
+					<dl class="variablelist">
+						<dt>none</dt>
+						<dd>
+							<p>Do not incorporate spine items in a Synthetic Spread.</p>
+						</dd>
+						<dt>landscape</dt>
+						<dd>
+							<p>Render a Synthetic Spread for spine items only when the device is in landscape
+								orientation.</p>
+						</dd>
+						<dt>portrait (deprecated)</dt>
+						<dd>
+							<p>The use of spreads only in portrait orientation is <a href="#deprecated"
+								>deprecated</a>.</p>
+							<p>Authors are advised to use the value "<code>both</code>" instead, as spreads that are
+								readable in portrait orientation are also readable in landscape.</p>
+						</dd>
+						<dt>both</dt>
+						<dd>
+							<p>Render a Synthetic Spread regardless of device orientation.</p>
+						</dd>
+						<dt>auto</dt>
+						<dd>
+							<p>No explicit Synthetic Spread behavior is defined. Default value.</p>
+						</dd>
+					</dl>
+
+					<p>The <code>rendition:spread</code> property MUST NOT be declared more than once.</p>
+
+					<div class="note">
+						<p>When Synthetic Spreads are used in the context of HTML and SVG Content Documents, the
+							dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
+								<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"><code>viewBox</code>
+								attribute</a> represents the size of one page in the spread, respectively.</p>
+					</div>
+
+					<div class="note">
+						<p>Refer to <a href="#sec-spine-elem">spine</a> for information about declaration of global flow
+							directionality using the <code>page-progression-direction</code> attribute and that of local
+							page-progression-direction within content documents.</p>
+					</div>
+
+					<aside class="example" id="fxl-ex3">
+						<p>The following example demonstrates fully fixed-layout content intended to be rendered using
+							synthetic spreads in landscape orientation, and with no spreads in portrait orientation.</p>
+						<pre>&lt;metadata&gt;
+    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
+    &lt;meta property="rendition:spread"&gt;landscape&lt;/meta&gt;
+&lt;/metadata&gt;</pre>
+					</aside>
+
+					<aside class="example" id="fxl-ex4">
+						<p>The following example demonstrates reflowable content with a single fixed-layout title page,
+							where the fixed-layout page is intended for right-hand spread slot if the device renders
+							Synthetic Spreads.</p>
+						<pre>&lt;metadata&gt;
+    &lt;meta property="rendition:layout"&gt;reflowable&lt;/meta&gt;
+    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
+&lt;/metadata&gt;
+
+&lt;spine&gt;
+    &lt;itemref idref="titlepage" properties="page-spread-right rendition:layout-pre-paginated"/&gt;
+&lt;/spine&gt;</pre>
+					</aside>
+
+					<section id="spread-overrides">
+						<h5>Spine Overrides</h5>
+
+						<p id="property-spread-local">Authors MAY specify the following properties locally on spine <a
+								href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+								href="#property-spread-global">global value</a> for the given spine item:</p>
+
+						<dl>
+							<dt id="spread-auto">spread-auto</dt>
+							<dd>Specifies the Reading System determines when to render a synthetic spread for the spine
+								item. </dd>
+
+							<dt id="spread-both">spread-both</dt>
+							<dd>Specifies the Reading System should render a synthetic spread for the spine item in both
+								portrait and landscape orientations. </dd>
+
+							<dt id="spread-landscape">spread-landscape</dt>
+							<dd>Specifies the Reading System should render a synthetic spread for the spine item only
+								when in landscape orientation.</dd>
+
+							<dt id="spread-none">spread-none</dt>
+							<dd>Specifies the Reading System should not render a synthetic spread for the spine
+								item.</dd>
+
+							<dt id="spread-portrait">spread-portrait</dt>
+							<dd>The <code>spread-portrait</code> property is <a href="#deprecated">deprecated</a>. Refer
+								to its definition in [[!EPUBPublications-301]] for more information.</dd>
+						</dl>
+
+						<p>Only one of these overrides is allowed on any given spine item.</p>
+					</section>
+				</section>
+
+				<section id="page-spread">
+					<h4>Spread Placement</h4>
+
+					<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to populate the
+						spread by rendering the next <a>EPUB Content Document</a> in the next available unpopulated
+						viewport, where the next available viewport is determined by the given <a href="#sec-spine-elem"
+							>page progression direction</a> or by local declarations within Content Documents. An Author
+						MAY override this automatic population behavior and force a document to be placed in a
+						particular viewport by specifying one of the following properties on its spine
+							<code>itemref</code> element:</p>
+
+					<dl>
+						<dt id="page-spread-center">
+							<code>rendition:page-spread-center</code>
+						</dt>
+						<dd>The <code>rendition:page-spread-center</code> property specifies the forced placement of a
+							Content Document in a <a>Synthetic Spread</a>. </dd>
+
+						<dt id="fxl-page-spread-left">
+							<code>rendition:page-spread-left</code>
+						</dt>
+						<dd>The <code>rendition:page-spread-left</code> property is an alias for the <code><a
+									href="#page-spread-left">page-spread-left</a></code> property.</dd>
+
+						<dt id="fxl-page-spread-right">
+							<code>rendition:page-spread-right</code>
+						</dt>
+						<dd>The <code>rendition:page-spread-right</code> property is an alias for the <code><a
+									href="#page-spread-right">page-spread-right</a></code> property.</dd>
+					</dl>
+
+					<p>The <code>rendition:page-spread-left</code> property indicates that the given spine item is to be
+						rendered in the left-hand slot in the spread, and <code>rendition:page-spread-right</code> that
+						it be rendered in the right-hand slot. The <code>rendition:page-spread-center</code> property
+						indicates to override the synthetic spread mode and render a single viewport positioned at the
+						center of the screen.</p>
+
+					<p>The <code>rendition:page-spread-left</code>, <code>rendition:page-spread-right</code> and
+							<code>rendition:page-spread-center</code> properties apply to both pre-paginated and
+						reflowable content, and they only apply when the Reading System is creating Synthetic
+						Spreads.</p>
+
+					<p>Although Authors often indicate to use a spread in certain device orientations, the content
+						itself does not represent true spreads (i.e., two consecutive pages that have to be rendered
+						side-by-side for readability, such as a two-page map). To indicate that two consecutive pages
+						represent a true spread, Authors SHOULD use the <code>rendition:page-spread-left</code> and
+							<code>rendition:page-spread-right</code> properties on the spine items for the two adjacent
+						EPUB Content Documents, and omit the properties on spine items where one-up or two-up
+						presentation is equally acceptable.</p>
+
+					<p>Only one <code>page-spread-*</code> property can be declared on any given spine item.</p>
+
+					<div class="note" id="note-page-spread-aliases">
+						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
+							properties are aliases for the <a href="#page-spread-left"><code>page-spread-left</code></a>
+							and <a href="#page-spread-right"><code>spread-right</code></a> properties. They allow the
+							use of a single vocabulary for all fixed-layout properties. Authors can use either property
+							set, but older Reading Systems might only recognize the unprefixed versions. The <a
+								href="#app-itemref-properties-vocab">EPUB Spine Properties Vocabulary</a> is no longer
+							being extended for package rendering metadata, so an unprefixed
+								<code>page-spread-center</code> is not available.</p>
+					</div>
+
+					<aside class="example" id="fxl-ex5">
+						<p>The following example demonstrates reflowable content with a two-page fixed-layout center
+							plate that is intended to be rendered using synthetic spreads in any device orientation.
+							Note that the author has left spread behavior for the other (reflowable) parts of the
+								<a>Rendition</a> undefined, since the global value of <code>rendition:spread</code> is
+							initialized to <code>auto</code> by default.</p>
+						<pre>&lt;spine page-progression-direction="ltr"&gt;
+    …
+    &lt;itemref idref="center-plate-left"
+             properties="rendition:spread-both rendition:page-spread-left"/&gt;
+    &lt;itemref idref="center-plate-right"
+             properties="rendition:spread-both rendition:page-spread-right"/&gt;
+    …
+&lt;/spine&gt;</pre>
+					</aside>
+
+					<aside class="example" id="fxl-ex6">
+						<p>The following example demonstrates fixed-layout content, where synthetic spreads, when used,
+							have to be disabled for a center plate. Note that the <code>rendition:spread</code>
+							declaration <code>none</code> expression is not needed on the center plate item, as the
+								<code>rendition:page-spread-center</code> property already specifies semantics that
+							dictates that synthetic spreads be disabled.</p>
+						<pre>&lt;metadata&gt;
+    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
+    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
+&lt;/metadata&gt;
+&lt;spine&gt;
+    &lt;itemref idref="center-plate" properties="rendition:page-spread-center"/&gt;
+&lt;/spine&gt;</pre>
+					</aside>
+				</section>
+
+				<section id="viewport">
+					<h4>Viewport Dimensions (Deprecated)</h4>
+
+					<p>The <code>rendition:viewport</code> property allows <a>Authors</a> to express the CSS initial
+						containing block (ICB) [[!CSS21]] for XHTML and SVG Content Documents whose
+							<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
+
+					<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its definition in
+						[[!EPUBPublications-301]] for more information.</p>
+				</section>
+			</section>
+
+			<section id="sec-fxl-content-dimensions">
+				<h3>Content Document Dimensions</h3>
+
+				<p>This section defines rules for the expression and interpretation of dimensional properties of
+						<a>Fixed-Layout Documents</a> — <a>EPUB Content Documents</a> marked as
+						<code>pre-paginated</code> in the <a>Package Document</a>.</p>
+
+				<div class="note">
+					<p>Refer to <a href="#sec-package-metadata-fxl"></a> for information on how to designate that a
+							<a>Rendition</a>, or its individual spine items, are to be rendered in a pre-paginated
+						manner (i.e., with fixed width and height dimensions).</p>
+				</div>
+
+				<section id="sec-fxl-html-svg-dimensions">
+					<h4>Initial Containing Block</h4>
+
+					<section id="sec-fxl-icb-html">
+						<h5>Expressing in HTML</h5>
+
+						<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
+								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
+								containing block</a> [[!CSS2]] dimensions MUST be expressed in a <code>viewport</code>
+							<code>meta</code> tag using the syntax defined in [[!CSS-Device-Adapt-1]].</p>
+
+						<aside class="example">
+							<p>The following example shows a <code>viewport</code>
+								<code>meta</code> tag.</p>
+							<pre>
+&lt;head&gt;
+   …
+   &lt;meta name="viewport" content="width=1200, height=600"/&gt;
+   …
+&lt;/head&gt;</pre>
+						</aside>
+					</section>
+
+					<section id="sec-fxl-icb-svg">
+						<h5>Expressing in SVG</h5>
+
+						<p>For SVG <a>Fixed-Layout Documents</a>, the ICB dimensions MUST be expressed using the <a
+								href="http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code>
+								attribute</a> [[!SVG]].</p>
+
+						<aside class="example">
+							<p>The following example shows a <code>viewBox</code> attribute declaration for an SVG
+								Content Document with an aspect ratio of 844 pixels wide by 1200 pixels high.</p>
+							<pre>
+&lt;svg xmlns="http://www.w3.org/2000/svg"
+     version="1.1" 
+     viewBox="0 0 844 1200"&gt;
+   …
+&lt;/svg&gt;</pre>
+						</aside>
+					</section>
 				</section>
 			</section>
 		</section>
@@ -8760,6 +8490,8 @@ html.-epub-media-overlay-playing * {
 
 			<div data-include="vocab/link.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 
+			<div data-include="vocab/rendering.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+			
 			<div data-include="vocab/item-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 
 			<div data-include="vocab/itemref-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
@@ -9292,7 +9024,7 @@ EPUB/images/cover.png</pre>
 								</li>
 								<li>
 									<p>
-										<a href="#sec-package-metadata">metadata</a>
+										<a href="#sec-mo-package-metadata">metadata</a>
 									</p>
 									<ul>
 										<li>
@@ -9617,7 +9349,7 @@ EPUB/images/cover.png</pre>
 						</li>
 						<li>
 							<p>
-								<a href="#sec-package-metadata-rendering">layout properties</a>
+								<a href="#sec-rendering-general">layout properties</a>
 							</p>
 							<ul>
 								<li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3258,72 +3258,67 @@ Manifest:
 				</section>
 			</section>
 
-			<section id="sec-package-metadata">
-				<h3>Package Metadata</h3>
+			<section id="sec-package-metadata-identifiers">
+				<h4>Publication Identifiers</h4>
 
-				<section id="sec-package-metadata-identifiers">
-					<h4>Publication Identifiers</h4>
+				<section id="sec-metadata-elem-identifiers-uid">
+					<h5>Unique Identifier</h5>
 
-					<section id="sec-metadata-elem-identifiers-uid">
-						<h5>Unique Identifier</h5>
+					<p>The <a>Author</a> is responsible for including a primary identifier in the <a>Package
+							Document</a> metadata that is unique to one and only one <a>EPUB Publication</a>. This
+							<a>Unique Identifier</a>, whether chosen or assigned, MUST be stored in the <a
+							href="#sec-opf-dcidentifier"><code>dc:identifier</code> element</a> and be referenced as the
+						Unique Identifier in the <a href="#elemdef-opf-package"><code>package</code> element</a>
+						<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code> attribute</a>.</p>
 
-						<p>The <a>Author</a> is responsible for including a primary identifier in the <a>Package
-								Document</a> metadata that is unique to one and only one <a>EPUB Publication</a>. This
-								<a>Unique Identifier</a>, whether chosen or assigned, MUST be stored in the <a
-								href="#sec-opf-dcidentifier"><code>dc:identifier</code> element</a> and be referenced as
-							the Unique Identifier in the <a href="#elemdef-opf-package"><code>package</code> element</a>
-							<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
-							attribute</a>.</p>
+					<p>Although not static, changes to the Unique Identifier for an EPUB Publication SHOULD be made as
+						infrequently as possible. New identifiers SHOULD NOT be issued when updating metadata, fixing
+						errata or making other minor changes to the EPUB Publication.</p>
+				</section>
 
-						<p>Although not static, changes to the Unique Identifier for an EPUB Publication SHOULD be made
-							as infrequently as possible. New identifiers SHOULD NOT be issued when updating metadata,
-							fixing errata or making other minor changes to the EPUB Publication.</p>
-					</section>
+				<section id="sec-metadata-elem-identifiers-pid">
+					<h5>Release Identifier</h5>
 
-					<section id="sec-metadata-elem-identifiers-pid">
-						<h5>Release Identifier</h5>
+					<p>The <a>Unique Identifier</a> of an <a>EPUB Publication</a> typically SHOULD NOT change with each
+						minor revision to the package or its contents, as Unique Identifiers are intended to have
+						maximal persistence both for referencing and distribution purposes. Each release of an EPUB
+						Publication normally requires that the new version be uniquely identifiable, however, which
+						results in the contradictory need for reliable Unique Identifiers that are changeable.</p>
 
-						<p>The <a>Unique Identifier</a> of an <a>EPUB Publication</a> typically SHOULD NOT change with
-							each minor revision to the package or its contents, as Unique Identifiers are intended to
-							have maximal persistence both for referencing and distribution purposes. Each release of an
-							EPUB Publication normally requires that the new version be uniquely identifiable, however,
-							which results in the contradictory need for reliable Unique Identifiers that are
-							changeable.</p>
+					<p>To redress this problem of identifying minor modifications and releases without changing the
+						Unique Identifier, this specification defines the semantics for a <em>Release Identifier</em>,
+						or means of distinguishing and sequentially ordering EPUB Publications with the same Unique
+						Identifier.</p>
 
-						<p>To redress this problem of identifying minor modifications and releases without changing the
-							Unique Identifier, this specification defines the semantics for a <em>Release
-								Identifier</em>, or means of distinguishing and sequentially ordering EPUB Publications
-							with the same Unique Identifier.</p>
+					<p>The Release Identifier is not an actual property in the package <code>metadata</code> section,
+						but is a value that can be obtained from two other mandatory pieces of metadata: the Unique
+						Identifier and the last modification date of the Rendition. When the taken together, the
+						combined value represents a unique identity that can be used to distinguish any particular
+						version of an EPUB Publication from another.</p>
 
-						<p>The Release Identifier is not an actual property in the package <code>metadata</code>
-							section, but is a value that can be obtained from two other mandatory pieces of metadata:
-							the Unique Identifier and the last modification date of the Rendition. When the taken
-							together, the combined value represents a unique identity that can be used to distinguish
-							any particular version of an EPUB Publication from another.</p>
+					<p id="last-modified-date">To ensure that a Release Identifier can be constructed, each
+							<a>Rendition</a> MUST include exactly one [[!DCTERMS]] <code>modified</code> property
+						containing its last modification date. The value of this property MUST be an [[!XMLSCHEMA-2]]
+						dateTime conformant date of the form:</p>
 
-						<p id="last-modified-date">To ensure that a Release Identifier can be constructed, each
-								<a>Rendition</a> MUST include exactly one [[!DCTERMS]] <code>modified</code> property
-							containing its last modification date. The value of this property MUST be an
-							[[!XMLSCHEMA-2]] dateTime conformant date of the form:</p>
+					<pre class="nohighlight">CCYY-MM-DDThh:mm:ssZ</pre>
 
-						<pre class="nohighlight">CCYY-MM-DDThh:mm:ssZ</pre>
+					<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST be
+						terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
 
-						<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST be
-							terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
+					<p>Additional modified properties MAY be included in the package metadata, but they MUST have a
+						different subject (i.e., they require a <code>refines</code> attribute that references an
+						element or resource).</p>
 
-						<p>Additional modified properties MAY be included in the package metadata, but they MUST have a
-							different subject (i.e., they require a <code>refines</code> attribute that references an
-							element or resource).</p>
+					<p>Although not a part of the package metadata, for referencing and other purposes all string
+						representations of the identifier MUST be constructed using the at sign (<code>@</code>) as the
+						separator (i.e., of the form "id<code>@</code>date"). Whitespace MUST NOT be included when
+						concatenating the strings.</p>
 
-						<p>Although not a part of the package metadata, for referencing and other purposes all string
-							representations of the identifier MUST be constructed using the at sign (<code>@</code>) as
-							the separator (i.e., of the form "id<code>@</code>date"). Whitespace MUST NOT be included
-							when concatenating the strings.</p>
-
-						<aside class="example">
-							<p>The following example shows how a Unique Identifier and modification date are combined to
-								form the Release Identifier.</p>
-							<pre class="nohighlight">&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
+					<aside class="example">
+						<p>The following example shows how a Unique Identifier and modification date are combined to
+							form the Release Identifier.</p>
+						<pre class="nohighlight">&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:identifier id="pub-id"&gt;urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier&gt;
     &lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;
     …
@@ -3333,1000 +3328,29 @@ results in the Package ID:
 
 urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 </pre>
-						</aside>
-
-						<p>Note that it is possible that the separator character MAY occur in the Unique Identifier, as
-							these identifiers MAY be any string value. The Release Identifier consequently MUST be split
-							on the last instance of the at sign when decomposing it into its component parts.</p>
-
-						<p>The Release Identifier does not supersede the Unique Identifier, but represents the means by
-							which different versions of the same EPUB Publication can be distinguished and identified in
-							distribution channels and by Reading Systems. The sequential, chronological order inherent
-							in the format of the timestamp also places EPUB Publications in order without requiring
-							knowledge of the exact identifier that came before.</p>
-
-						<p>The Release Identifier consequently allows a set of EPUB Publications to be inspected to
-							determine if they represent the same version of the same Publication, different versions of
-							a single EPUB Publication, or any combination of differing and similar EPUB
-							Publications.</p>
-
-						<div class="note">
-							<p>When an <a>EPUB Container</a> includes more than one <a>Rendition</a> of an EPUB
-								Publication, updating the last modified date of the <a>default rendition</a> for each
-								release — even if it has not been updated — will help ensure that the EPUB Publication
-								does not appear to be the same version as an earlier release, as Reading Systems only
-								have to process the default rendition.</p>
-						</div>
-					</section>
-				</section>
-
-				<section id="sec-metadata-assoc">
-					<h4>Vocabulary Association Mechanisms</h4>
-
-					<section id="sec-metadata-assoc-intro" class="informative">
-						<h5>Introduction</h5>
-
-						<p>The <code>property</code>, <code>properties</code>, <code>rel</code> and <code>scheme</code>
-							attributes use the <a href="#sec-property-datatype">property data type</a> to represent
-							terms from metadata vocabularies. Similar to a CURIE [[RDFA-CORE]], the property data type
-							represents an IRI [[RFC3987]] in compact form and simplifies the authoring of metadata from
-							standardized vocabularies.</p>
-
-						<p>A property value is an expression that consists of a prefix and a reference, where the prefix
-							— whether literal or implied — is a shorthand mapping of an IRI that typically resolves to a
-							term vocabulary. When the prefix is converted to its IRI representation and combined with
-							the reference, the resulting IRI normally resolves to a fragment within that vocabulary that
-							contains human- and/or machine-readable information about the term.</p>
-
-						<p>To assist Reading Systems in processing property values, this specification defines three
-							mechanisms to establish the IRI a prefix maps to:</p>
-
-						<ul>
-							<li>
-								<p><a href="#sec-metadata-default-vocab">default vocabularies</a> — define the mapping
-									when a property value does not include a prefix;</p>
-							</li>
-							<li>
-								<p><a href="#sec-metadata-reserved-prefixes">reserved prefixes</a> — these mappings are
-									predefined (i.e., all Reading Systems recognize them) and can be used without having
-									to be declared; and</p>
-							</li>
-							<li>
-								<p>the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute — a declarative
-									means of creating new prefix mappings on the root <a href="#sec-package-elem"
-											><code>package</code></a> element.</p>
-							</li>
-						</ul>
-
-					</section>
-
-					<section id="sec-metadata-default-vocab">
-						<h5>Default Vocabularies</h5>
-
-						<p>A default vocabulary is a vocabulary that does not require a prefix to be declared in order
-							to use its terms, and whose terms MUST always be unprefixed.</p>
-
-						<p>As the Package Document has multiple unrelated uses for metadata terms, a single default
-							vocabulary is not defined for all attributes. Instead, different default vocabularies are
-							defined for use in attributes that accept a <a href="#sec-property-datatype">property data
-								type</a> as follows:</p>
-
-						<ul>
-							<li>
-								<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is defined to
-									be the default vocabulary for the <a href="#elemdef-meta"><code>meta</code></a>
-									<code>property</code> attribute.</p>
-								<p>If the attribute's value does not include a prefix, the following IRI [[!RFC3987]]
-									stem MUST be used to generate the resulting IRI:
-										<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
-							</li>
-							<li>
-								<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is defined to be the
-									default vocabulary for the <a href="#elemdef-opf-link"><code>link</code></a>
-									<code>rel</code> and <code>properties</code> attributes.</p>
-								<p>If any of these attributes' values do not include a prefix, the following IRI
-									[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
-										<code>http://idpf.org/epub/vocab/package/link/#</code></p>
-							</li>
-							<li>
-								<p>The <a href="#app-item-properties-vocab">Manifest Properties Vocabulary</a> is
-									defined to be the default vocabulary for the <a href="#elemdef-package-item"
-											><code>item</code></a>
-									<code>properties</code> attribute.</p>
-								<p>If any of the attribute's values do not include a prefix, the following IRI
-									[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
-										<code>http://idpf.org/epub/vocab/package/item/#</code></p>
-							</li>
-							<li>
-								<p>The <a href="#app-itemref-properties-vocab">Spine Properties Vocabulary</a> is
-									defined to be the default vocabulary for the <a href="#elemdef-spine-itemref"
-											><code>itemref</code></a>
-									<code>properties</code> attribute.</p>
-								<p>If any of the attribute's values do not include a prefix, the following IRI
-									[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
-										<code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
-							</li>
-						</ul>
-
-						<p>The IRIs associated with these vocabularies MUST NOT be assigned a prefix using the <a
-								href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
-
-					</section>
-
-					<section id="sec-metadata-reserved-prefixes">
-						<h5>Reserved Prefixes</h5>
-
-						<p>This specification reserves the following set of prefixes that Authors MAY use in package
-							metadata without having to declare.</p>
-
-						<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
-							lead to interoperability issues. Validation tools will often reject new prefixes until the
-							tools are updated, for example. Authors are strongly encouraged to declare all prefixes they
-							use to avoid such issues.</p>
-
-						<table id="tbl-pkg-reserved-prefixes" class="prefix">
-							<thead>
-								<tr>
-									<th>Prefix</th>
-									<th>IRI</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>a11y</td>
-									<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
-								</tr>
-								<tr>
-									<td>dcterms</td>
-									<td>http://purl.org/dc/terms/</td>
-								</tr>
-								<tr>
-									<td>marc</td>
-									<td>http://id.loc.gov/vocabulary/</td>
-								</tr>
-								<tr>
-									<td>media</td>
-									<td>http://www.idpf.org/epub/vocab/overlays/#</td>
-								</tr>
-								<tr>
-									<td>onix</td>
-									<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
-								</tr>
-								<tr>
-									<td>rendition</td>
-									<td>http://www.idpf.org/vocab/rendition/#</td>
-								</tr>
-								<tr>
-									<td>schema</td>
-									<td>http://schema.org/</td>
-								</tr>
-								<tr>
-									<td>xsd</td>
-									<td>http://www.w3.org/2001/XMLSchema#</td>
-								</tr>
-							</tbody>
-						</table>
-
-						<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"
-									><code>prefix</code> attribute</a>.</p>
-					</section>
-
-					<section id="sec-prefix-attr">
-						<h5>The <code>prefix</code> Attribute</h5>
-
-						<p>The <code>prefix</code> attribute defines additional prefix mappings not <a
-								href="#sec-metadata-reserved-prefixes">reserved</a> by this specification.</p>
-
-						<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
-							prefix-to-IRI mappings of the form:</p>
-
-						<table class="productionset">
-							<caption>(EBNF productions <a
-									href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
-									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
-								(U+0000 to U+007F). </caption>
-							<tr>
-								<td id="prefix.ebnf.def">
-									<a href="#prefix.ebnf.def">prefixes</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
-										>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
-										href="#prefix.ebnf.mapping">mapping</a> } ; </td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.mapping">
-									<a href="#prefix.ebnf.mapping">mapping</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space"
-										>space</a> , { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.prefix">
-									<a href="#prefix.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.space">
-									<a href="#prefix.ebnf.space">space</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>#x20 ;</td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="prefix.ebnf.whitespace">
-									<a href="#prefix.ebnf.whitespace">whitespace</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>(#x20 | #x9 | #xD | #xA) ;</td>
-								<td> </td>
-							</tr>
-						</table>
-
-						<aside class="example">
-							<p>The following example shows prefixes for the Friend of a Friend (<code>foaf</code>) and
-								DBPedia (<code>dbp</code>) vocabularies being declared using the <code>prefix</code>
-								attribute.</p>
-							<pre>&lt;package … 
-	prefix="foaf: http://xmlns.com/foaf/spec/
-		 dbp: http://dbpedia.org/ontology/"&gt;
-	…
-&lt;/package&gt;</pre>
-						</aside>
-
-						<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix
-							that maps to the <a href="#sec-metadata-default-vocab">default vocabulary</a>.</p>
-
-						<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
-							[[!RDFA-CORE]] processing.</p>
-
-						<p>For future compatibility with alternative serializations of the Package Document, a prefix
-							for the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in
-							the <code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
-								href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
-					</section>
-
-					<section id="sec-property-datatype">
-						<h5>The <code>property</code> Data Type</h5>
-
-						<p>The property data type is a compact means of expressing an IRI [[!RFC3987]] and consists of
-							an OPTIONAL prefix separated from a reference by a colon.</p>
-
-						<table class="productionset">
-							<caption>(EBNF productions <a
-									href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
-									>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
-								(U+0000 to U+007F). </caption>
-							<tr>
-								<td id="property.ebnf.property">
-									<a href="#property.ebnf.property">property</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
-										href="#property.ebnf.reference">reference</a>; </td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.prefix">
-									<a href="#property.ebnf.prefix">prefix</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? xsd:NCName ? ;</td>
-								<td> </td>
-							</tr>
-							<tr>
-								<td id="property.ebnf.reference">
-									<a href="#property.ebnf.reference">reference</a>
-								</td>
-								<td>
-									<code>=</code>
-								</td>
-								<td>? irelative-ref ? ;</td>
-								<td>/* as defined in [[!RFC3987]] */<br /></td>
-							</tr>
-						</table>
-
-						<p>The property data type is derived from the CURIE data type defined in [[!RDFA-CORE]], and
-							represents a subset of CURIEs.</p>
-
-						<aside class="example">
-							<p>The following example shows a property value composed of the prefix <code>dcterms</code>
-								and the reference <code>modified</code>.</p>
-							<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
-						</aside>
-
-						<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
-							[[EPUB-RS-33]], this property would expand to the following IRI:</p>
-
-						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
-
-						<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
-								prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
-
-						<p>When a prefix is omitted from a property value, the expressed reference represents a term
-							from the <a href="#sec-metadata-default-vocab">default vocabulary</a> for that
-							attribute.</p>
-
-						<aside class="example">
-							<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
-								manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
-
-							<pre>&lt;item … properties="mathml"/&gt;</pre>
-
-							<p>This property expands to:</p>
-
-							<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
-
-							<p>when the IRI for the vocabulary is concatenated with the reference.</p>
-						</aside>
-
-						<p>An empty string does not represent a valid property value, even though it is valid to the
-							definition above.</p>
-
-					</section>
-				</section>
-
-				<section id="sec-package-metadata-rendering">
-					<h4>Package Rendering Metadata</h4>
-
-					<section id="sec-package-metadata-layout-general-intro" class="informative">
-						<h3>Introduction</h3>
-
-						<p>Not all rendering information can be expressed through the underlying technologies that EPUB
-							is built upon. For example, although HTML with CSS provides powerful layout capabilities,
-							those capabilities are limited to the scope of the document being rendered.</p>
-
-						<p>This section defines general-purpose properties that allow Authors to express package-level
-							rendering intentions (i.e., functionality that can only be implemented by the <a>EPUB
-								Reading System</a>). If a Reading System supports the desired rendering, these
-							properties enable the user to be presented the content as the Author optimally designed
-							it.</p>
-
-					</section>
-
-					<section id="rendition-vocab-ref">
-						<h5>Referencing</h5>
-
-						<p>The base IRI for referencing these properties is
-								<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
-
-						<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved
-								for use</a> with the package rendering properties and does not have to be declared in
-							the Package Document.</p>
-					</section>
-
-					<section id="sec-package-metadata-general">
-						<h5>General Properties</h5>
-
-						<section id="flow">
-							<h6>The <code>rendition:flow</code> Property</h6>
-
-							<p>The <code>rendition:flow</code> property specifies the Author preference for how Reading
-								Systems should handle content overflow. </p>
-
-							<section id="layout-property-flow-usage">
-								<h6>Usage</h6>
-
-								<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code>
-										property</a> is specified on a <code>meta</code> element, it indicates the
-									Author's global preference for overflow content handling (i.e., for all spine
-									items). Authors MAY indicate a preference for dynamic pagination or scrolling. For
-									scrolled content, it is also possible to specify whether consecutive <a>EPUB Content
-										Documents</a> are to be rendered as a continuous scrolling view or whether each
-									is to be rendered separately (i.e., with a dynamic page break between each).</p>
-
-								<p id="html-body-page-break-before">Note that when two reflowable EPUB Content Documents
-									occur sequentially in the spine, the default rendering for their [[!HTML]] <a
-										href="https://www.w3.org/TR/html/sections.html#the-body-element"
-											><code>body</code></a> elements is consistent with the <a
-										href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-											><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been
-									set to <code>always</code>. In addition to using the <code>rendition:flow</code>
-									property, Authors MAY override this behavior through an appropriate style sheet
-									declaration, if the Reading System supports such overrides.</p>
-
-								<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
-							</section>
-
-							<section id="layout-property-flow-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:flow</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt id="paginated">paginated</dt>
-									<dd>
-										<p>Dynamically paginate all overflow content.</p>
-									</dd>
-									<dt id="scrolled-continuous">scrolled-continuous</dt>
-									<dd>
-										<p>Render all Content Documents such that overflow content is scrollable, and
-											the EPUB Publication represented by the given <a>Rendition</a> is presented
-											as one continuous scroll from spine item to spine item (except where <a
-												href="#layout-property-flow-overrides">locally overridden</a>).</p>
-										<p>Note that Authors SHOULD NOT create publications in which different resources
-											have different block flow directions, as continuous scrolled rendition in
-											EPUB Reading Systems would be problematic.</p>
-									</dd>
-									<dt id="scrolled-doc">scrolled-doc</dt>
-									<dd>
-										<p>Render all Content Documents such that overflow content is scrollable, and
-											each spine item is presented as a separate scrollable document.</p>
-									</dd>
-									<dt id="auto">auto</dt>
-									<dd>
-										<p>Render overflow content using the Reading System default method or a user
-											preference, whichever is applicable.</p>
-									</dd>
-								</dl>
-							</section>
-
-							<section id="layout-property-flow-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="layout-property-flow-local">Authors MAY specify the following properties locally
-									on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
-									override the <a href="#property-flow-global">global value</a> for the given spine
-									item:</p>
-
-								<dl>
-									<dt id="flow-auto">flow-auto</dt>
-									<dd>Indicates no preference for overflow content handling by the Author.</dd>
-
-									<dt id="flow-paginated">flow-paginated</dt>
-									<dd>Indicates the Author preference is to dynamically paginate content
-										overflow.</dd>
-
-									<dt id="flow-scrolled-continuous">flow-scrolled-continuous</dt>
-									<dd>Indicates the Author preference is to provide a scrolled view for overflow
-										content, and that consecutive spine items with this property are to be rendered
-										as a continuous scroll.</dd>
-
-									<dt id="flow-scrolled-doc">flow-scrolled-doc</dt>
-									<dd>Indicates the Author preference is to provide a scrolled view for overflow
-										content, and each spine item with this property is to be rendered as a separate
-										scrollable document.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-							</section>
-
-							<section id="layout-property-flow-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="property-flow-ex1">
-									<p>The following example demonstrates an Author's intent to have a paginated
-										Rendition with a scrollable table of contents.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:flow"&gt;paginated&lt;/meta&gt;
-&lt;/metadata&gt;
-
-&lt;spine&gt;
-    &lt;itemref idref="toc" properties="rendition:flow-scrolled-doc"/&gt;
-    &lt;itemref idref="c01"/&gt;
-&lt;/spine&gt;</pre>
-								</aside>
-
-							</section>
-
-						</section>
-
-						<section id="align-x-center">
-							<h6>The <code>rendition:align-x-center</code> Property</h6>
-
-							<p>The <code>rendition:align-x-center</code> property specifies that the given spine item
-								should be centered horizontally in the viewport or spread. </p>
-
-							<div class="note">
-								<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title
-									pages), in the absence of reliable centering control within the content rendering.
-									As support for paged media evolves in CSS, however, this property is expected to be
-									deprecated. Authors are encouraged to use CSS solutions when effective.</p>
-							</div>
-
-						</section>
-					</section>
-
-					<section id="sec-package-metadata-fxl">
-						<h5>Fixed-Layout Properties</h5>
-
-						<section id="fxl-intro" class="informative">
-							<h6>Introduction</h6>
-
-							<p>EPUB documents, unlike print books or PDF files, are designed to change. The content
-								flows, or reflows, to fit the screen and to fit the needs of the user. As noted in <a
-									href="epub-overview.html#sec-rendering">Rendering and CSS</a> "content presentation
-								adapts to the user, rather than the user having to adapt to a particular presentation of
-								content." [[EPUB-OVERVIEW-33]]</p>
-
-							<p>But this principle doesn’t work for all types of documents. Sometimes content and design
-								are so intertwined they cannot be separated. Any change in appearance risks changing the
-								meaning, or losing all meaning. <a>Fixed-Layout Documents</a> give <a>Authors</a>
-								greater control over presentation when a reflowable EPUB is not suitable for the
-								content.</p>
-
-							<p>This section defines a set of metadata properties to allow declarative expression of
-								intended rendering behaviors of Fixed-Layout Documents in the context of EPUB 3.</p>
-
-							<div class="note" id="note-mechanisms">
-								<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When
-									fixed-layout content is necessary, the Author's choice of mechanism will depend on
-									many factors including desired degree of precision, file size, accessibility, etc.
-									This section does not attempt to dictate the Author's choice of mechanism.</p>
-							</div>
-
-						</section>
-
-						<section id="layout">
-							<h6>The <code>rendition:layout</code> Property</h6>
-
-							<p>The <code>rendition:layout</code> property specifies whether the given Rendition is
-								reflowable or pre-paginated.</p>
-
-							<section id="layout-usage">
-								<h5>Usage</h5>
-
-								<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code>
-										property</a> is specified on a <code>meta</code> element, it indicates that the
-									paginated or reflowable layout style applies globally for the <a>Rendition</a>
-									(i.e., for all spine items).</p>
-
-								<p>When the property is set to <code>pre-paginated</code> for a spine item, its content
-									dimensions MUST be set as defined in <a href="#sec-fixed-layouts"></a>.</p>
-
-								<p>The <code>rendition:layout</code> property MUST NOT be declared more than once.</p>
-
-							</section>
-
-							<section id="layout-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:layout</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt id="def-layout-reflowable">reflowable</dt>
-									<dd>
-										<p>The given Rendition is not pre-paginated (i.e., Reading Systems apply dynamic
-											pagination when rendering). Default value.</p>
-									</dd>
-									<dt id="def-layout-pre-paginated">pre-paginated</dt>
-									<dd>
-										<p>The given Rendition is pre-paginated (i.e., Reading Systems produce exactly
-											one page per spine <a href="#elemdef-spine-itemref"><code>itemref</code></a>
-											when rendering).</p>
-									</dd>
-								</dl>
-
-								<div class="note" id="uaag">
-									<p>Reading Systems typically restrict or deny the application of user or user agent
-										style sheets to pre-paginated documents, since, as a result of intrinsic
-										properties of such documents, dynamic style changes are highly likely to have
-										unintended consequences. Authors need to take into account the negative impact
-										on usability and accessibility that these restrictions have when choosing to use
-										pre-paginated instead of reflowable content. Refer to <a
-											href="https://www.w3.org/TR/2015/NOTE-UAAG20-20151215/#gl-text-config"
-											>Guideline 1.4 - Provide text configuration</a> [[UAAG20]] for related
-										information.</p>
-								</div>
-
-							</section>
-
-							<section id="layout-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="property-layout-local">Authors MAY specify the following properties locally on
-									spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override
-									the <a href="#property-layout-global">global value</a> for the given spine item:</p>
-
-								<dl>
-									<dt id="layout-pre-paginated">layout-pre-paginated</dt>
-									<dd>Specifies that the given spine item is pre-paginated.</dd>
-
-									<dt id="layout-reflowable">layout-reflowable</dt>
-									<dd>Specifies that the given spine item is reflowable.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-
-							</section>
-
-							<section id="layout-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex1">
-									<p>The following example demonstrates fully fixed-layout content, using
-										[[CSS3-MediaQueries]] to apply different style sheets for three different device
-										categories. Note that the Media Queries only affect the style sheet applied to
-										the document; the size of the content area set in the <code>viewport</code>
-										<code>meta</code> tag is static.</p>
-
-									<h5>Package Document</h5>
-
-									<pre>&lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;</pre>
-
-									<h5>XHTML</h5>
-
-									<pre>&lt;head&gt;
-    &lt;meta name="viewport" content="width=1200, height=900"/&gt;
-	
-    &lt;link rel="stylesheet" href="eink-style.css" media="(max-monochrome: 3)"/&gt;
-    &lt;link rel="stylesheet" href="skinnytablet-style.css" media="((color) and
-        (max-height:600px) and (orientation:landscape), (color) and (max-width:600px)
-        and (orientation:portrait))"/&gt;
-    &lt;link rel="stylesheet" href="fattablet-style.css" media="((color) and
-        (min-height:601px) and (orientation:landscape), (color) and (min-width:601px)
-        and (orientation:portrait)"/&gt;	
-&lt;/head&gt;
-</pre>
-								</aside>
-
-							</section>
-						</section>
-
-						<section id="orientation">
-							<h6>The <code>rendition:orientation</code> Property</h6>
-
-							<p>The <code>rendition:orientation</code> property specifies which orientation the Author
-								intends the given Rendition to be rendered in. </p>
-
-							<section id="orientation-usage">
-								<h5>Usage</h5>
-
-								<p id="property-orientation-global">When the <a href="#orientation"
-											><code>rendition:orientation</code> property</a> is specified on a
-										<code>meta</code> element, it indicates that the intended orientation applies
-									globally for the given Rendition (i.e., for all spine items).</p>
-
-								<p>The <code>rendition:orientation</code> property MUST NOT be declared more than
-									once.</p>
-
-							</section>
-
-							<section id="orientation-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:orientation</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt>landscape</dt>
-									<dd>
-										<p>The given Rendition is intended for landscape rendering.</p>
-									</dd>
-									<dt>portrait</dt>
-									<dd>
-										<p> The given Rendition is intended for portrait rendering.</p>
-									</dd>
-									<dt>auto</dt>
-									<dd>
-										<p>The given Rendition is not orientation constrained. Default value.</p>
-									</dd>
-								</dl>
-							</section>
-
-							<section id="orientation-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="property-orientation-local">Authors MAY specify the following properties locally
-									on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
-									override the <a href="#property-orientation-global">global value</a> for the given
-									spine item:</p>
-
-								<dl>
-									<dt id="orientation-auto">orientation-auto</dt>
-									<dd>Specifies that the Reading System determines the orientation to render the spine
-										item in.</dd>
-
-									<dt id="orientation-landscape">orientation-landscape</dt>
-									<dd>Specifies that the given spine item is to be rendered in landscape
-										orientation.</dd>
-
-									<dt id="orientation-portrait">orientation-portrait</dt>
-									<dd>Specifies that the given spine item is to be rendered in portrait
-										orientation.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-
-							</section>
-
-							<section id="orientation-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex2">
-									<p>The following example demonstrates fully fixed-layout content intended to be
-										rendered without synthetic spreads, and locked to landscape orientation.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;none&lt;/meta&gt;
-    
-    &lt;meta property="rendition:orientation"&gt;landscape&lt;/meta&gt;
-&lt;/metadata&gt;</pre>
-								</aside>
-
-							</section>
-
-						</section>
-
-						<section id="spread">
-							<h6>The <code>rendition:spread</code> Property</h6>
-
-							<p>The <code>rendition:spread</code> property specifies the intended Reading System
-								synthetic spread behavior for the given Rendition.</p>
-
-							<section id="spread-usage">
-								<h6>Usage</h6>
-
-								<p id="property-spread-global">When the <code>rendition:spread</code> property is
-									specified on a <code>meta</code> element, it indicates that the intended
-										<a>Synthetic Spread</a> behavior applies globally for the given Rendition (i.e.,
-									for all spine items).</p>
-
-								<p>The <code>rendition:spread</code> property MUST NOT be declared more than once.</p>
-							</section>
-
-							<section id="spread-values">
-								<h6>Allowed Values</h6>
-
-								<p>The following values are defined for use with the <code>rendition:spread</code>
-									property:</p>
-
-								<dl class="variablelist">
-									<dt>none</dt>
-									<dd>
-										<p>Do not incorporate spine items in a Synthetic Spread.</p>
-									</dd>
-									<dt>landscape</dt>
-									<dd>
-										<p>Render a Synthetic Spread for spine items only when the device is in
-											landscape orientation.</p>
-									</dd>
-									<dt>portrait (deprecated)</dt>
-									<dd>
-										<p>The use of spreads only in portrait orientation is <a href="#deprecated"
-												>deprecated</a>.</p>
-										<p>Authors are advised to use the value "<code>both</code>" instead, as spreads
-											that are readable in portrait orientation are also readable in
-											landscape.</p>
-									</dd>
-									<dt>both</dt>
-									<dd>
-										<p>Render a Synthetic Spread regardless of device orientation.</p>
-									</dd>
-									<dt>auto</dt>
-									<dd>
-										<p>No explicit Synthetic Spread behavior is defined. Default value.</p>
-									</dd>
-								</dl>
-
-								<div class="note">
-									<p>When Synthetic Spreads are used in the context of HTML and SVG Content Documents,
-										the dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
-											<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"
-												><code>viewBox</code> attribute</a> represents the size of one page in
-										the spread, respectively.</p>
-								</div>
-
-								<div class="note">
-									<p>Refer to <a href="#sec-spine-elem">spine</a> for information about declaration of
-										global flow directionality using the <code>page-progression-direction</code>
-										attribute and that of local page-progression-direction within content
-										documents.</p>
-								</div>
-
-							</section>
-
-							<section id="spread-overrides">
-								<h6>Spine Overrides</h6>
-
-								<p id="property-spread-local">Authors MAY specify the following properties locally on
-									spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override
-									the <a href="#property-spread-global">global value</a> for the given spine item:</p>
-
-								<dl>
-									<dt id="spread-auto">spread-auto</dt>
-									<dd>Specifies the Reading System determines when to render a synthetic spread for
-										the spine item. </dd>
-
-									<dt id="spread-both">spread-both</dt>
-									<dd>Specifies the Reading System should render a synthetic spread for the spine item
-										in both portrait and landscape orientations. </dd>
-
-									<dt id="spread-landscape">spread-landscape</dt>
-									<dd>Specifies the Reading System should render a synthetic spread for the spine item
-										only when in landscape orientation.</dd>
-
-									<dt id="spread-none">spread-none</dt>
-									<dd>Specifies the Reading System should not render a synthetic spread for the spine
-										item.</dd>
-
-									<dt id="spread-portrait">spread-portrait</dt>
-									<dd>The <code>spread-portrait</code> property is <a href="#deprecated"
-											>deprecated</a>. Refer to its definition in [[!EPUBPublications-301]] for
-										more information.</dd>
-								</dl>
-
-								<p>Only one of these overrides is allowed on any given spine item.</p>
-							</section>
-
-							<section id="spread-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex3">
-									<p>The following example demonstrates fully fixed-layout content intended to be
-										rendered using synthetic spreads in landscape orientation, and with no spreads
-										in portrait orientation.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;landscape&lt;/meta&gt;
-&lt;/metadata&gt;</pre>
-								</aside>
-
-								<aside class="example" id="fxl-ex4">
-									<p>The following example demonstrates reflowable content with a single fixed-layout
-										title page, where the fixed-layout page is intended for right-hand spread slot
-										if the device renders Synthetic Spreads.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;reflowable&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
-&lt;/metadata&gt;
-
-&lt;spine&gt;
-    &lt;itemref idref="titlepage" properties="page-spread-right rendition:layout-pre-paginated"/&gt;
-&lt;/spine&gt;</pre>
-								</aside>
-
-							</section>
-
-						</section>
-
-						<section id="page-spread">
-							<h6>The <code>rendition:page-spread-*</code> Properties</h6>
-
-							<section id="page-spread-usage">
-								<h6>Usage</h6>
-
-								<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to
-									populate the spread by rendering the next <a>EPUB Content Document</a> in the next
-									available unpopulated viewport, where the next available viewport is determined by
-									the given <a href="#sec-spine-elem">page progression direction</a> or by local
-									declarations within Content Documents. An Author MAY override this automatic
-									population behavior and force a document to be placed in a particular viewport by
-									specifying one of the following properties on its spine <code>itemref</code>
-									element:</p>
-
-								<dl>
-									<dt id="page-spread-center">
-										<code>rendition:page-spread-center</code>
-									</dt>
-									<dd>The <code>rendition:page-spread-center</code> property specifies the forced
-										placement of a Content Document in a <a>Synthetic Spread</a>. </dd>
-
-									<dt id="fxl-page-spread-left">
-										<code>rendition:page-spread-left</code>
-									</dt>
-									<dd>The <code>rendition:page-spread-left</code> property is an alias for the
-												<code><a href="#page-spread-left">page-spread-left</a></code>
-										property.</dd>
-
-									<dt id="fxl-page-spread-right">
-										<code>rendition:page-spread-right</code>
-									</dt>
-									<dd>The <code>rendition:page-spread-right</code> property is an alias for the
-												<code><a href="#page-spread-right">page-spread-right</a></code>
-										property.</dd>
-								</dl>
-
-								<p>The <code>rendition:page-spread-left</code> property indicates that the given spine
-									item is to be rendered in the left-hand slot in the spread, and
-										<code>rendition:page-spread-right</code> that it be rendered in the right-hand
-									slot. The <code>rendition:page-spread-center</code> property indicates to override
-									the synthetic spread mode and render a single viewport positioned at the center of
-									the screen.</p>
-
-								<p>The <code>rendition:page-spread-left</code>, <code>rendition:page-spread-right</code>
-									and <code>rendition:page-spread-center</code> properties apply to both pre-paginated
-									and reflowable content, and they only apply when the Reading System is creating
-									Synthetic Spreads.</p>
-
-								<p>Although Authors often indicate to use a spread in certain device orientations, the
-									content itself does not represent true spreads (i.e., two consecutive pages that
-									have to be rendered side-by-side for readability, such as a two-page map). To
-									indicate that two consecutive pages represent a true spread, Authors SHOULD use the
-										<code>rendition:page-spread-left</code> and
-										<code>rendition:page-spread-right</code> properties on the spine items for the
-									two adjacent EPUB Content Documents, and omit the properties on spine items where
-									one-up or two-up presentation is equally acceptable.</p>
-
-								<p>Only one <code>page-spread-*</code> property can be declared on any given spine
-									item.</p>
-
-								<div class="note" id="note-page-spread-aliases">
-									<p>The <code>rendition:page-spread-left</code> and
-											<code>rendition:page-spread-right</code> properties are aliases for the <a
-											href="#page-spread-left"><code>page-spread-left</code></a> and <a
-											href="#page-spread-right"><code>spread-right</code></a> properties. They
-										allow the use of a single vocabulary for all fixed-layout properties. Authors
-										can use either property set, but older Reading Systems might only recognize the
-										unprefixed versions. The <a href="#app-itemref-properties-vocab">EPUB Spine
-											Properties Vocabulary</a> is no longer being extended for package rendering
-										metadata, so an unprefixed <code>page-spread-center</code> is not available.</p>
-								</div>
-							</section>
-
-							<section id="page-spread-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="fxl-ex5">
-									<p>The following example demonstrates reflowable content with a two-page
-										fixed-layout center plate that is intended to be rendered using synthetic
-										spreads in any device orientation. Note that the author has left spread behavior
-										for the other (reflowable) parts of the <a>Rendition</a> undefined, since the
-										global value of <code>rendition:spread</code> is initialized to
-											<code>auto</code> by default.</p>
-									<pre>&lt;spine page-progression-direction="ltr"&gt;
-    …
-    &lt;itemref idref="center-plate-left"
-             properties="rendition:spread-both rendition:page-spread-left"/&gt;
-    &lt;itemref idref="center-plate-right"
-             properties="rendition:spread-both rendition:page-spread-right"/&gt;
-    …
-&lt;/spine&gt;</pre>
-								</aside>
-
-								<aside class="example" id="fxl-ex6">
-									<p>The following example demonstrates fixed-layout content, where synthetic spreads,
-										when used, have to be disabled for a center plate. Note that the
-											<code>rendition:spread</code> declaration <code>none</code> expression is
-										not needed on the center plate item, as the
-											<code>rendition:page-spread-center</code> property already specifies
-										semantics that dictates that synthetic spreads be disabled.</p>
-									<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
-&lt;/metadata&gt;
-&lt;spine&gt;
-    &lt;itemref idref="center-plate" properties="rendition:page-spread-center"/&gt;
-&lt;/spine&gt;</pre>
-								</aside>
-							</section>
-						</section>
-
-						<section id="viewport">
-							<h6>The <code>rendition:viewport</code> Property (Deprecated)</h6>
-
-							<p>The <code>rendition:viewport</code> property allows <a>Authors</a> to express the CSS
-								initial containing block (ICB) [[!CSS21]] for XHTML and SVG Content Documents whose
-									<code>rendition:layout</code> property has been set to
-								<code>pre-paginated</code>.</p>
-
-							<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its definition in
-								[[!EPUBPublications-301]] for more information.</p>
-						</section>
-					</section>
+					</aside>
+
+					<p>Note that it is possible that the separator character MAY occur in the Unique Identifier, as
+						these identifiers MAY be any string value. The Release Identifier consequently MUST be split on
+						the last instance of the at sign when decomposing it into its component parts.</p>
+
+					<p>The Release Identifier does not supersede the Unique Identifier, but represents the means by
+						which different versions of the same EPUB Publication can be distinguished and identified in
+						distribution channels and by Reading Systems. The sequential, chronological order inherent in
+						the format of the timestamp also places EPUB Publications in order without requiring knowledge
+						of the exact identifier that came before.</p>
+
+					<p>The Release Identifier consequently allows a set of EPUB Publications to be inspected to
+						determine if they represent the same version of the same Publication, different versions of a
+						single EPUB Publication, or any combination of differing and similar EPUB Publications.</p>
+
+					<div class="note">
+						<p>When an <a>EPUB Container</a> includes more than one <a>Rendition</a> of an EPUB Publication,
+							updating the last modified date of the <a>default rendition</a> for each release — even if
+							it has not been updated — will help ensure that the EPUB Publication does not appear to be
+							the same version as an earlier release, as Reading Systems only have to process the default
+							rendition.</p>
+					</div>
 				</section>
 			</section>
 
@@ -4865,91 +3889,61 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							are not supported features of EPUB 3.</p>
 					</div>
 
-					<section id="sec-xhtml-semantic-inflection">
-						<h5>Semantic Inflection</h5>
+					<section id="sec-epub-type-attribute">
+						<h5>The <code>epub:type</code> Attribute</h5>
 
-						<section id="sec-xhtml-semantic-inflection-intro" class="informative">
-							<h6>Introduction</h6>
+						<dl class="elemdef" id="attrdef-epub-type">
+							<dt>Attribute Name</dt>
+							<dd>
+								<p>
+									<code>type</code>
+								</p>
+							</dd>
+							<dt>Namespace</dt>
+							<dd>
+								<p>
+									<code>http://www.idpf.org/2007/ops</code>
+								</p>
+							</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p><a href="https://www.w3.org/TR/html/dom.html#global-attributes">Global attribute</a>.
+									MAY be specified on all elements.</p>
+							</dd>
+							<dt>Value</dt>
+							<dd>
+								<p>A white space-separated list of <a href="#sec-property-datatype">property</a> values,
+									with restrictions as defined in <a href="#sec-contentdocs-vocab-association"
+									></a>.</p>
+								<p>White space is the set of characters as defined in [[!XML]].</p>
+							</dd>
+						</dl>
 
-							<p>Semantic inflection is the process of attaching additional meaning about the specific
-								purpose and/or nature an element plays in an <a>XHTML Content Document</a>. The <a
-									href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is used to
-								express domain-specific semantics in XHTML Content Documents, with the inflection(s) it
-								carries complementing the underlying [[HTML]] vocabulary.</p>
+						<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears.
+							Its value is one or more white space-separated terms stemming from external vocabularies
+							associated with the document instance, as defined in <a
+								href="#sec-contentdocs-vocab-association"></a>.</p>
 
-							<p>The applied semantics are intended to refine the meaning of their containing elements;
-								they are not provided to override their nature (e.g., the attribute can be used to
-								indicate a <code>section</code> is a chapter in a work, but is not designed to turn
-									<code>p</code> elements into list items to avoid proper list structures).</p>
+						<p>The inflected semantic MUST express a subclass of the semantic of the carrying element. In
+							the case of semantically neutral elements, such as the [[!HTML]] <a
+								href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"
+								><code>div</code></a> and <a
+								href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element"
+									><code>span</code></a> elements, the inflected semantic MUST NOT attach a meaning
+							that is already conveyed by an existing element (e.g., that a <code>div</code> represents a
+							paragraph or section).</p>
 
-							<p>Semantic metadata is intended to enrich content for use in publishing workflows and for
-								author-defined purposes. While it also allows Reading Systems to learn more about the
-								structure and content of a document, no specific behaviors are defined for the semantics
-								by this specification. Any such behaviors are Reading System-dependent.</p>
+						<p>As the [[!HTML]] <a href="https://www.w3.org/TR/html/document-metadata.html#the-head-element"
+									><code>head</code> element</a> contains metadata for the document, structural
+							semantics expressed on this element or any descendant of it have no meaning.</p>
 
-							<p>This specification defines a method for semantic inflection using <em>the attribute
-									axis</em>: instead of adding new elements, the <code>epub:type</code> attribute can
-								be appended to existing elements to inflect the desired semantics. A mechanism to
-								identify external vocabularies that provide controlled values for the attributes is also
-								defined.</p>
-						</section>
+						<h4>Examples</h4>
 
-						<section id="sec-epub-type-attribute">
-							<h6>The <code>epub:type</code> Attribute</h6>
-
-							<dl class="elemdef" id="attrdef-epub-type">
-								<dt>Attribute Name</dt>
-								<dd>
-									<p>
-										<code>type</code>
-									</p>
-								</dd>
-								<dt>Namespace</dt>
-								<dd>
-									<p>
-										<code>http://www.idpf.org/2007/ops</code>
-									</p>
-								</dd>
-								<dt>Usage</dt>
-								<dd>
-									<p><a href="https://www.w3.org/TR/html/dom.html#global-attributes">Global
-											attribute</a>. MAY be specified on all elements.</p>
-								</dd>
-								<dt>Value</dt>
-								<dd>
-									<p>A white space-separated list of <a href="#sec-property-datatype">property</a>
-										values, with restrictions as defined in <a
-											href="#sec-contentdocs-vocab-association"></a>.</p>
-									<p>White space is the set of characters as defined in [[!XML]].</p>
-								</dd>
-							</dl>
-
-							<p>The <code>epub:type</code> attribute inflects semantics on the element on which it
-								appears. Its value is one or more white space-separated terms stemming from external
-								vocabularies associated with the document instance, as defined in <a
-									href="#sec-contentdocs-vocab-association"></a>.</p>
-
-							<p>The inflected semantic MUST express a subclass of the semantic of the carrying element.
-								In the case of semantically neutral elements, such as the [[!HTML]] <a
-									href="https://www.w3.org/TR/html/grouping-content.html#the-div-element"
-										><code>div</code></a> and <a
-									href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element"
-										><code>span</code></a> elements, the inflected semantic MUST NOT attach a
-								meaning that is already conveyed by an existing element (e.g., that a <code>div</code>
-								represents a paragraph or section).</p>
-
-							<p>As the [[!HTML]] <a
-									href="https://www.w3.org/TR/html/document-metadata.html#the-head-element"
-										><code>head</code> element</a> contains metadata for the document, structural
-								semantics expressed on this element or any descendant of it have no meaning.</p>
-
-							<h4>Examples</h4>
-
-							<aside class="example" id="ex.epubtype.note">
-								<p>The following example shows how a preamble could be marked up with the
-										<code>epub:type</code> attribute on its containing [[!HTML]]
-										<code>section</code> element.</p>
-								<pre>
+						<aside class="example" id="ex.epubtype.note">
+							<p>The following example shows how a preamble could be marked up with the
+									<code>epub:type</code> attribute on its containing [[!HTML]] <code>section</code>
+								element.</p>
+							<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
     …
     &lt;section epub:type="preamble"&gt;
@@ -4957,12 +3951,12 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
     &lt;/section&gt;
     …
 &lt;/html&gt;</pre>
-							</aside>
+						</aside>
 
-							<aside class="example" id="ex.epubtype.gloss">
-								<p>The following example shows the <code>epub:type</code> attribute used to add glossary
-									semantics on an [[!HTML]] definition list.</p>
-								<pre>
+						<aside class="example" id="ex.epubtype.gloss">
+							<p>The following example shows the <code>epub:type</code> attribute used to add glossary
+								semantics on an [[!HTML]] definition list.</p>
+							<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
     …
     &lt;dl epub:type="glossary"&gt;
@@ -4970,77 +3964,18 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
     &lt;/dl&gt;        
     …
 &lt;/html&gt;</pre>
-							</aside>
+						</aside>
 
-							<aside class="example" id="ex.epubtype.pg">
-								<p>The following example shows the <code>epub:type</code> attribute used to add
-									pagebreak semantics.</p>
-								<pre>
+						<aside class="example" id="ex.epubtype.pg">
+							<p>The following example shows the <code>epub:type</code> attribute used to add pagebreak
+								semantics.</p>
+							<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
    …
   &lt;p&gt; … &lt;span epub:type="pagebreak" id="p234"/&gt; … &lt;/p&gt;    
    … 
 &lt;/html&gt;</pre>
-							</aside>
-						</section>
-
-						<section id="sec-contentdocs-vocab-association">
-							<h6>Vocabulary Association</h6>
-
-							<p>This specification adopts the vocabulary association mechanisms defined in <a
-									href="#sec-metadata-assoc"></a>, with the following modifications:</p>
-
-							<section id="sec-contentdocs-default-vocab">
-								<h6>Default Vocabulary</h6>
-
-								<p>The default vocabulary for Content Documents is defined to be the [[!EPUB-SSV]].
-									Unprefixed terms that are not part of the [[!EPUB-SSV]] MAY be included, but their
-									use is discouraged. The use of prefixes is the preferred method for adding custom
-									semantics.</p>
-							</section>
-
-							<section id="sec-contentdocs-reserved-prefixes">
-								<h6>Reserved Prefixes</h6>
-
-								<p>Authors MAY use the following reserved prefixes in the <code>epub:type</code>
-									attribute without having to declare them.</p>
-
-								<p class="warning">Although reserved prefixes are an authoring convenience, reliance on
-									them can lead to interoperability issues. Validation tools will often reject new
-									prefixes until the tools are updated, for example. Authors are strongly encouraged
-									to declare all prefixes they use to avoid such issues.</p>
-
-								<table id="tbl-reserved-prefixes" class="prefix">
-									<thead>
-										<tr>
-											<th>Prefix</th>
-											<th>IRI</th>
-										</tr>
-									</thead>
-									<tbody>
-										<tr>
-											<td>msv</td>
-											<td>http://www.idpf.org/epub/vocab/structure/magazine/#</td>
-										</tr>
-										<tr>
-											<td>prism</td>
-											<td>http://www.prismstandard.org/specifications/3.0/PRISM_CV_Spec_3.0.htm#</td>
-										</tr>
-									</tbody>
-								</table>
-							</section>
-
-							<section id="sec-contentdocs-prefix-attr">
-								<h6>The prefix Attribute</h6>
-
-								<p>The <code>prefix</code> attribute definition is unchanged, but the attribute is
-									defined to be in the namespace <code>http://www.idpf.org/2007/ops</code> when used
-									in EPUB Content Documents.</p>
-
-								<p>The <code>prefix</code> attribute is only valid on the [[!HTML]] root
-										<code>html</code> element.</p>
-							</section>
-						</section>
+						</aside>
 					</section>
 
 					<section id="sec-xhtml-semantic-enrichment">
@@ -8559,18 +7494,445 @@ html.-epub-media-overlay-playing * {
 					requirement.</p>
 			</section>
 		</section>
-		<section id="app-vocabs" class="appendix">
-			<h2>Vocabularies</h2>
+		<section id="app-epub-semantics" class="appendix">
+			<h2>EPUB Semantics</h2>
 
-			<div data-include="vocab/meta-property.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+			<section id="sec-package-semantic-enrich">
+				<h4>Semantic Enrichment</h4>
 
-			<div data-include="vocab/link.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+				<section id="sec-metadata-assoc-intro" class="informative">
+					<h5>Introduction</h5>
 
-			<div data-include="vocab/item-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+					<p>The <code>property</code>, <code>properties</code>, <code>rel</code> and <code>scheme</code>
+						attributes use the <a href="#sec-property-datatype">property data type</a> to represent terms
+						from metadata vocabularies.</p>
+				</section>
 
-			<div data-include="vocab/itemref-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+				<section id="sec-metadata-default-vocab">
+					<h5>Default Vocabularies</h5>
 
-			<div data-include="vocab/overlays.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+					<p>As the Package Document has multiple unrelated uses for metadata terms, a single default
+						vocabulary is not defined for all attributes. Instead, different default vocabularies are
+						defined for use in attributes that accept a <a href="#sec-property-datatype">property data
+							type</a> as follows:</p>
+					<ul>
+						<li>
+							<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is defined to be
+								the default vocabulary for the <a href="#elemdef-meta"><code>meta</code></a>
+								<code>property</code> attribute.</p>
+							<p>If the attribute's value does not include a prefix, the following IRI [[!RFC3987]] stem
+								MUST be used to generate the resulting IRI:
+									<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
+						</li>
+						<li>
+							<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is defined to be the default
+								vocabulary for the <a href="#elemdef-opf-link"><code>link</code></a>
+								<code>rel</code> and <code>properties</code> attributes.</p>
+							<p>If any of these attributes' values do not include a prefix, the following IRI
+								[[!RFC3987]] stem MUST be used to generate the resulting IRI for them:
+									<code>http://idpf.org/epub/vocab/package/link/#</code></p>
+						</li>
+						<li>
+							<p>The <a href="#app-item-properties-vocab">Manifest Properties Vocabulary</a> is defined to
+								be the default vocabulary for the <a href="#elemdef-package-item"><code>item</code></a>
+								<code>properties</code> attribute.</p>
+							<p>If any of the attribute's values do not include a prefix, the following IRI [[!RFC3987]]
+								stem MUST be used to generate the resulting IRI for them:
+									<code>http://idpf.org/epub/vocab/package/item/#</code></p>
+						</li>
+						<li>
+							<p>The <a href="#app-itemref-properties-vocab">Spine Properties Vocabulary</a> is defined to
+								be the default vocabulary for the <a href="#elemdef-spine-itemref"
+									><code>itemref</code></a>
+								<code>properties</code> attribute.</p>
+							<p>If any of the attribute's values do not include a prefix, the following IRI [[!RFC3987]]
+								stem MUST be used to generate the resulting IRI for them:
+									<code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
+						</li>
+					</ul>
+				</section>
+
+				<section id="sec-metadata-reserved-prefixes">
+					<h5>Reserved Prefixes</h5>
+
+					<p>This specification reserves the following set of prefixes that Authors MAY use in package
+						metadata without having to declare.</p>
+
+					<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
+						lead to interoperability issues. Validation tools will often reject new prefixes until the tools
+						are updated, for example. Authors are strongly encouraged to declare all prefixes they use to
+						avoid such issues.</p>
+
+					<table id="tbl-pkg-reserved-prefixes" class="prefix">
+						<thead>
+							<tr>
+								<th>Prefix</th>
+								<th>IRI</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>a11y</td>
+								<td>http://www.idpf.org/epub/vocab/package/a11y/#</td>
+							</tr>
+							<tr>
+								<td>dcterms</td>
+								<td>http://purl.org/dc/terms/</td>
+							</tr>
+							<tr>
+								<td>marc</td>
+								<td>http://id.loc.gov/vocabulary/</td>
+							</tr>
+							<tr>
+								<td>media</td>
+								<td>http://www.idpf.org/epub/vocab/overlays/#</td>
+							</tr>
+							<tr>
+								<td>onix</td>
+								<td>http://www.editeur.org/ONIX/book/codelists/current.html#</td>
+							</tr>
+							<tr>
+								<td>rendition</td>
+								<td>http://www.idpf.org/vocab/rendition/#</td>
+							</tr>
+							<tr>
+								<td>schema</td>
+								<td>http://schema.org/</td>
+							</tr>
+							<tr>
+								<td>xsd</td>
+								<td>http://www.w3.org/2001/XMLSchema#</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+			</section>
+
+			<section id="sec-xhtml-semantic-inflection">
+				<h3>Semantic Inflection</h3>
+
+				<section id="sec-xhtml-semantic-inflection-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>Semantic inflection is the process of attaching additional meaning about the specific purpose
+						and/or nature an element plays in an <a>XHTML Content Document</a>. The <a
+							href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is used to express
+						domain-specific semantics in XHTML Content Documents, with the inflection(s) it carries
+						complementing the underlying [[HTML]] vocabulary.</p>
+
+					<p>The applied semantics are intended to refine the meaning of their containing elements; they are
+						not provided to override their nature (e.g., the attribute can be used to indicate a
+							<code>section</code> is a chapter in a work, but is not designed to turn <code>p</code>
+						elements into list items to avoid proper list structures).</p>
+
+					<p>Semantic metadata is intended to enrich content for use in publishing workflows and for
+						author-defined purposes. While it also allows Reading Systems to learn more about the structure
+						and content of a document, no specific behaviors are defined for the semantics by this
+						specification. Any such behaviors are Reading System-dependent.</p>
+
+					<p>This specification defines a method for semantic inflection using <em>the attribute axis</em>:
+						instead of adding new elements, the <code>epub:type</code> attribute can be appended to existing
+						elements to inflect the desired semantics. A mechanism to identify external vocabularies that
+						provide controlled values for the attributes is also defined.</p>
+				</section>
+
+				<section id="sec-inflection-default-vocabs">
+					<h5>Default Vocabularies</h5>
+
+					<p>The default vocabulary for EPUB Content Documents and Media Overlay Documents is defined to be
+						the [[!EPUB-SSV]]. Unprefixed terms that are not part of the [[!EPUB-SSV]] MAY be included, but
+						their use is discouraged. The use of prefixes is the preferred method for adding custom
+						semantics.</p>
+				</section>
+
+				<section id="sec-contentdocs-reserved-prefixes">
+					<h5>Reserved Prefixes</h5>
+
+					<p>Authors MAY use the following reserved prefixes in the <code>epub:type</code> attribute without
+						having to declare them.</p>
+
+					<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
+						lead to interoperability issues. Validation tools will often reject new prefixes until the tools
+						are updated, for example. Authors are strongly encouraged to declare all prefixes they use to
+						avoid such issues.</p>
+
+					<table id="tbl-reserved-prefixes" class="prefix">
+						<thead>
+							<tr>
+								<th>Prefix</th>
+								<th>IRI</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>msv</td>
+								<td>http://www.idpf.org/epub/vocab/structure/magazine/#</td>
+							</tr>
+							<tr>
+								<td>prism</td>
+								<td>http://www.prismstandard.org/specifications/3.0/PRISM_CV_Spec_3.0.htm#</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section id="sec-contentdocs-prefix-attr">
+					<h6>The <code>prefix</code> Attribute</h6>
+
+					<p>The <code>prefix</code> attribute is defined to be in the namespace
+							<code>http://www.idpf.org/2007/ops</code> when used in EPUB Content Documents and Media
+						Overlay Documents.</p>
+
+					<p>The <code>prefix</code> attribute is only valid on the [[!HTML]] root <code>html</code> element
+						in EPUB Content Documents.</p>
+
+					<p>The <code>prefix</code> attribute is only valid on the [[!SMIL]] root <code>smil</code> element
+						in Media Overlay Documents.</p>
+				</section>
+			</section>
+
+			<section id="sec-vocab-assoc">
+				<h3>Vocabulary Association Mechanisms</h3>
+				
+				<section id="sec-vocab-assoc-intro">
+					<h4>Introduction</h4>
+					
+					<p>Similar to a CURIE [[RDFA-CORE]], the property data type represents an IRI [[RFC3987]] in compact
+						form and simplifies the authoring of metadata from standardized vocabularies.</p>
+					
+					<p>A property value is an expression that consists of a prefix and a reference, where the prefix —
+						whether literal or implied — is a shorthand mapping of an IRI that typically resolves to a term
+						vocabulary. When the prefix is converted to its IRI representation and combined with the
+						reference, the resulting IRI normally resolves to a fragment within that vocabulary that
+						contains human- and/or machine-readable information about the term.</p>
+					
+					<p>To assist Reading Systems in processing property values, this specification defines three
+						mechanisms to establish the IRI a prefix maps to:</p>
+					
+					<ul>
+						<li>
+							<p><a href="#sec-metadata-default-vocab">default vocabularies</a> — define the mapping when
+								a property value does not include a prefix;</p>
+						</li>
+						<li>
+							<p><a href="#sec-metadata-reserved-prefixes">reserved prefixes</a> — these mappings are
+								predefined (i.e., all Reading Systems recognize them) and can be used without having to
+								be declared; and</p>
+						</li>
+						<li>
+							<p>the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute — a declarative means of
+								creating new prefix mappings on the root <a href="#sec-package-elem"
+									><code>package</code></a> element.</p>
+						</li>
+					</ul>
+				</section>
+				
+				<section id="sec-vocab-assoc-default-vocab">
+					<h5>Default Vocabularies</h5>
+					
+					<p>A default vocabulary is a vocabulary that does not require a prefix to be declared in order to
+						use its terms, and whose terms MUST always be unprefixed.</p>
+					
+					<p>The IRIs associated with these vocabularies MUST NOT be assigned a prefix using the <a
+						href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
+				</section>
+				
+				<section id="sec-vocab-assoc-reserved-prefixes">
+					<h4>Reserved Prefixes</h4>
+					
+					<p>Reserved prefixes SHOULD NOT be overridden in the <a href="#sec-prefix-attr"><code>prefix</code>
+						attribute</a>.</p>
+				</section>
+				
+				<section id="sec-prefix-attr">
+					<h4>The <code>prefix</code> Attribute</h4>
+					
+					<p>The <code>prefix</code> attribute defines additional prefix mappings not <a
+						href="#sec-metadata-reserved-prefixes">reserved</a> by this specification.</p>
+					
+					<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
+						prefix-to-IRI mappings of the form:</p>
+					
+					<table class="productionset">
+						<caption>(EBNF productions <a
+							href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
+							>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
+							(U+0000 to U+007F). </caption>
+						<tr>
+							<td id="prefix.ebnf.def">
+								<a href="#prefix.ebnf.def">prefixes</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
+								>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
+									href="#prefix.ebnf.mapping">mapping</a> } ; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.mapping">
+								<a href="#prefix.ebnf.mapping">mapping</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space">space</a>
+								, { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.prefix">
+								<a href="#prefix.ebnf.prefix">prefix</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? xsd:NCName ? ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.space">
+								<a href="#prefix.ebnf.space">space</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>#x20 ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="prefix.ebnf.whitespace">
+								<a href="#prefix.ebnf.whitespace">whitespace</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>(#x20 | #x9 | #xD | #xA) ;</td>
+							<td> </td>
+						</tr>
+					</table>
+					
+					<aside class="example">
+						<p>The following example shows prefixes for the Friend of a Friend (<code>foaf</code>) and
+							DBPedia (<code>dbp</code>) vocabularies being declared using the <code>prefix</code>
+							attribute.</p>
+						<pre>&lt;package … 
+	prefix="foaf: http://xmlns.com/foaf/spec/
+		 dbp: http://dbpedia.org/ontology/"&gt;
+	…
+&lt;/package&gt;</pre>
+					</aside>
+					
+					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
+						maps to the <a href="#sec-metadata-default-vocab">default vocabulary</a>.</p>
+					
+					<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
+						[[!RDFA-CORE]] processing.</p>
+					
+					<p>For future compatibility with alternative serializations of the Package Document, a prefix for
+						the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in the
+						<code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
+							href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
+				</section>
+				
+				<section id="sec-property-datatype">
+					<h4>The <code>property</code> Data Type</h4>
+					
+					<p>The property data type is a compact means of expressing an IRI [[!RFC3987]] and consists of an
+						OPTIONAL prefix separated from a reference by a colon.</p>
+					
+					<table class="productionset">
+						<caption>(EBNF productions <a
+							href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
+							>ISO/IEC 14977</a>)<br />All terminal symbols are in the Unicode Block 'Basic Latin'
+							(U+0000 to U+007F). </caption>
+						<tr>
+							<td id="property.ebnf.property">
+								<a href="#property.ebnf.property">property</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
+								href="#property.ebnf.reference">reference</a>; </td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="property.ebnf.prefix">
+								<a href="#property.ebnf.prefix">prefix</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? xsd:NCName ? ;</td>
+							<td> </td>
+						</tr>
+						<tr>
+							<td id="property.ebnf.reference">
+								<a href="#property.ebnf.reference">reference</a>
+							</td>
+							<td>
+								<code>=</code>
+							</td>
+							<td>? irelative-ref ? ;</td>
+							<td>/* as defined in [[!RFC3987]] */<br /></td>
+						</tr>
+					</table>
+					
+					<p>The property data type is derived from the CURIE data type defined in [[!RDFA-CORE]], and
+						represents a subset of CURIEs.</p>
+					
+					<aside class="example">
+						<p>The following example shows a property value composed of the prefix <code>dcterms</code> and
+							the reference <code>modified</code>.</p>
+						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
+					</aside>
+					
+					<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-processing">processing</a>
+						[[EPUB-RS-33]], this property would expand to the following IRI:</p>
+					
+					<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
+					
+					<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
+						prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
+					
+					<p>When a prefix is omitted from a property value, the expressed reference represents a term from
+						the <a href="#sec-metadata-default-vocab">default vocabulary</a> for that attribute.</p>
+					
+					<aside class="example">
+						<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
+							manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
+						
+						<pre>&lt;item … properties="mathml"/&gt;</pre>
+						
+						<p>This property expands to:</p>
+						
+						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
+						
+						<p>when the IRI for the vocabulary is concatenated with the reference.</p>
+					</aside>
+					
+					<p>An empty string does not represent a valid property value, even though it is valid to the
+						definition above.</p>
+				</section>
+			</section>
+			
+			<section id="sec-vocabs">
+				<h3>Vocabularies</h3>
+				
+				<div data-include="vocab/meta-property.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+				
+				<div data-include="vocab/link.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+				
+				<div data-include="vocab/item-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+				
+				<div data-include="vocab/itemref-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+				
+				<div data-include="vocab/overlays.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+				
+				<div data-include="vocab/structure.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+			</section>
 		</section>
 		<section id="app-schemas" class="appendix">
 			<h2>Schemas</h2>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -1,0 +1,212 @@
+<section id="app-rendering-vocab">
+	<h3>Package Rendering Vocabulary</h3>
+	
+	<section id="sec-package-metadata-layout-general-intro" class="informative">
+		<h4>Introduction</h4>
+		
+		<p>Not all rendering information can be expressed through the underlying technologies that EPUB is
+			built upon. For example, although HTML with CSS provides powerful layout capabilities, those
+			capabilities are limited to the scope of the document being rendered.</p>
+		
+		<p>This section defines general-purpose properties that allow Authors to express package-level
+			rendering intentions (i.e., functionality that can only be implemented by the <a>EPUB Reading
+				System</a>). If a Reading System supports the desired rendering, these properties enable the
+			user to be presented the content as the Author optimally designed it.</p>
+	</section>
+	
+	<section id="rendition-vocab-ref">
+		<h4>Referencing</h4>
+		
+		<p>The base IRI for referencing these properties is
+			<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
+		
+		<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved for
+			use</a> with the package rendering properties and does not have to be declared in the
+			Package Document.</p>
+	</section>
+	
+	<section id="sec-rendering-general">
+		<h4>General Properties</h4>
+		
+		<section id="flow">
+			<h5>The <code>rendition:flow</code> Property</h5>
+			
+			<p>The <code>rendition:flow</code> property specifies the Author preference for how Reading
+				Systems should handle content overflow. </p>
+			
+				<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code>
+					property</a> is specified on a <code>meta</code> element, it indicates the Author's
+					global preference for overflow content handling (i.e., for all spine items). Authors MAY
+					indicate a preference for dynamic pagination or scrolling. For scrolled content, it is
+					also possible to specify whether consecutive <a>EPUB Content Documents</a> are to be
+					rendered as a continuous scrolling view or whether each is to be rendered separately
+					(i.e., with a dynamic page break between each).</p>
+				
+			<p>The following values are defined for use with the <code>rendition:flow</code>
+				property:</p>
+			
+			<dl class="variablelist">
+				<dt id="paginated">paginated</dt>
+				<dd>
+					<p>Dynamically paginate all overflow content.</p>
+				</dd>
+				<dt id="scrolled-continuous">scrolled-continuous</dt>
+				<dd>
+					<p>Render all Content Documents such that overflow content is scrollable, and the
+						EPUB Publication represented by the given <a>Rendition</a> is presented as one
+						continuous scroll from spine item to spine item (except where <a
+							href="#layout-property-flow-overrides">locally overridden</a>).</p>
+					<p>Note that Authors SHOULD NOT create publications in which different resources
+						have different block flow directions, as continuous scrolled rendition in EPUB
+						Reading Systems would be problematic.</p>
+				</dd>
+				<dt id="scrolled-doc">scrolled-doc</dt>
+				<dd>
+					<p>Render all Content Documents such that overflow content is scrollable, and each
+						spine item is presented as a separate scrollable document.</p>
+				</dd>
+				<dt id="auto">auto</dt>
+				<dd>
+					<p>Render overflow content using the Reading System default method or a user
+						preference, whichever is applicable.</p>
+				</dd>
+			</dl>
+			
+			<p id="html-body-page-break-before">Note that when two reflowable EPUB Content Documents
+					occur sequentially in the spine, the default rendering for their [[!HTML]] <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element"
+						><code>body</code></a> elements is consistent with the <a
+							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
+							><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been set to
+					<code>always</code>. In addition to using the <code>rendition:flow</code> property,
+					Authors MAY override this behavior through an appropriate style sheet declaration, if
+					the Reading System supports such overrides.</p>
+				
+				<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
+			
+			<section id="layout-property-flow-overrides">
+				<h5>Spine Overrides</h5>
+				
+				<p id="layout-property-flow-local">Authors MAY specify the following properties locally on
+					spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
+					<a href="#property-flow-global">global value</a> for the given spine item:</p>
+				
+				<dl>
+					<dt id="flow-auto">flow-auto</dt>
+					<dd>Indicates no preference for overflow content handling by the Author.</dd>
+					
+					<dt id="flow-paginated">flow-paginated</dt>
+					<dd>Indicates the Author preference is to dynamically paginate content overflow.</dd>
+					
+					<dt id="flow-scrolled-continuous">flow-scrolled-continuous</dt>
+					<dd>Indicates the Author preference is to provide a scrolled view for overflow content,
+						and that consecutive spine items with this property are to be rendered as a
+						continuous scroll.</dd>
+					
+					<dt id="flow-scrolled-doc">flow-scrolled-doc</dt>
+					<dd>Indicates the Author preference is to provide a scrolled view for overflow content,
+						and each spine item with this property is to be rendered as a separate scrollable
+						document.</dd>
+				</dl>
+				
+				<p>Only one of these overrides is allowed on any given spine item.</p>
+
+				<aside class="example" id="property-flow-ex1">
+					<p>The following example demonstrates an Author's intent to have a paginated Rendition
+						with a scrollable table of contents.</p>
+					<pre>&lt;metadata&gt;
+    &lt;meta property="rendition:flow"&gt;paginated&lt;/meta&gt;
+&lt;/metadata&gt;
+
+&lt;spine&gt;
+    &lt;itemref idref="toc" properties="rendition:flow-scrolled-doc"/&gt;
+    &lt;itemref idref="c01"/&gt;
+&lt;/spine&gt;</pre>
+				</aside>
+			</section>
+		</section>
+		
+		<section id="align-x-center">
+			<h5>The <code>rendition:align-x-center</code> Property</h5>
+			
+			<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should
+				be centered horizontally in the viewport or spread. </p>
+			
+			<div class="note">
+				<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title
+					pages), in the absence of reliable centering control within the content rendering. As
+					support for paged media evolves in CSS, however, this property is expected to be
+					deprecated. Authors are encouraged to use CSS solutions when effective.</p>
+			</div>
+		</section>
+	</section>
+	<section id="sec-rendering-fxl">
+		<h4>Fixed-Layout Properties</h4>
+		
+		<p>The following properties belong to the Package Rendering Vocabulary. Refer to their respective
+			definitions in <a href="#sec-fixed-layouts"></a> for the details of their use.</p>
+		
+		<table class="zebra">
+			<thead>
+				<tr>
+					<th>Properties</th>
+					<th>Defined in</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>
+						<ul>
+							<li><code>rendition:layout</code></li>
+							<li><code>rendition:layout-pre-paginated</code></li>
+							<li><code>rendition:layout-reflowable</code></li>
+						</ul>
+					</td>
+					<td><a href="#layout"></a></td>
+				</tr>
+				<tr>
+					<td>
+						<ul>
+							<li><code>rendition:orientation</code></li>
+							<li><code>rendition:orientation-auto</code></li>
+							<li><code>rendition:orientation-landscape</code></li>
+							<li><code>rendition:orientation-portrait</code></li>
+						</ul>
+					</td>
+					<td><a href="#orientation"></a></td>
+				</tr>
+				<tr>
+					<td>
+						<ul>
+							<li><code>rendition:spread</code></li>
+							<li><code>rendition:spread-auto</code></li>
+							<li><code>rendition:spread-both</code></li>
+							<li><code>rendition:spread-landscape</code></li>
+							<li><code>rendition:spread-none</code></li>
+							<li><code>rendition:spread-portrait</code></li>
+						</ul>
+					</td>
+					<td><a href="#spread"></a></td>
+				</tr>
+				<tr>
+					<td>
+						<ul>
+							<li><code>rendition:page-spread-center</code></li>
+							<li><code>rendition:page-spread-left</code></li>
+							<li><code>rendition:page-spread-right</code></li>
+						</ul>
+					</td>
+					<td><a href="#page-spread"></a></td>
+				</tr>
+				<tr>
+					<td>
+						<ul>
+							<li><code>rendition:viewport</code></li>
+						</ul>
+					</td>
+					<td><a href="#viewport"></a></td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
+</section>

--- a/epub33/core/vocab/structure.html
+++ b/epub33/core/vocab/structure.html
@@ -1,0 +1,2495 @@
+<section id="structure-vocab">
+	<h3>Structural Semantics Vocabulary</h3>
+	
+	<section id="about" class="inoformative">
+		<h4>About this vocabulary</h4>
+		
+		<div property="dcterms:description">
+			<p>While the EPUB Structural Semantics vocabulary is generally host language agnostic, it has been
+				constructed primarily to enable semantic inflection of elements in the HTML vocabulary.</p>
+			<p class="output-htu-expl" id="htu-expl">The <i>HTML usage context</i> fields indicate contexts in
+				HTML documents where the given property is considered relevant. Authors may use the properties
+				on HTML markup elements not specifically listed, but must ensure that the semantics they express
+				represent a subset of the carrying element's semantics and do not attach an existing element's
+				meaning to a semantically neutral element.</p>
+			<p class="output-htu-expl">When processing HTML documents, Reading Systems may ignore such
+				non-compliant properties, unless their usage context is explicitly overridden or extended by the
+				host specification.</p>
+			<p>The <i>Usage Details</i> sections identify IDPF specifications that define or utilize the
+				specified properties.</p>
+		</div>
+	</section>
+	
+	<section id="partitions" about="#partitions" typeof="rdf:Bag">
+		<h4 about="#partitions" rev="dcterms:title">Document partitions</h4>
+		
+		<dl about="#partitions" rev="rdfs:member">
+			<dt id="cover" about="#cover" typeof="rdf:Property">cover</dt>
+			<dd about="#cover" property="rdfs:comment" datatype="xsd:string">
+				<p>A section that introduces the work, often consisting of a marketing image, the title, author
+					and publisher, and select quotes and reviews.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+				</p>
+			</dd>
+			<dt id="frontmatter" about="#frontmatter" typeof="rdf:Property">frontmatter</dt>
+			<dd about="#frontmatter" property="rdfs:comment" datatype="xsd:string">
+				<p>Preliminary material to the main content of a publication, such as tables of contents,
+					dedications, etc.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+				</p>
+			</dd>
+			<dt id="bodymatter" about="#bodymatter" typeof="rdf:Property">bodymatter</dt>
+			<dd about="#bodymatter" property="rdfs:comment" datatype="xsd:string">
+				<p>The main content of a publication.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+				</p>
+			</dd>
+			<dt id="backmatter" about="#backmatter" typeof="rdf:Property">backmatter</dt>
+			<dd about="#backmatter" property="rdfs:comment" datatype="xsd:string">
+				<p>Ancillary material occurring after the main content of a publication, such as indices,
+					appendices, etc.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="divisions" about="#divisions" typeof="rdf:Bag">
+		<h4 about="#divisions" rev="dcterms:title">Document divisions</h4>
+		
+		<dl about="#divisions" rev="rdfs:member">
+			<dt id="volume" about="#volume" typeof="rdf:Property">volume</dt>
+			<dd about="#volume" property="rdfs:comment" datatype="xsd:string">
+				<p>A component of a collection.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+				</p>
+			</dd>
+			<dt id="part" about="#part" typeof="rdf:Property">part</dt>
+			<dd about="#part" property="rdfs:comment" datatype="xsd:string">
+				<p>A major structural division in a work that contains a set of related sections dealing with a
+					particular subject, narrative arc or similar encapsulated theme.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+				</p>
+			</dd>
+			<dt id="chapter" about="#chapter" typeof="rdf:Property">chapter</dt>
+			<dd about="#chapter" property="rdfs:comment" datatype="xsd:string">
+				<p>A major thematic section of content in a work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+				</p>
+			</dd>
+			<dt id="subchapter" about="#subchapter" typeof="rdf:Property">subchapter<span
+					class="status deprecated" property="owl:deprecated" content="true"> [deprecated]</span>
+			</dt>
+			<dd about="#subchapter" property="rdfs:comment" datatype="xsd:string">
+				<p>A major sub-division of a chapter.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+				</p>
+			</dd>
+			<dt id="division" about="#division" typeof="rdf:Property">division</dt>
+			<dd about="#division" property="rdfs:comment" datatype="xsd:string">
+				<p>A major structural division that may also appear as a substructure of a part (esp. in
+					legislation).</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="sections" about="#sections" typeof="rdf:Bag">
+		<h4 about="#sections" rev="dcterms:title">Document sections and components</h4>
+		
+		<p about="#sections" rev="dcterms:description">Sections and components that typically occur in the
+			publication bodymatter.</p>
+		
+		<dl about="#sections" rev="rdfs:member">
+			<dt id="abstract-1" about="#abstract-1" typeof="rdf:Property">abstract<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#abstract-1" property="rdfs:comment" datatype="xsd:string">
+				<p>A short summary of the principle ideas, concepts and conclusions of the work, or of a section
+					or excerpt within it.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="foreword" about="#foreword" typeof="rdf:Property">foreword</dt>
+			<dd about="#foreword" property="rdfs:comment" datatype="xsd:string">
+				<p>An introductory section that precedes the work, typically not written by the author of the
+					work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="preface" about="#preface" typeof="rdf:Property">preface</dt>
+			<dd about="#preface" property="rdfs:comment" datatype="xsd:string">
+				<p>An introductory section that precedes the work, typically written by the author of the
+					work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="prologue" about="#prologue" typeof="rdf:Property">prologue</dt>
+			<dd about="#prologue" property="rdfs:comment" datatype="xsd:string">
+				<p>An introductory section that sets the background to a work, typically part of the
+					narrative.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="introduction" about="#introduction" typeof="rdf:Property">introduction</dt>
+			<dd about="#introduction" property="rdfs:comment" datatype="xsd:string">
+				<p>A preliminary section that typically introduces the scope or nature of the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="preamble" about="#preamble" typeof="rdf:Property">preamble</dt>
+			<dd about="#preamble" property="rdfs:comment" datatype="xsd:string">
+				<p>A section in the beginning of the work, typically containing introductory and/or explanatory
+					prose regarding the scope or nature of the work's content</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="conclusion" about="#conclusion" typeof="rdf:Property">conclusion</dt>
+			<dd about="#conclusion" property="rdfs:comment" datatype="xsd:string">
+				<p>A concluding section or statement that summarizes the work or wraps up the narrative.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="epilogue" about="#epilogue" typeof="rdf:Property">epilogue</dt>
+			<dd about="#epilogue" property="rdfs:comment" datatype="xsd:string">
+				<p>A concluding section of narrative that wraps up or comments on the actions and events of the
+					work, typically from a future perspective.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="afterword" about="#afterword" typeof="rdf:Property">afterword</dt>
+			<dd about="#afterword" property="rdfs:comment" datatype="xsd:string">
+				<p>A closing statement from the author or a person of importance, typically providing insight
+					into how the content came to be written, its significance, or related events that have
+					transpired since its timeline.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="epigraph" about="#epigraph" typeof="rdf:Property">epigraph</dt>
+			<dd about="#epigraph" property="rdfs:comment" datatype="xsd:string">
+				<p>A quotation set at the start of the work or a section that establishes the theme or sets the
+					mood.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="navigation" about="#navigation" typeof="rdf:Bag">
+		<h4 about="#navigation" rev="dcterms:title">Document navigation</h4>
+		
+		<dl about="#navigation" rev="rdfs:member">
+			<dt id="toc-1" about="#toc-1" typeof="rdf:Property">toc</dt>
+			<dd about="#toc-1" property="rdfs:comment" datatype="xsd:string">
+				<p>A navigational aid that provides an ordered list of links to the major sectional headings in
+					the content. A table of contents may cover an entire work, or only a smaller section of
+					it.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dt id="toc-brief" about="#toc-brief" typeof="rdf:Property">toc-brief<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#toc-brief" property="rdfs:comment" datatype="xsd:string">
+				<p>An abridged version of the table of contents.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dt id="landmarks" about="#landmarks" typeof="rdf:Property">landmarks</dt>
+			<dd about="#landmarks" property="rdfs:comment" datatype="xsd:string">
+				<p>A collection of references to well-known/recurring components within the publication</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dt id="loa" about="#loa" typeof="rdf:Property">loa</dt>
+			<dd about="#loa" property="rdfs:comment" datatype="xsd:string">
+				<p>A listing of audio clips included in the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dt id="loi" about="#loi" typeof="rdf:Property">loi</dt>
+			<dd about="#loi" property="rdfs:comment" datatype="xsd:string">
+				<p>A listing of illustrations included in the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dt id="lot" about="#lot" typeof="rdf:Property">lot</dt>
+			<dd about="#lot" property="rdfs:comment" datatype="xsd:string">
+				<p>A listing of tables included in the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dt id="lov" about="#lov" typeof="rdf:Property">lov</dt>
+			<dd about="#lov" property="rdfs:comment" datatype="xsd:string">
+				<p>A listing of video clips included in the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="references" about="#references" typeof="rdf:Bag">
+		<h4 about="#references" rev="dcterms:title">Document reference sections</h4>
+		
+		<dl about="#references" rev="rdfs:member">
+			<dt id="appendix" about="#appendix" typeof="rdf:Property">appendix</dt>
+			<dd about="#appendix" property="rdfs:comment" datatype="xsd:string">
+				<p>A section of supplemental information located after the primary content that informs the
+					content but is not central to it.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dt id="colophon" about="#colophon" typeof="rdf:Property">colophon</dt>
+			<dd about="#colophon" property="rdfs:comment" datatype="xsd:string">
+				<p>A short section of production notes particular to the edition (e.g., describing the typeface
+					used), often located at the end of a work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+						>grouping content</a>
+				</p>
+			</dd>
+			<dt id="credits" about="#credits" typeof="rdf:Property">credits<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#credits" property="rdfs:comment" datatype="xsd:string">
+				<p>A collection of <a href="#credit">credits</a>.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+						>grouping content</a>
+				</p>
+			</dd>
+			<dt id="keywords" about="#keywords" typeof="rdf:Property">keywords<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#keywords" property="rdfs:comment" datatype="xsd:string">
+				<p>A collection of <a href="#keyword">keywords</a>.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content"
+						>grouping content</a>
+				</p>
+			</dd>
+		</dl>
+		<div id="indexes" about="#indexes" typeof="rdf:Bag">
+			<h3 id="h_indexes" about="#indexes" rev="dcterms:title">Indexes</h3>
+			<dl about="#indexes" rev="rdfs:member">
+				<dt id="index" about="#index" typeof="rdf:Property">index</dt>
+				<dd about="#index" property="rdfs:comment" datatype="xsd:string">
+					<p>A navigational aid that provides a detailed list of links to key subjects, names and
+						other important topics covered in the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-index">EPUB Indexes – index
+							property</a>
+					</p>
+				</dd>
+				<dt id="index-headnotes" about="#index-headnotes" typeof="rdf:Property">index-headnotes</dt>
+				<dd about="#index-headnotes" property="rdfs:comment" datatype="xsd:string">
+					<p>Narrative or other content to assist users in using the index.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-headnotes" rel="role:scope" resource="#index">
+							<a href="#index">index</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>, <a
+							href="https://www.w3.org/TR/html/sections.html#the-header-element">header</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-headnotes">EPUB Indexes –
+							index-headnotes property</a>
+					</p>
+				</dd>
+				<dt id="index-legend" about="#index-legend" typeof="rdf:Property">index-legend</dt>
+				<dd about="#index-legend" property="rdfs:comment" datatype="xsd:string">
+					<p>List of symbols, abbreviations or special formatting used in the index, and their
+						meanings.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-legend" rel="role:scope"
+							resource="#index-headnotes">
+							<a href="#index-headnotes">index-headnotes</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#the-dl-element">dl</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-legend">EPUB Indexes –
+							index-legend property</a>
+					</p>
+				</dd>
+				<dt id="index-group" about="#index-group" typeof="rdf:Property">index-group</dt>
+				<dd about="#index-group" property="rdfs:comment" datatype="xsd:string">
+					<p>Collection of consecutive main entries that share a common characteristic, for example
+						the starting letter of the main entries.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-group" rel="role:scope" resource="#index">
+							<a href="#index">index</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-group">EPUB Indexes –
+							index-group property</a>
+					</p>
+				</dd>
+				<dt id="index-entry-list" about="#index-entry-list" typeof="rdf:Property">index-entry-list</dt>
+				<dd about="#index-entry-list" property="rdfs:comment" datatype="xsd:string">
+					<p>Collection of consecutive main entries or subentries.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-entry-list" rel="role:scope"
+							resource="#index-entry">
+							<a href="#index-entry">index-entry</a>
+						</span>, <span class="subpropref" about="#index-entry-list" rel="role:scope"
+							resource="#index-group">
+							<a href="#index-group">index-group</a>
+						</span> and <span class="subpropref" about="#index-entry-list" rel="role:scope"
+							resource="#index">
+							<a href="#index">index</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#the-ul-element">ul</a>; this
+						property is implied when the ul has an ancestor of index except within
+						index-headnotes</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-entry-list">EPUB Indexes –
+							index-entry-list property</a>
+					</p>
+				</dd>
+				<dt id="index-entry" about="#index-entry" typeof="rdf:Property">index-entry</dt>
+				<dd about="#index-entry" property="rdfs:comment" datatype="xsd:string">
+					<p>One term with any attendant subentries, locators, cross references, and/or editorial
+						note.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-entry" rel="role:scope"
+							resource="#index-entry-list">
+							<a href="#index-entry-list">index-entry-list</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>; this
+						property is implied when parent ul is of type index-entry-list (implicit or
+						explicit)</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-entry">EPUB Indexes –
+							index-entry property</a>
+					</p>
+				</dd>
+				<dt id="index-term" about="#index-term" typeof="rdf:Property">index-term</dt>
+				<dd about="#index-term" property="rdfs:comment" datatype="xsd:string">
+					<p>Word, phrase, string, glyph or image representing the indexable content.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-term" rel="role:scope"
+							resource="#index-xref-related">
+							<a href="#index-xref-related">index-xref-related</a>
+						</span>, <span class="subpropref" about="#index-term" rel="role:scope"
+							resource="#index-entry">
+							<a href="#index-entry">index-entry</a>
+						</span> and <span class="subpropref" about="#index-term" rel="role:scope"
+							resource="#index-xref-preferred">
+							<a href="#index-xref-preferred">index-xref-preferred</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+							content</a>; typically <a
+							href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element">span</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-term">EPUB Indexes –
+							index-term property</a>
+					</p>
+				</dd>
+				<dt id="index-editor-note" about="#index-editor-note" typeof="rdf:Property"
+					>index-editor-note</dt>
+				<dd about="#index-editor-note" property="rdfs:comment" datatype="xsd:string">
+					<p>Editorial note pertaining to a single entry.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-editor-note" rel="role:scope"
+							resource="#index-entry">
+							<a href="#index-entry">index-entry</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-editor-note">EPUB Indexes –
+							index-editor-note property</a>
+					</p>
+				</dd>
+				<dt id="index-locator" about="#index-locator" typeof="rdf:Property">index-locator</dt>
+				<dd about="#index-locator" property="rdfs:comment" datatype="xsd:string">
+					<p>A reference to an occurrence of the indexed content in the publication.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-locator" rel="role:scope" resource="#index-entry">
+							<a href="#index-entry">index-entry</a>
+						</span>, <span class="subpropref" about="#index-locator" rel="role:scope"
+							resource="#index-locator-list">
+							<a href="#index-locator-list">index-locator-list</a>
+						</span> and <span class="subpropref" about="#index-locator" rel="role:scope"
+							resource="#index-locator-range">
+							<a href="#index-locator-range">index-locator-range</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>; this
+						property is implied when parent context is index-locator-list or index-locator-range</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-locator">EPUB Indexes –
+							index-locator property</a>
+					</p>
+				</dd>
+				<dt id="index-locator-list" about="#index-locator-list" typeof="rdf:Property"
+					>index-locator-list</dt>
+				<dd about="#index-locator-list" property="rdfs:comment" datatype="xsd:string">
+					<p>Collection of sequential locators or locator ranges.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-locator-list" rel="role:scope"
+							resource="#index-entry">
+							<a href="#index-entry">index-entry</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#the-ul-element">ul</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-locator-list">EPUB Indexes –
+							index-locator-list property</a>
+					</p>
+				</dd>
+				<dt id="index-locator-range" about="#index-locator-range" typeof="rdf:Property"
+					>index-locator-range</dt>
+				<dd about="#index-locator-range" property="rdfs:comment" datatype="xsd:string">
+					<p>A pair of locators that connects a term to a range of content rather than a single
+						point.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-locator-range" rel="role:scope"
+							resource="#index-locator-list">
+							<a href="#index-locator-list">index-locator-list</a>
+						</span> and <span class="subpropref" about="#index-locator-range" rel="role:scope"
+							resource="#index-entry">
+							<a href="#index-entry">index-entry</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-locator-range">EPUB Indexes –
+							index-locator-range property</a>
+					</p>
+				</dd>
+				<dt id="index-xref-preferred" about="#index-xref-preferred" typeof="rdf:Property"
+					>index-xref-preferred</dt>
+				<dd about="#index-xref-preferred" property="rdfs:comment" datatype="xsd:string">
+					<p>Reference from one term to one or more preferred terms or term categories in an index
+						(analogous to "See xxx").</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-xref-preferred" rel="role:scope"
+							resource="#index-entry">
+							<a href="#index-entry">index-entry</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-xref-preferred">EPUB Indexes
+							– index-xref-preferred property</a>
+					</p>
+				</dd>
+				<dt id="index-xref-related" about="#index-xref-related" typeof="rdf:Property"
+					>index-xref-related</dt>
+				<dd about="#index-xref-related" property="rdfs:comment" datatype="xsd:string">
+					<p>Reference from one term to one or more related terms or term categories in an index
+						(analogous to "See also xxx").</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-xref-related" rel="role:scope"
+							resource="#index-entry">
+							<a href="#index-entry">index-entry</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-xref-related">EPUB Indexes –
+							index-xref-related property</a>
+					</p>
+				</dd>
+				<dt id="index-term-category" about="#index-term-category" typeof="rdf:Property"
+					>index-term-category</dt>
+				<dd about="#index-term-category" property="rdfs:comment" datatype="xsd:string">
+					<p>Word, phrase, string, glyph or image representing a category of terms in the index.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-term-category" rel="role:scope"
+							resource="#index-xref-related">
+							<a href="#index-xref-related">index-xref-related</a>
+						</span> and <span class="subpropref" about="#index-term-category" rel="role:scope"
+							resource="#index-xref-preferred">
+							<a href="#index-xref-preferred">index-xref-preferred</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-term-category">EPUB Indexes –
+							index-term-category property</a>
+					</p>
+				</dd>
+				<dt id="index-term-categories" about="#index-term-categories" typeof="rdf:Property"
+					>index-term-categories</dt>
+				<dd about="#index-term-categories" property="rdfs:comment" datatype="xsd:string">
+					<p>Wrapper for a list of the term categories belonging to an index.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#index-term-categories" rel="role:scope"
+							resource="#index-xref-related">
+							<a href="#index-xref-related">index-xref-related</a>
+						</span> and <span class="subpropref" about="#index-term-categories" rel="role:scope"
+							resource="#index-xref-preferred">
+							<a href="#index-xref-preferred">index-xref-preferred</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/idx/epub-indexes.html#bb-term-categories">EPUB Indexes
+							– index-term-categories property</a>
+					</p>
+				</dd>
+			</dl>
+		</div>
+		<div id="glossaries" about="#glossaries" typeof="rdf:Bag">
+			<h3 id="h_glossaries" about="#glossaries" rev="dcterms:title">Glossaries</h3>
+			<dl about="#glossaries" rev="rdfs:member">
+				<dt id="glossary" about="#glossary" typeof="rdf:Property">glossary</dt>
+				<dd about="#glossary" property="rdfs:comment" datatype="xsd:string">
+					<p>A brief dictionary of new, uncommon or specialized terms used in the content.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#the-dl-element">dl</a>, <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>
+					</p>
+				</dd>
+				<dt id="glossterm" about="#glossterm" typeof="rdf:Property">glossterm</dt>
+				<dd about="#glossterm" property="rdfs:comment" datatype="xsd:string">
+					<p>A glossary term.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#glossterm" rel="role:scope" resource="#glossary">
+							<a href="#glossary">glossary</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>The glossterm property is implied
+						on <a href="https://www.w3.org/TR/html/grouping-content.html#the-dt-element">dt</a>
+						elements within a <a
+							href="https://www.w3.org/TR/html/grouping-content.html#the-dl-element">dl</a>
+						element marked with the <a href="#glossary">glossary</a> property.</p>
+				</dd>
+				<dt id="glossdef" about="#glossdef" typeof="rdf:Property">glossdef</dt>
+				<dd about="#glossdef" property="rdfs:comment" datatype="xsd:string">
+					<p>The definition of a <a href="#glossterm">term in a glossary</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#glossdef" rel="role:scope" resource="#glossary">
+							<a href="#glossary">glossary</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>The glossdef property is implied
+						on <a href="https://www.w3.org/TR/html/grouping-content.html#the-dd-element">dd</a>
+						elements within a <a
+							href="https://www.w3.org/TR/html/grouping-content.html#the-dl-element">dl</a>
+						element marked with the <a href="#glossary">glossary</a> property.</p>
+				</dd>
+			</dl>
+		</div>
+		<div id="bibliographies" about="#bibliographies" typeof="rdf:Bag">
+			<h3 id="h_bibliographies" about="#bibliographies" rev="dcterms:title">Bibliographies</h3>
+			<dl about="#bibliographies" rev="rdfs:member">
+				<dt id="bibliography" about="#bibliography" typeof="rdf:Property">bibliography</dt>
+				<dd about="#bibliography" property="rdfs:comment" datatype="xsd:string">
+					<p>A list of external references cited in the work, which may be to print or digital
+						sources.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>
+					</p>
+				</dd>
+				<dt id="biblioentry" about="#biblioentry" typeof="rdf:Property">biblioentry</dt>
+				<dd about="#biblioentry" property="rdfs:comment" datatype="xsd:string">
+					<p>A single reference to an external source in a <a href="#bibliography">bibliography</a>. A
+						biblioentry typically provides more detailed information than its reference(s) in the
+						content (e.g., full title, author(s), publisher, publication date, etc.).</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Required parent context:</span>
+						<span class="subpropref" about="#biblioentry" rel="role:scope" resource="#bibliography">
+							<a href="#bibliography">bibliography</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+			</dl>
+		</div>
+	</section>
+	
+	<section id="preliminary" about="#preliminary" typeof="rdf:Bag">
+		<h4 about="#preliminary" rev="dcterms:title">Preliminary sections and components</h4>
+		
+		<p about="#preliminary" rev="dcterms:description">Preliminary sections and components, typically
+			occuring in the publication frontmatter.</p>
+		
+		<dl about="#preliminary" rev="rdfs:member">
+			<dt id="titlepage" about="#titlepage" typeof="rdf:Property">titlepage</dt>
+			<dd about="#titlepage" property="rdfs:comment" datatype="xsd:string">
+				<p>The title page of the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="halftitlepage" about="#halftitlepage" typeof="rdf:Property">halftitlepage</dt>
+			<dd about="#halftitlepage" property="rdfs:comment" datatype="xsd:string">
+				<p>The half title page of the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="copyright-page" about="#copyright-page" typeof="rdf:Property">copyright-page</dt>
+			<dd about="#copyright-page" property="rdfs:comment" datatype="xsd:string">
+				<p>The copyright page of the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="seriespage" about="#seriespage" typeof="rdf:Property">seriespage <span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#seriespage" property="rdfs:comment" datatype="xsd:string">
+				<p>Marketing section used to list related publications.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="acknowledgments" about="#acknowledgments" typeof="rdf:Property">acknowledgments</dt>
+			<dd about="#acknowledgments" property="rdfs:comment" datatype="xsd:string">
+				<p>A section or statement that acknowledges significant contributions by persons, organizations,
+					governments and other entities to the realization of the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="imprint" about="#imprint" typeof="rdf:Property">imprint</dt>
+			<dd about="#imprint" property="rdfs:comment" datatype="xsd:string">
+				<p>Information relating to the publication or distribution of the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="imprimatur" about="#imprimatur" typeof="rdf:Property">imprimatur</dt>
+			<dd about="#imprimatur" property="rdfs:comment" datatype="xsd:string">
+				<p>A formal statement authorizing the publication of the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="contributors" about="#contributors" typeof="rdf:Property">contributors</dt>
+			<dd about="#contributors" property="rdfs:comment" datatype="xsd:string">
+				<p>A list of contributors to the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="other-credits" about="#other-credits" typeof="rdf:Property">other-credits</dt>
+			<dd about="#other-credits" property="rdfs:comment" datatype="xsd:string">
+				<p>Acknowledgments of previously published parts of the work, illustration credits, and
+					permission to quote from copyrighted material.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="errata" about="#errata" typeof="rdf:Property">errata</dt>
+			<dd about="#errata" property="rdfs:comment" datatype="xsd:string">
+				<p>A set of corrections discovered after initial publication of the work, sometimes referred to
+					as corrigenda.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="dedication" about="#dedication" typeof="rdf:Property">dedication</dt>
+			<dd about="#dedication" property="rdfs:comment" datatype="xsd:string">
+				<p>An inscription at the front of the work, typically addressed in tribute to one or more
+					persons close to the author.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="revision-history" about="#revision-history" typeof="rdf:Property">revision-history</dt>
+			<dd about="#revision-history" property="rdfs:comment" datatype="xsd:string">
+				<p>A record of changes made to a work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="asides" about="#asides" typeof="rdf:Bag">
+		<h4 about="#asides" rev="dcterms:title">Complementary content</h4>
+		
+		<dl about="#asides" rev="rdfs:member">
+			<dt id="case-study" about="#case-study" typeof="rdf:Property">case-study<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#case-study" property="rdfs:comment" datatype="xsd:string">
+				<p>A detailed analysis of a specific topic.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#case-study" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dt id="help" about="#help" typeof="rdf:Property">help<span class="status deprecated"
+					property="owl:deprecated" content="true"> [deprecated]</span>
+			</dt>
+			<dd about="#help" property="rdfs:comment" datatype="xsd:string">
+				<p>Helpful information that clarifies some aspect of the content or assists in its
+					comprehension.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#help" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+						href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+						content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Replaced by:</span>
+					<span class="subpropref" about="#help" rel="dcterms:isReplacedBy">
+						<a href="#tip">tip</a>
+					</span>
+				</p>
+			</dd>
+			<dt id="marginalia" about="#marginalia" typeof="rdf:Property">marginalia<span
+					class="status deprecated" property="owl:deprecated" content="true"> [deprecated]</span>
+			</dt>
+			<dd about="#marginalia" property="rdfs:comment" datatype="xsd:string">
+				<p>Content, both textual and graphical, that is offset in the margin.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#marginalia" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+						href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+						content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Replaced by:</span>
+					<span class="subpropref" about="#marginalia" rel="dcterms:isReplacedBy">
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>
+					</span>
+				</p>
+			</dd>
+			<dt id="notice" about="#notice" typeof="rdf:Property">notice</dt>
+			<dd about="#notice" property="rdfs:comment" datatype="xsd:string">
+				<p>Notifies the user of consequences that might arise from an action or event. Examples include
+					warnings, cautions and dangers.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dt id="pullquote" about="#pullquote" typeof="rdf:Property">pullquote<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#pullquote" property="rdfs:comment" datatype="xsd:string">
+				<p>A distinctively placed or highlighted quotation from the current content designed to draw
+					attention to a topic or highlight a key point.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#pullquote" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>
+				</p>
+			</dd>
+			<dt id="sidebar" about="#sidebar" typeof="rdf:Property">sidebar<span class="status deprecated"
+					property="owl:deprecated" content="true"> [deprecated]</span>
+			</dt>
+			<dd about="#sidebar" property="rdfs:comment" datatype="xsd:string">
+				<p>Secondary or supplementary content, typically formatted as an inset or box.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#sidebar" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Replaced by:</span>
+					<span class="subpropref" about="#sidebar" rel="dcterms:isReplacedBy">
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>
+					</span>
+				</p>
+			</dd>
+			<dt id="tip" about="#tip" typeof="rdf:Property">tip</dt>
+			<dd about="#tip" property="rdfs:comment" datatype="xsd:string">
+				<p>Helpful information that clarifies some aspect of the content or assists in its
+					comprehension.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#tip" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+						href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+						content</a>
+				</p>
+			</dd>
+			<dt id="warning" about="#warning" typeof="rdf:Property">warning<span class="status deprecated"
+					property="owl:deprecated" content="true"> [deprecated]</span>
+			</dt>
+			<dd about="#warning" property="rdfs:comment" datatype="xsd:string">
+				<p>A warning.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-section-element">section</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+						content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Replaced by:</span>
+					<span class="subpropref" about="#warning" rel="dcterms:isReplacedBy">
+						<a href="#notice">notice</a>
+					</span>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="titles" about="#titles" typeof="rdf:Bag">
+		<h4 about="#titles" rev="dcterms:title">Titles and headings</h4>
+		
+		<dl about="#titles" rev="rdfs:member">
+			<dt id="halftitle" about="#halftitle" typeof="rdf:Property">halftitle</dt>
+			<dd about="#halftitle" property="rdfs:comment" datatype="xsd:string">
+				<p>The title appearing on the first page of a work or immediately before the text.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#halftitle" rel="rdfs:subPropertyOf" resource="#title">
+						<a href="#title">title</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+						content</a>. This property should only appear once within the document scope.</p>
+			</dd>
+			<dt id="fulltitle" about="#fulltitle" typeof="rdf:Property">fulltitle</dt>
+			<dd about="#fulltitle" property="rdfs:comment" datatype="xsd:string">
+				<p>The full title of the work, either simple, in which case it is identical to <a href="#title"
+						>title</a>, or compound, in which case it consists of a <a href="#title">title</a> and a
+						<a href="#subtitle">subtitle</a>.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#fulltitle" rel="rdfs:subPropertyOf" resource="#title">
+						<a href="#title">title</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Same as:</span>
+					<span class="subpropref" about="#fulltitle" rel="owl:sameAs"
+						resource="http://purl.org/dc/terms/title">
+						<a href="http://purl.org/dc/terms/title">http://purl.org/dc/terms/title</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+						content</a>. This property should only appear once within the document scope.</p>
+			</dd>
+			<dt id="covertitle" about="#covertitle" typeof="rdf:Property">covertitle</dt>
+			<dd about="#covertitle" property="rdfs:comment" datatype="xsd:string">
+				<p>The title of the work as displayed on the work's cover.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#covertitle" rel="rdfs:subPropertyOf" resource="#title">
+						<a href="#title">title</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+						content</a>. This property should only appear once within the document scope.</p>
+			</dd>
+			<dt id="title" about="#title" typeof="rdf:Property">title</dt>
+			<dd about="#title" property="rdfs:comment" datatype="xsd:string">
+				<p>The primary name of a document component, such as a list, table or figure.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+						content</a>, <a
+						href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+						content</a> descendants of <a
+						href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+						content</a>.</p>
+			</dd>
+			<dt id="subtitle" about="#subtitle" typeof="rdf:Property">subtitle</dt>
+			<dd about="#subtitle" property="rdfs:comment" datatype="xsd:string">
+				<p>An explanatory or alternate title for the work, or a section or component within it.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#subtitle" rel="rdfs:subPropertyOf" resource="#title">
+						<a href="#title">title</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+						content</a>, <a
+						href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+						content</a> descendants of <a
+						href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+						content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#the-p-element"
+						>paragraphs</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#the-div-element">divs</a>
+				</p>
+			</dd>
+			<dt id="label" about="#label" typeof="rdf:Property">label<span class="status draft"> [draft]</span>
+			</dt>
+			<dd about="#label" property="rdfs:comment" datatype="xsd:string">
+				<p>The text label that precedes an <a href="#ordinal">ordinal</a> in a component title (e.g.,
+					'Chapter', 'Part', 'Figure', 'Table').</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#label" rel="rdfs:subPropertyOf" resource="#title">
+						<a href="#title">title</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">Phrasing
+						content</a> descendants of <a
+						href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+						content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element"
+						>li</a> and <a
+						href="https://www.w3.org/TR/html/grouping-content.html#the-figcaption-element"
+						>figcaption</a>
+				</p>
+			</dd>
+			<dt id="ordinal" about="#ordinal" typeof="rdf:Property">ordinal<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#ordinal" property="rdfs:comment" datatype="xsd:string">
+				<p>An ordinal specifier for a component in a sequence of components (e.g., '1', 'IV',
+					'B-1').</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#ordinal" rel="rdfs:subPropertyOf" resource="#title">
+						<a href="#title">title</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">Phrasing
+						content</a> descendants of <a
+						href="https://www.w3.org/TR/html/dom.html#kinds-of-content-heading-content">heading
+						content</a>, <a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element"
+						>li</a> and <a
+						href="https://www.w3.org/TR/html/grouping-content.html#the-figcaption-element"
+						>figcaption</a>
+				</p>
+			</dd>
+			<dt id="bridgehead" about="#bridgehead" typeof="rdf:Property">bridgehead</dt>
+			<dd about="#bridgehead" property="rdfs:comment" datatype="xsd:string">
+				<p>A structurally insignificant heading that does not contribute to the hierarchical structure
+					of the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow
+					content</a>, typically <a
+						href="https://www.w3.org/TR/html/grouping-content.html#the-p-element">p</a>, <a
+						href="https://www.w3.org/TR/html/grouping-content.html#the-div-element">div</a> or <a
+						href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element">span</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="educational" about="#educational" typeof="rdf:Bag">
+		<h4 about="#educational" rev="dcterms:title">Educational content</h4>
+		
+		<div id="learning-obj" about="#learning-obj" typeof="rdf:Bag">
+			<h5 id="h_learning-obj" about="#learning-obj" rev="dcterms:title">Learning objectives</h5>
+			
+			<dl about="#learning-obj" rev="rdfs:member">
+				<dt id="learning-objective" about="#learning-objective" typeof="rdf:Property"
+					>learning-objective</dt>
+				<dd about="#learning-objective" property="rdfs:comment" datatype="xsd:string">
+					<p>An explicit designation or description of a learning objective or a reference to an
+						explicit learning objective.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow
+							content</a>, <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content"
+							>phrasing content</a>
+					</p>
+				</dd>
+				<dt id="learning-objectives" about="#learning-objectives" typeof="rdf:Property"
+						>learning-objectives<span class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#learning-objectives" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of <a href="#learning-objective">learning-objectives</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="learning-outcome" about="#learning-outcome" typeof="rdf:Property">learning-outcome<span
+						class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#learning-outcome" property="rdfs:comment" datatype="xsd:string">
+					<p>The understanding or ability a student is expected to achieve as a result of a lesson or
+						activity.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow
+							content</a>
+					</p>
+				</dd>
+				<dt id="learning-outcomes" about="#learning-outcomes" typeof="rdf:Property"
+						>learning-outcomes<span class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#learning-outcomes" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of <a href="#learning-outcome">learing-outcomes</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="learning-resource" about="#learning-resource" typeof="rdf:Property"
+					>learning-resource</dt>
+				<dd about="#learning-resource" property="rdfs:comment" datatype="xsd:string">
+					<p>A resource provided to enhance learning, or a reference to such a resource.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow
+							content</a>
+					</p>
+				</dd>
+				<dt id="learning-resources" about="#learning-resources" typeof="rdf:Property"
+						>learning-resources<span class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#learning-resources" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of <a href="#learning-resource">learning-resources</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="learning-standard" about="#learning-standard" typeof="rdf:Property"
+						>learning-standard<span class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#learning-standard" property="rdfs:comment" datatype="xsd:string">
+					<p>A formal set of expectations or requirements typically issued by a government or a
+						standards body.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>, <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content"
+							>phrasing content</a>
+					</p>
+				</dd>
+				<dt id="learning-standards" about="#learning-standards" typeof="rdf:Property"
+						>learning-standards<span class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#learning-standards" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of <a href="#learning-standard">learning-standards</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+			</dl>
+		</div>
+		
+		<div id="testing" about="#testing" typeof="rdf:Bag">
+			<h5 id="h_testing" about="#testing" rev="dcterms:title">Testing</h5>
+			
+			<dl about="#testing" rev="rdfs:member">
+				<dt id="answer" about="#answer" typeof="rdf:Property">answer<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#answer" property="rdfs:comment" datatype="xsd:string">
+					<p>The component of a self-assessment problem that provides the answer to the question.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="answers" about="#answers" typeof="rdf:Property">answers<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#answers" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of <a href="#answer">answers</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="assessment" about="#assessment" typeof="rdf:Property">assessment</dt>
+				<dd about="#assessment" property="rdfs:comment" datatype="xsd:string">
+					<p>A test, quiz, or other activity that helps measure a student's understanding of what is
+						being taught.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>
+					</p>
+				</dd>
+				<dt id="assessments" about="#assessments" typeof="rdf:Property">assessments<span
+						class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#assessments" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of <a href="#assessment">assessments</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>
+					</p>
+				</dd>
+				<dt id="feedback" about="#feedback" typeof="rdf:Property">feedback<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#feedback" property="rdfs:comment" datatype="xsd:string">
+					<p>Instruction to the reader based on the result of an assessment.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>, <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content"
+							>phrasing content</a>
+					</p>
+				</dd>
+				<dt id="fill-in-the-blank-problem" about="#fill-in-the-blank-problem" typeof="rdf:Property"
+						>fill-in-the-blank-problem<span class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#fill-in-the-blank-problem" property="rdfs:comment" datatype="xsd:string">
+					<p>A problem that requires the reader to input a text answer to complete a sentence,
+						statement or similar.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="general-problem" about="#general-problem" typeof="rdf:Property">general-problem<span
+						class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#general-problem" property="rdfs:comment" datatype="xsd:string">
+					<p>A problem with a free-form solution.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="qna" about="#qna" typeof="rdf:Property">qna</dt>
+				<dd about="#qna" property="rdfs:comment" datatype="xsd:string">
+					<p>A section of content structured as a series of questions and answers, such as an
+						interview or list of frequently asked questions.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>lists or <a
+							href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>
+					</p>
+				</dd>
+				<dt id="match-problem" about="#match-problem" typeof="rdf:Property">match-problem<span
+						class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#match-problem" property="rdfs:comment" datatype="xsd:string">
+					<p>A problem that requires the reader to match the contents of one list with the
+						corresponding items in another list.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="multiple-choice-problem" about="#multiple-choice-problem" typeof="rdf:Property"
+						>multiple-choice-problem<span class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#multiple-choice-problem" property="rdfs:comment" datatype="xsd:string">
+					<p>A problem with a set of potential answers to choose from ‒ some, all or none of which may
+						be correct.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="practice" about="#practice" typeof="rdf:Property">practice<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#practice" property="rdfs:comment" datatype="xsd:string">
+					<p>A review exercise or sample.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
+						<span class="subpropref" about="#practice" rel="rdfs:seeAlso" resource="#practices">
+							<a href="#practices">practices</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="question" about="#question" typeof="rdf:Property">question<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#question" property="rdfs:comment" datatype="xsd:string">
+					<p>The component of a self-assessment problem that identifies the question to be solved.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+				<dt id="practices" about="#practices" typeof="rdf:Property">practices<span class="status draft">
+						[draft]</span>
+				</dt>
+				<dd about="#practices" property="rdfs:comment" datatype="xsd:string">
+					<p>A collection of <a href="#practice">practices</a>.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content"
+							>sectioning content</a>
+					</p>
+				</dd>
+				<dt id="true-false-problem" about="#true-false-problem" typeof="rdf:Property"
+						>true-false-problem<span class="status draft"> [draft]</span>
+				</dt>
+				<dd about="#true-false-problem" property="rdfs:comment" datatype="xsd:string">
+					<p>A problem with either a true or false answer.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+							href="https://www.w3.org/TR/html/grouping-content.html#grouping-content">grouping
+							content</a>
+					</p>
+				</dd>
+			</dl>
+		</div>
+	</section>
+	
+	<section id="comics" about="#comics" typeof="rdf:Bag">
+		<h4 about="#comics" rev="dcterms:title">Comics</h4>
+		
+		<dl about="#comics" rev="rdfs:member">
+			<dt id="panel" about="#panel" typeof="rdf:Property">panel</dt>
+			<dd about="#panel" property="rdfs:comment" datatype="xsd:string">
+				<p>An individual frame, or drawing.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Usage details: </span>
+					<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+				</p>
+			</dd>
+			<dt id="panel-group" about="#panel-group" typeof="rdf:Property">panel-group</dt>
+			<dd about="#panel-group" property="rdfs:comment" datatype="xsd:string">
+				<p>A group of <a href="#panel">panels</a> (e.g., a strip).</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Usage details: </span>
+					<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+				</p>
+			</dd>
+			<dt id="balloon" about="#balloon" typeof="rdf:Property">balloon</dt>
+			<dd about="#balloon" property="rdfs:comment" datatype="xsd:string">
+				<p>An area in a comic <a href="#panel">panel</a> that contains the words, spoken or thought, of
+					a character.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Usage details: </span>
+					<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+				</p>
+			</dd>
+			<dt id="text-area" about="#text-area" typeof="rdf:Property">text-area</dt>
+			<dd about="#text-area" property="rdfs:comment" datatype="xsd:string">
+				<p>An area of text in a comic <a href="#panel">panel</a>. Used to represent titles, narrative
+					text, character dialogue (inside a <a href="#balloon">balloon</a> or not) and similar.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Usage details: </span>
+					<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+				</p>
+			</dd>
+			<dt id="sound-area" about="#sound-area" typeof="rdf:Property">sound-area</dt>
+			<dd about="#sound-area" property="rdfs:comment" datatype="xsd:string">
+				<p>An area of text in a comic <a href="#panel">panel</a> that represents a sound.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">li</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Usage details: </span>
+					<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="notes" about="#notes" typeof="rdf:Bag">
+		<h4 about="#notes" rev="dcterms:title">Notes and annotations</h4>
+		
+		<dl about="#notes" rev="rdfs:member">
+			<dt id="annotation" about="#annotation" typeof="rdf:Property">annotation<span
+					class="status deprecated" property="owl:deprecated" content="true"> [deprecated]</span>
+			</dt>
+			<dd about="#annotation" property="rdfs:comment" datatype="xsd:string">
+				<p>Explanatory information about passages in the work.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#annotation" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#complementary">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#complementary">xhv:complementary</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a>, <a
+						href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+						content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Replaced by:</span>
+					<span class="subpropref" about="#annotation" rel="dcterms:isReplacedBy">
+						<a href="http://www.idpf.org/epub/oa">Open Annotation in EPUB</a>
+					</span>
+				</p>
+			</dd>
+			<dt id="note" about="#note" typeof="rdf:Property">note<span class="status deprecated"
+					property="owl:deprecated" content="true"> [deprecated]</span>
+			</dt>
+			<dd about="#note" property="rdfs:comment" datatype="xsd:string">
+				<p>A note. This property does not carry spatial positioning semantics, as do the <a
+						href="#footnote">footnote</a> and <a href="#endnote">endnote</a> properties. It can be
+					used to identify footnotes, endnotes, marginal notes, inline notes, and similar when legacy
+					naming conventions are not desired.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>On the <a
+						href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a> element when
+					identifying a single note, or on descendants of sectioning content when identifying
+					individual notes in a group (refer to <a href="#footnotes">footnotes</a> and <a
+						href="#endnotes">endnotes</a>).</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Replaced by:</span>
+					<span class="subpropref" about="#note" rel="dcterms:isReplacedBy">
+						<a href="#footnote">footnote</a>, <a href="#endnote">endnote</a>
+					</span>
+				</p>
+			</dd>
+			<dt id="footnote" about="#footnote" typeof="rdf:Property">footnote</dt>
+			<dd about="#footnote" property="rdfs:comment" datatype="xsd:string">
+				<p>Ancillary information, such as a citation or commentary, that provides additional context to
+					a referenced passage of text.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">See also:</span>
+					<span class="subpropref" about="#footnote" rel="rdfs:seeAlso" resource="#footnotes">
+						<a href="#footnotes">footnotes</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>On the <a
+						href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a> element when
+					identifying a single footnote, or on descendants of sectioning content when identifying
+					individual footnotes in a group (refer to <a href="#footnotes">footnotes</a> and <a
+						href="#endnotes">endnotes</a>).</p>
+			</dd>
+			<dt id="endnote" about="#endnote" typeof="rdf:Property">endnote</dt>
+			<dd about="#endnote" property="rdfs:comment" datatype="xsd:string">
+				<p>One of a collection of notes that occur at the end of a work, or a section within it, that
+					provides additional context to a referenced passage of text.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">See also:</span>
+					<span class="subpropref" about="#endnote" rel="rdfs:seeAlso" resource="#endnotes">
+						<a href="#endnotes">endnotes</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>On the <a
+						href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a> element when
+					identifying a single endnote, or on descendants of sectioning content when identifying
+					individual endnotes in a group (refer to <a href="#footnotes">footnotes</a> and <a
+						href="#endnotes">endnotes</a>).</p>
+			</dd>
+			<dt id="rearnote" about="#rearnote" typeof="rdf:Property">rearnote<span class="status deprecated"
+					property="owl:deprecated" content="true"> [deprecated]</span>
+			</dt>
+			<dd about="#rearnote" property="rdfs:comment" datatype="xsd:string">
+				<p>A note appearing in the rear (backmatter) of the work, or at the end of a section.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">See also:</span>
+					<span class="subpropref" about="#rearnote" rel="rdfs:seeAlso" resource="#rearnotes">
+						<a href="#rearnotes">rearnotes</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>On the <a
+						href="https://www.w3.org/TR/html/sections.html#the-aside-element">aside</a> element when
+					identifying a single rearnote, or on descendants of sectioning content when identifying
+					individual rearnotes in a group (refer to <a href="#footnotes">footnotes</a> and <a
+						href="#rearnotes">rearnotes</a>).</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Replaced by:</span>
+					<span class="subpropref" about="#rearnote" rel="dcterms:isReplacedBy">
+						<a href="#endnote">endnote</a>
+					</span>
+				</p>
+			</dd>
+			<dt id="footnotes" about="#footnotes" typeof="rdf:Property">footnotes</dt>
+			<dd about="#footnotes" property="rdfs:comment" datatype="xsd:string">
+				<p>A collection of <a href="#footnote">footnotes</a>.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">See also:</span>
+					<span class="subpropref" about="#footnotes" rel="rdfs:seeAlso" resource="#footnote">
+						<a href="#footnote">footnote</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dt id="endnotes" about="#endnotes" typeof="rdf:Property">endnotes</dt>
+			<dd about="#endnotes" property="rdfs:comment" datatype="xsd:string">
+				<p>A collection of notes at the end of a work or a section within it.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">See also:</span>
+					<span class="subpropref" about="#endnotes" rel="rdfs:seeAlso" resource="#endnote">
+						<a href="#endnote">endnote</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dt id="rearnotes" about="#rearnotes" typeof="rdf:Property">rearnotes<span class="status deprecated"
+					property="owl:deprecated" content="true"> [deprecated]</span>
+			</dt>
+			<dd about="#rearnotes" property="rdfs:comment" datatype="xsd:string">
+				<p>A collection of notes appearing at the rear (backmatter) of the work, or at the end of a
+					section.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">See also:</span>
+					<span class="subpropref" about="#rearnotes" rel="rdfs:seeAlso" resource="#rearnote">
+						<a href="#rearnote">rearnote</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Replaced by:</span>
+					<span class="subpropref" about="#rearnotes" rel="dcterms:isReplacedBy">
+						<a href="#endnotes">endnotes</a>
+					</span>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="links" about="#links" typeof="rdf:Bag">
+		<h4 about="#links" rev="dcterms:title">References</h4>
+		
+		<dl about="#links" rev="rdfs:member">
+			<dt id="annoref" about="#annoref" typeof="rdf:Property">annoref<span class="status deprecated"
+					property="owl:deprecated" content="true"> [deprecated]</span>
+			</dt>
+			<dd about="#annoref" property="rdfs:comment" datatype="xsd:string">
+				<p>A reference to an annotation.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#annoref" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#link">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">See also:</span>
+					<span class="subpropref" about="#annoref" rel="rdfs:seeAlso" resource="#annotation">
+						<a href="#annotation">annotation</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Replaced by:</span>
+					<span class="subpropref" about="#annoref" rel="dcterms:isReplacedBy">
+						<a href="http://www.idpf.org/epub/oa">Open Annotation in EPUB</a>
+					</span>
+				</p>
+			</dd>
+			<dt id="biblioref" about="#biblioref" typeof="rdf:Property">biblioref<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#biblioref" property="rdfs:comment" datatype="xsd:string">
+				<p>A reference to a <a href="#biblioentry">bibliography entry</a>.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#biblioref" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#link">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+				</p>
+			</dd>
+			<dt id="glossref" about="#glossref" typeof="rdf:Property">glossref<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#glossref" property="rdfs:comment" datatype="xsd:string">
+				<p>A reference to a <a href="#glossdef">glossary definition</a>.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#glossref" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#link">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+				</p>
+			</dd>
+			<dt id="noteref" about="#noteref" typeof="rdf:Property">noteref</dt>
+			<dd about="#noteref" property="rdfs:comment" datatype="xsd:string">
+				<p>A reference to a note, typically appearing as a superscripted number or symbol in the main
+					body of text.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#noteref" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#link">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">See also:</span>
+					<span class="subpropref" about="#noteref" rel="rdfs:seeAlso" resource="#note">
+						<a href="#note">note</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+				</p>
+			</dd>
+			<dt id="backlink" about="#backlink" typeof="rdf:Property">backlink<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#backlink" property="rdfs:comment" datatype="xsd:string">
+				<p>A link that allows the user to return to a related location in the content (e.g., from a <a
+						href="#footnote">footnote</a> to its reference or from a <a href="#glossdef">glossary
+						definition</a> to where a <a href="#glossterm">term</a> is used).</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Inherits from:</span>
+					<span class="subpropref" about="#backlink" rel="rdfs:subPropertyOf"
+						resource="http://www.w3.org/1999/xhtml/vocab/#link">
+						<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+					</span>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">a</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="document-text" about="#document-text" typeof="rdf:Bag">
+		<h4 about="#document-text" rev="dcterms:title">Document text</h4>
+		
+		<p about="#document-text" rev="dcterms:description">Terms for describing components at the phrasing
+			level.</p>
+		
+		<dl about="#document-text" rev="rdfs:member">
+			<dt id="credit" about="#credit" typeof="rdf:Property">credit<span class="status draft">
+					[draft]</span>
+			</dt>
+			<dd about="#credit" property="rdfs:comment" datatype="xsd:string">
+				<p>An acknowledgment of the source of integrated content from third-party sources, such as
+					photos. Typically identifies the creator, copyright and any restrictions on reuse.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+						content</a>
+				</p>
+			</dd>
+			<dt id="keyword" about="#keyword" typeof="rdf:Property">keyword</dt>
+			<dd about="#keyword" property="rdfs:comment" datatype="xsd:string">
+				<p>A key word or phrase.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+						content</a>
+				</p>
+			</dd>
+			<dt id="topic-sentence" about="#topic-sentence" typeof="rdf:Property">topic-sentence</dt>
+			<dd about="#topic-sentence" property="rdfs:comment" datatype="xsd:string">
+				<p>A phrase or sentence serving as an introductory summary of the containing paragraph.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+						content</a>
+				</p>
+			</dd>
+			<dt id="concluding-sentence" about="#concluding-sentence" typeof="rdf:Property"
+				>concluding-sentence</dt>
+			<dd about="#concluding-sentence" property="rdfs:comment" datatype="xsd:string">
+				<p>A phrase or sentence serving as a concluding summary of the containing paragraph.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing
+						content</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="pagination" about="#pagination" typeof="rdf:Bag">
+		<h4 about="#pagination" rev="dcterms:title">Pagination</h4>
+		
+		<dl about="#pagination" rev="rdfs:member">
+			<dt id="pagebreak" about="#pagebreak" typeof="rdf:Property">pagebreak</dt>
+			<dd about="#pagebreak" property="rdfs:comment" datatype="xsd:string">
+				<p>A separator denoting the position before which a break occurs between two contiguous pages in
+					a statically paginated version of the content.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-phrasing-content">phrasing</a>
+					and <a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow</a>
+					content, where the value of the carrying elements title attribute takes precedence over
+					element content for the purposes of representing the pagebreak value</p>
+			</dd>
+			<dt id="page-list" about="#page-list" typeof="rdf:Property">page-list</dt>
+			<dd about="#page-list" property="rdfs:comment" datatype="xsd:string">
+				<p>A navigational aid that provides a list of links to the <a href="#pagebreak">pagebreaks</a>
+					in the content.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>
+					<a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-sectioning-content">sectioning
+						content</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="tables" about="#tables" typeof="rdf:Bag">
+		<h4 about="#tables" rev="dcterms:title">Tables</h4>
+		
+		<dl about="#tables" rev="rdfs:member">
+			<dt id="table" about="#table" typeof="rdf:Property">table</dt>
+			<dd about="#table" property="rdfs:comment" datatype="xsd:string">
+				<p>A structure containing data or content laid out in tabular form.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>Not Allowed</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+					escapable or skippable table structure.</p>
+			</dd>
+			<dt id="table-row" about="#table-row" typeof="rdf:Property">table-row</dt>
+			<dd about="#table-row" property="rdfs:comment" datatype="xsd:string">
+				<p>A row of data or content in a tabular structure.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>Not Allowed</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+					escapable or skippable table row.</p>
+			</dd>
+			<dt id="table-cell" about="#table-cell" typeof="rdf:Property">table-cell</dt>
+			<dd about="#table-cell" property="rdfs:comment" datatype="xsd:string">
+				<p>A single cell of tabular data or content.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>Not Allowed</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+					escapable or skippable table cell.</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="lists" about="#lists" typeof="rdf:Bag">
+		<h4 about="#lists" rev="dcterms:title">Lists</h4>
+		
+		<dl about="#lists" rev="rdfs:member">
+			<dt id="list" about="#list" typeof="rdf:Property">list</dt>
+			<dd about="#list" property="rdfs:comment" datatype="xsd:string">
+				<p>A structure that contains an enumeration of related content items.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>Not Allowed</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+					escapable or skippable list structure.</p>
+			</dd>
+			<dt id="list-item" about="#list-item" typeof="rdf:Property">list-item</dt>
+			<dd about="#list-item" property="rdfs:comment" datatype="xsd:string">
+				<p>A single item in an enumeration.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>Not Allowed</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+					escapable or skippable list item.</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="figures" about="#figures" typeof="rdf:Bag">
+		<h4 about="#figures" rev="dcterms:title">Figures</h4>
+		
+		<dl about="#figures" rev="rdfs:member">
+			<dt id="figure" about="#figure" typeof="rdf:Property">figure</dt>
+			<dd about="#figure" property="rdfs:comment" datatype="xsd:string">
+				<p>An illustration, diagram, photo, code listing or similar, referenced from the text of a work,
+					and typically annotated with a title, caption and/or credits.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>Not Allowed</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+					escapable or skippable figure.</p>
+			</dd>
+		</dl>
+	</section>
+	
+	<section id="asides" about="#asides" typeof="rdf:Bag">
+		<h4 about="#figures" rev="dcterms:title">Asides</h4>
+		
+		<dl about="#asides" rev="rdfs:member">
+			<dt id="aside" about="#aside" typeof="rdf:Property">aside</dt>
+			<dd about="#aside" property="rdfs:comment" datatype="xsd:string">
+				<p>Secondary or supplementary content.</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">HTML usage context: </span>Not Allowed</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">Media Overlays usage context: </span>Identifies a <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-seq-elem">seq</a> or <a
+						href="http://www.idpf.org/epub/latest/mediaoverlays#sec-smil-par-elem">par</a> as an
+					escapable or skippable aside.</p>
+			</dd>
+		</dl>
+	</section>
+</section>


### PR DESCRIPTION
This PR attempts to address the following vocabulary re-use issues:

- it moves the vocabulary association mechanisms section to an appendix and generalizes it to not be so specific to the package document
- the default vocabularies are defined in appropriate attribute to which they apply - the section in the appendix only describes their purpose
- it moves the epub:type attribute definition to an appendix because it is not strictly an HTML extension but used by HTML, SVG and media overlays. It is also generalized. (I tried to find a way to incorporate this under the vocabularies, but it just doesn't logically fit there.)

It also addresses some peripheral issues:

- it integrates the fixed layout re-org into this PR as it is also part of normalizing the vocabularies
- it adds the structure vocab to the vocabularies (this may be controversial, but it is getting to be a strange outlier now)
- it deletes the index - which, in addition to being unnecessary, also helps avoid too much bloat from adding the structure vocab

Fixes #1377 
Fixes #1386 
Fixes #1392


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1395.html" title="Last updated on Nov 4, 2020, 11:34 PM UTC (4c54db4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1395/e18ae7f...4c54db4.html" title="Last updated on Nov 4, 2020, 11:34 PM UTC (4c54db4)">Diff</a>