### PR TITLE
Remove accessibility control and api

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -400,7 +400,7 @@
 			<section class="suppress-numbering" id="meta-006">
 				<h3>META-006: Identify ARIA Conformance</h3>
 
-				<p>The use of the <code>schem:accesibilityAPI</code> property is no longer necessary for EPUB
+				<p>The use of the <code>schema:accesibilityAPI</code> property is no longer necessary for EPUB
 					Publications. Authors are not responsible for the interaction between Reading Systems and the
 					underlying platform APIs.</p>
 
@@ -412,7 +412,7 @@
 			<section class="suppress-numbering" id="meta-007">
 				<h3>META-007: Identify Input Control Methods</h3>
 
-				<p>The use of the <code>schem:accesibilityControl</code> property is no longer necessary for EPUB
+				<p>The use of the <code>schema:accesibilityControl</code> property is no longer necessary for EPUB
 					Publications. This property does not differentiate issues arising from the Reading System interface
 					from those in the underlying content, which has led to confusion about its use.</p>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -400,70 +400,24 @@
 			<section class="suppress-numbering" id="meta-006">
 				<h3>META-006: Identify ARIA Conformance</h3>
 
-				<p>Users of Assistive Technologies can interact with EPUB Publications through the accessibility APIs
-					built into whichever platform they use (Windows, Mac, iOS, Linux, etc.). These APIs allow the
-					Assistive Technology to communicate with the Reading System to read the text or control the
-					interface, as needed.</p>
+				<p>The use of the <code>schem:accesibilityAPI</code> property is no longer necessary for EPUB
+					Publications. Authors are not responsible for the interaction between Reading Systems and the
+					underlying platform APIs.</p>
 
-				<p>Authors of static content do not have to worry about this interaction, as the user's Reading System
-					exposes the necessary information to the accessibility APIs (provided it has been developed to be
-					accessible). Authors who create EPUB Publications that contain dynamic content — such as scripting
-					and custom controls — do need to pay attention to the compatibility of such content, as Assistive
-					Technologies may not receive sufficient information to provide an accessible interface.</p>
-
-				<p>In the case of scripted content, the static picture of the content that an Assistive Technology
-					initially generates will not get updated unless the Author follows the accessibility practices in
-					[[WAI-ARIA-1.1]]. Similarly, although Assistive Technologies have access to information about native
-					[[HTML]] form elements (e.g., buttons and inputs), Authors often create custom elements whose state
-					is opaque without correct use of [[WAI-ARIA-1.1]] roles, state and properties  (e.g., checkboxes
-					made out of images). Users want to know that such content has been made compatible with Reading
-					System that support ARIA.</p>
-
-				<p>ARIA compatibility is identified in the [[schema-org]] <a href="https://schema.org/accessibilityAPI"
-							><code>accessibilityAPI</code> property</a>.</p>
-
-				<aside class="example">
-					<p>The following example shows that an EPUB Publication contains scripted content that is ARIA
-						compatible.</p>
-					<pre>&lt;meta property="schema:accessibilityAPI"&gt;ARIA&lt;/meta&gt;</pre>
-				</aside>
-
-				<p>Refer to the <a href="https://schema.org/accessibilityAPI"
-					><code>accessibilityAPI</code></a> definition in [[schema-org]] for more information about this
-					property and its values.</p>
+				<p>Meeting the requirements of [[WCAG20]] is a better measure of the accessibility of scripting, as this
+					property does not differentiate between ARIA markup used for document structure or for identifying
+					controls.</p>
 			</section>
 
 			<section class="suppress-numbering" id="meta-007">
 				<h3>META-007: Identify Input Control Methods</h3>
 
-				<p>Not everyone who reads an EPUB Publication uses the same input control methods. Not only will the
-					device affect the input method (e.g., mobile or desktop), but so will the user's physical abilities.
-					Users might use any number of input methods, from touch to mice to keyboards to voice controls and
-					on.</p>
+				<p>The use of the <code>schem:accesibilityControl</code> property is no longer necessary for EPUB
+					Publications. This property does not differentiate issues arising from the Reading System interface
+					from those in the underlying content, which has led to confusion about its use.</p>
 
-				<p>As a result, all users need to know what input controls work with the content, as it will affect not
-					only whether they can operate the content but on what devices.</p>
-
-				<p>Similar to the <a href="#meta-006">accessibility APIs</a>, the input control methods that can be used
-					to read an EPUB Publication are greatly influenced by the accessibility of the Reading System. It is
-					only when Authors include dynamic content that they assume a responsibility for ensuring that such
-					is accessible to different input control methods.</p>
-
-				<p>Compatible input controls are identified in the [[schema-org]] <a
-						href="https://schema.org/accessibilityControl"><code>accessibilityControl</code> property</a>.
-					Repeat this property for each input control method.</p>
-
-				<aside class="example">
-					<p>The following example shows that an EPUB Publication contains content that is touch, mouse, and
-						keyboard compatible.</p>
-					<pre>&lt;meta property="schema:accessibilityControl"&gt;fullTouchControl&lt;/meta&gt;
-&lt;meta property="schema:accessibilityControl"&gt;fullMouseControl&lt;/meta&gt;
-&lt;meta property="schema:accessibilityControl"&gt;fullKeyboardControl&lt;/meta&gt;</pre>
-				</aside>
-
-				<p>Refer to the <a href="https://schema.org/accessibilityControl"
-					><code>accessibilityControl</code></a> definition in [[schema-org]] for more information about this
-					property and its values.</p>
+				<p>Meeting the requirements of [[WCAG20]] will mitigate most known issues with the content and is
+					sufficient for authoring purposes.</p>
 			</section>
 
 			<section class="suppress-numbering" id="sec-meta-ex">

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1518,7 +1518,10 @@
 						Techniques 1.0</a></h3>
 
 				<ul>
-					<li>&#8230;</li>
+					<li>16-Nov-2020: The techniques for <a href="#meta-007">accessibility controls</a> and <a
+							href="#meta-006">APIs</a> have been replaced with descriptions of why these properties are
+						not necessary to set. See <a href="https://github.com/w3c/epub-specs/issues/1286">issue
+						1286</a>.</li>
 				</ul>
 			</section>
 

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -960,6 +960,9 @@
 				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
 
 				<ul>
+					<li>16-Nov-2020: References to the optional accessibility control and API metadata have been removed
+						from the discoverability section. These metadata properties are more applicable to Reading
+						Systems. See <a href="https://github.com/w3c/epub-specs/issues/1327">issue 1327</a>.</li>
 					<li>26-Sept-2020: The revisions made to the Accessibility 1.0 specification as part of publishing it
 						as an ISO standard have been incorporated into the initial draft text.</li>
 				</ul>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -245,24 +245,6 @@
 					</li>
 				</ul>
 
-				<p>EPUB Publications MAY include the following accessibility metadata:</p>
-
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-schema-accessibilityAPI">Accessibility application programming interfaces (APIs)
-							— to indicate the resource is compatible with the specified accessibility API. This property
-							is typically only used to indicate that the use of scripting in an EPUB Publication follows
-							Accessible Rich Internet Applications (WAI-ARIA) 1.1 [[!WAI-ARIA-11]] authoring practices,
-							as compatibility with operating system accessibility APIs is a concern for Reading
-							Systems.</p>
-					</li>
-
-					<li>
-						<p id="confreq-schema-accessibilityControl">Accessibility controls —input methods that can be
-							used to access the content (e.g., keyboard, mouse).</p>
-					</li>
-				</ul>
-
 				<p>Authors MAY include additional accessibility metadata not specified in this section.</p>
 
 				<div class="note">


### PR DESCRIPTION
Removes mention of accessibility controls and APIs from the accessibility specification and replaces their explanations in the techniques document with info on why they are no longer necessary to set.

Fixes #1327 
Fixes #1286 

- [Accessibility preview](https://raw.githack.com/w3c/epub-specs/fix/issue-1327/epub33/a11y/)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-1327%2Fepub33%2Fa11y%2Findex.html)
- [Techniques preview](https://raw.githack.com/w3c/epub-specs/fix/issue-1327/epub33/a11y-tech/)
- [Techniques diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y-tech%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-1327%2Fepub33%2Fa11y-tech%2Findex.html)
