### PR TITLE
Promote navigation document to top-level section

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -54,26 +54,6 @@
 				postProcess:[addConformanceLinks]
 			};//]]>
       </script>
-		<style>
-			dd > ul.conformance-list,
-			li > ul.conformance-list {
-				margin-left: 2rem;
-			}
-			
-			dl.conformance-list > dt {
-				font-size: 105%;
-				color: rgb(0, 90, 156);
-			}
-			
-			dl.conformance-list > dd > dl.conformance-list > dt {
-				font-size: 100%;
-				color: rgb(0, 0, 0);
-			}
-			
-			dl.conformance-list > dd > dl.conformance-list > dd > dl.conformance-list > dt {
-				font-style: italic !important;
-				font-size: 95%;
-			}</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -3367,479 +3347,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					</div>
 				</section>
 			</section>
-
-			<section id="sec-package-nav">
-				<h3>EPUB Navigation Document</h3>
-
-				<section id="sec-package-nav-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>The EPUB Navigation Document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
-							Package</a>. It allows <a>Authors</a> to include a human- and machine-readable global
-						navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
-
-					<p>The EPUB Navigation Document is an <a>XHTML Content Document</a>, but with additional
-						restrictions on its structure to facilitate the machine-processing of its contents. [[HTML]] <a
-							href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code></a>
-						elements contain the specialized navigational information, which remains human-readable as well
-						as allowing Reading Systems to generate navigational interfaces.</p>
-
-					<p>But the EPUB Navigation Document is not exclusively for machine processing. Because it is an
-						XHTML Content Document, it can be part of the linear reading order, avoiding the need for
-						duplicate tables of contents. Content which is only destined for machine processing, such as <a
-							href="#sec-nav-pagelist">page lists</a>, can be hidden from visual rendering with the <a
-							href="#sec-package-nav-def-hidden">hidden</a> attribute.</p>
-
-					<p>Note that Reading Systems might strip scripting, styling, and HTML formatting as they generate
-						navigational interfaces from information found in the EPUB Navigation Document. If such
-						formatting and functionality is needed, then the EPUB Navigation Document also needs to be
-						included in the <a>spine</a>. The use of <a href="#confreq-cd-scripted-spine">progressive
-							enhancement</a> techniques for scripting and styling of the navigation document will help
-						ensure the content will retain its integrity when rendered in a non-browser context.</p>
-				</section>
-
-				<section id="sec-package-nav-def">
-					<h4>EPUB Navigation Document Definition</h4>
-
-					<section id="sec-package-nav-def-model">
-						<h3>The <code>nav</code> Element: Restrictions</h3>
-
-						<p>When a <code>nav</code> element carries the <a href="#sec-epub-type-attribute"
-									><code>epub:type</code> attribute</a> in an <a>EPUB Navigation Document</a>, this
-							specification restricts the content model of the element and its descendants as follows:</p>
-
-						<dl class="elemdef">
-							<dt>Content Model</dt>
-							<dd>
-								<dl class="variablelist">
-									<dt>
-										<a href="https://www.w3.org/TR/html/sections.html#the-nav-element">
-											<code>nav</code>
-										</a>
-									</dt>
-									<dd>
-										<p>In this order:</p>
-										<ul class="nomark">
-											<li>
-												<p>
-													<a href="https://www.w3.org/TR/html/dom.html#heading-content">
-														<code>HTML Heading content</code>
-													</a>
-													<code>[0 or 1]</code>
-												</p>
-											</li>
-											<li>
-												<p>
-													<code>ol</code>
-													<code>[exactly 1]</code>
-												</p>
-											</li>
-										</ul>
-									</dd>
-									<dt>
-										<a href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element">
-											<code>ol</code>
-										</a>
-									</dt>
-									<dd>
-										<p>In this order:</p>
-										<ul class="nomark">
-											<li>
-												<p>
-													<code>li</code>
-													<code>[1 or more]</code>
-												</p>
-											</li>
-										</ul>
-									</dd>
-									<dt>
-										<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">
-											<code>li</code>
-										</a>
-									</dt>
-									<dd>
-										<p>In this order:</p>
-										<ul class="nomark">
-											<li>
-												<p> (<code>span</code> or <code>a</code>) <code>[exactly 1]</code></p>
-											</li>
-											<li>
-												<p>
-													<code>ol</code>
-													<code>[conditionally required]</code>
-												</p>
-											</li>
-										</ul>
-									</dd>
-									<dt><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element"
-												><code>span</code></a> and <a
-											href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element"
-												><code>a</code></a></dt>
-									<dd>
-										<p>In any order:</p>
-										<ul class="nomark">
-											<li>
-												<p>
-													<a href="https://www.w3.org/TR/html/dom.html#phrasing-content">
-														<code>HTML Phrasing content</code>
-													</a>
-													<code>[1 or more]</code>
-												</p>
-											</li>
-										</ul>
-									</dd>
-								</dl>
-								<p>Note that there are no restrictions on the attributes allowed on these elements.</p>
-								<p>Refer the definition below for additional requirements.</p>
-							</dd>
-						</dl>
-
-						<p>The content model of the <code>nav</code> element is interpreted as follows:</p>
-
-						<ul class="conformance-list">
-							<li>
-								<p id="confreq-nav-ol">The <code>ol</code> child of the <code>nav</code> element
-									represents the primary level of content navigation.</p>
-							</li>
-							<li>
-								<p id="confreq-nav-a">Each list item of the ordered list represents a heading, structure
-									or other item of interest. A child <code>a</code> element describes the target that
-									the link points to, while a <code>span</code> element serves as a heading for
-									breaking down lists into distinct groups (for example, a large list of illustrations
-									can be segmented into several lists, one for each chapter).</p>
-							</li>
-							<li>
-								<p id="confreq-nav-a-cnt">The child <code>a</code> or <code>span</code> element MUST
-									provide a non zero-length text label after concatenation of all child content and
-									application of white space normalization rules. Although non-textual descendant
-									elements MAY be rendered directly to users, text content included in
-										<code>title</code> or <code>alt</code> attributes MUST be used when determining
-									compliance with this requirement.</p>
-							</li>
-							<li>
-								<p id="confreq-nav-a-title">If an <code>a</code> or <code>span</code> element contains
-									instances of <a href="https://www.w3.org/TR/html/dom.html#embedded-content">HTML
-										embedded content</a> that do not provide intrinsic text alternatives, the
-									element MUST also include a <code>title</code> attribute with an alternate text
-									rendering of the link label.</p>
-							</li>
-							<li>
-								<p id="confreq-nav-a-href">The IRI reference provided in the <code>href</code> attribute
-									of the <code>a</code> element MUST adhere to the following requirements:</p>
-								<ul>
-									<li>
-										<p id="confreq-nav-a-href-default">In the case of the <a href="#sec-nav-toc"
-													><code>toc nav</code></a>, <a href="#sec-nav-landmarks"
-													><code>landmarks nav</code></a> and <a href="#sec-nav-pagelist"
-													><code>page-list nav</code></a>, it MUST resolve to an <a>Top-level
-												Content Document</a> or fragment therein.</p>
-									</li>
-									<li>
-										<p id="confreq-nav-a-href-other">For all other <code>nav</code> types, it MAY
-											also reference <a>Remote Resources</a>.</p>
-									</li>
-								</ul>
-							</li>
-							<li>
-								<p id="confreq-nav-a-nest">An <code>a</code> element MAY be followed by an
-										<code>ol</code> ordered list representing a subsidiary content level below that
-									heading (e.g., all the subsection headings of a section).</p>
-							</li>
-							<li>
-								<p id="confreq-nav-span-nest">A <code>span</code> element MUST be followed by an
-										<code>ol</code> ordered list; it cannot be used in "leaf" <code>li</code>
-									elements.</p>
-							</li>
-							<li>
-								<p id="confreq-nav-sublist">Regardless of whether an <code>a</code> or <code>span</code>
-									element precedes it, every sublist MUST adhere to the content requirements defined
-									in this section for constructing the primary navigation list.</p>
-							</li>
-						</ul>
-
-						<p>EPUB specifications MAY introduce further restrictions on the content model defined above for
-								<code>nav</code> elements in the EPUB Navigation Document.</p>
-
-						<aside class="example">
-							<p>The following example shows the basic patterns of a navigation element.</p>
-							<pre>&lt;nav epub:type="…"&gt;
-  &lt;h1&gt;…&lt;/h1&gt;
-  &lt;ol&gt;
-    &lt;li&gt;
-      &lt;a href="chap1.xhtml"&gt;A basic leaf node&lt;/a&gt;
-    &lt;/li&gt;
-    &lt;li&gt;
-      &lt;a href="chap2.xhtml"&gt;A linked heading&lt;/a&gt;
-      &lt;ol&gt;
-        …
-      &lt;/ol&gt;
-    &lt;li&gt;
-      &lt;span&gt;An unlinked heading&lt;/span&gt;
-      &lt;ol&gt;
-        …
-      &lt;/ol&gt;
-    &lt;/li&gt;
-  &lt;/ol&gt;
-&lt;/nav&gt;
-</pre>
-						</aside>
-
-						<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, the EPUB
-							Navigation Document MAY be included in the <a href="#sec-spine-elem">spine</a>.</p>
-
-						<p id="confreq-nav-ol-style">In the context of this specification, the default display style of
-							list items within <code>nav</code> elements is equivalent to the <a
-								href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
-									none</code> property</a> [[!CSSSnapshot]]. <a>Authors</a> MAY specify alternative
-							list styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
-									><code>spine</code></a>.</p>
-					</section>
-
-					<section id="sec-package-nav-def-types">
-						<h5>The <code>nav</code> Element: Types</h5>
-
-						<section id="sec-package-nav-def-types-intro" class="informative">
-							<h6>Introduction</h6>
-
-							<p>The <code>nav</code> elements defined in an EPUB Navigation Document are distinguished
-								semantically by the value of their <a href="#sec-epub-type-attribute"
-										><code>epub:type</code> attribute</a>.</p>
-
-							<p>This specification defines three types of navigation aid:</p>
-
-							<dl class="variablelist">
-								<dt>
-									<a href="#sec-nav-toc">
-										<code>toc</code>
-									</a>
-								</dt>
-								<dd>
-									<p>Identifies the <code>nav</code> element that contains the table of contents. The
-											<code>toc</code>
-										<code>nav</code> is the only navigation aid that has to be included in the EPUB
-										Navigation Document.</p>
-								</dd>
-								<dt>
-									<a href="#sec-nav-pagelist">
-										<code>page-list</code>
-									</a>
-								</dt>
-								<dd>
-									<p>Identifies the <code>nav</code> element that contains a list of pages for a print
-										or other statically-paginated source for the <a>EPUB Publication</a>.</p>
-								</dd>
-								<dt>
-									<a href="#sec-nav-landmarks">
-										<code>landmarks</code>
-									</a>
-								</dt>
-								<dd>
-									<p>Identifies the <code>nav</code> element that contains a list of points of
-										interest.</p>
-								</dd>
-							</dl>
-
-							<p>Additional navigation types can be included in the EPUB Navigation Document. See <a
-									href="#sec-package-nav-def-types-other"></a> for more information.</p>
-
-						</section>
-
-						<section id="sec-nav-toc">
-							<h6>The <code>toc nav</code> Element </h6>
-
-							<p>The <code>toc</code>
-								<code>nav</code> element defines the primary navigational hierarchy of the given
-									<a>Rendition</a>. It conceptually corresponds to a table of contents in a printed
-								work (i.e., it provides navigation to the major structural sections of the
-								publication).</p>
-
-							<p>The references in the <code>toc</code>
-								<code>nav</code> element MUST be ordered such that they reflect both:</p>
-
-							<ul>
-								<li>
-									<p>the order of the <a href="#confreq-nav-a-href">referenced EPUB Content
-											Documents</a> in the <a>spine</a>;</p>
-								</li>
-								<li>
-									<p>the order of the targeted elements within their respective EPUB Content
-										Documents.</p>
-								</li>
-							</ul>
-
-							<p>The <code>toc</code>
-								<code>nav</code> element MUST occur exactly once in an EPUB Navigation Document.</p>
-						</section>
-
-						<section id="sec-nav-pagelist">
-							<h6>The <code>page-list nav</code> Element </h6>
-
-							<p>The <code>page-list</code>
-								<code>nav</code> element provides navigation to positions in the content that correspond
-								to the locations of page boundaries present in a print source being represented by the
-									<a>EPUB Publication</a>.</p>
-
-							<p>The <code>page-list</code>
-								<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur
-								more than once.</p>
-
-							<p>The page references within the <code>page-list</code>
-								<code>nav</code> MUST be ordered so that they match both the order of the <a
-									href="#confreq-nav-a-href">targeted EPUB Content Documents</a> in the <a
-									href="#sec-spine-elem">spine</a> and the order of each page within its respective
-								EPUB Content Document.</p>
-
-							<p>The <code>page-list</code>
-								<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e.,
-								no nested sublists).</p>
-
-							<p>The destinations of the <code>page-list</code> references MAY be identified in their
-								respective EPUB Content Documents using the <a href="#pagebreak"><code>pagebreak</code>
-									term</a>.</p>
-						</section>
-
-						<section id="sec-nav-landmarks">
-							<h6>The <code>landmarks nav</code> Element </h6>
-
-							<p>The <code>landmarks</code>
-								<code>nav</code> element identifies fundamental structural components in the given
-									<a>Rendition</a> in order to enable Reading Systems to provide the user efficient
-								access to them.</p>
-
-							<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is REQUIRED
-								on <code>a</code> element descendants of the <code>landmarks</code>
-								<code>nav</code> element. The structural semantics of each link target within the
-									<code>landmarks</code>
-								<code>nav</code> element is determined by the value of this attribute.</p>
-
-							<aside class="example">
-								<p>The following example shows a <code>landmarks</code>
-									<code>nav</code> element with structural semantics drawn from <a
-										href="#structure-vocab"></a>.</p>
-								<pre>&lt;nav epub:type="landmarks"&gt;
-    &lt;h2&gt;Guide&lt;/h2&gt;
-    &lt;ol&gt;
-        &lt;li&gt;&lt;a epub:type="toc" href="#toc"&gt;Table of Contents&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a epub:type="loi" href="content.html#loi"&gt;List of Illustrations&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a epub:type="bodymatter" href="content.html#bodymatter"&gt;Start of Content&lt;/a&gt;&lt;/li&gt;
-    &lt;/ol&gt;
-&lt;/nav&gt;</pre>
-							</aside>
-
-							<p>The <code>landmarks</code>
-								<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code>
-								value that reference the same resource, or fragment thereof.</p>
-
-							<p>The <code>landmarks</code>
-								<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur
-								more than once.</p>
-
-						</section>
-
-						<section id="sec-package-nav-def-types-other">
-							<h6>Other <code>nav</code> Elements</h6>
-
-							<p>EPUB Navigation Documents MAY include one or more <code>nav</code> elements in addition
-								to the <code>toc</code>, <code>page-list</code> and <code>landmarks</code>
-								<code>nav</code> elements defined in the preceding sections. These additional
-									<code>nav</code> elements SHOULD have an <code>epub:type</code> attribute to provide
-								a machine-readable semantic, and MUST have a human-readable heading as their first
-								child.</p>
-
-							<p>This specification imposes no restrictions on the semantics of any additional
-									<code>nav</code> elements: they MAY be used to represent navigational semantics for
-								any information domain, and they MAY contain link targets with homogeneous or
-								heterogeneous semantics.</p>
-
-							<aside class="example">
-								<p>The following example shows a custom list of tables navigation element.</p>
-								<pre>&lt;nav aria-labelledby="lot"&gt;
-    &lt;h2 id="lot"&gt;List of tables&lt;/h2&gt;
-    &lt;ol&gt;
-        &lt;li&gt;&lt;span&gt;Tables in Chapter 1&lt;/span&gt;
-            &lt;ol&gt;
-                &lt;li&gt;&lt;a href="chap1.xhtml#table-1.1"&gt;Table 1.1&lt;/a&gt;
-                &lt;/li&gt;
-                &lt;li&gt;&lt;a href="chap1.xhtml#table-1.2"&gt;Table 1.2&lt;/a&gt;&lt;/li&gt;
-            &lt;/ol&gt;
-        &lt;/li&gt;
-    	…
-    &lt;/ol&gt;
-&lt;/nav&gt;</pre>
-							</aside>
-						</section>
-					</section>
-
-					<section id="sec-package-nav-def-hidden">
-						<h5>The <code>hidden</code> attribute</h5>
-
-						<p>In some cases, <a>Authors</a> might wish to hide parts of the navigation data within the
-							content flow (i.e., the Reading System's principal rendering of the <a>spine</a> contents).
-							A typical example is the <a href="#sec-nav-pagelist">list of page breaks</a>, which usually
-							is not rendered as part of the content flow but is instead exposed to the user separately in
-							a dedicated navigation user interface.</p>
-
-						<p> While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"
-									><code>display</code> property</a> [[!CSSSnapshot]] can be used to control the
-							visual rendering of EPUB Navigation Documents in Reading Systems with <a>Viewports</a>, not
-							all Reading Systems provide such an interface. To control rendering across all Reading
-							Systems, authors MUST use the [[!HTML]] <a
-								href="https://www.w3.org/TR/html/editing.html#the-hidden-attribute"
-								><code>hidden</code></a> attribute to indicate which (if any) portions of the navigation
-							data are excluded from rendering in the content flow. The <code>hidden</code> attribute has
-							no effect on how navigation data is rendered outside of the content flow (such as in
-							dedicated navigation user interfaces provided by Reading Systems).</p>
-
-						<aside class="example">
-							<p>The following example shows a partial <code>page-list</code>
-								<code>nav</code> element. The presence of the <code>hidden</code> attribute on the root
-								indicates that the entire list is excluded from rendering in the content flow.</p>
-							<pre>&lt;nav epub:type="page-list" hidden=""&gt;
-    &lt;h2&gt;Pagebreaks of the print version, third edition&lt;/h2&gt;
-    &lt;ol&gt;
-        &lt;li&gt;&lt;a href="frontmatter.xhtml#pi"&gt;I&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a href="frontmatter.xhtml#pii"&gt;II&lt;/a&gt;&lt;/li&gt; … &lt;li&gt;&lt;a href="chap1.xhtml#p1"&gt;1&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a href="chap1.xhtml#p2"&gt;2&lt;/a&gt;&lt;/li&gt; … &lt;/ol&gt;
-&lt;/nav&gt;
-</pre>
-						</aside>
-
-						<aside class="example">
-							<p>The following example shows a partial <code>toc</code>
-								<code>nav</code> element where the <code>hidden</code> attribute is used to limit
-								content flow rendering to the two topmost hierarchical levels.</p>
-							<pre>&lt;nav epub:type="toc" id="toc"&gt;
-  &lt;h1&gt;Table of contents&lt;/h1&gt;
-  &lt;ol&gt;
-    &lt;li&gt;
-      &lt;a href="chap1.xhtml"&gt;Chapter 1&lt;/a&gt;
-      &lt;ol&gt;
-        &lt;li&gt;
-          &lt;a href="chap1.xhtml#sec-1.1"&gt;Chapter 1.1&lt;/a&gt;
-          &lt;ol hidden=""&gt;
-            &lt;li&gt;
-              &lt;a href="chap1.xhtml#sec-1.1.1"&gt;Section 1.1.1&lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li&gt;
-              &lt;a href="chap1.xhtml#sec-1.1.2"&gt;Section 1.1.2&lt;/a&gt;
-            &lt;/li&gt;
-          &lt;/ol&gt;
-         &lt;/li&gt;
-         &lt;li&gt;
-           &lt;a href="chap1.xhtml#sec-1.2"&gt;Chapter 1.2&lt;/a&gt;
-         &lt;/li&gt;
-       &lt;/ol&gt;
-     &lt;/li&gt;
-    &lt;li&gt;
-      &lt;a href="chap2.xhtml"&gt;Chapter 2&lt;/a&gt;
-    &lt;/li&gt;
-  &lt;/ol&gt;
-&lt;/nav&gt;
-</pre>
-						</aside>
-					</section>
-				</section>
-			</section>
 		</section>
 		<section id="sec-contentdocs">
 			<h2>EPUB Content Documents</h2>
@@ -5114,6 +4621,475 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					<p>For more information on EPUB 3 features related to synthetic speech, refer to <a
 							href="epub-overview.html#sec-tts">Text-to-speech</a> [[EPUB-OVERVIEW-33]].</p>
 				</div>
+			</section>
+		</section>
+		<section id="sec-package-nav">
+			<h2>EPUB Navigation Document</h2>
+
+			<section id="sec-package-nav-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>The EPUB Navigation Document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
+						Package</a>. It allows <a>Authors</a> to include a human- and machine-readable global navigation
+					layer, thereby ensuring increased usability and accessibility for the user.</p>
+
+				<p>The EPUB Navigation Document is an <a>XHTML Content Document</a>, but with additional restrictions on
+					its structure to facilitate the machine-processing of its contents. [[HTML]] <a
+						href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code></a> elements
+					contain the specialized navigational information, which remains human-readable as well as allowing
+					Reading Systems to generate navigational interfaces.</p>
+
+				<p>But the EPUB Navigation Document is not exclusively for machine processing. Because it is an XHTML
+					Content Document, it can be part of the linear reading order, avoiding the need for duplicate tables
+					of contents. Content which is only destined for machine processing, such as <a
+						href="#sec-nav-pagelist">page lists</a>, can be hidden from visual rendering with the <a
+						href="#sec-package-nav-def-hidden">hidden</a> attribute.</p>
+
+				<p>Note that Reading Systems might strip scripting, styling, and HTML formatting as they generate
+					navigational interfaces from information found in the EPUB Navigation Document. If such formatting
+					and functionality is needed, then the EPUB Navigation Document also needs to be included in the
+						<a>spine</a>. The use of <a href="#confreq-cd-scripted-spine">progressive enhancement</a>
+					techniques for scripting and styling of the navigation document will help ensure the content will
+					retain its integrity when rendered in a non-browser context.</p>
+			</section>
+
+			<section id="sec-package-nav-def">
+				<h3>EPUB Navigation Document Definition</h3>
+
+				<section id="sec-package-nav-def-model">
+					<h4>The <code>nav</code> Element: Restrictions</h4>
+
+					<p>When a <code>nav</code> element carries the <a href="#sec-epub-type-attribute"
+								><code>epub:type</code> attribute</a> in an <a>EPUB Navigation Document</a>, this
+						specification restricts the content model of the element and its descendants as follows:</p>
+
+					<dl class="elemdef">
+						<dt>Content Model</dt>
+						<dd>
+							<dl class="variablelist">
+								<dt>
+									<a href="https://www.w3.org/TR/html/sections.html#the-nav-element">
+										<code>nav</code>
+									</a>
+								</dt>
+								<dd>
+									<p>In this order:</p>
+									<ul class="nomark">
+										<li>
+											<p>
+												<a href="https://www.w3.org/TR/html/dom.html#heading-content">
+													<code>HTML Heading content</code>
+												</a>
+												<code>[0 or 1]</code>
+											</p>
+										</li>
+										<li>
+											<p>
+												<code>ol</code>
+												<code>[exactly 1]</code>
+											</p>
+										</li>
+									</ul>
+								</dd>
+								<dt>
+									<a href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element">
+										<code>ol</code>
+									</a>
+								</dt>
+								<dd>
+									<p>In this order:</p>
+									<ul class="nomark">
+										<li>
+											<p>
+												<code>li</code>
+												<code>[1 or more]</code>
+											</p>
+										</li>
+									</ul>
+								</dd>
+								<dt>
+									<a href="https://www.w3.org/TR/html/grouping-content.html#the-li-element">
+										<code>li</code>
+									</a>
+								</dt>
+								<dd>
+									<p>In this order:</p>
+									<ul class="nomark">
+										<li>
+											<p> (<code>span</code> or <code>a</code>) <code>[exactly 1]</code></p>
+										</li>
+										<li>
+											<p>
+												<code>ol</code>
+												<code>[conditionally required]</code>
+											</p>
+										</li>
+									</ul>
+								</dd>
+								<dt><a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-span-element"
+											><code>span</code></a> and <a
+										href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element"
+											><code>a</code></a></dt>
+								<dd>
+									<p>In any order:</p>
+									<ul class="nomark">
+										<li>
+											<p>
+												<a href="https://www.w3.org/TR/html/dom.html#phrasing-content">
+													<code>HTML Phrasing content</code>
+												</a>
+												<code>[1 or more]</code>
+											</p>
+										</li>
+									</ul>
+								</dd>
+							</dl>
+							<p>Note that there are no restrictions on the attributes allowed on these elements.</p>
+							<p>Refer the definition below for additional requirements.</p>
+						</dd>
+					</dl>
+
+					<p>The content model of the <code>nav</code> element is interpreted as follows:</p>
+
+					<ul class="conformance-list">
+						<li>
+							<p id="confreq-nav-ol">The <code>ol</code> child of the <code>nav</code> element represents
+								the primary level of content navigation.</p>
+						</li>
+						<li>
+							<p id="confreq-nav-a">Each list item of the ordered list represents a heading, structure or
+								other item of interest. A child <code>a</code> element describes the target that the
+								link points to, while a <code>span</code> element serves as a heading for breaking down
+								lists into distinct groups (for example, a large list of illustrations can be segmented
+								into several lists, one for each chapter).</p>
+						</li>
+						<li>
+							<p id="confreq-nav-a-cnt">The child <code>a</code> or <code>span</code> element MUST provide
+								a non zero-length text label after concatenation of all child content and application of
+								white space normalization rules. Although non-textual descendant elements MAY be
+								rendered directly to users, text content included in <code>title</code> or
+									<code>alt</code> attributes MUST be used when determining compliance with this
+								requirement.</p>
+						</li>
+						<li>
+							<p id="confreq-nav-a-title">If an <code>a</code> or <code>span</code> element contains
+								instances of <a href="https://www.w3.org/TR/html/dom.html#embedded-content">HTML
+									embedded content</a> that do not provide intrinsic text alternatives, the element
+								MUST also include a <code>title</code> attribute with an alternate text rendering of the
+								link label.</p>
+						</li>
+						<li>
+							<p id="confreq-nav-a-href">The IRI reference provided in the <code>href</code> attribute of
+								the <code>a</code> element MUST adhere to the following requirements:</p>
+							<ul>
+								<li>
+									<p id="confreq-nav-a-href-default">In the case of the <a href="#sec-nav-toc"
+												><code>toc nav</code></a>, <a href="#sec-nav-landmarks"><code>landmarks
+												nav</code></a> and <a href="#sec-nav-pagelist"><code>page-list
+												nav</code></a>, it MUST resolve to an <a>Top-level Content Document</a>
+										or fragment therein.</p>
+								</li>
+								<li>
+									<p id="confreq-nav-a-href-other">For all other <code>nav</code> types, it MAY also
+										reference <a>Remote Resources</a>.</p>
+								</li>
+							</ul>
+						</li>
+						<li>
+							<p id="confreq-nav-a-nest">An <code>a</code> element MAY be followed by an <code>ol</code>
+								ordered list representing a subsidiary content level below that heading (e.g., all the
+								subsection headings of a section).</p>
+						</li>
+						<li>
+							<p id="confreq-nav-span-nest">A <code>span</code> element MUST be followed by an
+									<code>ol</code> ordered list; it cannot be used in "leaf" <code>li</code>
+								elements.</p>
+						</li>
+						<li>
+							<p id="confreq-nav-sublist">Regardless of whether an <code>a</code> or <code>span</code>
+								element precedes it, every sublist MUST adhere to the content requirements defined in
+								this section for constructing the primary navigation list.</p>
+						</li>
+					</ul>
+
+					<p>EPUB specifications MAY introduce further restrictions on the content model defined above for
+							<code>nav</code> elements in the EPUB Navigation Document.</p>
+
+					<aside class="example">
+						<p>The following example shows the basic patterns of a navigation element.</p>
+						<pre>&lt;nav epub:type="…"&gt;
+  &lt;h1&gt;…&lt;/h1&gt;
+  &lt;ol&gt;
+    &lt;li&gt;
+      &lt;a href="chap1.xhtml"&gt;A basic leaf node&lt;/a&gt;
+    &lt;/li&gt;
+    &lt;li&gt;
+      &lt;a href="chap2.xhtml"&gt;A linked heading&lt;/a&gt;
+      &lt;ol&gt;
+        …
+      &lt;/ol&gt;
+    &lt;li&gt;
+      &lt;span&gt;An unlinked heading&lt;/span&gt;
+      &lt;ol&gt;
+        …
+      &lt;/ol&gt;
+    &lt;/li&gt;
+  &lt;/ol&gt;
+&lt;/nav&gt;
+</pre>
+					</aside>
+
+					<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, the EPUB Navigation
+						Document MAY be included in the <a href="#sec-spine-elem">spine</a>.</p>
+
+					<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
+						items within <code>nav</code> elements is equivalent to the <a
+							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
+								none</code> property</a> [[!CSSSnapshot]]. <a>Authors</a> MAY specify alternative list
+						styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
+								><code>spine</code></a>.</p>
+				</section>
+
+				<section id="sec-package-nav-def-types">
+					<h4>The <code>nav</code> Element: Types</h4>
+
+					<section id="sec-package-nav-def-types-intro" class="informative">
+						<h5>Introduction</h5>
+
+						<p>The <code>nav</code> elements defined in an EPUB Navigation Document are distinguished
+							semantically by the value of their <a href="#sec-epub-type-attribute"><code>epub:type</code>
+								attribute</a>.</p>
+
+						<p>This specification defines three types of navigation aid:</p>
+
+						<dl class="variablelist">
+							<dt>
+								<a href="#sec-nav-toc">
+									<code>toc</code>
+								</a>
+							</dt>
+							<dd>
+								<p>Identifies the <code>nav</code> element that contains the table of contents. The
+										<code>toc</code>
+									<code>nav</code> is the only navigation aid that has to be included in the EPUB
+									Navigation Document.</p>
+							</dd>
+							<dt>
+								<a href="#sec-nav-pagelist">
+									<code>page-list</code>
+								</a>
+							</dt>
+							<dd>
+								<p>Identifies the <code>nav</code> element that contains a list of pages for a print or
+									other statically-paginated source for the <a>EPUB Publication</a>.</p>
+							</dd>
+							<dt>
+								<a href="#sec-nav-landmarks">
+									<code>landmarks</code>
+								</a>
+							</dt>
+							<dd>
+								<p>Identifies the <code>nav</code> element that contains a list of points of
+									interest.</p>
+							</dd>
+						</dl>
+
+						<p>Additional navigation types can be included in the EPUB Navigation Document. See <a
+								href="#sec-package-nav-def-types-other"></a> for more information.</p>
+
+					</section>
+
+					<section id="sec-nav-toc">
+						<h5>The <code>toc nav</code> Element </h5>
+
+						<p>The <code>toc</code>
+							<code>nav</code> element defines the primary navigational hierarchy of the given
+								<a>Rendition</a>. It conceptually corresponds to a table of contents in a printed work
+							(i.e., it provides navigation to the major structural sections of the publication).</p>
+
+						<p>The references in the <code>toc</code>
+							<code>nav</code> element MUST be ordered such that they reflect both:</p>
+
+						<ul>
+							<li>
+								<p>the order of the <a href="#confreq-nav-a-href">referenced EPUB Content Documents</a>
+									in the <a>spine</a>;</p>
+							</li>
+							<li>
+								<p>the order of the targeted elements within their respective EPUB Content
+									Documents.</p>
+							</li>
+						</ul>
+
+						<p>The <code>toc</code>
+							<code>nav</code> element MUST occur exactly once in an EPUB Navigation Document.</p>
+					</section>
+
+					<section id="sec-nav-pagelist">
+						<h5>The <code>page-list nav</code> Element </h5>
+
+						<p>The <code>page-list</code>
+							<code>nav</code> element provides navigation to positions in the content that correspond to
+							the locations of page boundaries present in a print source being represented by the <a>EPUB
+								Publication</a>.</p>
+
+						<p>The <code>page-list</code>
+							<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more
+							than once.</p>
+
+						<p>The page references within the <code>page-list</code>
+							<code>nav</code> MUST be ordered so that they match both the order of the <a
+								href="#confreq-nav-a-href">targeted EPUB Content Documents</a> in the <a
+								href="#sec-spine-elem">spine</a> and the order of each page within its respective EPUB
+							Content Document.</p>
+
+						<p>The <code>page-list</code>
+							<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
+							nested sublists).</p>
+
+						<p>The destinations of the <code>page-list</code> references MAY be identified in their
+							respective EPUB Content Documents using the <a href="#pagebreak"><code>pagebreak</code>
+								term</a>.</p>
+					</section>
+
+					<section id="sec-nav-landmarks">
+						<h5>The <code>landmarks nav</code> Element </h5>
+
+						<p>The <code>landmarks</code>
+							<code>nav</code> element identifies fundamental structural components in the given
+								<a>Rendition</a> in order to enable Reading Systems to provide the user efficient access
+							to them.</p>
+
+						<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is REQUIRED on
+								<code>a</code> element descendants of the <code>landmarks</code>
+							<code>nav</code> element. The structural semantics of each link target within the
+								<code>landmarks</code>
+							<code>nav</code> element is determined by the value of this attribute.</p>
+
+						<aside class="example">
+							<p>The following example shows a <code>landmarks</code>
+								<code>nav</code> element with structural semantics drawn from <a href="#structure-vocab"
+								></a>.</p>
+							<pre>&lt;nav epub:type="landmarks"&gt;
+    &lt;h2&gt;Guide&lt;/h2&gt;
+    &lt;ol&gt;
+        &lt;li&gt;&lt;a epub:type="toc" href="#toc"&gt;Table of Contents&lt;/a&gt;&lt;/li&gt;
+        &lt;li&gt;&lt;a epub:type="loi" href="content.html#loi"&gt;List of Illustrations&lt;/a&gt;&lt;/li&gt;
+        &lt;li&gt;&lt;a epub:type="bodymatter" href="content.html#bodymatter"&gt;Start of Content&lt;/a&gt;&lt;/li&gt;
+    &lt;/ol&gt;
+&lt;/nav&gt;</pre>
+						</aside>
+
+						<p>The <code>landmarks</code>
+							<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code>
+							value that reference the same resource, or fragment thereof.</p>
+
+						<p>The <code>landmarks</code>
+							<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more
+							than once.</p>
+
+					</section>
+
+					<section id="sec-package-nav-def-types-other">
+						<h5>Other <code>nav</code> Elements</h5>
+
+						<p>EPUB Navigation Documents MAY include one or more <code>nav</code> elements in addition to
+							the <code>toc</code>, <code>page-list</code> and <code>landmarks</code>
+							<code>nav</code> elements defined in the preceding sections. These additional
+								<code>nav</code> elements SHOULD have an <code>epub:type</code> attribute to provide a
+							machine-readable semantic, and MUST have a human-readable heading as their first child.</p>
+
+						<p>This specification imposes no restrictions on the semantics of any additional
+								<code>nav</code> elements: they MAY be used to represent navigational semantics for any
+							information domain, and they MAY contain link targets with homogeneous or heterogeneous
+							semantics.</p>
+
+						<aside class="example">
+							<p>The following example shows a custom list of tables navigation element.</p>
+							<pre>&lt;nav aria-labelledby="lot"&gt;
+    &lt;h2 id="lot"&gt;List of tables&lt;/h2&gt;
+    &lt;ol&gt;
+        &lt;li&gt;&lt;span&gt;Tables in Chapter 1&lt;/span&gt;
+            &lt;ol&gt;
+                &lt;li&gt;&lt;a href="chap1.xhtml#table-1.1"&gt;Table 1.1&lt;/a&gt;
+                &lt;/li&gt;
+                &lt;li&gt;&lt;a href="chap1.xhtml#table-1.2"&gt;Table 1.2&lt;/a&gt;&lt;/li&gt;
+            &lt;/ol&gt;
+        &lt;/li&gt;
+    	…
+    &lt;/ol&gt;
+&lt;/nav&gt;</pre>
+						</aside>
+					</section>
+				</section>
+
+				<section id="sec-package-nav-def-hidden">
+					<h4>The <code>hidden</code> attribute</h4>
+
+					<p>In some cases, <a>Authors</a> might wish to hide parts of the navigation data within the content
+						flow (i.e., the Reading System's principal rendering of the <a>spine</a> contents). A typical
+						example is the <a href="#sec-nav-pagelist">list of page breaks</a>, which usually is not
+						rendered as part of the content flow but is instead exposed to the user separately in a
+						dedicated navigation user interface.</p>
+
+					<p> While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
+							property</a> [[!CSSSnapshot]] can be used to control the visual rendering of EPUB Navigation
+						Documents in Reading Systems with <a>Viewports</a>, not all Reading Systems provide such an
+						interface. To control rendering across all Reading Systems, authors MUST use the [[!HTML]] <a
+							href="https://www.w3.org/TR/html/editing.html#the-hidden-attribute"><code>hidden</code></a>
+						attribute to indicate which (if any) portions of the navigation data are excluded from rendering
+						in the content flow. The <code>hidden</code> attribute has no effect on how navigation data is
+						rendered outside of the content flow (such as in dedicated navigation user interfaces provided
+						by Reading Systems).</p>
+
+					<aside class="example">
+						<p>The following example shows a partial <code>page-list</code>
+							<code>nav</code> element. The presence of the <code>hidden</code> attribute on the root
+							indicates that the entire list is excluded from rendering in the content flow.</p>
+						<pre>&lt;nav epub:type="page-list" hidden=""&gt;
+    &lt;h2&gt;Pagebreaks of the print version, third edition&lt;/h2&gt;
+    &lt;ol&gt;
+        &lt;li&gt;&lt;a href="frontmatter.xhtml#pi"&gt;I&lt;/a&gt;&lt;/li&gt;
+        &lt;li&gt;&lt;a href="frontmatter.xhtml#pii"&gt;II&lt;/a&gt;&lt;/li&gt; … &lt;li&gt;&lt;a href="chap1.xhtml#p1"&gt;1&lt;/a&gt;&lt;/li&gt;
+        &lt;li&gt;&lt;a href="chap1.xhtml#p2"&gt;2&lt;/a&gt;&lt;/li&gt; … &lt;/ol&gt;
+&lt;/nav&gt;
+</pre>
+					</aside>
+
+					<aside class="example">
+						<p>The following example shows a partial <code>toc</code>
+							<code>nav</code> element where the <code>hidden</code> attribute is used to limit content
+							flow rendering to the two topmost hierarchical levels.</p>
+						<pre>&lt;nav epub:type="toc" id="toc"&gt;
+  &lt;h1&gt;Table of contents&lt;/h1&gt;
+  &lt;ol&gt;
+    &lt;li&gt;
+      &lt;a href="chap1.xhtml"&gt;Chapter 1&lt;/a&gt;
+      &lt;ol&gt;
+        &lt;li&gt;
+          &lt;a href="chap1.xhtml#sec-1.1"&gt;Chapter 1.1&lt;/a&gt;
+          &lt;ol hidden=""&gt;
+            &lt;li&gt;
+              &lt;a href="chap1.xhtml#sec-1.1.1"&gt;Section 1.1.1&lt;/a&gt;
+            &lt;/li&gt;
+            &lt;li&gt;
+              &lt;a href="chap1.xhtml#sec-1.1.2"&gt;Section 1.1.2&lt;/a&gt;
+            &lt;/li&gt;
+          &lt;/ol&gt;
+         &lt;/li&gt;
+         &lt;li&gt;
+           &lt;a href="chap1.xhtml#sec-1.2"&gt;Chapter 1.2&lt;/a&gt;
+         &lt;/li&gt;
+       &lt;/ol&gt;
+     &lt;/li&gt;
+    &lt;li&gt;
+      &lt;a href="chap2.xhtml"&gt;Chapter 2&lt;/a&gt;
+    &lt;/li&gt;
+  &lt;/ol&gt;
+&lt;/nav&gt;
+</pre>
+					</aside>
+				</section>
 			</section>
 		</section>
 		<section id="sec-fixed-layouts">
@@ -7834,7 +7810,7 @@ html.-epub-media-overlay-playing * {
 
 				<p>Semantic inflection is the process of attaching additional meaning about the specific purpose and/or
 					nature an element plays. The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a>
-					is used to express domain-specific semantics in <a>EPUB Content Documents</a> and <a>Media Ovelay
+					is used to express domain-specific semantics in <a>EPUB Content Documents</a> and <a>Media Overlay
 						Documents</a>, with the inflection(s) it carries complementing the underlying vocabulary.</p>
 
 				<p>The applied semantics are intended to refine the meaning of their containing elements; they are not


### PR DESCRIPTION
This is effectively the same as #1385 but re-opening a new PR as I don't want to spend the time trying to piece together the diff from all the other recent changes. :)

Fixes #1383


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1400.html" title="Last updated on Nov 5, 2020, 1:03 PM UTC (b88a558)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1400/eae154b...b88a558.html" title="Last updated on Nov 5, 2020, 1:03 PM UTC (b88a558)">Diff</a>