### PR TITLE
Changed the Refs for EPUB 3 and A11y

### DIFF
--- a/epub33/common/js/biblio.js
+++ b/epub33/common/js/biblio.js
@@ -33,12 +33,8 @@ var biblio = {
 		"href": "http://www.daisy.org/guidelines/epub/navigable-audio-only-epub3-guidelines"
 	},
 	"EPUB-3": {
-		"title": "EPUB 3 Overview",
-		"href": "https://www.w3.org/TR/epub-overview/",
-		"authors" : [
-			"Matt Garrish",
-			"Ivan Herman"
-		],
+		"title": "EPUB 3",
+		"href": "https://www.w3.org/TR/epub/",
 		"publisher": "W3C"
 	},
 	"EPUB-31": {

--- a/epub33/common/js/biblio.js
+++ b/epub33/common/js/biblio.js
@@ -33,8 +33,12 @@ var biblio = {
 		"href": "http://www.daisy.org/guidelines/epub/navigable-audio-only-epub3-guidelines"
 	},
 	"EPUB-3": {
-		"title": "EPUB 3",
-		"href": "https://www.w3.org/publishing/epub3/",
+		"title": "EPUB 3 Overview",
+		"href": "https://www.w3.org/TR/epub-overview/",
+		"authors" : [
+			"Matt Garrish",
+			"Ivan Herman"
+		],
 		"publisher": "W3C"
 	},
 	"EPUB-31": {
@@ -58,7 +62,13 @@ var biblio = {
 	},
 	"EPUB-A11Y": {
 		"title": "EPUB Accessibility",
-		"href": "https://www.w3.org/publishing/epub/a11y/",
+		"href": "https://www.w3.org/TR/epub-a11y/",
+		"authors": [
+			"Matt Garrish",
+			"George Kerscher",
+			"Gregorio Pellegrino",
+			"Avneesh Singh"
+		],
 		"publisher": "W3C"
 	},
 	"EPUB-A11Y-10": {


### PR DESCRIPTION
I have changed the references for EPUB 3 and EPUB Accessibility from the `/publishing/` to `/TR` equivalents.

Two comments:

- we may have to go through the full list at some point, maybe prune the unnecessary ones
- we may want to re-publish the Overview document to get the editors right...

This fixes #1552