### PR TITLE
Recommend sum of individual media overlay durations equal publication total

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7365,14 +7365,17 @@ html.-epub-media-overlay-playing * {
 					<section id="sec-mo-package-metadata">
 						<h5>Overlays Package Metadata</h5>
 
-						<p>The <a>Package Document</a> MUST specify the duration of the entire <a>EPUB Publication</a>
-							in a <a href="#elemdef-package-item"><code>meta</code> element</a> with the <a
-								href="#duration"><code>duration</code> property</a>.</p>
+						<p id="total-duration">The <a>Package Document</a> MUST specify the duration of the entire
+								<a>EPUB Publication</a> in a <a href="#elemdef-package-item"><code>meta</code>
+								element</a> with the <a href="#duration"><code>duration</code> property</a>.</p>
 
 						<p>In addition, the duration of each EPUB Content Document with an associated Media Overlay MUST
 							be provided. The <a href="#attrdef-refines"><code>refines</code> attribute</a> is used to
 							associate each duration declaration to the corresponding <a>manifest</a>
 							<a href="#elemdef-package-item"><code>item</code></a>.</p>
+
+						<p>The sum of the durations for each EPUB Content Document SHOULD equal the <a
+								href="#total-duration">total duration</a>.</p>
 
 						<p><a>Authors</a> also MAY specify <a href="#narrator"><code>narrator</code></a> information in
 							the Package Document, as well as <a href="#sec-docs-assoc-style">author-defined CSS class
@@ -8860,6 +8863,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>20-Jan-2021: Add recommendation that the sum of the media overlay durations for each Content
+						Document match the total duration specified for the EPUB Publication. See <a
+							href="https://github.com/w3c/publ-epub-revision/issues/1322">issue 1322</a>.</li>
 					<li>20-Jan-2021: Clarified that the <code>epub:type</code> attribute does not improve the
 						accessibility of publications. Added pointers to the <code>role</code> attribute and the
 						DPUB-ARIA vocabulary for accessibility.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7366,8 +7366,8 @@ html.-epub-media-overlay-playing * {
 						<h5>Overlays Package Metadata</h5>
 
 						<p id="total-duration">The <a>Package Document</a> MUST specify the duration of the entire
-								<a>EPUB Publication</a> in a <a href="#elemdef-package-item"><code>meta</code>
-								element</a> with the <a href="#duration"><code>duration</code> property</a>.</p>
+								<a>EPUB Publication</a> in a <a href="#elemdef-meta"><code>meta</code> element</a> with
+							the <a href="#duration"><code>duration</code> property</a>.</p>
 
 						<p>In addition, the duration of each EPUB Content Document with an associated Media Overlay MUST
 							be provided. The <a href="#attrdef-refines"><code>refines</code> attribute</a> is used to


### PR DESCRIPTION
Fixes #1322


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1478.html" title="Last updated on Jan 20, 2021, 9:32 PM UTC (57be718)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1478/5839683...57be718.html" title="Last updated on Jan 20, 2021, 9:32 PM UTC (57be718)">Diff</a>