### PR TITLE
Adding the "well-formed" requirement for "xml:lang"

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1372,7 +1372,9 @@
 								<p>Specifies the language used in the contents and attribute values of the carrying
 									element and its descendants, as defined in section <a
 										href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-lang-tag">2.12 Language
-										Identification</a> of [[!XML]].</p>
+										Identification</a> of [[!XML]]. The value of each <code>xml:lang</code> attribute MUST be a <a
+										href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
+										tag</a> [[!BCP47]].</p>
 								<div class="example">
 									<pre>&lt;package … xml:lang="ja"&gt;
    …


### PR DESCRIPTION
This requirement is indeed not part of the [xml:lang specification](https://www.w3.org/TR/REC-xml/#sec-lang-tag), only that its value must be BCP...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1510.html" title="Last updated on Feb 10, 2021, 11:31 AM UTC (71722c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1510/660afee...71722c6.html" title="Last updated on Feb 10, 2021, 11:31 AM UTC (71722c6)">Diff</a>