### PR TITLE
Remove definition tables for deprecated properties

### DIFF
--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -109,114 +109,33 @@
 		</section>
 		<section id="sec-marc21xml-record">
 			<h5>marc21xml-record (Deprecated)</h5>
-			<table id="marc2xml-record">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>marc21xml-record</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>Use of the <code>marc21xml-record</code> keyword is deprecated. It is replaced by
-							the <a href="#record"><code>record</code></a> keyword with the <a
-								href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
-								"<code>application/marcxml+xml</code>".</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>Zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
-								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
-					</tr>
-					<tr>
-						<th>Example:</th>
-						<td>
-							<code>&lt;link rel="marc21xml-record" href="pub/meta/nor-wood-marc21.xml"/></code>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+			
+			<p id="marc2xml-record">Use of the <code>marc21xml-record</code> keyword is <a href="#deprecated">deprecated</a>.
+				It is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
+					href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
+				"<code>application/marcxml+xml</code>".</p>
+			
+			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
 		</section>
 		<section id="sec-mods-record">
 			<h5>mods-record (Deprecated)</h5>
-			<table id="mods-record">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>mods-record</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>Use of the <code>mods-record</code> keyword is deprecated. It is replaced by the <a
-								href="#record"><code>record</code></a> keyword with the <a
-								href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
-								"<code>application/mods+xml</code>".</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>Zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
-								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
-					</tr>
-					<tr>
-						<th>Example:</th>
-						<td>
-							<code>&lt;link rel="mods-record" href="pub/meta/nor-wood-mods.xml"/></code>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+			
+			<p id="mods-record">Use of the <code>mods-record</code> keyword is <a href="#deprecated">deprecated</a>. It
+				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
+					href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
+				"<code>application/mods+xml</code>".</p>
+			
+			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
 		</section>
 		<section id="sec-onix-record">
 			<h5>onix-record (Deprecated)</h5>
-			<table id="onix-record">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>onix-record</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>Use of the <code>onix-record</code> keyword is deprecated. It is replaced by the <a
-								href="#record"><code>record</code></a> keyword with the <a
-								href="#attrdef-properties">properties attribute</a> value <a href="#onix"
-									><code>onix</code></a>.</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>Zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
-								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
-					</tr>
-					<tr>
-						<th>Example:</th>
-						<td>
-							<code>&lt;link rel="onix-record" href="pub/meta/nor-wood-onix.xml"/></code>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+			
+			<p id="onix-record">Use of the <code>onix-record</code> keyword is <a href="#deprecated">deprecated</a>. It
+				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
+					href="#attrdef-properties">properties attribute</a> value <a href="#onix"
+						><code>onix</code></a>.</p>
+			
+			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
 		</section>
 		<section id="sec-record">
 			<h5>record</h5>
@@ -308,76 +227,22 @@
 		</section>
 		<section id="sec-xml-signature">
 			<h5>xml-signature (Deprecated)</h5>
-			<table id="xml-signature">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>xml-signature</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>Use of the <code>xml-signature</code> keyword is deprecated. It is not replaced by
-							another linking method. Identification of XML signatures will be addressed in a
-							future version of EPUB.</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>Zero or more</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>All properties.</td>
-					</tr>
-					<tr>
-						<th>Example:</th>
-						<td>
-							<code>&lt;link refines="#meta-authority-01" rel="xml-signature"
-								href="../META-INF/signatures.xml#MAI-Signature"/></code>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+			
+			<p id="xml-signature">Use of the <code>xml-signature</code> keyword is <a href="#deprecated">deprecated</a>.
+				It is not replaced by another linking method. Identification of XML signatures will be addressed in a
+				future version of EPUB.</pv>
+				
+			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
 		</section>
 		<section id="sec-xmp-record">
 			<h5>xmp-record (Deprecated)</h5>
-			<table id="xml-record">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>xmp-record</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>Use of the <code>xmp-record</code> keyword is deprecated. It is replaced by the <a
-								href="#record"><code>record</code></a> keyword with the <a
-								href="#attrdef-properties">properties attribute</a> value <a href="#xmp"
-									><code>xmp</code></a>.</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>Zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
-								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
-					</tr>
-					<tr>
-						<th>Example:</th>
-						<td>
-							<code>&lt;link rel="xmp-record" href="pub/meta/nor-wood-xmp.xml"/></code>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+			
+			<p id="xmp-record">Use of the <code>xmp-record</code> keyword is <a href="#deprecated">deprecated</a>. It
+				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
+					href="#attrdef-properties">properties attribute</a> value <a href="#xmp"
+						><code>xmp</code></a>.</p>
+			
+			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
 		</section>
 	</section>
 	<section id="sec-link-properties">

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -492,42 +492,9 @@
 		<section id="sec-property-meta-auth">
 			<h5>meta-auth (Deprecated)</h5>
 
-			<table id="meta-auth">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>meta-auth</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>meta-auth</code> property identifies the party or authority responsible for an
-								instance of package metadata.</p>
-							<p>
-								<strong>Use of the <code>meta-auth</code> property is deprecated.</strong>
-							</p>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>xsd:string</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>All properties.</td>
-					</tr>
-				</tbody>
-			</table>
+			<p id="meta-auth">Use of the <code>meta-auth</code> property is <a href="#deprecated">deprecated</a>.</p>
+			
+			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
 		</section>
 
 		<section id="sec-property-role">

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -796,7 +796,7 @@
 				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     
     &lt;dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier>
-    &lt;meta refines="#pub-id" property="identifier-type" scheme="xsd:string">uuid&lt;/meta>
+    &lt;meta refines="#pub-id" property="identifier-type">uuid&lt;/meta>
     
     &lt;dc:identifier id="isbn-id">urn:isbn:9780101010101&lt;/dc:identifier>
     &lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>


### PR DESCRIPTION
Fixes #1397 by replacing the full definition tables with the explanation that the properties are deprecated and a reference back to Publications 3.0 for more information.