### PR TITLE
Adding reference for Audiobooks

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6580,9 +6580,8 @@ store destination as source in ocf
 					ability of Media Overlay-unaware Reading Systems to render the EPUB Publication as though the Media
 					Overlays are not present.</p>
 				
-					<p>Media Overlays are not an equivalent to audiobooks, as that format is primarily audio-based with text occasionally
-					provided as an alternate format. There is a W3C recommendation for building audio publications called
-					[[Audiobooks]].</p>
+				<p>Media Overlays in EPUB are not an equivalent to audiobooks, as audiobooks are primarily audio-based with text occasionally
+					provided as an alternate format. The W3C [[Audiobooks]] recommendation is designed for building audio publications.</p>
 
 				<p>Although future versions of this specification might incorporate support for video media (e.g.,
 					synchronized text/sign-language books), this version supports only synchronizing audio media with

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6573,13 +6573,16 @@ store destination as source in ocf
 					user who has difficulty following the text of a traditional book. Media Overlays also provide a
 					continuous listening experience for readers who are unable to read the text for any reason,
 					something that traditional audio embedding techniques cannot offer. They are even useful for
-					purposes not traditionally considered accessibility concerns (e.g., for language learning or reading
-					of commercial audio books).</p>
+					purposes not traditionally considered accessibility concerns (e.g., for language learning).</p>
 
 				<p>The Media Overlays feature is designed to be transparent to <a>EPUB Reading Systems</a> that do not
 					support the feature. The inclusion of Media Overlays in an EPUB Publication has no impact on the
 					ability of Media Overlay-unaware Reading Systems to render the EPUB Publication as though the Media
 					Overlays are not present.</p>
+				
+					<p>Media Overlays are not an equivalent to audiobooks, as that format is primarily audio-based with text occasionally
+					provided as an alternate format. There is a W3C recommendation for building audio publications called
+					[[Audiobooks]].</p>
 
 				<p>Although future versions of this specification might incorporate support for video media (e.g.,
 					synchronized text/sign-language books), this version supports only synchronizing audio media with


### PR DESCRIPTION
As mentioned in issue #1394. adujusting the description of what a book with media overlays should be (removing reference to commercial audiobooks), and adding a reference to the Audiobooks specification.

May want to merge this after publication tomorrow :).

Fixes #1394


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1412.html" title="Last updated on Nov 18, 2020, 9:19 PM UTC (05f28fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1412/614abf4...05f28fc.html" title="Last updated on Nov 18, 2020, 9:19 PM UTC (05f28fc)">Diff</a>