### PR TITLE
Clarify WCAG conformance thresholds

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -351,8 +351,7 @@
 				<section id="sec-wcag-conf">
 					<h4>WCAG Conformance Requirements</h4>
 
-					<p>An EPUB Publication has to meet to the following requirements to conform to this
-						specification</p>
+					<p>An EPUB Publication has to meet the following requirements to conform to this specification</p>
 
 					<ul class="conformance-list">
 						<li>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -351,17 +351,47 @@
 				<section id="sec-wcag-conf">
 					<h4>WCAG Conformance Requirements</h4>
 
-					<p>EPUB Publications MUST meet WCAG 2.0 <a href="https://www.w3.org/TR/WCAG20/#conformance-reqs"
-							>Level A</a> to be conformant with this document, but it is RECOMMENDED that they meet <a
-							href="https://www.w3.org/TR/WCAG20/#conformance-reqs">Level AA</a> [[!WCAG20]].</p>
+					<p>An EPUB Publication has to meet to the following requirements to conform to this
+						specification</p>
 
-					<div class="note">
-						<p>Although this document only requires Level A conformance, local and national laws can
-							influence the level of conformance an EPUB Publication has to meet to be considered
-							accessible. Level AA conformance is often cited as the benchmark for accessibility in legal
-							frameworks and policies, for example. Additionally, any procurer or distributor of EPUB
-							Publications can demand higher conformance requirements than the baseline defined here.</p>
-					</div>
+					<ul class="conformance-list">
+						<li>
+							<p id="confreq-wcag-20">It MUST meet the requirements of WCAG 2.0 [[!WCAG20]] but it is
+								strongly RECOMMENDED that it conform to the latest recommended version [[WCAG]].</p>
+						</li>
+
+						<li>
+							<p id="confreq-wcag-a">It MUST meet the requirements of <a
+									href="https://www.w3.org/TR/WCAG/#cc1_a">Level A</a> but it is strongly RECOMMENDED
+								that it meet <a href="https://www.w3.org/TR/WCAG/#cc1_aa">Level AA</a> [[!WCAG]].</p>
+						</li>
+					</ul>
+
+					<p>The reporting flexibility offered by these requirements is to ensure that this specification can
+						be adapted for use wherever accessibility is mandated but without negating or superseding the
+						requirements in effect in any region.</p>
+
+					<p>The baseline requirement for WCAG 2.0 Level A, for example, is primarily intended to provide
+						Authors backwards compatibility for older content and flexibility to encourage adoption of
+						accessible production where no formal requirements exist. It is not generally recognized as
+						providing a high degree of accessibility.</p>
+
+					<p>Ideally, Authors should try to conform to the latest version of WCAG at Level AA, but the formal
+						thresholds they must meet will be defined by local and national laws, or by procurer or
+						distributor requirements.</p>
+
+					<p>Keeping pace with WCAG has the benefit of continuously enhancing access for users. As web
+						technologies change and improve, and awareness of conditions that impede access evolve, new
+						requirements are added to the standard. Meeting these additional requirements helps ensure EPUB
+						Publications employ the most up-to-date techniques. Meeting the requirements of older versions,
+						while still helpful, can result in a less optimal reading experience.</p>
+
+					<p>Similarly, Level AA conformance is often cited as the benchmark for accessibility in legal
+						frameworks and policies. The reason for this is that it provides the greatest range of
+						improvements that can realistically be implemented (Authors are encouraged to try and meet the
+						AAA requirements if they can, but fully conforming at AAA is typically not possible). Only
+						meeting level A requires compromises for various user groups that can again result in a less
+						optimal reading experience.</p>
 				</section>
 
 				<section id="sec-wcag-eval">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -351,18 +351,19 @@
 				<section id="sec-wcag-conf">
 					<h4>WCAG Conformance Requirements</h4>
 
-					<p>An EPUB Publication has to meet the following requirements to conform to this specification</p>
+					<p>An EPUB Publication has to meet the following requirements to conform to this specification:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-wcag-20">It MUST meet the requirements of WCAG 2.0 [[!WCAG20]] but it is
-								strongly RECOMMENDED that it conform to the latest recommended version [[WCAG]].</p>
+							<p id="confreq-wcag-20">It MUST meet the requirements of WCAG 2.0 [[!WCAG20]], but it is
+								strongly RECOMMENDED that it conform to the <a href="https://www.w3.org/TR/WCAG/">latest
+									recommended version</a>.</p>
 						</li>
 
 						<li>
 							<p id="confreq-wcag-a">It MUST meet the requirements of <a
-									href="https://www.w3.org/TR/WCAG/#cc1_a">Level A</a> but it is strongly RECOMMENDED
-								that it meet <a href="https://www.w3.org/TR/WCAG/#cc1_aa">Level AA</a> [[!WCAG]].</p>
+									href="https://www.w3.org/TR/WCAG/#cc1">Level A</a>, but it is strongly RECOMMENDED
+								that it meet <a href="https://www.w3.org/TR/WCAG/#cc1">Level AA</a> [[!WCAG20]].</p>
 						</li>
 					</ul>
 


### PR DESCRIPTION
Rewrites the section on WCAG conformance to better explain why we have the baseline of 2.0 A and why authors should, and in many cases will have to, meet a higher standard.

- [Accessibility preview](https://raw.githack.com/w3c/epub-specs/a11y-11/conformance-issues/epub33/a11y/)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Fa11y-11%2Fconformance-issues%2Fepub33%2Fa11y%2Findex.html)

Fixes #1459 
Fixes #1454 