### PR TITLE
Change security best practice to unique origin per publication

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2197,7 +2197,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 
 				<ul>
 					<li>19-Feb-2021: Updated the <a href="sec-scripted-content-security">scripting security
-							considerations</a> so that the text discusses assigning a unique origin to each EPUB
+							considerations</a> so that the text recommends assigning a unique origin to each EPUB
 						Publication for security rather than domain isolation at the Content Document level. See <a
 							href="https://github.com/w3c/epub-specs/issues/1156">issue 1156</a>.</li>
 				</ul>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -957,20 +957,18 @@
 
 					<ul>
 						<li>
-							<p>Reading Systems need to behave as if a unique domain were allocated to each Content
-								Document, as browser-based security relies heavily on document URLs and domains.
-								Adopting this approach will isolate documents from each other and from other Internet
-								domains, thereby limiting access to external URLs, cookies, DOM storage, etc.</p>
+							<p>Reading Systems need to behave as if a unique origin were allocated to each <a>EPUB
+									Publication</a>. Adopting this approach will isolate publications from each other,
+								thereby limiting access to cookies, DOM storage, etc.</p>
+							<div class="note">
+								<p>Although domain isolation is the most effective way to secure EPUB Publications in
+									Web-based Reading Systems, it is not always a realistic option. Web-based Reading
+									Systems still need to maintain isolation in such cases, which may require limiting
+									access to scripting APIs that allow client-side data storage and access.</p>
+							</div>
 							<p>Reading Systems that enable scripting and network access also need to consider including
 								methods to notify the user that network activity is occurring and/or that allow them to
 								disable it.</p>
-							<div class="note">
-								<p>In practice, Reading Systems might share domains across documents, but they still
-									need to maintain isolation between documents.</p>
-								<p>If parts of a document are encrypted and parts are not, or if different encryption
-									keys are used for different parts of the document, a unique per-document domain
-									might not provide sufficient protection.</p>
-							</div>
 						</li>
 						<li>
 							<p>If a Reading System allows persistent data to be stored, that data needs to be treated as
@@ -2188,8 +2186,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<section id="changes-latest">
-				<h3>Substantive Changes since the <a href="https://www.w3.org/TR/2021/WD-epub-rs-33-20210112/">First
-						Public Working Draft</a></h3>
+				<h3>Substantive Changes since the <a href="https://www.w3.org/TR/2021/WD-epub-rs-33-20210223/">Previous
+						Working Draft</a></h3>
 
 				<!--
 					After each working draft is published:
@@ -2197,6 +2195,17 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						- move all changes down to the next section
 				-->
 
+				<ul>
+					<li>19-Feb-2021: Updated the scripting security recommendations so that the text discusses assigning
+						a unique origin to each EPUB Publication for security rather than domain isolation at the
+						Content Document level. See <a href="https://github.com/w3c/epub-specs/issues/1156">issue
+							1156</a>.</li>
+				</ul>
+			</section>
+
+			<section id="changes-older">
+				<h3>Substantive Changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
+					3.2</a></h3>
 				<ul>
 					<li>15-Feb-2021: Clarified the requirements for presenting nav elements in the navigation document.
 						The toc nav is now the only required element, the page-list nav is recommended when present, and
@@ -2211,13 +2220,6 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					<li>2-Feb-2021: Noted that language information in the new <code>hreflang</code> attribute on
 							<code>link</code> elements is not authoritative. See <a
 							href="https://github.com/w3c/epub-specs/issues/1488">issue 1488</a>.</li>
-				</ul>
-			</section>
-
-			<section id="changes-older">
-				<h3>Substantive Changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
-					3.2</a></h3>
-				<ul>
 					<li>24-Dec-2020: The creation of a <a
 							href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
 							>release identifier</a> [[EPUBPackages-32]] is no longer defined. See <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -957,29 +957,29 @@
 
 					<ul>
 						<li>
-							<p>Reading Systems need to behave as if a unique origin were allocated to each <a>EPUB
-									Publication</a>. Adopting this approach will isolate publications from each other,
-								thereby limiting access to cookies, DOM storage, etc.</p>
+							<p>Reading Systems must behave as if a unique <a href="https://url.spec.whatwg.org/#origin"
+									>origin</a> [[URL]] were allocated to each <a>EPUB Publication</a>. Adopting this
+								approach will isolate publications from each other, thereby limiting access to cookies,
+								DOM storage, etc.</p>
 							<div class="note">
 								<p>Although domain isolation is the most effective way to secure EPUB Publications in
 									Web-based Reading Systems, it is not always a realistic option. Web-based Reading
-									Systems still need to maintain isolation in such cases, which may require limiting
+									Systems must still maintain isolation in such cases, which may require limiting
 									access to scripting APIs that allow client-side data storage and access.</p>
 							</div>
-							<p>Reading Systems that enable scripting and network access also need to consider including
-								methods to notify the user that network activity is occurring and/or that allow them to
-								disable it.</p>
+							<p>Reading Systems that enable scripting and network access should also include methods to
+								notify the user that network activity is occurring and/or that allow them to disable
+								it.</p>
 						</li>
 						<li>
-							<p>If a Reading System allows persistent data to be stored, that data needs to be treated as
-								sensitive. Scripts might save persistent data through cookies and DOM storage but
-								Reading Systems might block such attempts. Reading Systems that do allow data to be
-								stored have to ensure that it is not made available to other unrelated documents (e.g.,
-								ones that could have been spoofed). In particular, checking for a matching document
-								identifier (or similar metadata) is not a valid method to control access to persistent
-								data.</p>
-							<p>Reading Systems that allow local storage also need to provide methods for users to
-								inspect, disable, or delete that data. The data needs to be destroyed if the
+							<p>If a Reading System allows persistent data to be stored, that data must be treated as
+								sensitive. Scripts may save persistent data through cookies and DOM storage but Reading
+								Systems may block such attempts. Reading Systems that do allow data to be stored must
+								ensure that it is not made available to other unrelated documents (e.g., ones that could
+								have been spoofed). In particular, checking for a matching document identifier (or
+								similar metadata) is not a valid method to control access to persistent data.</p>
+							<p>Reading Systems that allow local storage should also provide methods for users to
+								inspect, disable, and delete that data. The data needs to be destroyed if the
 								corresponding EPUB Publication is deleted.</p>
 						</li>
 					</ul>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2196,10 +2196,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
-					<li>19-Feb-2021: Updated the scripting security recommendations so that the text discusses assigning
-						a unique origin to each EPUB Publication for security rather than domain isolation at the
-						Content Document level. See <a href="https://github.com/w3c/epub-specs/issues/1156">issue
-							1156</a>.</li>
+					<li>19-Feb-2021: Updated the <a href="sec-scripted-content-security">scripting security
+							considerations</a> so that the text discusses assigning a unique origin to each EPUB
+						Publication for security rather than domain isolation at the Content Document level. See <a
+							href="https://github.com/w3c/epub-specs/issues/1156">issue 1156</a>.</li>
 				</ul>
 			</section>
 


### PR DESCRIPTION
This PR updates the security section so that it discusses assigning a unique origin to each publication rather than assigning a unique domain per content document.

Let me know if the new note captures the issues that were raised on the 2021-02-18 telecon relating to how web-based reading systems cannot always enforce this kind of restriction and/or if there's anything else missing or that needs fixing.

Fixes #1156 
Fixes #873 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1156/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1156/epub33/rs/index.html)

