### PR TITLE
Change the requirement for progressive enhancement with spine-level scripting

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4417,13 +4417,14 @@ Manifest:
 				<section id="sec-scripted-spine">
 					<h4>Spine-Level Scripts</h4>
 
-					<p id="confreq-cd-scripted-spine">EPUB Content Documents that include <a
-							href="#sec-scripted-content-type-spine-level">spine-level scripting</a> MUST utilize the
-							<em>progressive enhancement technique</em>, which for the purposes of this specification has
-						the following definition: when the document is rendered by a Reading System without scripting
-						support or with scripting support disabled, the <a>Top-level Content Document</a> MUST retain
-						its integrity, remaining consumable by the user without any information loss or other
-						significant deterioration.</p>
+					<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include <a
+							href="#sec-scripted-content-type-spine-level">spine-level scripting</a> SHOULD remain
+						consumable by the user without any information loss or other significant deterioration when
+						scripting is disabled (e.g., by employing progressive enhancement techniques).</p>
+
+					<p>Since Reading Systems are not required to support scripting, failing to account for non-scripted
+						environments in Top-level Content Documents can result in EPUB Publications being
+						unreadable.</p>
 				</section>
 
 				<section id="sec-scripted-a11y">
@@ -8834,9 +8835,26 @@ EPUB/images/cover.png</pre>
 					>working group's issue tracker</a>.</p>
 
 			<section id="changes-latest">
+				<h3>Substantive changes since the <a href="https://www.w3.org/TR/2021/WD-epub-33-20210112/">First Public
+						Working Draft</a></h3>
+
+				<!--
+					After each working draft is published:
+						- change the link/text in the section heading to refer to the published draft (use the dated URL)
+						- move all changes down to the next section
+				-->
+
+				<ul>
+					<li>13-Jan-2021: The requirement for progressive enhancement with spine-level scripting has been
+						changed to a recommendation that top-level content documents remain consumable when scripting is
+						not available. See <a href="https://github.com/w3c/publ-epub-revision/issues/1444">issue
+							1444</a>.</li>
+				</ul>
+			</section>
+
+			<section id="changes-older">
 				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
 					3.2</a></h3>
-
 				<ul>
 					<li>24-Dec-2020: The specification no longer makes reference to a release identifier, but the
 						requirement to include a last modification date remains for backwards compatibility. See <a
@@ -8874,19 +8892,6 @@ EPUB/images/cover.png</pre>
 						the reading system requirements from those documents.</li>
 				</ul>
 			</section>
-
-			<!--
-				After FPWD:
-				- Uncomment this section and move all pre-FPWD changes above here
-				- Change link/reference in preceding section heading to FPWD
-			
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
-					3.2</a></h3>
-				<ul>
-				</ul>
-			</section>
-			-->
 		</section>
 		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
 		></div>


### PR DESCRIPTION
This PR fixes #1444 as follows:

- changes the requirement for progressive enhancement to a recommendation that the top-level content documents remain consumable
- progressive enhancement is moved to a parenthetical as one way of accomplishing this
- adds context for why it is important that scripted top-level content documents be consumable


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1467.html" title="Last updated on Jan 20, 2021, 1:59 PM UTC (55db9eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1467/5839683...55db9eb.html" title="Last updated on Jan 20, 2021, 1:59 PM UTC (55db9eb)">Diff</a>