### PR TITLE
Make distribution section normative

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -825,7 +825,7 @@
 					endorsement of the standards is implied.</p>
 			</div>
 		</section>
-		<section id="sec-distribution" class="informative">
+		<section id="sec-distribution">
 			<h2>Distribution</h2>
 
 			<p>The creation of an EPUB Publication that is accessible does not in itself guarantee that the content will
@@ -848,8 +848,8 @@
 				following distribution practices:</p>
 
 			<ul>
-				<li>they do not impose restrictions that impair access by assistive technologies; and</li>
-				<li>they include accessibility metadata in the record format required for distribution of an EPUB
+				<li>they MUST NOT impose restrictions that impair access by assistive technologies; and</li>
+				<li>they MUST include accessibility metadata in the record format required for distribution of an EPUB
 					Publication when such metadata is supported by the format.</li>
 			</ul>
 

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -854,10 +854,11 @@
 			</ul>
 
 			<div class="note">
-				<p>Following the guidance in this section does not restrict Authors from using distributors whose
-					digital rights management schemes impair accessibility. The intent is that the Author does not
-					impair accessibility by activating a feature that that would normally not be active (e.g.,
-					restricting access to the text by assistive technologies).</p>
+				<p>A distributor may implement a digital rights management scheme that inherently impairs accessibility
+					through no fault of the Author. Following the guidance in this section does not restrict Authors
+					from using such distributors. The intent is that the Author does not impair accessibility by
+					activating a feature that that would normally not be active (e.g., restricting access to the text by
+					assistive technologies).</p>
 			</div>
 		</section>
 		<section id="app-a11y-vocab" class="appendix vocab">


### PR DESCRIPTION
Fixes #1487 

Returns the distribution section to normative and adds back the normative keywords to the two bullet items.

- [Accessibility preview](https://raw.githack.com/w3c/epub-specs/fix/issue-1487/epub33/a11y/)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-1487%2Fepub33%2Fa11y%2Findex.html)

