### PR TITLE
Add issue links and minor reorg of custom attributes

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3628,31 +3628,20 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					<section id="sec-xhtml-custom-attributes">
 						<h5>Custom Attributes</h5>
 
-						<p><a>Reading Systems</a> can introduce functionality not defined in this specification to
-							enhance the rendering of <a>EPUB Publications</a>. The allowance of custom attributes in
-								<a>XHTML Content Documents</a> is designed to facilitate this experimentation.</p>
+						<p><a>Authors</a> MAY include <a
+								href="https://www.w3.org/TR/epub-rs-33/#sec-xhtml-custom-attributes">custom
+								attributes</a> [[!EPUB-RS-33]] in <a>XHTML Content Documents</a> to take advantage of
+							Reading System-specific functionality not defined in this specification.</p>
 
-						<p>Custom attributes MAY be included on any element in an XHTML Content Document provided such
-							attributes are from a foreign namespace, which is defined as a namespace [[!XML-NAMES]] that
-							does not include either of the following domains in its URI's authority component
-							[[!RFC3986]]:</p>
+						<p>Custom attributes MAY be included on any element in an XHTML Content Document.</p>
 
-						<ul>
-							<li>
-								<p>
-									<code>w3.org</code>
-								</p>
-							</li>
-							<li>
-								<p>
-									<code>idpf.org</code>
-								</p>
-							</li>
-						</ul>
+						<p>When using custom attributes, the content MUST remain consumable by a user without any
+							information loss or other significant deterioration, regardless of the Reading System it is
+							rendered on.</p>
 
-						<p>Custom attributes, and the behaviors associated with them, MUST NOT alter the integrity of an
-							EPUB Publication. The content MUST remain consumable by a user without any information loss
-							or other significant deterioration, regardless of the Reading System it is rendered on.</p>
+						<div class="note">
+							<p>Refer to [[AttributeExtensions]] for a registry of custom attributes.</p>
+						</div>
 					</section>
 				</section>
 
@@ -8974,6 +8963,13 @@ EPUB/images/cover.png</pre>
 		<section id="change-log">
 			<h2>Change Log</h2>
 
+			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance
+				of <a>EPUB Publications</a>, or are similarly noteworthy.</p>
+
+			<p>For a list of all issues addressed during the revision, refer to the <a
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+-label%3ASpec-RS+"
+					>working group's issue tracker</a>.</p>
+
 			<section id="changes-latest">
 				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
 					3.2</a></h3>
@@ -8989,9 +8985,6 @@ EPUB/images/cover.png</pre>
 						now allowed in publication resources. <a href="#sec-xml-constraints">References to external
 							entities</a> from the internal DTD subset remain restricted, however. See <a
 							href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
-					<li>5-Nov-2020: Generalized the restriction on <a href="#sec-xhtml-custom-attributes">custom
-							attribute namespace URIs</a> to exclude all of idpf.org and w3.org. See <a
-							href="https://github.com/w3c/epub-specs/issues/1388">issue 1388</a>.</li>
 					<li>12-Oct-2020: Added OPUS to the <a href="#cmt-grp-audio">audio core media types</a> with a
 						warning that it is still subject to review depending on support in Mac/iOS. See <a
 							href="https://github.com/w3c/epub-specs/issues/645">issue 645</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -601,12 +601,29 @@
 					<section id="sec-xhtml-custom-attributes">
 						<h5>Custom Attributes</h5>
 
-						<p><a>Reading Systems</a> MAY introduce functionality not defined in this specification to
-							enhance the rendering of <a>EPUB Publications</a>. To facilitate this experimentation,
-							vendors MAY define custom attributes for use in <a>XHTML Content Documents</a> provided they
-							meet the requirements defined in <a
-								href="https://www.w3.org/TR/epub-33/#sec-xhtml-custom-attributes">Custom Attributes</a>
-							[[!EPUB-33]].</p>
+						<p>Vendors MAY introduce functionality not defined in this specification to enhance the
+							rendering of <a>EPUB Publications</a>.</p>
+
+						<p>To facilitate this experimentation, vendors MAY define custom attributes for use in <a>XHTML
+								Content Documents</a> provided they are from a foreign namespace, which is defined as a
+							namespace [[!XML-NAMES]] that does not include either of the following domains in its URI's
+							authority component [[!RFC3986]]:</p>
+
+						<ul>
+							<li>
+								<p>
+									<code>w3.org</code>
+								</p>
+							</li>
+							<li>
+								<p>
+									<code>idpf.org</code>
+								</p>
+							</li>
+						</ul>
+
+						<p>Custom attributes, and the behaviors associated with them, MUST NOT alter the integrity of an
+							EPUB Publication.</p>
 
 						<div class="note">
 							<p>To facilitate interoperability of custom attributes across Reading Systems, vendors are
@@ -2084,6 +2101,13 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 		<section id="change-log">
 			<h2>Change Log</h2>
 
+			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance
+				of <a>EPUB Reading Systems</a>, or are similarly noteworthy.</p>
+
+			<p>For a list of all issues addressed during the revision, refer to the <a
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+label%3ASpec-RS+"
+					>working group's issue tracker</a>.</p>
+
 			<section id="changes-latest">
 				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
 					3.2</a></h3>
@@ -2092,6 +2116,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					<li>6-Nov-2020: Reading systems are now required to <a href="#confreq-rs-xml-extid">not resolve
 							external identifiers</a> in doctype declarations. See <a
 							href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
+					<li>5-Nov-2020: Generalized the restriction on <a href="#sec-xhtml-custom-attributes">custom
+							attribute namespace URIs</a> to exclude all of idpf.org and w3.org. See <a
+							href="https://github.com/w3c/epub-specs/issues/1388">issue 1388</a>.</li>
 					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
 						understanding and access to information. This specification now consolidates the reading system
 						requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF


### PR DESCRIPTION
I started off only with the intention of adding an explanatory paragraph to each change log about what are substantive changes, plus provide a link to the resolved issues for each specification, but got on a bit of a tangent when I looked at the issues again.

Although the custom attribute namespace restriction looks like a content issue, it's really a restriction on how reading system devs can create these attributes. I don't see it as of primary importance to authors, as they just use the attributes, not create them.

To fix, I've moved the  restriction to the RS specification and only left the prose about using the attributes in the core spec (plus added a note with a link to the registry, as that belongs in both documents).

[Reading Systems preview](https://raw.githack.com/w3c/epub-specs/editorial/change-log-expl/epub33/rs/)
[Reading Systems diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Frs%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Feditorial%2Fchange-log-expl%2Fepub33%2Frs%2Findex.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1413.html" title="Last updated on Nov 10, 2020, 6:03 PM UTC (fbd1f64)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1413/37f274d...fbd1f64.html" title="Last updated on Nov 10, 2020, 6:03 PM UTC (fbd1f64)">Diff</a>