### PR TITLE
Clarifications about epub:type, structure vocab and accessibility

### DIFF
--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -319,3 +319,17 @@ table.zebra tr:nth-child(even) {
 
 table.zebra th{border-bottom:1px solid #bbb;padding:.2em 1em;}
 table.zebra td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+
+/* structure defs */
+
+section#structure-vocab dd > p:first-child {
+	margin-top: 1rem !important;
+}
+
+section#structure-vocab dd + dd {
+	font-size: 90%;
+}
+
+.subproplabel {
+	font-style: italic;
+}

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7814,6 +7814,19 @@ html.-epub-media-overlay-playing * {
 					already conveyed by an existing element (e.g., that a <code>div</code> represents a paragraph or
 					section).</p>
 
+				<div class="note">
+					<p>Although the <code>epub:type</code> attribute is similar in nature to the <a
+							href="https://html.spec.whatwg.org/multipage/infrastructure.html#attr-aria-role"
+								><code>role</code> attribute</a> [[HTML]], the attributes serve different purposes. The
+						values of the <code>epub:type</code> attribute do not enhance the accessibility of EPUB
+						Publications, for example, they do not map to accessibility <abbr
+							title="Application Programming Interfaces">APIs</abbr> used by assistive technologies. The
+							<code>epub:type</code> attribute is only intended for publishing semantics and Reading
+						System enhancements. Refer to <a href="https://www.w3.org/TR/dpub-aria-1.0/">Digital Publishing
+							WAI-ARIA Module 1.0</a> [[DPUB-ARIA-1.0]] for more information about accessible publishing
+						roles.</p>
+				</div>
+
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
 					the <a href="#structure-vocab">Structural Semantics Vocabulary</a>. Unprefixed terms that are not
 					part of this vocabulary MAY be included, but their use is discouraged. The use of <a

--- a/epub33/core/vocab/structure.html
+++ b/epub33/core/vocab/structure.html
@@ -1,24 +1,25 @@
 <section id="structure-vocab">
 	<h3>Structural Semantics Vocabulary</h3>
-	<section id="about" class="inoformative">
-		<h4>About this vocabulary</h4>
-		<div>
-			<p>While the EPUB Structural Semantics vocabulary is generally host language agnostic, it has been
-				constructed primarily to enable semantic inflection of elements in the HTML vocabulary.</p>
-			<p class="output-htu-expl" id="htu-expl">The <i>HTML usage context</i> fields indicate contexts in
-				HTML documents where the given property is considered relevant. Authors may use the properties
-				on HTML markup elements not specifically listed, but must ensure that the semantics they express
-				represent a subset of the carrying element's semantics and do not attach an existing element's
-				meaning to a semantically neutral element.</p>
-			<p class="output-htu-expl">When processing HTML documents, Reading Systems may ignore such
-				non-compliant properties, unless their usage context is explicitly overridden or extended by the
-				host specification.</p>
-			<p>The <i>Usage Details</i> sections identify IDPF specifications that define or utilize the
-				specified properties.</p>
-		</div>
+	<section id="about" class="informative">
+		<h4>About this Vocabulary</h4>
+		<p>While the EPUB Structural Semantics vocabulary is generally host language agnostic, it has been
+			constructed primarily to enable semantic inflection of elements in the HTML vocabulary.</p>
+		<p>The <i>HTML usage context</i> fields indicate contexts in HTML documents where the given property is
+			considered relevant. Authors may use the properties on HTML markup elements not specifically listed,
+			but must ensure that the semantics they express represent a subset of the carrying element's
+			semantics and do not attach an existing element's meaning to a semantically neutral element.</p>
+		<p>The <i>DPUB-ARIA role</i> fields indicate the [[DPUB-ARIA-1.0]] roles that can alternatively be used
+			with the [[HTML]] <code>role</code> attribute to improve accessibility. These roles may have more
+			restrictive usage contexts, however, so may not be valid wherever the <code>epub:type</code>
+			attribute is used. Refer to [[HTML-ARIA]] for more information about where the roles are
+			allowed.</p>
+		<p>When processing HTML documents, Reading Systems may ignore such non-compliant properties, unless
+			their usage context is explicitly overridden or extended by the host specification.</p>
+		<p>The <i>Usage Details</i> sections identify IDPF specifications that define or utilize the specified
+			properties.</p>
 	</section>
 	<section id="partitions">
-		<h4>Document partitions</h4>
+		<h4>Document Partitions</h4>
 		<dl>
 			<dt id="cover">cover</dt>
 			<dd>
@@ -32,6 +33,12 @@
 						>section</a>, <a
 						href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
 				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-cover">doc-cover</a> (only allowed on
+					cover image tag)</p>
 			</dd>
 			<dt id="frontmatter">frontmatter</dt>
 			<dd>
@@ -74,7 +81,7 @@
 		</dl>
 	</section>
 	<section id="divisions">
-		<h4>Document divisions</h4>
+		<h4>Document Divisions</h4>
 		<dl>
 			<dt id="volume">volume</dt>
 			<dd>
@@ -101,6 +108,12 @@
 						href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-part">doc-part</a>
+				</p>
+			</dd>
 			<dt id="chapter">chapter</dt>
 			<dd>
 				<p>A major thematic section of content in a work.</p>
@@ -111,6 +124,12 @@
 					<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
 						>section</a>, <a
 						href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-chapter">doc-chapter</a>
 				</p>
 			</dd>
 			<dt id="subchapter">subchapter<span class="status deprecated"> [deprecated]</span>
@@ -142,7 +161,7 @@
 		</dl>
 	</section>
 	<section id="sections">
-		<h4>Document sections and components</h4>
+		<h4>Document Sections and Components</h4>
 		<p>Sections and components that typically occur in the publication bodymatter.</p>
 		<dl>
 			<dt id="abstract-1">abstract<span class="status draft"> [draft]</span>
@@ -160,6 +179,12 @@
 						>grouping content</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-abstract">doc-abstract</a>
+				</p>
+			</dd>
 			<dt id="foreword">foreword</dt>
 			<dd>
 				<p>An introductory section that precedes the work, typically not written by the author of the
@@ -172,6 +197,12 @@
 						>section</a>, <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
 						>grouping content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-foreword">doc-foreword</a>
 				</p>
 			</dd>
 			<dt id="preface">preface</dt>
@@ -188,6 +219,12 @@
 						>grouping content</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-preface">doc-preface</a>
+				</p>
+			</dd>
 			<dt id="prologue">prologue</dt>
 			<dd>
 				<p>An introductory section that sets the background to a work, typically part of the
@@ -202,6 +239,12 @@
 						>grouping content</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-prologue">doc-prologue</a>
+				</p>
+			</dd>
 			<dt id="introduction">introduction</dt>
 			<dd>
 				<p>A preliminary section that typically introduces the scope or nature of the work.</p>
@@ -213,6 +256,12 @@
 						>section</a>, <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
 						>grouping content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-introduction">doc-introduction</a>
 				</p>
 			</dd>
 			<dt id="preamble">preamble</dt>
@@ -242,6 +291,12 @@
 						>grouping content</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-conclusion">doc-conclusion</a>
+				</p>
+			</dd>
 			<dt id="epilogue">epilogue</dt>
 			<dd>
 				<p>A concluding section of narrative that wraps up or comments on the actions and events of the
@@ -254,6 +309,12 @@
 						>section</a>, <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
 						>grouping content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-epilogue">doc-epilogue</a>
 				</p>
 			</dd>
 			<dt id="afterword">afterword</dt>
@@ -271,6 +332,12 @@
 						>grouping content</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-afterword">doc-afterword</a>
+				</p>
+			</dd>
 			<dt id="epigraph">epigraph</dt>
 			<dd>
 				<p>A quotation set at the start of the work or a section that establishes the theme or sets the
@@ -285,10 +352,16 @@
 						>grouping content</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-epigraph">doc-epigraph</a>
+				</p>
+			</dd>
 		</dl>
 	</section>
 	<section id="navigation">
-		<h4>Document navigation</h4>
+		<h4>Document Navigation</h4>
 		<dl>
 			<dt id="toc-1">toc</dt>
 			<dd>
@@ -301,6 +374,12 @@
 					<span class="subproplabel">HTML usage context: </span>
 					<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
 						content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-toc">doc-toc</a>
 				</p>
 			</dd>
 			<dt id="toc-brief">toc-brief<span class="status draft"> [draft]</span>
@@ -373,7 +452,7 @@
 		</dl>
 	</section>
 	<section id="document-references">
-		<h4>Document reference sections</h4>
+		<h4>Document Reference Sections</h4>
 		<dl>
 			<dt id="appendix">appendix</dt>
 			<dd>
@@ -385,6 +464,12 @@
 					<span class="subproplabel">HTML usage context: </span>
 					<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
 						content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-appendix">doc-appendix</a>
 				</p>
 			</dd>
 			<dt id="colophon">colophon</dt>
@@ -401,6 +486,12 @@
 						>grouping content</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-colophon">doc-colophon</a>
+				</p>
+			</dd>
 			<dt id="credits">credits<span class="status draft"> [draft]</span>
 			</dt>
 			<dd>
@@ -413,6 +504,12 @@
 						content</a>, <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
 						>grouping content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-credits">doc-credits</a>
 				</p>
 			</dd>
 			<dt id="keywords">keywords<span class="status draft"> [draft]</span>
@@ -452,6 +549,12 @@
 						<span class="subproplabel">Usage details: </span>
 						<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-index">EPUB Indexes – index
 							property</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-index">doc-index</a>
 					</p>
 				</dd>
 				<dt id="index-headnotes">index-headnotes</dt>
@@ -861,6 +964,12 @@
 							content</a>
 					</p>
 				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossary">doc-glossary</a>
+					</p>
+				</dd>
 				<dt id="glossterm">glossterm</dt>
 				<dd>
 					<p>A glossary term.</p>
@@ -918,6 +1027,12 @@
 							content</a>
 					</p>
 				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-bibliography">doc-bibliography</a>
+					</p>
+				</dd>
 				<dt id="biblioentry">biblioentry</dt>
 				<dd>
 					<p>A single reference to an external source in a <a href="#bibliography">bibliography</a>. A
@@ -939,11 +1054,17 @@
 							>grouping content</a>
 					</p>
 				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-biblioentry">doc-biblioentry</a>
+						(Deprecated)</p>
+				</dd>
 			</dl>
 		</div>
 	</section>
 	<section id="preliminary">
-		<h4>Preliminary sections and components</h4>
+		<h4>Preliminary Sections and Components</h4>
 		<p>Preliminary sections and components, typically occurring in the publication frontmatter.</p>
 		<dl>
 			<dt id="titlepage">titlepage</dt>
@@ -1011,6 +1132,12 @@
 						>section</a>, <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
 						>grouping content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-acknowledgments">doc-acknowledgments</a>
 				</p>
 			</dd>
 			<dt id="imprint">imprint</dt>
@@ -1081,6 +1208,12 @@
 						>grouping content</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-errata">doc-errata</a>
+				</p>
+			</dd>
 			<dt id="dedication">dedication</dt>
 			<dd>
 				<p>An inscription at the front of the work, typically addressed in tribute to one or more
@@ -1093,6 +1226,12 @@
 						>section</a>, <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
 						>grouping content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-dedication">doc-dedication</a>
 				</p>
 			</dd>
 			<dt id="revision-history">revision-history</dt>
@@ -1111,7 +1250,7 @@
 		</dl>
 	</section>
 	<section id="complementary">
-		<h4>Complementary content</h4>
+		<h4>Complementary Content</h4>
 		<dl>
 			<dt id="case-study">case-study<span class="status draft"> [draft]</span>
 			</dt>
@@ -1207,6 +1346,12 @@
 						>grouping content</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-notice">doc-notice</a>
+				</p>
+			</dd>
 			<dt id="pullquote">pullquote<span class="status draft"> [draft]</span>
 			</dt>
 			<dd>
@@ -1225,6 +1370,12 @@
 				<p>
 					<span class="subproplabel">HTML usage context: </span>
 					<a href="https://html.spec.whatwg.org/multipage/sections.html#the-aside-element">aside</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pullquote">doc-pullquote</a>
 				</p>
 			</dd>
 			<dt id="sidebar">sidebar<span class="status deprecated"> [deprecated]</span>
@@ -1276,6 +1427,12 @@
 						content</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-tip">doc-tip</a>
+				</p>
+			</dd>
 			<dt id="warning">warning<span class="status deprecated"> [deprecated]</span>
 			</dt>
 			<dd>
@@ -1301,7 +1458,7 @@
 		</dl>
 	</section>
 	<section id="titles">
-		<h4>Titles and headings</h4>
+		<h4>Titles and Headings</h4>
 		<dl>
 			<dt id="halftitle">halftitle</dt>
 			<dd>
@@ -1406,6 +1563,12 @@
 						>divs</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-subtitle">doc-subtitle</a>
+				</p>
+			</dd>
 			<dt id="label">label<span class="status draft"> [draft]</span>
 			</dt>
 			<dd>
@@ -1480,7 +1643,7 @@
 		</dl>
 	</section>
 	<section id="educational">
-		<h4>Educational content</h4>
+		<h4>Educational Content</h4>
 		<div id="learning-obj">
 			<h5 id="h_learning-obj">Learning objectives</h5>
 			<dl>
@@ -1703,6 +1866,12 @@
 							content</a>
 					</p>
 				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-qna">doc-qna</a>
+					</p>
+				</dd>
 				<dt id="match-problem">match-problem<span class="status draft"> [draft]</span>
 				</dt>
 				<dd>
@@ -1885,7 +2054,7 @@
 		</dl>
 	</section>
 	<section id="notes">
-		<h4>Notes and annotations</h4>
+		<h4>Notes and Annotations</h4>
 		<dl>
 			<dt id="annotation">annotation<span class="status deprecated"> [deprecated]</span>
 			</dt>
@@ -1961,6 +2130,12 @@
 					identifying individual footnotes in a group (refer to <a href="#footnotes">footnotes</a> and
 						<a href="#endnotes">endnotes</a>).</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-footnote">doc-footnote</a>
+				</p>
+			</dd>
 			<dt id="endnote">endnote</dt>
 			<dd>
 				<p>One of a collection of notes that occur at the end of a work, or a section within it, that
@@ -1981,6 +2156,11 @@
 					element when identifying a single endnote, or on descendants of sectioning content when
 					identifying individual endnotes in a group (refer to <a href="#footnotes">footnotes</a> and
 						<a href="#endnotes">endnotes</a>).</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-endnote">doc-endnote</a> (Deprecated)</p>
 			</dd>
 			<dt id="rearnote">rearnote<span class="status deprecated"> [deprecated]</span>
 			</dt>
@@ -2047,6 +2227,12 @@
 					<span class="subproplabel">HTML usage context: </span>
 					<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
 						content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-endnotes">doc-endnotes</a>
 				</p>
 			</dd>
 			<dt id="rearnotes">rearnotes<span class="status deprecated"> [deprecated]</span>
@@ -2139,6 +2325,12 @@
 						>a</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-biblioref">doc-biblioref</a>
+				</p>
+			</dd>
 			<dt id="glossref">glossref<span class="status draft"> [draft]</span>
 			</dt>
 			<dd>
@@ -2157,6 +2349,12 @@
 					<span class="subproplabel">HTML usage context: </span>
 					<a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
 						>a</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossref">doc-glossref</a>
 				</p>
 			</dd>
 			<dt id="noteref">noteref</dt>
@@ -2187,6 +2385,12 @@
 						>a</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-noteref">doc-noteref</a>
+				</p>
+			</dd>
 			<dt id="backlink">backlink<span class="status draft"> [draft]</span>
 			</dt>
 			<dd>
@@ -2209,10 +2413,16 @@
 						>a</a>
 				</p>
 			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-backlink">doc-backlink</a>
+				</p>
+			</dd>
 		</dl>
 	</section>
 	<section id="document-text">
-		<h4>Document text</h4>
+		<h4>Document Text</h4>
 		<p>Terms for describing components at the phrasing level.</p>
 		<dl>
 			<dt id="credit">credit<span class="status draft"> [draft]</span>
@@ -2226,6 +2436,12 @@
 					<span class="subproplabel">HTML usage context: </span>
 					<a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content">phrasing
 						content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-credit">doc-credit</a>
 				</p>
 			</dd>
 			<dt id="keyword">keyword</dt>
@@ -2270,6 +2486,12 @@
 			<dd>
 				<p>A separator denoting the position before which a break occurs between two contiguous pages in
 					a statically paginated version of the content.</p>
+				<p>Page break locators are also commonly used to provide static markers in purely digital
+					publications (i.e., where no statically paginated equivalent exists). These markers provide
+					consistent navigation regardless of differences in font and screen size that can otherwise
+					affect the dynamic pagination of the content.</p>
+				<p>Authors must ensure the name of the page break is an end user-consumable page number that
+					identifies the page that is beginning.</p>
 			</dd>
 			<dd>
 				<p>
@@ -2278,6 +2500,12 @@
 						<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow</a> content,
 					where the value of the carrying elements title attribute takes precedence over element
 					content for the purposes of representing the pagebreak value</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagebreak">doc-pagebreak</a>
+				</p>
 			</dd>
 			<dt id="page-list">page-list</dt>
 			<dd>
@@ -2289,6 +2517,12 @@
 					<span class="subproplabel">HTML usage context: </span>
 					<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
 						content</a>
+				</p>
+			</dd>
+			<dd>
+				<p>
+					<span class="subproplabel">DPUB-ARIA role: </span>
+					<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagelist">doc-pagelist</a>
 				</p>
 			</dd>
 		</dl>


### PR DESCRIPTION
I was initially just going to fix #1437 with this PR, but expanded to include some additional informative explanations:

- it includes a new note in the epub:type definition to clarify that the `role` attribute addresses accessibility;
- it adds "dpub-aria role" fields for the structural semantics entries that have matching roles to simplify finding the alternatives - with an explanation about the field that mentions that usage of roles may be more restrictive

Also includes the new pagebreak text from dpub-aria 1.1, but without the normative requirement and stripping the text about what assistive technologies might do with the value.

While we explain these issues outside the specification, it can only help to be clearer about usage inside, especially now that the structure vocabulary is integrated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1472.html" title="Last updated on Jan 19, 2021, 2:07 PM UTC (fed1074)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1472/9702689...fed1074.html" title="Last updated on Jan 19, 2021, 2:07 PM UTC (fed1074)">Diff</a>