### PR TITLE
Reformulated the beginning of §4.1

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4498,11 +4498,14 @@ Manifest:
 						Publication</a>. It allows <a>Authors</a> to include a human- and machine-readable global
 					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
 
-				<p>The EPUB Navigation Document is an <a>XHTML Content Document</a>, but with additional restrictions on
-					its structure to facilitate the machine-processing of its contents. [[HTML]] <a
-						href="https://html.spec.whatwg.org/multipage/sections.html#the-nav-element"><code>nav</code></a>
-					elements contain the specialized navigational information, which remains human-readable as well as
-					allowing Reading Systems to generate navigational interfaces.</p>
+				<p>The EPUB Navigation Document is an <a>XHTML Content Document</a>, which must include a single 
+					[[HTML]]&nbsp;<a href="https://html.spec.whatwg.org/multipage/sections.html#the-nav-element"><code>nav</code></a>
+					element with the <a href="#sec-epub-type-attribute"
+					><code>epub:type</code> attribute</a> set to the value 
+					<a href="#sec-nav-toc"><code>toc</code></a> for table of contents. It may also include other 
+					specialized <code>nav</code> elements, such as a <a href="#sec-nav-pagelist"><code>page-list</code></a> or a <a href="#sec-nav-landmarks"><code>landmark</code></a>, but only one of each. These special <code>nav</code> elements 
+					have additional restrictions on their content beyond those defined in&nbsp;[[HTML]], in order to facilitate
+					the machine-processing of its contents. There are no other restrictions on the structure or content of the EPUB Navigation Document.</p>
 
 				<p>But the EPUB Navigation Document is not exclusively for machine processing. Because it is an XHTML
 					Content Document, it can be part of the linear reading order, avoiding the need for duplicate tables

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4498,20 +4498,19 @@ Manifest:
 						Publication</a>. It allows <a>Authors</a> to include a human- and machine-readable global
 					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
 
-				<p>The EPUB Navigation Document is an <a>XHTML Content Document</a>, which must include a single 
-					[[HTML]]&nbsp;<a href="https://html.spec.whatwg.org/multipage/sections.html#the-nav-element"><code>nav</code></a>
-					element with the <a href="#sec-epub-type-attribute"
-					><code>epub:type</code> attribute</a> set to the value 
-					<a href="#sec-nav-toc"><code>toc</code></a> for table of contents. It may also include other 
-					specialized <code>nav</code> elements, such as a <a href="#sec-nav-pagelist"><code>page-list</code></a> or a <a href="#sec-nav-landmarks"><code>landmark</code></a>, but only one of each. These special <code>nav</code> elements 
-					have additional restrictions on their content beyond those defined in&nbsp;[[HTML]], in order to facilitate
-					the machine-processing of its contents. There are no other restrictions on the structure or content of the EPUB Navigation Document.</p>
-
-				<p>But the EPUB Navigation Document is not exclusively for machine processing. Because it is an XHTML
-					Content Document, it can be part of the linear reading order, avoiding the need for duplicate tables
-					of contents. Content which is only destined for machine processing, such as <a
-						href="#sec-nav-pagelist">page lists</a>, can be hidden from visual rendering with the <a
-						href="#sec-nav-def-hidden">hidden</a> attribute.</p>
+				<p>The EPUB Navigation Document is a special type of <a>XHTML Content Document</a> that defines 
+					the <a href="https://html.spec.whatwg.org/multipage/sections.html#sec-nav-toc">table of contents</a> 
+					for <a>Reading Systems</a>. It may also include other specialized navigation elements, such as 
+					a <a href="#sec-nav-pagelist">page list</a> and a list of key <a href="#sec-nav-landmarks">landmarks</a>. 
+					These navigation elements have <a href="#sec-nav-def-model">additional restrictions</a> on their content in
+					order to facilitate their processing.</p>
+	
+				<p>The EPUB Navigation Document is not exclusively for machine processing, however. There are no
+					restrictions on the structure or content of the EPUB Navigation Document outside of the specialized
+					navigation elements (i.e., Authors can mark the rest of the document up like any other XHTML Content Document).
+					As a result, it can also be part of the linear reading order, avoiding the need for duplicate tables of contents.
+					Navigation elements that are only destined for machine processing, such as the page list, can be hidden from
+					visual rendering with the <a href="#sec-nav-def-hidden">hidden</a> attribute.</p>
 
 				<p>Note that Reading Systems might strip scripting, styling, and HTML formatting as they generate
 					navigational interfaces from information found in the EPUB Navigation Document. If such formatting
@@ -4742,7 +4741,7 @@ Manifest:
 							<dd>
 								<p>Identifies the <code>nav</code> element that contains the table of contents. The
 										<code>toc</code>
-									<code>nav</code> is the only navigation aid that has to be included in the EPUB
+									<code>nav</code> is the only navigation aid that must be included in the EPUB
 									Navigation Document.</p>
 							</dd>
 							<dt>
@@ -4764,6 +4763,8 @@ Manifest:
 									interest.</p>
 							</dd>
 						</dl>
+
+						<p>An EPUB Navigation Document can contain at most one navigation aid for each of these types.</p>
 
 						<p>Additional navigation types can be included in the EPUB Navigation Document. See <a
 								href="#sec-nav-def-types-other"></a> for more information.</p>


### PR DESCRIPTION
I used mostly the text of @dauwhe (https://github.com/w3c/epub-specs/issues/1536#issuecomment-786868837) for the second paragraph, but reformulated it to follow the same style as the other paragraphs.

After all, I did not touch paragraph 1; I was not sure that this was necessary to answer to the issue.

Fixes #1536

cc @emuller-amazon


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1549.html" title="Last updated on Mar 1, 2021, 5:19 PM UTC (07f701e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1549/7960d10...07f701e.html" title="Last updated on Mar 1, 2021, 5:19 PM UTC (07f701e)">Diff</a>