### PR TITLE
Clarify manifest fallback selection statement

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -337,8 +337,8 @@
 						<dt id="dc-title">The <code>title</code> element</dt>
 						<dd>
 							<p id="title-order"><a>Reading Systems</a> MUST recognize the first <code>title</code>
-								element in document order as the main title of the EPUB Publication and present it
-								to users before other title elements.</p>
+								element in document order as the main title of the EPUB Publication and present it to
+								users before other title elements.</p>
 							<p>This specification does not define how to process additional <code>title</code>
 								elements.</p>
 						</dd>
@@ -407,8 +407,11 @@
 						</dd>
 						<dt>Manifest Fallbacks</dt>
 						<dd>
-							<p>Reading System MAY choose to utilize fallbacks to find the optimal version of a Content
-								Document to render in a given context.</p>
+							<p>When <a href="https://www.w3.org/TR/epub-33/#sec-foreign-restrictions-manifest">manifest
+									fallbacks</a> [[!EPUB-33]] are provided for <a>Top-level Content Documents</a>,
+								Reading Systems MAY choose from the available options in order to find the optimal
+								version to render in a given context (e.g., by inspecting the properties attribute for
+								each).</p>
 						</dd>
 					</dl>
 				</section>


### PR DESCRIPTION
Addresses the ambiguous wording in #1474 using the wording in https://github.com/w3c/epub-specs/issues/1474#issuecomment-763087704