### PR TITLE
Extending ECHIDNA to the A11y documents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ branches:
     - publish-rs
     - publish-overview
     - publish-multi-rend
+    - publish-a11y
+    - publish-a11y-tech
 
 jobs:
  include:
@@ -40,5 +42,21 @@ jobs:
     - secure: "RcLfNGfVjiVzoOng6MlMGUcofjAv8n0MbmGIv8R1l3Q4DsCoIjOFrmmhWy+JIS2N6VFXnMOtXJGTFPK/ADAsn9QrQcDM8qNk71TfsuDIXA8UqYnQCOGIaO/CYmhn9HN7Kgs9cbeB9MewWN2MfwqNkxODYnnsZ12KznGGkK1zskE="
    script:
      - curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN_MULTI_REND";
+     - echo "ok"
+ - if: branch = publish-a11y AND type = push
+   env:
+    - URL="https://w3c.github.io/epub-specs/epub33/snapshot/epub-a11y-11/ECHIDNA"
+    - DECISION="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-02-12-epub#resolution2"
+    - secure: "VN7k8FhSOvkcDJPaGqNaf0NjS6RQOi4w54exQO/Wd7WfqdT6z/rZNG6WQy4REHBKEN9AJ/P7JdXfvA3qnR76Z2ARqIUFP3lHVb5LWVWeGDKVjjUMHrkkLABuWtXtys7bTHzTq1BrVLuXb9nmvhrLm53YVyzhYSoe+YkCTCsFyAU="
+   script:
+     - curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN_A11Y";
+     - echo "ok"
+ - if: branch = publish-a11y-tech AND type = push
+   env:
+    - URL="https://w3c.github.io/epub-specs/epub33/snapshot/epub-a11y-tech-11/ECHIDNA"
+    - DECISION="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-02-12-epub#resolution2"
+    - secure: "RuI4gZDuKY0sgtQ84ialWn4Le+QzSJRBxZZwywvLFVihMOObJy55AbSNCISuIbfSL9r+krY+Xzm9B0eV0bD/C6RVYc1nN9sr81ew+8cpXUj/iV9TH782390sags/mZO/JYGqgu7w+32PlWyGWmW5xZMp0bBtGFYQ2cPPb4Ef514="
+   script:
+     - curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN_A11Y_TECH";
      - echo "ok"
 

--- a/epub33/snapshot/epub-a11y-11/ECHIDNA
+++ b/epub33/snapshot/epub-a11y-11/ECHIDNA
@@ -1,0 +1,2 @@
+# ECHIDNA configuration
+index.html

--- a/epub33/snapshot/epub-a11y-tech-11/ECHIDNA
+++ b/epub33/snapshot/epub-a11y-tech-11/ECHIDNA
@@ -1,0 +1,2 @@
+# ECHIDNA configuration
+index.html


### PR DESCRIPTION
Just a copy and paste for a11y and a11-tech. The TOKEN_A11Y and TOKEN_A11Y_TECH were used when creating the secure value in the relevant branch via, e.g.:

```
travis encrypt --pro TOKEN_A11Y="<token>"
```