### PR TITLE
Add note about alias rendition:page-spread-right

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5352,6 +5352,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 &lt;spine&gt;
     &lt;itemref idref="titlepage" properties="page-spread-right rendition:layout-pre-paginated"/&gt;
 &lt;/spine&gt;</pre>
+						<p>Note that the alias <a href="#page-spread"><code>rendition:page-spread-right</code></a> could
+							be used in place of <code>page-spread-right</code>.</p>
 					</aside>
 
 					<section id="spread-overrides">


### PR DESCRIPTION
Fixes #1381 by noting that `rendition:page-spread-right` is also valid in the FXL example.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1406.html" title="Last updated on Nov 5, 2020, 5:24 PM UTC (93d77a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1406/c7d0677...93d77a6.html" title="Last updated on Nov 5, 2020, 5:24 PM UTC (93d77a6)">Diff</a>