### PR TITLE
Update conformance reporting

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -57,6 +57,14 @@
 				preProcess:[inlineCustomCSS],
 				postProcess:[addConformanceLinks]
 			};</script>
+		<style>
+			.conf-pattern {
+				margin-left: 3rem;
+				font-style: italic;
+			}
+			.varlist {
+				margin-left: 3rem;
+			}</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -115,8 +123,9 @@
 					them. This approach allows the guidelines to remain stable even as the format evolves.</p>
 
 				<p>To facilitate this approach, the companion <a href="https://www.w3.org/TR/epub-a11y-tech-11/">EPUB
-						Accessibility Techniques</a> [[EPUB-A11Y-TECH-11]] document outlines conformance techniques. These
-					techniques explain how to meet the requirements of this document for different versions of EPUB.</p>
+						Accessibility Techniques</a> [[EPUB-A11Y-TECH-11]] document outlines conformance techniques.
+					These techniques explain how to meet the requirements of this document for different versions of
+					EPUB.</p>
 			</section>
 
 			<section id="sec-application" class="informative">
@@ -310,10 +319,10 @@
 					Publications. (The relationship to WCAG is explained for each requirement in its respective
 					section.)</p>
 
-				<p>The same is true of the techniques in the EPUB Accessibility Techniques document [[EPUB-A11Y-TECH-11]].
-					It provides coverage of techniques that are unique to EPUB Publications, or that need clarification
-					in the context of an EPUB Publication. It does not mean that the rest of the WCAG techniques are not
-					applicable.</p>
+				<p>The same is true of the techniques in the EPUB Accessibility Techniques document
+					[[EPUB-A11Y-TECH-11]]. It provides coverage of techniques that are unique to EPUB Publications, or
+					that need clarification in the context of an EPUB Publication. It does not mean that the rest of the
+					WCAG techniques are not applicable.</p>
 
 				<p>As a result, although this section can be read without deep knowledge of WCAG conformance, to
 					implement the accessibility requirements of this document will require an understanding of WCAG.</p>
@@ -604,162 +613,205 @@
 			<section id="sec-conf-reporting">
 				<h3>Conformance Reporting</h3>
 
-				<p>Conformance reporting is achieved through the expression of metadata properties in the EPUB Package
-					Document. The metadata uses a combination of properties from DCMI Metadata Terms [[DCTERMS]] and the
-						<a href="#app-a11y-vocab">EPUB Accessibility Vocabulary</a>.</p>
+				<section id="sec-conf-reporting-intro">
+					<h4>Introduction</h4>
 
-				<p>To indicate that an EPUB Publication conforms to the accessibility requirements of this document, it
-					MUST include a <code>conformsTo</code> property in accordance with [[!DCTERMS]] and an <a
-						href="#certifiedBy"><code>a11y:certifiedBy</code> property</a>.</p>
+					<p>Conformance reporting is achieved through the expression of metadata properties in the EPUB
+						Package Document.</p>
 
-				<p>The value of the <code>conformsTo</code> property MUST be one of the following URLs:</p>
+					<p>This metadata establishes both:</p>
 
-				<div class="issue" data-number="1455">
-					<p>The Working Group will replace these IDPF-based conformance URLs in a future update to this
-						revision. The method of reporting may also change to reflect the increased flexibility around
-						which version of WCAG has been met.</p>
-				</div>
+					<ul>
+						<li>the <a href="#sec-conf-reporting-pub">level of conformance achieved</a>; and</li>
+						<li>information about <a href="#sec-conf-reporting-eval">who performed the evaluation</a>.</li>
+					</ul>
 
-				<dl>
-					<dt>
-						<code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a</code>
-					</dt>
-					<dd>
-						<p>The EPUB Publication meets all <a href="#sec-access-pub">accessibility requirements</a> and
-							achieves <a href="https://www.w3.org/TR/WCAG20/#conformance-reqs">WCAG 2.0 Level A
-								conformance</a> [[!WCAG20]].</p>
-					</dd>
+					<p>The metadata uses a combination of properties from DCMI Metadata Terms [[DCTERMS]] and the <a
+							href="#app-a11y-vocab">EPUB Accessibility Vocabulary</a>, as explained in more detail in the
+						following sections.</p>
+				</section>
 
-					<dt>
-						<code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa</code>
-					</dt>
-					<dd>
-						<p>The EPUB Publication meets all <a href="#sec-access-pub">accessibility requirements</a> and
-							achieves <a href="https://www.w3.org/TR/WCAG20/#conformance-reqs">WCAG 2.0 Level AA
-								conformance</a> [[!WCAG20]].</p>
-					</dd>
+				<section id="sec-conf-reporting-pub">
+					<h4>Publication Conformance</h4>
 
-					<dt>
-						<code>http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aaa</code>
-					</dt>
-					<dd>
-						<p>The EPUB Publication meets all <a href="#sec-access-pub">accessibility requirements</a> and
-							achieves <a href="https://www.w3.org/TR/WCAG20/#conformance-reqs">WCAG 2.0 Level AAA
-								conformance</a> [[!WCAG20]].</p>
-					</dd>
-				</dl>
+					<p>To indicate that an EPUB Publication conforms to the accessibility requirements of this document,
+						it MUST include a <code>conformsTo</code> property whose value MUST exactly match (i.e., both in
+						case and spacing) the following pattern:</p>
 
-				<div class="note">
-					<p>An EPUB Publication that only meets the content requirements of this document can report
-						conformance using the WCAG conformance URL
-							"<code>http://www.w3.org/TR/2008/REC-WCAG20-20081211/</code>" [[!WCAG20]]. If accessibility
-						metadata is supported through other means (e.g., ONIX records [[ONIX]]), its inclusion will
-						further improve the discoverability of the publication.</p>
-				</div>
+					<p class="conf-pattern">EPUB Accessibility <a href="#epub-acc-num"><var>X</var></a> + WCAG <a
+							href="#wcag-num"><var>Y</var></a> Level <a href="#wcag-level"><var>Z</var></a></p>
 
-				<p>The <a href="#certifiedBy"><code>a11y:certifiedBy</code></a> property specifies the name of the party
-					that evaluated the EPUB Publication.</p>
+					<p><i>where:</i></p>
 
-				<div class="note">
-					<p>Conformance evaluation can be done by any individual or party. The evaluator can be the same
-						party that created the EPUB Publication or a third party.</p>
-				</div>
+					<dl class="varlist">
+						<dt id="epub-acc-num"><var>X</var></dt>
+						<dd>
+							<p>MUST be the version number of the EPUB Accessibility specification the publication
+								conforms to. For the purposes, of this specification, this value MUST be
+									<code>1.1</code>.</p>
+						</dd>
+						<dt id="wcag-num"><var>Y</var></dt>
+						<dd>
+							<p>MUST be the version number of WCAG the publication conforms to (e.g., <code>2.0</code> or
+									<code>2.1</code>).</p>
+						</dd>
+						<dt id="wcag-level"><var>Z</var></dt>
+						<dd>
+							<p>MUST be the WCAG conformance level the publication conforms to (e.g., <code>A</code> or
+									<code>AA</code>).</p>
+						</dd>
+					</dl>
 
-				<aside class="example">
-					<p>The following example shows an EPUB 3 Publication that has been self-evaluated by the publisher
-						(the values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code> property are the
-						same).</p>
-					<pre>&lt;metadata&gt;
+					<p>The following conformance strings are valid as of publication of this document:</p>
+
+					<ul>
+						<li>EPUB Accessibility 1.1 + WCAG 2.0 Level A</li>
+						<li>EPUB Accessibility 1.1 + WCAG 2.0 Level AA</li>
+						<li>EPUB Accessibility 1.1 + WCAG 2.0 Level AAA</li>
+						<li>EPUB Accessibility 1.1 + WCAG 2.1 Level A</li>
+						<li>EPUB Accessibility 1.1 + WCAG 2.1 Level AA</li>
+						<li>EPUB Accessibility 1.1 + WCAG 2.1 Level AAA</li>
+					</ul>
+					
+					<p>This list will change as new versions of WCAG are released. For new versions of [[!WCAG2]], only
+						the digit after the "2." should change from the above patterns.</p>
+					
+					<aside class="example">
+						<p>The following example shows a conformance statement for an EPUB 3 Publication that conforms
+							to the EPUB Accessibility 1.1 specification at WCAG 2.1 Level AA.</p>
+						<pre>&lt;package …>
+   &lt;metadata>
+      …
+      &lt;meta property="dcterms:conformsTo">EPUB Accessibility 1.1 + WCAG 2.1 Level AA&lt;/meta>
+      …
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+					</aside>
+
+					<div class="note">
+						<p>The future <a href="https://www.w3.org/TR/wcag-3.0/">3.0 version of WCAG</a> is likely to
+							also introduce new level names (currently Bronze, Silver and Gold). Those names would
+							replace A, AA and AAA in the string pattern.</p>
+					</div>
+
+					<div class="note">
+						<p>An EPUB Publication that only meets WCAG conformance requirements (i.e., does not fully
+							conform to this specification) can use a WCAG conformance URL (e.g.,
+								"<code>https://www.w3.org/TR/WCAG21/</code>" for [[WCAG21]]) with the
+								<code>confomsTo</code> property.</p>
+					</div>
+				</section>
+
+				<section id="sec-conf-reporting-eval">
+					<h4>Evaluator Information</h4>
+
+					<p>EPUB Publications MUST include an <a href="#certifiedBy"><code>a11y:certifiedBy</code></a>
+						property that specifies the name of the party that evaluated the EPUB Publication.</p>
+
+					<div class="note">
+						<p>Conformance evaluation can be done by any individual or party. The evaluator can be the same
+							party that created the EPUB Publication or a third party.</p>
+					</div>
+
+					<aside class="example">
+						<p>The following example shows an EPUB 3 Publication that has been self-evaluated by the
+							publisher (the values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code>
+							property are the same).</p>
+						<pre>&lt;metadata&gt;
   …
   &lt;dc:publisher&gt;Acme Publishing Inc.&lt;/dc:publisher&gt;
   &lt;meta property="a11y:certifiedBy"&gt;Acme Publishing Inc.&lt;/meta&gt;
   &lt;link rel="dcterms:conformsTo" href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"/&gt;
   …
 &lt;/metadata&gt;</pre>
-				</aside>
+					</aside>
 
-				<aside class="example">
-					<p>The following example shows an EPUB 3 Publication that has been evaluated by a third party (the
-						values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code> property differ).</p>
-					<pre>&lt;metadata&gt;
+					<aside class="example">
+						<p>The following example shows an EPUB 3 Publication that has been evaluated by a third party
+							(the values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code> property
+							differ).</p>
+						<pre>&lt;metadata&gt;
   …
   &lt;dc:publisher&gt;Acme Publishing Inc.&lt;/dc:publisher&gt;
   &lt;meta property="a11y:certifiedBy"&gt;Foo's Accessibility Testing&lt;/meta&gt;
   &lt;link rel="dcterms:conformsTo" href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"/&gt;
   …
 &lt;/metadata&gt;</pre>
-				</aside>
+					</aside>
 
-				<aside class="example">
-					<p>The following example shows an EPUB 3 Publication that has been self-evaluated by the author.</p>
-					<pre>&lt;metadata&gt;
+					<aside class="example">
+						<p>The following example shows an EPUB 3 Publication that has been self-evaluated by the
+							author.</p>
+						<pre>&lt;metadata&gt;
   …
   &lt;dc:creator&gt;Jane Doe&lt;/dc:creator&gt;
   &lt;meta property="a11y:certifiedBy"&gt;Jane Doe&lt;/meta&gt;
   &lt;link rel="dcterms:conformsTo" href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"/&gt;
   …
 &lt;/metadata&gt;</pre>
-				</aside>
+					</aside>
 
-				<aside class="example">
-					<p>The following example shows a self-evaluated EPUB 2 Publication.</p>
-					<pre>&lt;metadata&gt;
+					<aside class="example">
+						<p>The following example shows a self-evaluated EPUB 2 Publication.</p>
+						<pre>&lt;metadata&gt;
   …
   &lt;dc:publisher&gt;Acme Publishing Inc.&lt;/dc:publisher&gt;
   &lt;meta name="dcterms:conformsTo" content="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"/&gt;
   &lt;meta name="a11y:certifiedBy" content="Acme Publishing Inc."/&gt;
   …
 &lt;/metadata&gt;</pre>
-				</aside>
+					</aside>
 
-				<div class="note">
-					<p>If an EPUB Publication is evaluated by an organization, users will typically want to know the
-						name of that organization. Including the name of the individual(s) who carried out the
-						assessment, instead of the name of the organization, is generally discouraged, as it can
-						diminish the trust the user has in the claim.</p>
-				</div>
+					<div class="note">
+						<p>If an EPUB Publication is evaluated by an organization, users will typically want to know the
+							name of that organization. Including the name of the individual(s) who carried out the
+							assessment, instead of the name of the organization, is generally discouraged, as it can
+							diminish the trust the user has in the claim.</p>
+					</div>
 
-				<p>If the party that evaluates the content has been issued a credential or badge that establishes their
-					authority to evaluate content, that information is supplied in an <a href="#certifierCredential"
-							><code>a11y:certifierCredential</code> property</a>.</p>
+					<p>If the party that evaluates the content has been issued a credential or badge that establishes
+						their authority to evaluate content, that information is supplied in an <a
+							href="#certifierCredential"><code>a11y:certifierCredential</code> property</a>.</p>
 
-				<aside class="example">
-					<p>The following example shows a credential. The <code>refines</code> attribute is used to associate
-						the credential with the certifier.</p>
-					<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
+					<aside class="example">
+						<p>The following example shows a credential. The <code>refines</code> attribute is used to
+							associate the credential with the certifier.</p>
+						<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
 &lt;meta property="a11y:certifierCredential" refines="#certifier"&gt;A+ Accessibility Rating&lt;/meta&gt;</pre>
-				</aside>
+					</aside>
 
-				<p>If the party that evaluates the content has provided a detailed report of its assessment, a link to
-					the assessment is provided in an <a href="#certifierReport"><code>a11y:certifierReport</code>
-						property</a>.</p>
+					<p>If the party that evaluates the content has provided a detailed report of its assessment, a link
+						to the assessment is provided in an <a href="#certifierReport"><code>a11y:certifierReport</code>
+							property</a>.</p>
 
-				<aside class="example">
-					<p>The following example shows a link to a remotely hosted accessibility report.</p>
-					<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
+					<aside class="example">
+						<p>The following example shows a link to a remotely hosted accessibility report.</p>
+						<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
 &lt;link rel="a11y:certifierReport" refines="#certifier"
       href="http://www.example.com/a11y/report/9780000000001"/&gt;</pre>
-				</aside>
+					</aside>
 
-				<aside class="example">
-					<p>The following example shows a link to a locally hosted accessibility report.</p>
-					<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
+					<aside class="example">
+						<p>The following example shows a link to a locally hosted accessibility report.</p>
+						<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
 &lt;link rel="a11y:certifierReport" refines="#certifier" href="reports/a11y.xhtml"/&gt;</pre>
-				</aside>
+					</aside>
 
 
-				<div class="note">
-					<p>As each metadata format is unique in what it can express, this document does not mandate how
-						conformance metadata is expressed outside of the EPUB Package Document.</p>
-				</div>
+					<div class="note">
+						<p>As each metadata format is unique in what it can express, this document does not mandate how
+							conformance metadata is expressed outside of the EPUB Package Document.</p>
+					</div>
 
-				<div class="note">
-					<p>This document does not define requirements for accessibility metadata external to an EPUB 3
-						publication as part of distribution metadata. Ensuring consistency between internal and external
-						accessibility metadata expressions is the responsibility of authors, publishers, and
-						distributors. For further discussion of the effects of distribution on accessibility, see <a
-							href="#sec-distribution"></a>.</p>
-				</div>
+					<div class="note">
+						<p>This document does not define requirements for accessibility metadata external to an EPUB 3
+							publication as part of distribution metadata. Ensuring consistency between internal and
+							external accessibility metadata expressions is the responsibility of authors, publishers,
+							and distributors. For further discussion of the effects of distribution on accessibility,
+							see <a href="#sec-distribution"></a>.</p>
+					</div>
+				</section>
 			</section>
 		</section>
 		<section id="sec-opt-pubs">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -613,7 +613,7 @@
 			<section id="sec-conf-reporting">
 				<h3>Conformance Reporting</h3>
 
-				<section id="sec-conf-reporting-intro">
+				<section id="sec-conf-reporting-intro" class="informative">
 					<h4>Introduction</h4>
 
 					<p>Conformance reporting is achieved through the expression of metadata properties in the EPUB
@@ -639,7 +639,7 @@
 						case and spacing) the following pattern:</p>
 
 					<p class="conf-pattern">EPUB Accessibility <a href="#acc-ver"><var>A11Y-VER</var></a> + WCAG <a
-							href="#wcag-ver"><var>WCAG_VER</var></a> Level <a href="#wcag-lvl"><var>WCAG-LVL</var></a></p>
+							href="#wcag-ver"><var>WCAG-VER</var></a> Level <a href="#wcag-lvl"><var>WCAG-LVL</var></a></p>
 
 					<p><i>where:</i></p>
 

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -647,7 +647,7 @@
 						<dt id="acc-ver"><var>A11Y-VER</var></dt>
 						<dd>
 							<p>MUST be the version number of the EPUB Accessibility specification the publication
-								conforms to. For the purposes, of this specification, this value MUST be
+								conforms to. For the purpose of this specification, this value MUST be
 									<code>1.1</code>.</p>
 						</dd>
 						<dt id="wcag-ver"><var>WCAG-VER</var></dt>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -639,7 +639,8 @@
 						case and spacing) the following pattern:</p>
 
 					<p class="conf-pattern">EPUB Accessibility <a href="#acc-ver"><var>A11Y-VER</var></a> + WCAG <a
-							href="#wcag-ver"><var>WCAG-VER</var></a> Level <a href="#wcag-lvl"><var>WCAG-LVL</var></a></p>
+							href="#wcag-ver"><var>WCAG-VER</var></a> Level <a href="#wcag-lvl"
+						><var>WCAG-LVL</var></a></p>
 
 					<p><i>where:</i></p>
 
@@ -648,7 +649,7 @@
 						<dd>
 							<p>MUST be the version number of the EPUB Accessibility specification the publication
 								conforms to. For the purpose of this specification, this value MUST be
-									<code>1.1</code>.</p>
+								<code>1.1</code>.</p>
 						</dd>
 						<dt id="wcag-ver"><var>WCAG-VER</var></dt>
 						<dd>
@@ -672,10 +673,10 @@
 						<li>EPUB Accessibility 1.1 + WCAG 2.1 Level AA</li>
 						<li>EPUB Accessibility 1.1 + WCAG 2.1 Level AAA</li>
 					</ul>
-					
+
 					<p>This list will change as new versions of WCAG are released. For new versions of [[!WCAG2]], only
 						the digit after the "2." should change from the above patterns.</p>
-					
+
 					<aside class="example">
 						<p>The following example shows a conformance statement for an EPUB 3 Publication that conforms
 							to the EPUB Accessibility 1.1 specification at WCAG 2.1 Level AA.</p>
@@ -1084,8 +1085,24 @@
 					>working group's issue tracker</a>.</p>
 
 			<section id="changes-latest">
-				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
+				<h3>Substantive changes since the <a href="https://www.w3.org/TR/2021/WD-epub-a11y-11-20210223/">First
+						Public Working Draft</a></h3>
 
+				<!--
+					After each working draft is published:
+						- change the link/text in the section heading to refer to the published draft (use the dated URL)
+						- move all changes down to the next section
+				-->
+
+				<ul>
+					<li>25-Feb-2021: Replaced the IDPF URLs used to report conformance to the 1.0 specification with
+						more flexible text strings. See <a href="https://github.com/w3c/epub-specs/issues/1455">issue
+							1455</a>.</li>
+				</ul>
+			</section>
+
+			<section id="changes-older">
+				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
 				<ul>
 					<li>19-Feb-2021: References to WCAG 2.0 have been updated to undated references to WCAG 2 (except
 						where WCAG 2.0 is explicitly mentioned for conformance).</li>
@@ -1102,18 +1119,6 @@
 						as an ISO standard have been incorporated into the initial draft text.</li>
 				</ul>
 			</section>
-
-			<!--
-				After FPWD:
-				- Uncomment this section and move all pre-FPWD changes above here
-				- Change link/reference in preceding section heading to FPWD
-			
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
-				<ul>
-				</ul>
-			</section>
-			-->
 		</section>
 		<div data-include="../common/acknowledgements-a11y.html" data-oninclude="fixIncludes"
 			data-include-replace="true"></div>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -638,24 +638,24 @@
 						it MUST include a <code>conformsTo</code> property whose value MUST exactly match (i.e., both in
 						case and spacing) the following pattern:</p>
 
-					<p class="conf-pattern">EPUB Accessibility <a href="#epub-acc-num"><var>X</var></a> + WCAG <a
-							href="#wcag-num"><var>Y</var></a> Level <a href="#wcag-level"><var>Z</var></a></p>
+					<p class="conf-pattern">EPUB Accessibility <a href="#acc-ver"><var>A11Y-VER</var></a> + WCAG <a
+							href="#wcag-ver"><var>WCAG_VER</var></a> Level <a href="#wcag-lvl"><var>WCAG-LVL</var></a></p>
 
 					<p><i>where:</i></p>
 
 					<dl class="varlist">
-						<dt id="epub-acc-num"><var>X</var></dt>
+						<dt id="acc-ver"><var>A11Y-VER</var></dt>
 						<dd>
 							<p>MUST be the version number of the EPUB Accessibility specification the publication
 								conforms to. For the purposes, of this specification, this value MUST be
 									<code>1.1</code>.</p>
 						</dd>
-						<dt id="wcag-num"><var>Y</var></dt>
+						<dt id="wcag-ver"><var>WCAG-VER</var></dt>
 						<dd>
 							<p>MUST be the version number of WCAG the publication conforms to (e.g., <code>2.0</code> or
 									<code>2.1</code>).</p>
 						</dd>
-						<dt id="wcag-level"><var>Z</var></dt>
+						<dt id="wcag-lvl"><var>WCAG-LVL</var></dt>
 						<dd>
 							<p>MUST be the WCAG conformance level the publication conforms to (e.g., <code>A</code> or
 									<code>AA</code>).</p>


### PR DESCRIPTION
This PR makes the following changes per our discussion on the 2021-02-25 telecon:

- adds and explains the new text string pattern for reporting
- it splits the section in two so that publication reporting is separated from evaluator reporting - to make reading the relevant sections simpler
- it adds a short intro for some prose that was left hanging, although I'm not sure we really need this (can be convinced to drop it)

I formatted the new text string pattern with placeholder variables where each moving piece is filled in and then put a definition list beneath explaining what each value must be.

Let me know if this makes sense, or if anyone has other thoughts on how we might approach this. I can't think of a similar instance like this I've encountered before in a specification. (Have you run into this kind of a pattern before @iherman ?)

- [Accessibility preview](https://raw.githack.com/w3c/epub-specs/fix/issue-1455/epub33/a11y/)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-1455%2Fepub33%2Fa11y%2Findex.html)

Fixes #1455