### PR TITLE
Moved the note on external resource to the main text

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -965,6 +965,10 @@
 						</li>
 					</ul>
 
+					<p>Authors are encouraged to locate these resources inside the EPUB Container
+						whenever feasible to allow users access to the entire presentation regardless of
+						connectivity status.</p>
+
 					<aside class="example">
 						<p>The following example shows a reference to an audio file in an <a>XHTML Content Document</a>
 							that is located inside the EPUB Container.</p>
@@ -976,12 +980,6 @@
 							located outside the EPUB Container.</p>
 						<pre>&lt;audio src="http://www.example.com/book/audio/ch01.mp4" controls="controls"/&gt;</pre>
 					</aside>
-
-					<div class="note">
-						<p>Authors are encouraged to locate audio, video, and script resources inside the EPUB Container
-							whenever feasible to allow users access to the entire presentation regardless of
-							connectivity status.</p>
-					</div>
 
 					<div class="note">
 						<p>The rules in this section for Publication Resource locations apply regardless of whether the


### PR DESCRIPTION
Fixes #1525

cc: @emuller-amazon


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1543.html" title="Last updated on Mar 1, 2021, 11:19 AM UTC (c2a57c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1543/7960d10...c2a57c1.html" title="Last updated on Mar 1, 2021, 11:19 AM UTC (c2a57c1)">Diff</a>