### PR TITLE
clarify relocating reading position only applies to publication resources

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -486,7 +486,8 @@
 							using a synthesized voice.</p>
 					</dd>
 					<dt>
-						<dfn id="dfn-top-level-content-document">Top-level Content Document</dfn>
+						<dfn id="dfn-top-level-content-document" data-lt="Top-level Content Documents">Top-level Content
+							Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> referenced from the <a>spine</a>, whether directly or via a
@@ -8887,7 +8888,7 @@ EPUB/images/cover.png</pre>
 			<section id="changes-older">
 				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
 					3.2</a></h3>
-        
+
 				<ul>
 					<li>24-Dec-2020: The specification no longer makes reference to a release identifier, but the
 						requirement to include a last modification date remains for backwards compatibility. See <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1026,8 +1026,8 @@
 							fashion that allows the user to activate the links.</p>
 					</li>
 					<li>
-						<p id="confreq-nav-activation">When a link is activated, it MUST relocate the application's
-							current reading position to the destination identified by that link.</p>
+						<p id="confreq-nav-activation">When a link to a <a>Publication Resource</a> is activated, it
+							MUST relocate the current reading position to the destination identified by that link.</p>
 					</li>
 					<li>
 						<p id="confreq-nav-spine">It MUST honor the above requirements irrespective of whether the EPUB


### PR DESCRIPTION
Fixes #977


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1484.html" title="Last updated on Jan 26, 2021, 7:25 PM UTC (68aa555)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1484/645a534...68aa555.html" title="Last updated on Jan 26, 2021, 7:25 PM UTC (68aa555)">Diff</a>