### PR TITLE
Removed unnecessary paragraph in definition section of itemref

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3013,10 +3013,6 @@ Manifest:
 							<p>Authors MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
 								></a>.</p>
 
-							<p>All applicable descriptive metadata properties defined in the <a
-									href="#app-itemref-properties-vocab">Spine Properties Vocabulary</a> SHOULD be
-								declared.</p>
-
 							<h6>Examples</h6>
 
 							<aside class="example">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4923,7 +4923,9 @@ Manifest:
     &lt;h2&gt;Pagebreaks of the print version, third edition&lt;/h2&gt;
     &lt;ol&gt;
         &lt;li&gt;&lt;a href="frontmatter.xhtml#pi"&gt;I&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a href="frontmatter.xhtml#pii"&gt;II&lt;/a&gt;&lt;/li&gt; … &lt;li&gt;&lt;a href="chap1.xhtml#p1"&gt;1&lt;/a&gt;&lt;/li&gt;
+        &lt;li&gt;&lt;a href="frontmatter.xhtml#pii"&gt;II&lt;/a&gt;&lt;/li&gt;
+        …
+        &lt;li&gt;&lt;a href="chap1.xhtml#p1"&gt;1&lt;/a&gt;&lt;/li&gt;
         &lt;li&gt;&lt;a href="chap1.xhtml#p2"&gt;2&lt;/a&gt;&lt;/li&gt; … &lt;/ol&gt;
 &lt;/nav&gt;
 </pre>


### PR DESCRIPTION
See https://github.com/w3c/epub-specs/issues/1533#issuecomment-786330030

Fixes #1533


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1548.html" title="Last updated on Mar 1, 2021, 1:04 PM UTC (0ffb821)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1548/7960d10...0ffb821.html" title="Last updated on Mar 1, 2021, 1:04 PM UTC (0ffb821)">Diff</a>