### PR TITLE
Clarifications to language element

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1769,8 +1769,6 @@
 										href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
 										tag</a> [[!BCP47]].</p>
 
-								<p>This value is not inherited by <a>Publication Resources</a>.</p>
-
 								<aside class="example">
 									<p>The following example shows an <a>EPUB Publication</a> is in U.S. English.</p>
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
@@ -1781,10 +1779,15 @@
 </pre>
 								</aside>
 
-								<p>Additional <code>language</code> elements MAY be specified for multilingual
-									Publications, but each element's value MUST conform to [[!BCP47]]. The first
-										<code>language</code> element in document order is considered the primary
-									language of the EPUB Publication.</p>
+								<p>Although additional <code>language</code> elements MAY be specified for multilingual
+									Publications, the first <code>language</code> element in document order is
+									considered the primary language of the EPUB Publication.</p>
+
+								<div class="note">
+									<p><a>Publication Resources</a> do not inherit their language from the
+											<code>dc:language</code> element(s). The language of a resource has to be
+										set using the intrinsic methods of the format.</p>
+								</div>
 							</section>
 						</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1765,7 +1765,9 @@
 								</dl>
 
 								<p>The <code>metadata</code> section MUST contain at least one <code>language</code>
-									element with a value conforming to [[!BCP47]].</p>
+									element. The value of each <code>language</code> element MUST be a <a
+										href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
+										tag</a> [[!BCP47]].</p>
 
 								<p>This value is not inherited by <a>Publication Resources</a>.</p>
 
@@ -8869,6 +8871,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>4-Feb-2021: Clarify that the value of <code>dc:language</code> elements must be well-formed
+						language tags. See <a href="https://github.com/w3c/publ-epub-revision/issues/1325">issue
+							1325</a>.</li>
 					<li>20-Jan-2021: Clarified that user-defined media overlay style classes must be declared in the
 						Package Document metadata. See <a href="https://github.com/w3c/publ-epub-revision/issues/1319"
 							>issue 1319</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -343,6 +343,13 @@
 								elements.</p>
 						</dd>
 
+						<dt id="sec-opf-dclanguage">The <code>language</code> element</dt>
+						<dd>
+							<p>The language(s) of the <a>EPUB Publication</a> specified in <code>language</code>
+								elements are advisory. Reading Systems MUST use the language information associated with
+								a resource to determine its language.</p>
+						</dd>
+
 						<dt id="dc-creator">The <code>creator</code> element</dt>
 						<dd>
 							<p>When determining display priority, Reading Systems MUST use the document order of
@@ -426,10 +433,10 @@
 								defined in the <code>spine</code>, which includes: 1) recognizing the first primary
 									<code>itemref</code> as the beginning of the default reading order; and, 2)
 								rendering successive primary items in the order given in the <code>spine</code>.</p>
-							<p>When the <code>default</code> value of the <code>page-progression-direction</code> 
-								attribute is specified, the Reading System can choose the
-								rendering direction. The <code>default</code> value MUST be assumed when the attribute
-								is not specified. In this case, the reading system SHOULD choose a default
+							<p>When the <code>default</code> value of the <code>page-progression-direction</code>
+								attribute is specified, the Reading System can choose the rendering direction. The
+									<code>default</code> value MUST be assumed when the attribute is not specified. In
+								this case, the reading system SHOULD choose a default
 									<code>page-progression-direction</code> value based on the first
 									<code>language</code> element.</p>
 							<p>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
@@ -2120,7 +2127,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						- move all changes down to the next section
 				-->
 
-				<ul> </ul>
+				<ul>
+					<li>4-Feb-2021: Added explicit requirement that reading systems not use the language in
+							<code>dc:language</code> elements as the language of resources.</li>
+				</ul>
 			</section>
 
 			<section id="changes-older">


### PR DESCRIPTION
This PR makes the following changes:

- requires well-formed language tags for the dc:language element to match the history of what we've allowed plus match what we've required elsewhere
- removes a redundant second requirement for dc:language elements to have well-formed tags
- makes explicit in the RS specification that the language of the element(s) must not be used for resources

We can keep discussing a requirement for valid tags if someone feels strongly about that, but I want to get the specification to reflect current practice with this change.

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1325/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1325/epub33/rs/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1506.html" title="Last updated on Feb 9, 2021, 3:21 PM UTC (c9672cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1506/43a5515...c9672cf.html" title="Last updated on Feb 9, 2021, 3:21 PM UTC (c9672cf)">Diff</a>