### PR TITLE
Change requirement not to use resources listed in the package document

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2542,6 +2542,12 @@
 									<code>item</code> element that refers to the Package Document itself.</p>
 
 							<div class="note">
+								<p>Failure to provide a complete manifest of resources may lead to rendering issues.
+									Reading Systems might not unzip such resources or could prevent access to them for
+									security reasons.</p>
+							</div>
+
+							<div class="note">
 								<p>This specification supports internationalized resource naming, so elements and
 									attributes that reference Publication Resources accept IRIs as their value. For
 									compatibility with older Reading Systems that only accept URIs, resource names need

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -305,10 +305,10 @@
 							defined in <a href="#sec-fxl-props"></a>.</p>
 					</li>
 					<li>
-						<p id="confreq-rendition-rs-manifest">It MUST NOT use any resources not listed in the Package
-							Document in the processing of the Package (e.g., <a
-								href="https://www.w3.org/TR/epub-33/#sec-container-metainf"><code>META-INF</code>
-								files</a> [[EPUB-33]]).</p>
+						<p id="confreq-rendition-rs-manifest">It SHOULD NOT use non-<a>Publication Resources</a> in the
+							rendering of an EPUB Publication due to the inherent limitations and risks involved (e.g.,
+							lack of information about the resource and how to process it, security risks from
+							remotely-hosted sources, lack of fallbacks, etc.).</p>
 					</li>
 				</ul>
 			</section>
@@ -2183,6 +2183,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>10-Mar-2021: Changed restriction against using resources not listed in the Package Document to a
+						recommendation not to use. See <a href="https://github.com/w3c/epub-specs/issues/810">issue
+							810</a>.</li>
 					<li>8-Mar-2021: Remove unnecessary requirement to assume default value for rendering metadata. See
 							<a href="https://github.com/w3c/epub-specs/issues/1313">issue 1313</a>.</li>
 					<li>5-Mar-2021: Added requirement for reading systems to collapse whitespace in DCMES and meta


### PR DESCRIPTION
This PR implements the prose in https://github.com/w3c/epub-specs/issues/810#issuecomment-758615369

I've also added a note to the core spec explaining that resources omitted from the manifest may not render.

I'm assuming we don't want to get into how reading systems might alert users or ask for permission as we've avoided trying to spec this level of detail in the past.

Fixes #810 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-810/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-810/epub33/rs/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1567.html" title="Last updated on Mar 10, 2021, 6:08 PM UTC (4ee82a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1567/e548933...4ee82a3.html" title="Last updated on Mar 10, 2021, 6:08 PM UTC (4ee82a3)">Diff</a>