### PR TITLE
Consolidate and clean up the scripting section

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4295,8 +4295,8 @@ Manifest:
 			<section id="sec-scripted-content">
 				<h3>Scripting</h3>
 
-				<section id="sec-scripted-context">
-					<h4>Scripting Contexts</h4>
+				<section id="sec-scripted-support">
+					<h4>Script Inclusion</h4>
 
 					<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in the
 						respective underlying specifications ([[!HTML]] and [[!SVG]]). When an EPUB Content Document
@@ -4311,48 +4311,6 @@ Manifest:
 								Document</a>.</p>
 					</div>
 
-					<p id="sec-scripted-content-models">This specification defines two contexts in which scripts MAY
-						appear:</p>
-
-					<dl class="variablelist">
-						<dt id="sec-scripted-content-type-spine-level">spine-level</dt>
-						<dd>
-							<p>An instance of the [[!HTML]] <a
-									href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
-										><code>script</code></a> or [[!SVG]] <a
-									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
-								element contained in a <a>Top-level Content Document</a>.</p>
-						</dd>
-						<dt id="sec-scripted-content-type-container-constrained">container-constrained</dt>
-						<dd>
-							<p>Either of the following:</p>
-							<ul>
-								<li>
-									<p>An instance of the [[!HTML]] <a
-											href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
-												><code>script</code></a> element contained in an <a>XHTML Content
-											Document</a> that is embedded in a parent XHTML Content Document using the
-										[[!HTML]] <a
-											href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
-												><code>iframe</code></a> element.</p>
-								</li>
-								<li>
-									<p>An instance of the [[!SVG]] <a
-											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
-												><code>script</code></a> element contained in an <a>SVG Content
-											Document</a> that is embedded in a parent XHTML Content Document using the
-										[[!HTML]] <a
-											href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
-												><code>iframe</code></a> element.</p>
-								</li>
-							</ul>
-						</dd>
-					</dl>
-
-					<p>In both above-defined contexts, whether the code is embedded directly in the <code>script</code>
-						element or referenced via its <code>src</code> attribute makes no difference to the executing
-						context.</p>
-
 					<p>When an [[HTML]] <code>script</code> element contains a <a
 							href="https://html.spec.whatwg.org/multipage/scripting.html#data-block">data block</a>
 						[[HTML]], it does not represent scripted content.</p>
@@ -4362,13 +4320,15 @@ Manifest:
 							a future update adds the concept.</p>
 					</div>
 
-					<p>Which context a script is used in determines the rights and restrictions that a Reading System
-						places on it. Refer to <a href="#sec-scripted-container-constrained">the following sections</a>
-						and <a href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">Scripting
-							Conformance</a> [[EPUB-RS-33]] for some specific requirements that have to be adhered to
-						(not all Reading Systems will provide the same scripting functionality).</p>
+					<p>Authors should note that Reading Systems are expected to behave as though a unique <a
+							href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] has been assigned to each EPUB
+						Publication. In practice, this means that it is not possible for scripts to share data between
+						EPUB Publications.</p>
 
-					<h5>Example</h5>
+					<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the rights
+						and restrictions that a Reading System places on it (refer to <a
+							href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">Scripting
+							Conformance</a> [[EPUB-RS-33]] for more information).</p>
 
 					<aside class="example">
 						<p>Consider the following example Package Document:</p>
@@ -4442,43 +4402,102 @@ Manifest:
 					</aside>
 				</section>
 
-				<section id="sec-scripted-container-constrained">
-					<h4>Container-Constrained Scripts</h4>
+				<section id="sec-scripted-context">
+					<h4>Scripting Contexts</h4>
 
-					<p id="confreq-cd-scripted-container">A <a href="#sec-scripted-content-type-container-constrained"
-							>container-constrained script</a> MUST NOT contain instructions for modifying the DOM of the
-						parent Content Document or other contents in the EPUB Publication. It also MUST NOT contain
-						instructions for manipulating the size of its containing rectangle.</p>
-				</section>
+					<p>EPUB 3 defines two contexts for script execution:</p>
 
-				<section id="sec-scripted-spine">
-					<h4>Spine-Level Scripts</h4>
+					<ul>
+						<li><a href="#sec-scripted-container-constrained">container-constrained</a> &#8212; when the
+							execution of a script occurs within an <code>iframe</code>; and</li>
+						<li><a href="#sec-scripted-spine">spine-level</a> &#8212; when the execution of a script occurs
+							directly within a <a>Top-level Content Document</a>.</li>
+					</ul>
 
-					<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include <a
-							href="#sec-scripted-content-type-spine-level">spine-level scripting</a> SHOULD remain
-						consumable by the user without any information loss or other significant deterioration when
-						scripting is disabled (e.g., by employing progressive enhancement techniques).</p>
+					<p>Whether the code is embedded directly in the <code>script</code> element or referenced via its
+							<code>src</code> attribute makes no difference to its executing context.</p>
 
-					<p>Since Reading Systems are not required to support scripting, failing to account for non-scripted
-						environments in Top-level Content Documents can result in EPUB Publications being
-						unreadable.</p>
+					<p>Which context Authors use for their scripts affects both what actions the scripts can perform and
+						the likelihood of support in Reading Systems, as described in the following subsections.</p>
+
+					<section id="sec-scripted-container-constrained">
+						<h5>Container-Constrained Scripts</h5>
+
+						<p>A <dfn>container-constrained script</dfn> is either of the following:</p>
+
+						<ul>
+							<li>
+								<p>An instance of the [[!HTML]] <a
+										href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
+											><code>script</code></a> element contained in an <a>XHTML Content
+										Document</a> that is embedded in a parent XHTML Content Document using the
+									[[!HTML]] <a
+										href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
+											><code>iframe</code></a> element.</p>
+							</li>
+							<li>
+								<p>An instance of the [[!SVG]] <a
+										href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
+										><code>script</code></a> element contained in an <a>SVG Content Document</a>
+									that is embedded in a parent XHTML Content Document using the [[!HTML]] <a
+										href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
+											><code>iframe</code></a> element.</p>
+							</li>
+						</ul>
+
+						<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
+							instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e., the
+							one that contains the <code>iframe</code> element). It also MUST NOT contain instructions
+							for manipulating the size of its containing rectangle.</p>
+
+						<p>Authors should note that <a
+								href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">support for
+								container-constrained scripting in Reading Systems</a> is only recommended in reflowable
+							documents [[EPUB-RS-33]]. Furthermore, Reading System support in fixed-layouts EPUBs is
+							optional.</p>
+
+						<p>Ensuring container-constrained scripts degrade gracefully in Reading Systems without
+							scripting support is advised (see <a href="#sec-scripted-fallbacks"></a>).</p>
+					</section>
+
+					<section id="sec-scripted-spine">
+						<h5>Spine-Level Scripts</h5>
+
+						<p>A <dfn>spine-level script</dfn> is an instance of the [[!HTML]] <a
+								href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
+									><code>script</code></a> or [[!SVG]] <a
+								href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
+							element contained in a <a>Top-level Content Document</a>.</p>
+
+						<p>Authors should note that <a
+								href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">support for
+								spine-level scripting in Reading Systems</a> is only recommended in fixed layout
+							documents and reflowable documents when they are set to scroll [[EPUB-RS-33]]. Furthermore,
+							Reading System support in all other contexts is optional.</p>
+
+						<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include spine-level
+							scripting SHOULD remain consumable by the user without any information loss or other
+							significant deterioration when scripting is disabled or not available (e.g., by employing
+							progressive enhancement techniques or <a href="#sec-scripted-fallbacks">fallbacks</a>).
+							Failing to account for non-scripted environments in Top-level Content Documents can result
+							in EPUB Publications being unreadable.</p>
+					</section>
 				</section>
 
 				<section id="sec-scripted-a11y">
 					<h4>Scripting Accessibility</h4>
 
-					<p id="confreq-cd-scripted-a11y">EPUB Content Documents that <a href="#sec-scripted-content-models"
-							>contain scripting</a> SHOULD employ relevant [[!WAI-ARIA]] accessibility techniques to
-						ensure that the content remains consumable by all users.</p>
+					<p id="confreq-cd-scripted-a11y">EPUB Content Documents that contain scripting SHOULD employ
+						relevant [[!WAI-ARIA]] accessibility techniques to ensure that the content remains consumable by
+						all users.</p>
 				</section>
 
 				<section id="sec-scripted-fallbacks">
 					<h4 id="confreq-cd-scripted-flbk">Scripting Fallbacks</h4>
 
-					<p id="confreq-cd-scripted-fallback">EPUB Content Documents that <a
-							href="#sec-scripted-content-models">contain scripting</a> MAY provide fallbacks for such
-						content, either by using intrinsic fallback mechanisms (such as those available for the
-						[[!HTML]] <a
+					<p id="confreq-cd-scripted-fallback">EPUB Content Documents that contain scripting MAY provide
+						fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
+						available for the [[!HTML]] <a
 							href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element"
 								><code>object</code></a> and <a
 							href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element"
@@ -4565,9 +4584,9 @@ Manifest:
 				<p>Note that Reading Systems might strip scripting, styling, and HTML formatting as they generate
 					navigational interfaces from information found in the EPUB Navigation Document. If such formatting
 					and functionality is needed, then the EPUB Navigation Document also needs to be included in the
-						<a>spine</a>. The use of <a href="#confreq-cd-scripted-spine">progressive enhancement</a>
-					techniques for scripting and styling of the navigation document will help ensure the content will
-					retain its integrity when rendered in a non-browser context.</p>
+						<a>spine</a>. The use of progressive enhancement techniques for scripting and styling of the
+					navigation document will help ensure the content will retain its integrity when rendered in a
+					non-browser context.</p>
 			</section>
 
 			<section id="sec-nav-def">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4329,77 +4329,6 @@ Manifest:
 						and restrictions that a Reading System places on it (refer to <a
 							href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">Scripting
 							Conformance</a> [[EPUB-RS-33]] for more information).</p>
-
-					<aside class="example">
-						<p>Consider the following example Package Document:</p>
-						<pre>&lt;package …&gt;
-    …
-    &lt;manifest&gt;
-        …
-        &lt;item id="chap01" 
-            href="scripted01.xhtml" 
-            media-type="application/xhtml+xml"
-            properties="scripted"/&gt;
-        &lt;item id="inset01" 
-            href="scripted02.xhtml" 
-            media-type="application/xhtml+xml"
-            properties="scripted"/&gt;
-        &lt;item id="slideshowjs" 
-            href="slideshow.js" 
-            media-type="text/javascript"/&gt;
-    &lt;/manifest&gt;
-    
-    &lt;spine …&gt;
-        &lt;itemref idref="chap01"/&gt;
-        …
-    &lt;/spine&gt;
-    …
-&lt;/package&gt;</pre>
-
-						<p>and the following file <code>scripted01.xhtml</code>:</p>
-
-						<pre>&lt;html …&gt;
-    &lt;head&gt;
-        …
-        &lt;script type="text/javascript"&gt;
-            alert("Reading System name: " + navigator.epubReadingSystem.name);
-        &lt;/script&gt;
-    &lt;/head&gt;
-    &lt;body&gt;
-        …
-        &lt;iframe src="scripted02.xhtml" … /&gt;
-        …
-    &lt;/body&gt;
-&lt;/html&gt;</pre>
-
-
-						<p>and the following file <code>scripted02.xhtml</code>:</p>
-
-						<pre>&lt;html …&gt;
-    &lt;head&gt;
-        …
-        &lt;script type="text/javascript" href="slideshow.js"&gt;&lt;/script&gt;
-    &lt;/head&gt;
-    &lt;body&gt;
-        …
-    &lt;/body&gt;
-&lt;/html&gt;</pre>
-
-						<p>From these examples, it is true that:</p>
-
-						<ul>
-							<li>
-								<p>the code in the <code>script</code> element in the <code>head</code> in
-										<code>scripted01.xhtml</code> is a spine-level script because the document is
-									referenced from the spine; and</p>
-							</li>
-							<li>
-								<p>the code in the <code>script</code> element in <code>scripted02.xhtml</code> is a
-									container-constrained script because the HTML file it occurs in is included in
-										<code>scripted01.xhtml</code> via the <code>iframe</code> element.</p>
-							</li>
-						</ul>
-					</aside>
 				</section>
 
 				<section id="sec-scripted-context">
@@ -4419,6 +4348,11 @@ Manifest:
 
 					<p>Which context Authors use for their scripts affects both what actions the scripts can perform and
 						the likelihood of support in Reading Systems, as described in the following subsections.</p>
+
+					<div class="note">
+						<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference between
+							the two contexts.</p>
+					</div>
 
 					<section id="sec-scripted-container-constrained">
 						<h5>Container-Constrained Scripts</h5>
@@ -6986,7 +6920,7 @@ store destination as source in ocf
 										<p>MUST be a [[!SMIL3]] <a
 												href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">clock
 											value</a>.</p>
-										<p>See <a href="#app-clock-examples"></a>.</p>
+										<p>See <a href="#clock-examples"></a>.</p>
 									</dd>
 									<dt id="attrdef-smil-clipEnd">
 										<code>clipEnd</code>
@@ -6998,7 +6932,7 @@ store destination as source in ocf
 										<p>MUST be a [[!SMIL3]] <a
 												href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">clock
 											value</a>.</p>
-										<p>See <a href="#app-clock-examples"></a>.</p>
+										<p>See <a href="#clock-examples"></a>.</p>
 										<p>The chronological offset of the terminating position MUST be after the
 											starting offset specified in the <code>clipBegin</code> attribute.</p>
 									</dd>
@@ -8406,15 +8340,92 @@ html.my-document-playing * {
 				</div>
 			</section>
 		</section>
-		<section id="app-ocf-example" class="appendix informative">
-			<h2>OCF Example</h2>
+		<section id="app-examples" class="appendix infomative">
+			<h2>Detailed Examples</h2>
 
-			<p>The following example demonstrates the use of the OCF format to contain a signed and encrypted EPUB
-				Publication within an <a>OCF ZIP Container</a>.</p>
+			<section id="scripted-contexts-example">
+				<h3>Scripting Contexts</h3>
 
-			<aside class="example">
-				<p>Ordered list of files in the OCF ZIP Container</p>
-				<pre>mimetype
+				<p>Consider the following example Package Document:</p>
+
+				<pre>&lt;package …&gt;
+    …
+    &lt;manifest&gt;
+        …
+        &lt;item id="chap01" 
+            href="scripted01.xhtml" 
+            media-type="application/xhtml+xml"
+            properties="scripted"/&gt;
+        &lt;item id="inset01" 
+            href="scripted02.xhtml" 
+            media-type="application/xhtml+xml"
+            properties="scripted"/&gt;
+        &lt;item id="slideshowjs" 
+            href="slideshow.js" 
+            media-type="text/javascript"/&gt;
+    &lt;/manifest&gt;
+    
+    &lt;spine …&gt;
+        &lt;itemref idref="chap01"/&gt;
+        …
+    &lt;/spine&gt;
+    …
+&lt;/package&gt;</pre>
+
+				<p>and the following file <code>scripted01.xhtml</code>:</p>
+
+				<pre>&lt;html …&gt;
+    &lt;head&gt;
+        …
+        &lt;script type="text/javascript"&gt;
+            alert("Reading System name: " + navigator.epubReadingSystem.name);
+        &lt;/script&gt;
+    &lt;/head&gt;
+    &lt;body&gt;
+        …
+        &lt;iframe src="scripted02.xhtml" … /&gt;
+        …
+    &lt;/body&gt;
+&lt;/html&gt;</pre>
+
+
+				<p>and the following file <code>scripted02.xhtml</code>:</p>
+
+				<pre>&lt;html …&gt;
+    &lt;head&gt;
+        …
+        &lt;script type="text/javascript" href="slideshow.js"&gt;&lt;/script&gt;
+    &lt;/head&gt;
+    &lt;body&gt;
+        …
+    &lt;/body&gt;
+&lt;/html&gt;</pre>
+
+				<p>From these examples, it is true that:</p>
+
+				<ul>
+					<li>
+						<p>the code in the <code>script</code> element in the <code>head</code> in
+								<code>scripted01.xhtml</code> is a spine-level script because the document is referenced
+							from the spine; and</p>
+					</li>
+					<li>
+						<p>the code in the <code>script</code> element in <code>scripted02.xhtml</code> is a
+							container-constrained script because the HTML file it occurs in is included in
+								<code>scripted01.xhtml</code> via the <code>iframe</code> element.</p>
+					</li>
+				</ul>
+			</section>
+
+			<section id="ocf-example">
+				<h3>Packaged EPUB</h3>
+
+				<p>The following example demonstrates the use of the OCF format to contain a signed and encrypted EPUB
+					Publication within an <a>OCF ZIP Container</a>.</p>
+
+				<aside class="example">
+					<p>Ordered list of files in the OCF ZIP Container</p>
+					<pre>mimetype
 META-INF/container.xml
 META-INF/signatures.xml
 META-INF/encryption.xml
@@ -8422,27 +8433,27 @@ EPUB/As_You_Like_It.opf
 EPUB/book.html
 EPUB/nav.html
 EPUB/images/cover.png</pre>
-			</aside>
+				</aside>
 
-			<aside class="example">
-				<p>The contents of the <code>mimetype</code> file</p>
-				<pre>application/epub+zip</pre>
-			</aside>
+				<aside class="example">
+					<p>The contents of the <code>mimetype</code> file</p>
+					<pre>application/epub+zip</pre>
+				</aside>
 
-			<aside class="example">
-				<p>The contents of the <code>META-INF/container.xml</code> file</p>
-				<pre>&lt;?xml version="1.0"?&gt;
+				<aside class="example">
+					<p>The contents of the <code>META-INF/container.xml</code> file</p>
+					<pre>&lt;?xml version="1.0"?&gt;
 &lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
     &lt;rootfiles&gt;
         &lt;rootfile full-path="EPUB/As_You_Like_It.opf"
             media-type="application/oebps-package+xml"/&gt;
     &lt;/rootfiles&gt;
 &lt;/container&gt;</pre>
-			</aside>
+				</aside>
 
-			<aside class="example">
-				<p>The contents of the <code>META-INF/signatures.xml</code> file</p>
-				<pre>&lt;signatures xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
+				<aside class="example">
+					<p>The contents of the <code>META-INF/signatures.xml</code> file</p>
+					<pre>&lt;signatures xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
     &lt;Signature Id="AsYouLikeItSignature" xmlns="http://www.w3.org/2000/09/xmldsig#"&gt;
         
         &lt;!--
@@ -8509,11 +8520,11 @@ EPUB/images/cover.png</pre>
         &lt;/Object&gt;
     &lt;/Signature&gt;
 &lt;/signatures&gt;</pre>
-			</aside>
+				</aside>
 
-			<aside class="example">
-				<p>The contents of the <code>META-INF/encryption.xml</code> file</p>
-				<pre>&lt;?xml version="1.0"?&gt;
+				<aside class="example">
+					<p>The contents of the <code>META-INF/encryption.xml</code> file</p>
+					<pre>&lt;?xml version="1.0"?&gt;
 &lt;encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
     xmlns:enc="http://www.w3.org/2001/04/xmlenc#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"&gt;
 
@@ -8557,11 +8568,11 @@ EPUB/images/cover.png</pre>
         &lt;/enc:CipherData&gt;
     &lt;/enc:EncryptedData&gt;
 &lt;/encryption&gt;</pre>
-			</aside>
+				</aside>
 
-			<aside class="example">
-				<p>The contents of the <code>EPUB/As_You_Like_It.opf</code> file</p>
-				<pre>&lt;?xml version="1.0"?&gt;
+				<aside class="example">
+					<p>The contents of the <code>EPUB/As_You_Like_It.opf</code> file</p>
+					<pre>&lt;?xml version="1.0"?&gt;
 &lt;package version="3.0"
          xml:lang="en"
          xmlns="http://www.idpf.org/2007/opf"
@@ -8609,48 +8620,50 @@ EPUB/images/cover.png</pre>
         &lt;itemref idref="r4915"/&gt;
     &lt;/spine&gt;
 &lt;/package&gt;</pre>
-			</aside>
-		</section>
-		<section id="app-clock-examples" class="appendix informative">
-			<h2>Examples of Clock Values</h2>
+				</aside>
+			</section>
 
-			<p>The following are examples of allowed clock values:</p>
+			<section id="clock-examples">
+				<h3>Clock Values</h3>
 
-			<ul>
-				<li>
-					<p><code>5:34:31.396</code> = 5 hours, 34 minutes, 31 seconds, and 396 milliseconds</p>
-				</li>
-				<li>
-					<p><code>124:59:36</code> = 124 hours, 59 minutes, and 36 seconds</p>
-				</li>
-				<li>
-					<p><code>0:05:01.2</code> = 5 minutes, 1 second, and 200 milliseconds</p>
-				</li>
-				<li>
-					<p><code>0:00:04</code> = 4 seconds</p>
-				</li>
-				<li>
-					<p><code>09:58</code> = 9 minutes and 58 seconds</p>
-				</li>
-				<li>
-					<p><code>00:56.78</code> = 56 seconds and 780 milliseconds</p>
-				</li>
-				<li>
-					<p><code>76.2s</code> = 76.2 seconds = 76 seconds and 200 milliseconds</p>
-				</li>
-				<li>
-					<p><code>7.75h</code> = 7.75 hours = 7 hours and 45 minutes</p>
-				</li>
-				<li>
-					<p><code>13min</code> = 13 minutes</p>
-				</li>
-				<li>
-					<p><code>2345ms</code> = 2345 milliseconds</p>
-				</li>
-				<li>
-					<p><code>12.345</code> = 12 seconds and 345 milliseconds</p>
-				</li>
-			</ul>
+				<p>The following are examples of allowed clock values:</p>
+
+				<ul>
+					<li>
+						<p><code>5:34:31.396</code> = 5 hours, 34 minutes, 31 seconds, and 396 milliseconds</p>
+					</li>
+					<li>
+						<p><code>124:59:36</code> = 124 hours, 59 minutes, and 36 seconds</p>
+					</li>
+					<li>
+						<p><code>0:05:01.2</code> = 5 minutes, 1 second, and 200 milliseconds</p>
+					</li>
+					<li>
+						<p><code>0:00:04</code> = 4 seconds</p>
+					</li>
+					<li>
+						<p><code>09:58</code> = 9 minutes and 58 seconds</p>
+					</li>
+					<li>
+						<p><code>00:56.78</code> = 56 seconds and 780 milliseconds</p>
+					</li>
+					<li>
+						<p><code>76.2s</code> = 76.2 seconds = 76 seconds and 200 milliseconds</p>
+					</li>
+					<li>
+						<p><code>7.75h</code> = 7.75 hours = 7 hours and 45 minutes</p>
+					</li>
+					<li>
+						<p><code>13min</code> = 13 minutes</p>
+					</li>
+					<li>
+						<p><code>2345ms</code> = 2345 milliseconds</p>
+					</li>
+					<li>
+						<p><code>12.345</code> = 12 seconds and 345 milliseconds</p>
+					</li>
+				</ul>
+			</section>
 		</section>
 		<section id="app-media-types" class="appendix informative">
 			<h2>Media Type Registrations</h2>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4305,11 +4305,9 @@ Manifest:
 						instances of [[!HTML]] <a href="https://html.spec.whatwg.org/multipage/forms.html#forms"
 							>forms</a>.</p>
 
-					<div class="note">
-						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
-							<code>item</code> element indicates that an EPUB Content Document is a <a>Scripted Content
-								Document</a>.</p>
-					</div>
+					<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
+						<code>item</code> element is used to indicate that an EPUB Content Document is a <a>Scripted
+							Content Document</a>.</p>
 
 					<p>When an [[HTML]] <code>script</code> element contains a <a
 							href="https://html.spec.whatwg.org/multipage/scripting.html#data-block">data block</a>
@@ -4320,7 +4318,7 @@ Manifest:
 							a future update adds the concept.</p>
 					</div>
 
-					<p>Authors should note that Reading Systems are expected to behave as though a unique <a
+					<p>Authors should note that Reading Systems are required to behave as though a unique <a
 							href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] has been assigned to each EPUB
 						Publication. In practice, this means that it is not possible for scripts to share data between
 						EPUB Publications.</p>
@@ -4403,11 +4401,10 @@ Manifest:
 								href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 							element contained in a <a>Top-level Content Document</a>.</p>
 
-						<p>Authors should note that <a
-								href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">support for
-								spine-level scripting in Reading Systems</a> is only recommended in fixed layout
-							documents and reflowable documents when they are set to scroll [[EPUB-RS-33]]. Furthermore,
-							Reading System support in all other contexts is optional.</p>
+						<p>Authors should note that support for spine-level scripting in Reading Systems is only
+							recommended in <a href="#confreq-rs-scripted-fxl-support">fixed-layout documents</a> and <a
+								href="confreq-rs-scripted-scrolled">reflowable documents set to scroll</a>
+							[[EPUB-RS-33]]. Furthermore, Reading System support in all other contexts is optional.</p>
 
 						<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include spine-level
 							scripting SHOULD remain consumable by the user without any information loss or other

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -840,16 +840,15 @@
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-rs-scripted-reflow-support">It SHOULD support <a
-									href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-container-constrained"
+									href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained"
 									>container-constrained scripting</a> [[!EPUB-33]] in reflowable EPUB Content
 								Documents.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-scripted-fxl-support">It SHOULD support <a
-									href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-spine-level"
-									>spine-level scripting</a> [[!EPUB-33]] in <a
-									href="https://www.w3.org/TR/epub-33/#sec-fixed-layouts">fixed-layout documents</a>
-								[[!EPUB-33]].</p>
+									href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level scripting</a>
+								[[!EPUB-33]] in <a href="https://www.w3.org/TR/epub-33/#sec-fixed-layouts">fixed-layout
+									documents</a> [[!EPUB-33]].</p>
 						</li>
 						<li>
 							<p id="confreq-rs-scripted-scrolled">It SHOULD support spine-level scripting in reflowable
@@ -907,7 +906,7 @@
 							capabilities and/or provides a different rendering and user experience (e.g., by disabling
 							pagination).</p>
 						<p>Authors choosing to restrict the usage of scripting to the <a
-								href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-container-constrained"
+								href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained"
 								>container-constrained model</a> [[!EPUB-33]] will ensure a more consistent user
 							experience between scripted and non-scripted content (e.g., consistent pagination
 							behavior).</p>
@@ -2006,8 +2005,8 @@ partial interface Navigator {
 
 				<p>Reading Systems MUST expose the <code>epubReadingSystem</code> object on the <code>navigator</code>
 					object of all loaded Scripted Content Documents, including any nested <a
-						href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-container-constrained"
-						>container-constrained scripting contexts</a> [[!EPUB-33]]. Reading Systems MUST ensure that the
+						href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained">container-constrained
+						scripting contexts</a> [[!EPUB-33]]. Reading Systems MUST ensure that the
 						<code>epubReadingSystem</code> object is available no later than when the <a
 						href="https://html.spec.whatwg.org/multipage/parsing.html#the-end"><code>DOMContentLoaded</code>
 						event is triggered</a> [[!HTML]].</p>
@@ -2122,17 +2121,16 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 										<code>dom-manipulation</code>
 									</td>
 									<td>Scripts MAY make structural changes to the document’s DOM (applies to <a
-											href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-spine-level"
-											>spine-level scripting</a> [[!EPUB-33]] only).</td>
+											href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level
+											scripting</a> [[!EPUB-33]] only).</td>
 								</tr>
 								<tr>
 									<td id="feature-layout-changes">
 										<code>layout-changes</code>
 									</td>
 									<td>Scripts MAY modify attributes and CSS styles that affect content layout (applies
-										to <a
-											href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-spine-level"
-											>spine-level scripting</a> [[!EPUB-33]] only).</td>
+										to <a href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level
+											scripting</a> [[!EPUB-33]] only).</td>
 								</tr>
 								<tr>
 									<td id="feature-touch-events">
@@ -2160,9 +2158,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 										<code>spine-scripting</code>
 									</td>
 									<td>Indicates whether the Reading System supports <a
-											href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-spine-level"
-											>spine-level scripting</a> [[!EPUB-33]] (e.g., so a <a
-											href="https://www.w3.org/TR/epub-33/#sec-scripted-content-type-container-constrained"
+											href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level
+											scripting</a> [[!EPUB-33]] (e.g., so a <a
+											href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained"
 											>container-constrained script</a> [[EPUB-33]] can determine whether any
 										actions that depend on scripting support in a <a>Top-level Content Document</a>
 										have any chance of success before attempting them).</td>


### PR DESCRIPTION
This PR makes the following changes:

- creates a new section called "script inclusion" that includes the text about adding scripts to content documents (removes the scripting context definitions)
- adds an explanation about origins and the effect on scripting (no data sharing) to the inclusion section
- creates a new "scripting contexts" section with a short intro followed by subsections that cover each of the contexts in detail (basically consolidates prose that was spread across sections before)
- creates a new appendix for detailed examples and moves the context example to it (adding together with the example of a packaged epub and wall clock values so we avoid a proliferation of top-level appendixes)

Mostly shuffling with some rewriting, in other words, but hopefully a little easier to read now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1519.html" title="Last updated on Feb 24, 2021, 2:23 PM UTC (bd562a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1519/b9642ea...bd562a3.html" title="Last updated on Feb 24, 2021, 2:23 PM UTC (bd562a3)">Diff</a>