### PR TITLE
Clarify "descriptive metadata properties"

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -337,8 +337,8 @@
 						<dt id="dc-title">The <code>title</code> element</dt>
 						<dd>
 							<p id="title-order"><a>Reading Systems</a> MUST recognize the first <code>title</code>
-								element in document order as the main title of the EPUB Publication and present it
-								to users before other title elements.</p>
+								element in document order as the main title of the EPUB Publication and present it to
+								users before other title elements.</p>
 							<p>This specification does not define how to process additional <code>title</code>
 								elements.</p>
 						</dd>
@@ -393,8 +393,8 @@
 								IRI of the Package Document as the base when resolving to an absolute IRI.</p>
 							<p>Reading Systems MAY optimize the rendering depending on the properties set in the
 									<code>properties</code> attribute (e.g., disable a rendering process or use a
-								fallback). Reading Systems MUST ignore all descriptive metadata properties that they do
-								not recognize.</p>
+								fallback). Reading Systems MUST ignore values of the <code>properties</code> attribute
+								they do not recognize.</p>
 							<p>A Reading System that does not support the Media Type of a given Publication Resource
 								MUST traverse the fallback chain until it has identified at least one supported
 								Publication Resource to use in place of the unsupported resource. If the Reading System


### PR DESCRIPTION
Addresses the first part of #1475 as described in https://github.com/w3c/epub-specs/issues/1475#issuecomment-763160192