### PR TITLE
Missing space in example 33 (was example 34)

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4923,7 +4923,9 @@ Manifest:
     &lt;h2&gt;Pagebreaks of the print version, third edition&lt;/h2&gt;
     &lt;ol&gt;
         &lt;li&gt;&lt;a href="frontmatter.xhtml#pi"&gt;I&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a href="frontmatter.xhtml#pii"&gt;II&lt;/a&gt;&lt;/li&gt; … &lt;li&gt;&lt;a href="chap1.xhtml#p1"&gt;1&lt;/a&gt;&lt;/li&gt;
+        &lt;li&gt;&lt;a href="frontmatter.xhtml#pii"&gt;II&lt;/a&gt;&lt;/li&gt;
+        …
+        &lt;li&gt;&lt;a href="chap1.xhtml#p1"&gt;1&lt;/a&gt;&lt;/li&gt;
         &lt;li&gt;&lt;a href="chap1.xhtml#p2"&gt;2&lt;/a&gt;&lt;/li&gt; … &lt;/ol&gt;
 &lt;/nav&gt;
 </pre>


### PR DESCRIPTION
Fixes #1535


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1547.html" title="Last updated on Mar 1, 2021, 12:56 PM UTC (08072e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1547/7960d10...08072e1.html" title="Last updated on Mar 1, 2021, 12:56 PM UTC (08072e1)">Diff</a>