### PR TITLE
Add better explainer about linked records and precedence

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2421,9 +2421,14 @@
 </pre>
 							</aside>
 
-							<p id="sec-linked-records">Linked records are only intended to enhance the information
-								available to Reading Systems, and the package metadata typically contains important
-								rendering information.</p>
+							<p id="sec-linked-records">Authors MAY provide one or more <a href="#record">linked metadata
+									records</a> to enhance the information available to Reading Systems, but Reading
+								Systems are not required to process these records.</p>
+
+							<p>When a Reading System <a href="https://www.w3.org/TR/epub-rs-33/#sec-linked-records"
+									>processes linked records</a> [[!EPUB-RS-33]], the document order of
+									<code>link</code> elements is used to determine which has the highest priority in
+								the case of conflicts (i.e., first in document order has the highest priority).</p>
 
 							<aside class="example">
 								<p>The following example shows a remote record that has higher precedence than a local


### PR DESCRIPTION
Fixes #1530 

Removes the odd statement about the package metadata defining rendering info. That looks like a leftover of the 3.1 revision where we were thinking linked records might become more prominent. Didn't make sense in its current context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1555.html" title="Last updated on Mar 3, 2021, 8:32 PM UTC (5f728a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1555/7d0a2f9...5f728a6.html" title="Last updated on Mar 3, 2021, 8:32 PM UTC (5f728a6)">Diff</a>