### PR TITLE
Remove requirement for overlay order to match reading order

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7064,9 +7064,7 @@ store destination as source in ocf
 							of two elements: the <a href="#elemdef-smil-par"><code>par</code> element</a> and the <a
 								href="#elemdef-smil-seq"><code>seq</code> element</a>. The ordering of these elements
 							represents how the content in the corresponding EPUB Content Documents is rendered during
-							playback. In general, the order of these elements will match the order of the elements in
-							each EPUB Content Document (i.e., the logical reading order), but other rendering orders are
-							possible.</p>
+							playback.</p>
 
 						<p>The <code>par</code> element represents phrases. Each element identifies a text and audio
 							component to synchronize during playback.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7063,7 +7063,10 @@ store destination as source in ocf
 						<p>The <a href="#elemdef-smil-body"><code>body</code></a> of a Media Overlay Document consists
 							of two elements: the <a href="#elemdef-smil-par"><code>par</code> element</a> and the <a
 								href="#elemdef-smil-seq"><code>seq</code> element</a>. The ordering of these elements
-							MUST match the default reading order of the EPUB Content Document.</p>
+							represents how the content in the corresponding EPUB Content Documents is rendered during
+							playback. In general, the order of these elements will match the order of the elements in
+							each EPUB Content Document (i.e., the logical reading order), but other rendering orders are
+							possible.</p>
 
 						<p>The <code>par</code> element represents phrases. Each element identifies a text and audio
 							component to synchronize during playback.</p>
@@ -8982,6 +8985,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>8-Mar-2021: Change requirement that Media Overlay <code>par</code> and <code>seq</code> ordering
+						match the default reading order to guidance. See <a
+							href="https://github.com/w3c/epub-specs/issues/1458">issue 1458</a></li>
 					<li>26-Feb-2021: Created a new section for describing general metadata value requirements,
 						specifically whitespace handling. See <a href="https://github.com/w3c/epub-specs/issues/1528"
 							>issue 1528</a>.</li>


### PR DESCRIPTION
This PR only addresses the media overlays part of the issue. I'm going to add this as a requirement to the accessibility specification, but I want to make it fit with the pending re-org in #1558 so am going to update that PR with the requirement.

Fixes #1458

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1563.html" title="Last updated on Mar 8, 2021, 7:06 PM UTC (bf09ce2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1563/6f49938...bf09ce2.html" title="Last updated on Mar 8, 2021, 7:06 PM UTC (bf09ce2)">Diff</a>