### PR TITLE
Add requirement to collapse whitespace in metadata element values

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1560,7 +1560,7 @@
 
 						</section>
 
-						<section id="sec-package-elem-value">
+						<section id="sec-metadata-values">
 							<h5>Metadata Values</h5>
 
 							<p>The Dublin Core elements [[!DC11]] and <a href="#sec-meta-elem"><code>meta</code>
@@ -1573,6 +1573,11 @@
 									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
 									>leading and trailing ASCII whitespace</a> [[!Infra]] is stripped (i.e., they must
 								consist of at least one non-whitespace character).</p>
+
+							<p>Whitespace within these element values are not significant. Sequences of one or more
+								whitespace characters are <a
+									href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">collapsed
+									to a single space</a> [[!Infra]] during processing .</p>
 						</section>
 
 						<section id="sec-opf-dcmes-required">
@@ -8982,6 +8987,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>5-Mar-2021: Clarified that whitespace within metadata element values is collapsed per the
+						[[Infra]] specification definition. See <a href="https://github.com/w3c/epub-specs/issues/1528"
+							>issue 1528</a>.</li>
 					<li>26-Feb-2021: Created a new section for describing general metadata value requirements,
 						specifically whitespace handling. See <a href="https://github.com/w3c/epub-specs/issues/1528"
 							>issue 1528</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2187,7 +2187,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 
 				<ul>
 					<li>5-Mar-2021: Added requirement for reading systems to collapse whitespace in DCMES and meta
-						elements per the [[Infa]] specification definition. See <a
+						elements per the [[Infra]] specification definition. See <a
 							href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
 					<li>26-Feb-2021: Clarified the trimming of leading and trailing whitespace is to be done in
 						accordance with the [[Infra]] specification definition, and removed the exception that

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -337,11 +337,11 @@
 						<dt id="conf-meta-ws">White Space</dt>
 						<dd>
 							<p>Reading Systems MUST <a
-									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
-									>strip leading and trailing ASCII whitespace</a> [[!Infra]] from Dublin Core
-								[[!DC11]] and <a href="https://www.w3.org/TR/epub-33/#sec-meta-elem"
-									><code>meta</code></a> element <a href="https://www.w3.org/TR/epub-33/#dfn-value"
-									>values</a> [[!EPUB-33]] before processing.</p>
+									href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">strip and
+									collapse ASCII whitespace</a> [[!Infra]] from Dublin Core [[!DC11]] and <a
+									href="https://www.w3.org/TR/epub-33/#sec-meta-elem"><code>meta</code></a> element <a
+									href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[!EPUB-33]] before
+								processing.</p>
 						</dd>
 
 						<dt id="dc-identifier">The <code>identifier</code> element</dt>
@@ -2186,6 +2186,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>5-Mar-2021: Added requirement for reading systems to collapse whitespace in DCMES and meta
+						elements per the [[Infa]] specification definition. See <a
+							href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
 					<li>26-Feb-2021: Clarified the trimming of leading and trailing whitespace is to be done in
 						accordance with the [[Infra]] specification definition, and removed the exception that
 							<code>meta</code> element properties may define their own whitespace handling rules. See <a


### PR DESCRIPTION
Changes the trimming requirement in the RS spec to trim and collapse per issue #1528 and also adds a statement to the core spec that whitespace within elements is collapsed.

Fixes #1528 
Fixes #1295 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1295/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1295/epub33/rs/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1557.html" title="Last updated on Mar 9, 2021, 1:57 PM UTC (41ab9dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1557/c373ad9...41ab9dc.html" title="Last updated on Mar 9, 2021, 1:57 PM UTC (41ab9dc)">Diff</a>