### PR TITLE
Add clarifying note about legislated a11y requirements

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -362,6 +362,15 @@
 						thresholds they must meet will be defined by local and national laws, or by procurer or
 						distributor requirements.</p>
 
+					<div class="note">
+						<p>Examples of legislative requirements for accessibility include the <a
+								href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">2019
+								European Union (EU) Directive</a> and <a href="https://www.access-board.gov/ict/"
+								>Section 508 of the Rehabilitation Act of 1973 (United States)</a>. EPUB Publications
+							will need to meet more than just the basic Level A success criteria to be compliant with
+							these laws.</p>
+					</div>
+
 					<p>Keeping pace with WCAG has the benefit of continuously enhancing access for users. As web
 						technologies change and improve, and awareness of conditions that impede access evolve, new
 						requirements are added to the standard. Meeting these additional requirements helps ensure EPUB


### PR DESCRIPTION
As requested on the 2021-02-11 telecon, adds a note that meeting level a is not sufficient for conforming to European accessibility act or section 508