### PR TITLE
Remove release identifier

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1596,12 +1596,6 @@
 									NOT be issued when making minor revisions such as updating metadata, fixing errata,
 									or making similar minor changes.</p>
 
-								<div class="note">
-									<p>To differentiate versions of an EPUB Publication with the same Unique Identifier,
-										this specification also defines a <a href="#sec-metadata-elem-identifiers-pid"
-											>release identifier</a>.</p>
-								</div>
-
 								<p>Authors MAY include additional identifiers.</p>
 
 								<p>The <a href="#identifier-type"><code>identifier-type</code> property</a> is used to
@@ -2153,32 +2147,21 @@
 
 						</section>
 
-						<section id="sec-metadata-elem-identifiers-pid">
-							<h5>Release Identifier</h5>
+						<section id="sec-metadata-last-modified">
+							<h5>Last Modified Date</h5>
 
-							<p id="last-modified-date">To aid <a>Reading Systems</a> in distinguishing different
-								versions of an EPUB Publication that have the same <a>Unique Identifier</a>, the
-									<code>metadata</code> section MUST include exactly one [[!DCTERMS]]
-									<code>modified</code> property containing the last modification date. The value of
-								this property MUST be an [[!XMLSCHEMA-2]] dateTime conformant date of the form:</p>
-
-							<pre class="nohighlight">CCYY-MM-DDThh:mm:ssZ</pre>
+							<p id="last-modified-date">The <code>metadata</code> section MUST include exactly one
+								[[!DCTERMS]] <code>modified</code> property containing the last modification date. The
+								value of this property MUST be an [[!XMLSCHEMA-2]] dateTime conformant date of the form:
+									<code>CCYY-MM-DDThh:mm:ssZ</code></p>
 
 							<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST
 								be terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
 
-							<p>The inclusion of this value allows Reading Systems to construct a <a
-									href="https://www.w3.org/TR/epub-rs-33/#app-release-identifier">release
-									identifier</a> [[!EPUB-RS-33]] &#8212; a unique value that combines the Unique
-								Identifier with this last modification date. This value allows different versions of the
-								same EPUB Publication to be sorted and compared.</p>
-
 							<aside class="example">
-								<p>The following example shows the two components of the release identifier.</p>
+								<p>The following example shows a last modification date.</p>
 								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    &lt;dc:identifier id="pub-id"&gt;
-        urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
-    &lt;/dc:identifier&gt;
+    …
     &lt;meta property="dcterms:modified"&gt;2016-01-01T00:00:01Z&lt;/meta&gt;
     …
 &lt;/metadata&gt;</pre>
@@ -2190,6 +2173,13 @@
 							<p>Additional modified properties MAY be included in the Package Document metadata, but they
 								MUST have a different subject (i.e., they require a <code>refines</code> attribute that
 								references an element or resource).</p>
+
+							<div class="note">
+								<p>The requirements for the last modification date are to ensure compatibility with
+									earlier versions of EPUB 3 that defined a <a
+										href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
+										>release identifier</a> [[EPUB-Packages-32]] for EPUB Publications.</p>
+							</div>
 						</section>
 
 						<section id="sec-link-elem">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2178,7 +2178,7 @@
 								<p>The requirements for the last modification date are to ensure compatibility with
 									earlier versions of EPUB 3 that defined a <a
 										href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
-										>release identifier</a> [[EPUB-Packages-32]] for EPUB Publications.</p>
+										>release identifier</a> [[EPUBPackages-32]] for EPUB Publications.</p>
 							</div>
 						</section>
 
@@ -5699,7 +5699,7 @@ Manifest:
 							<div class="note">
 								<p>Although the EPUB Container provides the ability to reference more than one Package
 									Document, this specification does not define how to interpret, or select from, the
-									available options. Refer to [[EPUB-Multi-Rend-11]] for more information on how to
+									available options. Refer to [[EPUB-MULTI-REND-11]] for more information on how to
 									bundle more than one rendering of the content.</p>
 							</div>
 
@@ -8823,7 +8823,7 @@ EPUB/images/cover.png</pre>
 						been simplified to improve the readability of the specifications (i.e., to align with the
 						generally understood concept that an EPUB Publication has only a single rendering described by a
 						single Package Document). These changes do not affect the ability to include multiple
-						renditions, which are now more fully covered in [[EPUB-Multi-Rend-11]]. See <a
+						renditions, which are now more fully covered in [[EPUB-MULTI-REND-11]]. See <a
 							href="https://github.com/w3c/publ-epub-revision/issues/1436">issue 1436</a>.</li>
 					<li>14-Nov-2020: The term "semantic inflection" is no longer used to describe the process of adding
 						structural semantics to elements. The term is not widely understood outside of EPUB, and is

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8816,6 +8816,9 @@ EPUB/images/cover.png</pre>
 					3.2</a></h3>
 
 				<ul>
+					<li>24-Dec-2020: The specification no longer makes reference to a release identifier, but the
+						requirement to include a last modification date remains for backwards compatibility. See <a
+							href="https://github.com/w3c/publ-epub-revision/issues/1440">issue 1440</a>.</li>
 					<li>16-Dec-2020: Terminology and requirements related to "renditions" of an EPUB Publication have
 						been simplified to improve the readability of the specifications (i.e., to align with the
 						generally understood concept that an EPUB Publication has only a single rendering described by a

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -1191,5 +1191,45 @@
 						>http://www.idpf.org/epub/renditions/multiple/schema/epub-rendition-mapping.rnc</a>.</p>
 			</section>
 		</section>
+		<section id="change-log">
+			<h2>Change Log</h2>
+
+			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance
+				of <a>EPUB Publications</a> or are similarly noteworthy.</p>
+
+			<p>For a list of all issues addressed during the revision, refer to the <a
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AMultipleRenditions11"
+					>working group's issue tracker</a>.</p>
+
+			<section id="changes-latest">
+				<h3>Substantive changes since <a href="http://idpf.org/epub/renditions/multiple/">EPUB
+						Multiple-Rendition Publications 1.0</a></h3>
+
+				<ul>
+					<li>24-Dec-2020: The specification no longer makes reference to a release identifier, but the
+						requirement to include a unique identifier and last modification date in the
+							<code>metadata.xml</code> file remain for backwards compatibility. See <a
+							href="https://github.com/w3c/publ-epub-revision/issues/1440">issue 1440</a>.</li>
+					<li>16-Dec-2020: Terminology and requirements related to renditions of an EPUB Publication have been
+						moved to this specification to simplify readability of both this and the [[EPUB-33]]
+						specification. These changes do not affect the ability to include multiple renditions in an EPUB
+						Publication. See <a href="https://github.com/w3c/publ-epub-revision/issues/1436">issue
+						1436</a>.</li>
+				</ul>
+			</section>
+
+			<!--
+				After FPWD:
+				- Uncomment this section and move all pre-FPWD changes above here
+				- Change link/reference in preceding section heading to FPWD
+			
+			<section id="changes-older">
+				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
+					3.2</a></h3>
+				<ul>
+				</ul>
+			</section>
+			-->
+		</section>
 	</body>
 </html>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -276,17 +276,23 @@
 							element</a> [[EPUB-33]], with the following differences in syntax and semantics:</p>
 
 					<ul>
-						<li>Only a <a href="#release-id">Release Identifier</a> is REQUIRED; all other metadata is
-							OPTIONAL.</li>
+						<li>A <code>dc:identifier</code> element [[DCTERMS]] MUST contain the <a
+								href="https://www.w3.org/TR/epub3/core/#sec-opf-metadata-identifiers-uid">unique
+								identifier</a> [[EPUB-33]] for the EPUB Publication.</li>
+						<li>A <code>meta</code> element [[EPUB-33]] MUST contain the last modified date, expressed using
+							the <code>dcterms:modified</code> property [[DCTERMS]]. The value of the property MUST
+							conform to the pattern and rules defined in <a
+								href="https://www.w3.org/TR/epub3/core/#sec-metadata-last-modified">Last Modified
+								Date</a> [[EPUB-33]]. Only one <code>dcterms:modified</code> property without a <a
+								href="https://www.w3.org/TR/epub3/core/#attrdef-meta-refines"><code>refines</code>
+								attribute</a> [[EPUB-33]] is allowed.</li>
+						<li>All other metadata is OPTIONAL.</li>
 						<li>The obsolete <a href="https://www.w3.org/TR/epub3/core/#sec-opf-meta-elem">OPF2
 									<code>meta</code> element</a> [[EPUB-33]] is not allowed.</li>
 						<li>The <code>meta</code> and <code>link</code> elements are defined in the same namespace as
 							the <code>metadata</code> root element: <code class="uri"><a
 									href="http://www.idpf.org/2013/metadata"
 								>http://www.idpf.org/2013/metadata</a></code></li>
-					</ul>
-
-					<ul>
 						<li>In order to enable the full expression of metadata in the <code>metadata.xml</code> file,
 							all attributes allowed on the <a href="https://www.w3.org/TR/epub3/core/#sec-package-elem"
 									><code>package</code> element</a> [[EPUB-33]] are allowed on the root <code
@@ -330,88 +336,6 @@
 
 					<p><a href="https://www.w3.org/TR/epub3/core/#sec-metadata-reserved-vocabs">Reserved prefixes</a>
 						[[EPUB-33]] for metadata attribute expressions are adopted without change.</p>
-				</section>
-
-				<section id="release-id">
-					<h3>Release Identifier</h3>
-
-					<section id="release-id-intro" class="informative">
-						<h4>Introduction</h4>
-
-						<p>For reliable processing of EPUB Publications, each needs to be uniquely identifiable. But
-							uniqueness between EPUB Publications is not enough for total reliability, as more than one
-							version of a given EPUB Publication could exist. As a result, it is also necessary to be
-							able to identify and order each release of an EPUB Publication</p>
-
-						<p>To distinguish both these characteristics, the concept of a <a
-								href="https://www.w3.org/TR/epub3/core/#sec-metadata-elem-identifiers-pid">release
-								identifier</a> [[EPUB-33]] was introduced in EPUB 3. This identifier is a combination of
-							the Unique Identifier and the last modified date, where the Unique Identifier enables
-							differentiation between EPUB Publications and the last modified date enables differentiation
-							between different versions of the same EPUB Publication.</p>
-
-						<p>The problem with this identifier, however, is that it is unique to each <a>Rendition</a>
-							because it is expressed in the Package Document metadata. For example, the last modification
-							dates for Renditions could be different if minor corrections only were necessary to some of
-							them, and each could have a different Unique Identifier. As a result, it only effectively
-							identifies an EPUB Publication if that EPUB Publication contains only one Rendition.</p>
-
-						<p>Consequently, a new Release Identifier that covers all the Renditions of the EPUB Publication
-							is necessary for Multiple-Rendition Publications, otherwise comparisons are complicated by
-							trying to figure out which Rendition(s) have changed and how to compare them from one
-							release to the next (e.g., if their order in the <a
-								href="https://www.w3.org/TR/epub3/core/#sec-container-metainf-container.xml"
-									><code>container.xml</code> file</a> [[EPUB-33]] changes). This section details how
-							to define such a global Release Identifier.</p>
-					</section>
-
-					<section id="release-id-express">
-						<h4>Expressing</h4>
-
-						<p>The <a href="https://www.w3.org/TR/epub3/core/#sec-metadata-elem-identifiers-pid">release
-								identifier</a> [[EPUB-33]] for a Multiple-Rendition Publication is expressed in the <a
-								href="https://www.w3.org/TR/epub3/core/#sec-container-metainf-metadata.xml"
-									><code>metadata.xml</code> file</a> [[EPUB-33]] in the same manner as it is in the
-							Package Document:</p>
-
-						<ul>
-							<li>A <code>dc:identifier</code> element [[DCTERMS]] MUST contain the <a
-									href="https://www.w3.org/TR/epub3/core/#sec-opf-metadata-identifiers-uid">unique
-									identifier</a> [[EPUB-33]] for the EPUB Publication.</li>
-							<li>A <code>meta</code> element [[EPUB-33]] MUST contain the last modified date, expressed
-								using the <code>dcterms:modified</code> property [[DCTERMS]].</li>
-						</ul>
-
-						<p>The identifier MUST conform to the requirements for identifiers defined in <a
-								href="https://www.w3.org/TR/epub3/core/#sec-opf-dcidentifier">3.4.3 The DCMES
-									<code>identifier</code> Element</a> [[EPUB-33]].</p>
-
-						<p>The value of the <code>dcterms:modified</code> property must conform to the pattern and rules
-							defined in <a href="https://www.w3.org/TR/epub3/core/#sec-metadata-elem-identifiers-pid"
-								>Release Identifier</a> [[EPUB-33]]. Only one <code>dcterms:modified</code> property
-							without a <a href="https://www.w3.org/TR/epub3/core/#attrdef-meta-refines"
-									><code>refines</code> attribute</a> [[EPUB-33]] is allowed in the <code
-								class="markup">metadata.xml</code> file.</p>
-
-						<div class="note">
-							<p>When an <a>EPUB Container</a> includes more than one <a>Rendition</a> of an EPUB
-								Publication, updating the last modified date of the <a>Default Rendition</a> for each
-								release — even if it has not been updated — will help ensure that the EPUB Publication
-								does not appear to be the same version as an earlier release, as Reading Systems only
-								have to process the Default Rendition.</p>
-						</div>
-
-						<aside class="example">
-							<p>The following example shows a Release Identifier expressed in the metadata.xml file:</p>
-
-							<pre>&lt;metadata xmlns="http://www.idpf.org/2013/metadata"
-          xmlns:dc="http://purl.org/dc/elements/1.1/"
-          unique-identifier="pub-id"&gt;
-   &lt;dc:identifier id="pub-id"&gt;urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier&gt;
-   &lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;
-&lt;/metadata&gt;</pre>
-						</aside>
-					</section>
 				</section>
 			</section>
 		</section>

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -77,10 +77,9 @@
 				the EPUB® 3 specifications. It consists entirely of informative overview material that describes the
 				features available in EPUB 3.</p>
 
-			<p>The current version of EPUB 3 is defined in [[EPUB-33]], which represents the second minor revision of the standard.
-				The substantive changes since EPUB 3.2 [[EPUB-32]] are documented in a separate <a href="epub-core.html#changes-latest">section</a> 
-				in the EPUB 3.3 document itself.
-			</p>
+			<p>The current version of EPUB 3 is defined in [[EPUB-33]], which represents the second minor revision of
+				the standard. The substantive changes since EPUB 3.2 [[EPUB-32]] are documented in a separate <a
+					href="epub-core.html#changes-latest">section</a> in the EPUB 3.3 document itself. </p>
 		</section>
 		<section id="sotd"></section>
 		<section id="sec-features">
@@ -121,7 +120,8 @@
 					preview content, or assemble an index or dictionary from its constituent XHTML Content
 					Documents.</p>
 
-				<p>The Package Document is specified in the dedicated <a href="epub-core.html#sec-nav-def-hidden">section</a> of [[EPUB-33]].</p>
+				<p>The Package Document is specified in the dedicated <a href="epub-core.html#sec-nav-def-hidden"
+						>section</a> of [[EPUB-33]].</p>
 			</section>
 
 			<section id="sec-nav">
@@ -140,11 +140,11 @@
 						have at least one logical ordering of all their top-level content items, whether by date, topic,
 						location, or some other criteria (e.g., a cookbook is typically ordered by type of recipe).</p>
 
-					<p>Each EPUB Publication defines at least one such logical ordering of all its
-						top-level content (the <a href="epub-core.html#sec-spine-elem">spine</a> [[EPUB-33]]), as well
-						as a declarative table of contents (the <a>EPUB Navigation Document</a> [[EPUB-33]]). EPUB
-						Publications make these data structures available in a machine-readable way <em>external</em> to
-						the content, simplifying their discovery and use.</p>
+					<p>Each EPUB Publication defines at least one such logical ordering of all its top-level content
+						(the <a href="epub-core.html#sec-spine-elem">spine</a> [[EPUB-33]]), as well as a declarative
+						table of contents (the <a>EPUB Navigation Document</a> [[EPUB-33]]). EPUB Publications make
+						these data structures available in a machine-readable way <em>external</em> to the content,
+						simplifying their discovery and use.</p>
 
 					<p>EPUB Publications are not limited to the linear ordering of their contents, nor do they preclude
 						linking in arbitrary ways — just like the Web, EPUB Publications are built on hypertext — but
@@ -155,24 +155,24 @@
 				<section id="sec-nav-nav-doc">
 					<h3>Navigation Document</h3>
 
-					<p>Each EPUB Publication contains a special XHTML Content Document called the
-							<a>EPUB Navigation Document</a>, which uses the [[HTML]] <code>nav</code> element to define
-						human- and machine-readable navigation information.</p>
+					<p>Each EPUB Publication contains a special XHTML Content Document called the <a>EPUB Navigation
+							Document</a>, which uses the [[HTML]] <code>nav</code> element to define human- and
+						machine-readable navigation information.</p>
 
-					<p>The Navigation Document contains baseline accessibility and navigation support,
-						but also features to enhance navigation for all users. Prime
-						among these are support for internationalization (for example, as an XHTML document itself, the
-						Navigation Document natively supports ruby annotations) and support for embedded grammars
-						(MathML and SVG can be included within navigation links).</p>
+					<p>The Navigation Document contains baseline accessibility and navigation support, but also features
+						to enhance navigation for all users. Prime among these are support for internationalization (for
+						example, as an XHTML document itself, the Navigation Document natively supports ruby
+						annotations) and support for embedded grammars (MathML and SVG can be included within navigation
+						links).</p>
 
-					<p>Navigation Documents also provide a flexible means of tailoring the
-						navigation display using CSS and the <a href="epub-core.html#sec-nav-def-hidden"
-								><code>hidden</code> attribute</a> [[EPUB-33]] while not impacting access to information
-						for accessible Reading Systems.</p>
+					<p>Navigation Documents also provide a flexible means of tailoring the navigation display using CSS
+						and the <a href="epub-core.html#sec-nav-def-hidden"><code>hidden</code> attribute</a>
+						[[EPUB-33]] while not impacting access to information for accessible Reading Systems.</p>
 
-					<p>The structure and semantics of Navigation Documents are specified in the relevant <a href="epub-core.html#sec-nav-def-hidden">section</a> of [[EPUB-33]].</p>
+					<p>The structure and semantics of Navigation Documents are specified in the relevant <a
+							href="epub-core.html#sec-nav-def-hidden">section</a> of [[EPUB-33]].</p>
 
-					<p>The structure and semantics of Navigation Documents are defined in specified in the dedicated  <a
+					<p>The structure and semantics of Navigation Documents are defined in specified in the dedicated <a
 							href="epub-core.html#sec-nav">section</a> of [[EPUB-33]].</p>
 
 				</section>
@@ -182,37 +182,31 @@
 			<section id="sec-metadata">
 				<h2>Metadata</h2>
 
-				<p>EPUB Publications provide a rich array of options for adding metadata. Each Package
-					Document includes a dedicated <a href="epub-core.html#sec-metadata-elem"><code>metadata</code>
-						section</a> [[EPUB-33]] for general information about the EPUB Publication, allowing titles,
-					authors, identifiers and other information about the EPUB Publication to be easily accessed. It also
-					provides the means to attach complete bibliographic records using the <a
-						href="epub-core.html#sec-link-elem"><code>link</code> element</a> [[EPUB-33]].</p>
+				<p>EPUB Publications provide a rich array of options for adding metadata. Each Package Document includes
+					a dedicated <a href="epub-core.html#sec-metadata-elem"><code>metadata</code> section</a> [[EPUB-33]]
+					for general information about the EPUB Publication, allowing titles, authors, identifiers and other
+					information about the EPUB Publication to be easily accessed. It also provides the means to attach
+					complete bibliographic records using the <a href="epub-core.html#sec-link-elem"><code>link</code>
+						element</a> [[EPUB-33]].</p>
 
 				<p>The Package Document also allows a <a>Unique Identifier</a> to be established for the EPUB
 					Publication using the <a href="epub-core.html#attrdef-package-unique-identifier"
-							><code>unique-identifier</code> attribute</a> [[EPUB-33]]. The required last-modified date
-					in the Package metadata section can be joined with this identifier to define a <a>Release
-						Identifier</a>, which provides a means of distinguishing different versions of an EPUB
-					Publication (see <a href="epub-core.html#sec-package-metadata-identifiers">Publication
-						Identifiers</a> [[EPUB-33]]). The Package Identifier addresses the issue of how to release an
-					EPUB Publication without changing its Unique Identifier while still identifying it as a new
-					version.</p>
+							><code>unique-identifier</code> attribute</a> [[EPUB-33]].</p>
 
 				<p>XHTML Content Documents also include the means of annotating document markup with rich metadata,
 					making them more semantically meaningful and useful both for processing and accessibility purposes.
-				    Both RDFa [[RDFA-CORE]] and Microdata [[Microdata]] attributes can be used in XHTML Content Documents for that purpose.
-				</p>
+					Both RDFa [[RDFA-CORE]] and Microdata [[Microdata]] attributes can be used in XHTML Content
+					Documents for that purpose. </p>
 
 			</section>
 
 			<section id="sec-content-docs">
 				<h2>Content Documents</h2>
 
-				<p>Each EPUB Publication contains one or more <a>EPUB Content Documents</a>, as defined
-					in the dedicated  <a href="epub-core.html#sec-contentdocs">section</a> of [[EPUB-33]].
-					These are XHTML or SVG documents that describe the readable content and reference
-					associated media resources (e.g., images, audio, and video clips).</p>
+				<p>Each EPUB Publication contains one or more <a>EPUB Content Documents</a>, as defined in the dedicated
+						<a href="epub-core.html#sec-contentdocs">section</a> of [[EPUB-33]]. These are XHTML or SVG
+					documents that describe the readable content and reference associated media resources (e.g., images,
+					audio, and video clips).</p>
 
 				<p><a>XHTML Content Documents</a> are defined by a profile of [[HTML]].</p>
 			</section>
@@ -224,11 +218,11 @@
 					themselves easily to reflowing. Page-precise layouts are required to meaningfully represent
 					children's books, comics and manga, magazines, and many other content forms.</p>
 
-				<p>EPUB 3 includes metadata that allows the creation of <a
-						href="epub-core.html#sec-fixed-layouts">fixed-layout XHTML Content Documents</a>
-					[[EPUB-33]], in addition to existing capabilities for fixed layouts in SVG. This metadata enables
-					the control of the <a href="epub-core.html#sec-fxl-content-dimensions">page dimensions</a> [[EPUB-33]], 
-					creating a canvas on which elements can be absolutely positioned.</p>
+				<p>EPUB 3 includes metadata that allows the creation of <a href="epub-core.html#sec-fixed-layouts"
+						>fixed-layout XHTML Content Documents</a> [[EPUB-33]], in addition to existing capabilities for
+					fixed layouts in SVG. This metadata enables the control of the <a
+						href="epub-core.html#sec-fxl-content-dimensions">page dimensions</a> [[EPUB-33]], creating a
+					canvas on which elements can be absolutely positioned.</p>
 
 				<p>The metadata does not just flag whether content is to be fixed or reflowed, but also allows Authors
 					to specify the desired <a href="epub-core.html#orientation">orientation of pages</a> [[EPUB-33]],
@@ -257,8 +251,8 @@
 					rendering properties. EPUB 3 follows support for CSS as defined in the [[CSSSnapshot]].</p>
 
 				<p>EPUB 3 also supports CSS styles that enable both horizontal and vertical layout and both
-					left-to-right and right-to-left writing. Refer to <a href="#sec-gls-css"></a> in the Global
-					Language Support section for more information.</p>
+					left-to-right and right-to-left writing. Refer to <a href="#sec-gls-css"></a> in the Global Language
+					Support section for more information.</p>
 			</section>
 
 			<section id="sec-multimedia">
@@ -266,38 +260,40 @@
 
 				<p>EPUB 3 supports audio and video embedded in <a>XHTML Content Documents</a> via the [[HTML]]
 						<code>audio</code> and <code>video</code> elements, inheriting all the functionality and
-					features these elements provide. For more information on audio and video formats, refer to
-					the section on <a href="epub-core.html#sec-core-media-types">core media types</a> [[EPUB-33]].</p>
+					features these elements provide. For more information on audio and video formats, refer to the
+					section on <a href="epub-core.html#sec-core-media-types">core media types</a> [[EPUB-33]].</p>
 
 				<p>Another key multimedia feature in EPUB 3 is the inclusion of <a>Media Overlay Documents</a>
-					[[EPUB-33]]. When pre-recorded narration is available for an EPUB Publication, Media
-					Overlays provide the ability to synchronize that audio with the text of a Content Document (see also
-						<a href="#sec-access-overlays"></a>).</p>
+					[[EPUB-33]]. When pre-recorded narration is available for an EPUB Publication, Media Overlays
+					provide the ability to synchronize that audio with the text of a Content Document (see also <a
+						href="#sec-access-overlays"></a>).</p>
 			</section>
 
 			<section id="sec-fonts">
 				<h2>Fonts</h2>
 
-				<p>EPUB 3 supports two closely related font formats — OpenType [[OpenType]] and WOFF [[WOFF]] [[WOFF2]] — to 
-					accommodate both traditional publishing workflows and emerging Web-based workflows. Word
-					processing programs used to create EPUB Publications are likely to have access only to a collection
-					of installed OpenType fonts, for example, whereas Web-archival EPUB generators will likely only have
-					access to WOFF resources (which cannot be converted to OpenType without undesirable, and potentially
-					unlicensed, stripping of WOFF metadata).</p>
+				<p>EPUB 3 supports two closely related font formats — OpenType [[OpenType]] and WOFF [[WOFF]]
+					[[WOFF2]] — to accommodate both traditional publishing workflows and emerging Web-based workflows.
+					Word processing programs used to create EPUB Publications are likely to have access only to a
+					collection of installed OpenType fonts, for example, whereas Web-archival EPUB generators will
+					likely only have access to WOFF resources (which cannot be converted to OpenType without
+					undesirable, and potentially unlicensed, stripping of WOFF metadata).</p>
 
 				<p>EPUB 3 also supports both obfuscated and regular font resources for both OpenType and WOFF font
 					formats. Support for obfuscated font resources is required to accommodate font licensing
-					restrictions for many commercially available fonts. See the dedicated  <a
-					href="epub-core.html#sec-resource-obfuscation">section on Resource Obfuscation</a> in [[EPUB-33]] for more details.</p>
+					restrictions for many commercially available fonts. See the dedicated <a
+						href="epub-core.html#sec-resource-obfuscation">section on Resource Obfuscation</a>
+					in [[EPUB-33]] for more details.</p>
 
 			</section>
 
 			<section id="sec-scripting">
 				<h2>Scripting</h2>
 
-				<p>EPUB strives to treat content <em>declaratively</em> — as data that can be manipulated, not as programs
-					to be executed — but does support scripting as defined in [[HTML]] and [[SVG2]] (refer to the section on <a
-						href="epub-core.html#sec-scripted-content">Scripting</a> [[EPUB-33]] for more information).</p>
+				<p>EPUB strives to treat content <em>declaratively</em> — as data that can be manipulated, not as
+					programs to be executed — but does support scripting as defined in [[HTML]] and [[SVG2]] (refer to
+					the section on <a href="epub-core.html#sec-scripted-content">Scripting</a> [[EPUB-33]] for more
+					information).</p>
 
 				<p>It is important to note, however, that EPUB 3 does not require scripting support in Reading Systems,
 					and scripting might be disabled for security reasons.</p>
@@ -306,7 +302,8 @@
 					that are different from scripting within a Web browser. For example, typical same-origin policies
 					are not applicable to content that has been downloaded to a user's local system. Therefore, it is
 					strongly encouraged that scripting be limited to container constrained contexts, as further
-					described in the section on <a href="epub-core.html#sec-scripted-container-constrained">Container-Constrained Scripts</a> [[EPUB-33]].</p>
+					described in the section on <a href="epub-core.html#sec-scripted-container-constrained"
+						>Container-Constrained Scripts</a> [[EPUB-33]].</p>
 
 				<p>In other words, consider limiting scripting to cases where it is essential to the user experience,
 					since it greatly increases the likelihood that content will not be portable across all Reading
@@ -345,15 +342,15 @@
 
 				<p>An EPUB Publication is transported and interchanged as a single file (a "portable document") that
 					contains the Package Documents, all Content Documents, and all other required resources for
-					processing the Publication. The single-file container format for EPUB is based on the widely
-					adopted ZIP format, and an XML document that identifies the location of the Package Document for
-					the Publication in the ZIP archive is located at a pre-defined location within the archive.</p>
+					processing the Publication. The single-file container format for EPUB is based on the widely adopted
+					ZIP format, and an XML document that identifies the location of the Package Document for the
+					Publication in the ZIP archive is located at a pre-defined location within the archive.</p>
 
 				<p>This approach provides a clear contract between any creator of an EPUB Publication and any system
 					which consumes such EPUB Publications, as well as a reliable representation that is independent of
 					network transport or file system specifics.</p>
 
-				<p>An EPUB Publication's representation as a container file is specified in the dedicated  <a
+				<p>An EPUB Publication's representation as a container file is specified in the dedicated <a
 						href="epub-core.html#sec-ocf">section</a> of [[EPUB-33]].</p>
 
 			</section>
@@ -434,8 +431,8 @@
 					not natively render as intended on all Reading Systems.</p>
 
 				<p>To address this problem, EPUB 3 supports the embedding of fonts to facilitate the rendering of text
-					content, and this practice is advised to ensure content is rendered as intended. 
-					See also <a href="#sec-fonts"></a> in the Features section for more information.</p>
+					content, and this practice is advised to ensure content is rendered as intended. See also <a
+						href="#sec-fonts"></a> in the Features section for more information.</p>
 
 				<p>Support for embedded fonts also ensures that characters and glyphs unique to an EPUB Publication can
 					be embedded for proper display.</p>
@@ -483,8 +480,8 @@
 			<section id="sec-access-nav">
 				<h2>Navigation</h2>
 
-				<p>As noted in <a href="#sec-nav-nav-doc"></a> above, the navigation features represent a
-					universal and flexible navigation system.</p>
+				<p>As noted in <a href="#sec-nav-nav-doc"></a> above, the navigation features represent a universal and
+					flexible navigation system.</p>
 
 				<p>The Navigation Document can also be reused in the body of an EPUB Publication by including it in the
 						<code>spine</code>. To avoid the situation in highly structured documents where it might not be
@@ -503,18 +500,20 @@
 				<h2>Semantic Markup</h2>
 
 				<p>[[HTML]] supports a number of elements that make markup more semantically meaningful (e.g.,
-						<code>section</code>, <code>nav</code>, and <code>aside</code>). Authors are encouraged to use these elements,
-					in conjunction with best practices for authoring well-structured Web content, when creating EPUB XHTML Content Documents.
-					These additions allow content to be better grouped and defined, both for representing the structure
-					of documents and to facilitate their logical navigation. XHTML Content Documents also natively
-					support the inclusion of ARIA role and state attributes and events, enhancing the ability of
-					Assistive Technologies to interact with the content.</p>
+						<code>section</code>, <code>nav</code>, and <code>aside</code>). Authors are encouraged to use
+					these elements, in conjunction with best practices for authoring well-structured Web content, when
+					creating EPUB XHTML Content Documents. These additions allow content to be better grouped and
+					defined, both for representing the structure of documents and to facilitate their logical
+					navigation. XHTML Content Documents also natively support the inclusion of ARIA role and state
+					attributes and events, enhancing the ability of Assistive Technologies to interact with the
+					content.</p>
 
 				<p>EPUB 3 includes the <code>epub:type</code> attribute, which is meant to be functionally equivalent to
 					the W3C Role Attribute [[Role-Attribute]]. This attribute allows any element in an XHTML Content
 					Document to include additional information about its purpose and meaning within the work, using
-					controlled vocabularies and terms. Refer to the section on <a href="epub-core.html#app-structural-semantics"
-						>Expressing Structural Semantics</a> [[EPUB-33]] for more information.</p>
+					controlled vocabularies and terms. Refer to the section on <a
+						href="epub-core.html#app-structural-semantics">Expressing Structural Semantics</a> [[EPUB-33]]
+					for more information.</p>
 
 			</section>
 
@@ -544,12 +543,12 @@
 
 				<p>Aural renderings of content are important for accessibility and are a desirable feature for many
 					other users. A baseline to facilitate aural rendering is to utilize semantic HTML designed for
-					dynamic layout. Refer to <a href="#sec-tts"></a> for more information on how to use
-					the native facilities that EPUB XHTML Documents include.</p>
+					dynamic layout. Refer to <a href="#sec-tts"></a> for more information on how to use the native
+					facilities that EPUB XHTML Documents include.</p>
 
 				<p>Media Overlays provides the ability to synchronize the text and audio content of an EPUB Publication.
-					Overlays transcend the accessibility domain in their usefulness: the synchronization of text and audio as a tool for
-					learning to read, for example, being of benefit in many circumstances.</p>
+					Overlays transcend the accessibility domain in their usefulness: the synchronization of text and
+					audio as a tool for learning to read, for example, being of benefit in many circumstances.</p>
 			</section>
 
 			<section id="sec-access-fallbacks">
@@ -640,31 +639,30 @@
 
 			<section id="epub32">
 				<h3>EPUB 3.2: 2018</h3>
-				<p>The work on EPUB 3.2 was undertaken shortly after EPUB 3.1 to restore compatibility of content to EPUB 3. The
-					change of version number introduced in EPUB 3.1 meant that authors, vendors and reading system
-					developers would have to produce, distribute and consume two versions of EPUB content, but the costs
-					of this change outweighed the benefits of the new version. EPUB 3.2 instead keeps all the best parts
-					of EPUB 3.1 but returns and deprecates the removed elements so that a new version number is not
-					necessary in the Package Document. [[EPUB-32]] [[EPUBPackages-32]] [[EPUBContentDocs-32]] [[OCF-32]]
-					[[EPUBMediaOverlays-32]] [[EPUBChanges-32]]</p>
+				<p>The work on EPUB 3.2 was undertaken shortly after EPUB 3.1 to restore compatibility of content to
+					EPUB 3. The change of version number introduced in EPUB 3.1 meant that authors, vendors and reading
+					system developers would have to produce, distribute and consume two versions of EPUB content, but
+					the costs of this change outweighed the benefits of the new version. EPUB 3.2 instead keeps all the
+					best parts of EPUB 3.1 but returns and deprecates the removed elements so that a new version number
+					is not necessary in the Package Document. [[EPUB-32]] [[EPUBPackages-32]] [[EPUBContentDocs-32]]
+					[[OCF-32]] [[EPUBMediaOverlays-32]] [[EPUBChanges-32]]</p>
 			</section>
 
 			<section id="epub33">
 				<h3>EPUB 3.3: 2021</h3>
-				<p class=ednote>
-					The text in this section must be updated as EPUB 3.3 evolves and is more of a placeholder for now. It currently reflects the aspirations of the work rather than the final characterization of EPUB 3.3.
-				</p>
-				<p>
-					The work on EPUB 3.3 [[EPUB-33]] was undertaken in 2020-21, and is the first version of the EPUB 3 series published as a W3C Recommendation. 
-					EPUB 3.3 does not include any significant technical change to, and is strongly backward compatible with, EPUB 3.2.
-					This means that any valid EPUB 3.2 Publication is also a valid EPUB 3.3 Publication. On the other hand, through a thorough
-					testing regime developed by the <a href="https://www.w3.org//publishing/groups/epub-wg/">W3C EPUB 3 Working Group</a>, the interoperability of Reading Systems, as well as 
-					of EPUB 3 Publications, is greatly improved. Finally, the documents have become more readable as a result of an extensive editorial revision.
-				</p> 
-				<p>
-					The separate <a href="epub-core.html#changes-latest">section</a> in [[EPUB-33]] provides a more detailed overview of the changes.
-				</p>				
-
+				<p class="ednote">The text in this section must be updated as EPUB 3.3 evolves and is more of a
+					placeholder for now. It currently reflects the aspirations of the work rather than the final
+					characterization of EPUB 3.3.</p>
+				<p>The work on EPUB 3.3 [[EPUB-33]] was undertaken in 2020-21, and is the first version of the EPUB 3
+					series published as a W3C Recommendation. EPUB 3.3 does not include any significant technical change
+					to, and is strongly backward compatible with, EPUB 3.2. This means that any valid EPUB 3.2
+					Publication is also a valid EPUB 3.3 Publication. On the other hand, through a thorough testing
+					regime developed by the <a href="https://www.w3.org//publishing/groups/epub-wg/">W3C EPUB 3 Working
+						Group</a>, the interoperability of Reading Systems, as well as of EPUB 3 Publications, is
+					greatly improved. Finally, the documents have become more readable as a result of an extensive
+					editorial revision.</p>
+				<p>The separate <a href="epub-core.html#changes-latest">section</a> in [[EPUB-33]] provides a more
+					detailed overview of the changes.</p>
 			</section>
 		</section>
 	</body>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2091,7 +2091,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<ul>
 					<li>24-Dec-2020: The creation of a <a
 							href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
-							>release identifier</a> [[EPUB-Packages-32]] is no longer defined. See <a
+							>release identifier</a> [[EPUBPackages-32]] is no longer defined. See <a
 							href="https://github.com/w3c/publ-epub-revision/issues/1440">issue 1440</a>.</li>
 					<li>6-Nov-2020: Reading systems are now required to <a href="#confreq-rs-xml-extid">not resolve
 							external identifiers</a> in doctype declarations. See <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2089,6 +2089,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					3.2</a></h3>
 
 				<ul>
+					<li>24-Dec-2020: The creation of a <a
+							href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
+							>release identifier</a> [[EPUB-Packages-32]] is no longer defined. See <a
+							href="https://github.com/w3c/publ-epub-revision/issues/1440">issue 1440</a>.</li>
 					<li>6-Nov-2020: Reading systems are now required to <a href="#confreq-rs-xml-extid">not resolve
 							external identifiers</a> in doctype declarations. See <a
 							href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -459,9 +459,8 @@
 					<dd>
 						<p>Reading Systems MUST NOT depend on the Unique Identifier being unique to one and only one
 							EPUB Publication. Determining whether two EPUB Publications with the same Unique Identifier
-							represent different versions of the same publication (see <a href="#app-release-identifier"
-							></a>), or different publications, might require inspecting other metadata, such as the
-							titles or authors.</p>
+							represent different versions of the same publication, or different publications, might
+							require inspecting other metadata, such as the titles or authors.</p>
 					</dd>
 				</dl>
 			</section>
@@ -1856,48 +1855,6 @@
 					</section>
 				</section>
 			</section>
-		</section>
-		<section id="app-release-identifier" class="appendix">
-			<h2>Release Identifier</h2>
-
-			<p>The release identifier allows a set of EPUB Publications to be inspected to determine if they represent
-				the same version of the same Publication, different versions of a single EPUB Publication, or any
-				combination of differing and similar EPUB Publications.</p>
-
-			<p>The release identifier does not supersede the <a>Unique Identifier</a> but represents how different
-				versions of the same EPUB Publication can be distinguished and identified. The sequential, chronological
-				order inherent in the format of the timestamp also places EPUB Publications in order without requiring
-				knowledge of the exact identifier that came before.</p>
-
-			<p>The release identifier is not an actual property in the Package Document <code>metadata</code> section
-				but is a value that can be obtained from two other mandatory pieces of metadata: the <a
-					href="https://www.w3.org/TR/epub-33/#sec-metadata-elem-identifiers-uid">Unique Identifier</a> and
-				the <a href="https://www.w3.org/TR/epub-33/#sec-metadata-elem-identifiers-pid">last modification
-					date</a> [[EPUB-33]] of the EPUB Publication. When the taken together, the combined value represents
-				a unique identity that can be used to distinguish any version of an EPUB Publication from another.</p>
-
-			<p>For referencing and other purposes all string representations of the identifier MUST be constructed using
-				the at sign (<code>@</code>) as the separator (i.e., of the form "id<code>@</code>date"). Whitespace
-				MUST NOT be included when concatenating the strings.</p>
-
-			<aside class="example">
-				<p>The following example shows how a Unique Identifier and modification date are combined to form the
-					release identifier.</p>
-				<pre class="nohighlight">&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    &lt;dc:identifier id="pub-id"&gt;urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier&gt;
-    &lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;
-    …
-&lt;/metadata&gt;
-
-results in the release identifier:
-
-urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809@2011-01-01T12:00:00Z
-</pre>
-			</aside>
-
-			<p>Note that it is possible that the separator character MAY occur in the Unique Identifier, as these
-				identifiers MAY be any string value. The release identifier consequently MUST be split on the last
-				instance of the at sign when decomposing it into its component parts.</p>
 		</section>
 		<section id="app-epubReadingSystem" class="appendix">
 			<h2>JavaScript <dfn>epubReadingSystem</dfn> Object</h2>


### PR DESCRIPTION
This PR fixes #1440 as follows:

- Removes references to the release identifier from the core specification leaving only a section labelled "last modification date" with the same requirements. Adds a note for future generations about the release identifier to explain why these requirements exist as there's no other context for them.
- Removes all reference to creating a release identifier from the reading system specification.
- Removes explanation of release identifier from the overview.
- Removes the sections on the release identifier from the multiple renditions document and moves the requirements for the unique identifier and last mod date into the publication metadata section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1453.html" title="Last updated on Dec 24, 2020, 2:39 PM UTC (218b7ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1453/2ee308e...218b7ff.html" title="Last updated on Dec 24, 2020, 2:39 PM UTC (218b7ff)">Diff</a>