### PR TITLE
Update certifierCredential and certifierReport

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -696,8 +696,10 @@
 							><code>a11y:certifierCredential</code> property</a>.</p>
 
 				<aside class="example">
-					<p>The following example shows a credential.</p>
-					<pre>&lt;meta property="a11y:certifierCredential"&gt;A+ Accessibility Rating&lt;/meta&gt;</pre>
+					<p>The following example shows a credential. The <code>refines</code> attribute is used to associate
+						the credential with the certifier.</p>
+					<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
+&lt;meta property="a11y:certifierCredential" refines="#certifier"&gt;A+ Accessibility Rating&lt;/meta&gt;</pre>
 				</aside>
 
 				<p>If the party that evaluates the content has provided a detailed report of its assessment, a link to
@@ -706,13 +708,15 @@
 
 				<aside class="example">
 					<p>The following example shows a link to a remotely hosted accessibility report.</p>
-					<pre>&lt;link rel="a11y:certifierReport"
+					<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
+&lt;link rel="a11y:certifierReport" refines="#certifier"
       href="http://www.example.com/a11y/report/9780000000001"/&gt;</pre>
 				</aside>
 
 				<aside class="example">
 					<p>The following example shows a link to a locally hosted accessibility report.</p>
-					<pre>&lt;link rel="a11y:certifierReport" href="reports/a11y.xhtml"/&gt;</pre>
+					<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
+&lt;link rel="a11y:certifierReport" refines="#certifier" href="reports/a11y.xhtml"/&gt;</pre>
 				</aside>
 
 
@@ -872,7 +876,7 @@
 							<tr>
 								<th>Description:</th>
 								<td>Identifies a party responsible for the testing and certification of the
-									accessibility of an EPUB Publication</td>
+									accessibility of an EPUB Publication.</td>
 							</tr>
 							<tr>
 								<th>Allowed value(s):</th>
@@ -906,7 +910,8 @@
 							<tr>
 								<th>Description:</th>
 								<td>Identifies a credential or badge that establishes the authority of the party
-									identified in the certifiedBy property to certify content accessible</td>
+									identified in the associated <a href="#certifiedBy"><code>certifiedBy</code>
+										property</a> to certify content accessible.</td>
 							</tr>
 							<tr>
 								<th>Allowed value(s):</th>
@@ -920,9 +925,16 @@
 
 							</tr>
 							<tr>
+								<th>Extends:</th>
+								<td>
+									<code>a11y:certifiedBy</code>
+								</td>
+							</tr>
+							<tr>
 								<th>Example:</th>
 								<td>
-									<pre>&lt;meta property="a11y:certifierCredential">DAISY OK&lt;/meta></pre>
+									<pre>&lt;meta property="a11y:certifiedBy" id="certifier">Accessibility Testers Group&lt;/meta>
+&lt;meta property="a11y:certifierCredential" refines="#certifier">DAISY OK&lt;/meta></pre>
 								</td>
 							</tr>
 						</table>
@@ -941,7 +953,7 @@
 							<tr>
 								<th>Description:</th>
 								<td>Provides a link to an accessibility report created by the party identified in the
-									certifiedBy property</td>
+									associated <a href="#certifiedBy"><code>certifiedBy</code> property</a>.</td>
 							</tr>
 							<tr>
 								<th>Allowed value(s):</th>
@@ -954,9 +966,18 @@
 								<td>Zero or more</td>
 							</tr>
 							<tr>
+								<th>Extends:</th>
+								<td>
+									<a href="#certifiedBy">
+										<code>certifiedBy</code>
+									</a>
+								</td>
+							</tr>
+							<tr>
 								<th>Example:</th>
 								<td>
-									<pre>&lt;link rel="a11y:certifierReport" href="http://example.com/a11y/reports/9780000000001"/></pre>
+									<pre>&lt;meta property="a11y:certifiedBy" id="certifier">Accessibility Testers Group&lt;/meta>
+&lt;link rel="a11y:certifierReport" refines="#certifier" href="http://example.com/a11y/reports/9780000000001"/></pre>
 								</td>
 							</tr>
 						</table>
@@ -978,6 +999,9 @@
 				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
 
 				<ul>
+					<li>17-Nov-2020: Added the <code>refines</code> attribute to the <code>certifierCredential</code>
+						and <code>certifierReport</code> properties and examples. See <a
+							href="https://github.com/w3c/epub-specs/issues/1410">issue 1410</a>.</li>
 					<li>26-Sept-2020: The revisions made to the Accessibility 1.0 specification as part of publishing it
 						as an ISO standard have been incorporated into the initial draft text.</li>
 				</ul>


### PR DESCRIPTION
This pull request makes the following changes for the `certifierCredential` and `certifierReport` properties:

- fixes the definitions to say "the associated certifiedBy property"
- adds the "Extends" field to the definition table to additionally specify these are only associated with `certifiedBy`
- updates all examples with the properties to link them to a certifier using the `refines` attribute

Fixes #1410 

[Accessibility preview](https://raw.githack.com/w3c/epub-specs/fix/issue-1410/epub33/a11y/)
[Accessibility diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-1410%2Fepub33%2Fa11y%2Findex.html)