### PR TITLE
Change in RS conformance on unique identifier

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -330,6 +330,15 @@
 							data-cite="bidi#P2">Rule P2</a> of [[!BIDI]].</p>
 				</section>
 
+				<section id="sec-pub-identifiers">
+					<h3>Unique Identifier</h3>
+
+					<p>Reading Systems SHOULD NOT depend on the <code>unique-identifier</code> attribute being unique to one and only one
+						EPUB Publication. Determining whether two EPUB Publications with the same Unique Identifier
+						represent different versions of the same publication, or different publications, might
+						require inspecting other metadata, such as the titles or authors.</p>
+				</section>
+	
 				<section id="metadata">
 					<h4>Metadata</h4>
 
@@ -351,6 +360,7 @@
 									href="https://www.w3.org/TR/epub-33/#identifier-type"><code>identifier-type</code>
 									property</a> [[!EPUB-33]].</p>
 						</dd>
+
 
 						<dt id="dc-title">The <code>title</code> element</dt>
 						<dd>
@@ -486,20 +496,6 @@
 						Reading Systems MUST ignore <code>collection</code> elements that define unrecognized roles.</p>
 				</section>
 
-			</section>
-
-			<section id="sec-pub-identifiers">
-				<h3>Publication Identifiers</h3>
-
-				<dl class="conformance-list">
-					<dt id="sec-unique-id">Unique Identifiers</dt>
-					<dd>
-						<p>Reading Systems MUST NOT depend on the Unique Identifier being unique to one and only one
-							EPUB Publication. Determining whether two EPUB Publications with the same Unique Identifier
-							represent different versions of the same publication, or different publications, might
-							require inspecting other metadata, such as the titles or authors.</p>
-					</dd>
-				</dl>
 			</section>
 		</section>
 		<section id="contentdocs">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2182,6 +2182,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>09-March-2021: the statement on unique identifiers has been set to non-normative, following 
+						the discussion and <a href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-12-18-epub#resolution2">Working Group resolution</a>. See <a href="https://github.com/w3c/epub-specs/issues/1310">issue 1310</a>.
+					</li>
 					<li>26-Feb-2021: Clarified the trimming of leading and trailing whitespace is to be done in
 						accordance with the [[Infra]] specification definition, and removed the exception that
 							<code>meta</code> element properties may define their own whitespace handling rules. See <a


### PR DESCRIPTION
Per [WG resolution](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-12-18-epub#resolution2) the statement on unique identifiers should not be normative.

I also propose an editorial change: after PR https://github.com/w3c/epub-specs/pull/1453 only the `unique-identifier` property is relevant as an identifier, so I created a new section on the package conformance to handle only that case and removed the old one that was a leftover of a time when we also had release identifiers.

Fixes #1310


See preview:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1310/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1310/epub33/rs/index.html)

