### PR TITLE
Add clarifying note about inclusion of media overlays

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -565,6 +565,11 @@
 									href="https://www.w3.org/publishing/epub/core/#sec-nav-doc">EPUB Navigation
 									Document</a> [[EPUB-3]].</li>
 						</ul>
+
+						<div class="note">
+							<p>This criterion does not require Authors to include Media Overlays in their EPUB
+								Publications, only that they conform to these requirements when present.</p>
+						</div>
 					</section>
 
 					<section id="sec-mo-wcag" class="informative">


### PR DESCRIPTION
Adds the note text proposed in https://github.com/w3c/epub-specs/issues/1328#issuecomment-728166705

Fixes #1328 

- [Accessibility preview](https://raw.githack.com/w3c/epub-specs/editorial/issue-1328/epub33/a11y/)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Feditorial%2Fissue-1328%2Fepub33%2Fa11y%2Findex.html)
