### PR TITLE
Add reference to multiple renditions from note about links element

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5734,7 +5734,10 @@ Manifest:
 								value MUST be a media type [[!RFC2046]] that specifies the type and format of the
 								resource referenced by the <code>link</code>.</p>
 
-							<p class="note">This specification does not define uses for the <code>links</code> element. </p>
+							<div class="note">
+								<p>This specification currently does not define uses for the <code>links</code> element.
+									Refer to [[EPUB-Multi-Rend-11]] for examples of its use.</p>
+							</div>
 
 							<p>The value of the <code>rootfile</code> element <code>full-path</code> attribute and the
 									<code>link</code> element <code>href</code> attribute MUST contain a <em

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5736,7 +5736,7 @@ Manifest:
 
 							<div class="note">
 								<p>This specification currently does not define uses for the <code>links</code> element.
-									Refer to [[EPUB-Multi-Rend-11]] for examples of its use.</p>
+									Refer to [[EPUB-Multi-Rend-11]] for an example of its use.</p>
 							</div>
 
 							<p>The value of the <code>rootfile</code> element <code>full-path</code> attribute and the


### PR DESCRIPTION
Requested from #1393


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1473.html" title="Last updated on Jan 19, 2021, 5:58 PM UTC (e9d8fb9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1473/9702689...e9d8fb9.html" title="Last updated on Jan 19, 2021, 5:58 PM UTC (e9d8fb9)">Diff</a>