### PR TITLE
Replace reference to idpf accessibility forum

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -135,10 +135,11 @@
 			<p>If Authors encounter issues that are not covered in these or related techniques, they are encouraged to
 				report the issue to the appropriate community for guidance on how to meet accessibility standards. The
 					<a href="https://www.w3.org/WAI/IG/">W3C Web Accessibility Interest Group</a> has a public mailing
-				list where issues meeting [[WCAG20]] and [[WAI-ARIA-1.1]] requirements can be raised. The IDPF similarly
-				has an <a href="http://idpf.org/forums/epub-accessibility">accessibility forum</a> where EPUB-related
-				issues can be raised.</p>
-
+				list where issues meeting [[WCAG20]] and [[WAI-ARIA-1.1]] requirements can be raised. The <a
+					href="https://github.com/w3c/publ-a11y/issues">W3C Publishing Community Group issue tracker</a> can
+				be used to ask for support implementing EPUB-specific requirements and the <a
+					href="https://github.com/w3c/epub-specs/issues">EPUB 3 Working Group's issue tracker</a> to report
+				issues with this document.</p>
 		</section>
 		<section id="sec-discovery">
 			<h2>Discovery Metadata Techniques</h2>


### PR DESCRIPTION
Fixes #1417 by replacing the sentence in question to:

> The [W3C Publishing Community Group issue tracker](https://github.com/w3c/publ-a11y/issues) can be used to ask for support implementing EPUB-specific requirements and the [EPUB 3 Working Group's issue tracker](https://github.com/w3c/epub-specs/issues) to report issues with this document.

Techniques: [preview](https://raw.githack.com/w3c/epub-specs/fix/issue-1417/epub33/a11y-tech/) [diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y-tech%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-1417%2Fepub33%2Fa11y-tech%2Findex.html)
