### PR TITLE
Generalize custom attribute domain restriction

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8899,6 +8899,9 @@ EPUB/images/cover.png</pre>
 					3.2</a></h3>
 
 				<ul>
+					<li>5-Nov-2020: Generalized the restriction on custom attribute namespace URIs to exclude all of
+						idpf.org and w3.org. See <a href="https://github.com/w3c/epub-specs/issues/1388">issue
+						1388</a>.</li>
 					<li>12-Oct-2020: Added OPUS to the audio core media types with a warning that it is still subject to
 						review depending on support in Mac/iOS. See <a
 							href="https://github.com/w3c/epub-specs/issues/645">issue 645</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4108,17 +4108,18 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 						<p>Custom attributes MAY be included on any element in an XHTML Content Document provided such
 							attributes are from a foreign namespace, which is defined as a namespace [[!XML-NAMES]] that
-							does not map to either of the following URIs:</p>
+							does not include either of the following domains in its URI's authority component
+							[[!RFC3986]]:</p>
 
 						<ul>
 							<li>
 								<p>
-									<code>http://www.w3.org/1999/xhtml</code>
+									<code>w3.org</code>
 								</p>
 							</li>
 							<li>
 								<p>
-									<code>http://www.idpf.org/2007/ops</code>
+									<code>idpf.org</code>
 								</p>
 							</li>
 						</ul>


### PR DESCRIPTION
Fixes #1388 by disallowing w3.org and idpf.org in the authority component of a custom namespace URI.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1404.html" title="Last updated on Nov 5, 2020, 3:25 PM UTC (ed908aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1404/eae154b...ed908aa.html" title="Last updated on Nov 5, 2020, 3:25 PM UTC (ed908aa)">Diff</a>