### PR TITLE
Exchanged the order of section in §2.3.2.

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1154,8 +1154,8 @@
 								<p>An absolute or relative IRI reference [[!RFC3987]] to a resource.</p>
 								<div class="example">
 									<pre>&lt;link rel="record"
-		href="meta/9780000000001.xml" 
-		media-type="application/marc"/&gt;</pre>
+      href="meta/9780000000001.xml" 
+      media-type="application/marc"/&gt;</pre>
 								</div>
 								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
 										href="#sec-link-elem"><code>link</code></a>.</p>
@@ -1198,9 +1198,9 @@
 									resource.</p>
 								<div class="example">
 									<pre>&lt;link rel="record"
-		href="http://example.org/meta/12389347?format=xmp"
-		media-type="application/xml"
-		properties="xmp"/&gt;</pre>
+      href="http://example.org/meta/12389347?format=xmp"
+      media-type="application/xml"
+      properties="xmp"/&gt;</pre>
 								</div>
 								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
 										href="#sec-link-elem"><code>link</code></a>.</p>
@@ -1214,9 +1214,9 @@
 										vocabulary</a> that can be used with the attribute.</p>
 								<div class="example">
 									<pre>&lt;item id="nav" 
-	href="nav.xhtml" 
-	properties="nav"
-	media-type="application/xhtml+xml"/&gt;</pre>
+      href="nav.xhtml" 
+      properties="nav"
+      media-type="application/xhtml+xml"/&gt;</pre>
 								</div>
 								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a
 										href="#sec-itemref-elem"><code>itemref</code></a> and <a href="#sec-link-elem"

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1103,6 +1103,169 @@
 					<p>When an element defined in this section has mandatory text content, that content is referred to
 						as the value of the element in the explanatory descriptions.</p>
 
+					<section id="sec-shared-attrs">
+						<h5>Shared Attributes</h5>
+
+						<p>This section provides definitions for shared attributes (i.e., attributes that are allowed on
+							two or more elements).</p>
+
+						<dl class="variablelist">
+							<dt id="attrdef-dir">
+								<code>dir</code>
+							</dt>
+							<dd>
+								<p>Specifies the base direction [[!BIDI]] of the carrying element and its
+									descendants.</p>
+								<p>Allowed values are:</p>
+								<ul>
+									<li><code>ltr</code> &#8212; left-to-right base direction;</li>
+									<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
+									<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
+										Algorithm [[BIDI]].</li>
+								</ul>
+								<p>The value <code>auto</code> is assumed when the attribute is not specified or
+									contains an invalid value.</p>
+								<div class="note">
+									<p>The base direction specified in the <code>dir</code> attribute does not affect
+										the ordering of characters within directional runs, only the relative ordering
+										of those runs and the placement of weak directional characters such as
+										punctuation.</p>
+								</div>
+								<div class="example">
+									<pre>&lt;package … dir="ltr"&gt;</pre>
+								</div>
+								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+										href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
+										href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a
+										href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-meta-elem"
+											><code>meta</code></a> and <a href="#sec-package-elem"
+										><code>package</code></a>.</p>
+							</dd>
+							<dt id="attrdef-href">
+								<code>href</code>
+							</dt>
+							<dd>
+								<p>An absolute or relative IRI reference [[!RFC3987]] to a resource.</p>
+								<div class="example">
+									<pre>&lt;link rel="record"
+		href="meta/9780000000001.xml" 
+		media-type="application/marc"/&gt;</pre>
+								</div>
+								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
+										href="#sec-link-elem"><code>link</code></a>.</p>
+							</dd>
+							<dt id="attrdef-id">
+								<code>id</code>
+							</dt>
+							<dd>
+								<p>The ID [[!XML]] of the element, which MUST be unique within the document scope.</p>
+								<div class="example">
+									<pre>&lt;dc:identifier id="pub-id"&gt;urn:isbn:97800000000001&lt;/dc:identifier&gt;</pre>
+								</div>
+								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+										href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:date</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, <a
+										href="#sec-opf-dcidentifier"><code>dc:identifier</code></a>, <a
+										href="#sec-opf-dclanguage"><code>dc:language</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, <a
+										href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a
+										href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-opf-dctype"
+											><code>dc:type</code></a>, <a href="#sec-item-elem"><code>item</code></a>,
+										<a href="#sec-itemref-elem"><code>itemref</code></a>, <a href="#sec-link-elem"
+											><code>link</code></a>, <a href="#sec-manifest-elem"
+										><code>manifest</code></a>, <a href="#sec-meta-elem"><code>meta</code></a>, <a
+										href="#sec-package-elem"><code>package</code></a> and <a href="#sec-spine-elem"
+											><code>spine</code></a>.</p>
+							</dd>
+							<dt id="attrdef-media-type">
+								<code>media-type</code>
+							</dt>
+							<dd>
+								<p>A media type [[!RFC2046]] that specifies the type and format of the referenced
+									resource.</p>
+								<div class="example">
+									<pre>&lt;link rel="record"
+		href="http://example.org/meta/12389347?format=xmp"
+		media-type="application/xml"
+		properties="xmp"/&gt;</pre>
+								</div>
+								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
+										href="#sec-link-elem"><code>link</code></a>.</p>
+							</dd>
+							<dt id="attrdef-properties">
+								<code>properties</code>
+							</dt>
+							<dd>
+								<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
+								<p>Refer to each element's definition for the <a href="#sec-default-vocab">reserved
+										vocabulary</a> that can be used with the attribute.</p>
+								<div class="example">
+									<pre>&lt;item id="nav" 
+	href="nav.xhtml" 
+	properties="nav"
+	media-type="application/xhtml+xml"/&gt;</pre>
+								</div>
+								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a
+										href="#sec-itemref-elem"><code>itemref</code></a> and <a href="#sec-link-elem"
+											><code>link</code></a>.</p>
+							</dd>
+							<dt id="attrdef-refines">
+								<code>refines</code>
+							</dt>
+							<dd>
+								<p>Establishes an association between the current expression and the element or resource
+									identified by its value. The value of the attribute must be a relative IRI
+									[[!RFC3987]] that references the resource or element being described.</p>
+								<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata
+									being expressed. When omitted, the element defines a <a href="#primary-expression"
+										>primary expression</a>.</p>
+								<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a
+										href="#sec-meta-elem"><code>meta</code></a>.</p>
+							</dd>
+							<dt id="attrdef-xml-lang">
+								<code>xml:lang</code>
+							</dt>
+							<dd>
+								<p>Specifies the language used in the contents and attribute values of the carrying
+									element and its descendants, as defined in section <a
+										href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-lang-tag">2.12 Language
+										Identification</a> of [[!XML]]. The value of each <code>xml:lang</code>
+									attribute MUST be a <a href="https://tools.ietf.org/html/bcp47#section-2.2.9"
+										>well-formed language tag</a> [[!BCP47]].</p>
+								<div class="example">
+									<pre>&lt;package … xml:lang="ja"&gt;
+	…
+&lt;/package&gt;</pre>
+								</div>
+								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+										href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+										href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
+										href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a
+										href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-meta-elem"
+											><code>meta</code></a> and <a href="#sec-package-elem"
+										><code>package</code></a>.</p>
+							</dd>
+						</dl>
+					</section>
+	
 					<section id="sec-package-elem">
 						<h5>The <code>package</code> Element</h5>
 
@@ -1250,169 +1413,6 @@
 							mechanism for prefixes not <a href="#sec-metadata-reserved-prefixes">reserved by this
 								specification</a>. Refer to <a href="#sec-prefix-attr"></a> for more information.</p>
 
-					</section>
-
-					<section id="sec-shared-attrs">
-						<h5>Shared Attributes</h5>
-
-						<p>This section provides definitions for shared attributes (i.e., attributes that are allowed on
-							two or more elements).</p>
-
-						<dl class="variablelist">
-							<dt id="attrdef-dir">
-								<code>dir</code>
-							</dt>
-							<dd>
-								<p>Specifies the base direction [[!BIDI]] of the carrying element and its
-									descendants.</p>
-								<p>Allowed values are:</p>
-								<ul>
-									<li><code>ltr</code> &#8212; left-to-right base direction;</li>
-									<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
-									<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
-										Algorithm [[BIDI]].</li>
-								</ul>
-								<p>The value <code>auto</code> is assumed when the attribute is not specified or
-									contains an invalid value.</p>
-								<div class="note">
-									<p>The base direction specified in the <code>dir</code> attribute does not affect
-										the ordering of characters within directional runs, only the relative ordering
-										of those runs and the placement of weak directional characters such as
-										punctuation.</p>
-								</div>
-								<div class="example">
-									<pre>&lt;package … dir="ltr"&gt;</pre>
-								</div>
-								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-										href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-										href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a
-										href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-meta-elem"
-											><code>meta</code></a> and <a href="#sec-package-elem"
-										><code>package</code></a>.</p>
-							</dd>
-							<dt id="attrdef-href">
-								<code>href</code>
-							</dt>
-							<dd>
-								<p>An absolute or relative IRI reference [[!RFC3987]] to a resource.</p>
-								<div class="example">
-									<pre>&lt;link rel="record"
-      href="meta/9780000000001.xml" 
-      media-type="application/marc"/&gt;</pre>
-								</div>
-								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
-										href="#sec-link-elem"><code>link</code></a>.</p>
-							</dd>
-							<dt id="attrdef-id">
-								<code>id</code>
-							</dt>
-							<dd>
-								<p>The ID [[!XML]] of the element, which MUST be unique within the document scope.</p>
-								<div class="example">
-									<pre>&lt;dc:identifier id="pub-id"&gt;urn:isbn:97800000000001&lt;/dc:identifier&gt;</pre>
-								</div>
-								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-										href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:date</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, <a
-										href="#sec-opf-dcidentifier"><code>dc:identifier</code></a>, <a
-										href="#sec-opf-dclanguage"><code>dc:language</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, <a
-										href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a
-										href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-opf-dctype"
-											><code>dc:type</code></a>, <a href="#sec-item-elem"><code>item</code></a>,
-										<a href="#sec-itemref-elem"><code>itemref</code></a>, <a href="#sec-link-elem"
-											><code>link</code></a>, <a href="#sec-manifest-elem"
-										><code>manifest</code></a>, <a href="#sec-meta-elem"><code>meta</code></a>, <a
-										href="#sec-package-elem"><code>package</code></a> and <a href="#sec-spine-elem"
-											><code>spine</code></a>.</p>
-							</dd>
-							<dt id="attrdef-media-type">
-								<code>media-type</code>
-							</dt>
-							<dd>
-								<p>A media type [[!RFC2046]] that specifies the type and format of the referenced
-									resource.</p>
-								<div class="example">
-									<pre>&lt;link rel="record"
-      href="http://example.org/meta/12389347?format=xmp"
-      media-type="application/xml"
-      properties="xmp"/&gt;</pre>
-								</div>
-								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
-										href="#sec-link-elem"><code>link</code></a>.</p>
-							</dd>
-							<dt id="attrdef-properties">
-								<code>properties</code>
-							</dt>
-							<dd>
-								<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
-								<p>Refer to each element's definition for the <a href="#sec-default-vocab">reserved
-										vocabulary</a> that can be used with the attribute.</p>
-								<div class="example">
-									<pre>&lt;item id="nav" 
-    href="nav.xhtml" 
-    properties="nav"
-    media-type="application/xhtml+xml"/&gt;</pre>
-								</div>
-								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a
-										href="#sec-itemref-elem"><code>itemref</code></a> and <a href="#sec-link-elem"
-											><code>link</code></a>.</p>
-							</dd>
-							<dt id="attrdef-refines">
-								<code>refines</code>
-							</dt>
-							<dd>
-								<p>Establishes an association between the current expression and the element or resource
-									identified by its value. The value of the attribute must be a relative IRI
-									[[!RFC3987]] that references the resource or element being described.</p>
-								<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata
-									being expressed. When omitted, the element defines a <a href="#primary-expression"
-										>primary expression</a>.</p>
-								<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a
-										href="#sec-meta-elem"><code>meta</code></a>.</p>
-							</dd>
-							<dt id="attrdef-xml-lang">
-								<code>xml:lang</code>
-							</dt>
-							<dd>
-								<p>Specifies the language used in the contents and attribute values of the carrying
-									element and its descendants, as defined in section <a
-										href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-lang-tag">2.12 Language
-										Identification</a> of [[!XML]]. The value of each <code>xml:lang</code>
-									attribute MUST be a <a href="https://tools.ietf.org/html/bcp47#section-2.2.9"
-										>well-formed language tag</a> [[!BCP47]].</p>
-								<div class="example">
-									<pre>&lt;package … xml:lang="ja"&gt;
-   …
-&lt;/package&gt;</pre>
-								</div>
-								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-										href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-										href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a
-										href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-meta-elem"
-											><code>meta</code></a> and <a href="#sec-package-elem"
-										><code>package</code></a>.</p>
-							</dd>
-						</dl>
 					</section>
 
 					<section id="sec-pkg-metadata">


### PR DESCRIPTION
Changing the order of the 'shared attributes' and 'The package element' sections.

Fixes #1526

cc @emuller-amazon


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1544.html" title="Last updated on Mar 1, 2021, 12:34 PM UTC (d74975e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1544/7960d10...d74975e.html" title="Last updated on Mar 1, 2021, 12:34 PM UTC (d74975e)">Diff</a>