### PR TITLE
Clarify that meta-inf directory is only for configuration files

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5554,15 +5554,16 @@ Spine:
 					<p>The virtual file system for the <a>OCF Abstract Container</a> MUST have a single common <a>Root
 							Directory</a> for all the contents of the container.</p>
 
-					<p> The OCF Abstract Container MUST include a directory named <code>META-INF</code> that is a direct
-						child of the container's Root Directory. Requirements for the contents of this directory are
-						described in <a href="#sec-container-metainf"></a>.</p>
+					<p>The OCF Abstract Container MUST include a directory for configuration files named
+							<code>META-INF</code> that is a direct child of the container's Root Directory. Requirements
+						for the contents of this directory are described in <a href="#sec-container-metainf"></a>.</p>
 
 					<p>The file name <code>mimetype</code> in the Root Directory is reserved for use by <a>OCF ZIP
 							Containers</a>, as explained in <a href="#sec-container-zip"></a>.</p>
 
 					<p>All other files within the OCF Abstract Container MAY be in any location descendant from the Root
-						Directory, provided they are not within the <code>META-INF</code> directory.</p>
+						Directory, provided they are not within the <code>META-INF</code> directory. In particular,
+						files referenced from an EPUB Publication MUST NOT be in <code>META-INF</code>.</p>
 				</section>
 
 				<section id="sec-container-iri">
@@ -5727,9 +5728,8 @@ Spine:
 						<p>All <a>OCF Abstract Containers</a> MUST include a directory called <code>META-INF</code> in
 							their <a>Root Directory</a>.</p>
 
-						<p>This directory contains the files specified in <a href="#sec-container-metainf-files"></a>.
-							Files other than the ones listed in that section MAY be included in the
-								<code>META-INF</code> directory.</p>
+						<p>This directory is reserved for configuration files, in particular those specified in <a
+								href="#sec-container-metainf-files"></a>.</p>
 					</section>
 
 					<section id="sec-container-metainf-files">
@@ -9017,6 +9017,8 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>10-Mar-2021: Require that Publication Resources not be located in the <code>META-INF</code>
+						directory. See <a href="https://github.com/w3c/epub-specs/issues/1205">issue 1205</a>.</li>
 					<li>8-Mar-2021: The fix for <a href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>
 						on 20-Jan-2021 incorrectly mentioned EPUB Content Documents having durations. Corrected to Media
 						Overlay Documents.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9017,8 +9017,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
-					<li>10-Mar-2021: Require that Publication Resources not be located in the <code>META-INF</code>
-						directory. See <a href="https://github.com/w3c/epub-specs/issues/1205">issue 1205</a>.</li>
+					<li>10-Mar-2021: Require that resources referenced from an EPUB Publication not be located in the
+							<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205"
+							>issue 1205</a>.</li>
 					<li>8-Mar-2021: The fix for <a href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>
 						on 20-Jan-2021 incorrectly mentioned EPUB Content Documents having durations. Corrected to Media
 						Overlay Documents.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1350,7 +1350,7 @@
 
 						<dt id="sec-container-metainf-inc">Other Files</dt>
 						<dd>
-							<p><a>Reading Systems</a> MUST NOT fail when encountering files in the <code
+							<p><a>Reading Systems</a> MUST NOT fail when encountering configuration files in the <code
 									class="filename">META-INF</code> directory not listed in <a
 									href="https://www.w3.org/TR/epub-33/#sec-container-metainf-files">Reserved Files</a>
 								[[!EPUB-33]].</p>


### PR DESCRIPTION
Implements the text in https://github.com/w3c/epub-specs/issues/1205#issuecomment-463439151.

The reading system requirement to not fail on unknown files was already present so I only added the word "configuration" to match the core spec wording.

Fixes #1205


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1565.html" title="Last updated on Mar 10, 2021, 1:33 PM UTC (cef8975)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1565/4f841dc...cef8975.html" title="Last updated on Mar 10, 2021, 1:33 PM UTC (cef8975)">Diff</a>