### PR TITLE
Add hreflang attribute to link element

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2220,6 +2220,14 @@
 										</li>
 										<li>
 											<p>
+												<a href="#attrdef-hreflang">
+													<code>hreflang</code>
+												</a>
+												<code>[optional]</code>
+											</p>
+										</li>
+										<li>
+											<p>
 												<a href="#attrdef-id">
 													<code>id</code>
 												</a>
@@ -2287,7 +2295,8 @@
     … 
     &lt;link rel="record"
           href="front.xhtml#meta-json"
-          media-type="application/xhtml+xml"/&gt;
+          media-type="application/xhtml+xml"
+          hreflang="en"/&gt;
     …
 &lt;/metadata&gt;</pre>
 							</aside>
@@ -2301,6 +2310,11 @@
 									attribute</a> is OPTIONAL when a linked resource is located outside the EPUB
 								Container, as more than one media type could be served from the same IRI. The attribute
 								is REQUIRED for all <a>Local Resources</a>.</p>
+
+							<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the
+								language of the linked resource. The value MUST be a <a
+									href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language tag</a>
+								[[!BCP47]].</p>
 
 							<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated
 								list of <a href="#sec-property-datatype">property</a> values that establish the
@@ -8869,6 +8883,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>2-Feb-2021: Added the <code>hreflang</code> attribute to <code>link</code> elements to identify
+						the language of linked resources. See <a
+							href="https://github.com/w3c/publ-epub-revision/issues/1488">issue 1488</a>.</li>
 					<li>20-Jan-2021: Clarified that user-defined media overlay style classes must be declared in the
 						Package Document metadata. See <a href="https://github.com/w3c/publ-epub-revision/issues/1319"
 							>issue 1319</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -365,6 +365,8 @@
 						<dt id="conf-metadata-link">The <code>link</code> element</dt>
 						<dd>
 							<p>Retrieval of Remote Resources is OPTIONAL.</p>
+							<p>The language identified in an <code>hreflang</code> attribute is not authoritative.
+								Language information defined in a linked resource determines its language.</p>
 							<p>Reading System do not have to use or present linked resources, even if they recognize the
 								relationship defined in the <code>rel</code> attribute.</p>
 							<p id="sec-linked-records">In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
@@ -426,10 +428,10 @@
 								defined in the <code>spine</code>, which includes: 1) recognizing the first primary
 									<code>itemref</code> as the beginning of the default reading order; and, 2)
 								rendering successive primary items in the order given in the <code>spine</code>.</p>
-							<p>When the <code>default</code> value of the <code>page-progression-direction</code> 
-								attribute is specified, the Reading System can choose the
-								rendering direction. The <code>default</code> value MUST be assumed when the attribute
-								is not specified. In this case, the reading system SHOULD choose a default
+							<p>When the <code>default</code> value of the <code>page-progression-direction</code>
+								attribute is specified, the Reading System can choose the rendering direction. The
+									<code>default</code> value MUST be assumed when the attribute is not specified. In
+								this case, the reading system SHOULD choose a default
 									<code>page-progression-direction</code> value based on the first
 									<code>language</code> element.</p>
 							<p>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
@@ -2120,7 +2122,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						- move all changes down to the next section
 				-->
 
-				<ul> </ul>
+				<ul>
+					<li>2-Feb-2021: Noted that language information in the new <code>hreflang</code> attribute on
+							<code>link</code> elements is not authoritative. See <a
+							href="https://github.com/w3c/publ-epub-revision/issues/1488">issue 1488</a>.</li>
+				</ul>
 			</section>
 
 			<section id="changes-older">


### PR DESCRIPTION
Fixes #1488 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/feature/issue-1488/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/feature/issue-1488/epub33/rs/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1497.html" title="Last updated on Feb 9, 2021, 3:19 PM UTC (148aec3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1497/c82cfa5...148aec3.html" title="Last updated on Feb 9, 2021, 3:19 PM UTC (148aec3)">Diff</a>