### PR TITLE
Clarify MO user classes must be defined in package document

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2131,7 +2131,7 @@
     …
     &lt;meta property="dcterms:modified"&gt;2016-02-29T12:34:56Z&lt;/meta&gt;
     &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="media:active-class"&gt;-epub-media-overlay-active&lt;/meta&gt;
+    &lt;meta property="media:active-class"&gt;my-active-item&lt;/meta&gt;
     …
 &lt;/metadata&gt;
 </pre>
@@ -7266,6 +7266,16 @@ store destination as source in ocf
 							href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 								><code>playback-active-class</code></a> properties.</p>
 
+					<p>Authors MUST define exactly one CSS class name in each property they define. Each property MUST
+						define a <a href="https://www.w3.org/TR/CSS2/syndata.html#characters">valid CSS class name</a>
+						not including any <a href="https://www.w3.org/TR/CSS2/selector.html">selectors</a> [[!CSS2]].
+						This specification <strong>does not</strong> reserve names for use with these properties.</p>
+
+					<p>Authors MAY define any CSS properties for the specified CSS classes. Authors only need to ensure
+						that each EPUB Content Document with an associated Media Overlay Document includes a link to the
+						CSS style sheet that contains the class definitions. Reading Systems might provide their own
+						styling, or no styling at all, in the absence of a linked definition.</p>
+
 					<p>The <code>active-class</code> and <code>playback-active-class</code> properties MUST NOT be used
 						in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a> as they are
 						always considered to apply to the entire <a>EPUB Publication</a>.</p>
@@ -7277,29 +7287,26 @@ store destination as source in ocf
 						<p>The author-defined CSS class names, declared using the metadata properties <a
 								href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 									><code>playback-active-class</code></a> in the Package Document:</p>
-						<pre>&lt;meta property="media:active-class"&gt;-epub-media-overlay-active&lt;/meta&gt;
-&lt;meta property="media:playback-active-class"&gt;-epub-media-overlay-playing&lt;/meta&gt;</pre>
 
-						<div class="note">
-							<p>Although this example uses the class names <code>-epub-media-overlay-active</code> and
-									<code>-epub-media-overlay-playing</code>, any class names are permitted. The class
-								names chosen can be used along with any supported CSS features.</p>
-						</div>
+						<pre>&lt;meta property="media:active-class"&gt;my-active-item&lt;/meta&gt;
+&lt;meta property="media:playback-active-class"&gt;my-document-playing&lt;/meta&gt;</pre>
 
 						<p>The CSS Style Sheet containing the author-defined class names:</p>
+
 						<pre>/* emphasize the active element */
-.-epub-media-overlay-active {
+.my-active-item {
     background-color: yellow;
     color: black !important;
 }
 
 /* fade out the inactive text */
-html.-epub-media-overlay-playing * {
+html.my-document-playing * {
     color: gray;
 }
 </pre>
 
 						<p>The relevant EPUB Content Document excerpt:</p>
+
 						<pre>&lt;html&gt;
     …
     &lt;span id="txt1"&gt;This is the first phrase.&lt;/span&gt;
@@ -7309,19 +7316,18 @@ html.-epub-media-overlay-playing * {
 &lt;/html&gt;</pre>
 
 						<p>In this example, the Reading System would apply the author-defined
-								<code>-epub-media-overlay-active</code> class to each text element in the EPUB Content
-							Document as it became active during playback. Conversely, the class name is removed when the
-							element is no longer active. The user would see each EPUB Content Document element styled
-							with a yellow background for the duration of that element's playback.</p>
+								<code>my-active-item</code> class to each text element in the EPUB Content Document as
+							it became active during playback. Conversely, the class name is removed when the element is
+							no longer active. The user would see each EPUB Content Document element styled with a yellow
+							background for the duration of that element's playback.</p>
 
-						<p>The Reading System would also apply the author-defined
-								<code>-epub-media-overlay-playing</code> class to the document element of the EPUB
-							Content Document when Media Overlays playback begins. The class name is removed when
-							playback stops. In the case of an XHTML Content Document, the class name would be applied to
-							the <code>html</code> element. In the case of an SVG Content Document, it would be applied
-							to the <code>svg</code> element. The user would see all the inactive text elements turn gray
-							during Media Overlays playback. When playback stopped, the elements' colors would return to
-							their defaults.</p>
+						<p>The Reading System would also apply the author-defined <code>my-document-playing</code> class
+							to the document element of the EPUB Content Document when Media Overlays playback begins.
+							The class name is removed when playback stops. In the case of an XHTML Content Document, the
+							class name would be applied to the <code>html</code> element. In the case of an SVG Content
+							Document, it would be applied to the <code>svg</code> element. The user would see all the
+							inactive text elements turn gray during Media Overlays playback. When playback stopped, the
+							elements' colors would return to their defaults.</p>
 					</aside>
 				</section>
 
@@ -7385,8 +7391,8 @@ html.-epub-media-overlay-playing * {
    &lt;meta property="media:duration" refines="#ch3_audio">0:29:49&lt;/meta>
    &lt;meta property="media:duration"&gt;1:36:20&lt;/meta&gt;
    &lt;meta property="media:narrator"&gt;Joe Speaker&lt;/meta&gt;
-   &lt;meta property="media:active-class"&gt;-epub-media-overlay-active&lt;/meta&gt;
-   &lt;meta property="media:playback-active-class"&gt;-epub-media-overlay-playing&lt;/meta&gt;
+   &lt;meta property="media:active-class"&gt;my-active-item&lt;/meta&gt;
+   &lt;meta property="media:playback-active-class"&gt;my-document-playing&lt;/meta&gt;
    …
 &lt;/metadata&gt;</pre>
 						</aside>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7260,33 +7260,32 @@ store destination as source in ocf
 					<h4>Associating Style Information</h4>
 
 					<p>Visual rendering information for the currently playing <a>EPUB Content Document</a> element MAY
-						be expressed in the CSS Style Sheet using author-defined classes. These author-defined class
-						names SHOULD be declared in the <a>Package Document</a> metadata using the metadata properties
-							<a href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
-								><code>playback-active-class</code></a>. The class names are then discoverable by
-						Reading Systems.</p>
+						be expressed in the CSS Style Sheet using author-defined classes.</p>
+
+					<p>When used, the author-defined class names MUST be declared in the Package Document using the <a
+							href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
+								><code>playback-active-class</code></a> properties.</p>
 
 					<p>The <code>active-class</code> and <code>playback-active-class</code> properties MUST NOT be used
-						in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a>, as they are
+						in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a> as they are
 						always considered to apply to the entire <a>EPUB Publication</a>.</p>
 
-					<p>This example demonstrates how Authors can associate style information with the currently playing
-						EPUB Content Document.</p>
-
-					<div class="note">
-						<p>Although this example uses the class names <code>-epub-media-overlay-active</code> and
-								<code>-epub-media-overlay-playing</code>, any class names are permitted. The class names
-							chosen can be used along with any supported CSS features.</p>
-					</div>
-
 					<aside class="example">
+						<p>This example demonstrates how Authors can associate style information with the currently
+							playing EPUB Content Document.</p>
+
 						<p>The author-defined CSS class names, declared using the metadata properties <a
 								href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 									><code>playback-active-class</code></a> in the Package Document:</p>
 						<pre>&lt;meta property="media:active-class"&gt;-epub-media-overlay-active&lt;/meta&gt;
-&lt;meta property="media:playback-active-class"&gt;-epub-media-overlay-playing&lt;/meta&gt;
-                </pre>
-
+&lt;meta property="media:playback-active-class"&gt;-epub-media-overlay-playing&lt;/meta&gt;</pre>
+						
+						<div class="note">
+							<p>Although this example uses the class names <code>-epub-media-overlay-active</code> and
+								<code>-epub-media-overlay-playing</code>, any class names are permitted. The class
+								names chosen can be used along with any supported CSS features.</p>
+						</div>
+						
 						<p>The CSS Style Sheet containing the author-defined class names:</p>
 						<pre>/* emphasize the active element */
 .-epub-media-overlay-active {
@@ -7299,7 +7298,7 @@ html.-epub-media-overlay-playing * {
     color: gray;
 }
 </pre>
-
+						
 						<p>The relevant EPUB Content Document excerpt:</p>
 						<pre>&lt;html&gt;
     …
@@ -7309,22 +7308,21 @@ html.-epub-media-overlay-playing * {
     …
 &lt;/html&gt;</pre>
 
+						<p>In this example, the Reading System would apply the author-defined
+								<code>-epub-media-overlay-active</code> class to each text element in the EPUB Content
+							Document as it became active during playback. Conversely, the class name is removed when the
+							element is no longer active. The user would see each EPUB Content Document element styled
+							with a yellow background for the duration of that element's playback.</p>
+
+						<p>The Reading System would also apply the author-defined
+								<code>-epub-media-overlay-playing</code> class to the document element of the EPUB
+							Content Document when Media Overlays playback begins. The class name is removed when
+							playback stops. In the case of an XHTML Content Document, the class name would be applied to
+							the <code>html</code> element. In the case of an SVG Content Document, it would be applied
+							to the <code>svg</code> element. The user would see all the inactive text elements turn gray
+							during Media Overlays playback. When playback stopped, the elements' colors would return to
+							their defaults.</p>
 					</aside>
-
-					<p>In this example, the Reading System would apply the author-defined
-							<code>-epub-media-overlay-active</code> class to each text element in the EPUB Content
-						Document as it became active during playback. Conversely, the class name is removed when the
-						element is no longer active. The user would see each EPUB Content Document element styled with a
-						yellow background for the duration of that element's playback.</p>
-
-					<p>The Reading System would also apply the author-defined <code>-epub-media-overlay-playing</code>
-						class to the document element of the EPUB Content Document when Media Overlays playback begins.
-						The class name is removed when playback stops. In the case of an XHTML Content Document, the
-						class name would be applied to the <code>html</code> element. In the case of an SVG Content
-						Document, it would be applied to the <code>svg</code> element. The user would see all the
-						inactive text elements turn gray during Media Overlays playback. When playback stopped, the
-						elements’ colors would return to their defaults.</p>
-
 				</section>
 
 				<section id="sec-docs-package">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7279,13 +7279,13 @@ store destination as source in ocf
 									><code>playback-active-class</code></a> in the Package Document:</p>
 						<pre>&lt;meta property="media:active-class"&gt;-epub-media-overlay-active&lt;/meta&gt;
 &lt;meta property="media:playback-active-class"&gt;-epub-media-overlay-playing&lt;/meta&gt;</pre>
-						
+
 						<div class="note">
 							<p>Although this example uses the class names <code>-epub-media-overlay-active</code> and
-								<code>-epub-media-overlay-playing</code>, any class names are permitted. The class
+									<code>-epub-media-overlay-playing</code>, any class names are permitted. The class
 								names chosen can be used along with any supported CSS features.</p>
 						</div>
-						
+
 						<p>The CSS Style Sheet containing the author-defined class names:</p>
 						<pre>/* emphasize the active element */
 .-epub-media-overlay-active {
@@ -7298,7 +7298,7 @@ html.-epub-media-overlay-playing * {
     color: gray;
 }
 </pre>
-						
+
 						<p>The relevant EPUB Content Document excerpt:</p>
 						<pre>&lt;html&gt;
     …
@@ -8858,6 +8858,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>20-Jan-2021: Clarified that user-defined media overlay style classes must be declared in the
+						Package Document metadata. See <a href="https://github.com/w3c/publ-epub-revision/issues/1319"
+							>issue 1319</a>.</li>
 					<li>20-Jan-2021: Clarified that the <code>epub:type</code> attribute does not improve the
 						accessibility of publications. Added pointers to the <code>role</code> attribute and the
 						DPUB-ARIA vocabulary for accessibility.</li>


### PR DESCRIPTION
Fixes the ambiguous wording noted in https://github.com/w3c/epub-specs/issues/1319#issue-663689940

I also noticed that the paragraph before the example and the two after are part of the example -- they're explanatory text. I've grouped them all together as one big example to make this clearer. I also repositioned the note about the class names just being examples immediately after their declarations.

Fixes #1319
Fixes #1320


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1479.html" title="Last updated on Jan 25, 2021, 11:49 AM UTC (9ae6dce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1479/90a703b...9ae6dce.html" title="Last updated on Jan 25, 2021, 11:49 AM UTC (9ae6dce)">Diff</a>