### PR TITLE
Change media overlays conformance from a recommendation to requirement

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -566,9 +566,9 @@
 					<section id="sec-mo-conf">
 						<h5>Meeting this Objective</h5>
 
-						<p>Media Overlay Documents MUST meet the requirements in [[EPUB-3]]. It is not necessary to
-							meet any additional requirements beyond those defined in [[EPUB-3]] to be conformant with
-							this document.</p>
+						<p>Media Overlay Documents MUST meet the requirements in [[EPUB-3]]. It is not necessary to meet
+							any additional requirements beyond those defined in [[EPUB-3]] to be conformant with this
+							document.</p>
 
 						<p>To improve the usability of Media Overlays, however, Authors are encouraged to ensure their
 							EPUB Publications:</p>
@@ -1021,6 +1021,9 @@
 				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
 
 				<ul>
+					<li>01-Feb-2021: Changed the recommendation that media overlays conform to the requirements of the
+						EPUB specification to a requirement. See <a href="https://github.com/w3c/epub-specs/issues/1486"
+							>issue 1486</a>.</li>
 					<li>17-Nov-2020: Added the <code>refines</code> attribute to the <code>certifierCredential</code>
 						and <code>certifierReport</code> properties and examples. See <a
 							href="https://github.com/w3c/epub-specs/issues/1410">issue 1410</a>.</li>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -566,18 +566,18 @@
 					<section id="sec-mo-conf">
 						<h5>Meeting this Objective</h5>
 
-						<p>Media Overlay Documents SHOULD meet the requirements in [[EPUB-3]]. It is not necessary to
+						<p>Media Overlay Documents MUST meet the requirements in [[EPUB-3]]. It is not necessary to
 							meet any additional requirements beyond those defined in [[EPUB-3]] to be conformant with
 							this document.</p>
 
 						<p>To improve the usability of Media Overlays, however, Authors are encouraged to ensure their
-							EPUB Publications meet the following criteria:</p>
+							EPUB Publications:</p>
 
 						<ul>
 							<li>identify all <a href="https://www.w3.org/publishing/epub/core/#sec-skippability"
 									>skippable structures</a> [[EPUB-3]] in the Media Overlay Documents;</li>
 							<li>identify all <a href="https://www.w3.org/publishing/epub/core/#sec-escapability"
-									>escapable structures</a> [[EPUB-3]] in the Media Overlay Documents;</li>
+									>escapable structures</a> [[EPUB-3]] in the Media Overlay Documents; and</li>
 							<li>include a Media Overlay Document for the <a
 									href="https://www.w3.org/publishing/epub/core/#sec-nav-doc">EPUB Navigation
 									Document</a> [[EPUB-3]].</li>


### PR DESCRIPTION
Fixes #1486 

The informative conformance items (skippability, escapability, and a media overlay for the navigation document) are not affected by this change. It only requires media overlays to conform to the EPUB specification requirements when present.

- [Accessibility preview](https://raw.githack.com/w3c/epub-specs/fix/issue-1486/epub33/a11y/)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-1486%2Fepub33%2Fa11y%2Findex.html)

