### PR TITLE
Fix titles with duplicative or ambiguous wording

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -58,8 +58,8 @@
 	<body>
 		<section id="abstract">
 			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
-				format provides a means of representing, packaging, and encoding structured and semantically enhanced Web
-				content — including HTML, CSS, SVG, and other resources — for distribution in a single-file
+				format provides a means of representing, packaging, and encoding structured and semantically enhanced
+				Web content — including HTML, CSS, SVG, and other resources — for distribution in a single-file
 				container.</p>
 			<p>This specification defines the authoring requirements for EPUB Publications and represents the third
 				major revision of the standard.</p>
@@ -1854,8 +1854,8 @@
 								<p>All [[!DC11]] elements except for <a href="#sec-opf-dcidentifier"
 											><code>identifier</code></a>, <a href="#sec-opf-dclanguage"
 											><code>language</code></a>, and <a href="#sec-opf-dctitle"
-										><code>title</code></a> are designated as OPTIONAL. These elements conform to
-									the following generalized definition:</p>
+											><code>title</code></a> are designated as OPTIONAL. These elements conform
+									to the following generalized definition:</p>
 
 								<dl class="elemdef">
 									<dt>Element Name</dt>
@@ -3902,8 +3902,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						<li>
 							<p id="confreq-svg-structural-semantics">It MAY include the <a href="#attrdef-epub-type"
 										><code>epub:type</code></a> attribute for expressing <a
-									href="#app-structural-semantics">structural semantics</a> and use all applicable <a href="#sec-vocab-assoc"
-									>vocabulary association mechanisms</a>.</p>
+									href="#app-structural-semantics">structural semantics</a> and use all applicable <a
+									href="#sec-vocab-assoc">vocabulary association mechanisms</a>.</p>
 						</li>
 						<li>
 							<p id="confreq-svg-fileprops-name">It SHOULD use the file extension <code>.svg</code>.</p>
@@ -7367,8 +7367,8 @@ store destination as source in ocf
 					<h4>Structural Semantics in Overlays</h4>
 
 					<p>To express <a href="#app-structural-semantics">structural semantics</a> in <a>Media Overlay
-            Documents</a>, the <a href="#attrdef-epub-type"><code>epub:type</code> attribute</a> MAY be
-            attached <a href="#elemdef-smil-par"><code>par</code></a>, <a href="#elemdef-smil-seq"
+							Documents</a>, the <a href="#attrdef-epub-type"><code>epub:type</code> attribute</a> MAY be
+						attached to <a href="#elemdef-smil-par"><code>par</code></a>, <a href="#elemdef-smil-seq"
 								><code>seq</code></a>, and <a href="#elemdef-smil-body"><code>body</code></a>
 						elements.</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3217,7 +3217,7 @@ Manifest:
 					</section>
 
 					<section id="sec-pkg-legacy">
-						<h5>Legacy Features</h5>
+						<h5>Legacy Content</h5>
 
 						<section id="sec-opf2-meta">
 							<h6>The <code>meta</code> Element</h6>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1422,7 +1422,7 @@
 					</section>
 
 					<section id="sec-pkg-metadata">
-						<h5>Metadata</h5>
+						<h5>Metadata Section</h5>
 
 						<section id="sec-metadata-elem">
 							<h6>The <code>metadata</code> Element</h6>
@@ -1519,7 +1519,7 @@
 								</li>
 								<li>
 									<p>to provide access to all rendering metadata needed to control the layout and
-										display of the Rendition's content (e.g., <a href="#sec-package-metadata-fxl"
+										display of the Rendition's content (e.g., <a href="#sec-fxl-package"
 											>fixed-layout properties</a>).</p>
 								</li>
 							</ol>
@@ -2420,7 +2420,7 @@
 					</section>
 
 					<section id="sec-pkg-manifest">
-						<h5>Manifest</h5>
+						<h5>Manifest Section</h5>
 
 						<section id="sec-manifest-elem">
 							<h6>The <code>manifest</code> Element</h6>
@@ -2780,7 +2780,7 @@ Manifest:
 					</section>
 
 					<section id="sec-pkg-spine">
-						<h5>Spine</h5>
+						<h5>Spine Section</h5>
 
 						<section id="sec-spine-elem">
 							<h6>The <code>spine</code> Element</h6>
@@ -3217,7 +3217,7 @@ Manifest:
 					</section>
 
 					<section id="sec-pkg-legacy">
-						<h5>Legacy</h5>
+						<h5>Legacy Features</h5>
 
 						<section id="sec-opf2-meta">
 							<h6>The <code>meta</code> Element</h6>
@@ -3429,10 +3429,11 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					</div>
 
 					<section id="sec-xhtml-semantic-inflection">
-						<h5>Semantic Inflection</h5>
+						<h5>Structural Semantics</h5>
 
 						<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> MAY be used in
-								<a>XHTML Content Documents</a> to express structural semantics.</p>
+								<a>XHTML Content Documents</a> to express <a href="#sec-semantic-inflection-intro"
+								>structural semantics</a>.</p>
 
 						<p>As the [[!HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element"
@@ -3900,9 +3901,10 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						</li>
 						<li>
 							<p id="confreq-svg-semantic-inflection">It MAY include the <a href="#attrdef-epub-type"
-										><code>epub:type</code></a> attribute for <a href="#app-semantic-inflection"
-									>semantic inflection</a>, and use all applicable <a href="#sec-vocab-assoc"
-									>vocabulary association mechanisms</a> for that attribute.</p>
+										><code>epub:type</code></a> attribute for expressing <a
+									href="#app-semantic-inflection">structural semantics</a>, and use all applicable <a
+									href="#sec-vocab-assoc">vocabulary association mechanisms</a> for that
+								attribute.</p>
 						</li>
 						<li>
 							<p id="confreq-svg-fileprops-name">It SHOULD use the file extension <code>.svg</code>.</p>
@@ -5127,13 +5129,14 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					the user, rather than the user having to adapt to a particular presentation of content."
 					[[EPUB-OVERVIEW-33]]</p>
 
-				<p>But this principle doesn’t work for all types of documents. Sometimes content and design are so
+				<p>But this principle does not work for all types of documents. Sometimes content and design are so
 					intertwined they cannot be separated. Any change in appearance risks changing the meaning, or losing
 					all meaning. <a>Fixed-Layout Documents</a> give <a>Authors</a> greater control over presentation
 					when a reflowable EPUB is not suitable for the content.</p>
 
-				<p>This section defines a set of metadata properties to allow declarative expression of intended
-					rendering behaviors of Fixed-Layout Documents in the context of EPUB 3.</p>
+				<p>Fixed layouts are defined using a <a href="#sec-fxl-package">set of Package Document properties</a>
+					to control the rendering in <a>Reading Systems</a>. In addition, <a href="#sec-fxl-package">the
+						dimensions of each Fixed-Layout Document</a> is set in its respective EPUB Content Document.</p>
 
 				<div class="note" id="note-mechanisms">
 					<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
@@ -5143,8 +5146,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				</div>
 			</section>
 
-			<section id="sec-package-metadata-fxl">
-				<h3>Package Definition</h3>
+			<section id="sec-fxl-package">
+				<h3>Fixed-Layout Package Settings</h3>
 
 				<section id="layout">
 					<h4>Layout</h4>
@@ -5214,7 +5217,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					</aside>
 
 					<section id="layout-overrides">
-						<h5>Spine Overrides</h5>
+						<h5>Layout Overrides</h5>
 
 						<p id="property-layout-local">Authors MAY specify the following properties locally on spine <a
 								href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
@@ -5276,7 +5279,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					</aside>
 
 					<section id="orientation-overrides">
-						<h5>Spine Overrides</h5>
+						<h5>Orientation Overrides</h5>
 
 						<p id="property-orientation-local">Authors MAY specify the following properties locally on spine
 								<a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
@@ -5379,7 +5382,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					</aside>
 
 					<section id="spread-overrides">
-						<h5>Spine Overrides</h5>
+						<h5>Synthetic Spread Overrides</h5>
 
 						<p id="property-spread-local">Authors MAY specify the following properties locally on spine <a
 								href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
@@ -7193,7 +7196,7 @@ store destination as source in ocf
 					</div>
 
 					<section id="sec-media-overlays-structure">
-						<h5>Structure</h5>
+						<h5>Overlay Structure</h5>
 
 						<p>The <a href="#elemdef-smil-body"><code>body</code></a> of a Media Overlay Document consists
 							of two elements: the <a href="#elemdef-smil-par"><code>par</code> element</a> and the <a
@@ -7320,7 +7323,7 @@ store destination as source in ocf
 					</section>
 
 					<section id="sec-media-overlays-granularity" class="informative">
-						<h5>Granularity</h5>
+						<h5>Overlay Granularity</h5>
 
 						<p>Media Overlay <a href="#elemdef-smil-text"><code>text</code> elements'</a>
 							<code>src</code> attributes refer to <a>EPUB Content Document</a> elements by their IDs
@@ -7351,7 +7354,7 @@ store destination as source in ocf
 					</section>
 
 					<section id="sec-tts">
-						<h5>Text-to-Speech</h5>
+						<h5>Text-to-Speech Rendering</h5>
 
 						<p>This specification allows the use of <a>Text-to-Speech</a> (TTS) in addition to pre-recorded
 							audio clips. When a Media Overlay <a href="#elemdef-smil-text"><code>text</code> element</a>
@@ -7363,15 +7366,15 @@ store destination as source in ocf
 				</section>
 
 				<section id="sec-docs-semantic-inflection">
-					<h4>Semantic Inflection</h4>
+					<h4>Structural Semantics in Overlays</h4>
 
-					<p>In order to express <a href="#app-semantic-inflection">semantic inflections</a>, the <a
+					<p>In order to express <a href="#app-semantic-inflection">structural semantics</a>, the <a
 							href="#attrdef-epub-type"><code>epub:type</code> attribute</a> MAY be attached to Media
 						Overlay <a href="#elemdef-smil-par"><code>par</code></a>, <a href="#elemdef-smil-seq"
 								><code>seq</code></a>, and <a href="#elemdef-smil-body"><code>body</code></a>
 						elements.</p>
 
-					<p> The <code>epub:type</code> attribute facilitates Reading System behavior appropriate for the
+					<p>The <code>epub:type</code> attribute facilitates Reading System behavior appropriate for the
 						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
 							>skippability and escapability</a> and <a
 							href="https://www.w3.org/TR/epub-rs-33/#note-table-reading-mode">table reading mode</a>
@@ -7477,7 +7480,7 @@ html.-epub-media-overlay-playing * {
 				</section>
 
 				<section id="sec-docs-package">
-					<h4>Packaging</h4>
+					<h4>Media Overlays Packaging</h4>
 
 					<section id="sec-package-including">
 						<h5>Including Media Overlays</h5>
@@ -7512,7 +7515,7 @@ html.-epub-media-overlay-playing * {
 					</section>
 
 					<section id="sec-mo-package-metadata">
-						<h5>Package Metadata</h5>
+						<h5>Overlays Package Metadata</h5>
 
 						<p>The <a>Package Document</a> MUST include the duration of the entire <a>Rendition</a> in a <a
 								href="#elemdef-package-item"><code>meta</code> element</a> with the <a href="#duration"
@@ -7743,7 +7746,7 @@ html.-epub-media-overlay-playing * {
 			</section>
 
 			<section id="sec-nav-doc">
-				<h3>EPUB Navigation Document</h3>
+				<h3>Navigation Document Overlays</h3>
 
 				<p>The <a>EPUB Navigation Document</a> is an <a>XHTML Content Document</a> and can therefore be
 					associated with an audio Media Overlay. Unlike traditional XHTML Content Documents, however,
@@ -7889,10 +7892,11 @@ html.-epub-media-overlay-playing * {
 			<section id="sec-semantic-inflection-intro">
 				<h3>Introduction</h3>
 
-				<p>Semantic inflection is the process of attaching additional meaning about the specific purpose and/or
-					nature an element plays. The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a>
-					is used to express domain-specific semantics in <a>EPUB Content Documents</a> and <a>Media Overlay
-						Documents</a>, with the inflection(s) it carries complementing the underlying vocabulary.</p>
+				<p>Semantic inflection is the process of attaching additional meaning about the specific structural
+					purpose an element plays. The <a href="#sec-epub-type-attribute"><code>epub:type</code>
+						attribute</a> is used to express domain-specific semantics in <a>EPUB Content Documents</a> and
+						<a>Media Overlay Documents</a>, with the inflection(s) it carries complementing the underlying
+					vocabulary.</p>
 
 				<p>The applied semantics are intended to refine the meaning of their containing elements; they are not
 					provided to override their nature (e.g., the attribute can be used to indicate a [[HTML]]

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3428,11 +3428,11 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							are not supported features of EPUB 3.</p>
 					</div>
 
-					<section id="sec-xhtml-semantic-inflection">
+					<section id="sec-xhtml-structural-semantics">
 						<h5>Structural Semantics</h5>
 
 						<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> MAY be used in
-								<a>XHTML Content Documents</a> to express <a href="#sec-semantic-inflection-intro"
+								<a>XHTML Content Documents</a> to express <a href="#sec-structural-semantics-intro"
 								>structural semantics</a>.</p>
 
 						<p>As the [[!HTML]] <a
@@ -3900,9 +3900,9 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								in <a href="#sec-svg-restrictions"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-svg-semantic-inflection">It MAY include the <a href="#attrdef-epub-type"
+							<p id="confreq-svg-structural-semanics">It MAY include the <a href="#attrdef-epub-type"
 										><code>epub:type</code></a> attribute for expressing <a
-									href="#app-semantic-inflection">structural semantics</a>, and use all applicable <a
+									href="#app-structural-semantics">structural semantics</a>, and use all applicable <a
 									href="#sec-vocab-assoc">vocabulary association mechanisms</a> for that
 								attribute.</p>
 						</li>
@@ -6597,7 +6597,7 @@ store destination as source in ocf
 								Document.</p>
 						</li>
 						<li>
-							<p id="confreq-mo-docprops-semantics">It SHOULD use <a href="#sec-docs-semantic-inflection"
+							<p id="confreq-mo-docprops-semantics">It SHOULD use <a href="#sec-docs-structural-semantic"
 									>semantic markup</a> where appropriate.</p>
 						</li>
 						<li>
@@ -6655,7 +6655,7 @@ store destination as source in ocf
 									</dt>
 									<dd>
 										<p>Declares additional metadata vocabulary prefixes.</p>
-										<p>Refer to <a href="#sec-docs-semantic-inflection"></a> for more
+										<p>Refer to <a href="#sec-docs-structural-semantic"></a> for more
 											information.</p>
 									</dd>
 								</dl>
@@ -6785,7 +6785,7 @@ store destination as source in ocf
 										<p>An expression of the structural semantics of the corresponding element in the
 												<a>EPUB Content Document</a>.</p>
 										<p>The value is a white space separated list of <a href="#sec-property-datatype"
-												>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"
+												>property</a> types. Refer to <a href="#sec-docs-structural-semantic"
 											></a> for more information.</p>
 									</dd>
 									<dt>
@@ -6863,7 +6863,7 @@ store destination as source in ocf
 										<p>An expression of the structural semantics of the corresponding element in the
 												<a>EPUB Content Document</a>.</p>
 										<p>The value is a white space separated list of <a href="#sec-property-datatype"
-												>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"
+												>property</a> types. Refer to <a href="#sec-docs-structural-semantic"
 											></a> for more information.</p>
 									</dd>
 									<dt>
@@ -6942,7 +6942,7 @@ store destination as source in ocf
 										<p>An expression of the structural semantics of the corresponding element in the
 												<a>EPUB Content Document</a>.</p>
 										<p>The value is a white space separated list of <a href="#sec-property-datatype"
-												>property</a> types. Refer to <a href="#sec-docs-semantic-inflection"
+												>property</a> types. Refer to <a href="#sec-docs-structural-semantic"
 											></a> for more information.</p>
 									</dd>
 									<dt>
@@ -7365,10 +7365,10 @@ store destination as source in ocf
 					</section>
 				</section>
 
-				<section id="sec-docs-semantic-inflection">
+				<section id="sec-docs-structural-semantic">
 					<h4>Structural Semantics in Overlays</h4>
 
-					<p>In order to express <a href="#app-semantic-inflection">structural semantics</a>, the <a
+					<p>In order to express <a href="#app-structural-semantics">structural semantics</a>, the <a
 							href="#attrdef-epub-type"><code>epub:type</code> attribute</a> MAY be attached to Media
 						Overlay <a href="#elemdef-smil-par"><code>par</code></a>, <a href="#elemdef-smil-seq"
 								><code>seq</code></a>, and <a href="#elemdef-smil-body"><code>body</code></a>
@@ -7405,7 +7405,7 @@ store destination as source in ocf
 					</aside>
 
 					<p>Media Overlays MAY use the applicable <a href="#sec-vocab-assoc">vocabulary association
-							mechanisms</a> for the <code>epub:type</code> attribute to define additinal semantics.</p>
+							mechanisms</a> for the <code>epub:type</code> attribute to define additional semantics.</p>
 				</section>
 
 				<section id="sec-docs-assoc-style">
@@ -7562,7 +7562,7 @@ html.-epub-media-overlay-playing * {
 					<p>While reading, users might want to turn on or off certain features of the content, such as
 						footnotes, page numbers, or other types of secondary content. This feature is called
 						skippability. Reading Systems use the semantic information provided by Media Overlay elements'
-							<a href="#sec-docs-semantic-inflection"><code>epub:type</code></a> attribute to determine
+							<a href="#sec-docs-structural-semantic"><code>epub:type</code></a> attribute to determine
 						when to offer users the option of skippable features.</p>
 
 					<aside class="example">
@@ -7886,17 +7886,16 @@ html.-epub-media-overlay-playing * {
 				</tbody>
 			</table>
 		</section>
-		<section id="app-semantic-inflection">
-			<h2>Semantic Inflection</h2>
+		<section id="app-structural-semantics">
+			<h2>Expressing Structural Semantics</h2>
 
-			<section id="sec-semantic-inflection-intro">
+			<section id="sec-structural-semantics-intro">
 				<h3>Introduction</h3>
 
-				<p>Semantic inflection is the process of attaching additional meaning about the specific structural
-					purpose an element plays. The <a href="#sec-epub-type-attribute"><code>epub:type</code>
-						attribute</a> is used to express domain-specific semantics in <a>EPUB Content Documents</a> and
-						<a>Media Overlay Documents</a>, with the inflection(s) it carries complementing the underlying
-					vocabulary.</p>
+				<p>Structural semantics add additional meaning about the specific structural purpose an element plays.
+					The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is used to express
+					domain-specific semantics in <a>EPUB Content Documents</a> and <a>Media Overlay Documents</a>, with
+					the structural information it carries complementing the underlying vocabulary.</p>
 
 				<p>The applied semantics are intended to refine the meaning of their containing elements; they are not
 					provided to override their nature (e.g., the attribute can be used to indicate a [[HTML]]
@@ -7908,9 +7907,9 @@ html.-epub-media-overlay-playing * {
 					content of a document (e.g., to enable <a href="#sec-behaviors-skip-escape">skippability and
 						escapability</a> in Media Ovelays).</p>
 
-				<p>This specification defines a method for semantic inflection using <em>the attribute axis</em>:
-					instead of adding new elements, the <code>epub:type</code> attribute can be appended to existing
-					elements to inflect the desired semantics.</p>
+				<p>This specification defines a method for adding structural semantics using <em>the attribute
+					axis</em>: instead of adding new elements, the <code>epub:type</code> attribute can be appended to
+					existing elements to add the desired semantics.</p>
 			</section>
 
 			<section id="sec-epub-type-attribute">
@@ -8014,10 +8013,9 @@ html.-epub-media-overlay-playing * {
 					<p>EPUB defines a formal method of referencing terms and properties defined in metadata and semantic
 						vocabularies using the <a href="#sec-property-datatype"><var>property</var> data type</a>. The
 							<code>epub:type</code> attribute uses this data type in <a>EPUB Content Documents</a> and
-							<a>Media Overlay Documents</a> to add <a href="#app-semantic-inflection">semantic
-							inflections</a>, for example, while the <code>property</code> and <code>rel</code>
-						attributes use the data type to define properties and relationships in the <a>Package
-							Document</a>.</p>
+							<a>Media Overlay Documents</a> to add <a href="#app-structural-semantics">structural
+							semantics</a>, for example, while the <code>property</code> and <code>rel</code> attributes
+						use the data type to define properties and relationships in the <a>Package Document</a>.</p>
 
 					<p>A <var>property</var> value is similar to a CURIE [[RDFA-CORE]] &#8212; it represents an IRI
 						[[RFC3987]] in compact form. The expression consists of a prefix and a reference, where the
@@ -8335,10 +8333,11 @@ html.-epub-media-overlay-playing * {
 							</table>
 						</dd>
 
-						<dt id="sec-content-reserved-prefixes">Semantic Inflection</dt>
+						<dt id="sec-content-reserved-prefixes">Structural Semantics</dt>
 						<dd>
-							<p>Authors MAY use the following reserved prefixes in the <a href="#app-semantic-inflection"
-										><code>epub:type</code> attribute</a> without having to declare them.</p>
+							<p>Authors MAY use the following reserved prefixes in the <a
+									href="#app-structural-semantics"><code>epub:type</code> attribute</a> without having
+								to declare them.</p>
 
 							<table id="tbl-reserved-prefixes" class="prefix">
 								<thead>
@@ -8979,6 +8978,10 @@ EPUB/images/cover.png</pre>
 					3.2</a></h3>
 
 				<ul>
+					<li>14-Nov-2020: The term "semantic inflection" is no longer used to describe the process of adding
+						structural semantics to elements. The term is not widely understood outside of EPUB, and is
+						unnecessarily complex. The specification now simply refers to "expressing" or "adding" structual
+						semantics.</li>
 					<li>9-Nov-2020: The requirement that the ordering of the <code>toc nav</code> match the ordering of
 						EPUB Content Documents in the spine, and the elements within each file, has been reduced to a
 						recommendation. See <a href="https://github.com/w3c/publ-epub-revision/issues/1283">issue

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -528,10 +528,10 @@
 				<section id="sec-xhtml-extensions">
 					<h4>HTML Extensions</h4>
 
-					<section id="sec-xhtml-semantic-inflection">
-						<h5>Semantic Inflection</h5>
+					<section id="sec-xhtml-structural-semantics">
+						<h5>Structural Semantics</h5>
 
-						<p>In addition to the requirements in <a href="#sec-semantic-inflection"></a>, a Reading System
+						<p>In addition to the requirements in <a href="#sec-structural-semantics"></a>, a Reading System
 							has to process the <code>epub:type</code> attribute as follows in XHTML Content
 							Documents:</p>
 
@@ -1708,7 +1708,7 @@
 						<h5>Skippability</h5>
 
 						<p>Reading Systems SHOULD use the semantic information provided by Media Overlay elements' <a
-								href="#sec-semantic-inflection"><code>epub:type</code> attribute</a> to determine when
+								href="#sec-structural-semantics"><code>epub:type</code> attribute</a> to determine when
 							to offer users the option of skippable features.</p>
 					</section>
 
@@ -1716,15 +1716,15 @@
 						<h5>Escapability</h5>
 
 						<p>Reading Systems SHOULD allow escaping of nested structures. Reading Systems MUST determine
-							the start of nested structures by the value of the <a href="#sec-semantic-inflection"
+							the start of nested structures by the value of the <a href="#sec-structural-semantics"
 									><code>epub:type</code> attribute</a> and SHOULD offer users the option to skip
 							playback of that structure and resume with whatever content comes after it.</p>
 					</section>
 				</section>
 			</section>
 		</section>
-		<section id="sec-semantic-inflection">
-			<h2>Semantic Inflection</h2>
+		<section id="sec-structural-semantics">
+			<h2>Expressing Structural Semantics</h2>
 
 			<p>A Reading System has to process the <code>epub:type</code> attribute as follows:</p>
 
@@ -1741,7 +1741,7 @@
 					<p id="confreq-rs-epubtype-ign">It MUST ignore terms that it does not recognize.</p>
 				</li>
 				<li>
-					<p id="confreq-rs-epubtype-conflict">It MUST <a href="#confreq-rs-epubtype-prec">ignore inflected
+					<p id="confreq-rs-epubtype-conflict">It MUST <a href="#confreq-rs-epubtype-prec">ignore structural
 							semantics</a> that conflict with the carrying element.</p>
 				</li>
 			</ul>


### PR DESCRIPTION
An attempt to rewrite some of the more duplicative/ambiguous titles so we won't have issues when respec adds references.

We have endless "introductions", but as they're rarely ever referenced I'm not concerned about their lack of context.

Most of the changes were in the package doc definition, fxl and media overlays sections.

The only slightly notable change is probably using "Structural Semantics" instead of "Semantic Inflection". Semantic inflection is the process, so keeping that title for where epub:type is defined. Structural semantics are what is being added, so used that where we're extending html/svg/smil.

Fixes #1375


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1425.html" title="Last updated on Nov 16, 2020, 12:12 PM UTC (7151e1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1425/358b499...7151e1b.html" title="Last updated on Nov 16, 2020, 12:12 PM UTC (7151e1b)">Diff</a>