### PR TITLE
Remove requirement to assume default rendering property values

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1126,10 +1126,9 @@
 				<section id="layout">
 					<h4>The <code>rendition:layout</code> Property</h4>
 
-					<p>The default value <code>reflowable</code> MUST be assumed by <a>EPUB Reading Systems</a> as the
-						global value if no <code>meta</code> element carrying this property occurs in the <a
-							href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code> section</a>
-						[[!EPUB-33]].</p>
+					<p>The default global value is <code>reflowable</code> if no <code>meta</code> element carrying this
+						property occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"
+								><code>metadata</code> section</a> [[!EPUB-33]].</p>
 
 					<p>When the <code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading
 						Systems MUST NOT include space between the adjacent content slots when rendering <a>Synthetic
@@ -1154,9 +1153,8 @@
 				<section id="orientation">
 					<h4>The <code>rendition:orientation</code> Property</h4>
 
-					<p>The default value <code>auto</code> MUST be assumed by Reading Systems as the global value if no
-							<code>meta</code> element carrying this property occurs in the <code>metadata</code>
-						section.</p>
+					<p>The default global value is <code>auto</code> if no <code>meta</code> element carrying this
+						property occurs in the <code>metadata</code> section.</p>
 
 					<p>Reading Systems that support multiple orientations SHOULD convey the intended orientation to the
 						user unless the given value is <code>auto</code>. The means by which the intent is conveyed is
@@ -1166,9 +1164,8 @@
 				<section id="spread">
 					<h4>The <code>rendition:spread</code> Property</h4>
 
-					<p>The default value <code>auto</code> MUST be assumed by Reading Systems as the global value if no
-							<code>meta</code> element carrying this property occurs in the <code>metadata</code>
-						section.</p>
+					<p>The default global value is <code>auto</code> if no <code>meta</code> element carrying this
+						property occurs in the <code>metadata</code> section.</p>
 
 					<p>The <code>rendition:spread</code> property values have the following processing requirements:</p>
 
@@ -1841,10 +1838,10 @@
 							overflow content, but MAY provide the option for users to override the requested
 							rendering.</p>
 
-						<p>The default value <code>auto</code> MUST be assumed by Reading Systems as the global value if
-							no <code>meta</code> element carrying this property occurs in the <a
-								href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code>
-								section</a> [[!EPUB-33]]. Reading Systems MAY support only this default value.</p>
+						<p>The default global value is <code>auto</code> when no <code>meta</code> element carrying this
+							property occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"
+									><code>metadata</code> section</a> [[!EPUB-33]]. Reading Systems MAY support only
+							this default value.</p>
 
 						<p>If a Reading Systems supports the <a href="#layout"><code>rendition:layout</code></a>
 							property, it MUST ignore the <code>rendition:flow</code> property when it has been set on a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1838,7 +1838,7 @@
 							overflow content, but MAY provide the option for users to override the requested
 							rendering.</p>
 
-						<p>The default global value is <code>auto</code> when no <code>meta</code> element carrying this
+						<p>The default global value is <code>auto</code> if no <code>meta</code> element carrying this
 							property occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"
 									><code>metadata</code> section</a> [[!EPUB-33]]. Reading Systems MAY support only
 							this default value.</p>
@@ -2183,6 +2183,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>8-Mar-2021: Remove unnecessary requirement to assume default value for rendering metadata. See
+							<a href="https://github.com/w3c/epub-specs/issues/1313">issue 1313</a>.</li>
 					<li>26-Feb-2021: Clarified the trimming of leading and trailing whitespace is to be done in
 						accordance with the [[Infra]] specification definition, and removed the exception that
 							<code>meta</code> element properties may define their own whitespace handling rules. See <a


### PR DESCRIPTION
Issue #1313 only makes reference to the rendition:flow property, but this requirement to assume the default value is stated for every rendering property. I've updated all the instances to say "The default global value is xxx if no meta element..."

Fixes #1313 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1313/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1313/epub33/rs/index.html)
