### PR TITLE
Clarify refines should reference pub resources by manifest id

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1247,7 +1247,7 @@
 									the ID of the resource's <a href="#sec-item-elem">manifest entry</a>.</p>
 								<aside class="example">
 									<p>The following example shows the <code>refines</code> element used to set the
-										duration of an XHTML Content Document.</p>
+										duration of an Media Overlay Document.</p>
 									<pre>&lt;metadata&gt;
    …
    &lt;meta property="media:duration" refines="#c01_overlay">0:32:29&lt;/meta>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1229,9 +1229,38 @@
 								<p>Establishes an association between the current expression and the element or resource
 									identified by its value. The value of the attribute must be a relative IRI
 									[[!RFC3987]] that references the resource or element being described.</p>
+								<aside class="example">
+									<p>The following example shows the <code>refines</code> element used to indicate a
+										creator is the illustrator.</p>
+									<pre>&lt;metadata&gt;
+   …
+   &lt;dc:creator id="creator02">E.H. Shepard&lt;/dc:creator>
+   &lt;meta refines="#creator02" property="role" scheme="marc:relators">ill&lt;/meta>
+   …
+&lt;/metadata&gt;</pre>
+								</aside>
 								<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata
 									being expressed. When omitted, the element defines a <a href="#primary-expression"
 										>primary expression</a>.</p>
+								<p>When creating expressions about a <a>Publication Resource</a>, the
+										<code>refines</code> attribute SHOULD be a fragment identifier that references
+									the ID of the resource's <a href="#sec-item-elem">manifest entry</a>.</p>
+								<aside class="example">
+									<p>The following example shows the <code>refines</code> element used to set the
+										duration of an XHTML Content Document.</p>
+									<pre>&lt;metadata&gt;
+   …
+   &lt;meta property="media:duration" refines="#c01_overlay">0:32:29&lt;/meta>
+   …
+&lt;/metadata&gt;
+&lt;manifest>
+   …
+   &lt;item id="c01_overlay"
+         href="overlays/chapter01.smil"
+         media-type="application/smil+xml"/>
+   …
+&lt;/manifest></pre>
+								</aside>
 								<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a
 										href="#sec-meta-elem"><code>meta</code></a>.</p>
 							</dd>
@@ -7387,12 +7416,12 @@ html.my-document-playing * {
 								<a>EPUB Publication</a> in a <a href="#elemdef-meta"><code>meta</code> element</a> with
 							the <a href="#duration"><code>duration</code> property</a>.</p>
 
-						<p>In addition, the duration of each EPUB Content Document with an associated Media Overlay MUST
-							be provided. The <a href="#attrdef-refines"><code>refines</code> attribute</a> is used to
-							associate each duration declaration to the corresponding <a>manifest</a>
+						<p>In addition, the duration of each Media Overlay Document MUST be provided. The <a
+								href="#attrdef-refines"><code>refines</code> attribute</a> is used to associate each
+							duration declaration to the corresponding <a>manifest</a>
 							<a href="#elemdef-package-item"><code>item</code></a>.</p>
 
-						<p>The sum of the durations for each EPUB Content Document SHOULD equal the <a
+						<p>The sum of the durations for each Media Overlay Document SHOULD equal the <a
 								href="#total-duration">total duration</a>.</p>
 
 						<p><a>Authors</a> also MAY specify <a href="#narrator"><code>narrator</code></a> information in
@@ -8982,6 +9011,12 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>8-Mar-2021: The fix for <a href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>
+						on 20-Jan-2021 incorrectly mentioned EPUB Content Documents having durations. Corrected to Media
+						Overlay Documents.</li>
+					<li>8-Mar-2021: Added recommendation that <code>refines</code> attribute use fragment identifiers to
+						reference Publication Resources. See <a href="https://github.com/w3c/epub-specs/issues/1313"
+							>issue 1313</a>.</li>
 					<li>26-Feb-2021: Created a new section for describing general metadata value requirements,
 						specifically whitespace handling. See <a href="https://github.com/w3c/epub-specs/issues/1528"
 							>issue 1528</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9015,8 +9015,8 @@ EPUB/images/cover.png</pre>
 						on 20-Jan-2021 incorrectly mentioned EPUB Content Documents having durations. Corrected to Media
 						Overlay Documents.</li>
 					<li>8-Mar-2021: Added recommendation that <code>refines</code> attribute use fragment identifiers to
-						reference Publication Resources. See <a href="https://github.com/w3c/epub-specs/issues/1313"
-							>issue 1313</a>.</li>
+						reference Publication Resources. See <a href="https://github.com/w3c/epub-specs/issues/1361"
+							>issue 1361</a>.</li>
 					<li>26-Feb-2021: Created a new section for describing general metadata value requirements,
 						specifically whitespace handling. See <a href="https://github.com/w3c/epub-specs/issues/1528"
 							>issue 1528</a>.</li>


### PR DESCRIPTION
(Reopening after realizing I fixed this in the wrong branch and referenced the wrong issue... Mondays.)

While looking for a real example of using refines for resources, I noticed the earlier fix for durations was incorrectly making the requirement to specify a duration for each epub content document. I've updated the section to specify durations are for media overlay documents.

Also adds a couple of examples to the refines definition.

Fixes #1361


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1561.html" title="Last updated on Mar 9, 2021, 1:56 PM UTC (7f47744)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1561/c301528...7f47744.html" title="Last updated on Mar 9, 2021, 1:56 PM UTC (7f47744)">Diff</a>