### PR TITLE
update media type registrations

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8626,8 +8626,8 @@ EPUB/images/cover.png</pre>
 
 				<p>The Package Document is an XML file that describes a Rendition of an EPUB Publication. It identifies
 					the resources in the Rendition and provides metadata information. The Package Document and its
-					related specifications are maintained and defined by the W3C’s <a
-						href="https://www.w3.org/community/epub3/">EPUB 3 Community Group</a>.</p>
+					related specifications are maintained and defined by the <a href="https://www.w3.org">World Wide Web
+						Consortium</a> (W3C).</p>
 
 				<dl class="variablelist">
 					<dt>MIME media type name:</dt>
@@ -8662,8 +8662,8 @@ EPUB/images/cover.png</pre>
 							conformance.</p>
 						<p>All processors that read Package Documents should rigorously check the size and validity of
 							data retrieved.</p>
-						<p>There is no current provision in the EPUB Packages 3.2 specification for encryption, signing,
-							or authentication within the Package Document format.</p>
+						<p>There is no current provision in the EPUB 3 specification for encryption, signing, or
+							authentication within the Package Document format.</p>
 					</dd>
 					<dt>Interoperability considerations:</dt>
 					<dd>
@@ -8671,12 +8671,11 @@ EPUB/images/cover.png</pre>
 					</dd>
 					<dt>Published specification:</dt>
 					<dd>
-						<p>This media type registration is for the EPUB Package Document, as described by the EPUB
-							Packages 3.2 specification located at <a
-								href="https://www.w3.org/publishing/epub32/epub-packages.html"
-								>https://www.w3.org/publishing/epub32/epub-packages.html</a>.</p>
-						<p>The EPUB Packages 3.2 specification supersedes the Open Packaging Format 2.0.1 specification,
-							which is located at <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm"
+						<p>This media type registration is for the EPUB Package Document, as described by the EPUB 3
+							specification located at <a href="https://www.w3.org/publishing/epub3/core/"
+								>https://www.w3.org/publishing/epub3/core/</a>.</p>
+						<p>The EPUB 3 specification supersedes the Open Packaging Format 2.0.1 specification, which is
+							located at <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm"
 								>http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm</a> and which also uses the <code
 								class="media-type">application/oepbs-package+xml</code> media type.</p>
 					</dd>
@@ -8757,8 +8756,7 @@ EPUB/images/cover.png</pre>
 					</dd>
 					<dt>Author/Change controller:</dt>
 					<dd>
-						<p>The published specification is a work product of the World Wide Web Consortium’s EPUB 3
-							Community Group. W3C has change control over this specification.</p>
+						<p>World Wide Web Consortium (W3C)</p>
 					</dd>
 				</dl>
 			</section>
@@ -8771,7 +8769,8 @@ EPUB/images/cover.png</pre>
 
 				<p>An <a>OCF ZIP Container</a>, or <a>EPUB Container</a>, file is a container technology based on the
 					[[!ZIP]] archive format. It is used to encapsulate the Renditions of EPUB Publications. OCF and its
-					related standards are maintained and defined by the World Wide Web Consortium (W3C).</p>
+					related standards are maintained and defined by the <a href="https://www.w3.org">World Wide Web
+						Consortium</a> (W3C).</p>
 
 				<dl class="variablelist">
 					<dt>MIME media type name:</dt>
@@ -8820,11 +8819,10 @@ EPUB/images/cover.png</pre>
 					<dt>Published specification:</dt>
 					<dd>
 						<p>This media type registration is for the EPUB Open Container Format (OCF), as described by the
-							EPUB Open Container Format (OCF) 3.2 specification located at <a
-								href="https://www.w3.org/publishing/epub32/epub-ocf.html"
-									><code>https://www.w3.org/publishing/epub32/epub-ocf.html</code></a>.</p>
-						<p>The EPUB OCF 3.2 specification supersedes both <a href="https://tools.ietf.org/html/rfc4839"
-								>RFC 4839</a> and the Open Container Format 2.0.1 specification, which is located at <a
+							EPUB 3 specification located at <a href="https://www.w3.org/publishing/epub3/core/"
+									><code>https://www.w3.org/publishing/epub3/core/</code></a>.</p>
+						<p>The EPUB 3 specification supersedes both <a href="https://tools.ietf.org/html/rfc4839">RFC
+								4839</a> and the Open Container Format 2.0.1 specification, which is located at <a
 								href="http://www.idpf.org/doc_library/epub/OCF_2.0.1_draft.doc"
 									><code>http://www.idpf.org/doc_library/epub/OCF_2.0.1_draft.doc</code></a>, and
 							which also uses the <code>application/epub+zip</code> media type.</p>
@@ -8884,8 +8882,7 @@ EPUB/images/cover.png</pre>
 					</dd>
 					<dt>Author/change controller:</dt>
 					<dd>
-						<p>The published specification is a work product of the World Wide Web Consortium (W3C)’s EPUB 3
-							Community Group. The W3C has change control over this specification.</p>
+						<p>World Wide Web Consortium (W3C)</p>
 					</dd>
 				</dl>
 			</section>


### PR DESCRIPTION
I've updated the references to W3C and to avoid referencing subversions of EPUB 3, but I noticed that both registrations also mention the linking registry. We'll have to return to fix those once we figure out where we're maintaining that document.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1403.html" title="Last updated on Nov 5, 2020, 2:32 PM UTC (19de209)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1403/eae154b...19de209.html" title="Last updated on Nov 5, 2020, 2:32 PM UTC (19de209)">Diff</a>