### PR TITLE
Restructure the accessibility specification requirements

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -513,7 +513,7 @@
 						<h5>Objectives</h5>
 
 						<section id="sec-page-src">
-							<h4>Pagination Source</h4>
+							<h6>Pagination Source</h6>
 
 							<dl>
 								<dt id="sec-page-src-obj">Objective</dt>
@@ -543,7 +543,7 @@
 						</section>
 
 						<section id="sec-page-list">
-							<h5>Page List</h5>
+							<h6>Page List</h6>
 
 							<dl>
 								<dt id="sec-page-list-obj">Objective</dt>
@@ -578,7 +578,7 @@
 						</section>
 
 						<section id="sec-page-breaks">
-							<h4>Page Breaks</h4>
+							<h6>Page Breaks</h6>
 
 							<dl>
 								<dt id="sec-page-breaks-obj">Objective</dt>
@@ -667,8 +667,53 @@
 					<section id="sec-mo-obj">
 						<h5>Objectives</h5>
 
+						<section id="sec-mo-order">
+							<h6>Reading Order</h6>
+
+							<dl>
+								<dt id="sec-mo-order-obj">Objective</dt>
+								<dd>
+									<p>Ensure Media Overlay playback matches logical reading order.</p>
+								</dd>
+
+								<dt id="sec-mo-order-understand">Understanding this Objective</dt>
+								<dd>
+									<p>Every EPUB Publication has a default reading order that allows users to logically
+										progress through the content. It ensures that readers are able to follow the
+										primary narrative and also that secondary content is encountered where it makes
+										the most sense. The default reading order also establishes some less obvious
+										relations, like the progress within a table from cell to cell and row to
+										row.</p>
+									<p>If the sequence of <code>par</code> and <code>seq</code> elements in a Media
+										Overlay Documents does not match this progression, it can cause confusion for
+										readers, whether they are only listening to the audio or trying to also follow
+										visually.</p>
+									<p>Ordering the playback to match the default reading order is the safest way to
+										ensure that users can follow the text. In some cases, however, strict adherence
+										to this practice could result in a suboptimal reading experience (e.g., playback
+										of a table by column instead of row might make more logical sense in some
+										cases). The goal of this objective is not to forbid alternate presentations, but
+										to ensure that any deviations retain the logical flow of the content.</p>
+								</dd>
+
+								<dt id="sec-mo-order-conf">Meeting this Objective</dt>
+								<dd>
+									<p>The <code>par</code> and <code>seq</code> elements in a Media Overlays Document
+										SHOULD be ordered such that they reflect both:</p>
+									<ul>
+										<li>the order of the referenced EPUB Content Documents in the <a
+												href="https://www.w3.org/TR/epub/#dfn-spine">spine</a> [[!EPUB-3]];
+											and</li>
+										<li>the order of each element within its respective EPUB Content Document.</li>
+									</ul>
+									<p>If a different ordering is used, it MUST still result in a logical playback of
+										the content.</p>
+								</dd>
+							</dl>
+						</section>
+
 						<section id="sec-mo-skippability">
-							<h5>Skippability</h5>
+							<h6>Skippability</h6>
 
 							<dl>
 								<dt id="sec-mo-skippability-obj">Objective</dt>
@@ -702,7 +747,7 @@
 						</section>
 
 						<section id="sec-mo-escapability">
-							<h5>Escapability</h5>
+							<h6>Escapability</h6>
 
 							<dl>
 								<dt id="sec-mo-escapability-obj">Objective</dt>
@@ -737,7 +782,7 @@
 						</section>
 
 						<section id="sec-mo-navdoc">
-							<h5>Navigation Document</h5>
+							<h6>Navigation Document</h6>
 
 							<dl>
 								<dt id="sec-mo-navdoc-obj">Objective</dt>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -449,14 +449,8 @@
 				<section id="sec-page-nav">
 					<h4>Page Navigation</h4>
 
-					<section id="sec-page-nav-obj">
-						<h5>Objective</h5>
-
-						<p>Provide navigation to static page break locations.</p>
-					</section>
-
-					<section id="sec-page-nav-understand" class="informative">
-						<h5>Understanding this Objective</h5>
+					<section id="sec-page-nav-overview" class="informative">
+						<h5>Overview</h5>
 
 						<p>Statically paginated content is still ubiquitous, as print continues to be the most consumed
 							medium for books both among the general reading public and in educational settings. Print is
@@ -476,13 +470,28 @@
 							static since it changes depending on the viewport size and user's font settings. As a
 							result, coordinating locations among users of the same EPUB Publication can be complicated
 							without static references.</p>
+
+						<p>The inclusion of page navigation represents one method of achieving the <a
+								href="https://www.w3.org/TR/WCAG2/#multiple-ways">Multiple Ways success criterion</a>
+							[[WCAG2]], as it provides another meaningful way for users to access the content (e.g., in
+							addition to the table of contents, linear reading order and any other navigation aids).</p>
+
+						<p>Given the importance of page navigation in mixed print/digital environments, the requirement
+							to include this feature has higher precedence than it would be given solely as one of many
+							ways to meet the Multiple Ways success criterion.</p>
+
+						<div class="note">
+							<p>See <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-epub-page-markers">Page
+									Markers</a> [[EPUB-A11Y-TECH-11]] for more information on the inclusion of page
+								navigation in EPUB Publications.</p>
+						</div>
 					</section>
 
-					<section id="sec-page-nav-conf">
-						<h5>Meeting this Objective</h5>
+					<section id="sec-page-nav-applicability">
+						<h5>Applicability</h5>
 
-						<p>Authors SHOULD include page navigation in an EPUB Publication whenever any of the following
-							cases is true:</p>
+						<p>An EPUB Publication SHOULD include the page navigation objectives defined in this section in
+							whenever any of the following cases is true:</p>
 
 						<ul>
 							<li>the EPUB Publication is identified as the dynamically paginated equivalent of a
@@ -498,54 +507,99 @@
 
 						<p>Authors MAY include page navigation in reflowable EPUB Publications without statically
 							paginated equivalents.</p>
-
-						<p>A conformant EPUB Publication has to meet the following criteria when it includes page
-							navigation:</p>
-
-						<ul>
-							<li>It MUST provide a means of locating the page break locations.</li>
-
-							<li>It MAY include page break markers.</li>
-
-							<li>It MUST identify the source of the page breaks.</li>
-						</ul>
-
-						<p>In addition, if page numbers are read aloud in a synchronized text-audio playback of the
-							content (e.g., EPUB 3 Media Overlays [[EPUB-3]]), Authors MUST identify the page numbers in
-							the markup that controls the playback.</p>
-
-						<div class="note">
-							<p>See <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-epub-page-markers">Page
-									Markers</a> [[EPUB-A11Y-TECH-11]] for more information on the inclusion of page
-								navigation in EPUB Publications.</p>
-						</div>
 					</section>
 
-					<section id="sec-page-nav-wcag" class="informative">
-						<h5>Relationship to WCAG</h5>
+					<section id="sec-page-nav-obj">
+						<h5>Objectives</h5>
 
-						<p>The inclusion of page navigation represents one method of achieving the <a
-								href="https://www.w3.org/TR/WCAG2/#multiple-ways">Multiple Ways success criterion</a>
-							[[WCAG2]], as it provides another meaningful way for users to access the content (e.g., in
-							addition to the table of contents, linear reading order and any other navigation aids).</p>
+						<section id="sec-page-src">
+							<h4>Pagination Source</h4>
 
-						<p>Given the importance of page navigation in mixed print/digital environments, the requirement
-							to include this feature has higher precedence than it would be given solely as one of many
-							ways to meet the Multiple Ways success criterion.</p>
+							<dl>
+								<dt id="sec-page-src-obj">Objective</dt>
+								<dd>
+									<p>Identify the source of static page break locations.</p>
+								</dd>
+
+								<dt id="sec-page-src-understand">Understanding this Objective</dt>
+								<dd>
+									<p></p>
+								</dd>
+
+								<dt id="sec-page-src-conf">Meeting this Objective</dt>
+
+								<dd>
+									<p>Authors MUST identify the source of the pagination in the EPUB Publication
+										metadata.</p>
+								</dd>
+							</dl>
+						</section>
+
+						<section id="sec-page-list">
+							<h5>Page List</h5>
+
+							<dl>
+								<dt id="sec-page-list-obj">Objective</dt>
+								<dd>
+									<p>Provide navigation to static page break locations.</p>
+								</dd>
+
+								<dt id="sec-page-list-understand">Understanding this Objective</dt>
+								<dd>
+									<p></p>
+								</dd>
+
+								<dt id="sec-page-list-conf">Meeting this Objective</dt>
+								<dd>
+									<p>An EPUB Publication MUST include a page list.</p>
+									<p>Authors SHOULD include links to all pages of content reproduced from the source
+										(i.e., links are not required for blank pages or content not reproduced in the
+										digital edition).</p>
+									<p>Authors are encouraged to include links for all pages in the source whether they
+										are reproduced or not.</p>
+								</dd>
+							</dl>
+						</section>
+
+						<section id="sec-page-breaks">
+							<h4>Page Breaks</h4>
+
+							<dl>
+								<dt id="sec-page-breaks-obj">Objective</dt>
+								<dd>
+									<p>Provide static page break locations.</p>
+								</dd>
+
+								<dt id="sec-page-breaks-understand">Understanding this Objective</dt>
+								<dd>
+									<p></p>
+								</dd>
+
+								<dt id="sec-page-break-conf">Meeting this Objective</dt>
+								<dd>
+									<p>Inclusion of page break markers in an EPUB Publication is OPTIONAL.</p>
+									<p>If page break markers are included:</p>
+									<ul>
+										<li>Authors SHOULD include page break markers for all pages reproduced from the
+											source (i.e., markers are not required for blank pages or content not
+											reproduced in the digital edition).</li>
+										<li>Authors are encouraged to include page break markers for all pages in the
+											source whether they are reproduced or not.</li>
+									</ul>
+									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
+										of the content (e.g., EPUB 3 Media Overlays [[EPUB-3]]), Authors MUST identify
+										the page numbers in the markup that controls the playback.</p>
+								</dd>
+							</dl>
+						</section>
 					</section>
 				</section>
 
 				<section id="sec-mo">
 					<h4>Media Overlays Playback</h4>
 
-					<section id="sec-mo-obj">
-						<h5>Objective</h5>
-
-						<p>Structure Media Overlays [[!EPUB-3]] to provide more accessible playback experiences.</p>
-					</section>
-
-					<section id="sec-mo-understand" class="informative">
-						<h5>Understanding this Objective</h5>
+					<section id="sec-mo-overview" class="informative">
+						<h5>Overview</h5>
 
 						<p>Media Overlays provide an accessible playback experience for anyone who benefits from having
 							text and audio synchronized. They are also useful to users who only require audio playback,
@@ -563,41 +617,103 @@
 							narrative, escape users from deeply nested structures like tables, and allow them to
 							navigate through the sections of the publication without having to go to the table of
 							contents.</p>
-					</section>
-
-					<section id="sec-mo-conf">
-						<h5>Meeting this Objective</h5>
-
-						<p>Media Overlay Documents MUST meet the requirements in [[EPUB-3]]. It is not necessary to meet
-							any additional requirements beyond those defined in [[EPUB-3]] to be conformant with this
-							document.</p>
-
-						<p>To improve the usability of Media Overlays, however, Authors are encouraged to ensure their
-							EPUB Publications:</p>
-
-						<ul>
-							<li>identify all <a href="https://www.w3.org/TR/epub/#sec-skippability">skippable
-									structures</a> [[EPUB-3]] in the Media Overlay Documents;</li>
-							<li>identify all <a href="https://www.w3.org/TR/epub/#sec-escapability">escapable
-									structures</a> [[EPUB-3]] in the Media Overlay Documents; and</li>
-							<li>include a Media Overlay Document for the <a
-									href="https://www.w3.org/TR/epub/#sec-nav-doc">EPUB Navigation Document</a>
-								[[EPUB-3]].</li>
-						</ul>
-
-						<div class="note">
-							<p>This criterion does not require Authors to include Media Overlays in their EPUB
-								Publications, only that they conform to these requirements when present.</p>
-						</div>
-					</section>
-
-					<section id="sec-mo-wcag" class="informative">
-						<h5>Relationship to WCAG</h5>
 
 						<p>Adding structure and semantics to Media Overlay Documents broadly falls under the objective
 							of the <a href="https://www.w3.org/TR/WCAG2/#info-and-relationships">Info and Relationships
 								success criterion</a> [[WCAG2]]. Without structured and semantically meaningful playback
 							sequences, the effect is to deprive users of rich navigation of the content.</p>
+					</section>
+
+					<section id="sec-mo-applicability">
+						<h5>Applicability</h5>
+
+						<p>Media Overlay Documents MUST meet the requirements in [[EPUB-3]]. It is not necessary to meet
+							any additional requirements beyond those defined in [[EPUB-3]] to be conformant with this
+							document.</p>
+
+						<p>To improve the usability of Media Overlays, however, Authors are encouraged to meet the <a
+								href="#sec-mo-obj">objectives defined in this section</a>.</p>
+
+						<div class="note">
+							<p>Authors are not required to include Media Overlays in their EPUB Publications, only that
+								they conform to these requirements when present.</p>
+						</div>
+					</section>
+
+					<section id="sec-mo-obj">
+						<h5>Objectives</h5>
+
+						<section id="sec-mo-skippability">
+							<h5>Skippability</h5>
+
+							<dl>
+								<dt id="sec-mo-skippability-obj">Objective</dt>
+								<dd>
+									<p>Enable users to automatically skip over content.</p>
+								</dd>
+
+								<dt id="sec-mo-skippability-understand">Understanding this Objective</dt>
+								<dd>
+									<p></p>
+								</dd>
+
+								<dt id="sec-mo-skippability-conf">Meeting this Objective</dt>
+
+								<dd>
+									<p>Authors are encouraged to identify all <a
+											href="https://www.w3.org/TR/epub/#sec-skippability">skippable structures</a>
+										[[EPUB-3]] in Media Overlay Documents.</p>
+								</dd>
+							</dl>
+						</section>
+
+						<section id="sec-mo-escapability">
+							<h5>Escapability</h5>
+
+							<dl>
+								<dt id="sec-mo-escapability-obj">Objective</dt>
+								<dd>
+									<p>Enable users to automatically escape from structured content.</p>
+								</dd>
+
+								<dt id="sec-mo-escapability-understand">Understanding this Objective</dt>
+								<dd>
+									<p></p>
+								</dd>
+
+								<dt id="sec-mo-escapability-conf">Meeting this Objective</dt>
+
+								<dd>
+									<p>Authors are encouraged to identify all <a
+											href="https://www.w3.org/TR/epub/#sec-escapability">escapable structures</a>
+										[[EPUB-3]] in the Media Overlay Documents.</p>
+								</dd>
+							</dl>
+						</section>
+
+						<section id="sec-mo-navdoc">
+							<h5>Navigation Document</h5>
+
+							<dl>
+								<dt id="sec-mo-navdoc-obj">Objective</dt>
+								<dd>
+									<p>Enable users to automatically skip unwanted content when reading.</p>
+								</dd>
+
+								<dt id="sec-mo-navdoc-understand">Understanding this Objective</dt>
+								<dd>
+									<p></p>
+								</dd>
+
+								<dt id="sec-mo-navdoc-conf">Meeting this Objective</dt>
+
+								<dd>
+									<p>Authors are encouraged to include a Media Overlay Document for the <a
+											href="https://www.w3.org/TR/epub/#sec-nav-doc">EPUB Navigation Document</a>
+										[[EPUB-3]].</p>
+								</dd>
+							</dl>
+						</section>
 					</section>
 				</section>
 			</section>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1246,16 +1246,34 @@
 					>working group's issue tracker</a>.</p>
 
 			<section id="changes-latest">
-				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
+				<h3>Substantive changes since the <a href="https://www.w3.org/TR/2021/WD-epub-a11y-11-20210223/">First
+						Public Working Draft</a></h3>
+
+				<!--
+					After each working draft is published:
+						- change the link/text in the section heading to refer to the published draft (use the dated URL)
+						- move all changes down to the next section
+				-->
 
 				<ul>
 					<li>8-Mar-2021: Add objective for the sequence of <code>par</code> and <code>seq</code> elements in
 						media overlay documents to reflect a logical reading order. See <a
 							href="https://github.com/w3c/epub-specs/issues/1556">issue 1556</a>.</li>
-					<!-- todo add change log entry for page list and marker requirements when accepted -->
+					<li>5-Mar-2021: Added recommendation that page markers be included for all pages of content
+						reproduced from source and best practice to include markers for all pages in the source. See <a
+							href="https://github.com/w3c/epub-specs/issues/1502">issue 1502</a>.</li>
+					<li>5-Mar-2021: Added recommendation that page list include links to all pages of content reproduced
+						from source and best practice to include links to all pages in the source. See <a
+							href="https://github.com/w3c/epub-specs/issues/1503">issue 1503</a>.</li>
 					<li>5-Mar-2021: Restructured the EPUB Requirements section to split out the individual objectives
 						that were grouped together under the Page Navigation and Media Overlays headings. See <a
 							href="https://github.com/w3c/epub-specs/issues/1458">issue 1458</a>.</li>
+				</ul>
+			</section>
+
+			<section id="changes-older">
+				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
+				<ul>
 					<li>19-Feb-2021: References to WCAG 2.0 have been updated to undated references to WCAG 2 (except
 						where WCAG 2.0 is explicitly mentioned for conformance).</li>
 					<li>01-Feb-2021: Changed the recommendation that media overlays conform to the requirements of the
@@ -1271,18 +1289,6 @@
 						as an ISO standard have been incorporated into the initial draft text.</li>
 				</ul>
 			</section>
-
-			<!--
-				After FPWD:
-				- Uncomment this section and move all pre-FPWD changes above here
-				- Change link/reference in preceding section heading to FPWD
-			
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
-				<ul>
-				</ul>
-			</section>
-			-->
 		</section>
 		<div data-include="../common/acknowledgements-a11y.html" data-oninclude="fixIncludes"
 			data-include-replace="true"></div>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1249,6 +1249,13 @@
 				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
 
 				<ul>
+					<li>8-Mar-2021: Add objective for the sequence of <code>par</code> and <code>seq</code> elements in
+						media overlay documents to reflect a logical reading order. See <a
+							href="https://github.com/w3c/epub-specs/issues/1556">issue 1556</a>.</li>
+					<!-- todo add change log entry for page list and marker requirements when accepted -->
+					<li>5-Mar-2021: Restructured the EPUB Requirements section to split out the individual objectives
+						that were grouped together under the Page Navigation and Media Overlays headings. See <a
+							href="https://github.com/w3c/epub-specs/issues/1458">issue 1458</a>.</li>
 					<li>19-Feb-2021: References to WCAG 2.0 have been updated to undated references to WCAG 2 (except
 						where WCAG 2.0 is explicitly mentioned for conformance).</li>
 					<li>01-Feb-2021: Changed the recommendation that media overlays conform to the requirements of the

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -523,20 +523,20 @@
 
 								<dt id="sec-page-src-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Users need to know the source of the pagination in an EPUB Publication in order
-										to determine whether it will be useful for their needs. Print publications, for
+									<p>Users need to know the source of the pagination in an EPUB Publication to
+										determine whether it will be useful for their needs. Print publications, for
 										example, produced in both hard and soft cover editions will have different
 										pagination. Different editions of the same book often also have different
 										pagination.</p>
 									<p>Including a recognizable identifier for the statically paginated source, such as
-										its ISBN or ISSN, ensures that users are able to determine which version the
-										pagination corresponds to.</p>
+										its ISBN or ISSN, ensures that users can determine which version the pagination
+										corresponds to.</p>
 								</dd>
 
 								<dt id="sec-page-src-conf">Meeting this Objective</dt>
 
 								<dd>
-									<p>Authors MUST identify the source of the pagination in the <a>Package Document</a>
+									<p>Authors MUST identify the source of the pagination in the Package Document
 										metadata.</p>
 								</dd>
 							</dl>
@@ -595,7 +595,7 @@
 									<p>The inclusion of page break markers can also allow users to move quickly forwards
 										and backwards by page without having to access the page list each time.</p>
 									<p>The inclusion of these markers also simplifies the creation a <a
-											href="#sec-page-list">page list</a>, as the they provide easily referenced
+											href="#sec-page-list">page list</a>, as they provide easily referenced
 										destinations for the links.</p>
 								</dd>
 
@@ -712,12 +712,12 @@
 
 								<dt id="sec-mo-escapability-understand">Understanding this Objective</dt>
 								<dd>
-									<p>When reading visually, users are able to quickly move through, and escape from,
-										highly-structured content such as tables, lists, and figures. Tables, for
-										example, are laid out in rows and columns, which allows users to quickly move
-										along either axis to find the information they want, and to easily return to the
-										primary narrative when they are done. Lists, similarly, do not have to be read
-										in their entirety but can be escaped from once the desired information has been
+									<p>When reading visually, users can quickly move through, and escape from, highly
+										structured content such as tables, lists, and figures. Tables, for example, are
+										laid out in rows and columns, which allows users to quickly move along either
+										axis to find the information they want, and to easily return to the primary
+										narrative when they are done. Lists, similarly, do not have to be read in their
+										entirety but can be escaped from once the desired information has been
 										found.</p>
 									<p>The same ease of escaping from content is not available in Media Overlay
 										Documents by default. Users cannot escape from table cells, rows, or even the
@@ -751,7 +751,7 @@
 									<p>Reading Systems typically provide their own interfaces to the navigation aids in
 										the EPUB Navigation Document. The table of contents, for example, is often
 										opened as a specialized interface on top of the content being read.</p>
-									<p>To access these interfaces, users typically have rely on text-to-speech playback,
+									<p>To access these interfaces, users typically must rely on text-to-speech playback,
 										when available, to hear the entries.</p>
 									<p>Providing a Media Overlay Document for the EPUB Navigation Document provides
 										Reading Systems the ability to use auditory labels for the links, improving the

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -523,13 +523,20 @@
 
 								<dt id="sec-page-src-understand">Understanding this Objective</dt>
 								<dd>
-									<p></p>
+									<p>Users need to know the source of the pagination in an EPUB Publication in order
+										to determine whether it will be useful for their needs. Print publications, for
+										example, produced in both hard and soft cover editions will have different
+										pagination. Different editions of the same book often also have different
+										pagination.</p>
+									<p>Including a recognizable identifier for the statically paginated source, such as
+										its ISBN or ISSN, ensures that users are able to determine which version the
+										pagination corresponds to.</p>
 								</dd>
 
 								<dt id="sec-page-src-conf">Meeting this Objective</dt>
 
 								<dd>
-									<p>Authors MUST identify the source of the pagination in the EPUB Publication
+									<p>Authors MUST identify the source of the pagination in the <a>Package Document</a>
 										metadata.</p>
 								</dd>
 							</dl>
@@ -546,7 +553,16 @@
 
 								<dt id="sec-page-list-understand">Understanding this Objective</dt>
 								<dd>
-									<p></p>
+									<p>The page list is the primary means of navigating to page break locations as it
+										provides a list of links to each of the static page break locations in the EPUB
+										Publication.</p>
+									<p>Reading Systems typically use this list to generate a "go to page" interface in
+										which users can plug in the page number that they wish to move to, but sometimes
+										offer users the ability to access the full list and select the page number to go
+										to.</p>
+									<p>Without a page list, page navigation becomes extremely difficult as it would rely
+										on navigating the individual <a href="#sec-page-breaks">page break markers</a>
+										(if they are even present).</p>
 								</dd>
 
 								<dt id="sec-page-list-conf">Meeting this Objective</dt>
@@ -572,7 +588,15 @@
 
 								<dt id="sec-page-breaks-understand">Understanding this Objective</dt>
 								<dd>
-									<p></p>
+									<p>Inserting page breaks markers into an EPUB Publication provides users with
+										context about where they are in the text. Assistive technologies can use this
+										information to announce the current page number the user is on, for example, if
+										the user wants to cite something on the page.</p>
+									<p>The inclusion of page break markers can also allow users to move quickly forwards
+										and backwards by page without having to access the page list each time.</p>
+									<p>The inclusion of these markers also simplifies the creation a <a
+											href="#sec-page-list">page list</a>, as the they provide easily referenced
+										destinations for the links.</p>
 								</dd>
 
 								<dt id="sec-page-break-conf">Meeting this Objective</dt>
@@ -654,11 +678,21 @@
 
 								<dt id="sec-mo-skippability-understand">Understanding this Objective</dt>
 								<dd>
-									<p></p>
+									<p>Being able to read the primary narrative of a work without being interrupted is
+										central to reading comprehension. Publications are typically structured so that
+										secondary information such as sidebars and footnotes is visually represented as
+										outside the main narrative flow (e.g., by using different background colours or
+										placement so readers can filter this information visually out while
+										reading).</p>
+									<p>Readers who prefer auditory playback, however, cannot skip this information with
+										the same ease by default. Media overlays playback will typically result in
+										secondary content being read where it occurs.</p>
+									<p>By adding structural semantics to Media Overlay Documents, it is possible to
+										create reading experiences in which users can decide which secondary content to
+										skip by default during playback.</p>
 								</dd>
 
 								<dt id="sec-mo-skippability-conf">Meeting this Objective</dt>
-
 								<dd>
 									<p>Authors are encouraged to identify all <a
 											href="https://www.w3.org/TR/epub/#sec-skippability">skippable structures</a>
@@ -678,11 +712,22 @@
 
 								<dt id="sec-mo-escapability-understand">Understanding this Objective</dt>
 								<dd>
-									<p></p>
+									<p>When reading visually, users are able to quickly move through, and escape from,
+										highly-structured content such as tables, lists, and figures. Tables, for
+										example, are laid out in rows and columns, which allows users to quickly move
+										along either axis to find the information they want, and to easily return to the
+										primary narrative when they are done. Lists, similarly, do not have to be read
+										in their entirety but can be escaped from once the desired information has been
+										found.</p>
+									<p>The same ease of escaping from content is not available in Media Overlay
+										Documents by default. Users cannot escape from table cells, rows, or even the
+										table itself, unless the structural semantics of those elements is encoded in
+										the document.</p>
+									<p>By providing this information, it is possible to simplify playback for auditory
+										readers so that a comparable reading experience is available.</p>
 								</dd>
 
 								<dt id="sec-mo-escapability-conf">Meeting this Objective</dt>
-
 								<dd>
 									<p>Authors are encouraged to identify all <a
 											href="https://www.w3.org/TR/epub/#sec-escapability">escapable structures</a>
@@ -697,16 +742,23 @@
 							<dl>
 								<dt id="sec-mo-navdoc-obj">Objective</dt>
 								<dd>
-									<p>Enable users to automatically skip unwanted content when reading.</p>
+									<p>Ensure auditory playback is possible for the navigation aids in the EPUB
+										Navigation Document when presented by Reading Systems.</p>
 								</dd>
 
 								<dt id="sec-mo-navdoc-understand">Understanding this Objective</dt>
 								<dd>
-									<p></p>
+									<p>Reading Systems typically provide their own interfaces to the navigation aids in
+										the EPUB Navigation Document. The table of contents, for example, is often
+										opened as a specialized interface on top of the content being read.</p>
+									<p>To access these interfaces, users typically have rely on text-to-speech playback,
+										when available, to hear the entries.</p>
+									<p>Providing a Media Overlay Document for the EPUB Navigation Document provides
+										Reading Systems the ability to use auditory labels for the links, improving the
+										experience for auditory readers.</p>
 								</dd>
 
 								<dt id="sec-mo-navdoc-conf">Meeting this Objective</dt>
-
 								<dd>
 									<p>Authors are encouraged to include a Media Overlay Document for the <a
 											href="https://www.w3.org/TR/epub/#sec-nav-doc">EPUB Navigation Document</a>


### PR DESCRIPTION
This PR generally matches what I wrote in #1556 but I made a few additional changes:

- I merged the "relationship to wcag" sections into the general overviews.
- I grouped the requirements for each section under an "objectives" heading.
- I used definition lists within each objective as sectioning them seemed a bit excessive now that they're much smaller.

I also had to write "understanding" sections for all six objectives from scratch, so please take some time to review those.

And, finally, I integrated the page list and break requirements I had suggested in the other issues but only using normative keywords for now (no mention of levels). See if these make sense, too.

Otherwise, let me know if you find anything amiss or have any concerns with the new structure.


[Accessibility preview](https://raw.githack.com/w3c/epub-specs/restructure/a11y-spec/epub33/a11y/)
[Accessibility diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Frestructure%2Fa11y-spec%2Fepub33%2Fa11y%2Findex.html)

Fixes #1556 
Fixes #1458