### PR TITLE
Update whitespace handling

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1561,12 +1561,15 @@
 							<h5>Metadata Values</h5>
 
 							<p>The Dublin Core elements [[!DC11]] and <a href="#sec-meta-elem"><code>meta</code>
-									element</a> have mandatory text content. That content is referred to as the
-									<dfn>value</dfn> of the element in their descriptions.</p>
+									element</a> have mandatory <a
+									href="https://dom.spec.whatwg.org/#concept-child-text-content">child text
+									content</a> [[!DOM]]. That content is referred to as the <dfn>value</dfn> of the
+								element in their descriptions.</p>
 
-							<p>These elements MUST have non-empty values after Reading Systems <a
-									href="https://www.w3.org/TR/epub-rs-33/#conf-meta-ws">strip leading and trailing
-									whitespace</a> [[!EPUB-RS-33]].</p>
+							<p>These elements MUST have non-empty values after <a
+									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
+									>leading and trailing ASCII whitespace</a> [[!Infra]] is stripped (i.e., they must
+								consist of at least one non-whitespace character).</p>
 						</section>
 
 						<section id="sec-opf-dcmes-required">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1100,9 +1100,6 @@
 							<code>http://www.idpf.org/2007/opf</code> namespace [[!XML-NAMES]] unless otherwise
 						specified.</p>
 
-					<p>When an element defined in this section has mandatory text content, that content is referred to
-						as the value of the element in the explanatory descriptions.</p>
-
 					<section id="sec-package-elem">
 						<h5>The <code>package</code> Element</h5>
 
@@ -1560,6 +1557,18 @@
 
 						</section>
 
+						<section id="sec-package-elem-value">
+							<h5>Metadata Values</h5>
+
+							<p>When a child element of the <a href="#sec-metadata-elem"><code>metadata</code>
+									element</a> has mandatory text content, that content is referred to as the value of
+								the element in the explanatory descriptions.</p>
+
+							<p>These values MUST be at least one character in length after <a
+									href="https://www.w3.org/TR/epub-rs-33/#conf-meta-ws">stripping leading and trailing
+									ASCII whitespace</a> [[!EPUB-RS-33]].</p>
+						</section>
+
 						<section id="sec-opf-dcmes-required">
 							<h6>DCMES Required Elements</h6>
 
@@ -1634,7 +1643,8 @@
 									NOT be issued when making minor revisions such as updating metadata, fixing errata,
 									or making similar minor changes.</p>
 
-								<p>Authors MAY specify additional identifiers.</p>
+								<p>Authors MAY specify additional identifiers. It is strongly advised that identifiers
+									be fully qualified URIs.</p>
 
 								<p>The <a href="#identifier-type"><code>identifier-type</code> property</a> is used to
 									indicate that an <code>identifier</code> conforms to an established system or has
@@ -1651,11 +1661,6 @@
     …
 &lt;/metadata></pre>
 								</aside>
-
-								<p>This specification imposes no additional restrictions or the requirements of the
-									identifier except that it MUST be at least one character in length after white space
-									has been trimmed. It is strongly advised that the identifier be a fully qualified
-									URI, however.</p>
 							</section>
 
 							<section id="sec-opf-dctitle">
@@ -1751,10 +1756,6 @@
 &lt;/metadata&gt;
 </pre>
 								</aside>
-
-								<p>This specification imposes no additional restrictions or requirements on the title
-									except that it MUST be at least one character in length after white space has been
-									trimmed.</p>
 							</section>
 
 							<section id="sec-opf-dclanguage">
@@ -1885,9 +1886,6 @@
 										<p>Text</p>
 									</dd>
 								</dl>
-
-								<p>The value of all OPTIONAL [[!DC11]] elements MUST be at least one character in length
-									after white space has been trimmed.</p>
 
 								<p>This specification does not modify the [[!DC11]] element definitions except as noted
 									in the following sections.</p>
@@ -2185,10 +2183,6 @@
 									value of the <code>meta</code> tag is drawn from ONIX code list 5.</p>
 								<pre>&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta></pre>
 							</aside>
-
-							<p>Every <code>meta</code> element MUST express a value that is at least one character in
-								length after white space normalization.</p>
-
 						</section>
 
 						<section id="sec-metadata-last-modified">
@@ -8943,7 +8937,7 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<section id="changes-latest">
-				<h3>Substantive Changes since the <a href="https://www.w3.org/TR/2021/WD-epub-33-20210112/">First Public
+				<h3>Substantive Changes since the <a href="https://www.w3.org/TR/2021/WD-epub-33-20210224/">Previous
 						Working Draft</a></h3>
 
 				<!--
@@ -8951,6 +8945,17 @@ EPUB/images/cover.png</pre>
 						- change the link/text in the section heading to refer to the published draft (use the dated URL)
 						- move all changes down to the next section
 				-->
+
+				<ul>
+					<li>26-Feb-2021: Created a new section for describing general metadata value requirements,
+						specifically whitespace handling. See <a href="https://github.com/w3c/epub-specs/issues/1528"
+							>issue 1528</a>.</li>
+				</ul>
+			</section>
+
+			<section id="changes-older">
+				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
+					3.2</a></h3>
 
 				<ul>
 					<li>17-Feb-2020: File extension recommendations have been removed (affects the Package Document,
@@ -8980,14 +8985,6 @@ EPUB/images/cover.png</pre>
 					<li>13-Jan-2021: The requirement for progressive enhancement with spine-level scripting has been
 						changed to a recommendation that top-level content documents remain consumable when scripting is
 						not available. See <a href="https://github.com/w3c/epub-specs/issues/1444">issue 1444</a>.</li>
-				</ul>
-			</section>
-
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
-					3.2</a></h3>
-
-				<ul>
 					<li>24-Dec-2020: The specification no longer makes reference to a release identifier, but the
 						requirement to include a last modification date remains for backwards compatibility. See <a
 							href="https://github.com/w3c/epub-specs/issues/1440">issue 1440</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1560,13 +1560,13 @@
 						<section id="sec-package-elem-value">
 							<h5>Metadata Values</h5>
 
-							<p>When a child element of the <a href="#sec-metadata-elem"><code>metadata</code>
-									element</a> has mandatory text content, that content is referred to as the value of
-								the element in the explanatory descriptions.</p>
+							<p>The Dublin Core elements [[!DC11]] and <a href="#sec-meta-elem"><code>meta</code>
+									element</a> have mandatory text content. That content is referred to as the
+									<dfn>value</dfn> of the element in their descriptions.</p>
 
-							<p>These values MUST be at least one character in length after <a
-									href="https://www.w3.org/TR/epub-rs-33/#conf-meta-ws">stripping leading and trailing
-									ASCII whitespace</a> [[!EPUB-RS-33]].</p>
+							<p>These elements MUST have non-empty values after Reading Systems <a
+									href="https://www.w3.org/TR/epub-rs-33/#conf-meta-ws">strip leading and trailing
+									whitespace</a> [[!EPUB-RS-33]].</p>
 						</section>
 
 						<section id="sec-opf-dcmes-required">
@@ -1798,7 +1798,7 @@
 								</dl>
 
 								<p>The <code>metadata</code> section MUST contain at least one <code>language</code>
-									element. The value of each <code>language</code> element MUST be a <a
+									element. The <a>value</a> of each <code>language</code> element MUST be a <a
 										href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
 										tag</a> [[!BCP47]].</p>
 
@@ -1999,12 +1999,12 @@
 								<h6>The <code>subject</code> Element</h6>
 
 								<p>The [[!DC11]] <code>subject</code> element identifies the subject of the EPUB
-									Publication. The value of the element SHOULD be the human-readable heading or label,
-									but MAY be the code value if the subject taxonomy does not provide a separate
+									Publication. The <a>value</a> of the element SHOULD be the human-readable heading or
+									label, but MAY be the code value if the subject taxonomy does not provide a separate
 									descriptive label.</p>
 
-								<p>Authors MAY identify the system or scheme the element's value is drawn from using the
-										<a href="#authority"><code>authority</code> property</a>.</p>
+								<p>Authors MAY identify the system or scheme the element's <a>value</a> is drawn from
+									using the <a href="#authority"><code>authority</code> property</a>.</p>
 
 								<p>When a scheme is identified, a subject code MUST be <a href="#subexpression"
 										>associated with the element</a> using the <a href="#term"><code>term</code>
@@ -2027,8 +2027,8 @@
 								<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
 											<code>subject</code> element</a> that does not specify a scheme.</p>
 
-								<p>The values of the <code>subject</code> element and <code>term</code> property are
-									case sensitive only when the designated scheme requires.</p>
+								<p>The <a>values</a> of the <code>subject</code> element and <code>term</code> property
+									are case sensitive only when the designated scheme requires.</p>
 							</section>
 
 							<section id="sec-opf-dctype">
@@ -2040,7 +2040,7 @@
 
 								<p>An informative registry of specialized EPUB Publication types for use with this
 									element is maintained in the [[TypesRegistry]], but Authors MAY use any text string
-									as a value.</p>
+									as a <a>value</a>.</p>
 							</section>
 
 						</section>
@@ -2174,13 +2174,13 @@
 							</aside>
 
 							<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme
-								that the element's value is drawn from. The value of the attribute MUST be a <a
+								that the element's <a>value</a> is drawn from. The value of the attribute MUST be a <a
 									href="#sec-property-datatype"><var>property</var> data type value</a> that resolves
 								to the resource that defines the scheme.</p>
 
 							<aside class="example">
 								<p>The following example shows the <code>scheme</code> attribute used to indicate the
-									value of the <code>meta</code> tag is drawn from ONIX code list 5.</p>
+										<a>value</a> of the <code>meta</code> tag is drawn from ONIX code list 5.</p>
 								<pre>&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta></pre>
 							</aside>
 						</section>
@@ -2190,8 +2190,8 @@
 
 							<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one
 								[[!DCTERMS]] <code>modified</code> property containing the last modification date. The
-								value of this property MUST be an [[!XMLSCHEMA-2]] dateTime conformant date of the form:
-									<code>CCYY-MM-DDThh:mm:ssZ</code></p>
+									<a>value</a> of this property MUST be an [[!XMLSCHEMA-2]] dateTime conformant date
+								of the form: <code>CCYY-MM-DDThh:mm:ssZ</code></p>
 
 							<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST
 								be terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -341,13 +341,15 @@
 					<dl class="conformance-list">
 						<dt id="conf-meta-ws">White Space</dt>
 						<dd>
-							<p>Reading Systems MUST trim all leading and trailing <a
-									href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] from Dublin Core
-								element values before processing.</p>
-							<p>Unless an individual property explicitly defines a different white space normalization
-								algorithm, Reading Systems MUST trim all leading and trailing <a
-									href="https://www.w3.org/TR/xml/#white">white space</a> [[!XML]] from
-									<code>meta</code> element values before further processing them.</p>
+							<p>Reading Systems MUST <a
+									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
+									>strip leading and trailing ASCII whitespace</a> [[!Infra]] from Dublin Core element
+								values before processing.</p>
+							<p>Unless an individual property explicitly defines a different whitespace normalization
+								algorithm, Reading Systems MUST <a
+									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
+									>strip leading and trailing ASCII whitespace</a> [[!Infra]] from <code>meta</code>
+								element values before further processing them.</p>
 						</dd>
 
 						<dt id="dc-identifier">The <code>identifier</code> element</dt>
@@ -2182,7 +2184,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<section id="changes-latest">
-				<h3>Substantive Changes since the <a href="https://www.w3.org/TR/2021/WD-epub-rs-33-20210223/">Previous
+				<h3>Substantive Changes since the <a href="https://www.w3.org/TR/2021/WD-epub-rs-33-20210224/">Previous
 						Working Draft</a></h3>
 
 				<!--
@@ -2192,6 +2194,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>26-Feb-2021: Clarified the trimming of leading and trailing whitespace is to be done in
+						accordance with the [[Infra]] specification definition. See <a
+							href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
 					<li>19-Feb-2021: Updated the <a href="sec-scripted-content-security">scripting security
 							considerations</a> so that the text recommends assigning a unique origin to each EPUB
 						Publication for security rather than domain isolation at the Content Document level. See <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -338,15 +338,10 @@
 						<dd>
 							<p>Reading Systems MUST <a
 									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
-									>strip leading and trailing ASCII whitespace</a> [[!Infra]] from Dublin Core element
-									<a href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[!EPUB-33]] before
-								processing.</p>
-							<p>Unless an individual property explicitly defines a different whitespace normalization
-								algorithm, Reading Systems MUST <a
-									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
-									>strip leading and trailing ASCII whitespace</a> [[!Infra]] from <code>meta</code>
-								element <a href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[!EPUB-33]]
-								before further processing them.</p>
+									>strip leading and trailing ASCII whitespace</a> [[!Infra]] from Dublin Core
+								[[!DC11]] and <a href="https://www.w3.org/TR/epub-33/#sec-meta-elem"
+									><code>meta</code></a> element <a href="https://www.w3.org/TR/epub-33/#dfn-value"
+									>values</a> [[!EPUB-33]] before processing.</p>
 						</dd>
 
 						<dt id="dc-identifier">The <code>identifier</code> element</dt>
@@ -2192,7 +2187,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 
 				<ul>
 					<li>26-Feb-2021: Clarified the trimming of leading and trailing whitespace is to be done in
-						accordance with the [[Infra]] specification definition. See <a
+						accordance with the [[Infra]] specification definition, and removed the exception that
+							<code>meta</code> element properties may define their own whitespace handling rules. See <a
 							href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
 					<li>19-Feb-2021: Updated the <a href="sec-scripted-content-security">scripting security
 							considerations</a> so that the text recommends assigning a unique origin to each EPUB

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -333,23 +333,20 @@
 				<section id="metadata">
 					<h4>Metadata</h4>
 
-					<div class="note">
-						<p>When an element has mandatory text content, that content is referred to as the value of the
-							element in the following requirements.</p>
-					</div>
-
 					<dl class="conformance-list">
 						<dt id="conf-meta-ws">White Space</dt>
 						<dd>
 							<p>Reading Systems MUST <a
 									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
 									>strip leading and trailing ASCII whitespace</a> [[!Infra]] from Dublin Core element
-								values before processing.</p>
+									<a href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[!EPUB-33]] before
+								processing.</p>
 							<p>Unless an individual property explicitly defines a different whitespace normalization
 								algorithm, Reading Systems MUST <a
 									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
 									>strip leading and trailing ASCII whitespace</a> [[!Infra]] from <code>meta</code>
-								element values before further processing them.</p>
+								element <a href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[!EPUB-33]]
+								before further processing them.</p>
 						</dd>
 
 						<dt id="dc-identifier">The <code>identifier</code> element</dt>


### PR DESCRIPTION
As discussed on the 2021-02-26 telecon, this PR adds a cross-reference to infra spec definition for stripping leading and trailing whitespace from metadata elements in the reading system spec definition.

I've also created a new section in the core spec under the package metadata section for common metadata value requirements. These are the only elements that accept text values, so I've moved the floating paragraph that used be at the start of the package doc definition into it. I've also added a single statement to cover the requirement for at least one character after whitespace stripping so we don't have to maintain these statements in every definition.

This only partially solves #1295 and #1528 since we haven't yet addressed whitespace collapsing within elements.


- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1295/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1295/epub33/rs/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1539.html" title="Last updated on Mar 1, 2021, 4:34 PM UTC (8ee4fd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1539/7a60ccf...8ee4fd0.html" title="Last updated on Mar 1, 2021, 4:34 PM UTC (8ee4fd0)">Diff</a>