### PR TITLE
Move authoring note about xml base to core spec

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1045,6 +1045,14 @@
 
 					<p>The above constraints apply regardless of whether the given Publication Resource is a <a>Core
 							Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
+
+
+					<div class="note">
+						<p>Although EPUB Reading Systems are <a
+								href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-xml-base">required to support</a>
+							[[EPUB-RS-33]] the XML `base` attribute [[XMLBase]], [[HTML]] and [[SVG]] are removing
+							support. Authors are advised to avoid using this feature.</p>
+					</div>
 				</section>
 			</section>
 		</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -247,9 +247,8 @@
 									>conformant processor</a> as defined in [[!XML-NAMES]].</p>
 						</li>
 						<li>
-							<p id="confreq-rs-xml-base">It MUST be a conformant application as defined by [[!XMLBase]].
-									<span class="note">Note: [[HTML]] and [[SVG]] are removing support for [[!XMLBase]].
-									Authors are advised to avoid using this feature.</span></p>
+							<p id="confreq-rs-xml-base">It MUST be a conformant application as defined by
+								[[!XMLBase]].</p>
 						</li>
 					</ul>
 				</dd>


### PR DESCRIPTION
I had to add some additional context to the note because xmlbase support isn't specifically mentioned for authoring.

Fixes #1415


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1421.html" title="Last updated on Nov 11, 2020, 3:45 PM UTC (9f67daa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1421/97cdad9...9f67daa.html" title="Last updated on Nov 11, 2020, 3:45 PM UTC (9f67daa)">Diff</a>