### PR TITLE
Add explanatory note about difference between prefix and epub:prefix

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -54,26 +54,6 @@
 				postProcess:[addConformanceLinks]
 			};//]]>
       </script>
-		<style>
-			dd > ul.conformance-list,
-			li > ul.conformance-list {
-				margin-left: 2rem;
-			}
-			
-			dl.conformance-list > dt {
-				font-size: 105%;
-				color: rgb(0, 90, 156);
-			}
-			
-			dl.conformance-list > dd > dl.conformance-list > dt {
-				font-size: 100%;
-				color: rgb(0, 0, 0);
-			}
-			
-			dl.conformance-list > dd > dl.conformance-list > dd > dl.conformance-list > dt {
-				font-style: italic !important;
-				font-size: 95%;
-			}</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -8175,6 +8155,21 @@ html.-epub-media-overlay-playing * {
    …
 &lt;/html></pre>
 					</aside>
+
+					<div class="note">
+						<p>Although the <code>prefix</code> attribute is modeled on the identically named
+								<code>prefix</code> attribute in [[RDFA-CORE]], Authors cannot use the attributes
+							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB Content
+							Documents is the RDFa attribute.</p>
+
+						<p>It is common for both attributes to appear in EPUB Content Documents that also include RDFa
+							expressions.</p>
+
+						<pre>&lt;html … prefix="…"
+        xmlns:epub="http://www.idpf.org/2007/ops"
+        epub:prefix="…">   …
+&lt;/html></pre>
+					</div>
 
 					<p>Note that for <a href="#sec-xhtml-svg">embedded SVG</a>, prefixes MUST be declared on the
 						[[!HTML]] root <a href="https://www.w3.org/TR/html/semantics.html#the-html-element"


### PR DESCRIPTION
Fixes #1387 

@iherman let me know if this is sufficient. I think we only need to explain this in the epub:prefix definition. It doesn't change RDFa at all.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1405.html" title="Last updated on Nov 5, 2020, 5:07 PM UTC (cc8eff1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1405/178f744...cc8eff1.html" title="Last updated on Nov 5, 2020, 5:07 PM UTC (cc8eff1)">Diff</a>