### PR TITLE
Remove exemption that only alternative text needs to be provided for images

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1146,34 +1146,11 @@
 				<section class="suppress-numbering" id="desc-001">
 					<h4>DESC-001: Include alternative text descriptions</h4>
 
-					<p>[[WCAG20]] <a href="https://www.w3.org/TR/WCAG20/#text-equiv-all">Success Criterion
-						1.1.1</a> requires a text alternative for all non-text content. In the case of image content,
-						the provision of alternative text (e.g., in an [[HTML]] <code>alt</code> attribute) is
-						sufficient for meeting the requirements of the [[EPUB-A11Y]] specification.</p>
+					<p>The first version of these techniques only required alternative text for images regardless of
+						their complexity. This exception is no longer valid.</p>
 
-					<p>Authors are strongly encouraged to include extended descriptions, but the utility of extended
-						descriptions often depends on the needs of the user. Until the publishing ecosystem matures,
-						making it easier for Authors to include extended descriptions and write them to optimally meet
-						the needs of the greatest number of users, they are not required.</p>
-
-					<p>If extended descriptions are not included, note the omission in the <a href="#meta-005"
-							>accessibility summary</a>.</p>
-
-					<div class="note">
-						<p>The requirement for a text alternative does not apply to decorative images that contribute no
-							information to the text. These are identified by an empty <code>alt</code> attribute.</p>
-					</div>
-
-					<div class="caution">
-
-						<p>This guidance applies to the evaluation of EPUB Publications strictly for achieving
-							conformance to the [[EPUB-A11Y]] specification. If an EPUB Publication is distributed in an
-							environment where extended descriptions are required, this guidance for conformance will not
-							be sufficient.</p>
-
-						<p>The use of alternative text as a sufficient description for all images may be removed in a
-							future version of these techniques.</p>
-					</div>
+					<p>Authors must now ensure that their image-based content meets [[WCAG20]] requirements for
+						alternative text and extended descriptions to conform with [[EPUB-A11Y-11]].</p>
 
 					<section class="suppress-numbering" id="sec-desc-001-res">
 						<h5>Helpful Resources</h5>


### PR DESCRIPTION
Fixes #1441 by rewriting the technique that allowed only alt text. The new wording is as follows:

> The first version of these techniques only required alternative text for images regardless of their complexity. This exception is no longer valid.
> 
> Authors must now ensure that their image-based content meets [[WCAG20]] requirements for alternative text and extended descriptions to conform with [[EPUB-A11Y-11]].

I've left the helpful resources section and link to the diagram document since it's still relevant.

Techniques: [preview](https://raw.githack.com/w3c/epub-specs/fix/issue-1441/epub33/a11y-tech/) [diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y-tech%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-1441%2Fepub33%2Fa11y-tech%2Findex.html)
