### PR TITLE
Note that data blocks are not scripted content

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8881,6 +8881,9 @@ EPUB/images/cover.png</pre>
 					3.2</a></h3>
 
 				<ul>
+					<li>6-Nov-2020: Clarified that HTML <code>script</code> elements that contain <a
+							href="#sec-scripted-context">data blocks are not instances of scripting</a>. See <a
+							href="https://github.com/w3c/epub-specs/issues/1352">issue 1352</a>.</li>
 					<li>5-Nov-2020: Generalized the restriction on custom attribute namespace URIs to exclude all of
 						idpf.org and w3.org. See <a href="https://github.com/w3c/epub-specs/issues/1388">issue
 						1388</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7846,9 +7846,15 @@ html.-epub-media-overlay-playing * {
 					<tr>
 						<td>
 							<ul class="flat">
-								<li><code>application/mathml+xml</code></li>
-								<li><code>application/mathml-presentation+xml</code></li>
-								<li><code>application/mathml-content+xml</code></li>
+								<li>
+									<code>application/mathml+xml</code>
+								</li>
+								<li>
+									<code>application/mathml-presentation+xml</code>
+								</li>
+								<li>
+									<code>application/mathml-content+xml</code>
+								</li>
 							</ul>
 						</td>
 						<td>
@@ -7859,7 +7865,9 @@ html.-epub-media-overlay-playing * {
 						</td>
 					</tr>
 					<tr>
-						<td><code>application/svg+xml</code></td>
+						<td>
+							<code>application/svg+xml</code>
+						</td>
 						<td>
 							<code>-//W3C//DTD SVG 1.1//EN</code>
 						</td>
@@ -8958,20 +8966,20 @@ EPUB/images/cover.png</pre>
 							href="#sec-scripted-context">data blocks are not instances of scripting</a>. See <a
 							href="https://github.com/w3c/epub-specs/issues/1352">issue 1352</a>.</li>
 					<li>6-Nov-2020: A <a href="#app-identifiers-allowed">restricted set of external identifiers</a> are
-							now allowed in publication resources. <a href="#sec-xml-constraints">References to external
+						now allowed in publication resources. <a href="#sec-xml-constraints">References to external
 							entities</a> from the internal DTD subset remain restricted, however. See <a
 							href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
 					<li>5-Nov-2020: Generalized the restriction on <a href="#sec-xhtml-custom-attributes">custom
 							attribute namespace URIs</a> to exclude all of idpf.org and w3.org. See <a
 							href="https://github.com/w3c/epub-specs/issues/1388">issue 1388</a>.</li>
 					<li>12-Oct-2020: Added OPUS to the <a href="#cmt-grp-audio">audio core media types</a> with a
-							warning that it is still subject to review depending on support in Mac/iOS. See <a
+						warning that it is still subject to review depending on support in Mac/iOS. See <a
 							href="https://github.com/w3c/epub-specs/issues/645">issue 645</a>.</li>
 					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
-							understanding and access to information. This specification now consolidates the authoring
-							requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF
-							and Media Overlays specifications. A separate document, EPUB Reading Systems 3.3, consolidates
-							the reading system requirements from those documents.</li>
+						understanding and access to information. This specification now consolidates the authoring
+						requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF
+						and Media Overlays specifications. A separate document, EPUB Reading Systems 3.3, consolidates
+						the reading system requirements from those documents.</li>
 				</ul>
 			</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4445,9 +4445,16 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						</dd>
 					</dl>
 
-					<p>In both of the above-defined contexts, whether the JavaScript code is embedded directly in the
+					<p>In both of the above-defined contexts, whether the code is embedded directly in the
 							<code>script</code> element or referenced via its <code>src</code> attribute makes no
 						difference to the executing context.</p>
+
+					<div class="note">
+						<p>When an [[HTML]] <code>script</code> element contains a <a
+								href="https://html.spec.whatwg.org/multipage/scripting.html#data-block">data block</a>
+							[[HTML]], it does not represent scripted content. [[SVG]] does not define data blocks as of
+							publication, but the same exclusion would apply to a future update.</p>
+					</div>
 
 					<p>Which context a script is used in determines the rights and restrictions that a Reading System
 						places on it. Refer to <a href="#sec-scripted-container-constrained">the following sections</a>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4449,11 +4449,13 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							<code>script</code> element or referenced via its <code>src</code> attribute makes no
 						difference to the executing context.</p>
 
+					<p>When an [[HTML]] <code>script</code> element contains a <a
+							href="https://html.spec.whatwg.org/multipage/scripting.html#data-block">data block</a>
+						[[HTML]], it does not represent scripted content.</p>
+
 					<div class="note">
-						<p>When an [[HTML]] <code>script</code> element contains a <a
-								href="https://html.spec.whatwg.org/multipage/scripting.html#data-block">data block</a>
-							[[HTML]], it does not represent scripted content. [[SVG]] does not define data blocks as of
-							publication, but the same exclusion would apply to a future update.</p>
+						<p>[[SVG]] does not define data blocks as of publication, but the same exclusion would apply if
+							a future update adds the concept.</p>
 					</div>
 
 					<p>Which context a script is used in determines the rights and restrictions that a Reading System


### PR DESCRIPTION
Fixes #1352 by adding a note to the scripting section that HTML data blocks do not represent scripted content.

The SVG case is a little murkier, as it says the element is the same as HTML but goes on to define things slightly differently. A script without a `type` is treated as javascript, otherwise the block is executed or not depending on whether the media type is recognized as a supported scripting language. That's not the same as HTML where everything outside of JS and 'module' types are data blocks.

I added a sentence noting the same data block concept does not apply, but could in the future. We might just have to live with json in svg having to be set as scripted in the package for now. It's probably not a common case, though.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1409.html" title="Last updated on Nov 15, 2020, 2:17 PM UTC (6085350)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1409/358b499...6085350.html" title="Last updated on Nov 15, 2020, 2:17 PM UTC (6085350)">Diff</a>