### PR TITLE
Improved example 26

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2721,10 +2721,9 @@ No Entry</pre>
 							</aside>
 
 							<aside class="example">
-								<p>The following example shows a link to a local version of the audio file. Because
-									audio files are not EPUB Content Documents, it requires a fallback to an EPUB
-									Content Document (it also has to be listed in the <a href="#sec-spine-elem"
-										>spine</a>).</p>
+								<p>The following example shows a link to a local version of the audio file. 
+									For this link to be valid, the audio file has to be listed in the <a href="#sec-spine-elem"
+									>spine</a> and requires a fallback to an EPUB Content Document in its manifest declaration.</p>
 								<pre>XHTML:
 &lt;a href="audio/ch01.mp4"&gt;Open Audio File&lt;/a&gt;
 
@@ -2732,7 +2731,10 @@ Manifest:
 &lt;item id="audio01"
       href="audio/ch01.mp4"
       media-type="audio/mp4"
-      fallback="#audio01-xhtml"/&gt;</pre>
+      fallback="#audio01-xhtml"/&gt;
+
+Spine:
+&lt;itemref idref="audio01" linear="no"/&gt;</pre>
 							</aside>
 
 						</section>


### PR DESCRIPTION
Updated along the lines of https://github.com/w3c/epub-specs/issues/1532#issuecomment-786282294. I am not fully sure whether the `linear="no"` is worth, although it looks appropriate.

Fixes #1532

cc @emuller-amazon


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1546.html" title="Last updated on Mar 1, 2021, 12:48 PM UTC (0d9e27e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1546/7960d10...0d9e27e.html" title="Last updated on Mar 1, 2021, 12:48 PM UTC (0d9e27e)">Diff</a>