### PR TITLE
Move renditions terminology and requirements to multiple renditions document

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -81,9 +81,6 @@
 						<a href="https://www.w3.org/publishing/epub3/core/#dfn-author">Author</a>
 					</li>
 					<li>
-						<a href="https://www.w3.org/publishing/epub3/core/#dfn-default-rendition">Default Rendition</a>
-					</li>
-					<li>
 						<a href="https://www.w3.org/publishing/epub3/core/#dfn-epub-content-document">EPUB Content
 							Document</a>
 					</li>
@@ -103,9 +100,6 @@
 					</li>
 					<li>
 						<a href="https://www.w3.org/publishing/epub3/core/#dfn-reading-system">Reading System</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/publishing/epub3/core/#dfn-rendition">Rendition</a>
 					</li>
 				</ul>
 
@@ -1224,7 +1218,7 @@
 			<section id="sec-wcag-alt">
 				<h3>Accessible Alternatives</h3>
 
-				<p>As EPUB Publications can be composed of more than one Rendition, it is possible that different
+				<p>As EPUB Publications can be composed of more than one rendition, it is possible that different
 					versions of the content will have different levels of accessibility. For example, an image-based
 					version of the content that lacks alternative text or descriptions could be bundled with a
 					WCAG-compliant text-based serialization. This type of accessible bundling is acceptable, as
@@ -1234,18 +1228,18 @@
 
 				<p>The [[EPUBMultipleRenditions-10]] specification defines a set of features for creating these types of
 					EPUB Publications. It specifies a set of attributes that allow a Reading System to automatically
-					select a preferred Rendition for the user or to provide the user the option to manually select
+					select a preferred rendition for the user or to provide the user the option to manually select
 					between the available options. This functionality technically meets the requirements of
 					[[WCAG20]] in terms of ensuring the user can access the accessible version.</p>
 
 				<p>In practice, however, the [[EPUBMultipleRenditions-10]] specification is not broadly supported in
 					Reading Systems at the time of publication. As a result, a user who obtains an EPUB Publication that
-					contains more than one Rendition will only have access to the Default Rendition. Unless this
-					Rendition is the accessible one, the EPUB Publication might not be readable by them.</p>
+					contains more than one rendition will only have access to the default. Unless this rendition is the
+					accessible one, the EPUB Publication might not be readable by them.</p>
 
 				<p>Authors therefore need to use their best discretion when implementing this functionality to meet
 					accessibility requirements. EPUB Publications that contain multiple renditions are conformant to the
-					[[EPUB-A11Y]] specification if at least one Rendition meets all the content requirements, but
+					[[EPUB-A11Y]] specification if at least one rendition meets all the content requirements, but
 					Authors at a minimum need to note that a Reading System that supports multiple renditions is
 					required in their <a href="#meta-005">accessibility summary</a>. Any other methods the Author can
 					use to make this dependence known is advisable (e.g., in the <a href="#dist-002">distribution

--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -15,6 +15,10 @@ ul.conformance-list {
 	padding-left: 0;
 }
 
+ul.conformance-list > li > ul.conformance-list {
+	padding-left: 2em;
+}
+
 dl.elemdef {
     border-left: 0.5em solid rgb(145,200,255);
     background-color: rgb(236,246,255);

--- a/epub33/common/js/biblio.js
+++ b/epub33/common/js/biblio.js
@@ -418,42 +418,53 @@ var biblio = {
 	
 	"EPUB-33": {
 		"authors":[
-		"Garth Conboy",
-		"Dave Cramer",
-		"Marisa DeMeglio",
-		"Matt Garrish",
-		"Daniel Weck"],
+			"Garth Conboy",
+			"Dave Cramer",
+			"Marisa DeMeglio",
+			"Matt Garrish",
+			"Daniel Weck"
+		],
 		"title": "EPUB 3.3",
 		"href": "https://www.w3.org/TR/epub-33/",
 		"publisher": "W3C"
 	},
 	"EPUB-RS-33": {
 		"authors":[
-		"Garth Conboy",
-		"Dave Cramer",
-		"Marisa DeMeglio",
-		"Matt Garrish",
-		"Daniel Weck"],
+			"Garth Conboy",
+			"Dave Cramer",
+			"Marisa DeMeglio",
+			"Matt Garrish",
+			"Daniel Weck"
+		],
 		"title": "EPUB Reading Systems 3.3",
 		"href": "https://www.w3.org/TR/epub-rs-33/",
 		"publisher": "W3C"
 	},
 	"EPUB-CHANGES-33": {
 		"authors":[
-		"Matt Garrish",
-		"Dave Cramer"],
+			"Matt Garrish",
+			"Dave Cramer"
+		],
 		"title": "EPUB Changes 3.3",
 		"href": "https://www.w3.org/TR/epub-changes-33/",
 		"publisher": "W3C"
 	},
 	"EPUB-OVERVIEW-33": {
 		"authors":[
-		"Garth Conboy",
-		"Matt Garrish",
-		"MURATA Makoto",
-		"Daniel Weck"],
+    		"Garth Conboy",
+    		"Matt Garrish",
+    		"MURATA Makoto",
+    		"Daniel Weck"],
 		"title": "EPUB 3 Overview",
 		"href": "https://www.w3.org/TR/epub-overview-33/",
+		"publisher": "W3C"
+	},
+	"EPUB-Multi-Rend-11": {
+		"authors":[
+    		"Matt Garrish"
+		],
+		"title": "EPUB Multiple Renditions 1.1",
+		"href": "https://www.w3.org/TR/epub-multi-rend-11/",
 		"publisher": "W3C"
 	}
 }

--- a/epub33/common/js/dfn-crossref.js
+++ b/epub33/common/js/dfn-crossref.js
@@ -32,7 +32,7 @@ function fixDefinitionCrossrefs() {
         var link_txt = link.hasAttribute('data-lt') ? link.getAttribute('data-lt').trim().replace(/\s+/g,' ').toLowerCase() : link.textContent.trim().replace(/\s+/g,' ').toLowerCase();
         
         if (dfn.hasOwnProperty(link_txt)) {
-            link.setAttribute('href','../core/index.html#dfn-'+dfn[link_txt]);
+            link.setAttribute('href','https://www.w3.org/TR/epub-33/index.html#dfn-'+dfn[link_txt]);
         }
     });
 }

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9,50 +9,50 @@
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
-			var respecConfig = {
-				group: "epub",
-				wgPublicList: "public-epub-wg",
-				specStatus: "ED",
-				shortName: "epub-33",
-				edDraftURI: "https://w3c.github.io/epub-specs/epub33/core/",
-				copyrightStart: "1999",
-				editors:[ {
-					name: "Garth Conboy",
-					company: "Google",
-					companyURL: "https://www.google.com"
-				},
-				{
-					name: "Dave Cramer",
-					company: "Hachette Livre",
-					companyURL: "https://www.hachettebookgroup.com",
-				},
-				{
-					name: "Marisa DeMeglio",
-					company: "DAISY Consortium",
-					companyURL: "https://www.daisy.org"
-				},
-				{
-					name: "Matt Garrish",
-					company: "DAISY Consortium",
-					companyURL: "https://www.daisy.org"
-				},
-				{
-					name: "Daniel Weck",
-					company: "DAISY Consortium",
-					companyURL: "https://www.daisy.org"
-				}],
-				includePermalinks: true,
-				permalinkEdge: true,
-				permalinkHide: false,
-				diffTool: "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
-				github: {
-					repoURL: "https://github.com/w3c/epub-specs",
-					branch: "master"
-				},
-				localBiblio: biblio,
-				preProcess:[inlineCustomCSS],
-				postProcess:[addConformanceLinks]
-			};//]]>
+            var respecConfig = {
+                group: "epub",
+                wgPublicList: "public-epub-wg",
+                specStatus: "ED",
+                shortName: "epub-33",
+                edDraftURI: "https://w3c.github.io/epub-specs/epub33/core/",
+                copyrightStart: "1999",
+                editors:[ {
+                    name: "Garth Conboy",
+                    company: "Google",
+                    companyURL: "https://www.google.com"
+                },
+                {
+                    name: "Dave Cramer",
+                    company: "Hachette Livre",
+                    companyURL: "https://www.hachettebookgroup.com",
+                },
+                {
+                    name: "Marisa DeMeglio",
+                    company: "DAISY Consortium",
+                    companyURL: "https://www.daisy.org"
+                },
+                {
+                    name: "Matt Garrish",
+                    company: "DAISY Consortium",
+                    companyURL: "https://www.daisy.org"
+                },
+                {
+                    name: "Daniel Weck",
+                    company: "DAISY Consortium",
+                    companyURL: "https://www.daisy.org"
+                }],
+                includePermalinks: true,
+                permalinkEdge: true,
+                permalinkHide: false,
+                diffTool: "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+                github: {
+                    repoURL: "https://github.com/w3c/epub-specs",
+                    branch: "master"
+                },
+                localBiblio: biblio,
+                preProcess:[inlineCustomCSS],
+                postProcess:[addConformanceLinks]
+            };//]]>
       </script>
 	</head>
 	<body>
@@ -103,9 +103,6 @@
 				<p>The informative <a href="epub-overview.html">EPUB 3 Overview</a> [[EPUB-OVERVIEW-33]] provides a
 					general introduction to EPUB 3. A list of technical changes from the previous version is also
 					available in the <a href="#change-log">change log</a>.</p>
-
-				<p>An <a href="#index">index to key concepts and definitions</a> is also provided at the end of this
-					specification.</p>
 			</section>
 
 			<section id="sec-intro-spec-org" class="informative">
@@ -114,46 +111,33 @@
 				<p>This section reviews the organization of the EPUB specifications through the central product they
 					define: the <a>EPUB Publication</a>.</p>
 
-				<p>An EPUB Publication consists of one or more <a>Renditions</a> of its content, each of which is
-					represented by what is called an <a>EPUB Package</a>. An EPUB Package consists of all the resources
-					needed to render the content. The key file among these is the <a>Package Document</a>, which
-					includes all the metadata used by <a>Reading Systems</a> to present the EPUB Publication to the user
-					(e.g., the title and author for display in a bookshelf, as well rendering metadata such as whether
-					content has a fixed layout or can be reflowed). It also provides a complete manifest of resources
-					and includes a <a>spine</a> that lists the sequence to render documents in as a user progresses
-					through the content.</p>
+				<p>An EPUB Publication is typically represented by a single <a>Package Document</a>. This document
+					includes metadata used by <a>Reading Systems</a> to present the content to the user, such as the
+					title and author for display in a bookshelf as well as rendering metadata (e.g., whether the content
+					is reflowable or has a fixed layout). It also provides a manifest of resources and includes a
+						<a>spine</a> that lists the default sequence in which to render documents as a user progresses
+					through the content. The requirements for the Package Document are defined in <a
+						href="#sec-package-doc"></a>.</p>
 
-				<p>An EPUB Package also include another key file called the <a>EPUB Navigation Document</a>. This
+				<p>An EPUB Publication also includes another key file called the <a>EPUB Navigation Document</a>. This
 					document provides critical navigation capabilities, such as the table of contents, that allow users
-					to navigate the content quickly and easilys.</p>
+					to navigate the content quickly and easily. This document is defined in <a href="#sec-nav"></a>.</p>
 
-				<p>The requirements for EPUB Packages are defined in <a href="#sec-packages"></a>.</p>
-
-				<p>The EPUB Publication's resources are bundled for distribution in a ZIP-based archive with the file
-					extension <code>.epub</code>. As conformant ZIP archives, EPUB Publications can be unzipped by many
-					software programs, simplifying both their production and consumption.</p>
-
-				<p>The container format not only provides a means of determining that the zipped content represents an
-					EPUB Publication (the <code>mimetype</code> file), but also provides a universally-named directory
-					of informative resources (<code>/META-INF</code>). Key among these resources is the
-						<code>container.xml</code> file, which directs Reading Systems to the available Package
-					Documents.</p>
-
-				<p>The container format is defined in <a href="#sec-ocf"></a>.</p>
-
+				<!--
 				<figure>
 					<figcaption> The following example visually represents the structure of the EPUB format. </figcaption>
 					<object data="images/epub.svg" width="350">
 						<img src="images/epub.png" width="350" alt="" />
 					</object>
 				</figure>
+-->
 
-				<p>The structure and containment of an EPUB Publication is only one half of the format, the other half
-					being the content that gets presented to users. This content is built on the Open Web Platform and
-					comes in two flavors: <a data-lt="XHTML Content Document">XHTML</a> and <a
-						data-lt="SVG Content Document">SVG</a>. Called <a>EPUB Content Documents</a>, these documents
-					typically reference many additional resources required for their proper rendering, such as images,
-					audio and video clips, scripts, and style sheets.</p>
+				<p>The actual content of an EPUB Publication &#8212; what users are presented with when they begin
+					reading &#8212; is built on the Open Web Platform and comes in two flavors: <a
+						data-lt="XHTML Content Document">XHTML</a> and <a data-lt="SVG Content Document">SVG</a>. Called
+						<a>EPUB Content Documents</a>, these documents typically reference many additional resources
+					required for their proper rendering, such as images, audio and video clips, scripts, and style
+					sheets.</p>
 
 				<p>Detailed information about the rules and requirements to produce EPUB Content Documents is provided
 					in <a href="#sec-contentdocs"></a>, and accessibility requirements are defined in
@@ -164,6 +148,16 @@
 					to create a read-aloud experience where text is highlighted as it is narrated. Media Overlay
 					Documents are defined in <a href="#sec-media-overlays"></a>.</p>
 
+				<p>The EPUB Publication's resources are bundled for distribution in a ZIP-based archive with the file
+					extension <code>.epub</code>. As conformant ZIP archives, EPUB Publications can be unzipped by many
+					software programs, simplifying both their production and consumption.</p>
+
+				<p>The container format not only provides a means of determining that the zipped content represents an
+					EPUB Publication (the <code>mimetype</code> file), but also provides a universally-named directory
+					of informative resources (<code>/META-INF</code>). Key among these resources is the
+						<code>container.xml</code> file, which directs Reading Systems to the available Package
+					Documents. The container format is defined in <a href="#sec-ocf"></a>.</p>
+
 				<p>While conceptually simple, an EPUB Publication is more than just a collection of HTML pages and
 					dependent assets in a ZIP package as presented here. Additional information about the primary
 					features and functionality that EPUB Publications provide to enhance the reading experience is
@@ -171,8 +165,8 @@
 					EPUB 3 is provided in the informative [[EPUB-OVERVIEW-33]].</p>
 
 				<p>The processing requirements for <a>Reading Systems</a> are defined in [[EPUB-RS-33]]. Although it is
-					not necessary that Authors read this document to create EPUB Publications, an understanding of how
-					Reading Systems have to present the content can help craft publications for optimal presentation to
+					not necessary that Authors read that document to create EPUB Publications, an understanding of how
+					Reading Systems present the content can help craft publications for optimal presentation to
 					users.</p>
 			</section>
 
@@ -280,18 +274,15 @@
 								href="#sec-foreign-restrictions">fallback</a> (cf. <a>Foreign Resource</a>).</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-default-rendition" data-lt="Default Renditions">Default Rendition</dfn>
-					</dt>
-					<dd>
-						<p>The <a>Rendition</a> listed in the first <code>rootfile</code> element in the <a
-								href="#sec-container-metainf-container.xml">container.xml</a> file.</p>
-					</dd>
-					<dt>
 						<dfn id="dfn-epub-container" data-lt="EPUB Containers">EPUB Container</dfn>
+					</dt>
+					<dt>
+						<dfn id="dfn-zip-container">OCF ZIP Container</dfn>
 					</dt>
 					<dd>
 						<p>The ZIP-based packaging and distribution format for <a>EPUB Publications</a> defined in <a
 								href="#sec-container-zip"></a>.</p>
+						<p>EPUB Container and OCF ZIP Container are synonymous.</p>
 					</dd>
 					<dt>
 						<dfn id="dfn-epub-content-document" data-lt="EPUB Content Documents">EPUB Content Document</dfn>
@@ -302,9 +293,8 @@
 							resources have to conform to their respective <a data-lt="XHTML Content Document">XHTML</a>
 							or <a data-lt="SVG Content Document">SVG</a> definitions to be used in the spine or be
 							referenced from another EPUB Content Document.</p>
-						<p>An EPUB Content Document is a <a>Core Media Type Resource</a>, so can be included in the
-								<a>EPUB Publication</a> without the provision of <a href="#sec-foreign-restrictions"
-								>fallbacks</a>.</p>
+						<p>An EPUB Content Document is a <a>Core Media Type Resource</a>, so can be included without the
+							provision of <a href="#sec-foreign-restrictions">fallbacks</a>.</p>
 					</dd>
 					<dt>
 						<dfn id="dfn-epub-navigation-document" data-lt="EPUB Navigation Documents">EPUB Navigation
@@ -316,21 +306,13 @@
 							constraints expressed in <a href="#sec-nav"></a>.</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-epub-package" data-lt="EPUB Packages">EPUB Package</dfn>
-					</dt>
-					<dd>
-						<p>A logical document entity consisting of a set of interrelated <a
-								data-lt="Publication Resource">resources</a> representing one <a>Rendition</a> of an
-								<a>EPUB Publication</a>, as defined by a <a>Package Document</a>.</p>
-					</dd>
-					<dt>
 						<dfn id="dfn-epub-publication" data-lt="EPUB Publications">EPUB Publication</dfn>
 					</dt>
 					<dd>
-						<p>A collection of one or more <a>Renditions</a> that conform to this specification, packaged in
-							an <a>EPUB Container</a>.</p>
+						<p>A logical document entity consisting of a set of interrelated <a
+								data-lt="Publication Resource">resources</a> packaged in an <a>EPUB Container</a>.</p>
 						<p>An EPUB Publication typically represents a single intellectual or artistic work, but this
-							specification does not circumscribe the nature of the content.</p>
+							specification does not restrict the nature of the content.</p>
 					</dd>
 					<dt><dfn id="dfn-epub-reading-system" data-lt="EPUB Reading Systems|Reading System|Reading Systems"
 							>EPUB Reading System</dfn> (or Reading System)</dt>
@@ -349,11 +331,9 @@
 						<dfn id="dfn-fixed-layout-document" data-lt="Fixed-Layout Documents">Fixed-Layout Document</dfn>
 					</dt>
 					<dd>
-						<p>An <a>EPUB Content Document</a> directly referenced from the <a>spine</a> that has been
-							designated <code>pre-paginated</code> in the <a>Package Document</a>, as defined in <a
-								href="#layout"></a>.</p>
-						<p>The dimensions to use for rendering Fixed-Layout Documents are defined in <a
-								href="#sec-fixed-layouts"></a>.</p>
+						<p>An <a>EPUB Content Document</a> with fixed dimensions directly referenced from the
+								<a>spine</a>. Fixed-Layout Documents are designated <code>pre-paginated</code> in the
+								<a>Package Document</a>, as defined in <a href="#sec-fixed-layouts"></a>.</p>
 					</dd>
 					<dt>
 						<dfn id="dfn-foreign-resource" data-lt="Foreign Resources">Foreign Resource</dfn>
@@ -375,8 +355,7 @@
 						<dfn id="dfn-manifest" data-lt="Manifests">Manifest</dfn>
 					</dt>
 					<dd>
-						<p>A list of all <a>Publication Resources</a> that constitute the given <a>Rendition</a> of a
-								<a>EPUB Publication</a>.</p>
+						<p>The section of the <a>Package Document</a> that lists the <a>Publication Resources</a>.</p>
 						<p>Refer to <a href="#sec-manifest-elem"></a> for more information.</p>
 					</dd>
 					<dt>
@@ -387,15 +366,6 @@
 						<p>An XML document that associates the <a>XHTML Content Document</a> with pre-recorded audio
 							narration to provide a synchronized playback experience, as defined in <a
 								href="#sec-media-overlays"></a>.</p>
-					</dd>
-					<dt>
-						<dfn id="dfn-package-document" data-lt="Package Documents">Package Document</dfn>
-					</dt>
-					<dd>
-						<p>A <a>Publication Resource</a> that describes one <a>Rendition</a> of an <a>EPUB
-								Publication</a>, as defined in <a href="#sec-package-doc"></a>. The Package Document
-							carries meta information about the Rendition, provides a manifest of resources and defines
-							the default reading order.</p>
 					</dd>
 					<dt>
 						<dfn id="dfn-non-codec" data-lt="Non-Codecs">Non-Codec</dfn>
@@ -414,12 +384,13 @@
 								Container</a>, as defined in <a href="#sec-container-abstract"></a>.</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-zip-container" data-lt="OCF ZIP Containers">OCF ZIP Container</dfn>
+						<dfn id="dfn-package-document" data-lt="Package Documents|Package Document(s)">Package Document</dfn>
 					</dt>
 					<dd>
-						<p>The ZIP-based packaging and distribution format for EPUB Publications, as defined in <a
-								href="#sec-container-zip"></a>.</p>
-						<p>OCF ZIP Container and <a>EPUB Container</a> are synonymous.</p>
+						<p>A <a>Publication Resource</a> that describes the rendering of an <a>EPUB Publication</a>, as
+							defined in <a href="#sec-package-doc"></a>. The Package Document carries meta information
+							about the EPUB Publication, provides a manifest of resources and defines a default reading
+							order.</p>
 					</dd>
 					<dt>
 						<dfn id="dfn-path-name" data-lt="Path Names">Path Name</dfn>
@@ -439,28 +410,19 @@
 					</dt>
 					<dd>
 						<p>A resource that contains content or instructions that contribute to the logic and rendering
-							of at least one <a>Rendition</a> of an <a>EPUB Publication</a>. In the absence of this
-							resource, the EPUB Publication might not render as intended by the <a>Author</a>. Examples
-							of Publication Resources include a Rendition's <a>Package Document</a>, <a>EPUB Content
-								Document</a>, CSS Style Sheets, audio, video, images, embedded fonts, and scripts.</p>
-						<p>Except for the Package Document itself, the Publication Resources necessary to render a
-							Rendition are listed in that Rendition's <a href="#sec-manifest-elem">manifest</a> and
-							bundled in the <a>EPUB Container</a> file (unless specified otherwise in <a
-								href="#sec-resource-locations"></a>).</p>
+							of an <a>EPUB Publication</a>. In the absence of this resource, the EPUB Publication might
+							not render as intended by the <a>Author</a>. Examples of Publication Resources include the
+								<a>Package Document</a>, <a>EPUB Content Document</a>, CSS Style Sheets, audio, video,
+							images, embedded fonts, and scripts.</p>
+						<p>Publication Resources are listed in the Package Document <a href="#sec-manifest-elem"
+								>manifest</a> and bundled in the <a>EPUB Container</a> file unless specified otherwise
+							in <a href="#sec-resource-locations"></a>.</p>
 						<p>Examples of resources that are not Publication Resources include those identified by the
 							Package Document <a href="#sec-link-elem"><code>link</code> element</a> and those identified
 							in outbound hyperlinks that resolve to <a>Remote Resources</a> (e.g., referenced from the
 								<code>href</code> attribute of an [[!HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
 									><code>a</code></a> element).</p>
-					</dd>
-					<dt>
-						<dfn id="dfn-release-identifier" data-lt="Release Identifiers">Release Identifier</dfn>
-					</dt>
-					<dd>
-						<p>The Release Identifier allows any instance of an <a>EPUB Publication</a> to be compared
-							against another to determine if they are identical, different versions, or unrelated.</p>
-						<p>Refer to <a href="#sec-metadata-elem-identifiers-pid"></a> for more information.</p>
 					</dd>
 					<dt>
 						<dfn id="dfn-remote-resource" data-lt="Remote Resources">Remote Resource</dfn>
@@ -472,14 +434,7 @@
 							locations.</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-rendition" data-lt="Renditions">Rendition</dfn>
-					</dt>
-					<dd>
-						<p>One rendering of the content of an <a>EPUB Publication</a>, as expressed by an <a>EPUB
-								Package</a>.</p>
-					</dd>
-					<dt>
-						<dfn id="dfn-root-directory" data-lt="Root Directories">Root Directory</dfn>
+						<dfn id="dfn-root-directory">Root Directory</dfn>
 					</dt>
 					<dd>
 						<p>The root directory represents the base of the <a>OCF Abstract Container</a> file system. This
@@ -488,8 +443,7 @@
 							unzipped.</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-scripted-content-document" data-lt="Scripted Content Documents">Scripted Content
-							Document</dfn>
+						<dfn id="dfn-scripted-content-document" data-lt="Scripted Content Documents">Scripted Content Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> that includes scripting or an <a>XHTML Content Document</a>
@@ -498,12 +452,12 @@
 						<p>Refer to <a href="#sec-scripted-content"></a> for more information.</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-spine" data-lt="Spines">Spine</dfn>
+						<dfn id="dfn-spine">Spine</dfn>
 					</dt>
 					<dd>
-						<p>An ordered list of <a>Publication Resources</a>, <a href="#confreq-spine-itemtypes">typically
-								EPUB Content Documents</a>, representing the default reading order of the given
-								<a>Rendition</a> of an EPUB Publication.</p>
+						<p>An ordered list of <a>Publication Resources</a> in the <a>Package Document</a>, <a
+								href="#confreq-spine-itemtypes">typically EPUB Content Documents</a>, that represent the
+							default reading order.</p>
 						<p>Refer to <a href="#sec-spine-elem"></a> for more information.</p>
 					</dd>
 					<dt>
@@ -525,33 +479,30 @@
 							using a synthesized voice.</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-top-level-content-document" data-lt="Top-level Content Documents">Top-level Content
-							Document</dfn>
+						<dfn id="dfn-top-level-content-document">Top-level Content Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> referenced from the <a>spine</a>, whether directly or via a
 								<a href="#sec-foreign-restrictions-manifest">fallback chain</a>.</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-unique-identifier" data-lt="Unique Identifiers">Unique Identifier</dfn>
+						<dfn id="dfn-unique-identifier">Unique Identifier</dfn>
 					</dt>
 					<dd>
-						<p>The Unique Identifier is the primary identifier for an <a>EPUB Publication</a>, as identified
-							by the <a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
-								attribute</a>. The Unique Identifier can be shared by one or more <a>Renditions</a> of
-							the same EPUB Publication.</p>
+						<p>The primary identifier for an <a>EPUB Publication</a> in the <a>Package Document</a>, as
+							identified by the <a href="#attrdef-package-unique-identifier"
+									><code>unique-identifier</code> attribute</a>.</p>
 						<p>Significant revision, abridgement, etc. of the content requires a new Unique Identifier.</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-viewport" data-lt="Viewports">Viewport</dfn>
+						<dfn id="dfn-viewport">Viewport</dfn>
 					</dt>
 					<dd>
 						<p>The region of an <a>EPUB Reading System</a> in which an <a>EPUB Publication</a> is rendered
 							visually to a user.</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-xhtml-content-document" data-lt="XHTML Content Documents">XHTML Content
-							Document</dfn>
+						<dfn id="dfn-xhtml-content-document" data-lt="XHTML Content Documents">XHTML Content Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> that conforms to the profile of [[!HTML]] defined in <a
@@ -561,7 +512,6 @@
 							in [[!HTML]].</p>
 					</dd>
 				</dl>
-
 			</section>
 
 			<section id="conformance"></section>
@@ -614,19 +564,34 @@
 			<section id="sec-epub-conf">
 				<h3>Conformance Criteria</h3>
 
-				<p>The basic requirements for an EPUB Publication are that:</p>
+				<p>The minimal requirements for an EPUB Publication are that:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-packages">It MUST include one or more <a href="#sec-packages">EPUB
-							Packages</a>.</p>
+						<p id="confreq-package">It MUST define at least one rendering of its content as follows:</p>
+						<ul class="conformance-list">
+							<li>
+								<p id="confreq-package-doc">It MUST contain a <a>Package Document</a> that conforms to
+										<a href="#sec-package-doc"></a> and meet all <a>Publication Resource</a>
+									requirements for the Package Document.</p>
+							</li>
+							<li>
+								<p id="confreq-nav">It MUST contain an <a>EPUB Navigation Document</a> that conforms to
+										<a href="#sec-nav-doc"></a>.</p>
+							</li>
+						</ul>
+					</li>
+					<li>
+						<p id="confreq-res-location">Its Publication Resources MUST adhere to the requirements in <a
+								href="#sec-publication-resources"></a>.</p>
 					</li>
 					<li>
 						<p id="confreq-a11y">It SHOULD conform to the accessibility requirements defined in
 							[[!EPUB-A11Y-10]].</p>
 					</li>
 					<li>
-						<p id="confreq-ocf">It MUST be packaged in an <a href="#sec-ocf">OCF Container</a>.</p>
+						<p id="confreq-ocf">It MUST be packaged in an <a>EPUB Container</a> as defined in <a
+								href="#sec-ocf"></a>.</p>
 					</li>
 				</ul>
 
@@ -642,10 +607,9 @@
 					<section id="sec-cmt-intro">
 						<h5>Introduction</h5>
 
-						<p>Each <a>Rendition</a> of an <a>EPUB Publication</a> typically consists of many <a>Publication
-								Resources</a>. These resources are divided into two categories: those that can be
-							included without fallbacks (<a>Core Media Type Resources</a>) and those that cannot
-								(<a>Foreign Resources</a>).</p>
+						<p>An <a>EPUB Publication</a> typically consists of many <a>Publication Resources</a>. These
+							resources are divided into two categories: those that can be included without fallbacks
+								(<a>Core Media Type Resources</a>) and those that cannot (<a>Foreign Resources</a>).</p>
 
 						<p>Formats are typically only included as Core Media Type Resources when it can be shown that
 							they have broad support in web browser cores &#8212; the rendering engines on which EPUB 3
@@ -662,7 +626,7 @@
 
 						<p>Foreign Resources come with no guarantee of rendering support, which is why they require a
 							fallback to a Core Media Type Resource. EPUB Publications are designed to be fully
-							consumable on any compliant Reading System, so providing a fallback is necessary to ensure
+							consumable on any conforming Reading System, so providing a fallback is necessary to ensure
 							that the use of Foreign Resources does not impact on the ability of the user to consume the
 							content.</p>
 
@@ -1002,9 +966,8 @@
 					</div>
 
 					<div class="note">
-						<p>The inclusion of Remote Resources in an <a>EPUB Publication</a> is indicated via the <a
-								href="#remote-resources"><code>remote-resources</code> property</a> on the
-								<a>manifest</a>
+						<p>The inclusion of Remote Resources is indicated via the <a href="#remote-resources"
+									><code>remote-resources</code> property</a> on the <a>manifest</a>
 							<a href="#sec-item-elem"><code>item</code> element</a>.</p>
 					</div>
 				</section>
@@ -1055,26 +1018,6 @@
 					</div>
 				</section>
 			</section>
-		</section>
-		<section id="sec-packages">
-			<h2>EPUB Packages</h2>
-
-			<section id="sec-package-construction">
-				<h3>Package Construction</h3>
-
-				<p>An EPUB Package has the following requirements:</p>
-
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-package">It MUST contain exactly one <a>Package Document</a>, including all
-							content requirements defined in <a href="#sec-package-doc"></a>.</p>
-					</li>
-					<li>
-						<p id="confreq-nav">It MUST contain exactly one <a href="#sec-nav-doc">EPUB Navigation
-								Document</a>.</p>
-					</li>
-				</ul>
-			</section>
 
 			<section id="sec-package-doc">
 				<h3>Package Document</h3>
@@ -1083,26 +1026,25 @@
 					<h4>Introduction</h4>
 
 					<p>The <a>Package Document</a> is an XML document that consists of a set of elements that each
-						encapsulate information about a particular aspect of the <a>EPUB Package</a>. These elements
-						serve to centralize metadata, detail the individual resources that compose the Package and
-						provide the reading order and other information necessary to render the <a>Rendition</a>.</p>
+						encapsulate information about a particular aspect of an <a>EPUB Publication</a>. These elements
+						serve to centralize metadata, detail the individual resources, and provide the reading order and
+						other information necessary for its rendering.</p>
 
 					<p>The following list summarizes the information found in the Package Document:</p>
 
 					<ul>
 						<li>
 							<p><a href="#sec-pkg-metadata">Metadata</a> — mechanisms to include and/or reference
-								metadata applicable to the given Rendition of the <a>EPUB Publication</a>.</p>
+								metadata.</p>
 						</li>
 						<li>
-							<p>A <a href="#sec-manifest-elem">manifest</a> — identifies (via IRI [[RFC3987]]) and
-								describes (via MIME media type [[RFC4839]]) the set of resources that collectively
-								compose the given Rendition.</p>
+							<p>A <a href="#sec-manifest-elem">manifest</a> — identifies via IRI [[RFC3987]], and
+								describes via MIME media type [[RFC4839]], the set of <a>Publication Resources</a>.</p>
 						</li>
 						<li>
 							<p>A <a href="#sec-spine-elem">spine</a> — an ordered sequence of ID references to top-level
 								resources in the manifest from which all other resources in the set can be reached or
-								utilized. The spine defines the default reading order of the given Rendition.</p>
+								utilized. The spine defines the default reading order.</p>
 						</li>
 						<li>
 							<p><a href="#sec-collection-elem">Collections</a> — a method of encapsulating and
@@ -1115,6 +1057,12 @@
 								rendering.</p>
 						</li>
 					</ul>
+
+					<div class="note">
+						<p>An EPUB Publication can reference more than one Package Document, allowing for alternative
+							representations of the content. For more information, refer to <a
+								href="#sec-container-metainf-container.xml"></a></p>
+					</div>
 				</section>
 
 				<section id="sec-package-def">
@@ -1130,9 +1078,7 @@
 					<section id="sec-package-elem">
 						<h5>The <code>package</code> Element</h5>
 
-						<p>The <code>package</code> element is the root element of the <a>Package Document</a> and
-							defines various aspects of the <a>EPUB Package</a> (see the <a href="#sec-package-intro"
-								>introduction</a> for a general overview).</p>
+						<p>The <code>package</code> element is the root element of the <a>Package Document</a>.</p>
 
 						<dl id="elemdef-opf-package" class="elemdef">
 							<dt>Element Name</dt>
@@ -1257,8 +1203,8 @@
 						</dl>
 
 						<p id="attrdef-package-version">The <code>version</code> attribute specifies the EPUB
-							specification version to which the given EPUB Package conforms. The attribute MUST have the
-							value "<code>3.0</code>" to indicate conformance with EPUB 3.</p>
+							specification version to which the given EPUB Publication conforms. The attribute MUST have
+							the value "<code>3.0</code>" to indicate conformance with EPUB 3.</p>
 
 						<div class="note">
 							<p>Updates to this specification do not represent new versions of EPUB 3 (i.e., each new 3.X
@@ -1270,8 +1216,7 @@
 						<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an
 							IDREF [[!XML]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"
 									><code>dc:identifier</code></a> element that provides the preferred, or primary,
-							identifier. Refer to <a href="#sec-package-metadata-identifiers"></a> for more
-							information.</p>
+							identifier.</p>
 
 						<p id="attrdef-package-prefix">The <code>prefix</code> attribute provides a declaration
 							mechanism for prefixes not <a href="#sec-metadata-reserved-prefixes">reserved by this
@@ -1435,8 +1380,7 @@
 						<section id="sec-metadata-elem">
 							<h6>The <code>metadata</code> Element</h6>
 
-							<p>The <code>metadata</code> element encapsulates meta information for the given
-									<a>Rendition</a>.</p>
+							<p>The <code>metadata</code> element encapsulates meta information.</p>
 
 							<dl id="elemdef-opf-metadata" class="elemdef">
 								<dt>Element Name</dt>
@@ -1527,8 +1471,8 @@
 								</li>
 								<li>
 									<p>to provide access to all rendering metadata needed to control the layout and
-										display of the Rendition's content (e.g., <a href="#sec-fxl-package"
-											>fixed-layout properties</a>).</p>
+										display of the content (e.g., <a href="#sec-fxl-package">fixed-layout
+											properties</a>).</p>
 								</li>
 							</ol>
 
@@ -1565,9 +1509,9 @@
 							</aside>
 
 							<p>The <a href="#sec-meta-elem"><code>meta</code> element</a> provides a generic mechanism
-								for including metadata properties from any vocabulary. It is typically used to include
-								rendering metadata defined in EPUB specifications, but MAY be used for any metadata
-								purposes.</p>
+								for including <a href="#sec-vocab-assoc">metadata properties from any vocabulary</a>. It
+								is typically used to include rendering metadata defined in EPUB specifications, but MAY
+								be used for any metadata purposes.</p>
 
 							<div class="note">
 								<p>See [[EPUB-A11Y-10]] for accessibility metadata recommendations.</p>
@@ -1581,9 +1525,9 @@
 							<section id="sec-opf-dcidentifier">
 								<h6>The <code>identifier</code> Element</h6>
 
-								<p>The [[!DC11]] <code>identifier</code> element contains an identifier associated with
-									the given <a>Rendition</a>, such as a <abbr title="Universally Unique Identifier"
-										>UUID</abbr>, <abbr title="Digital Object Identfier">DOI</abbr> or <abbr
+								<p>The [[!DC11]] <code>identifier</code> element contains an identifier such as a <abbr
+										title="Universally Unique Identifier">UUID</abbr>, <abbr
+										title="Digital Object Identfier">DOI</abbr> or <abbr
 										title="International Standard Book Number">ISBN</abbr>.</p>
 
 								<dl id="elemdef-opf-dcidentifier" class="elemdef">
@@ -1623,15 +1567,16 @@
 									</dd>
 								</dl>
 
-								<p>The <code>metadata</code> section MUST include an <code>identifier</code> element
-									that contains an unambiguous identifier for the Rendition. This identifier MUST be
-									marked as the <a>Unique Identifier</a> via the <code>package</code> element <a
-										href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
+								<p>The <a>Author</a> MUST provide a primary identifier that is unique to one and only
+									one <a>EPUB Publication</a> in the <a href="#sec-opf-dcidentifier"
+											><code>dc:identifier</code> element</a>. This identifier MUST be referenced
+									as the Unique Identifier in the <a href="#elemdef-opf-package"><code>package</code>
+										element's</a>
+									<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
 										attribute</a>.</p>
 
 								<aside class="example">
-									<p>The following example shows the unique <code>identifier</code> element for an
-										EPUB Publication.</p>
+									<p>The following example shows the unique <code>identifier</code> element.</p>
 									<pre>&lt;package … unique-identifier="pub-id"&gt;
     &lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
         &lt;dc:identifier id="pub-id"&gt;
@@ -1642,31 +1587,19 @@
 &lt;/package&gt;</pre>
 								</aside>
 
-								<p>The Unique Identifier for each Rendition MAY differ, and a Rendition MAY include
-									additional identifier elements.</p>
+								<p>Although not static, changes to the Unique Identifier for an EPUB Publication SHOULD
+									be made as infrequently as possible. Unique Identifiers are intended to have maximal
+									persistence both for referencing and distribution purposes. New identifiers SHOULD
+									NOT be issued when making minor revisions such as updating metadata, fixing errata,
+									or making similar minor changes.</p>
 
-								<p>To differentiate different versions of the same EPUB Publication, this specification
-									makes a distinction between the <a>Unique Identifier</a> for an EPUB Publication and
-									the <a>Release Identifier</a> that uniquely identifies a specific version of it.</p>
+								<div class="note">
+									<p>To differentiate versions of an EPUB Publication with the same Unique Identifier,
+										this specification also defines a <a href="#sec-metadata-elem-identifiers-pid"
+											>release identifier</a>.</p>
+								</div>
 
-								<p>To identify a specific version of a packaged EPUB Publication, a Release Identifier
-									can be constructed by combining the Unique Identifier with the <a
-										href="#last-modified-date">last modified date</a> of the Rendition. For more
-									information on the semantics and requirements of the Release Identifier, refer to <a
-										href="#sec-metadata-elem-identifiers-pid"></a>.</p>
-
-								<aside class="example">
-									<p>The following example shows the two components of the Release Identifier.</p>
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    &lt;dc:identifier id="pub-id"&gt;
-        urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
-    &lt;/dc:identifier&gt;
-    &lt;meta property="dcterms:modified"&gt;2016-01-01T00:00:01Z&lt;/meta&gt;
-    …
-&lt;/metadata&gt;</pre>
-								</aside>
-
-								<p>Whenever a Rendition is modified, it MUST include a new last modified date.</p>
+								<p>Authors MAY include additional identifiers.</p>
 
 								<p>The <a href="#identifier-type"><code>identifier-type</code> property</a> is used to
 									indicate that an <code>identifier</code> conforms to an established system or has
@@ -1686,16 +1619,15 @@
 
 								<p>This specification imposes no additional restrictions or the requirements of the
 									identifier except that it MUST be at least one character in length after white space
-									has been trimmed. It is strongly encouraged that the identifier be a fully qualified
+									has been trimmed. It is strongly advised that the identifier be a fully qualified
 									URI, however.</p>
-
 							</section>
 
 							<section id="sec-opf-dctitle">
 								<h6>The <code>title</code> Element</h6>
 
-								<p>The [[!DC11]] <code>title</code> element represents an instance of a name given to
-									the <a>EPUB Publication</a>.</p>
+								<p>The [[!DC11]] <code>title</code> element represents an instance of a name for the
+										<a>EPUB Publication</a>.</p>
 
 								<dl id="elemdef-opf-dctitle" class="elemdef">
 									<dt>Element Name</dt>
@@ -1784,8 +1716,6 @@
 </pre>
 								</aside>
 
-								<p>The title for each <a>Rendition</a> MAY differ.</p>
-
 								<p>This specification imposes no additional restrictions or requirements on the title
 									except that it MUST be at least one character in length after white space has been
 									trimmed.</p>
@@ -1795,8 +1725,7 @@
 								<h6>The <code>language</code> Element</h6>
 
 								<p>The [[!DC11]] <code>language</code> element specifies the language of the content of
-									the given <a>Rendition</a>. This value is not inherited by the individual resources
-									of the Rendition.</p>
+									the <a>EPUB Publication</a>.</p>
 
 								<dl id="elemdef-opf-dclanguage" class="elemdef">
 									<dt>Element Name</dt>
@@ -1834,6 +1763,8 @@
 								<p>The <code>metadata</code> section MUST include at least one <code>language</code>
 									element with a value conforming to [[!BCP47]].</p>
 
+								<p>This value is not inherited by <a>Publication Resources</a>.</p>
+
 								<aside class="example">
 									<p>The following example shows an <a>EPUB Publication</a> is in U.S. English.</p>
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
@@ -1847,9 +1778,7 @@
 								<p>Additional <code>language</code> elements MAY be included for multilingual
 									Publications, but each element's value MUST conform to [[!BCP47]]. The first
 										<code>language</code> element in document order is considered the primary
-									language of the rendition.</p>
-
-								<p>Languages for each <a>Rendition</a> MAY differ.</p>
+									language of the EPUB Publication.</p>
 							</section>
 						</section>
 
@@ -1916,10 +1845,8 @@
 									</dd>
 								</dl>
 
-								<p>The OPTIONAL [[!DC11]] metadata for each <a>Rendition</a> MAY differ.</p>
-
-								<p> The value of all OPTIONAL [[!DC11]] elements MUST be at least one character in
-									length after white space has been trimmed.</p>
+								<p>The value of all OPTIONAL [[!DC11]] elements MUST be at least one character in length
+									after white space has been trimmed.</p>
 
 								<p>This specification does not modify the [[!DC11]] element definitions except as noted
 									in the following sections.</p>
@@ -1930,7 +1857,7 @@
 
 								<p>The [[!DC11]] <code>contributor</code> element is used to represent the name of a
 									person, organization, etc. that played a secondary role in the creation of the
-									content of an EPUB Publication.</p>
+									content.</p>
 
 								<p>The requirements for the <code>contributor</code> element are identical to those for
 									the <a href="#sec-opf-dccreator"><code>creator</code> element</a> in all other
@@ -1942,10 +1869,9 @@
 								<h6>The <code>creator</code> Element</h6>
 
 								<p>The [[!DC11]] <code>creator</code> element represents the name of a person,
-									organization, etc. responsible for the creation of the content of the
-										<a>Rendition</a>. The <a href="#role"><code>role</code> property</a> can be <a
-										href="#subexpression">associated with the element</a> to indicate the function
-									the creator played in the creation of the content.</p>
+									organization, etc. responsible for the creation of the content. The <a href="#role"
+											><code>role</code> property</a> can be <a href="#subexpression">associated
+										with the element</a> to indicate the function the creator played.</p>
 
 								<aside class="example">
 									<p>The following example shows how to represent a creator as an author using a <a
@@ -2000,7 +1926,6 @@
 
 								<p>Secondary contributors SHOULD be represented using the <a
 										href="#sec-opf-dccontributor"><code>contributor</code> element</a>.</p>
-
 							</section>
 
 							<section id="sec-opf-dcdate">
@@ -2008,8 +1933,8 @@
 
 								<p>The [[!DC11]] <code>date</code> element MUST only be used to define the publication
 									date of the <a>EPUB Publication</a>. The publication date is not the same as the <a
-										href="#last-modified-date">last modified date</a> (the last time the
-										<a>Rendition</a> was changed).</p>
+										href="#last-modified-date">last modified date</a> (the last time the EPUB
+									Publication was changed).</p>
 
 								<p>It is RECOMMENDED that the date string conform to [[!ISO8601]], particularly the
 									subset expressed in W3C Date and Time Formats [[!DateTime]], as such strings are
@@ -2028,12 +1953,7 @@
 								<p>Additional dates SHOULD be expressed using the specialized date properties available
 									in the [[!DCTERMS]] vocabulary, or similar.</p>
 
-								<p>The publication date MAY be common to all instances of an EPUB Publication or MAY
-									change from instance to instance (e.g., if the EPUB Publication gets generated on
-									demand).</p>
-
 								<p>Only one <code>date</code> element is allowed.</p>
-
 							</section>
 
 							<section id="sec-opf-dcsubject">
@@ -2075,9 +1995,9 @@
 							<section id="sec-opf-dctype">
 								<h6>The <code>type</code> Element</h6>
 
-								<p>The [[!DC11]] <code>type</code> element is used to indicate that the given EPUB
-									Publication is of a specialized type (e.g., annotations or a dictionary packaged in
-									EPUB format).</p>
+								<p>The [[!DC11]] <code>type</code> element is used to indicate that the EPUB Publication
+									is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
+									format).</p>
 
 								<p>An informative registry of specialized EPUB Publication types for use with this
 									element is maintained in the [[TypesRegistry]], but Authors MAY use any text string
@@ -2185,7 +2105,7 @@
 							</ul>
 
 							<p>Subexpressions are not limited to refining only primary expressions and resources; they
-								may be used to refine the meaning of other subexpressions, thereby creating chains of
+								MAY be used to refine the meaning of other subexpressions, thereby creating chains of
 								information.</p>
 
 							<p class="note">All the DCMES [[!DC11]] elements represent primary expressions, and permit
@@ -2230,11 +2150,50 @@
 
 						</section>
 
+						<section id="sec-metadata-elem-identifiers-pid">
+							<h5>Release Identifier</h5>
+
+							<p id="last-modified-date">To aid <a>Reading Systems</a> in distinguishing different
+								versions of an EPUB Publication that have the same <a>Unique Identifier</a>, the
+									<code>metadata</code> section MUST include exactly one [[!DCTERMS]]
+									<code>modified</code> property containing the last modification date. The value of
+								this property MUST be an [[!XMLSCHEMA-2]] dateTime conformant date of the form:</p>
+
+							<pre class="nohighlight">CCYY-MM-DDThh:mm:ssZ</pre>
+
+							<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST
+								be terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
+
+							<p>The inclusion of this value allows Reading Systems to construct a <a
+									href="https://www.w3.org/TR/epub-rs-33/#app-release-identifier">release
+									identifier</a> [[!EPUB-RS-33]] &#8212; a unique value that combines the Unique
+								Identifier with this last modification date. This value allows different versions of the
+								same EPUB Publication to be sorted and compared.</p>
+
+							<aside class="example">
+								<p>The following example shows the two components of the release identifier.</p>
+								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
+    &lt;dc:identifier id="pub-id"&gt;
+        urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
+    &lt;/dc:identifier&gt;
+    &lt;meta property="dcterms:modified"&gt;2016-01-01T00:00:01Z&lt;/meta&gt;
+    …
+&lt;/metadata&gt;</pre>
+							</aside>
+
+							<p>Authors MUST update the last modified date whenever changes are made to the EPUB
+								Publication.</p>
+
+							<p>Additional modified properties MAY be included in the Package Document metadata, but they
+								MUST have a different subject (i.e., they require a <code>refines</code> attribute that
+								references an element or resource).</p>
+						</section>
+
 						<section id="sec-link-elem">
 							<h6>The <code>link</code> Element</h6>
 
-							<p>The <code>link</code> element is used to associate resources with the given
-									<a>Rendition</a>, such as metadata records.</p>
+							<p>The <code>link</code> element is used to associate resources with the <a>EPUB
+									Publication</a>, such as metadata records.</p>
 
 							<dl id="elemdef-opf-link" class="elemdef">
 								<dt>Element Name</dt>
@@ -2345,7 +2304,7 @@
 
 							<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated
 								list of <a href="#sec-property-datatype">property</a> values that establish the
-								relationship the resource has with the Rendition.</p>
+								relationship the resource has with the EPUB Publication.</p>
 
 							<aside class="example">
 								<p>The following example shows the <code>link</code> element used to associate a local
@@ -2433,9 +2392,8 @@
 						<section id="sec-manifest-elem">
 							<h6>The <code>manifest</code> Element</h6>
 
-							<p>The <code>manifest</code> element provides an exhaustive list of the <a>Publication
-									Resources</a> that constitute the given <a>Rendition</a>, each represented by an <a
-									class="codelink" href="#sec-item-elem"><code>item</code></a> element.</p>
+							<p>The <code>manifest</code> element provides an exhaustive list of <a>Publication
+									Resources</a> used in the rendering of the content.</p>
 
 							<dl id="elemdef-opf-manifest" class="elemdef">
 								<dt>Element name</dt>
@@ -2470,8 +2428,13 @@
 								</dd>
 							</dl>
 
-							<p id="confreq-rendition-manifest">All <a>Publication Resources</a> associated with the
-								Package MUST be listed in the <code>manifest</code>.</p>
+							<p id="confreq-rendition-manifest">All <a>Publication Resources</a> MUST be listed in the
+									<code>manifest</code>, regardless of whether they are <a data-lt="Local Resource"
+									>Local</a> or <a>Remote Resources</a>. Each is represented by an <a class="codelink"
+									href="#sec-item-elem"><code>item</code></a> element.</p>
+
+							<p>Note that the <code>manifest</code> is not self-referencing: it MUST NOT include an
+									<code>item</code> element that refers to the Package Document itself.</p>
 
 							<div class="note">
 								<p>This specification supports internationalized resource naming, so elements and
@@ -2557,19 +2520,11 @@
 								</dd>
 							</dl>
 
-							<p>Each <code>item</code> element in the <code>manifest</code> identifies a <a>Publication
-									Resource</a> by the IRI [[!RFC3987]] provided in its <code>href</code> attribute.
-								The IRI MAY be absolute or relative. In the case of relative IRIs, the IRI of the
-								Package Document is used as the base when resolving to absolute IRIs. The resulting
-								absolute IRI MUST be unique within the <code>manifest</code> scope.</p>
-
-							<p id="manifest-inclusion">All Publication Resources MUST be referenced from the
-									<code>manifest</code>, regardless of whether they are <a data-lt="Local Resource"
-									>Local</a> or <a>Remote Resources</a>. Refer to <a href="#sec-resource-locations"
-								></a> for media type-specific requirements regarding resource locations.</p>
-
-							<p>Note that the <code>manifest</code> is not self-referencing: it MUST NOT include an
-									<code>item</code> element that refers to the Package Document itself.</p>
+							<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the IRI
+								[[!RFC3987]] provided in its <code>href</code> attribute. The IRI MAY be absolute or
+								relative. In the case of relative IRIs, the IRI of the Package Document is used as the
+								base when resolving to absolute IRIs. The resulting absolute IRI MUST be unique within
+								the <code>manifest</code> scope.</p>
 
 							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
 								element MUST conform to the applicable specification(s) as inferred from the MIME media
@@ -2768,7 +2723,7 @@ Manifest:
 								</li>
 							</ul>
 
-							<p>Fallback chains MUST NOT contain any circular- or self-references to <code>item</code>
+							<p>Fallback chains MUST NOT contain circular or self-references to <code>item</code>
 								elements in the chain. User agents MUST terminate the fallback chain at the first
 								reference to a manifest item that has already been encountered.</p>
 
@@ -2794,8 +2749,8 @@ Manifest:
 							<h6>The <code>spine</code> Element</h6>
 
 							<p>The <code>spine</code> element defines an ordered list of <a href="#sec-itemref-elem"
-									>manifest <code>item</code> references</a> that represent the default reading order
-								of the given <a>Rendition</a>.</p>
+									>manifest <code>item</code> references</a> that represent the default reading
+								order.</p>
 
 							<dl id="elemdef-opf-spine" class="elemdef">
 								<dt>Element name</dt>
@@ -2903,10 +2858,8 @@ Manifest:
 						<section id="sec-itemref-elem">
 							<h6>The <code>itemref</code> Element</h6>
 
-							<p>The child <code>itemref</code> elements of the <code>spine</code> represent a sequential
-								list of <a>Publication Resources</a> (<a href="#confreq-spine-itemtypes">typically</a>
-								<a>EPUB Content Documents</a>). The order of the <code>itemref</code> elements defines
-								the default reading order of the given <a>Rendition</a>.</p>
+							<p>The <code>itemref</code> element identifies a <a>Publication Resource</a> in the default
+								reading order.</p>
 
 							<dl id="elemdef-spine-itemref" class="elemdef">
 								<dt>Element Name</dt>
@@ -2993,7 +2946,7 @@ Manifest:
 								which might, for example, be presented in a popup window or omitted from an aural
 								rendering.</p>
 
-							<p>Each Rendition MUST include at least one <code>itemref</code> whose <code>linear</code>
+							<p>The <a>spine</a> MUST include at least one <code>itemref</code> whose <code>linear</code>
 								attribute value is either explicitly or implicitly set to "<code>yes</code>". An
 									<code>itemref</code> that omits the <code>linear</code> attribute is assumed to have
 								the value "<code>yes</code>".</p>
@@ -3108,14 +3061,14 @@ Manifest:
 									<a>EPUB Content Documents</a> to be reassembled back into a meaningful unit (e.g.,
 								an index split across multiple documents), identifying resources for specialized
 								purposes (e.g., preview content), or collecting together resources that present
-								additional information about the given <a>Rendition</a>.</p>
+								additional information about the <a>EPUB Publication</a>.</p>
 
 							<p>The <code>collection</code> element, as defined in this section, represents a generic
 								framework from which specializations are intended to be derived (e.g., through EPUB
 								sub-specifications). Such specializations MUST define the purpose of the
-									<code>collection</code> element within a Rendition, as well as all requirements for
-								its valid production and use (specifically any requirements that differ from the general
-								framework presented below).</p>
+									<code>collection</code> element, as well as all requirements for its valid
+								production and use (specifically any requirements that differ from the general framework
+								presented below).</p>
 
 							<p id="attrdef-collection-role">Each specialization MUST define a role value that uniquely
 								identifies all conformant <code>collection</code> elements. The role of each
@@ -3198,7 +3151,7 @@ Manifest:
 								requirements of the <a href="#elemdef-opf-manifest"><code>manifest</code></a> and <a
 									href="#elemdef-opf-spine"><code>spine</code></a>.</p>
 
-							<p>The rendering of a Rendition MUST NOT be dependent on the recognition of
+							<p>The rendering of an EPUB Publication MUST NOT be dependent on the recognition of
 									<code>collection</code> elements. The content MUST remain consumable by a user
 								without any information loss or other significant deterioration.</p>
 
@@ -3245,9 +3198,9 @@ Manifest:
 
 							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
 										><code>guide</code> element</a> [[!OPF-201]] is a <a href="#legacy">legacy</a>
-								feature that previously provided machine-processable navigation to key structures in an
-									<a>EPUB Publication</a>. It is replaced in EPUB 3 by <a href="#sec-nav-landmarks"
-									>landmarks</a> in the <a>EPUB Navigation Document</a>.</p>
+								feature that previously provided machine-processable navigation to key structures. It is
+								replaced in EPUB 3 by <a href="#sec-nav-landmarks">landmarks</a> in the <a>EPUB
+									Navigation Document</a>.</p>
 
 							<p>For more information about the <code>guide</code> element, refer to its definition in
 								[[!OPF-201]].</p>
@@ -3258,8 +3211,8 @@ Manifest:
 
 							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a>
 								[[!OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the
-								table of contents for <a>EPUB Publications</a>. It is replaced in EPUB 3 by the <a
-									href="#sec-nav">EPUB Navigation Document</a>.</p>
+								table of contents. It is replaced in EPUB 3 by the <a href="#sec-nav">EPUB Navigation
+									Document</a>.</p>
 
 							<p>For more information about the NCX, refer to its definition in [[!OPF-201]].</p>
 						</section>
@@ -3274,102 +3227,6 @@ Manifest:
 
 					<p id="media-type">Package Documents have the MIME media type
 							<code>application/oebps-package+xml</code> [[!RFC4839]].</p>
-				</section>
-			</section>
-
-			<section id="sec-package-metadata-identifiers">
-				<h4>Publication Identifiers</h4>
-
-				<section id="sec-metadata-elem-identifiers-uid">
-					<h5>Unique Identifier</h5>
-
-					<p>The <a>Author</a> is responsible for including a primary identifier in the <a>Package
-							Document</a> metadata that is unique to one and only one <a>EPUB Publication</a>. This
-							<a>Unique Identifier</a>, whether chosen or assigned, MUST be stored in the <a
-							href="#sec-opf-dcidentifier"><code>dc:identifier</code> element</a> and be referenced as the
-						Unique Identifier in the <a href="#elemdef-opf-package"><code>package</code> element</a>
-						<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code> attribute</a>.</p>
-
-					<p>Although not static, changes to the Unique Identifier for an EPUB Publication SHOULD be made as
-						infrequently as possible. New identifiers SHOULD NOT be issued when updating metadata, fixing
-						errata, or making other minor changes to the EPUB Publication.</p>
-				</section>
-
-				<section id="sec-metadata-elem-identifiers-pid">
-					<h5>Release Identifier</h5>
-
-					<p>The <a>Unique Identifier</a> of an <a>EPUB Publication</a> typically SHOULD NOT change with each
-						minor revision to the package or its contents, as Unique Identifiers are intended to have
-						maximal persistence both for referencing and distribution purposes. Each release of an EPUB
-						Publication normally requires that the new version be uniquely identifiable, however, which
-						results in the contradictory need for reliable Unique Identifiers that are changeable.</p>
-
-					<p>To redress this problem of identifying minor modifications and releases without changing the
-						Unique Identifier, this specification defines the semantics for a <em>Release Identifier</em>,
-						or means of distinguishing and sequentially ordering EPUB Publications with the same Unique
-						Identifier.</p>
-
-					<p>The Release Identifier is not an actual property in the package <code>metadata</code> section but
-						is a value that can be obtained from two other mandatory pieces of metadata: the Unique
-						Identifier and the last modification date of the Rendition. When the taken together, the
-						combined value represents a unique identity that can be used to distinguish any version of an
-						EPUB Publication from another.</p>
-
-					<p id="last-modified-date">To ensure that a Release Identifier can be constructed, each
-							<a>Rendition</a> MUST include exactly one [[!DCTERMS]] <code>modified</code> property
-						containing its last modification date. The value of this property MUST be an [[!XMLSCHEMA-2]]
-						dateTime conformant date of the form:</p>
-
-					<pre class="nohighlight">CCYY-MM-DDThh:mm:ssZ</pre>
-
-					<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST be
-						terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
-
-					<p>Additional modified properties MAY be included in the package metadata, but they MUST have a
-						different subject (i.e., they require a <code>refines</code> attribute that references an
-						element or resource).</p>
-
-					<p>Although not a part of the package metadata, for referencing and other purposes all string
-						representations of the identifier MUST be constructed using the at sign (<code>@</code>) as the
-						separator (i.e., of the form "id<code>@</code>date"). Whitespace MUST NOT be included when
-						concatenating the strings.</p>
-
-					<aside class="example">
-						<p>The following example shows how a Unique Identifier and modification date are combined to
-							form the Release Identifier.</p>
-						<pre class="nohighlight">&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    &lt;dc:identifier id="pub-id"&gt;urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier&gt;
-    &lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;
-    …
-&lt;/metadata&gt;
-
-results in the Package ID:
-
-urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
-</pre>
-					</aside>
-
-					<p>Note that it is possible that the separator character MAY occur in the Unique Identifier, as
-						these identifiers MAY be any string value. The Release Identifier consequently MUST be split on
-						the last instance of the at sign when decomposing it into its component parts.</p>
-
-					<p>The Release Identifier does not supersede the Unique Identifier but represents how different
-						versions of the same EPUB Publication can be distinguished and identified in distribution
-						channels and by Reading Systems. The sequential, chronological order inherent in the format of
-						the timestamp also places EPUB Publications in order without requiring knowledge of the exact
-						identifier that came before.</p>
-
-					<p>The Release Identifier consequently allows a set of EPUB Publications to be inspected to
-						determine if they represent the same version of the same Publication, different versions of a
-						single EPUB Publication, or any combination of differing and similar EPUB Publications.</p>
-
-					<div class="note">
-						<p>When an <a>EPUB Container</a> includes more than one <a>Rendition</a> of an EPUB Publication,
-							updating the last modified date of the <a>default rendition</a> for each release — even if
-							it has not been updated — will help ensure that the EPUB Publication does not appear to be
-							the same version as an earlier release, as Reading Systems only have to process the default
-							rendition.</p>
-					</div>
 				</section>
 			</section>
 		</section>
@@ -3878,9 +3735,9 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					<p>The Scalable Vector Graphics (SVG) specification [[SVG]] defines a format for representing
 						final-form vector graphics and text.</p>
 
-					<p>Although an EPUB Publication typically uses <a href="#sec-xhtml">XHTML Content Documents</a> as
-						the <a data-lt="Top-level Content Document">top-level</a> document type, the use of <a>SVG
-							Content Documents</a> is also permitted. SVGs are typically only used in certain special
+					<p>Although <a>Authors</a> typically use <a href="#sec-xhtml">XHTML Content Documents</a> as the <a
+							data-lt="Top-level Content Document">top-level</a> document type, the use of <a>SVG Content
+							Documents</a> is also permitted. SVGs are typically only used in certain special
 						circumstances, such as when final-form page images are the only suitable representation of the
 						content (e.g., for cover art or in the context of manga or comic books).</p>
 
@@ -3900,7 +3757,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 					<p>An SVG Content Document has to meet the following requirements:</p>
 
-					<ul>
+					<ul class="conformance-list">
 						<li>
 							<p id="confreq-cd-svg-docprops-schema">It MUST be an <a
 									href="https://www.w3.org/TR/SVG/intro.html#TermSVGDocumentFragment">SVG document
@@ -4600,11 +4457,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					semantics for XML-based pronunciation lexicons to be used by Automatic Speech Recognition and
 						<a>Text-to-Speech</a> (TTS) engines.</p>
 
-				<p id="confreq-cd-pls-docprops-schema">PLS Documents MUST be valid to the RELAX NG schema available at
-					the URI <a class="uri" href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
-							><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/</code></a>
-					[[!PRONUNCIATION-LEXICON]].</p>
-
 				<p id="confreq-cd-pls-xht">A PLS Document MAY be associated with <a>XHTML Content Documents</a>. Each
 					XHTML Content Document MAY contain zero or more PLS document associations.</p>
 
@@ -4634,6 +4486,11 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 &lt;/html&gt;</pre>
 				</aside>
 
+				<p id="confreq-cd-pls-docprops-schema">PLS Documents MUST be valid to the RELAX NG schema available at
+					the URI <a href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
+							><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng</code></a>
+					[[!PRONUNCIATION-LEXICON]].</p>
+
 				<p id="confreq-cd-pls-fileprops-name">PLS Documents SHOULD use the file extension <code class="filename"
 						>.pls</code>.</p>
 
@@ -4650,8 +4507,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<h3>Introduction</h3>
 
 				<p>The EPUB Navigation Document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
-						Package</a>. It allows <a>Authors</a> to include a human- and machine-readable global navigation
-					layer, thereby ensuring increased usability and accessibility for the user.</p>
+						Publication</a>. It allows <a>Authors</a> to include a human- and machine-readable global
+					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
 
 				<p>The EPUB Navigation Document is an <a>XHTML Content Document</a>, but with additional restrictions on
 					its structure to facilitate the machine-processing of its contents. [[HTML]] <a
@@ -4807,7 +4664,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						<li>
 							<p id="confreq-nav-a-href">The IRI reference provided in the <code>href</code> attribute of
 								the <code>a</code> element MUST adhere to the following requirements:</p>
-							<ul>
+							<ul class="conformance-list">
 								<li>
 									<p id="confreq-nav-a-href-default">In the case of the <a href="#sec-nav-toc"
 												><code>toc nav</code></a>, <a href="#sec-nav-landmarks"><code>landmarks
@@ -4837,9 +4694,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								this section for constructing the primary navigation list.</p>
 						</li>
 					</ul>
-
-					<p>EPUB specifications MAY introduce further restrictions on the content model defined above for
-							<code>nav</code> elements in the EPUB Navigation Document.</p>
 
 					<aside class="example">
 						<p>The following example shows the basic patterns of a navigation element.</p>
@@ -4907,7 +4761,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							</dt>
 							<dd>
 								<p>Identifies the <code>nav</code> element that contains a list of pages for a print or
-									other statically paginated source for the <a>EPUB Publication</a>.</p>
+									other statically paginated source.</p>
 							</dd>
 							<dt>
 								<a href="#sec-nav-landmarks">
@@ -4929,9 +4783,9 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						<h5>The <code>toc nav</code> Element </h5>
 
 						<p>The <code>toc</code>
-							<code>nav</code> element defines the primary navigational hierarchy of the given
-								<a>Rendition</a>. It conceptually corresponds to a table of contents in a printed work
-							(i.e., it provides navigation to the major structural sections of the publication).</p>
+							<code>nav</code> element defines the primary navigational hierarchy. It conceptually
+							corresponds to a table of contents in a printed work (i.e., it provides navigation to the
+							major structural sections of the publication).</p>
 
 						<p>The references in the <code>toc</code>
 							<code>nav</code> element SHOULD be ordered such that they reflect both:</p>
@@ -4956,8 +4810,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 						<p>The <code>page-list</code>
 							<code>nav</code> element provides navigation to positions in the content that correspond to
-							the locations of page boundaries present in a print source being represented by the <a>EPUB
-								Publication</a>.</p>
+							the locations of page boundaries present in a print source.</p>
 
 						<p>The <code>page-list</code>
 							<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more
@@ -4989,9 +4842,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						<h5>The <code>landmarks nav</code> Element </h5>
 
 						<p>The <code>landmarks</code>
-							<code>nav</code> element identifies fundamental structural components in the given
-								<a>Rendition</a> to enable Reading Systems to provide the user efficient access to
-							them.</p>
+							<code>nav</code> element identifies fundamental structural components in the content to
+							enable Reading Systems to provide the user efficient access to them.</p>
 
 						<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is REQUIRED on
 								<code>a</code> element descendants of the <code>landmarks</code>
@@ -5159,25 +5011,25 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<section id="layout">
 					<h4>Layout</h4>
 
-					<p>The <code>rendition:layout</code> property specifies whether the given Rendition is reflowable or
+					<p>The <code>rendition:layout</code> property specifies whether the content is reflowable or
 						pre-paginated.</p>
 
 					<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code> property</a>
 						is specified on a <code>meta</code> element, it indicates that the paginated or reflowable
-						layout style applies globally for the <a>Rendition</a> (i.e., for all spine items).</p>
+						layout style applies globally (i.e., for all spine items).</p>
 
 					<p>The following values are defined for use with the <code>rendition:layout</code> property:</p>
 
 					<dl class="variablelist">
 						<dt id="def-layout-reflowable">reflowable</dt>
 						<dd>
-							<p>The given Rendition is not pre-paginated (i.e., Reading Systems apply dynamic pagination
-								when rendering). Default value.</p>
+							<p>The content is not pre-paginated (i.e., Reading Systems apply dynamic pagination when
+								rendering). Default value.</p>
 						</dd>
 						<dt id="def-layout-pre-paginated">pre-paginated</dt>
 						<dd>
-							<p>The given Rendition is pre-paginated (i.e., Reading Systems produce exactly one page per
-								spine <a href="#elemdef-spine-itemref"><code>itemref</code></a> when rendering).</p>
+							<p>The content is pre-paginated (i.e., Reading Systems produce exactly one page per spine <a
+									href="#elemdef-spine-itemref"><code>itemref</code></a> when rendering).</p>
 						</dd>
 					</dl>
 
@@ -5247,12 +5099,12 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					<h4>Orientation</h4>
 
 					<p>The <code>rendition:orientation</code> property specifies which orientation the Author intends
-						the given Rendition to be rendered in. </p>
+						the content to be rendered in. </p>
 
 					<p id="property-orientation-global">When the <a href="#orientation"
 								><code>rendition:orientation</code> property</a> is specified on a <code>meta</code>
-						element, it indicates that the intended orientation applies globally for the given Rendition
-						(i.e., for all spine items).</p>
+						element, it indicates that the intended orientation applies globally (i.e., for all spine
+						items).</p>
 
 					<p>The following values are defined for use with the <code>rendition:orientation</code>
 						property:</p>
@@ -5260,15 +5112,15 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					<dl class="variablelist">
 						<dt>landscape</dt>
 						<dd>
-							<p>The given Rendition is intended for landscape rendering.</p>
+							<p>The content is intended for landscape rendering.</p>
 						</dd>
 						<dt>portrait</dt>
 						<dd>
-							<p> The given Rendition is intended for portrait rendering.</p>
+							<p> The content is intended for portrait rendering.</p>
 						</dd>
 						<dt>auto</dt>
 						<dd>
-							<p>The given Rendition is not orientation constrained. Default value.</p>
+							<p>The content is not orientation constrained. Default value.</p>
 						</dd>
 					</dl>
 
@@ -5313,11 +5165,11 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					<h4>Synthetic Spreads</h4>
 
 					<p>The <code>rendition:spread</code> property specifies the intended Reading System synthetic spread
-						behavior for the given Rendition.</p>
+						behavior.</p>
 
 					<p id="property-spread-global">When the <code>rendition:spread</code> property is specified on a
 							<code>meta</code> element, it indicates that the intended <a>Synthetic Spread</a> behavior
-						applies globally for the given Rendition (i.e., for all spine items).</p>
+						applies globally (i.e., for all spine items).</p>
 
 					<p>The following values are defined for use with the <code>rendition:spread</code> property:</p>
 
@@ -5487,9 +5339,9 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					<aside class="example" id="fxl-ex5">
 						<p>The following example demonstrates reflowable content with a two-page fixed-layout center
 							plate that is intended to be rendered using synthetic spreads in any device orientation.
-							Note that the author has left spread behavior for the other (reflowable) parts of the
-								<a>Rendition</a> undefined, since the global value of <code>rendition:spread</code> is
-							initialized to <code>auto</code> by default.</p>
+							Note that the author has left spread behavior for the other (reflowable) parts undefined,
+							since the global value of <code>rendition:spread</code> is initialized to <code>auto</code>
+							by default.</p>
 						<pre>&lt;spine page-progression-direction="ltr"&gt;
     …
     &lt;itemref idref="center-plate-left"
@@ -5545,7 +5397,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
 								containing block</a> [[!CSS2]] dimensions MUST be expressed in a <code>viewport</code>
 							<code>meta</code> tag using the syntax defined in [[!CSS-Device-Adapt-1]].</p>
-
 						<aside class="example">
 							<p>The following example shows a <code>viewport</code>
 								<code>meta</code> tag.</p>
@@ -5563,7 +5414,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 						<p>For SVG <a>Fixed-Layout Documents</a>, the ICB dimensions MUST be expressed using the <a
 								href="http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code>
 								attribute</a> [[!SVG]].</p>
-
 						<aside class="example">
 							<p>The following example shows a <code>viewBox</code> attribute declaration for an SVG
 								Content Document with an aspect ratio of 844 pixels wide by 1200 pixels high.</p>
@@ -5601,8 +5451,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							<code>[required]</code>
 						</dt>
 						<dd>
-							<p>Identifies the <a>Package Documents</a> that define each <a>Rendition</a> of the EPUB
-								Publication.</p>
+							<p>Identifies the <a>Package Document(s)</a> that define the EPUB Publication.</p>
 						</dd>
 						<dt>
 							<code>signatures.xml</code>
@@ -5838,21 +5687,26 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 							<h6>Container File (<code>container.xml</code>)</h6>
 
 							<p>The REQUIRED <code>container.xml</code> file in the <code>META-INF</code> directory
-								identifies the <a>EPUB Packages</a> in the <a>OCF Abstract Container</a>.</p>
+								identifies the <a>Package Documents</a> available in the <a>OCF Abstract
+								Container</a>.</p>
 
 							<p>The contents of this file MUST be valid to the schema in <a href="#app-schema-container"
 								></a> after removing all elements and attributes from other namespaces (including all
 								attributes and contents of such elements).</p>
 
 							<p id="elemdef-container-rootfile">Each <code>rootfile</code> element MUST identify the
-								location of a <a>Package Document</a> representing one <a>Rendition</a> of the <a>EPUB
-									Publication</a>. Each rendition MUST conform to the same version of EPUB as its
-								container.</p>
+								location of a <a>Package Document</a>.</p>
 
-							<p class="note">Although the EPUB Container provides the ability to include more than one
-								rendition of the content, Reading System support for multiple renditions remains largely
-								unrealized, outside specialized environments where the purpose and meaning of the
-								renditions is established by the involved parties.</p>
+							<p>If more than one <code>rootfile</code> element is defined, each MUST reference a Package
+								Document that conforms to the same version of EPUB. Each Package Document represents one
+								rendering of the EPUB Publication.</p>
+
+							<div class="note">
+								<p>Although the EPUB Container provides the ability to reference more than one Package
+									Document, this specification does not define how to interpret, or select from, the
+									available options. Refer to [[EPUB-Multi-Rend-11]] for more information on how to
+									bundle more than one rendering of the content.</p>
+							</div>
 
 							<aside class="example">
 								<p>The following example shows a sample <code>container.xml</code> for an EPUB
@@ -5869,22 +5723,6 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
                     </pre>
 							</aside>
 
-							<aside class="example">
-								<p>The following example shows SVG and XHTML Renditions bundled in the same
-									container:</p>
-								<pre>
-&lt;?xml version="1.0"?&gt;
-&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
-    &lt;rootfiles&gt;
-        &lt;rootfile full-path="SVG/Sandman.opf"
-            media-type="application/oebps-package+xml" /&gt;
-        &lt;rootfile full-path="XHTML/Sandman.opf"
-            media-type="application/oebps-package+xml" /&gt;
-    &lt;/rootfiles&gt;
-&lt;/container&gt;
-                    </pre>
-							</aside>
-
 							<p>The OPTIONAL <code id="elemdef-container-links">links</code> element identifies resources
 								necessary for the processing of the <a>OCF ZIP Container</a>. Each of its child <code
 									id="elemdef-container-link">link</code> elements MUST include an <code>href</code>
@@ -5894,9 +5732,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								value MUST be a media type [[!RFC2046]] that specifies the type and format of the
 								resource referenced by the <code>link</code>.</p>
 
-							<p class="note"> The <code>links</code> element is used to point to rendition mapping
-								documents for <a href="http://www.idpf.org/epub/renditions/multiple/#sec-4.4.4"
-									>multiple-rendition EPUBs</a> [[EPUBMultipleRenditions-10]]. </p>
+							<p class="note">This specification does not define uses for the <code>links</code> element. </p>
 
 							<p>The value of the <code>rootfile</code> element <code>full-path</code> attribute and the
 									<code>link</code> element <code>href</code> attribute MUST contain a <em
@@ -5946,12 +5782,11 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								Deflate-compressed.</p>
 
 							<p id="encryption-obfuscation">Note that some situations require obfuscating the storage of
-								embedded resources referenced by a <a>Rendition</a> to tie them to the "parent" EPUB
-								Publication and make them more difficult to extract for unrestricted use (e.g., fonts).
-								Although obfuscation is not encryption, the <code>encryption.xml</code> file is used in
-								conjunction with the <a href="#sec-resource-obfuscation">resource obfuscation
-									algorithm</a> to identify resources that need to be de-obfuscated before they can be
-								used.</p>
+								embedded resources referenced by an <a>EPUB Publication</a> to make them more difficult
+								to extract for unrestricted use (e.g., fonts). Although obfuscation is not encryption,
+								the <code>encryption.xml</code> file is used in conjunction with the <a
+									href="#sec-resource-obfuscation">resource obfuscation algorithm</a> to identify
+								resources that need to be de-obfuscated before they can be used.</p>
 
 							<p id="encryption-restrictions">The following files MUST NOT be encrypted, regardless of
 								whether default or specific encryption is requested:</p>
@@ -6118,10 +5953,10 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 
 							<p>The OCF specification does not mandate a format for the manifest.</p>
 
-							<p>Note that the <code>manifest</code> element contained within a <a>Package Document</a>
-								specifies the one and only manifest used for processing a given Rendition. Ancillary
-								manifest information contained in the ZIP archive or in the OPTIONAL
-									<code>manifest.xml</code> file MUST NOT be used for processing the Rendition.</p>
+							<p>Note that <a>Package Documents</a> specify the only manifests used for processing <a>EPUB
+									Publications</a>. Ancillary manifest information contained in the ZIP archive or in
+								the OPTIONAL <code>manifest.xml</code> file MUST NOT be used for processing an EPUB
+								Publication.</p>
 
 							<div class="note">This feature exists only for compatibility with [[ODF]].</div>
 						</section>
@@ -6157,8 +5992,8 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 								future format.</p>
 
 							<p>When the <code>rights.xml</code> file is not present, no part of the container is rights
-								governed at the container level. Rights expressions might exist within the contained
-								Renditions.</p>
+								governed at the container level. Rights expressions might exist within the EPUB
+								Publications.</p>
 
 							<p>If the <code>rights.xml</code> file is not present, no part of the OCF Abstract Container
 								is rights governed.</p>
@@ -6437,8 +6272,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 				<section id="obfus-keygen">
 					<h4>Obfuscation Key</h4>
 
-					<p>The key used in the obfuscation algorithm is derived from the <a>Unique Identifier</a> of the
-							<a>Default Rendition</a>.</p>
+					<p>The key used in the obfuscation algorithm is derived from the <a>Unique Identifier</a>.</p>
 
 					<p>All white space characters, as defined in <a
 							href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-common-syn">section 2.3 of the XML
@@ -6510,7 +6344,7 @@ store destination as source in ocf
 							compression was not specified. As a result, invalid fonts might be encountered after
 							decompression and de-obfuscation. In such instances, de-obfuscating the data before
 							inflating it might return a valid font. This specification does not require support for this
-							method of retrieval, as it is not compliant with this version of this specification, but it
+							method of retrieval, as it is not conforming with this version of this specification, but it
 							needs to be considered when supporting EPUB 3 content generally.</p>
 					</div>
 
@@ -7296,9 +7130,9 @@ store destination as source in ocf
 							<p>The reason for grouping structures like sections, figures, tables, and footnotes in a
 									<code>seq</code> element is so that their start and end positions can be identified
 								during playback. Reading Systems can then offer playback options tailored to the layout
-								of the given <a>Rendition</a>, such as jumping past a long figure, turning off rendering
-								of page break announcements (see <a href="#sec-behaviors-skip-escape"></a>), or
-								customizing the reading mode to suit structures such as tables.</p>
+								of the content, such as jumping past a long figure, turning off rendering of page break
+								announcements (see <a href="#sec-behaviors-skip-escape"></a>), or customizing the
+								reading mode to suit structures such as tables.</p>
 						</div>
 
 						<aside class="example">
@@ -7428,7 +7262,7 @@ store destination as source in ocf
 
 					<p>The <code>active-class</code> and <code>playback-active-class</code> properties MUST NOT be used
 						in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a>, as they are
-						always considered to apply to the entire <a>Rendition</a>.</p>
+						always considered to apply to the entire <a>EPUB Publication</a>.</p>
 
 					<p>This example demonstrates how Authors can associate style information with the currently playing
 						EPUB Content Document.</p>
@@ -7525,9 +7359,9 @@ html.-epub-media-overlay-playing * {
 					<section id="sec-mo-package-metadata">
 						<h5>Overlays Package Metadata</h5>
 
-						<p>The <a>Package Document</a> MUST include the duration of the entire <a>Rendition</a> in a <a
-								href="#elemdef-package-item"><code>meta</code> element</a> with the <a href="#duration"
-									><code>duration</code> property</a>.</p>
+						<p>The <a>Package Document</a> MUST include the duration of the entire <a>EPUB Publication</a>
+							in a <a href="#elemdef-package-item"><code>meta</code> element</a> with the <a
+								href="#duration"><code>duration</code> property</a>.</p>
 
 						<p>In addition, the duration of each EPUB Content Document with an associated Media Overlay MUST
 							be provided. The <a href="#attrdef-refines"><code>refines</code> attribute</a> is used to
@@ -8298,7 +8132,6 @@ html.-epub-media-overlay-playing * {
 						<dd id="sec-metadata-reserved-prefixes">
 							<p>Authors MAY use the following prefixes in <a>Package Document</a> attributes without
 								having to declare them.</p>
-
 							<table id="tbl-pkg-reserved-prefixes" class="prefix">
 								<thead>
 									<tr>
@@ -8348,7 +8181,6 @@ html.-epub-media-overlay-playing * {
 							<p>Authors MAY use the following reserved prefixes in the <a
 									href="#app-structural-semantics"><code>epub:type</code> attribute</a> without having
 								to declare them.</p>
-
 							<table id="tbl-reserved-prefixes" class="prefix">
 								<thead>
 									<tr>
@@ -8710,9 +8542,9 @@ EPUB/images/cover.png</pre>
 				<p>This appendix registers the media type <code>application/oebps-package+xml</code> for the EPUB
 					Package Document. This registration supersedes [[!RFC4839]].</p>
 
-				<p>The Package Document is an XML file that describes a Rendition of an EPUB Publication. It identifies
-					the resources in the Rendition and provides metadata information. The Package Document and its
-					related specifications are maintained and defined by the <a href="https://www.w3.org">World Wide Web
+				<p>The Package Document is an XML file that describes an EPUB Publication. It identifies the resources
+					in the EPUB Publication and provides metadata information. The Package Document and its related
+					specifications are maintained and defined by the <a href="https://www.w3.org">World Wide Web
 						Consortium</a> (W3C).</p>
 
 				<dl class="variablelist">
@@ -8854,8 +8686,8 @@ EPUB/images/cover.png</pre>
 					Format (OCF).</p>
 
 				<p>An <a>OCF ZIP Container</a>, or <a>EPUB Container</a>, file is a container technology based on the
-					[[!ZIP]] archive format. It is used to encapsulate the Renditions of EPUB Publications. OCF and its
-					related standards are maintained and defined by the <a href="https://www.w3.org">World Wide Web
+					[[!ZIP]] archive format. It is used to encapsulate the EPUB Publication. OCF and its related
+					standards are maintained and defined by the <a href="https://www.w3.org">World Wide Web
 						Consortium</a> (W3C).</p>
 
 				<dl class="variablelist">

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -102,7 +102,7 @@
 					<tr>
 						<th>Description:</th>
 						<td>The <code>nav</code> property indicates that the described Publication Resource
-							constitutes the <a>EPUB Navigation Document</a> of the given <a>Rendition</a>.</td>
+							constitutes the <a>EPUB Navigation Document</a> of the <a>EPUB Publication</a>.</td>
 					</tr>
 					<tr>
 						<th>Applies to:</th>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -569,7 +569,7 @@
 						<th>Description:</th>
 						<td>
 							<p>The <code>source-of</code> property indicates a unique aspect of an adapted source
-								resource that has been retained in the given Rendition of the EPUB Publication. </p>
+								resource that has been retained in the <a>EPUB Publication</a>. </p>
 							<p>This specification defines the <code>pagination</code> value to indicate that the
 								referenced <code>dc:source</code> element is the source of the <a
 									href="http://www.idpf.org/epub/vocab/structure/#pagebreak"><code>pagebreak</code>
@@ -759,7 +759,7 @@
 			<h5>Examples</h5>
 
 			<aside class="example">
-				<p>The following example represents a typical set of refined metadata a Rendition might contain.</p>
+				<p>The following example represents a typical set of refined metadata an <a>EPUB Publication</a> might contain.</p>
 				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     
     &lt;dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier>

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -92,7 +92,7 @@
 					</tr>
 					<tr>
 						<th>Cardinality:</th>
-						<td>Exactly one for a given <span class="phrase"><a>Rendition</a></span> and for each Media Overlay.</td>
+						<td>Exactly one for the <a>EPUB Publication</a> and for each Media Overlay.</td>
 					</tr>
 					<tr>
 						<th>Example:</th>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -53,9 +53,8 @@
 				<dt id="scrolled-continuous">scrolled-continuous</dt>
 				<dd>
 					<p>Render all Content Documents such that overflow content is scrollable, and the
-						EPUB Publication represented by the given <a>Rendition</a> is presented as one
-						continuous scroll from spine item to spine item (except where <a
-							href="#layout-property-flow-overrides">locally overridden</a>).</p>
+						EPUB Publication is presented as one continuous scroll from spine item to spine
+						item (except where <a href="#layout-property-flow-overrides">locally overridden</a>).</p>
 					<p>Note that Authors SHOULD NOT create publications in which different resources
 						have different block flow directions, as continuous scrolled rendition in EPUB
 						Reading Systems would be problematic.</p>
@@ -112,7 +111,7 @@
 				<p>Only one of these overrides is allowed on any given spine item.</p>
 
 				<aside class="example" id="property-flow-ex1">
-					<p>The following example demonstrates an Author's intent to have a paginated Rendition
+					<p>The following example demonstrates an Author's intent to have a paginated EPUB Publication
 						with a scrollable table of contents.</p>
 					<pre>&lt;metadata&gt;
     &lt;meta property="rendition:flow"&gt;paginated&lt;/meta&gt;

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -5,35 +5,37 @@
 		<title>EPUB Multiple-Rendition Publications 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/biblio.js" class="remove"></script>
+		<script src="../common/js/dfn-crossref.js" class="remove"></script>
 		<script src="../common/js/confreq-permalinks.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
-			var respecConfig = {
-				group: "epub",
-				wgPublicList: "public-epub-wg",
-				specStatus: "ED",
-				shortName: "epub-multi-rend-11",
-				edDraftURI: "https://w3c.github.io/epub-specs/epub33/multi-rend/",
-				copyrightStart: "2015",
-				noRecTrack: true,
-				editors:[{
-					name: "Matt Garrish",
-					company: "DAISY Consortium",
-					companyURL: "https://www.daisy.org"
-				}],
-				includePermalinks: true,
-				permalinkEdge: true,
-				permalinkHide: false,
-				diffTool: "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
-				github: {
-					repoURL: "https://github.com/w3c/epub-specs",
-					branch: "master"
-				},
-				localBiblio: biblio,
-				preProcess:[inlineCustomCSS],
-				postProcess:[addConformanceLinks]
-			};//]]>
+            var respecConfig = {
+                group: "epub",
+                wgPublicList: "public-epub-wg",
+                specStatus: "ED",
+                shortName: "epub-multi-rend-11",
+                edDraftURI: "https://w3c.github.io/epub-specs/epub33/multi-rend/",
+                copyrightStart: "2015",
+                noRecTrack: true,
+                editors:[ {
+                    name: "Matt Garrish",
+                    company: "DAISY Consortium",
+                    companyURL: "https://www.daisy.org"
+                }],
+                includePermalinks: true,
+                permalinkEdge: true,
+                permalinkHide: false,
+                diffTool: "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+                github: {
+                    repoURL: "https://github.com/w3c/epub-specs",
+                    branch: "master"
+                },
+                pluralize: true,
+                localBiblio: biblio,
+                preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
+                postProcess:[addConformanceLinks]
+            };//]]>
       </script>
 	</head>
 	<body>
@@ -46,14 +48,14 @@
 		<section id="intro">
 			<h2>Introduction</h2>
 
-			<section id="scope" class="informative">
-				<h3>Purpose and Scope</h3>
+			<section id="overview" class="informative">
+				<h3>Overview</h3>
 
-				<p>The need to include more than one Rendition of the content in an EPUB Publication has grown as
-					Reading Systems have evolved and become more sophisticated. While some measure of content adaptation
-					has always been possible at the style sheet level, it is both limited in what it can accomplish and
-					limited to content rendering. Existing fallback mechanisms within the EPUB Package Document
-					similarly only ensure that resources can be rendered.</p>
+				<p>The need to include more than one <a>Rendition</a> of an <a>EPUB Publication</a> has grown as
+						<a>Reading Systems</a> have evolved and become more sophisticated. While some measure of content
+					adaptation has always been possible at the style sheet level, it is both limited in what it can
+					accomplish and limited to content rendering. Existing fallback mechanisms within the <a>Package
+						Document</a> similarly only ensure that resources can be rendered.</p>
 
 				<p>Adaptation is not just about optimizing styling and positioning content for screen considerations,
 					such as dimensions and color or Reading System orientation, but often involves changing the content
@@ -65,11 +67,12 @@
 					move from the same spot in one Rendition to the equivalent spot in another as changes in the reading
 					environment occur.</p>
 
-				<p>This specification does not define methods for modifying content on the fly, but defines how a
-					Reading System selects from multiple Author-provided Renditions of the content to best match the
-					current device characteristics and User preferences. As changes occur to device orientation or the
-					User's preferred reading modality, for example, the Reading System will be able to check for a
-					better Rendition and seamlessly present it to the User using the functionality defined herein.</p>
+				<p>This specification defines how a Reading System selects from multiple <a>Author</a>-provided
+					Renditions of the content to best match the current device characteristics and user preferences
+					&#8212; it does not define methods for modifying content on the fly. As changes occur to device
+					orientation or the user's preferred reading modality, for example, the Reading System will be able
+					to check for a better Rendition and seamlessly present it using the functionality defined
+					herein.</p>
 
 				<p>The specification addresses each of the major requirements in the discovery of, selection of, and
 					mapping between, multiple Renditions of an EPUB Publication. In particular:</p>
@@ -78,249 +81,337 @@
 					<li>the establishment of a unique identifier common to all the Renditions in the
 							<code>META-INF/metadata.xml</code> file;</li>
 					<li>the selection of Renditions through a set of attributes that can be attached to
-							<code>rootfile</code> elements in the Container Document;</li>
+							<code>rootfile</code> elements in the <a>Container Document</a>;</li>
 					<li>the optional ability to move from a point in one Rendition to the same location in another by
 						means of a mapping document.</li>
 				</ul>
 
 				<p>Taken together, these features enable the creation of advanced Multiple-Rendition Publications that
-					Reading Systems can adapt to changing User needs.</p>
+					Reading Systems can adapt to changing user needs.</p>
 			</section>
 
-			<section id="rel">
-				<h3>Relationship to Other Specifications</h3>
+			<section id="background">
+				<h3>Background</h3>
 
-				<section id="rel-ocf">
-					<h4>Relationship to OCF 3.0.1</h4>
+				<p>The notion of including multiple renditions of an <a>EPUB Publication</a> has existed for as long as
+					the EPUB standard, but the specification has never fully addressed what these renditions are for and
+					how to access them. As a result, the EPUB 3 specification generally equates an EPUB Publication with
+					a single rendering of the content. Moreover, most <a>Authors</a> and <a>Reading System</a>
+					developers equate an EPUB Publication with a single <a>Package Document</a> referenced from the
+					first <code>rootfile</code> element in the <code>container.xml</code> file [[EPUB-33]].</p>
 
-					<p>The method for including multiple Renditions within an OCF Container [[OCF-301]] defined in this
-						specification is not a requirement for the production of compliant EPUB Publications. Multiple
-						Renditions MAY be included in a Container without adhering to this specification, as the ability
-						to create multiple-Rendition Containers pre-dates this specification.</p>
+				<p>In practice, however, the <code>container.xml</code> file does not restrict Authors to listing only a
+					single Package Document. In EPUB 2, for example, <a>Authors</a> could add additional
+						<code>rootfile</code> elements referencing any other format they desired (e.g., another Package
+					Document, a PDF file, or even a Word Document). In EPUB 3, <code>rootfile</code> elements were
+					restricted to referencing only Package Documents of the same version of the standard.</p>
 
-					<p>It is strongly RECOMMENDED that all future needs for multiple Renditions in a Container follow
-						this specification. Existing implementations that utilize other methods for selecting from
-						multiple Renditions are also encouraged to consider migrating to use this specification to
-						improve the overall interoperability of Multiple-Rendition Publications.</p>
-				</section>
+				<p>This specification moves beyond merely allowing multiple renderings to define a more complete
+					framework for identifying and selecting from among them. Each Package Document referenced from a
+						<code>rootfile</code> element is defined to be one <a>Rendition</a> of the EPUB Publication,
+					with the first Package Document representing the <a>Default Rendition</a> (i.e., the one that all
+					Reading Systems have to process).</p>
 
-				<section id="rel-publications">
-					<h3>Relationship to Publications 3.0.1</h3>
+				<p>Although this model is intended to work as seamlessly as possible with existing the EPUB ecosystem,
+					the authoring of multiple Renditions requires some compromises to maintain compatibility (e.g., some
+					duplication of metadata will be necessary for Reading Systems that do not handle multiple
+					renditions).</p>
+			</section>
 
-					<p>Some of the <a href="#rendition-selection-attr">Rendition selection attributes</a> defined in
-						this specification share common names with Package Document elements and properties
-						[[EPUBPublications-301]] as they are designed to reflect that information for selection
-						purposes.</p>
+			<section id="rel-epub3">
+				<h4>Relationship to EPUB 3</h4>
 
-					<p>Despite this commonality, this specification does not enforce equivalence between the Rendition
-						selection properties expressed on a <code>rootfile</code> element [[OCF-301]] and the metadata
-						expressed in the corresponding Package Document, as direct equivalence is not always
-						possible.</p>
+				<p>The method defined in this specification for including multiple <a>Renditions</a> within an <a>EPUB
+						Container</a> is not required for all <a>EPUB Publications</a>. Multiple Renditions MAY be
+					included in a Container without adhering to this specification, as the ability to create
+					multiple-Rendition Containers pre-dates this specification.</p>
 
-					<p>For example, a multilingual EPUB Publication will define more than one <a
-							href="http://idpf.org/epub/301/spec/epub-publications.html#sec-opf-dclanguage">DCMES
-								<code>language</code> element</a> [[EPUBPublications-301]] ‒ one for each language ‒ but
-						for Rendition selection only the primary language is defined. Likewise, the language defined in
-						the Package Document could include a specific region code, but for selection purposes the Author
-						might identify only the language code.</p>
+				<p>It is strongly RECOMMENDED, however, that all future needs for multiple Renditions in a Container
+					follow this specification. Existing implementations that utilize other methods for selecting from
+					multiple Renditions are also encouraged to consider migrating to use this specification to improve
+					the overall interoperability of Multiple-Rendition Publications.</p>
 
-					<p>The reason for common metadata in both locations is to simplify the selection process: including
-						attributes avoids the requirement to parse each referenced Package Document and allows for
-						expressions of primacy that aren't possible at the package level. It also avoids collisions and
-						ambiguities between metadata being used for different purposes (selection versus rendering).</p>
+				<p>Some of the <a href="#rendition-selection-attr">Rendition selection attributes</a> defined in this
+					specification share common names with Package Document elements and properties [[EPUB-33]] as they
+					are designed to reflect that information for selection purposes.</p>
 
-					<p>The selection properties defined in the <a
-							href="http://idpf.org/epub/301/spec/epub-ocf.html#sec-container-metainf-container.xml"
-								><code>container.xml</code> file</a> [[OCF-301]] have no rendering behaviors attached to
-						them, either. For example, indicating that a Rendition is fixed layout in the <a
-							href="#layout-attr"><code>rendition:layout</code> attribute</a> does not trigger fixed
-						layout rendering behaviors within the specified Rendition.</p>
+				<p>Despite this commonality, this specification does not enforce equivalence between the Rendition
+					selection properties expressed on a <code>rootfile</code> element [[EPUB-33]] and the metadata
+					expressed in the corresponding Package Document, as direct equivalence is not always possible.</p>
 
-					<p>A Reading System renders a Rendition according to the metadata expressed in the Package Document
-						only.</p>
-				</section>
+				<p>For example, a multilingual EPUB Publication will define more than one <a
+						href="https://www.w3.org/TR/epub3/core/#sec-opf-dclanguage">DCMES <code>language</code>
+						element</a> [[EPUB-33]] &#8212; one for each language &#8212; but for Rendition selection only
+					the primary language is defined. Likewise, the language defined in the Package Document could
+					include a specific region code, but for selection purposes the Author might identify only the
+					language code.</p>
+
+				<p>The reason for common metadata in both locations is to simplify the selection process: including
+					attributes avoids the requirement to parse each referenced Package Document and allows for
+					expressions of primacy that are not possible at the package level. It also avoids collisions and
+					ambiguities between metadata being used for different purposes (selection versus rendering).</p>
+
+				<p>The selection properties defined in the <a
+						href="https://www.w3.org/TR/epub3/core/#sec-container-metainf-container.xml"
+							><code>container.xml</code> file</a> [[EPUB-33]] have no rendering behaviors attached to
+					them, either. For example, indicating that a Rendition is fixed layout in the <a href="#layout-attr"
+							><code>rendition:layout</code> attribute</a> does not trigger fixed layout rendering
+					behaviors within the specified Rendition.</p>
+
+				<p>A Reading System renders a Rendition according to the metadata expressed in the Package Document
+					only.</p>
 			</section>
 
 			<section id="terminology">
 				<h3>Terminology</h3>
 
-				<p>Refer to the <a href="http://idpf.org/epub/301/">EPUB Specifications</a> for definitions of
-					EPUB-specific terminology used in this document.</p>
+				<p>The following terms used in this document are defined in [[EPUB-33]]:</p>
+
+				<ul>
+					<li><a href="https://www.w3.org/TR/epub3/core/#dfn-author">Author</a></li>
+					<li><a href="https://www.w3.org/TR/epub3/core/#dfn-epub-container">EPUB Container</a></li>
+					<li><a href="https://www.w3.org/TR/epub3/core/#dfn-epub-content-document">EPUB Content
+						Document</a></li>
+					<li><a href="https://www.w3.org/TR/epub3/core/#dfn-epub-publication">EPUB Publication</a></li>
+					<li><a href="https://www.w3.org/TR/epub3/core/#dfn-package-document">Package Document</a></li>
+					<li><a href="https://www.w3.org/TR/epub3/core/#dfn-reading-system">Reading System</a></li>
+					<li><a href="https://www.w3.org/TR/epub3/core/#dfn-root-directory">Root Directory</a></li>
+					<li><a href="https://www.w3.org/TR/epub3/core/#dfn-top-level-content-document">Top-Level Content
+							Document</a></li>
+					<li><a href="https://www.w3.org/TR/epub3/core/#dfn-xhtml-content-document">XHTML Content
+							Document</a></li>
+				</ul>
+
+				<p>In addition, this document defines the following terms:</p>
 
 				<dl>
-					<dt>Container Document</dt>
+					<dt><dfn>Container Document</dfn></dt>
 					<dd>
-						<p>The <a href="http://idpf.org/epub/301/spec/epub-ocf.html#sec-container-metainf-container.xml"
+						<p>The <a href="https://www.w3.org/TR/epub3/core/#sec-container-metainf-container.xml"
 									><code>container.xml</code> file</a> located in the child <a
-								href="http://idpf.org/epub/301/spec/epub-ocf.html#sec-container-metainf"
-									><code>META-INF</code> directory</a> of the OCF Container Root Directory
-							[[OCF-301]]. Each Rendition in the Container is identified by a <code>rootfile</code>
-							element [[OCF-301]].</p>
+								href="https://www.w3.org/TR/epub3/core/#sec-container-metainf"><code>META-INF</code>
+								directory</a> of the EPUB Container Root Directory [[EPUB-33]]. Each <a>Rendition</a> in
+							the Container is identified by a <code>rootfile</code> element [[EPUB-33]].</p>
 					</dd>
 
-					<dt>Multiple-Rendition Publication</dt>
+					<dt><dfn>Default Rendition</dfn></dt>
 					<dd>
-						<p>An EPUB Publication that consists of two or more Renditions of the content.</p>
+						<p>The <a>Rendition</a> listed in the first <code>rootfile</code> element in the <a
+								href="https://www.w3.org/TR/epub3/core/#sec-container-metainf-container.xml"
+									><code>container.xml</code> file</a> [[EPUB-33]].</p>
 					</dd>
 
-					<dt>Rendition Mapping Document</dt>
+					<dt><dfn>Multiple-Rendition Publication</dfn></dt>
+					<dd>
+						<p>An EPUB Publication that consists of two or more <a>Renditions</a> of the content.</p>
+					</dd>
+
+					<dt><dfn>Rendition</dfn></dt>
+					<dd>
+						<p>One rendering of the content of an EPUB Publication, as expressed by a Package Document.</p>
+					</dd>
+
+					<dt><dfn>Rendition Mapping Document</dfn></dt>
 					<dd>
 						<p>A specialization of the XHTML Content Document, containing machine-readable mappings between
-							equivalent content in different Renditions, conforming to the constraints expressed in <a
-								href="#rendition-mapping">Rendition Mapping</a>.</p>
+							equivalent content in different <a>Renditions</a>, conforming to the constraints expressed
+							in <a href="#rendition-mapping">Rendition Mapping</a>.</p>
 					</dd>
 				</dl>
 			</section>
 
 			<section id="conformance"></section>
 		</section>
-		<section id="pub-metadata">
-			<h2>Publication Metadata</h2>
+		<section id="container">
+			<h2>Specifying Multiple Renditions</h2>
 
-			<section id="pub-metadata-file">
-				<h3>The <code>metadata.xml</code> File</h3>
+			<p>Each Rendition of an <a>EPUB Publication</a> MUST meet the <a
+					href="https://www.w3.org/TR/epub-33/#sec-epub-conf">requirements for EPUB Publications</a>
+				[[!EPUB-33]].</p>
 
-				<p>To ensure consistency of metadata at the Publication and Rendition levels, this specification defines
-					the content model of the root <code>metadata</code> element in the <a
-						href="http://idpf.org/epub/301/spec/epub-ocf.html#sec-container-metainf-metadata.xml"
-							><code>metadata.xml</code> file</a> [[OCF-301]] to be the same as the Package Document <a
-						href="http://idpf.org/epub/301/spec/epub-publications.html#elemdef-opf-metadata"
-							><code>metadata</code> element</a> [[EPUBPublications-301]], with the following differences
-					in syntax and semantics:</p>
+			<p>The Package Document for each Rendition MUST be listed in the <code>container.xml</code> file
+				[[!EPUB-33]], where the first Package Document listed represents the <a>Default Rendition</a>.</p>
 
-				<ul>
-					<li>Only a <a href="#release-id">Release Identifier</a> is REQUIRED; all other metadata is
-						OPTIONAL.</li>
-					<li>The obsolete <a href="http://idpf.org/epub/301/spec/epub-publications.html#sec-opf-meta-elem"
-							>OPF2 <code>meta</code> element</a> [[EPUBPublications-301]] is not allowed.</li>
-					<li>The <code>meta</code> and <code>link</code> elements are defined in the same namespace as the
-							<code>metadata</code> root element: <code class="uri"><a
-								href="http://www.idpf.org/2013/metadata"
-						>http://www.idpf.org/2013/metadata</a></code></li>
-				</ul>
+			<aside class="example">
+				<p>The following example shows SVG and XHTML Renditions bundled in the same container:</p>
 
-				<ul>
-					<li>In order to enable the full expression of metadata in the <code>metadata.xml</code> file, all
-						attributes allowed on the <a
-							href="http://idpf.org/epub/301/spec/epub-publications.html#sec-package-elem"
-								><code>package</code> element</a> [[EPUBPublications-301]] are allowed on the root <code
-							class="markup">metadata</code> element.</li>
-				</ul>
+				<pre>&lt;?xml version="1.0"?&gt;
+&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
+    &lt;rootfiles&gt;
+        &lt;rootfile full-path="SVG/Sandman.opf"
+            media-type="application/oebps-package+xml" /&gt;
+        &lt;rootfile full-path="XHTML/Sandman.opf"
+            media-type="application/oebps-package+xml" /&gt;
+    &lt;/rootfiles&gt;
+&lt;/container&gt;</pre>
+			</aside>
 
-				<p>This specification does not define a model for the inheritance of metadata from the Publication level
-					to the Rendition level, as EPUB processing only requires that the default Rendition be recognized by
-					Reading Systems (i.e., reliance on inheritance could result in Reading Systems not locating
-					necessary metadata).</p>
+			<p>Each Rendition of the EPUB Publication SHOULD only list the <a>Publication Resources</a> necessary for
+				its rendering in its Package Document <a>manifest</a> [[!EPUB-33]]. Renditions MAY reference the same
+				Publication Resources.</p>
+		</section>
+		<section id="sec-metadata">
+			<h2>Expressing Metadata</h2>
 
-				<div class="note">
-					<p>Authors are strongly encouraged to include a complete set of Publication metadata in the default
-						Rendition to ensure cross-compatibility, even when making use of this file.</p>
-					<p>Titles, languages and other metadata is often not applicable from one Rendition to another,
-						further complicating the sharing of metadata. No assumption can be made that metadata in the
-							<code>metadata.xml</code> file is applicable to any given Rendition, whether the metadata is
-						expressed in the Rendition or not.</p>
-				</div>
+			<section id="rendition-metadata">
+				<h3>Rendition Metadata</h3>
 
-				<div class="note">
-					<p>As [[OCF-301]] does not define a content model for the <code>metadata.xml</code> file, EPUB
-						Publications that do not conform to this specification can include different metadata. EPUB
-						Publications that are not valid to the schema in <a href="#schema-metadata"></a> are not valid
-						Multiple-Rendition Publications as defined by this specification, but might still be valid EPUB
-						3.0.1 Publications.</p>
-					<p>Authors are strongly encouraged to migrate to the content model defined in this specification,
-						even if not producing Multiple-Rendition Publications, to ensure consistent processing.</p>
-				</div>
+				<p>Metadata expressed at the Rendition level MAY change from instance to instance. For example,
+					Renditions in different languages will have different primary languages and language-specific
+					metadata such as titles will be expressed differently. Similarly, bundled fixed-layout and
+					reflowbale Renditions will express different rendering metadata.</p>
 			</section>
 
-			<section id="vocab-assoc">
-				<h3>Vocabulary Association Mechanisms</h3>
+			<section id="pub-metadata">
+				<h3>Publication Metadata</h3>
 
-				<p>This specification inherits the mechanisms for associating vocabularies defined in <a
-						href="http://idpf.org/epub/301/spec/epub-publications.html#sec-metadata-assoc">4.2 Vocabulary
-						Association Mechanisms</a> [[EPUBPublications-301]] as they relate to the Package Document
-					metadata, with only the following modification: the <code>prefix</code> attribute MAY be attached
-					only to the root <code>metadata</code> element.</p>
+				<section id="pub-metadata-file">
+					<h3>The <code>metadata.xml</code> File</h3>
 
-				<p><a href="http://idpf.org/epub/301/spec/epub-publications.html#sec-metadata-reserved-vocabs">Reserved
-						prefixes</a> [[EPUBPublications-301]] for metadata attribute expressions are adopted without
-					change.</p>
-			</section>
-
-			<section id="release-id">
-				<h3>Release Identifier</h3>
-
-				<section id="release-id-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>For reliable processing of EPUB Publications, each needs to be uniquely identifiable. But
-						uniqueness between EPUB Publications is not enough for total reliability, as more than one
-						version of a given EPUB Publication could exist. As a result, it is also necessary to be able to
-						identify and order each release of an EPUB Publication</p>
-
-					<p>To distinguish both these characteristics, the concept of a <a
-							href="http://idpf.org/epub/301/spec/epub-publications.html#sec-opf-metadata-identifiers-pid"
-							>Release Identifier</a> [[EPUBPublications-301]] was introduced in EPUB 3. This identifier
-						is a combination of the Unique Identifier and the last modified date, where the Unique
-						Identifier enables differentiation between EPUB Publications and the last modified date enables
-						differentiation between different versions of the same EPUB Publication.</p>
-
-					<p>The problem with this identifier, however, is that it is unique to each Rendition because it is
-						expressed in the Package Document metadata. For example, the last modification dates for
-						Renditions could be different if minor corrections only were necessary to some of them, and each
-						could have a different Unique Identifier. As a result, it only effectively identifies an EPUB
-						Publication if that EPUB Publication contains only one Rendition.</p>
-
-					<p>Consequently, a new Release Identifier that covers all the Renditions of the EPUB Publication is
-						necessary for Multiple-Rendition Publications, otherwise comparisons are complicated by trying
-						to figure out which Rendition(s) have changed and how to compare them from one release to the
-						next (e.g., if their order in the <a
-							href="http://idpf.org/epub/301/spec/epub-ocf.html#sec-container-metainf-container.xml"
-								><code>container.xml</code> file</a> [[OCF-301]] changes). This section details how to
-						define such a global Release Identifier.</p>
-				</section>
-
-				<section id="release-id-express">
-					<h4>Expressing</h4>
-
-					<p>The <a
-							href="http://idpf.org/epub/301/spec/epub-publications.html#sec-opf-metadata-identifiers-pid"
-							>Release Identifier</a> [[EPUBPublications-301]] for a Multiple-Rendition Publication is
-						expressed in the <a
-							href="http://idpf.org/epub/301/spec/epub-ocf.html#sec-container-metainf-metadata.xml"
-								><code>metadata.xml</code> file</a> [[OCF-301]] in the same manner as it is in the
-						Package Document:</p>
+					<p>To ensure consistency of metadata at the Publication and <a>Rendition</a> levels, this
+						specification defines the content model of the root <code>metadata</code> element in the <a
+							href="https://www.w3.org/TR/epub3/core/#sec-container-metainf-metadata.xml"
+								><code>metadata.xml</code> file</a> [[EPUB-33]] to be the same as the Package Document
+							<a href="https://www.w3.org/TR/epub3/core/#elemdef-opf-metadata"><code>metadata</code>
+							element</a> [[EPUB-33]], with the following differences in syntax and semantics:</p>
 
 					<ul>
-						<li>A <code>dc:identifier</code> element [[DCTERMS]] MUST contain the <a
-								href="http://idpf.org/epub/301/spec/epub-publications.html#sec-opf-metadata-identifiers-uid"
-								>unique identifier</a> [[EPUBPublications-301]] for the EPUB Publication.</li>
-						<li>A <code>meta</code> element [[EPUBPublications-301]] MUST contain the last modified date,
-							expressed using the <code>dcterms:modified</code> property [[DCTERMS]].</li>
+						<li>Only a <a href="#release-id">Release Identifier</a> is REQUIRED; all other metadata is
+							OPTIONAL.</li>
+						<li>The obsolete <a href="https://www.w3.org/TR/epub3/core/#sec-opf-meta-elem">OPF2
+									<code>meta</code> element</a> [[EPUB-33]] is not allowed.</li>
+						<li>The <code>meta</code> and <code>link</code> elements are defined in the same namespace as
+							the <code>metadata</code> root element: <code class="uri"><a
+									href="http://www.idpf.org/2013/metadata"
+								>http://www.idpf.org/2013/metadata</a></code></li>
 					</ul>
 
-					<p>The identifier MUST conform to the requirements for identifiers defined in <a
-							href="http://idpf.org/epub/301/spec/epub-publications.html#sec-opf-dcidentifier">3.4.3 The
-							DCMES <code>identifier</code> Element</a> [[EPUBPublications-301]].</p>
+					<ul>
+						<li>In order to enable the full expression of metadata in the <code>metadata.xml</code> file,
+							all attributes allowed on the <a href="https://www.w3.org/TR/epub3/core/#sec-package-elem"
+									><code>package</code> element</a> [[EPUB-33]] are allowed on the root <code
+								class="markup">metadata</code> element.</li>
+					</ul>
 
-					<p>The value of the <code>dcterms:modified</code> property must conform to the pattern and rules
-						defined in <a
-							href="http://idpf.org/epub/301/spec/epub-publications.html#sec-opf-metadata-identifiers-pid"
-							>4.1.2 Release Identifier</a> [[EPUBPublications-301]]. Only one
-							<code>dcterms:modified</code> property without a <a
-							href="http://idpf.org/epub/301/spec/epub-publications.html#attrdef-meta-refines"
-								><code>refines</code> attribute</a> [[EPUBPublications-301]] is allowed in the <code
-							class="markup">metadata.xml</code> file.</p>
+					<p>This specification does not define a model for the inheritance of metadata from the Publication
+						level to the <a>Rendition</a> level, as EPUB processing only requires that the <a>Default
+							Rendition</a> be recognized by Reading Systems (i.e., reliance on inheritance could result
+						in Reading Systems not locating necessary metadata).</p>
 
-					<aside class="example">
-						<p>The following example shows a Release Identifier expressed in the metadata.xml file:</p>
+					<div class="note">
+						<p>Authors are strongly encouraged to include a complete set of Publication metadata in the
+							Default Rendition to ensure cross-compatibility, even when making use of this file.</p>
+						<p>Titles, languages and other metadata is often not applicable from one Rendition to another,
+							further complicating the sharing of metadata. No assumption can be made that metadata in the
+								<code>metadata.xml</code> file is applicable to any given Rendition, whether the
+							metadata is expressed in the Rendition or not.</p>
+					</div>
 
-						<pre>&lt;metadata xmlns="http://www.idpf.org/2013/metadata"
+					<div class="note">
+						<p>As [[EPUB-33]] does not define a content model for the <code>metadata.xml</code> file, EPUB
+							Publications that do not conform to this specification can include different metadata. EPUB
+							Publications that are not valid to the schema in <a href="#schema-metadata"></a> are not
+							valid Multiple-Rendition Publications as defined by this specification, but might still be
+							valid EPUB 3.0.1 Publications.</p>
+						<p>Authors are strongly encouraged to migrate to the content model defined in this
+							specification, even if not producing Multiple-Rendition Publications, to ensure consistent
+							processing.</p>
+					</div>
+				</section>
+
+				<section id="vocab-assoc">
+					<h3>Vocabulary Association Mechanisms</h3>
+
+					<p>This specification inherits the mechanisms for associating vocabularies defined in <a
+							href="https://www.w3.org/TR/epub3/core/#sec-metadata-assoc">4.2 Vocabulary Association
+							Mechanisms</a> [[EPUB-33]] as they relate to the Package Document metadata, with only the
+						following modification: the <code>prefix</code> attribute MAY be attached only to the root
+							<code>metadata</code> element.</p>
+
+					<p><a href="https://www.w3.org/TR/epub3/core/#sec-metadata-reserved-vocabs">Reserved prefixes</a>
+						[[EPUB-33]] for metadata attribute expressions are adopted without change.</p>
+				</section>
+
+				<section id="release-id">
+					<h3>Release Identifier</h3>
+
+					<section id="release-id-intro" class="informative">
+						<h4>Introduction</h4>
+
+						<p>For reliable processing of EPUB Publications, each needs to be uniquely identifiable. But
+							uniqueness between EPUB Publications is not enough for total reliability, as more than one
+							version of a given EPUB Publication could exist. As a result, it is also necessary to be
+							able to identify and order each release of an EPUB Publication</p>
+
+						<p>To distinguish both these characteristics, the concept of a <a
+								href="https://www.w3.org/TR/epub3/core/#sec-metadata-elem-identifiers-pid">release
+								identifier</a> [[EPUB-33]] was introduced in EPUB 3. This identifier is a combination of
+							the Unique Identifier and the last modified date, where the Unique Identifier enables
+							differentiation between EPUB Publications and the last modified date enables differentiation
+							between different versions of the same EPUB Publication.</p>
+
+						<p>The problem with this identifier, however, is that it is unique to each <a>Rendition</a>
+							because it is expressed in the Package Document metadata. For example, the last modification
+							dates for Renditions could be different if minor corrections only were necessary to some of
+							them, and each could have a different Unique Identifier. As a result, it only effectively
+							identifies an EPUB Publication if that EPUB Publication contains only one Rendition.</p>
+
+						<p>Consequently, a new Release Identifier that covers all the Renditions of the EPUB Publication
+							is necessary for Multiple-Rendition Publications, otherwise comparisons are complicated by
+							trying to figure out which Rendition(s) have changed and how to compare them from one
+							release to the next (e.g., if their order in the <a
+								href="https://www.w3.org/TR/epub3/core/#sec-container-metainf-container.xml"
+									><code>container.xml</code> file</a> [[EPUB-33]] changes). This section details how
+							to define such a global Release Identifier.</p>
+					</section>
+
+					<section id="release-id-express">
+						<h4>Expressing</h4>
+
+						<p>The <a href="https://www.w3.org/TR/epub3/core/#sec-metadata-elem-identifiers-pid">release
+								identifier</a> [[EPUB-33]] for a Multiple-Rendition Publication is expressed in the <a
+								href="https://www.w3.org/TR/epub3/core/#sec-container-metainf-metadata.xml"
+									><code>metadata.xml</code> file</a> [[EPUB-33]] in the same manner as it is in the
+							Package Document:</p>
+
+						<ul>
+							<li>A <code>dc:identifier</code> element [[DCTERMS]] MUST contain the <a
+									href="https://www.w3.org/TR/epub3/core/#sec-opf-metadata-identifiers-uid">unique
+									identifier</a> [[EPUB-33]] for the EPUB Publication.</li>
+							<li>A <code>meta</code> element [[EPUB-33]] MUST contain the last modified date, expressed
+								using the <code>dcterms:modified</code> property [[DCTERMS]].</li>
+						</ul>
+
+						<p>The identifier MUST conform to the requirements for identifiers defined in <a
+								href="https://www.w3.org/TR/epub3/core/#sec-opf-dcidentifier">3.4.3 The DCMES
+									<code>identifier</code> Element</a> [[EPUB-33]].</p>
+
+						<p>The value of the <code>dcterms:modified</code> property must conform to the pattern and rules
+							defined in <a href="https://www.w3.org/TR/epub3/core/#sec-metadata-elem-identifiers-pid"
+								>Release Identifier</a> [[EPUB-33]]. Only one <code>dcterms:modified</code> property
+							without a <a href="https://www.w3.org/TR/epub3/core/#attrdef-meta-refines"
+									><code>refines</code> attribute</a> [[EPUB-33]] is allowed in the <code
+								class="markup">metadata.xml</code> file.</p>
+
+						<div class="note">
+							<p>When an <a>EPUB Container</a> includes more than one <a>Rendition</a> of an EPUB
+								Publication, updating the last modified date of the <a>Default Rendition</a> for each
+								release — even if it has not been updated — will help ensure that the EPUB Publication
+								does not appear to be the same version as an earlier release, as Reading Systems only
+								have to process the Default Rendition.</p>
+						</div>
+
+						<aside class="example">
+							<p>The following example shows a Release Identifier expressed in the metadata.xml file:</p>
+
+							<pre>&lt;metadata xmlns="http://www.idpf.org/2013/metadata"
           xmlns:dc="http://purl.org/dc/elements/1.1/"
           unique-identifier="pub-id"&gt;
    &lt;dc:identifier id="pub-id"&gt;urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier&gt;
    &lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;
 &lt;/metadata&gt;</pre>
-					</aside>
+						</aside>
+					</section>
 				</section>
 			</section>
 		</section>
@@ -336,17 +427,16 @@
 					for smaller cellphone screens where the fixed layout would be scaled to illegibility (or
 					automatically reflowed in unwanted ways if fixed layouts are not supported).</p>
 
-				<p>The OCF Container allows multiple Renditions of the content to be included in an EPUB Publication,
-					but does not specify how Reading Systems are to determine the unique properties of the Renditions
-					listed in the Container Document, or select between them.</p>
+				<p>The EPUB Container allows multiple <a>Renditions</a> of the content to be included in an EPUB
+					Publication, but does not specify how Reading Systems are to determine the unique properties of the
+					Renditions listed in the Container Document, or select between them.</p>
 
 				<p>This section redresses this problem by defining both a set of rendition selection attributes that can
-					be attached to <a
-						href="http://idpf.org/epub/301/spec/epub-ocf.html#sec-container-metainf-container.xml"
-							><code>rootfile</code> elements</a> [[OCF-301]] in the Container Document and a processing
+					be attached to <a href="https://www.w3.org/TR/epub3/core/#sec-container-metainf-container.xml"
+							><code>rootfile</code> elements</a> [[EPUB-33]] in the Container Document and a processing
 					model that allows Authors to specify which Rendition is the best representation depending on various
 					conditions. Reading Systems can then select the appropriate representation from the list of
-					Renditions to match the current configuration and User preferences.</p>
+					Renditions to match the current configuration and user preferences.</p>
 			</section>
 
 			<section id="rendition-selection-pub-confomance">
@@ -357,13 +447,13 @@
 				<ul class="conformancelist">
 					<li id="confreq-container">It MUST be valid to the definition and requirements for the
 							<code>container.xml</code> file specified in <a
-							href="http://idpf.org/epub/301/spec/epub-ocf.html#sec-container-metainf-container.xml"
-							>Container – META-INF/container.xml</a> [[OCF-301]].</li>
+							href="https://www.w3.org/TR/epub3/core/#sec-container-metainf-container.xml">Container –
+							META-INF/container.xml</a> [[EPUB-33]].</li>
 					<li id="confreq-selection-attr">It MAY include any of the selection attributes defined in <a
 							href="#rendition-selection-attr">Rendition Selection Attributes</a>.</li>
 					<li id="confreq-selection-min">Inclusion of selection attributes is OPTIONAL on the <a
 							href="https://www.w.org/TR/epub3/core/#elemdef-container-rootfile"><code>rootfile</code>
-							element</a> [[OCF-301]] for the Default Rendition, but it SHOULD include at least one
+							element</a> [[EPUB-33]] for the <a>Default Rendition</a>, but it SHOULD include at least one
 						selection attribute ‒ in addition to the OPTIONAL label ‒ on each subsequent
 							<code>rootfile</code> element.</li>
 				</ul>
@@ -372,10 +462,10 @@
 			<section id="rendition-selection-rs-conformance">
 				<h3>Reading System Conformance</h3>
 
-				<p>An EPUB Reading System MUST meet all of the following criteria for Rendition selection:</p>
+				<p>An EPUB Reading System MUST meet all of the following criteria for <a>Rendition</a> selection:</p>
 
 				<ul class="conformancelist">
-					<li id="confreq-rs-processing">It SHOULD determine the Rendition to present to a User as defined in
+					<li id="confreq-rs-processing">It SHOULD determine the Rendition to present to a user as defined in
 							<a href="#rendition-selection-proc-model"></a>.</li>
 				</ul>
 			</section>
@@ -387,7 +477,7 @@
 					<h4>The <code>rendition:media</code> attribute</h4>
 
 					<p>The <code>rendition:media</code> attribute identifies the media features of a Reading System the
-						given Rendition is best suitable for rendering on.</p>
+						given <a>Rendition</a> is best suitable for rendering on.</p>
 
 					<div class="elem-synopsis" id="attrdef-media">
 						<dl>
@@ -412,7 +502,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on Container Document <code>rootfile</code> elements
-									[[OCF-301]].</p>
+									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -452,8 +542,8 @@
 				<section id="layout-attr">
 					<h4>The <code>rendition:layout</code> attribute</h4>
 
-					<p>The <code>rendition:layout</code> attribute indicates whether the given Rendition is reflowable
-						or pre-paginated.</p>
+					<p>The <code>rendition:layout</code> attribute indicates whether the given <a>Rendition</a> is
+						reflowable or pre-paginated.</p>
 
 					<div class="elem-synopsis" id="attrdef-layout">
 						<dl>
@@ -478,7 +568,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on Container Document <code>rootfile</code> elements
-									[[OCF-301]].</p>
+									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -491,11 +581,11 @@
 					</div>
 
 					<p>When specified, the value of this attribute MUST match the <a
-							href="http://idpf.org/epub/301/spec/epub-publications.html#property-layout-global">global
-							rendition:layout setting</a> [[EPUBPublications-301]] for the referenced Rendition.</p>
+							href="https://www.w3.org/TR/epub3/core/#property-layout-global">global rendition:layout
+							setting</a> [[EPUB-33]] for the referenced Rendition.</p>
 
-					<p>If a User layout preference is defined in the Reading System, the attribute evaluates to true if
-						the preference matches the specified value, otherwise it evaluates to false. If no User
+					<p>If a user layout preference is defined in the Reading System, the attribute evaluates to true if
+						the preference matches the specified value, otherwise it evaluates to false. If no user
 						preference is defined, the Reading System SHOULD ignore the attribute when selecting from the
 						available Renditions.</p>
 
@@ -520,8 +610,8 @@
 				<section id="language-attr">
 					<h4>The <code>rendition:language</code> attribute</h4>
 
-					<p>The <code>rendition:language</code> attribute indicates that the given Rendition is optimized for
-						the specified language. </p>
+					<p>The <code>rendition:language</code> attribute indicates that the given <a>Rendition</a> is
+						optimized for the specified language. </p>
 
 					<div class="elem-synopsis" id="attrdef-language">
 						<dl>
@@ -546,7 +636,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on Container Document <code>rootfile</code> elements
-									[[OCF-301]].</p>
+									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -558,14 +648,14 @@
 					</div>
 
 					<p>The <code>rendition:language</code> attribute more precisely identifies the primary language of a
-						Rendition than does the inclusion of <code>dc:language</code> elements in the Rendition’s
+						Rendition than does the inclusion of <code>dc:language</code> elements in the Rendition's
 						Package Document, as the presence of <code>dc:language</code> elements only indicates that the
 						specified languages are prominently used in the prose.</p>
 
-					<p>If a User language preference is defined in the Reading System, the attribute evaluates to true
+					<p>If a user language preference is defined in the Reading System, the attribute evaluates to true
 						if the preference matches the specified value, otherwise it evaluates to false. Several matching
 						schemes are defined in Section 3 of [[RFC4647]]. Reading systems can use the most appropriate
-						matching scheme. If no User preference is defined, the Reading System SHOULD ignore the
+						matching scheme. If no user preference is defined, the Reading System SHOULD ignore the
 						attribute when selecting from the available Renditions.</p>
 
 					<aside class="example">
@@ -594,7 +684,8 @@
 					<h4>The <code>rendition:accessMode</code> attribute</h4>
 
 					<p>The <code>rendition:accessMode</code> attribute identifies the way in which intellectual content
-						is communicated in a Rendition, and is based on the [[ISO24751-3]] "Access Mode" property.</p>
+						is communicated in a <a>Rendition</a>, and is based on the [[ISO24751-3]] "Access Mode"
+						property.</p>
 
 					<div class="elem-synopsis" id="attrdef-accessMode">
 						<dl>
@@ -619,7 +710,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on Container Document <code>rootfile</code> elements
-									[[OCF-301]].</p>
+									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -642,16 +733,16 @@
 						burned into an image format, the access mode is visual (e.g., character dialogue in a JPEG page
 						of a comic or a scan of a document).</p>
 
-					<p>A rendition MAY include more than one primary access mode. For example, the textual version might
+					<p>A Rendition MAY include more than one primary access mode. For example, the textual version might
 						also embed the auditory version using media overlays. In such cases, the attribute should list
 						each primary access mode that is available.</p>
 
-					<p>If a User access mode preference is defined in the Reading System, the attribute evaluates to
+					<p>If a user access mode preference is defined in the Reading System, the attribute evaluates to
 						true if that preference matches any of the access modes defined in it, otherwise it evaluates to
-						false. If no User preference is defined, the Reading System SHOULD ignore the attribute when
+						false. If no user preference is defined, the Reading System SHOULD ignore the attribute when
 						selecting from the available Renditions.</p>
 
-					<p>The <a href="#label-attr"><code>rendition:label</code> attribute</a> can be use to inform Users
+					<p>The <a href="#label-attr"><code>rendition:label</code> attribute</a> can be use to inform users
 						about the nature of the content, particularly where such information is not available, or not
 						yet standardized, for selection. For example, a tactile rendition could indicate the braille
 						code and grade in its label, or a textual rendition could be marked as optimized for
@@ -679,7 +770,7 @@
 				<section id="label-attr">
 					<h4>The <code>rendition:label</code> attribute</h4>
 
-					<p>The <code>rendition:label</code> attribute allows each <code>rootfile</code> element [[OCF-301]]
+					<p>The <code>rendition:label</code> attribute allows each <code>rootfile</code> element [[EPUB-33]]
 						to be annotated with a human-readable name.</p>
 
 					<div class="elem-synopsis" id="attrdef-label">
@@ -705,7 +796,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on Container Document <code>rootfile</code> elements
-									[[OCF-301]].</p>
+									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -716,8 +807,8 @@
 						</dl>
 					</div>
 
-					<p>The <code>rendition:label</code> attribute provides a name for the given rendition (e.g., for
-						manual rendition selection).</p>
+					<p>The <code>rendition:label</code> attribute provides a name for the given <a>Rendition</a> (e.g.,
+						for manual Rendition selection).</p>
 
 					<p>The language of the <code>rendition:label</code> attribute MAY be expressed in an
 							<code>xml:lang</code> attribute.</p>
@@ -749,15 +840,15 @@
 			<section id="rendition-selection-proc-model">
 				<h3>Processing Model</h3>
 
-				<p>This section describes the method by which Reading Systems locate the optimal Rendition to present to
-					a User.</p>
+				<p>This section describes the method by which Reading Systems locate the optimal <a>Rendition</a> to
+					present to a user.</p>
 
 				<p>Rendition selection SHOULD occur on initial rendering, and Reading Systems SHOULD re-evaluate the
-					selection in response to changes in the User environment (e.g., change in device orientation or
+					selection in response to changes in the user environment (e.g., change in device orientation or
 					viewport size).</p>
 
 				<p>When a change condition is triggered, the Reading System SHOULD evaluate the <code>rootfile</code>
-					elements [[OCF-301]] in the Container Document as follows, starting with the last
+					elements [[EPUB-33]] in the Container Document as follows, starting with the last
 						<code>rootfile</code> entry:</p>
 
 				<ul>
@@ -779,7 +870,7 @@
 				<p>If the Default Rendition is reached, select that Rendition and exit the process.</p>
 
 				<div class="note">
-					<p>This processing model does not require that the selection process occur on a User's device, or
+					<p>This processing model does not require that the selection process occur on a user's device, or
 						that all Renditions be provided in the Container. Rendition selection could occur on the server
 						side of a cloud-based delivery system, for example, and only a single best-match Rendition sent
 						to the device.</p>
@@ -791,7 +882,7 @@
 						the greatest compatibility across Reading Systems and ensure it is listed first.</p>
 				</div>
 
-				<p>A Reading System MAY provide the User the option to manually select any of the Renditions in the
+				<p>A Reading System MAY provide the user the option to manually select any of the Renditions in the
 					Container. It SHOULD use the <a href="#label-attr"><code>rendition:label</code> attribute</a>
 					attribute value to present the option, when available.</p>
 
@@ -807,9 +898,9 @@
 			<section id="rendition-mapping-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>The Rendition Mapping Document identifies related content locations across the Renditions in a
+				<p>The Rendition Mapping Document identifies related content locations across the <a>Renditions</a> in a
 					Multiple-Rendition Publication, allowing Reading Systems to switch between Renditions while keeping
-					the User’s place.</p>
+					the user's place.</p>
 
 				<p>The Rendition Mapping Document is represented as XHTML, and uses <code>nav</code> elements with
 					unordered lists to group the mappings. There is no display component to the Rendition Mapping
@@ -817,7 +908,7 @@
 					the XHTML content model for this document is very restrictive, allowing only a single
 						<code>nav</code> element in the <code>body</code>, to ease both authoring and processing.</p>
 
-				<p>To enable the mapping of content locations between Renditions, the Rendition Mapping Document’s
+				<p>To enable the mapping of content locations between Renditions, the Rendition Mapping Document's
 						<code>nav</code> element consists of a series of one or more unordered lists, each of which
 					represents a common point across all the Renditions (e.g., a chapter, a page or a component within a
 					page). The list items in each unordered list represent the set of equivalent link destinations
@@ -826,8 +917,8 @@
 					Rendition might point to the corresponding page break indicator within the XHTML Content Document
 					containing the page).</p>
 
-				<p>Knowing the position of the User in the current Rendition, when a change in context occurs, or is
-					triggered by the User, the Reading System can inspect the sibling list items to determine the EPUB
+				<p>Knowing the position of the user in the current Rendition, when a change in context occurs, or is
+					triggered by the user, the Reading System can inspect the sibling list items to determine the EPUB
 					Content Document to load that best meets the new conditions.</p>
 			</section>
 
@@ -843,8 +934,8 @@
 				<ul class="conformancelist">
 					<li id="confreq-map-xhtml">It MUST conform to all content conformance constraints for XHTML Content
 						Documents as defined in <a
-							href="http://www.idpf.org/epub/301/spec/epub-EPUBContentDocs.html#sec-xhtml-conf-content"
-							>XHTML Content Documents — Content Conformance</a> [[EPUBContentDocs-301]].</li>
+							href="http://www.idpf.org/epub/301/spec/epub-contentdocs.html#sec-xhtml-conf-content">XHTML
+							Content Documents — Content Conformance</a> [[EPUB-33]].</li>
 					<li id="confreq-map-content-model">It MUST conform to all content conformance constraints specific
 						for EPUB Rendition Mapping Documents expressed in <a href="#rendition-mapping-doc-def">EPUB
 							Rendition Mapping Document Definition</a>.</li>
@@ -854,7 +945,7 @@
 
 				<ul class="conformancelist">
 					<li id="confreq-map-unlisted">It MUST NOT be listed in the Package Document manifest of any of the
-						EPUB Publication’s Renditions.</li>
+						EPUB Publication's Renditions.</li>
 				</ul>
 			</section>
 
@@ -877,7 +968,7 @@
 				<section id="rendition-mapping-doc-xhtml">
 					<h4>XHTML Content Document: Restrictions</h4>
 
-					<p>The Rendition Mapping Document is a compliant EPUB XHTML Content Document, but with the following
+					<p>The Rendition Mapping Document is a compliant XHTML Content Document, but with the following
 						restrictions on the [[HTML]] content model:</p>
 
 					<ul>
@@ -945,9 +1036,8 @@
 
 					<p>Each list item in the unordered list MUST identify an EPUB Content Document, or a fragment
 						therein, for one of the Renditions ‒ defined in a child <code>a</code> element. Each of these
-						links MUST reference a <a
-							href="http://idpf.org/epub/301/spec/epub-publications.html#sec-itemref-elem">linear
-							Top-level Content Document</a> [[EPUBPublications-301]].</p>
+						links MUST reference a <a href="https://www.w3.org/TR/epub3/core/#sec-itemref-elem">linear
+							Top-level Content Document</a> [[EPUB-33]].</p>
 
 					<p>Each <code>a</code> element MUST specify which Rendition it refers to either 1) by including an
 							<a href="http://www.idpf.org/epub/linking/cfi/#sec-intra-cfis">Intra-Publication CFI</a>
@@ -972,7 +1062,7 @@
 
 					<aside class="example">
 						<p>The following example shows a Rendition Mapping Document for a magazine with 3 Renditions:
-							text, portrait and landscape. ‘article 1’ is on pages 5 and 6 of the fixed layout Renditions
+							text, portrait and landscape. ‘article 1' is on pages 5 and 6 of the fixed layout Renditions
 							and the landscape Rendition uses spreads (non-synthetic).</p>
 
 						<pre>&lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
@@ -1061,12 +1151,12 @@
 					<h4>Container Identification</h4>
 
 					<p>The location of the Rendition Mapping Document is identified in the Container Document using an
-						[[OCF-301]] <code>link</code> element child of the root <code>container</code> element,
+						[[EPUB-33]] <code>link</code> element child of the root <code>container</code> element,
 						where:</p>
 
 					<ul>
 						<li>the <code>href</code> attribute MUST reference the location of the Rendition Mapping
-							Document relative to the root of the OCF Container;</li>
+							Document relative to the root of the EPUB Container;</li>
 						<li>the <code>rel</code> attribute MUST specify the value "<code>mapping</code>";</li>
 						<li>the <code>media-type</code> attribute MUST specify the value
 								"<code>application/xhtml+xml</code>".</li>
@@ -1106,7 +1196,7 @@
 				<p>This section provides an informative model by which the Rendition Mapping Document could be processed
 					by a Reading System. It does not address how or when a Reading System should switch Renditions. </p>
 
-				<p>The desired outcome of the Rendition Mapping Document’s mapping capabilities is to display content in
+				<p>The desired outcome of the Rendition Mapping Document's mapping capabilities is to display content in
 					the new Rendition that is equivalent to their location in the current Rendition, so that a user
 					maintains their place during reading. To accomplish this goal, a compliant Reading System could
 					follow these steps to reset the current Rendition when a change condition is triggered:</p>
@@ -1133,7 +1223,7 @@
 							<li>If there is one and only one such <code>ul</code> element, the Reading System would
 								navigate to the beginning of the range in the new rendition. </li>
 							<li>If there is more than one such <code>ul</code> element, then the Reading System behavior
-								is undefined. The Reading System might prompt the User to select between the new
+								is undefined. The Reading System might prompt the user to select between the new
 								locations, or might choose between them using its own heuristics.<br /></li>
 							<li>If no matching <code>ul</code> elements are found, the Reading System will have to
 								determine the location to navigate to in the new Rendition as if there was no Rendition

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -78,12 +78,10 @@
 			<section id="sec-package-file">
 				<h2>Package Document</h2>
 
-				<p>Every EPUB Publication contains at least one <a>Rendition</a> of its contents, each of which is
-					represented by a <a>Package Document</a>.</p>
-
-				<p>The Package Document specifies all the resources required to render that representation of the
-					content. The Package Document also defines a reading order for linear consumption, and associates
-					metadata and navigation information for the Rendition.</p>
+				<p>Every EPUB Publication is represented by a <a>Package Document</a>. The Package Document specifies
+					all the resources required to render that representation of the content. The Package Document also
+					defines a reading order for linear consumption, and associates metadata and navigation
+					information.</p>
 
 				<p>The Package Document represents a significant improvement on a typical Web site. A Web site, for
 					example, embeds references to its resources within its content, which, while a simple and flexible
@@ -101,8 +99,6 @@
 					content identification, processing and rendering features, such as the ability to define embedded
 					preview content, or assemble an index or dictionary from its constituent XHTML Content
 					Documents.</p>
-
-				<p>The Package Document and other Rendition-specific constructs are specified in [[EPUB-33]].</p>
 			</section>
 
 			<section id="sec-nav">
@@ -121,25 +117,24 @@
 						have at least one logical ordering of all their top-level content items, whether by date, topic,
 						location, or some other criteria (e.g., a cookbook is typically ordered by type of recipe).</p>
 
-					<p>Each Rendition of an EPUB Publication defines at least one such logical ordering of all its
-						top-level content (the <a href="epub-core.html#sec-spine-elem">spine</a> [[EPUB-33]]), as well
-						as a declarative table of contents (the <a>EPUB Navigation Document</a> [[EPUB-33]]). EPUB
-						Publications make these data structures available in a machine-readable way <em>external</em> to
-						the content, simplifying their discovery and use.</p>
+					<p>An EPUB Publication defines at least one such logical ordering of all its top-level content (the
+							<a href="epub-core.html#sec-spine-elem">spine</a> [[EPUB-33]]), as well as a declarative
+						table of contents (the <a>EPUB Navigation Document</a> [[EPUB-33]]). EPUB Publications make
+						these data structures available in a machine-readable way <em>external</em> to the content,
+						simplifying their discovery and use.</p>
 
 					<p>EPUB Publications are not limited to the linear ordering of their contents, nor do they preclude
 						linking in arbitrary ways — just like the Web, EPUB Publications are built on hypertext — but
 						the basic consumption and navigation can be reliably accomplished in a way that is not true for
 						a set of HTML pages.</p>
-
 				</section>
 
 				<section id="sec-nav-nav-doc">
 					<h3>Navigation Document</h3>
 
-					<p>Each Rendition of an EPUB Publication contains a special XHTML Content Document called the
-							<a>EPUB Navigation Document</a>, which uses the [[HTML]] <code>nav</code> element to define
-						human- and machine-readable navigation information.</p>
+					<p>An EPUB Publication contains a special XHTML Content Document called the <a>EPUB Navigation
+							Document</a>, which uses the [[HTML]] <code>nav</code> element to define human- and
+						machine-readable navigation information.</p>
 
 					<p>The Navigation Document replaces the EPUB 2 NCX document [[OPS-201]]. The Navigation Document,
 						while maintaining the baseline accessibility and navigation support and features of the NCX,
@@ -163,12 +158,12 @@
 			<section id="sec-metadata">
 				<h2>Metadata</h2>
 
-				<p>EPUB Publications provide a rich array of options for adding metadata. Each Rendition's Package
-					Document includes a dedicated <a href="epub-core.html#sec-metadata-elem"><code>metadata</code>
-						section</a> [[EPUB-33]] for general information about the EPUB Publication, allowing titles,
-					authors, identifiers and other information about the EPUB Publication to be easily accessed. It also
-					provides the means to attach complete bibliographic records using the <a
-						href="epub-core.html#sec-link-elem"><code>link</code> element</a> [[EPUB-33]].</p>
+				<p>EPUB Publications provide a rich array of options for adding metadata. The Package Document includes
+					a dedicated <a href="epub-core.html#sec-metadata-elem"><code>metadata</code> section</a> [[EPUB-33]]
+					for general information about the EPUB Publication, allowing titles, authors, identifiers, and other
+					information about the EPUB Publication to be easily accessed. It also provides the means to attach
+					complete bibliographic records using the <a href="epub-core.html#sec-link-elem"><code>link</code>
+						element</a> [[EPUB-33]].</p>
 
 				<p>The Package Document also allows a <a>Unique Identifier</a> to be established for the EPUB
 					Publication using the <a href="epub-core.html#attrdef-package-unique-identifier"
@@ -192,9 +187,9 @@
 			<section id="sec-content-docs">
 				<h2>Content Documents</h2>
 
-				<p>Each Rendition of an EPUB Publication contains one or more <a>EPUB Content Documents</a>, as defined
-					in [[EPUB-33]]. These are XHTML or SVG documents that describe the readable content and reference
-					associated media resources (e.g., images, audio, and video clips).</p>
+				<p>An EPUB Publication contains one or more <a>EPUB Content Documents</a>, as defined in [[EPUB-33]].
+					These are XHTML or SVG documents that describe the readable content and reference associated media
+					resources (e.g., images, audio, and video clips).</p>
 
 				<p><a>XHTML Content Documents</a> are defined by a profile of [[HTML]].</p>
 
@@ -254,9 +249,9 @@
 					[[EPUB-33]].</p>
 
 				<p>Another key multimedia feature in EPUB 3 is the inclusion of <a>Media Overlay Documents</a>
-					[[EPUB-33]]. When pre-recorded narration is available for a Rendition of an EPUB Publication, Media
-					Overlays provide the ability to synchronize that audio with the text of a Content Document (see also
-						<a href="#sec-access-overlays">Aural Renditions and Media Overlays</a>).</p>
+					[[EPUB-33]]. When pre-recorded narration is available for an EPUB Publication, Media Overlays
+					provide the ability to synchronize that audio with the text of a Content Document (see also <a
+						href="#sec-access-overlays">Aural Renditions and Media Overlays</a>).</p>
 
 			</section>
 
@@ -329,10 +324,10 @@
 				<h2>Container</h2>
 
 				<p>An EPUB Publication is transported and interchanged as a single file (a "portable document") that
-					contains the Package Documents, all Content Documents, and all other required resources for
-					processing the included Renditions. The single-file container format for EPUB is based on the widely
-					adopted ZIP format, and an XML document that identifies the location of the Package Document for
-					each Rendition in the ZIP archive is located at a pre-defined location within the archive.</p>
+					contains the Package Document, all Content Documents, and all other required resources for
+					processing the publication. The single-file container format for EPUB is based on the widely adopted
+					ZIP format, and an XML document that identifies the location of the Package Document in the ZIP
+					archive is located at a pre-defined location within the archive.</p>
 
 				<p>This approach provides a clear contract between any creator of an EPUB Publication and any system
 					which consumes such EPUB Publications, as well as a reliable representation that is independent of
@@ -553,14 +548,6 @@
 					of EPUB 3 content across Reading Systems with varying capabilities (e.g., they allow the inclusion
 					of multiple video formats, and the inclusion of XHTML fallbacks to SVG Content Documents for EPUB 2
 					Reading Systems).</p>
-
-				<p>In addition, multiple instances of a complete work can be delivered in a single EPUB Publication by
-					defining multiple <code>rootfile</code> elements in the OCF container file (as described in <a
-						href="epub-core.html#sec-container-metainf-container.xml">Container File
-							(<code>container.xml</code>)</a> [[OCF-32]]). These alternate Rendition fallbacks might be
-					used, for example, so that a formatted graphic novel defined via a sequence of SVG pages can be
-					accompanied by an accessible text version defined via XHTML.</p>
-
 			</section>
 
 			<section id="sec-access-scripting">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -143,8 +143,8 @@
 									href="#ocf"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-rs-epub3-package">It MUST process <a>EPUB Packages</a> as defined in <a
-									href="#packages"></a>.</p>
+							<p id="confreq-rs-epub3-package">It MUST process the <a>Package Document</a> as defined in
+									<a href="#package-doc"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-foreign">It MAY support an arbitrary set of <a>Foreign Resource</a> types,
@@ -206,9 +206,8 @@
 				<dd>
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-rs-backward-epub">It MUST attempt to process any given rendition of an EPUB
-								Publication whose Package Document <code>version</code> attribute is less than
-									"<code>3.0</code>".</p>
+							<p id="confreq-rs-backward-epub">It MUST attempt to process an EPUB Publication whose
+								Package Document <code>version</code> attribute is less than "<code>3.0</code>".</p>
 						</li>
 						<li>
 							<p id="confreq-rs-backward-conf">EPUB Publications with older version numbers will not
@@ -222,9 +221,8 @@
 				<dd>
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-rs-forward-epubn">It SHOULD attempt to process any given Rendition of an EPUB
-								Publication whose Package Document <code>version</code> attribute is greater than
-									"<code>3.0</code>".</p>
+							<p id="confreq-rs-forward-epubn">It SHOULD attempt to process an EPUB Publication whose
+								Package Document <code>version</code> attribute is greater than "<code>3.0</code>".</p>
 						</li>
 					</ul>
 				</dd>
@@ -258,11 +256,11 @@
 					as a distributed system.</p>
 			</div>
 		</section>
-		<section id="packages">
-			<h2>Package Processing</h2>
+		<section id="package-doc">
+			<h2>Package Document Processing</h2>
 
 			<section id="sec-package-rs-conformance">
-				<h3>Package Conformance</h3>
+				<h3>Package Document Conformance</h3>
 
 				<p>An <a>EPUB Reading System</a> is conformant with this section if meets all of the following
 					criteria:</p>
@@ -295,8 +293,7 @@
 						<p id="confreq-rendition-rs-manifest">It MUST NOT use any resources not listed in the Package
 							Document in the processing of the Package (e.g., <a
 								href="https://www.w3.org/TR/epub-33/#sec-container-metainf"><code>META-INF</code>
-								files</a> [[EPUB-33]] or resources specific to other Renditions of the EPUB
-							Publication).</p>
+								files</a> [[EPUB-33]]).</p>
 					</li>
 				</ul>
 			</section>
@@ -318,7 +315,6 @@
 							<p>Reading Systems MUST trim all leading and trailing <a
 									href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] from Dublin Core
 								element values before processing.</p>
-
 							<p>Unless an individual property explicitly defines a different white space normalization
 								algorithm, Reading Systems MUST trim all leading and trailing <a
 									href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] from
@@ -355,7 +351,6 @@
 						<dd>
 							<p>If a Reading System does not recognize the <code>scheme</code> attribute value, it SHOULD
 								treat the value of the element as a string.</p>
-
 							<p>Reading Systems SHOULD ignore all <code>meta</code> elements whose <code>property</code>
 								attributes define expressions they do not recognize. A Reading System MUST NOT fail when
 								encountering unknown expressions.</p>
@@ -364,23 +359,19 @@
 						<dt id="conf-metadata-link">The <code>link</code> element</dt>
 						<dd>
 							<p>Retrieval of Remote Resources is OPTIONAL.</p>
-
 							<p>Reading System do not have to use or present linked resources, even if they recognize the
 								relationship defined in the <code>rel</code> attribute.</p>
-
 							<p id="sec-linked-records">In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
 									>linked metadata record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing
 								the metadata expressed in the Package Document and only use the information expressed in
 								the record. Reading Systems MAY compile metadata from multiple linked records; they do
 								not have to select only one record.</p>
-
 							<p>When it comes to resolving discrepancies and conflicts between metadata expressed in the
 								Package Document and in linked metadata records, Reading Systems MUST use the document
 								order of <code>link</code> elements in the Package Document to establish precedence
 								(i.e., metadata in the first linked record encountered has the highest precedence and
 								metadata in the Package Document the lowest, regardless of whether the <code>link</code>
 								elements occur before, within or after the package metadata elements).</p>
-
 							<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
 								layout and rendering of the EPUB Publication.</p>
 						</dd>
@@ -394,12 +385,10 @@
 						<dd>
 							<p>When an <code>href</code> attribute contains a relative IRI, Reading Systems MUST use the
 								IRI of the Package Document as the base when resolving to an absolute IRI.</p>
-
 							<p>Reading Systems MAY optimize the rendering depending on the properties set in the
 									<code>properties</code> attribute (e.g., disable a rendering process or use a
 								fallback). Reading Systems MUST ignore all descriptive metadata properties that they do
 								not recognize.</p>
-
 							<p>A Reading System that does not support the Media Type of a given Publication Resource
 								MUST traverse the fallback chain until it has identified at least one supported
 								Publication Resource to use in place of the unsupported resource. If the Reading System
@@ -424,17 +413,15 @@
 					<dl class="conformance-list">
 						<dt id="sec-spine-elem">The <code>spine</code> element</dt>
 						<dd>
-							<p>Reading Systems MUST provide a means of rendering the Rendition in the order defined in
-								the <code>spine</code>, which includes: 1) recognizing the first primary
+							<p>Reading Systems MUST provide a means of rendering the EPUB Publication in the order
+								defined in the <code>spine</code>, which includes: 1) recognizing the first primary
 									<code>itemref</code> as the beginning of the default reading order; and, 2)
 								rendering successive primary items in the order given in the <code>spine</code>.</p>
-
 							<p>When the <code>default</code> value is specified, the Reading System can choose the
 								rendering direction. The <code>default</code> value MUST be assumed when the attribute
 								is not specified. In this case, the reading system SHOULD choose a default
 									<code>page-progression-direction</code> value based on the first
 									<code>language</code> element.</p>
-
 							<p>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
 										><code>pre-paginated</code></a> XHTML Content Documents. The
 									<code>page-progression-direction</code> attribute defines the flow direction from
@@ -449,7 +436,6 @@
 								EPUB Publication. This specification does not mandate which model Reading Systems have
 								to use. A Reading System MAY also provide the option for users to toggle between the two
 								models.</p>
-
 							<p>Reading Systems MUST ignore all metadata properties expressed in the
 									<code>properties</code> attribute that they do not recognize.</p>
 						</dd>
@@ -1311,14 +1297,10 @@
 					<dl class="conformance-list">
 						<dt id="sec-container-metainf-container.xml">Container File (<code>container.xml</code>)</dt>
 						<dd>
-							<p id="container-default-rendition">A Reading System MUST consider the first
-									<code>rootfile</code> element within the <code>rootfiles</code> element to represent
-								the <a>Default Rendition</a> for the contained EPUB Publication. <a>Reading Systems</a>
-								are REQUIRED to present the Default Rendition, but MAY present other Renditions in the
-								container.</p>
-
-							<p><a>Reading Systems</a> MUST ignore foreign elements and attributes within a
-									<code>container.xml</code> file.</p>
+							<p id="container-default-rendition">A Reading System MUST, by default, use the Package
+								Document referenced from first <code>rootfile</code> element to render the EPUB
+								Publication. If the Reading System recognizes a means of selecting from the other
+								available options, it MAY choose a more appropriate Package Document.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-inc">Other Files</dt>
@@ -1762,7 +1744,6 @@
 							predefined URIs unless a local <a href="#sec-prefix-attr">prefix</a> is declared. Reading
 							Systems MUST use locally overridden prefixes in the <code>prefix</code> attribute when
 							encountered.</p>
-
 						<p>As changes to the reserved prefixes and updates to Reading Systems are not always going
 							happen in synchrony, Reading Systems MUST NOT fail when encountering unrecognized prefixes
 							(i.e., not reserved and not declared using the <code>prefix</code> attribute).</p>
@@ -1780,7 +1761,6 @@
 					<dd>
 						<p>A Reading System MUST use the following rules to create an IRI [[!RFC3987]] from a
 							property:</p>
-
 						<ul>
 							<li>
 								<p>If the property consists only of a reference, the IRI is obtained by concatenating
@@ -1794,7 +1774,6 @@
 									matching prefix has been defined, the property is invalid and MUST be ignored.</p>
 							</li>
 						</ul>
-
 						<p>The resulting IRI MUST be valid to [[!RFC3987]]. Reading Systems do not have to resolve this
 							IRI, however.</p>
 					</dd>
@@ -1835,10 +1814,10 @@
 							<dt id="scrolled-continuous">scrolled-continuous</dt>
 							<dd>
 								<p>The Reading System SHOULD render all Content Documents such that overflow content is
-									scrollable, and the EPUB Publication represented by the given <a>Rendition</a>
-									SHOULD be presented as one continuous scroll from spine item to spine item (except
-									where <a href="https://www.w3.org/TR/epub-33/#layout-property-flow-overrides"
-										>locally overridden</a> [[!EPUB-33]]).</p>
+									scrollable, and the EPUB Publication SHOULD be presented as one continuous scroll
+									from spine item to spine item (except where <a
+										href="https://www.w3.org/TR/epub-33/#layout-property-flow-overrides">locally
+										overridden</a> [[!EPUB-33]]).</p>
 							</dd>
 							<dt id="scrolled-doc">scrolled-doc</dt>
 							<dd>
@@ -1879,7 +1858,49 @@
 				</section>
 			</section>
 		</section>
-		<section class="appendix" id="app-epubReadingSystem">
+		<section id="app-release-identifier" class="appendix informative">
+			<h2>Release Identifier</h2>
+
+			<p>The release identifier allows a set of EPUB Publications to be inspected to determine if they represent
+				the same version of the same Publication, different versions of a single EPUB Publication, or any
+				combination of differing and similar EPUB Publications.</p>
+
+			<p>The release identifier does not supersede the <a>Unique Identifier</a> but represents how different
+				versions of the same EPUB Publication can be distinguished and identified. The sequential, chronological
+				order inherent in the format of the timestamp also places EPUB Publications in order without requiring
+				knowledge of the exact identifier that came before.</p>
+
+			<p>The Release Identifier is not an actual property in the Package Document <code>metadata</code> section
+				but is a value that can be obtained from two other mandatory pieces of metadata: the <a
+					href="https://www.w3.org/TR/epub-33/#sec-metadata-elem-identifiers-uid">Unique Identifier</a> and
+				the <a href="https://www.w3.org/TR/epub-33/#sec-metadata-elem-identifiers-pid">last modification
+					date</a> [[EPUB-33]] of the EPUB Publication. When the taken together, the combined value represents
+				a unique identity that can be used to distinguish any version of an EPUB Publication from another.</p>
+
+			<p>For referencing and other purposes all string representations of the identifier MUST be constructed using
+				the at sign (<code>@</code>) as the separator (i.e., of the form "id<code>@</code>date"). Whitespace
+				MUST NOT be included when concatenating the strings.</p>
+
+			<aside class="example">
+				<p>The following example shows how a Unique Identifier and modification date are combined to form the
+					Release Identifier.</p>
+				<pre class="nohighlight">&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
+    &lt;dc:identifier id="pub-id"&gt;urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier&gt;
+    &lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;
+    …
+&lt;/metadata&gt;
+
+results in the release identifier:
+
+urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
+</pre>
+			</aside>
+
+			<p>Note that it is possible that the separator character MAY occur in the Unique Identifier, as these
+				identifiers MAY be any string value. The Release Identifier consequently MUST be split on the last
+				instance of the at sign when decomposing it into its component parts.</p>
+		</section>
+		<section id="app-epubReadingSystem" class="appendix">
 			<h2>JavaScript <dfn>epubReadingSystem</dfn> Object</h2>
 
 			<section id="app-ers-idl">


### PR DESCRIPTION
This PR picks up from #1438 with a more complete rewrite of the specifications. The primary changes include:

- Rewriting the specifications not to use the term renditions.
- Moving the rendition definitions, examples and requirements in the core specification to multiple renditions specification.
- Adding a new background section to multiple renditions document to explain their history and purpose.
- Reduce the overuse of the phrasing "of the EPUB Publication" to avoid misunderstandings.
- Clean up/move the unique and release identifier sections into the package document definition.
- Move the release identifier processing to RS spec.

Probably the key section to look at is the publication conformance: https://raw.githack.com/w3c/epub-specs/editorial/issue-1436/epub33/core/index.html#sec-epub-conf

I've tried to retain the original requirement of multiple packages each with its own package document and nav doc but without using the old terminology. There's also a note in the package document intro about multiple package documents being allowed.

The other key section is the container.xml file definition: https://raw.githack.com/w3c/epub-specs/editorial/issue-1436/epub33/core/index.html#sec-container-metainf-container.xml

The multiple renditions document has a couple of new sections to deal with material that is better explained in it: the section on expressing multiple renditions and the clarification that renditions can each contain unique metadata in their package documents.

Otherwise, the rest of the changes are primarily editorial in nature. Everything that was allowed before is still allowed, but this should make the core specification simpler to read.

Fixes #1436 
Fixes #1442


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1448.html" title="Last updated on Dec 17, 2020, 12:44 AM UTC (374a6b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1448/efac8bb...374a6b9.html" title="Last updated on Dec 17, 2020, 12:44 AM UTC (374a6b9)">Diff</a>