### PR TITLE
Add clarification that align-x-center cannot be set globally

### DIFF
--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -131,6 +131,11 @@
 			<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should
 				be centered horizontally in the viewport or spread. </p>
 			
+			<p>The property cannot be set globally for all EPUB Content Documents. It is only available as a spine
+				override for individual EPUB Content Documents via the <a
+					href="#sec-itemref-elem"><code>itemref</code> element's <code>properties</code>
+					attribute</a>.</p>
+			
 			<div class="note">
 				<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title
 					pages), in the absence of reliable centering control within the content rendering. As


### PR DESCRIPTION
Only partially addresses #1380 since we haven't determined whether to deprecate this property yet.