### PR TITLE
Add note about distribution requirements in EU

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1104,7 +1104,7 @@
 				<p>Although it is not required to follow the recommendations in this section to conform to this
 					specification, some jurisdictions require these practices be followed. <a
 						href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">Directive
-						2019/882</a>, for example, includes similar requirements for digital publications produced in
+						2019/882</a>, for example, includes similar requirements for digital publications distributed in
 					the European Union.</p>
 			</div>
 

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -368,11 +368,11 @@
 
 					<div class="note">
 						<p>Examples of legislative requirements for accessibility include the <a
-								href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">2019
-								European Union (EU) Directive</a> and <a href="https://www.access-board.gov/ict/"
-								>Section 508 of the Rehabilitation Act of 1973 (United States)</a>. EPUB Publications
-							will need to meet more than just the basic Level A success criteria to be compliant with
-							these laws.</p>
+								href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">Directive
+								2019/882</a> in the European Union and <a href="https://www.access-board.gov/ict/"
+								>Section 508 of the Rehabilitation Act of 1973</a> in the United States. EPUB
+							Publications will need to meet more than just the basic Level A success criteria to be
+							compliant with these laws.</p>
 					</div>
 
 					<p>Keeping pace with WCAG has the benefit of continuously enhancing access for users. As web
@@ -1097,8 +1097,16 @@
 					endorsement of the standards is implied.</p>
 			</div>
 		</section>
-		<section id="sec-distribution">
+		<section id="sec-distribution" class="informative">
 			<h2>Distribution</h2>
+
+			<div class="note">
+				<p>Although it is not required to follow the recommendations in this section to conform to this
+					specification, some jurisdictions require these practices be followed. <a
+						href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">Directive
+						2019/882</a>, for example, includes similar requirements for digital publications produced in
+					the European Union.</p>
+			</div>
 
 			<p>The creation of an EPUB Publication that is accessible does not in itself guarantee that the content will
 				be obtainable or consumable by users. Depending on how the EPUB Publication is distributed, other
@@ -1120,8 +1128,8 @@
 				following distribution practices:</p>
 
 			<ul>
-				<li>they MUST NOT impose restrictions that impair access by assistive technologies; and</li>
-				<li>they MUST include accessibility metadata in the record format required for distribution of an EPUB
+				<li>they must not impose restrictions that impair access by assistive technologies; and</li>
+				<li>they must include accessibility metadata in the record format required for distribution of an EPUB
 					Publication when such metadata is supported by the format.</li>
 			</ul>
 
@@ -1308,6 +1316,9 @@
 				-->
 
 				<ul>
+					<li>12-Mar-2021: Changed the distribution section to informative but added a note that the
+						requirements have to be followed where required by law (e.g., in the EU). See <a
+							href="https://github.com/w3c/epub-specs/issues/1487">issue 1487</a>.</li>
 					<li>8-Mar-2021: Add objective for the sequence of <code>par</code> and <code>seq</code> elements in
 						media overlay documents to reflect a logical reading order. See <a
 							href="https://github.com/w3c/epub-specs/issues/1556">issue 1556</a>.</li>


### PR DESCRIPTION
This PR makes the changes noted on the 2021-03-11 telecon - changes the distribution section to informative but adds a note to the top that the requirements may be required by law, specifically citing the EU directive.

- [Accessibility preview](https://raw.githack.com/w3c/epub-specs/fix/issue-1487/epub33/a11y/)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Fa11y%2F&doc2=https%3A%2F%2Flabs.w3.org%2Fspec-generator%2F%3Ftype%3Drespec%26url%3Dhttps%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Ffix%2Fissue-1487%2Fepub33%2Fa11y%2Findex.html)

Fixes #1487 