### PR TITLE
Add technique recommending that toc order match the linear reading order

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -529,7 +529,6 @@
 &lt;/package&gt;</pre>
 				</aside>
 			</section>
-
 		</section>
 		<section id="sec-wcag">
 			<h2>WCAG Techniques</h2>
@@ -741,6 +740,38 @@
 							</li>
 						</ul>
 					</section>
+				</section>
+
+				<section class="suppress-numbering" id="access-003">
+					<h4>ACCESS-003: Ensure the order of table of contents entries matches linear order</h4>
+
+					<p>The table of contents provides users more than just links into the content. It is also a means to
+						understand the structure and ordering of an <a>EPUB Publication</a>. Consequently, users may
+						have difficulty locating where they are in a publication, where they want to go, and also how to
+						return to previous locations when the order of entries in the table of contents does not match
+						the linear reading order.</p>
+
+					<p>Authors should therefore ensure that the entries in the table of contents always match the linear
+						order of the content. Specifically, the order of entries should reflect both:</p>
+
+					<ul>
+						<li>the order of <a>EPUB Content Documents</a> in the <code>spine</code>; and</li>
+						<li>the order of each referenced section within its respective Content Document.</li>
+					</ul>
+
+					<p>Only if there is a logical case for an alternative arrangement of entries should the ordering
+						differ. Such scenarios typically only occur when the content does not have to be read linearly
+						or when additional information is included at the end of a table of contents. For example, the
+						table of contents for a magazine might be ordered to list all the major articles first, followed
+						by features, etc.</p>
+
+					<p>When the ordering of the table of contents does not match the content, Authors should include an
+						explanation why in the <a href="#meta-005">accessibility summary</a>.</p>
+
+					<p>Authors should avoid including links to supplementary content at the end of the table of
+						contents. Links to figure, tables, illustrations and similar content is better included as a
+						separate navigation elements (either in the <a>EPUB Navigation Document</a> or in the spine).
+						Authors can include links to these additional navigation lists in the table of contents.</p>
 				</section>
 			</section>
 
@@ -1550,7 +1581,8 @@
 						Techniques 1.0</a></h3>
 
 				<ul>
-					<li>&#8230;</li>
+					<li>8-Jan-2021: Added technique recommending the <a href="#access-003">order of the table of
+							contents</a> match the linear reading order of content.</li>
 				</ul>
 			</section>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -746,8 +746,8 @@
 					<h4>ACCESS-003: Ensure the order of table of contents entries matches linear order</h4>
 
 					<p>The table of contents provides users more than just links into the content. It is also a means to
-						understand the structure and ordering of an <a>EPUB Publication</a>. Consequently, users may
-						have difficulty locating where they are in a publication, where they want to go, and also how to
+						understand the structure and ordering of an EPUB Publication. Consequently, users may have
+						difficulty locating where they are in a publication, where they want to go, and also how to
 						return to previous locations when the order of entries in the table of contents does not match
 						the linear reading order.</p>
 
@@ -755,7 +755,7 @@
 						order of the content. Specifically, the order of entries should reflect both:</p>
 
 					<ul>
-						<li>the order of <a>EPUB Content Documents</a> in the <code>spine</code>; and</li>
+						<li>the order of EPUB Content Documents in the <code>spine</code>; and</li>
 						<li>the order of each referenced section within its respective Content Document.</li>
 					</ul>
 
@@ -770,8 +770,8 @@
 
 					<p>Authors should avoid including links to supplementary content at the end of the table of
 						contents. Links to figure, tables, illustrations and similar content is better included as a
-						separate navigation elements (either in the <a>EPUB Navigation Document</a> or in the spine).
-						Authors can include links to these additional navigation lists in the table of contents.</p>
+						separate navigation elements (either in the EPUB Navigation Document or in the spine). Authors
+						can include links to these additional navigation lists in the table of contents.</p>
 				</section>
 			</section>
 
@@ -1190,7 +1190,7 @@
 						their complexity. This exception is no longer valid.</p>
 
 					<p>Authors must now ensure that their image-based content meets [[WCAG20]] requirements for
-						alternative text and extended descriptions to conform with [[EPUB-A11Y-11]].</p>
+						alternative text and extended descriptions to conform with [[EPUB-A11Y]].</p>
 
 					<section class="suppress-numbering" id="sec-desc-001-res">
 						<h5>Helpful Resources</h5>


### PR DESCRIPTION
Here's a start on a new technique for the reading order.

Fixes #1430 
Fixes #1287 

- [Techniques preview](https://raw.githack.com/w3c/epub-specs/technique/nav-order/epub33/a11y-tech/)
- [Techniques diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y-tech%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ftechnique%2Fnav-order%2Fepub33%2Fa11y-tech%2Findex.html)
