### PR TITLE
change containing block reference from CSSS 2.1 to CSS2 per #1399

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5520,7 +5520,7 @@ urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
 					<h4>Viewport Dimensions (Deprecated)</h4>
 
 					<p>The <code>rendition:viewport</code> property allows <a>Authors</a> to express the CSS initial
-						containing block (ICB) [[!CSS21]] for XHTML and SVG Content Documents whose
+						containing block (ICB) [[!CSS2]] for XHTML and SVG Content Documents whose
 							<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
 
 					<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its definition in


### PR DESCRIPTION
Fixes #1399


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dauwhe/epub-specs/pull/1451.html" title="Last updated on Dec 16, 2020, 5:53 PM UTC (c164845)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1451/86bdece...dauwhe:c164845.html" title="Last updated on Dec 16, 2020, 5:53 PM UTC (c164845)">Diff</a>