### PR TITLE
Change Author to EPUB Creator

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -82,10 +82,10 @@
 
 				<ul>
 					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-author">Author</a>
+						<a href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB Content Document</a>
 					</li>
 					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB Content Document</a>
+						<a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB Creator</a>
 					</li>
 					<li>
 						<a href="https://www.w3.org/TR/epub/#dfn-epub-navigation-document">EPUB Navigation Document</a>
@@ -119,7 +119,7 @@
 			<h2>About the Techniques</h2>
 
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
-				Authors create EPUB Publications that conform to the requirements in [[EPUB-A11Y-11]], but they are not
+				EPUB Creators create EPUB Publications that conform to the requirements in [[EPUB-A11Y-11]], but they are not
 				all applicable in all situations and there may be other ways to meet the requirements of that
 				specification. As a result, this document should not be read as providing prescriptive requirements.</p>
 
@@ -128,7 +128,7 @@
 				these issues [[DPUB-Accessibility]]. As solutions become available, they will be incorporated into the
 				appropriate document, whether this one or one it refers to.</p>
 
-			<p>If Authors encounter issues that are not covered in these or related techniques, they are encouraged to
+			<p>If EPUB Creators encounter issues that are not covered in these or related techniques, they are encouraged to
 				report the issue to the appropriate community for guidance on how to meet accessibility standards. The
 					<a href="https://www.w3.org/WAI/IG/">W3C Web Accessibility Interest Group</a> has a public mailing
 				list where issues meeting [[WCAG2]] and [[WAI-ARIA-1.1]] requirements can be raised. The <a
@@ -205,7 +205,7 @@
 					Repeat the property for each set of sufficient access modes.</p>
 
 				<p>For example, consider an EPUB Publication that contains graphics and charts, as well as descriptions
-					for all these images. The publication has both textual and visual content, so the Author will
+					for all these images. The publication has both textual and visual content, so the EPUB Creator will
 					include the following metadata entries to indicate this:</p>
 
 				<div class="example">
@@ -217,7 +217,7 @@
 					publication, or whether a visual one is, only that two modes are required by default. This
 					discrepancy is why sufficiency is also important to know.</p>
 
-				<p>The first set of sufficiency metadata the Author inputs will establish the textual and visual
+				<p>The first set of sufficiency metadata the EPUB Creator inputs will establish the textual and visual
 					requirement:</p>
 
 				<div class="example">
@@ -227,7 +227,7 @@
 				<p>The order in which the access modes are listed is not important. The only requirement is that they be
 					separated by commas.</p>
 
-				<p>Since the Author has also included descriptions for all the images, the Author can also indicate that
+				<p>Since the EPUB Creator has also included descriptions for all the images, the EPUB Creator can also indicate that
 					a purely textual access mode is sufficient to read the content:</p>
 
 				<div class="example">
@@ -254,9 +254,9 @@
 </pre>
 				</div>
 
-				<p>Note that sufficiency of access is often a subjective determination of the Author based on their
+				<p>Note that sufficiency of access is often a subjective determination of the EPUB Creator based on their
 					understanding of what information is essential to comprehending the text. Some information loss
-					occurs by not being able to view a video, for example, but the Author might regard the visual or
+					occurs by not being able to view a video, for example, but the EPUB Creator might regard the visual or
 					auditory losses as inconsequential if a transcript provides all the necessary information to
 					understand the concepts being conveyed.</p>
 
@@ -328,7 +328,7 @@
 					</li>
 				</ul>
 
-				<p>Authors have to report whether their EPUB Publications contain resources that present any of these
+				<p>EPUB Creators have to report whether their EPUB Publications contain resources that present any of these
 					hazards to users, as they can have real physical effects.</p>
 
 				<p>Hazards are identified in the [[schema-org]] <a href="https://schema.org/accessibilityHazard"
@@ -406,7 +406,7 @@
 				<h3>META-006: Identify ARIA Conformance</h3>
 
 				<p>The use of the <code>schema:accesibilityAPI</code> property is no longer necessary for EPUB
-					Publications. Authors are not responsible for the interaction between Reading Systems and the
+					Publications. EPUB Creators are not responsible for the interaction between Reading Systems and the
 					underlying platform APIs.</p>
 
 				<p>Meeting the requirements of [[WCAG2]] is a better measure of the accessibility of scripting, as this
@@ -534,7 +534,7 @@
 				<section class="suppress-numbering" id="sec-wcag-general-res">
 					<h4>Helpful Resources</h4>
 
-					<p>Authors not familiar with the [[WCAG2]] may find the number of techniques daunting, as they are
+					<p>EPUB Creators not familiar with the [[WCAG2]] may find the number of techniques daunting, as they are
 						intended to provide broad coverage of possible solutions.</p>
 
 					<p>Assistance applying these techniques to EPUB Content Documents is available from the following
@@ -567,7 +567,7 @@
 						EPUB Content Document has a meaningful order, but that the order is meaningful from document to
 						document.</p>
 
-					<p>Authors need to ensure that all EPUB Content Documents are included in the <a
+					<p>EPUB Creators need to ensure that all EPUB Content Documents are included in the <a
 							href="https://www.w3.org/TR/epub/#sec-spine-elem">spine</a> [[EPUB-3]] and put in sequence
 						so that the reading order is preserved.</p>
 
@@ -593,7 +593,7 @@
 &lt;/package&gt;</pre>
 					</aside>
 
-					<p>Authors also need to ensure that they identify whether items in the spine contain primary or
+					<p>EPUB Creators also need to ensure that they identify whether items in the spine contain primary or
 						supplementary information using the <a href="https://www.w3.org/TR/epub/#attrdef-itemref-linear"
 								><code>linear</code> attribute</a> [[EPUB-3]] so that the Reading System can optimally
 						present such content.</p>
@@ -615,7 +615,7 @@
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#multiple-ways">Success Criterion
 						2.4.5</a> requires there be more than one way to locate a Web page within a set of Web pages. By
-						default, EPUB Publications meet this WCAG requirement so long as Authors follow the EPUB
+						default, EPUB Publications meet this WCAG requirement so long as EPUB Creators follow the EPUB
 						requirements to <a href="https://www.w3.org/TR/epub/#sec-spine-elem">include all EPUB Content
 							Documents in the spine</a> and <a href="https://www.w3.org/TR/epub/#sec-itemref-elem">ensure
 							access to all non-linear documents</a> [[EPUB-3]].</p>
@@ -633,10 +633,10 @@
 						how the publication is chunked.</p>
 
 					<p>Following these two requirements therefore satisfies the need for multiple ways to access the
-						content. Reading Systems also typically provide search capabilities, something the Author cannot
+						content. Reading Systems also typically provide search capabilities, something the EPUB Creator cannot
 						provide, so users also have a third option available in most cases.</p>
 
-					<p>Although Authors only need to follow EPUB requirements to meet this criterion, they are still
+					<p>Although EPUB Creators only need to follow EPUB requirements to meet this criterion, they are still
 						encouraged to provide additional methods to improve access beyond the minimum. Some suggestions
 						include:</p>
 
@@ -663,7 +663,7 @@
 							usability challenges to this approach.</p>
 
 						<p>Factors such as device screen sizes can make the table of contents for publications with a
-							deep hierarchy of headings unreadable, so Authors will trim headings below a certain depth
+							deep hierarchy of headings unreadable, so EPUB Creators will trim headings below a certain depth
 							to improve the readability. Further, Reading Systems do not always provide structured access
 							to the headings in the table of contents, or provide shortcuts to navigate the links. The
 							result is that users have to listen to each link one at a time to find where they want to
@@ -673,7 +673,7 @@
 							accessibility support for EPUB evolves — making complete tables of contents usable by
 							everyone — there are legitimate usability reasons why they are not provided now.</p>
 
-						<p>When Authors choose not to provide links to all the headings, however, they should optimize
+						<p>When EPUB Creators choose not to provide links to all the headings, however, they should optimize
 							the linking they do provide for the best overall reading experience. Some considerations on
 							how to achieve this include:</p>
 
@@ -701,7 +701,7 @@
 						return to previous locations when the order of entries in the table of contents does not match
 						the linear reading order.</p>
 
-					<p>Authors should therefore ensure that the entries in the table of contents always match the linear
+					<p>EPUB Creators should therefore ensure that the entries in the table of contents always match the linear
 						order of the content. Specifically, the order of entries should reflect both:</p>
 
 					<ul>
@@ -715,12 +715,12 @@
 						table of contents for a magazine might be ordered to list all the major articles first, followed
 						by features, etc.</p>
 
-					<p>When the ordering of the table of contents does not match the content, Authors should include an
+					<p>When the ordering of the table of contents does not match the content, EPUB Creators should include an
 						explanation why in the <a href="#meta-005">accessibility summary</a>.</p>
 
-					<p>Authors should avoid including links to supplementary content at the end of the table of
+					<p>EPUB Creators should avoid including links to supplementary content at the end of the table of
 						contents. Links to figure, tables, illustrations and similar content is better included as a
-						separate navigation elements (either in the EPUB Navigation Document or in the spine). Authors
+						separate navigation elements (either in the EPUB Navigation Document or in the spine). EPUB Creators
 						can include links to these additional navigation lists in the table of contents.</p>
 				</section>
 			</section>
@@ -735,7 +735,7 @@
 							attribute</a> is used to provide additional semantic information about the host markup to
 						Assistive Technologies. The use of roles allows Assistive Technologies to automatically scan the
 						markup and compile a list of <a href="#sem-003">landmarks</a> for users, enabling quick access
-						to key features of the content. Authors can attach this attribute to any element.</p>
+						to key features of the content. EPUB Creators can attach this attribute to any element.</p>
 
 					<aside class="example">
 						<p>The following example shows a generic landmark role. The name to use for this landmark is
@@ -801,7 +801,7 @@
 							</li>
 						</ul>
 
-						<p>The following documents explain the application of ARIA roles for Authors already familiar
+						<p>The following documents explain the application of ARIA roles for EPUB Creators already familiar
 							with the use of the EPUB 3 <code>type</code> attribute for semantic inflection:</p>
 
 						<ul>
@@ -825,9 +825,9 @@
 						books, for an EPUB Publication to contain only one Content Document with all the content in
 						it.</p>
 
-					<p>When content is chunked in this way, it often requires the Author to make decisions about how
+					<p>When content is chunked in this way, it often requires the EPUB Creator to make decisions about how
 						best to restructure the information. A part, for example, will typically not include all the
-						chapters that belong to it. The Author will instead separate the part heading from each chapter,
+						chapters that belong to it. The EPUB Creator will instead separate the part heading from each chapter,
 						putting each into a separate document.</p>
 
 					<p>Although visually these restructuring decisions can be hidden from readers, they impact the
@@ -836,12 +836,12 @@
 						An Assistive Technology cannot provide a list of landmarks for the whole publication, as it
 						cannot see outside the current document.</p>
 
-					<p>To counteract this destructuring effect, Authors sometimes think to re-add or re-identify
+					<p>To counteract this destructuring effect, EPUB Creators sometimes think to re-add or re-identify
 						structures in the belief that having this information in every document will be helpful to users
 						(e.g., adding an extra [[HTML]] <code>section</code> element around a chapter to indicate it
 						belongs to a part, or putting the part semantic on the <code>body</code> tag). All this practice
 						does, however, is add repetition that is not only disruptive when reading but can make the
-						structure of the publication harder to follow. Authors are therefore advised not to attempt to
+						structure of the publication harder to follow. EPUB Creators are therefore advised not to attempt to
 						rebuild structures in these ways.</p>
 
 					<p>For example, consider a book that has five parts and each part contains five chapters.
@@ -909,7 +909,7 @@
 						landmarks</a> [[EPUB-3]]: both are designed to provide users with quick access to the major
 						structures of a document, such as chapters, glossaries and indexes. ARIA landmarks are compiled
 						automatically by Assistive Technologies from the <a href="#sem-001">roles</a> that have been
-						applied to the markup, so Authors only need to follow the requirement to include roles for the
+						applied to the markup, so EPUB Creators only need to follow the requirement to include roles for the
 						landmarks to be made available to users.</p>
 
 					<p>Although automatic generation of ARIA landmarks simplifies authoring, it also means that ARIA
@@ -918,7 +918,7 @@
 						it cannot provide a complete picture of all the landmarks in a multi-document publication (see
 						the <a href="#sem-002">previous section</a> for more discussion about content chunking).</p>
 
-					<p>EPUB landmarks, on the other hand, are compiled by the Author prior to distribution, and are not
+					<p>EPUB landmarks, on the other hand, are compiled by the EPUB Creator prior to distribution, and are not
 						directly linked to the use of the <a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
 								><code>type</code> attribute</a> [[EPUB-3]] in the content. They are designed to
 						simplify linking to major sections of the publication in a machine-readable way, as Reading
@@ -930,7 +930,7 @@
 						not rely only on the presence of ARIA roles to facilitate navigation, and vice versa. Each aids
 						navigation in its own way.</p>
 
-					<p>The EPUB specification does not require that Authors include a specific set of landmarks, but it
+					<p>The EPUB specification does not require that EPUB Creators include a specific set of landmarks, but it
 						is recommended to include a link to the start of the body matter as well as to any major
 						reference sections (e.g., table of contents, endnotes, bibliography, glossary, index).</p>
 
@@ -1074,14 +1074,14 @@
 						the part will have an <code>h2</code> heading).</p>
 
 					<p>Technique <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G141">G141: Organizing a page
-							using headings</a> instructs Authors on correctly using numbered headings within a document,
+							using headings</a> instructs EPUB Creators on correctly using numbered headings within a document,
 						but with EPUB Publications the numbered headings also need to remain consistent across
 						documents. Practically, this means that each EPUB Content Document does not have to begin with
 						an <code>h1</code> heading unless the first heading is a top-level heading — the first heading
 						needs to have a numbered heading element that reflects its actual position in the
 						publication.</p>
 
-					<p>Authors also to need chunk their content so that the first heading in a document always has the
+					<p>EPUB Creators also to need chunk their content so that the first heading in a document always has the
 						highest number. For example, if a document starts with an <code>h3</code> heading, there should
 						not be an <code>h2</code> heading later in the document (e.g., do not include the start of a new
 						section with the trailing subsections of the previous). It is acceptable for there to be
@@ -1137,7 +1137,7 @@
 					<p>The first version of these techniques only required alternative text for images regardless of
 						their complexity. This exception is no longer valid.</p>
 
-					<p>Authors must now ensure that their image-based content meets [[WCAG2]] requirements for
+					<p>EPUB Creators must now ensure that their image-based content meets [[WCAG2]] requirements for
 						alternative text and extended descriptions to conform with [[EPUB-A11Y-11]].</p>
 
 					<section class="suppress-numbering" id="sec-desc-001-res">
@@ -1179,7 +1179,7 @@
 					<p>The use of Unicode characters for all text content avoids this problem, allowing content to
 						successfully meet the minimum requirement for Level A.</p>
 
-					<p>For compliance with Level AA, Authors are directed to <a
+					<p>For compliance with Level AA, EPUB Creators are directed to <a
 							href="https://www.w3.org/TR/WCAG2/#images-of-text">Success Criterion 1.4.5</a> which further
 						restricts the use of images of text to only a set of essential cases.</p>
 				</section>
@@ -1207,11 +1207,11 @@
 					contains more than one rendition will only have access to the default. Unless this rendition is the
 					accessible one, the EPUB Publication might not be readable by them.</p>
 
-				<p>Authors therefore need to use their best discretion when implementing this functionality to meet
+				<p>EPUB Creators therefore need to use their best discretion when implementing this functionality to meet
 					accessibility requirements. EPUB Publications that contain multiple renditions are conformant to the
 					[[EPUB-A11Y-11]] specification if at least one rendition meets all the content requirements, but
-					Authors at a minimum need to note that a Reading System that supports multiple renditions is
-					required in their <a href="#meta-005">accessibility summary</a>. Any other methods the Author can
+					EPUB Creators at a minimum need to note that a Reading System that supports multiple renditions is
+					required in their <a href="#meta-005">accessibility summary</a>. Any other methods the EPUB Creator can
 					use to make this dependence known is advisable (e.g., in the <a href="#dist-002">distribution
 						metadata</a>).</p>
 
@@ -1273,7 +1273,7 @@
 						in the audio playback of a publication it is not only distracting, but can be confusing, as well
 						(e.g., the number could be read out in the middle of a sentence).</p>
 
-					<p>To mitigate this potential annoyance to readers, Authors need to identify page announcements in
+					<p>To mitigate this potential annoyance to readers, EPUB Creators need to identify page announcements in
 						the EPUB 3 media overlays document when they are included. Identification allows a Reading
 						System to provide a playback experience where the numbers are automatically skipped.</p>
 

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -94,8 +94,8 @@
 
 				<p>Although it has always been possible to create EPUB Publications with a high degree of accessibility,
 					this document also sets formal requirements for content to be certified as accessible. These
-					requirements provide Authors a clear set of guidelines to evaluate their content against and allow
-					certification of quality. An accessible EPUB Publication is one that meets the accessibility
+					requirements provide EPUB Creators a clear set of guidelines to evaluate their content against and
+					allow certification of quality. An accessible EPUB Publication is one that meets the accessibility
 					requirements as described in <a href="#sec-access-pub"></a>.</p>
 
 				<p>The document also establishes how to identify content that is optimized for specific user needs so
@@ -134,7 +134,7 @@
 				<p>This document is designed to be applicable to any EPUB Publication, even if the content conforms to
 					an older version of EPUB that does not refer to this document (e.g., EPUB 2 [[OPF-201]]).</p>
 
-				<p>Authors of such EPUB Publications are encouraged to create content in conformance with the
+				<p>Creators of such EPUB Publications are encouraged to create content in conformance with the
 					accessibility and discoverability requirements of this document. Upgrading to the latest version of
 					EPUB to get access to the most advanced accessibility features and techniques is also
 					encouraged.</p>
@@ -147,10 +147,10 @@
 
 				<ul>
 					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-author">Author</a>
+						<a href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB Content Document</a>
 					</li>
 					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB Content Document</a>
+						<a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB Creator</a>
 					</li>
 					<li>
 						<a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB Publication</a>
@@ -254,7 +254,7 @@
 					</li>
 				</ul>
 
-				<p>Authors MAY include additional accessibility metadata not specified in this section.</p>
+				<p>EPUB Creators MAY include additional accessibility metadata not specified in this section.</p>
 
 				<div class="note">
 					<p>See <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-discovery">Discovery Metadata
@@ -357,13 +357,13 @@
 						be adapted for use wherever accessibility is mandated but without negating or superseding the
 						requirements in effect in any region.</p>
 
-					<p>The baseline requirement for WCAG 2.0 Level A, for example, is primarily intended to provide
-						Authors backwards compatibility for older content and flexibility to encourage adoption of
+					<p>The baseline requirement for WCAG 2.0 Level A, for example, is primarily intended to provide EPUB
+						Creators backwards compatibility for older content and flexibility to encourage adoption of
 						accessible production where no formal requirements exist. It is not generally recognized as
 						providing a high degree of accessibility.</p>
 
-					<p>Ideally, Authors should try to conform to the latest version of WCAG at Level AA, but the formal
-						thresholds they must meet will be defined by local and national laws, or by procurer or
+					<p>Ideally, EPUB Creators should try to conform to the latest version of WCAG at Level AA, but the
+						formal thresholds they must meet will be defined by local and national laws, or by procurer or
 						distributor requirements.</p>
 
 					<div class="note">
@@ -383,8 +383,8 @@
 
 					<p>Similarly, Level AA conformance is often cited as the benchmark for accessibility in legal
 						frameworks and policies. The reason for this is that it provides the greatest range of
-						improvements that can realistically be implemented (Authors are encouraged to try and meet the
-						AAA requirements if they can, but fully conforming at AAA is typically not possible). Only
+						improvements that can realistically be implemented (EPUB Creators are encouraged to try and meet
+						the AAA requirements if they can, but fully conforming at AAA is typically not possible). Only
 						meeting level A requires compromises for various user groups that can again result in a less
 						optimal reading experience.</p>
 				</section>
@@ -429,7 +429,7 @@
 							<li>When determining compliance with a conformance level, the whole EPUB Publication MUST
 								meet the conformance requirements of the level claimed.</li>
 
-							<li>Authors MUST NOT use EPUB's fallback mechanisms to provide a <a
+							<li>EPUB Creators MUST NOT use EPUB's fallback mechanisms to provide a <a
 									href="https://www.w3.org/TR/WCAG2/#dfn-conforming-alternate-version">conforming
 									alternate version</a> [[!WCAG2]], as there is no reliable way for users to access
 								such fallbacks. If fallbacks are used, both the primary content and its fallback(s) MUST
@@ -513,7 +513,7 @@
 								workflow that allows the retention of page break locations across formats.</li>
 						</ul>
 
-						<p>Authors MAY include page navigation in reflowable EPUB Publications without statically
+						<p>EPUB Creators MAY include page navigation in reflowable EPUB Publications without statically
 							paginated equivalents.</p>
 					</section>
 
@@ -544,7 +544,7 @@
 								<dt id="sec-page-src-conf">Meeting this Objective</dt>
 
 								<dd>
-									<p>Authors MUST identify the source of the pagination in the Package Document
+									<p>EPUB Creators MUST identify the source of the pagination in the Package Document
 										metadata.</p>
 								</dd>
 							</dl>
@@ -576,11 +576,11 @@
 								<dt id="sec-page-list-conf">Meeting this Objective</dt>
 								<dd>
 									<p>An EPUB Publication MUST include a page list.</p>
-									<p>Authors SHOULD include links to all pages of content reproduced from the source
-										(i.e., links are not required for blank pages or content not reproduced in the
-										digital edition).</p>
-									<p>Authors are encouraged to include links for all pages in the source whether they
-										are reproduced or not.</p>
+									<p>EPUB Creators SHOULD include links to all pages of content reproduced from the
+										source (i.e., links are not required for blank pages or content not reproduced
+										in the digital edition).</p>
+									<p>EPUB Creators are encouraged to include links for all pages in the source whether
+										they are reproduced or not.</p>
 								</dd>
 							</dl>
 						</section>
@@ -612,15 +612,15 @@
 									<p>Inclusion of page break markers in an EPUB Publication is OPTIONAL.</p>
 									<p>If page break markers are included:</p>
 									<ul>
-										<li>Authors SHOULD include page break markers for all pages reproduced from the
-											source (i.e., markers are not required for blank pages or content not
-											reproduced in the digital edition).</li>
-										<li>Authors are encouraged to include page break markers for all pages in the
-											source whether they are reproduced or not.</li>
+										<li>EPUB Creators SHOULD include page break markers for all pages reproduced
+											from the source (i.e., markers are not required for blank pages or content
+											not reproduced in the digital edition).</li>
+										<li>EPUB Creators are encouraged to include page break markers for all pages in
+											the source whether they are reproduced or not.</li>
 									</ul>
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
-										of the content (e.g., EPUB 3 Media Overlays [[EPUB-3]]), Authors MUST identify
-										the page numbers in the markup that controls the playback.</p>
+										of the content (e.g., EPUB 3 Media Overlays [[EPUB-3]]), EPUB Creators MUST
+										identify the page numbers in the markup that controls the playback.</p>
 								</dd>
 							</dl>
 						</section>
@@ -643,7 +643,7 @@
 							They indicate the text to highlight and the audio clip that corresponds to the text. The
 							result is that users only have basic start and stop options available.</p>
 
-						<p>Authors need to add structure and semantics to media overlay documents to allow Reading
+						<p>EPUB Creators need to add structure and semantics to media overlay documents to allow Reading
 							Systems to present more usable experiences. With richer markup, a Reading System could
 							provide the ability to skip past secondary content that interferes with the primary
 							narrative, escape users from deeply nested structures like tables, and allow them to
@@ -663,12 +663,12 @@
 							any additional requirements beyond those defined in [[EPUB-3]] to be conformant with this
 							document.</p>
 
-						<p>To improve the usability of Media Overlays, however, Authors are encouraged to meet the <a
-								href="#sec-mo-obj">objectives defined in this section</a>.</p>
+						<p>To improve the usability of Media Overlays, however, EPUB Creators are encouraged to meet the
+								<a href="#sec-mo-obj">objectives defined in this section</a>.</p>
 
 						<div class="note">
-							<p>Authors are not required to include Media Overlays in their EPUB Publications, only that
-								they conform to these requirements when present.</p>
+							<p>EPUB Creators are not required to include Media Overlays in their EPUB Publications, only
+								that they conform to these requirements when present.</p>
 						</div>
 					</section>
 
@@ -747,7 +747,7 @@
 
 								<dt id="sec-mo-skippability-conf">Meeting this Objective</dt>
 								<dd>
-									<p>Authors are encouraged to identify all <a
+									<p>EPUB Creators are encouraged to identify all <a
 											href="https://www.w3.org/TR/epub/#sec-skippability">skippable structures</a>
 										[[EPUB-3]] in Media Overlay Documents.</p>
 								</dd>
@@ -782,7 +782,7 @@
 
 								<dt id="sec-mo-escapability-conf">Meeting this Objective</dt>
 								<dd>
-									<p>Authors are encouraged to identify all <a
+									<p>EPUB Creators are encouraged to identify all <a
 											href="https://www.w3.org/TR/epub/#sec-escapability">escapable structures</a>
 										[[EPUB-3]] in the Media Overlay Documents.</p>
 								</dd>
@@ -813,7 +813,7 @@
 
 								<dt id="sec-mo-navdoc-conf">Meeting this Objective</dt>
 								<dd>
-									<p>Authors are encouraged to include a Media Overlay Document for the <a
+									<p>EPUB Creators are encouraged to include a Media Overlay Document for the <a
 											href="https://www.w3.org/TR/epub/#sec-nav-doc">EPUB Navigation Document</a>
 										[[EPUB-3]].</p>
 								</dd>
@@ -955,8 +955,8 @@
 					</aside>
 
 					<aside class="example">
-						<p>The following example shows an EPUB 3 Publication that has been self-evaluated by the
-							author.</p>
+						<p>The following example shows an EPUB 3 Publication that has been self-evaluated by the EPUB
+							Creator.</p>
 						<pre>&lt;metadata&gt;
   …
   &lt;dc:creator&gt;Jane Doe&lt;/dc:creator&gt;
@@ -1112,20 +1112,20 @@
 				be obtainable or consumable by users. Depending on how the EPUB Publication is distributed, other
 				factors will influence its overall accessibility.</p>
 
-			<p>Not all these factors are under the control of the Author. For example, an accessible interface for
+			<p>Not all these factors are under the control of the EPUB Creator. For example, an accessible interface for
 				locating and obtaining content is an essential part of the distribution process, as is the ability to
-				search and review accessibility metadata. Such interfaces are typically out of the control of content
-				Authors, however, as distribution of EPUB Publications is often done through third parties. Even when an
-				Author controls their own distribution, the accessibility of their bookstore, library and/or Reading
-				System can be outside their control.</p>
+				search and review accessibility metadata. Such interfaces are typically out of the control of EPUB
+				Creators, however, as distribution of EPUB Publications is often done through third parties. Even when
+				an EPUB Creator controls their own distribution, the accessibility of their bookstore, library and/or
+				Reading System can be outside their control.</p>
 
-			<p>There are, however, decisions an Author can control when their content is distributed, such as what
+			<p>There are, however, decisions an EPUB Creator can control when their content is distributed, such as what
 				digital rights to apply to their EPUB Publications. Although these decisions are not part of the
 				preparation of their EPUB Publications, their potential impact on users means attention needs to be paid
 				to them.</p>
 
-			<p>To minimize the effects of distribution on accessibility, Authors are therefore advised to adhere to the
-				following distribution practices:</p>
+			<p>To minimize the effects of distribution on accessibility, EPUB Creators are therefore advised to adhere
+				to the following distribution practices:</p>
 
 			<ul>
 				<li>they must not impose restrictions that impair access by assistive technologies; and</li>
@@ -1135,10 +1135,10 @@
 
 			<div class="note">
 				<p>A distributor may implement a digital rights management scheme that inherently impairs accessibility
-					through no fault of the Author. Following the guidance in this section does not restrict Authors
-					from using such distributors. The intent is that the Author does not impair accessibility by
-					activating a feature that that would normally not be active (e.g., restricting access to the text by
-					assistive technologies).</p>
+					through no fault of the EPUB Creator. Following the guidance in this section does not restrict EPUB
+					Creators from using such distributors. The intent is that the EPUB Creator does not impair
+					accessibility by activating a feature that that would normally not be active (e.g., restricting
+					access to the text by assistive technologies).</p>
 			</div>
 		</section>
 		<section id="privacy">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -117,7 +117,7 @@
 					functionality normatively referenced as part of the standard. New functionality is also added
 					periodically through the development of extension specifications. Features and functionality defined
 					outside of core revisions to the standard, while not formally recognized in this specification, are
-					nonetheless available for use by <a>Authors</a> and Reading System developers.</p>
+					nonetheless available for use by <a>EPUB Creators</a> and Reading System developers.</p>
 
 				<p>The informative <a href="https://www.w3.org/TR/epub-overview-33/">EPUB 3 Overview</a>
 					[[EPUB-OVERVIEW-33]] provides a general introduction to EPUB 3. A list of technical changes from the
@@ -184,9 +184,9 @@
 					EPUB 3 is provided in the informative [[EPUB-OVERVIEW-33]].</p>
 
 				<p>The processing requirements for <a>Reading Systems</a> are defined in [[EPUB-RS-33]]. Although it is
-					not necessary that Authors read that document to create EPUB Publications, an understanding of how
-					Reading Systems present the content can help craft publications for optimal presentation to
-					users.</p>
+					not necessary that <a>EPUB Creators</a> read that document to create EPUB Publications, an
+					understanding of how Reading Systems present the content can help craft publications for optimal
+					presentation to users.</p>
 			</section>
 
 			<section id="sec-intro-relations" class="informative">
@@ -199,10 +199,10 @@
 						it. That standard, in turn, references various technologies that continue to evolve, such as
 						MathML, SVG, CSS, and JavaScript.</p>
 
-					<p>The benefit of this approach for EPUB is that EPUB Publications always keep pace with changes to
-						the Web without the need for new revisions. Authors, however, will need to keep track of the
-						various changes to HTML and the technologies it references, and ensure that their processes are
-						kept up to date.</p>
+					<p>The benefit of this approach for EPUB is that <a>EPUB Publications</a> always keep pace with
+						changes to the Web without the need for new revisions. <a>EPUB Creators</a>, however, will need
+						to keep track of the various changes to HTML and the technologies it references, and ensure that
+						their processes are kept up to date.</p>
 
 					<div class="warning">
 						<p>As HTML evolves, it is possible that features that were valid in previous versions could
@@ -214,7 +214,7 @@
 						of semantics, structure and processing behaviors from HTML unless otherwise specified.</p>
 
 					<p>In addition, this specification <a href="#sec-xhtml-extensions">defines a set of extensions</a>
-						to the [[HTML]] document model that <a>Authors</a> can include in <a>XHTML Content
+						to the [[HTML]] document model that EPUB Creators can include in <a>XHTML Content
 						Documents</a>.</p>
 				</section>
 
@@ -225,14 +225,14 @@
 						reference. Whenever there is any ambiguity in this reference, the latest recommended
 						specification is the authoritative reference.</p>
 
-					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. Authors
-						and Reading System developers will need to keep track of changes to the SVG standard and ensure
-						that their processes are kept up to date.</p>
+					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. <a>EPUB
+							Creators</a> will need to keep track of changes to the SVG standard and ensure that their
+						processes are kept up to date.</p>
 
 					<div class="caution">
 						<p>As SVG evolves, it is possible that features that were valid in previous versions could
 							become obsolete or be removed. It is anticipated that the W3C will make any such changes
-							carefully to ensure minimal disruption for Authors, but in the case of a
+							carefully to ensure minimal disruption for EPUB Creators, but in the case of a
 							backwards-incompatible revision the use of an undated reference could be revisited.</p>
 					</div>
 				</section>
@@ -247,8 +247,8 @@
 				<section id="d46451e218">
 					<h4>Relationship to SMIL</h4>
 
-					<p>This specification relies on a subset of [[SMIL3]], from which the EPUB Media Overlays elements
-						and attributes defined in <a href="#sec-overlays-def"></a> are derived.</p>
+					<p>This specification relies on a subset of [[SMIL3]], from which the Media Overlays elements and
+						attributes defined in <a href="#sec-overlays-def"></a> are derived.</p>
 				</section>
 			</section>
 
@@ -260,13 +260,6 @@
 				<p>Only the first instance of a term in a section is linked to its definition.</p>
 
 				<dl class="termlist">
-					<dt>
-						<dfn id="dfn-author" data-lt="Authors">Author</dfn>
-					</dt>
-					<dd>
-						<p>The person(s) or organization responsible for the creation of an <a>EPUB Publication</a>. The
-							Author is not necessarily the creator of the content.</p>
-					</dd>
 					<dt>
 						<dfn id="dfn-codec" data-lt="Codecs">Codec</dfn>
 					</dt>
@@ -314,6 +307,19 @@
 							referenced from another EPUB Content Document.</p>
 						<p>An EPUB Content Document is a <a>Core Media Type Resource</a>, so can be included without the
 							provision of <a href="#sec-foreign-restrictions">fallbacks</a>.</p>
+					</dd>
+					<dt>
+						<dfn id="dfn-epub-creator" data-lt="EPUB Creators">EPUB Creator</dfn>
+					</dt>
+					<dd>
+						<p>The person(s) or organization responsible for the creation of an <a>EPUB Publication</a>.</p>
+						<p>Depending on how EPUB Publications are produced, EPUB Creator may sometimes refer to
+							responsibilities of the organization (e.g., the publisher) or the individuals preparing the
+							publication (e.g., technical editors).</p>
+						<div class="note">
+							<p>Previous versions of this specification referred to the EPUB Creator as the <dfn
+									id="dfn-author">Author</dfn>.</p>
+						</div>
 					</dd>
 					<dt>
 						<dfn id="dfn-epub-navigation-document" data-lt="EPUB Navigation Documents">EPUB Navigation
@@ -431,8 +437,8 @@
 					<dd>
 						<p>A resource that contains content or instructions that contribute to the logic and rendering
 							of an <a>EPUB Publication</a>. In the absence of this resource, the EPUB Publication might
-							not render as intended by the <a>Author</a>. Examples of Publication Resources include the
-								<a>Package Document</a>, <a>EPUB Content Document</a>, CSS Style Sheets, audio, video,
+							not render as intended by the <a>EPUB Creator</a>. Examples of Publication Resources include
+							the <a>Package Document</a>, <a>EPUB Content Document</a>, CSS Style Sheets, audio, video,
 							images, embedded fonts, and scripts.</p>
 						<p>Publication Resources are listed in the Package Document <a href="#sec-manifest-elem"
 								>manifest</a> and bundled in the <a>EPUB Container</a> file unless specified otherwise
@@ -637,7 +643,7 @@
 						<p>Formats are typically only included as Core Media Type Resources when it can be shown that
 							they have broad support in web browser cores &#8212; the rendering engines on which EPUB 3
 							Reading Systems are built. They are an agreement between Reading System developers and
-								<a>Authors</a> to ensure the predictability of rendering of EPUB Publications.</p>
+								<a>EPUB Creators</a> to ensure the predictability of rendering of EPUB Publications.</p>
 
 						<p>Inclusion as a Core Media Type Resource does not mean that all Reading Systems will support
 							the rendering of a resource, however. Only Reading Systems that can render the type of
@@ -766,10 +772,13 @@
 								<tr>
 									<td colspan="3" id="cmt-vide-note">EPUB 3 allows any video codecs to be included
 										without fallbacks, although none are technically considered Core Media Type
-										Resources. Refer to the note in <a
-											href="https://www.w3.org/TR/epub-rs-33/#note-video-codecs">Conformance —
-											General Requirements</a> [[EPUB-RS-33]] for informative recommendations on
-										support for video codecs in EPUB Publications. </td>
+										Resources. Although Reading Systems are recommended to support at least one of
+										the H.264 [[H264]] and VP8 [[RFC6386]] video codecs, it is not a conformance
+										requirement &#8212; a Reading System might support other video codecs, or none
+										at all. EPUB Creators and need to take into consideration factors such as
+										breadth of adoption, video playback quality, and technology usage royalty
+										requirements when making a choice to include video in either format, or both.
+									</td>
 								</tr>
 								<tr>
 									<th colspan="3" id="cmt-grp-text" class="tbl-group">Style</th>
@@ -906,12 +915,12 @@
 								<a href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
 									><code>foreignObject</code></a> elements).</p>
 
-						<p class="note">This exception allows Authors to include resources in the <a>EPUB Container</a>
-							that are not for use by EPUB Reading Systems. The primary case for this exception is to
-							allow data files to travel with an EPUB Publication, whether for use by scripts in its
-							constituent EPUB Content Documents or for use by external applications (e.g., a scientific
-							journal might include a data set with instructions on how to extract it from the EPUB
-							Container).</p>
+						<p class="note">This exception allows EPUB Creators to include resources in the <a>EPUB
+								Container</a> that are not for use by EPUB Reading Systems. The primary case for this
+							exception is to allow data files to travel with an EPUB Publication, whether for use by
+							scripts in its constituent EPUB Content Documents or for use by external applications (e.g.,
+							a scientific journal might include a data set with instructions on how to extract it from
+							the EPUB Container).</p>
 
 						<p id="confreq-cmt">When a <a>Foreign Resource</a> is included in the spine or directly rendered
 							in its native format in an EPUB Content Document, a fallback <a>Core Media Type Resource</a>
@@ -965,9 +974,8 @@
 						</li>
 					</ul>
 
-					<p>Authors are encouraged to locate these resources inside the EPUB Container
-						whenever feasible to allow users access to the entire presentation regardless of
-						connectivity status.</p>
+					<p>EPUB Creators are encouraged to locate these resources inside the EPUB Container whenever
+						feasible to allow users access to the entire presentation regardless of connectivity status.</p>
 
 					<aside class="example">
 						<p>The following example shows a reference to an audio file in an <a>XHTML Content Document</a>
@@ -1035,7 +1043,7 @@
 						<p>Although EPUB Reading Systems are <a
 								href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-xml-base">required to support</a>
 							[[EPUB-RS-33]] the XML `base` attribute [[XMLBase]], [[HTML]] and [[SVG]] are removing
-							support. Authors are advised to avoid using this feature.</p>
+							support. EPUB Creators are advised to avoid using this feature.</p>
 					</div>
 				</section>
 			</section>
@@ -1561,8 +1569,8 @@
 								metadata is OPTIONAL.</p>
 
 							<aside class="example">
-								<p>The following example shows the minimal set of metadata that Authors have to include
-									in the Package Document.</p>
+								<p>The following example shows the minimal set of metadata that EPUB Creators have to
+									include in the Package Document.</p>
 								<pre>&lt;package … unique-identifier="pub-id"&gt;
     …
     &lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
@@ -1655,7 +1663,7 @@
 									</dd>
 								</dl>
 
-								<p>The <a>Author</a> MUST provide an identifier that is unique to one and only one
+								<p>The <a>EPUB Creator</a> MUST provide an identifier that is unique to one and only one
 										<a>EPUB Publication</a> &#8212; its <a>Unique Identifier</a> &#8212; in an
 										<code>identifier</code> element. This <code>identifier</code> element MUST
 									specify an <code>id</code> attribute whose value is referenced from the <a
@@ -1681,8 +1689,8 @@
 									NOT be issued when making minor revisions such as updating metadata, fixing errata,
 									or making similar minor changes.</p>
 
-								<p>Authors MAY specify additional identifiers. It is strongly advised that identifiers
-									be fully qualified URIs.</p>
+								<p>EPUB Creators MAY specify additional identifiers. It is strongly advised that
+									identifiers be fully qualified URIs.</p>
 
 								<p>The <a href="#identifier-type"><code>identifier-type</code> property</a> is used to
 									indicate that an <code>identifier</code> conforms to an established system or has
@@ -1962,8 +1970,8 @@
 &lt;/metadata></pre>
 								</aside>
 
-								<p>The <code>creator</code> element SHOULD contain the name of the creator as the Author
-									intends it to be displayed to a user. The <a href="#file-as"><code>file-as</code>
+								<p>The <code>creator</code> element SHOULD contain the name of the creator as it is
+									intended to be displayed to a user. The <a href="#file-as"><code>file-as</code>
 										property</a> MAY be <a href="#subexpression">associated with the element</a> to
 									include a normalized form of the name, and the <a href="#alternate-script"
 											><code>alternate-script</code> property</a> to represent a creator's name in
@@ -2041,8 +2049,8 @@
 									label, but MAY be the code value if the subject taxonomy does not provide a separate
 									descriptive label.</p>
 
-								<p>Authors MAY identify the system or scheme the element's <a>value</a> is drawn from
-									using the <a href="#authority"><code>authority</code> property</a>.</p>
+								<p>EPUB Creators MAY identify the system or scheme the element's <a>value</a> is drawn
+									from using the <a href="#authority"><code>authority</code> property</a>.</p>
 
 								<p>When a scheme is identified, a subject code MUST be <a href="#subexpression"
 										>associated with the element</a> using the <a href="#term"><code>term</code>
@@ -2077,8 +2085,8 @@
 									format).</p>
 
 								<p>An informative registry of specialized EPUB Publication types for use with this
-									element is maintained in the [[TypesRegistry]], but Authors MAY use any text string
-									as a <a>value</a>.</p>
+									element is maintained in the [[TypesRegistry]], but EPUB Creators MAY use any text
+									string as a <a>value</a>.</p>
 							</section>
 
 						</section>
@@ -2194,8 +2202,8 @@
 								the following IRI [[!RFC3987]] stem MUST be used to generate the resulting IRI:
 									<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
 
-							<p>Authors MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-								></a>.</p>
+							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
+									href="#sec-vocab-assoc"></a>.</p>
 
 							<aside class="example">
 								<p>The following example shows various property declarations using <a
@@ -2243,7 +2251,7 @@
 &lt;/metadata&gt;</pre>
 							</aside>
 
-							<p>Authors MUST update the last modified date whenever changes are made to the EPUB
+							<p>EPUB Creators MUST update the last modified date whenever changes are made to the EPUB
 								Publication.</p>
 
 							<p>Additional modified properties MAY be specified in the Package Document metadata, but
@@ -2386,8 +2394,8 @@
 							</aside>
 
 							<p id="linked-res-location">Linked resources MAY be located <a data-lt="Local Resource"
-									>locally</a> or <a data-lt="Remote Resource">remotely</a>, but Authors need to be
-								aware that <a>Reading Systems</a> are not required to retrieve to Remote Resources
+									>locally</a> or <a data-lt="Remote Resource">remotely</a>, but EPUB Creators need to
+								be aware that <a>Reading Systems</a> are not required to retrieve to Remote Resources
 								(i.e., the resource might not be available).</p>
 
 							<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
@@ -2433,8 +2441,8 @@
 								include a prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the
 								resulting IRI for them: <code>http://idpf.org/epub/vocab/package/link/#</code></p>
 
-							<p><a>Authors</a> MAY add relationships and properties from other vocabularies as defined in
-									<a href="#sec-vocab-assoc"></a>.</p>
+							<p><a>EPUB Creators</a> MAY add relationships and properties from other vocabularies as
+								defined in <a href="#sec-vocab-assoc"></a>.</p>
 
 							<aside class="example">
 								<p>The following example shows the <code>link</code> element used to associate an
@@ -2453,9 +2461,9 @@
 </pre>
 							</aside>
 
-							<p id="sec-linked-records">Authors MAY provide one or more <a href="#record">linked metadata
-									records</a> to enhance the information available to Reading Systems, but Reading
-								Systems are not required to process these records.</p>
+							<p id="sec-linked-records">EPUB Creators MAY provide one or more <a href="#record">linked
+									metadata records</a> to enhance the information available to Reading Systems, but
+								Reading Systems are not required to process these records.</p>
 
 							<p>When a Reading System <a href="https://www.w3.org/TR/epub-rs-33/#sec-linked-records"
 									>processes linked records</a> [[!EPUB-RS-33]], the document order of
@@ -2654,11 +2662,11 @@
 								prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the resulting IRI
 								for them: <code>http://idpf.org/epub/vocab/package/item/#</code></p>
 
-							<p>Authors MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-								></a>.</p>
+							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
+									href="#sec-vocab-assoc"></a>.</p>
 
-							<p>Authors MUST declare all applicable descriptive metadata properties for each Publication
-								Resource in this attribute.</p>
+							<p>EPUB Creators MUST declare all applicable descriptive metadata properties for each
+								Publication Resource in this attribute.</p>
 
 							<p>Exactly one <code>item</code> MUST be declared as the <a>EPUB Navigation Document</a>
 								using the <code>nav</code> property.</p>
@@ -2768,9 +2776,9 @@ Manifest:
 							<aside class="example">
 								<p>The following example shows a link to the same audio file, but in this case the file
 									is not listed in the manifest (hyperlinked Remote Resources are not Publication
-									Resources). The audio file would only be listed in the manifest if the Author has
-									also referenced it from an [[HTML]] embedded content element, as above (i.e., in a
-									context where it is used as a Publication Resource).</p>
+									Resources). The audio file would only be listed in the manifest if the EPUB Creator
+									has also referenced it from an [[HTML]] embedded content element, as above (i.e., in
+									a context where it is used as a Publication Resource).</p>
 								<pre>XHTML:
 &lt;a href="http://www.example.com/book/audio/ch01.mp4"&gt;Go to audio file&lt;/a&gt;
 
@@ -2818,8 +2826,8 @@ Spine:
 
 							<p>The ordered list of all the ID references that can be reached starting from a given
 								item's <code>fallback</code> attribute represents the <em>fallback chain</em> for that
-								item. The order of the resources in the fallback chain represents the Author's preferred
-								fallback order.</p>
+								item. The order of the resources in the fallback chain represents the EPUB Creator's
+								preferred fallback order.</p>
 
 							<p>Fallback chains MUST conform to one of the following requirements, as appropriate:</p>
 
@@ -2952,8 +2960,8 @@ Spine:
 							<p id="attrdef-spine-page-progression-direction">The <code>page-progression-direction</code>
 								attribute sets the global direction in which the content flows. Allowed values are
 									<code>ltr</code> (left-to-right), <code>rtl</code> (right-to-left) and
-									<code>default</code>. When the <code>default</code> value is specified, the Author
-								is expressing no preference and the Reading System can choose the rendering
+									<code>default</code>. When the <code>default</code> value is specified, the EPUB
+								Creator is expressing no preference and the Reading System can choose the rendering
 								direction.</p>
 
 							<p>Although the <code>page-progression-direction</code> attribute sets the global flow
@@ -3062,8 +3070,8 @@ Spine:
 									<code>itemref</code> that omits the <code>linear</code> attribute is assumed to have
 								the value "<code>yes</code>".</p>
 
-							<p>Authors MUST provide a means of accessing all non-linear content (e.g., hyperlinks in the
-								content or from the <a href="#sec-nav">EPUB Navigation Document</a>).</p>
+							<p>EPUB Creators MUST provide a means of accessing all non-linear content (e.g., hyperlinks
+								in the content or from the <a href="#sec-nav">EPUB Navigation Document</a>).</p>
 
 							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
 									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>
@@ -3071,8 +3079,8 @@ Spine:
 								include a prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the
 								resulting IRI for them: <code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
 
-							<p>Authors MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-								></a>.</p>
+							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
+									href="#sec-vocab-assoc"></a>.</p>
 
 							<h6>Examples</h6>
 
@@ -3411,8 +3419,8 @@ Spine:
 
 						<div class="note">
 							<p>The listing of RDFa is does not express a preference on the part of the Working Group,
-								only that these attributes represent an extension of the HTML grammar. Authors can also
-								specify <a href="https://html.spec.whatwg.org/multipage/microdata.html#microdata"
+								only that these attributes represent an extension of the HTML grammar. EPUB Creators can
+								also specify <a href="https://html.spec.whatwg.org/multipage/microdata.html#microdata"
 									>microdata attributes</a> [[HTML]] and <a href="https://www.w3.org/TR/json-ld/"
 									>linked data</a> [[JSON-LD11]] in XHTML Content Documents as both are natively
 								supported.</p>
@@ -3548,9 +3556,9 @@ Spine:
 							<div class="note">
 								<p>Although the [[SSML]] specification refers to a registry of alphabets, one has not
 									been published. As the charter of the W3C Voice Browser Working Group has expired,
-									the publication of such a registry is not anticipated. Authors therefore need to
-									reference Reading System support documentation to determine what alphabet values are
-									supported. Some common alphabets include x-JEITA (also x-JEITA-IT-4002 and
+									the publication of such a registry is not anticipated. EPUB Creators therefore need
+									to reference Reading System support documentation to determine what alphabet values
+									are supported. Some common alphabets include x-JEITA (also x-JEITA-IT-4002 and
 									x-JEITA-IT-4006) and x-sampa.</p>
 							</div>
 						</section>
@@ -3559,9 +3567,9 @@ Spine:
 					<section id="sec-xhtml-content-switch">
 						<h5>Content Switching (Deprecated)</h5>
 
-						<p>The <code>switch</code> element provides a simple mechanism through which <a>Authors</a> can
-							tailor the content displayed to users, one that is not dependent on the scripting
-							capabilities of the <a>EPUB Reading System</a>.</p>
+						<p>The <code>switch</code> element provides a simple mechanism through which <a>EPUB
+								Creators</a> can tailor the content displayed to users, one that is not dependent on the
+							scripting capabilities of the <a>EPUB Reading System</a>.</p>
 
 						<p>Use of the <code>switch</code> element is <a href="#deprecated">deprecated</a>. Refer to its
 							definition in [[!EPUBContentDocs-301]] for usage information.</p>
@@ -3581,7 +3589,7 @@ Spine:
 					<section id="sec-xhtml-custom-attributes">
 						<h5>Custom Attributes</h5>
 
-						<p><a>Authors</a> MAY specify <a
+						<p><a>EPUB Creators</a> MAY specify <a
 								href="https://www.w3.org/TR/epub-rs-33/#sec-xhtml-custom-attributes">custom
 								attributes</a> [[!EPUB-RS-33]] in <a>XHTML Content Documents</a> to take advantage of
 							Reading System-specific functionality not defined in this specification.</p>
@@ -3705,9 +3713,9 @@ Spine:
 							<p id="confreq-html-vocab-embed">Since the [[!HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element"
 										><code>embed</code></a> element does not include intrinsic facilities to provide
-								fallback content for Reading Systems that do not support scripting, <a>Authors</a> are
-								discouraged from using the element when the referenced resource includes scripting. The
-								[[!HTML]] <a
+								fallback content for Reading Systems that do not support scripting, <a>EPUB Creators</a>
+								are discouraged from using the element when the referenced resource includes scripting.
+								The [[!HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element"
 										><code>object</code> element</a> can be used instead, as it includes intrinsic
 								fallback capabilities.</p>
@@ -3811,9 +3819,9 @@ Spine:
 
 				<div class="caution">
 					<p>Some features of [[!SVG]] are not fully supported in <a>Reading Systems</a> or supported across
-						all platforms on which Reading Systems run. When utilizing such features, <a>Authors</a> need to
-						consider the inherent risks in terms of the potential impact on interoperability and document
-						longevity.</p>
+						all platforms on which Reading Systems run. When utilizing such features, <a>EPUB Creators</a>
+						need to consider the inherent risks in terms of the potential impact on interoperability and
+						document longevity.</p>
 				</div>
 
 				<section id="sec-svg-intro" class="informative">
@@ -3822,9 +3830,9 @@ Spine:
 					<p>The Scalable Vector Graphics (SVG) specification [[SVG]] defines a format for representing
 						final-form vector graphics and text.</p>
 
-					<p>Although <a>Authors</a> typically use <a href="#sec-xhtml">XHTML Content Documents</a> as the <a
-							data-lt="Top-level Content Document">top-level</a> document type, the use of <a>SVG Content
-							Documents</a> is also permitted. SVGs are typically only used in certain special
+					<p>Although <a>EPUB Creators</a> typically use <a href="#sec-xhtml">XHTML Content Documents</a> as
+						the <a data-lt="Top-level Content Document">top-level</a> document type, the use of <a>SVG
+							Content Documents</a> is also permitted. SVGs are typically only used in certain special
 						circumstances, such as when final-form page images are the only suitable representation of the
 						content (e.g., for cover art or in the context of manga or comic books).</p>
 
@@ -3988,14 +3996,14 @@ Spine:
 					<h4>Prefixed Properties</h4>
 
 					<div class="caution">
-						<p><a>Authors</a> are strongly encouraged to use unprefixed properties and <a>Reading
+						<p><a>EPUB Creators</a> are strongly encouraged to use unprefixed properties and <a>Reading
 								Systems</a> to support current CSS specifications. The widely-used prefixed properties
 							from [[!EPUBContentDocs-301]] have been retained, but support for the other properties has
-							been removed. Authors are advised to use CSS-native solutions for the removed properties
-							where and when they are available.</p>
-						<p>Authors currently using these prefixed properties are advised to move to unprefixed versions
-							as soon as support allows, as these properties are not anticipated to be supported in the
-							next major version of EPUB.</p>
+							been removed. EPUB Creators are advised to use CSS-native solutions for the removed
+							properties where and when they are available.</p>
+						<p>EPUB Creators currently using these prefixed properties are advised to move to unprefixed
+							versions as soon as support allows, as these properties are not anticipated to be supported
+							in the next major version of EPUB.</p>
 					</div>
 
 					<section id="sec-css-prefixed-writing-modes">
@@ -4373,7 +4381,7 @@ Spine:
 							a future update adds the concept.</p>
 					</div>
 
-					<p>Authors should note that Reading Systems are required to behave as though a unique <a
+					<p>EPUB Creators should note that Reading Systems are required to behave as though a unique <a
 							href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] has been assigned to each EPUB
 						Publication. In practice, this means that it is not possible for scripts to share data between
 						EPUB Publications.</p>
@@ -4382,6 +4390,12 @@ Spine:
 						and restrictions that a Reading System places on it (refer to <a
 							href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">Scripting
 							Conformance</a> [[EPUB-RS-33]] for more information).</p>
+
+					<div class="note">
+						<p>Reading Systems may render Scripted Content Documents in a manner that disables other EPUB
+							capabilities and/or provides a different rendering and user experience (e.g., by disabling
+							pagination).</p>
+					</div>
 				</section>
 
 				<section id="sec-scripted-context">
@@ -4399,8 +4413,9 @@ Spine:
 					<p>Whether the code is embedded directly in the <code>script</code> element or referenced via its
 							<code>src</code> attribute makes no difference to its executing context.</p>
 
-					<p>Which context Authors use for their scripts affects both what actions the scripts can perform and
-						the likelihood of support in Reading Systems, as described in the following subsections.</p>
+					<p>Which context EPUB Creators use for their scripts affects both what actions the scripts can
+						perform and the likelihood of support in Reading Systems, as described in the following
+						subsections.</p>
 
 					<div class="note">
 						<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference between
@@ -4437,7 +4452,7 @@ Spine:
 							one that contains the <code>iframe</code> element). It also MUST NOT contain instructions
 							for manipulating the size of its containing rectangle.</p>
 
-						<p>Authors should note that <a
+						<p>EPUB Creators should note that <a
 								href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content-rs-reqs">support for
 								container-constrained scripting in Reading Systems</a> is only recommended in reflowable
 							documents [[EPUB-RS-33]]. Furthermore, Reading System support in fixed-layouts EPUBs is
@@ -4445,6 +4460,12 @@ Spine:
 
 						<p>Ensuring container-constrained scripts degrade gracefully in Reading Systems without
 							scripting support is advised (see <a href="#sec-scripted-fallbacks"></a>).</p>
+
+						<div class="note">
+							<p>EPUB Creators choosing to restrict the usage of scripting to the container-constrained
+								model will ensure a more consistent user experience between scripted and non-scripted
+								content (e.g., consistent pagination behavior).</p>
+						</div>
 					</section>
 
 					<section id="sec-scripted-spine">
@@ -4456,7 +4477,7 @@ Spine:
 								href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 							element contained in a <a>Top-level Content Document</a>.</p>
 
-						<p>Authors should note that support for spine-level scripting in Reading Systems is only
+						<p>EPUB Creators should note that support for spine-level scripting in Reading Systems is only
 							recommended in <a href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-fxl-support"
 								>fixed-layout documents</a> and <a
 								href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-scrolled">reflowable
@@ -4470,6 +4491,16 @@ Spine:
 							Failing to account for non-scripted environments in Top-level Content Documents can result
 							in EPUB Publications being unreadable.</p>
 					</section>
+				</section>
+
+				<section id="sec-scripted-content-events" class="informative">
+					<h4>Event Model</h4>
+
+					<p><a>EPUB Creators</a> need to take into account the wide variety of possible Reading System
+						implementations when adding scripting functionality to their EPUB Publications (e.g., not all
+						devices have physical keyboards, and in many cases a soft keyboard is activated only for text
+						input elements). Consequently, relying on keyboard events alone is not advised; alternative ways
+						to trigger a desired action always need to be provided.</p>
 				</section>
 
 				<section id="sec-scripted-a11y">
@@ -4491,8 +4522,8 @@ Spine:
 							href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element"
 								><code>canvas</code></a> elements) or, when an intrinsic fallback is not applicable, by
 						using a <a href="#sec-foreign-restrictions-manifest">manifest-level fallback</a>.</p>
-					<p id="confreq-cd-scripted-foreign-resources">Authors MUST ensure that scripts only generate <a
-							href="#sec-core-media-types">Core Media Type Resources</a> or fragments thereof.</p>
+					<p id="confreq-cd-scripted-foreign-resources">EPUB Creators MUST ensure that scripts only generate
+							<a href="#sec-core-media-types">Core Media Type Resources</a> or fragments thereof.</p>
 				</section>
 			</section>
 
@@ -4554,7 +4585,7 @@ Spine:
 				<h3>Introduction</h3>
 
 				<p>The EPUB Navigation Document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
-						Publication</a>. It allows <a>Authors</a> to include a human- and machine-readable global
+						Publication</a>. It allows <a>EPUB Creators</a> to include a human- and machine-readable global
 					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
 
 				<p>The EPUB Navigation Document is a special type of <a>XHTML Content Document</a> that defines the <a
@@ -4566,9 +4597,9 @@ Spine:
 
 				<p>The EPUB Navigation Document is not exclusively for machine processing, however. There are no
 					restrictions on the structure or content of the EPUB Navigation Document outside of the specialized
-					navigation elements (i.e., Authors can mark the rest of the document up like any other XHTML Content
-					Document). As a result, it can also be part of the linear reading order, avoiding the need for
-					duplicate tables of contents. Navigation elements that are only destined for machine processing,
+					navigation elements (i.e., EPUB Creators can mark the rest of the document up like any other XHTML
+					Content Document). As a result, it can also be part of the linear reading order, avoiding the need
+					for duplicate tables of contents. Navigation elements that are only destined for machine processing,
 					such as the page list, can be hidden from visual rendering with the <a href="#sec-nav-def-hidden"
 						>hidden</a> attribute.</p>
 
@@ -4775,8 +4806,8 @@ Spine:
 					<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
 						items within <code>nav</code> elements is equivalent to the <a
 							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
-								none</code> property</a> [[!CSSSnapshot]]. <a>Authors</a> MAY specify alternative list
-						styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
+								none</code> property</a> [[!CSSSnapshot]]. <a>EPUB Creators</a> MAY specify alternative
+						list styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
 								><code>spine</code></a>.</p>
 				</section>
 
@@ -4964,17 +4995,17 @@ Spine:
 				<section id="sec-nav-def-hidden">
 					<h4>The <code>hidden</code> attribute</h4>
 
-					<p>In some cases, <a>Authors</a> might wish to hide parts of the navigation data within the content
-						flow (i.e., the Reading System's principal rendering of the <a>spine</a> contents). A typical
-						example is the <a href="#sec-nav-pagelist">list of page breaks</a>, which usually is not
+					<p>In some cases, <a>EPUB Creators</a> might wish to hide parts of the navigation data within the
+						content flow (i.e., the Reading System's principal rendering of the <a>spine</a> contents). A
+						typical example is the <a href="#sec-nav-pagelist">list of page breaks</a>, which usually is not
 						rendered as part of the content flow but is instead exposed to the user separately in a
 						dedicated navigation user interface.</p>
 
 					<p> While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
 							property</a> [[!CSSSnapshot]] can be used to control the visual rendering of EPUB Navigation
 						Documents in Reading Systems with <a>Viewports</a>, not all Reading Systems provide such an
-						interface. To control rendering across all Reading Systems, authors MUST use the [[!HTML]] <a
-							href="https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute"
+						interface. To control rendering across all Reading Systems, EPUB Creators MUST use the [[!HTML]]
+							<a href="https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute"
 								><code>hidden</code></a> attribute to indicate which (if any) portions of the navigation
 						data are excluded from rendering in the content flow. The <code>hidden</code> attribute has no
 						effect on how navigation data is rendered outside of the content flow (such as in dedicated
@@ -5046,8 +5077,8 @@ Spine:
 
 				<p>But this principle does not work for all types of documents. Sometimes content and design are so
 					intertwined they cannot be separated. Any change in appearance risks changing the meaning or losing
-					all meaning. <a>Fixed-Layout Documents</a> give <a>Authors</a> greater control over presentation
-					when a reflowable EPUB is not suitable for the content.</p>
+					all meaning. <a>Fixed-Layout Documents</a> give <a>EPUB Creators</a> greater control over
+					presentation when a reflowable EPUB is not suitable for the content.</p>
 
 				<p>Fixed layouts are defined using a <a href="#sec-fxl-package">set of Package Document properties</a>
 					to control the rendering in <a>Reading Systems</a>. In addition, <a href="#sec-fxl-package">the
@@ -5055,9 +5086,9 @@ Spine:
 
 				<div class="note" id="note-mechanisms">
 					<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
-						content is necessary, the Author's choice of mechanism will depend on many factors including
-						desired degree of precision, file size, accessibility, etc. This section does not attempt to
-						dictate the Author's choice of mechanism.</p>
+						content is necessary, the EPUB Creator's choice of mechanism will depend on many factors
+						including desired degree of precision, file size, accessibility, etc. This section does not
+						attempt to dictate the EPUB Creator's choice of mechanism.</p>
 				</div>
 			</section>
 
@@ -5092,9 +5123,9 @@ Spine:
 					<div class="note" id="uaag">
 						<p>Reading Systems typically restrict or deny the application of user or user agent style sheets
 							to pre-paginated documents because dynamic style changes are likely to have unintended
-							consequence on the intrinsic properties of such documents. Authors need to consider the
-							negative impact on usability and accessibility that these restrictions have when choosing to
-							use pre-paginated instead of reflowable content. Refer to <a
+							consequence on the intrinsic properties of such documents. EPUB Creators need to consider
+							the negative impact on usability and accessibility that these restrictions have when
+							choosing to use pre-paginated instead of reflowable content. Refer to <a
 								href="https://www.w3.org/TR/2015/NOTE-UAAG20-20151215/#gl-text-config">Guideline 1.4 -
 								Provide text configuration</a> [[UAAG20]] for related information.</p>
 					</div>
@@ -5134,8 +5165,8 @@ Spine:
 					<section id="layout-overrides">
 						<h5>Layout Overrides</h5>
 
-						<p id="property-layout-local">Authors MAY specify the following properties locally on spine <a
-								href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+						<p id="property-layout-local">EPUB Creators MAY specify the following properties locally on
+							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
 								href="#property-layout-global">global value</a> for the given spine item:</p>
 
 						<dl>
@@ -5154,8 +5185,8 @@ Spine:
 				<section id="orientation">
 					<h4>Orientation</h4>
 
-					<p>The <code>rendition:orientation</code> property specifies which orientation the Author intends
-						the content to be rendered in. </p>
+					<p>The <code>rendition:orientation</code> property specifies which orientation the EPUB Creator
+						intends the content to be rendered in. </p>
 
 					<p id="property-orientation-global">When the <a href="#orientation"
 								><code>rendition:orientation</code> property</a> is specified on a <code>meta</code>
@@ -5196,8 +5227,8 @@ Spine:
 					<section id="orientation-overrides">
 						<h5>Orientation Overrides</h5>
 
-						<p id="property-orientation-local">Authors MAY specify the following properties locally on spine
-								<a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+						<p id="property-orientation-local">EPUB Creators MAY specify the following properties locally on
+							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
 								href="#property-orientation-global">global value</a> for the given spine item:</p>
 
 						<dl>
@@ -5243,8 +5274,8 @@ Spine:
 						<dd>
 							<p>The use of spreads only in portrait orientation is <a href="#deprecated"
 								>deprecated</a>.</p>
-							<p>Authors are advised to use the value "<code>both</code>" instead, as spreads that are
-								readable in portrait orientation are also readable in landscape.</p>
+							<p>EPUB Creators are advised to use the value "<code>both</code>" instead, as spreads that
+								are readable in portrait orientation are also readable in landscape.</p>
 						</dd>
 						<dt>both</dt>
 						<dd>
@@ -5299,8 +5330,8 @@ Spine:
 					<section id="spread-overrides">
 						<h5>Synthetic Spread Overrides</h5>
 
-						<p id="property-spread-local">Authors MAY specify the following properties locally on spine <a
-								href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+						<p id="property-spread-local">EPUB Creators MAY specify the following properties locally on
+							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
 								href="#property-spread-global">global value</a> for the given spine item:</p>
 
 						<dl>
@@ -5335,8 +5366,8 @@ Spine:
 					<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to populate the
 						spread by rendering the next <a>EPUB Content Document</a> in the next available unpopulated
 						viewport, where the next available viewport is determined by the given <a href="#sec-spine-elem"
-							>page progression direction</a> or by local declarations within Content Documents. An Author
-						MAY override this automatic population behavior and force a document to be placed in a
+							>page progression direction</a> or by local declarations within Content Documents. An EPUB
+						Creator MAY override this automatic population behavior and force a document to be placed in a
 						particular viewport by specifying one of the following properties on its spine
 							<code>itemref</code> element:</p>
 
@@ -5371,11 +5402,11 @@ Spine:
 						reflowable content, and they only apply when the Reading System is creating Synthetic
 						Spreads.</p>
 
-					<p>Although Authors often indicate to use a spread in certain device orientations, the content
+					<p>Although EPUB Creators often indicate to use a spread in certain device orientations, the content
 						itself does not represent true spreads (i.e., two consecutive pages that have to be rendered
 						side-by-side for readability, such as a two-page map). To indicate that two consecutive pages
-						represent a true spread, Authors SHOULD use the <code>rendition:page-spread-left</code> and
-							<code>rendition:page-spread-right</code> properties on the spine items for the two adjacent
+						represent a true spread, EPUB Creators SHOULD use the <code>rendition:page-spread-left</code>
+						and <code>rendition:page-spread-right</code> properties on the spine items for the two adjacent
 						EPUB Content Documents, and omit the properties on spine items where one-up or two-up
 						presentation is equally acceptable.</p>
 
@@ -5385,8 +5416,8 @@ Spine:
 						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 							properties are aliases for the <a href="#page-spread-left"><code>page-spread-left</code></a>
 							and <a href="#page-spread-right"><code>spread-right</code></a> properties. They allow the
-							use of a single vocabulary for all fixed-layout properties. Authors can use either property
-							set, but older Reading Systems might only recognize the unprefixed versions. The <a
+							use of a single vocabulary for all fixed-layout properties. EPUB Creators can use either
+							property set, but older Reading Systems might only recognize the unprefixed versions. The <a
 								href="#app-itemref-properties-vocab">EPUB Spine Properties Vocabulary</a> is no longer
 							being extended for package rendering metadata, so an unprefixed
 								<code>page-spread-center</code> is not available.</p>
@@ -5395,9 +5426,9 @@ Spine:
 					<aside class="example" id="fxl-ex5">
 						<p>The following example demonstrates reflowable content with a two-page fixed-layout center
 							plate that is intended to be rendered using synthetic spreads in any device orientation.
-							Note that the author has left spread behavior for the other (reflowable) parts undefined,
-							since the global value of <code>rendition:spread</code> is initialized to <code>auto</code>
-							by default.</p>
+							Note that the EPUB Creator has left spread behavior for the other (reflowable) parts
+							undefined, since the global value of <code>rendition:spread</code> is initialized to
+								<code>auto</code> by default.</p>
 						<pre>&lt;spine page-progression-direction="ltr"&gt;
     …
     &lt;itemref idref="center-plate-left"
@@ -5427,8 +5458,8 @@ Spine:
 				<section id="viewport">
 					<h4>Viewport Dimensions (Deprecated)</h4>
 
-					<p>The <code>rendition:viewport</code> property allows <a>Authors</a> to express the CSS initial
-						containing block (ICB) [[!CSS2]] for XHTML and SVG Content Documents whose
+					<p>The <code>rendition:viewport</code> property allows <a>EPUB Creators</a> to express the CSS
+						initial containing block (ICB) [[!CSS2]] for XHTML and SVG Content Documents whose
 							<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
 
 					<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its definition in
@@ -5714,11 +5745,11 @@ Spine:
 
 					<div class="note">
 						<p>Some commercial ZIP tools do not support the full Unicode range and might support only the
-							[[US-ASCII]] range for File Names. <a>Authors</a> who want to use ZIP tools that have these
-							restrictions might find it is best to restrict their File Names to the [[US-ASCII]] range.
-							If the names of files cannot be preserved during the unzipping process, it will be necessary
-							to compensate for any name translation which took place when the files are referenced by URI
-							from within the content.</p>
+							[[US-ASCII]] range for File Names. <a>EPUB Creators</a> who want to use ZIP tools that have
+							these restrictions might find it is best to restrict their File Names to the [[US-ASCII]]
+							range. If the names of files cannot be preserved during the unzipping process, it will be
+							necessary to compensate for any name translation which took place when the files are
+							referenced by URI from within the content.</p>
 					</div>
 
 				</section>
@@ -6296,11 +6327,11 @@ Spine:
 						(e.g., a folder).</p>
 
 					<p>While this simplicity of ZIP files is quite useful, it also poses a problem when ease of
-						extraction of resources is not a desired side-effect of not encrypting them. An <a>Author</a>
-						who wishes to include a third-party font, for example, typically does not want that font
-						extracted and re-used by others. More critically, many commercial fonts allow embedding, but
-						embedding a font implies making it an integral part of the EPUB Publication, not just providing
-						the original font file along with the content.</p>
+						extraction of resources is not a desired side-effect of not encrypting them. An <a>EPUB
+							Creator</a> who wishes to include a third-party font, for example, typically does not want
+						that font extracted and re-used by others. More critically, many commercial fonts allow
+						embedding, but embedding a font implies making it an integral part of the EPUB Publication, not
+						just providing the original font file along with the content.</p>
 
 					<p>Since integrated ZIP support is so ubiquitous in modern operating systems, simply placing a font
 						in the ZIP archive is insufficient to signify that it is not intended to be reused in other
@@ -7250,8 +7281,9 @@ store destination as source in ocf
 						<p>When a <code>text</code> element references embedded media that contains audio, the <a
 								href="#elemdef-smil-audio"><code>audio</code></a> sibling element is OPTIONAL.</p>
 
-						<p><a>Authors</a> SHOULD avoid using scripts to control playback of referenced embedded EPUB
-							Content Document media, as this might conflict with Media Overlays playback behavior.</p>
+						<p><a>EPUB Creators</a> SHOULD avoid using scripts to control playback of referenced embedded
+							EPUB Content Document media, as this might conflict with Media Overlays playback
+							behavior.</p>
 					</section>
 
 					<section id="sec-tts">
@@ -7319,23 +7351,25 @@ store destination as source in ocf
 							href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 								><code>playback-active-class</code></a> properties.</p>
 
-					<p>Authors MUST define exactly one CSS class name in each property they define. Each property MUST
-						define a <a href="https://www.w3.org/TR/CSS2/syndata.html#characters">valid CSS class name</a>
-						not including any <a href="https://www.w3.org/TR/CSS2/selector.html">selectors</a> [[!CSS2]].
-						This specification <strong>does not</strong> reserve names for use with these properties.</p>
+					<p>EPUB Creators MUST define exactly one CSS class name in each property they define. Each property
+						MUST define a <a href="https://www.w3.org/TR/CSS2/syndata.html#characters">valid CSS class
+							name</a> not including any <a href="https://www.w3.org/TR/CSS2/selector.html">selectors</a>
+						[[!CSS2]]. This specification <strong>does not</strong> reserve names for use with these
+						properties.</p>
 
-					<p>Authors MAY define any CSS properties for the specified CSS classes. Authors only need to ensure
-						that each EPUB Content Document with an associated Media Overlay Document includes a link to the
-						CSS style sheet that contains the class definitions. Reading Systems might provide their own
-						styling, or no styling at all, in the absence of a linked definition.</p>
+					<p>EPUB Creators MAY define any CSS properties for the specified CSS classes. EPUB Creators only
+						need to ensure that each EPUB Content Document with an associated Media Overlay Document
+						includes a link to the CSS style sheet that contains the class definitions. Reading Systems
+						might provide their own styling, or no styling at all, in the absence of a linked
+						definition.</p>
 
 					<p>The <code>active-class</code> and <code>playback-active-class</code> properties MUST NOT be used
 						in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a> as they are
 						always considered to apply to the entire <a>EPUB Publication</a>.</p>
 
 					<aside class="example">
-						<p>This example demonstrates how Authors can associate style information with the currently
-							playing EPUB Content Document.</p>
+						<p>This example demonstrates how EPUB Creators can associate style information with the
+							currently playing EPUB Content Document.</p>
 
 						<p>The author-defined CSS class names, declared using the metadata properties <a
 								href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
@@ -7434,9 +7468,10 @@ html.my-document-playing * {
 						<p>The sum of the durations for each Media Overlay Document SHOULD equal the <a
 								href="#total-duration">total duration</a>.</p>
 
-						<p><a>Authors</a> also MAY specify <a href="#narrator"><code>narrator</code></a> information in
-							the Package Document, as well as <a href="#sec-docs-assoc-style">author-defined CSS class
-								names</a> to be applied to the currently playing EPUB Content Document element.</p>
+						<p><a>EPUB Creators</a> also MAY specify <a href="#narrator"><code>narrator</code></a>
+							information in the Package Document, as well as <a href="#sec-docs-assoc-style"
+								>author-defined CSS class names</a> to be applied to the currently playing EPUB Content
+							Document element.</p>
 
 						<aside class="example">
 							<p>The following example shows a Package Document with metadata about Media Overlays.</p>
@@ -7678,8 +7713,8 @@ html.my-document-playing * {
 				<div class="note">
 					<p>Specific implementation details are beyond the scope of this specification. The <a
 							href="https://www.daisy.org/guidelines/epub/media-overlays-playback-requirements">DAISY
-							Media Overlays Playback Requirements</a> document describes best practices for Authors and
-						provides recommendations for Reading System developers.</p>
+							Media Overlays Playback Requirements</a> document describes best practices for EPUB Creators
+						and provides recommendations for Reading System developers.</p>
 				</div>
 			</section>
 		</section>
@@ -7737,7 +7772,7 @@ html.my-document-playing * {
 
 				<ul>
 					<li>
-						<p><a>Authors</a> are strongly RECOMMENDED not to use the feature in their <a>EPUB
+						<p><a>EPUB Creators</a> are strongly RECOMMENDED not to use the feature in their <a>EPUB
 								Publications</a>.</p>
 					</li>
 					<li>
@@ -7747,8 +7782,8 @@ html.my-document-playing * {
 					</li>
 				</ul>
 
-				<p>Validation tools SHOULD alert Authors that inclusion of the feature is deprecated when encountered in
-					an EPUB Publication.</p>
+				<p>Validation tools SHOULD alert EPUB Creators that inclusion of the feature is deprecated when
+					encountered in an EPUB Publication.</p>
 			</section>
 
 			<section id="legacy">
@@ -7760,7 +7795,7 @@ html.my-document-playing * {
 
 				<ul>
 					<li>
-						<p><a>Authors</a> MAY include the legacy feature for compatibility purposes.</p>
+						<p><a>EPUB Creators</a> MAY include the legacy feature for compatibility purposes.</p>
 					</li>
 					<li>
 						<p><a>Reading Systems</a> MUST NOT support the legacy feature in content that conforms to this
@@ -7768,10 +7803,10 @@ html.my-document-playing * {
 					</li>
 				</ul>
 
-				<p>Validation tools SHOULD NOT alert Authors about the presence of legacy features in an <a>EPUB
+				<p>Validation tools SHOULD NOT alert EPUB Creators about the presence of legacy features in an <a>EPUB
 						Publication</a>, as their inclusion is valid for backwards compatibility. Validation tools MUST
-					alert Authors if a legacy feature does not conform to its definition or otherwise breaks a usage
-					requirement.</p>
+					alert EPUB Creators if a legacy feature does not conform to its definition or otherwise breaks a
+					usage requirement.</p>
 			</section>
 		</section>
 		<section id="app-identifiers-allowed" class="appendix">
@@ -7990,10 +8025,10 @@ html.my-document-playing * {
 							Systems</a> use to map to a IRI is predefined.</p>
 
 					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
-						terms and properties, authors only need to declare a <a href="#sec-prefix-attr">prefix</a>. In
-						another authoring convenience, this specification also <a href="#sec-metadata-reserved-prefixes"
-							>reserves prefixes</a> for many commonly used publishing vocabularies (i.e., they do not
-						have to be declared).</p>
+						terms and properties, EPUB Creators only need to declare a <a href="#sec-prefix-attr"
+						>prefix</a>. In another authoring convenience, this specification also <a
+							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
+						publishing vocabularies (i.e., they do not have to be declared).</p>
 
 					<p>Additional details on the <var>property</var> data type and vocabulary association mechanism are
 						provided in the following sections.</p>
@@ -8197,7 +8232,7 @@ html.my-document-playing * {
 
 					<div class="note">
 						<p>Although the <code>prefix</code> attribute is modeled on the identically named
-								<code>prefix</code> attribute in [[RDFA-CORE]], Authors cannot use the attributes
+								<code>prefix</code> attribute in [[RDFA-CORE]], EPUB Creators cannot use the attributes
 							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB Content
 							Documents is the RDFa attribute.</p>
 
@@ -8222,7 +8257,7 @@ html.my-document-playing * {
 
 					<p>For future compatibility with alternative serializations of the Package Document, a prefix for
 						the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in the
-							<code>prefix</code> attribute. <a>Authors</a> MUST use only the [[!DC11]] elements <a
+							<code>prefix</code> attribute. <a>EPUB Creators</a> MUST use only the [[!DC11]] elements <a
 							href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
 				</section>
 
@@ -8231,10 +8266,10 @@ html.my-document-playing * {
 
 					<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
 						lead to interoperability issues. Validation tools will often reject new prefixes until the tools
-						are updated, for example. Authors are strongly encouraged to declare all prefixes they use to
-						avoid such issues.</p>
+						are updated, for example. EPUB Creators are strongly encouraged to declare all prefixes they use
+						to avoid such issues.</p>
 
-					<p><a>Authors</a> MAY use reserved prefixes in attributes that expect a <a
+					<p><a>EPUB Creators</a> MAY use reserved prefixes in attributes that expect a <a
 							href="#sec-property-datatype"><var>property</var> value</a> without declaring them in a <a
 							href="#sec-prefix-attr"><code>prefix</code> attribute</a>.</p>
 
@@ -8246,8 +8281,8 @@ html.my-document-playing * {
 					<dl class="conformance-list">
 						<dt>Package Document</dt>
 						<dd id="sec-metadata-reserved-prefixes">
-							<p>Authors MAY use the following prefixes in <a>Package Document</a> attributes without
-								having to declare them.</p>
+							<p>EPUB Creators MAY use the following prefixes in <a>Package Document</a> attributes
+								without having to declare them.</p>
 							<table id="tbl-pkg-reserved-prefixes" class="prefix">
 								<thead>
 									<tr>
@@ -8294,7 +8329,7 @@ html.my-document-playing * {
 
 						<dt id="sec-content-reserved-prefixes">Structural Semantics</dt>
 						<dd>
-							<p>Authors MAY use the following reserved prefixes in the <a
+							<p>EPUB Creators MAY use the following reserved prefixes in the <a
 									href="#app-structural-semantics"><code>epub:type</code> attribute</a> without having
 								to declare them.</p>
 							<table id="tbl-reserved-prefixes" class="prefix">

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -5,10 +5,10 @@
 		built upon. For example, although HTML with CSS provides powerful layout capabilities, those
 		capabilities are limited to the scope of the document being rendered.</p>
 	
-	<p>This section defines general-purpose properties that allow Authors to express package-level
+	<p>This section defines general-purpose properties that allow EPUB Creators to express package-level
 		rendering intentions (i.e., functionality that can only be implemented by the <a>EPUB Reading
 			System</a>). If a Reading System supports the desired rendering, these properties enable the
-		user to be presented the content as the Author optimally designed it.</p>
+		user to be presented the content as the EPUB Creator optimally designed it.</p>
 	
 	<p>The base IRI for referencing these properties is
 		<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
@@ -23,12 +23,12 @@
 		<section id="flow">
 			<h5>The <code>rendition:flow</code> Property</h5>
 			
-			<p>The <code>rendition:flow</code> property specifies the Author preference for how Reading
+			<p>The <code>rendition:flow</code> property specifies the EPUB Creator preference for how Reading
 				Systems should handle content overflow. </p>
 			
 				<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code>
-					property</a> is specified on a <code>meta</code> element, it indicates the Author's
-					global preference for overflow content handling (i.e., for all spine items). Authors MAY
+					property</a> is specified on a <code>meta</code> element, it indicates the EPUB Creator's
+					global preference for overflow content handling (i.e., for all spine items). EPUB Creators MAY
 					indicate a preference for dynamic pagination or scrolling. For scrolled content, it is
 					also possible to specify whether consecutive <a>EPUB Content Documents</a> are to be
 					rendered as a continuous scrolling view or whether each is to be rendered separately
@@ -47,7 +47,7 @@
 					<p>Render all Content Documents such that overflow content is scrollable, and the
 						EPUB Publication is presented as one continuous scroll from spine item to spine
 						item (except where <a href="#layout-property-flow-overrides">locally overridden</a>).</p>
-					<p>Note that Authors SHOULD NOT create publications in which different resources
+					<p>Note that EPUB Creators SHOULD NOT create publications in which different resources
 						have different block flow directions, as continuous scrolled rendition in EPUB
 						Reading Systems would be problematic.</p>
 				</dd>
@@ -70,7 +70,7 @@
 							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
 							><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been set to
 					<code>always</code>. In addition to using the <code>rendition:flow</code> property,
-					Authors MAY override this behavior through an appropriate style sheet declaration, if
+					EPUB Creators MAY override this behavior through an appropriate style sheet declaration, if
 					the Reading System supports such overrides.</p>
 				
 				<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
@@ -78,24 +78,24 @@
 			<section id="layout-property-flow-overrides">
 				<h5>Spine Overrides</h5>
 				
-				<p id="layout-property-flow-local">Authors MAY specify the following properties locally on
+				<p id="layout-property-flow-local">EPUB Creators MAY specify the following properties locally on
 					spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
 					<a href="#property-flow-global">global value</a> for the given spine item:</p>
 				
 				<dl>
 					<dt id="flow-auto">flow-auto</dt>
-					<dd>Indicates no preference for overflow content handling by the Author.</dd>
+					<dd>Indicates no preference for overflow content handling by the EPUB Creator.</dd>
 					
 					<dt id="flow-paginated">flow-paginated</dt>
-					<dd>Indicates the Author preference is to dynamically paginate content overflow.</dd>
+					<dd>Indicates the EPUB Creator preference is to dynamically paginate content overflow.</dd>
 					
 					<dt id="flow-scrolled-continuous">flow-scrolled-continuous</dt>
-					<dd>Indicates the Author preference is to provide a scrolled view for overflow content,
+					<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow content,
 						and that consecutive spine items with this property are to be rendered as a
 						continuous scroll.</dd>
 					
 					<dt id="flow-scrolled-doc">flow-scrolled-doc</dt>
-					<dd>Indicates the Author preference is to provide a scrolled view for overflow content,
+					<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow content,
 						and each spine item with this property is to be rendered as a separate scrollable
 						document.</dd>
 				</dl>
@@ -103,7 +103,7 @@
 				<p>Only one of these overrides is allowed on any given spine item.</p>
 
 				<aside class="example" id="property-flow-ex1">
-					<p>The following example demonstrates an Author's intent to have a paginated EPUB Publication
+					<p>The following example demonstrates an EPUB Creator's intent to have a paginated EPUB Publication
 						with a scrollable table of contents.</p>
 					<pre>&lt;metadata&gt;
     &lt;meta property="rendition:flow"&gt;paginated&lt;/meta&gt;
@@ -132,7 +132,7 @@
 				<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title
 					pages), in the absence of reliable centering control within the content rendering. As
 					support for paged media evolves in CSS, however, this property is expected to be
-					deprecated. Authors are encouraged to use CSS solutions when effective.</p>
+					deprecated. EPUB Creators are encouraged to use CSS solutions when effective.</p>
 			</div>
 		</section>
 	</section>

--- a/epub33/core/vocab/structure.html
+++ b/epub33/core/vocab/structure.html
@@ -5,7 +5,7 @@
 		<p>While the EPUB Structural Semantics vocabulary is generally host language agnostic, it has been
 			constructed primarily to enable semantic inflection of elements in the HTML vocabulary.</p>
 		<p>The <i>HTML usage context</i> fields indicate contexts in HTML documents where the given property is
-			considered relevant. Authors may use the properties on HTML markup elements not specifically listed,
+			considered relevant. EPUB Creators may use the properties on HTML markup elements not specifically listed,
 			but must ensure that the semantics they express represent a subset of the carrying element's
 			semantics and do not attach an existing element's meaning to a semantically neutral element.</p>
 		<p>The <i>DPUB-ARIA role</i> fields indicate the [[DPUB-ARIA-1.0]] roles that can alternatively be used
@@ -2490,7 +2490,7 @@
 					publications (i.e., where no statically paginated equivalent exists). These markers provide
 					consistent navigation regardless of differences in font and screen size that can otherwise
 					affect the dynamic pagination of the content.</p>
-				<p>Authors must ensure the name of the page break is an end user-consumable page number that
+				<p>EPUB Creators must ensure the name of the page break is an end user-consumable page number that
 					identifies the page that is beginning.</p>
 			</dd>
 			<dd>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -79,7 +79,7 @@
 					move from the same spot in one Rendition to the equivalent spot in another as changes in the reading
 					environment occur.</p>
 
-				<p>This specification defines how a Reading System selects from multiple <a>Author</a>-provided
+				<p>This specification defines how a Reading System selects from multiple <a>EPUB Creator</a>-provided
 					Renditions of the content to best match the current device characteristics and user preferences
 					&#8212; it does not define methods for modifying content on the fly. As changes occur to device
 					orientation or the user's preferred reading modality, for example, the Reading System will be able
@@ -108,12 +108,12 @@
 				<p>The notion of including multiple renditions of an <a>EPUB Publication</a> has existed for as long as
 					the EPUB standard, but the specification has never fully addressed what these renditions are for and
 					how to access them. As a result, the EPUB 3 specification generally equates an EPUB Publication with
-					a single rendering of the content. Moreover, most <a>Authors</a> and <a>Reading System</a>
+					a single rendering of the content. Moreover, most <a>EPUB Creators</a> and <a>Reading System</a>
 					developers equate an EPUB Publication with a single <a>Package Document</a> referenced from the
 					first <code>rootfile</code> element in the <code>container.xml</code> file [[EPUB-33]].</p>
 
-				<p>In practice, however, the <code>container.xml</code> file does not restrict Authors to listing only a
-					single Package Document. In EPUB 2, for example, <a>Authors</a> could add additional
+				<p>In practice, however, the <code>container.xml</code> file does not restrict EPUB Creators to listing
+					only a single Package Document. In EPUB 2, for example, <a>EPUB Creators</a> could add additional
 						<code>rootfile</code> elements referencing any other format they desired (e.g., another Package
 					Document, a PDF file, or even a Word Document). In EPUB 3, <code>rootfile</code> elements were
 					restricted to referencing only Package Documents of the same version of the standard.</p>
@@ -155,7 +155,7 @@
 						href="https://www.w3.org/TR/epub-33/#sec-opf-dclanguage">DCMES <code>language</code> element</a>
 					[[EPUB-33]] &#8212; one for each language &#8212; but for Rendition selection only the primary
 					language is defined. Likewise, the language defined in the Package Document could include a specific
-					region code, but for selection purposes the Author might identify only the language code.</p>
+					region code, but for selection purposes the EPUB Creator might identify only the language code.</p>
 
 				<p>The reason for common metadata in both locations is to simplify the selection process: including
 					attributes avoids the requirement to parse each referenced Package Document and allows for
@@ -179,10 +179,10 @@
 				<p>The following terms used in this document are defined in [[EPUB-33]]:</p>
 
 				<ul>
-					<li><a href="https://www.w3.org/TR/epub-33/#dfn-author">Author</a></li>
 					<li><a href="https://www.w3.org/TR/epub-33/#dfn-epub-container">EPUB Container</a></li>
 					<li><a href="https://www.w3.org/TR/epub-33/#dfn-epub-content-document">EPUB Content
 						Document</a></li>
+					<li><a href="https://www.w3.org/TR/epub-33/#dfn-epub-creator">EPUB Creator</a></li>
 					<li><a href="https://www.w3.org/TR/epub-33/#dfn-epub-publication">EPUB Publication</a></li>
 					<li><a href="https://www.w3.org/TR/epub-33/#dfn-epub-reading-system">EPUB Reading System</a></li>
 					<li><a href="https://www.w3.org/TR/epub-33/#dfn-package-document">Package Document</a></li>
@@ -316,8 +316,8 @@
 						in Reading Systems not locating necessary metadata).</p>
 
 					<div class="note">
-						<p>Authors are strongly encouraged to include a complete set of Publication metadata in the
-							Default Rendition to ensure cross-compatibility, even when making use of this file.</p>
+						<p>EPUB Creators are strongly encouraged to include a complete set of Publication metadata in
+							the Default Rendition to ensure cross-compatibility, even when making use of this file.</p>
 						<p>Titles, languages and other metadata is often not applicable from one Rendition to another,
 							further complicating the sharing of metadata. No assumption can be made that metadata in the
 								<code>metadata.xml</code> file is applicable to any given Rendition, whether the
@@ -330,7 +330,7 @@
 							Publications that are not valid to the schema in <a href="#schema-metadata"></a> are not
 							valid Multiple-Rendition Publications as defined by this specification, but might still be
 							valid EPUB 3.0.1 Publications.</p>
-						<p>Authors are strongly encouraged to migrate to the content model defined in this
+						<p>EPUB Creators are strongly encouraged to migrate to the content model defined in this
 							specification, even if not producing Multiple-Rendition Publications, to ensure consistent
 							processing.</p>
 					</div>
@@ -369,8 +369,8 @@
 				<p>This section redresses this problem by defining both a set of rendition selection attributes that can
 					be attached to <a href="https://www.w3.org/TR/epub-33/#sec-container-metainf-container.xml"
 							><code>rootfile</code> elements</a> [[EPUB-33]] in the Container Document and a processing
-					model that allows Authors to specify which Rendition is the best representation depending on various
-					conditions. Reading Systems can then select the appropriate representation from the list of
+					model that allows EPUB Creators to specify which Rendition is the best representation depending on
+					various conditions. Reading Systems can then select the appropriate representation from the list of
 					Renditions to match the current configuration and user preferences.</p>
 			</section>
 
@@ -813,8 +813,8 @@
 
 				<div class="note">
 					<p>Since EPUB 2 Reading Systems, and EPUB 3 Reading Systems that do not support multiple-Rendition
-						selection, will render the Default Rendition, Authors need to consider which Rendition will have
-						the greatest compatibility across Reading Systems and ensure it is listed first.</p>
+						selection, will render the Default Rendition, EPUB Creators need to consider which Rendition
+						will have the greatest compatibility across Reading Systems and ensure it is listed first.</p>
 				</div>
 
 				<p>A Reading System MAY provide the user the option to manually select any of the Renditions in the

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -231,9 +231,9 @@
 						dimensions</a> [[EPUB-33]], creating a canvas on which elements can be absolutely
 					positioned.</p>
 
-				<p>The metadata does not just flag whether content is to be fixed or reflowed, but also allows Authors
-					to specify the desired <a href="https://www.w3.org/TR/epub-33/#orientation">orientation of
-					pages</a> [[EPUB-33]], when to <a href="https://www.w3.org/TR/epub-33/#spread">create synthetic
+				<p>The metadata does not just flag whether content is to be fixed or reflowed, but also allows EPUB
+					Creators to specify the desired <a href="https://www.w3.org/TR/epub-33/#orientation">orientation of
+						pages</a> [[EPUB-33]], when to <a href="https://www.w3.org/TR/epub-33/#spread">create synthetic
 						spreads</a> [[EPUB-33]], and <a href="https://www.w3.org/TR/epub-33/#page-spread">how to
 						position pages</a> [[EPUB-33]] within those spreads, providing a broad range of control over the
 					presentation of EPUB Publications.</p>
@@ -255,7 +255,7 @@
 					supporting dynamic adaptive layout and accessibility has been a primary design consideration
 					throughout the evolution of the EPUB standard.</p>
 
-				<p>EPUB Content Documents can reference CSS Style Sheets, allowing Authors to define the desired
+				<p>EPUB Content Documents can reference CSS Style Sheets, allowing EPUB Creators to define the desired
 					rendering properties. EPUB 3 follows support for CSS as defined in the [[CSSSnapshot]].</p>
 
 				<p>EPUB 3 also supports CSS styles that enable both horizontal and vertical layout and both
@@ -307,11 +307,11 @@
 				<p>It is important to note, however, that EPUB 3 does not require scripting support in Reading Systems,
 					and scripting might be disabled for security reasons.</p>
 
-				<p>Authors need to be aware that scripting in an EPUB Publication can create security considerations
-					that are different from scripting within a Web browser. For example, typical same-origin policies
-					are not applicable to content that has been downloaded to a user's local system. Therefore, it is
-					strongly encouraged that scripting be limited to container constrained contexts, as further
-					described in the section on <a
+				<p>EPUB Creators need to be aware that scripting in an EPUB Publication can create security
+					considerations that are different from scripting within a Web browser. For example, typical
+					same-origin policies are not applicable to content that has been downloaded to a user's local
+					system. Therefore, it is strongly encouraged that scripting be limited to container constrained
+					contexts, as further described in the section on <a
 						href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained">Container-Constrained
 						Scripts</a> [[EPUB-33]].</p>
 
@@ -331,8 +331,8 @@
 					<dt>Pronunciation Lexicons</dt>
 					<dd>
 						<p>The inclusion of generic pronunciation lexicons using the W3C PLS format
-							[[PRONUNCIATION-LEXICON]] enables Authors to provide pronunciation rules that apply to the
-							entire EPUB Publication. Refer to <a href="https://www.w3.org/TR/epub-33/#sec-pls"
+							[[PRONUNCIATION-LEXICON]] enables EPUB Creators to provide pronunciation rules that apply to
+							the entire EPUB Publication. Refer to <a href="https://www.w3.org/TR/epub-33/#sec-pls"
 								>Pronunciation Lexicons</a> [[EPUB-33]] for more information.</p>
 					</dd>
 					<dt>Inline SSML Phonemes</dt>
@@ -452,8 +452,8 @@
 			<section id="sec-gls-tts">
 				<h2>Text-to-speech</h2>
 
-				<p>EPUB 3's support for PLS documents and SSML attributes increases the pronunciation control that
-					Authors have over the rendering of any natural language in text-to-speech-enabled Reading Systems.
+				<p>EPUB 3's support for PLS documents and SSML attributes increases the pronunciation control that EPUB
+					Creators have over the rendering of any natural language in text-to-speech-enabled Reading Systems.
 					Refer to <a href="#sec-tts"></a> in the Features section for more information on these
 					capabilities.</p>
 
@@ -485,7 +485,7 @@
 			<p>It is important to note that while accessibility is important in its own right, accessible content is
 				also more valuable content: an accessible EPUB Publication will be adaptable to more devices and be
 				easier to reuse, in whole or in part, via human and automated workflows. The EPUB Working Group strongly
-				recommends that Authors ensure that they generate accessible content.</p>
+				recommends that EPUB Creators ensure that they generate accessible content.</p>
 
 			<section id="sec-access-nav">
 				<h2>Navigation</h2>
@@ -500,9 +500,9 @@
 					Systems when they render the table of contents outside the <code>spine</code> (e.g., in their own
 					specialized views), which avoids minimizing the information that is available.</p>
 
-				<p>Authors are also encouraged to supply additional <code>nav</code> elements if their EPUB Publications
-					contain non-structural points of interest, such as figures, tables, etc., to further enhance access
-					to the content.</p>
+				<p>EPUB Creators are also encouraged to supply additional <code>nav</code> elements if their EPUB
+					Publications contain non-structural points of interest, such as figures, tables, etc., to further
+					enhance access to the content.</p>
 
 			</section>
 
@@ -510,9 +510,9 @@
 				<h2>Semantic Markup</h2>
 
 				<p>[[HTML]] supports a number of elements that make markup more semantically meaningful (e.g.,
-						<code>section</code>, <code>nav</code>, and <code>aside</code>). Authors are encouraged to use
-					these elements, in conjunction with best practices for authoring well-structured Web content, when
-					creating EPUB XHTML Content Documents. These additions allow content to be better grouped and
+						<code>section</code>, <code>nav</code>, and <code>aside</code>). EPUB Creators are encouraged to
+					use these elements, in conjunction with best practices for authoring well-structured Web content,
+					when creating EPUB XHTML Content Documents. These additions allow content to be better grouped and
 					defined, both for representing the structure of documents and to facilitate their logical
 					navigation. XHTML Content Documents also natively support the inclusion of ARIA role and state
 					attributes and events, enhancing the ability of Assistive Technologies to interact with the
@@ -537,9 +537,9 @@
 
 				<p>While it is possible to incorporate more highly formatted content in EPUB — for example via bitmap
 					images or SVG graphics, or even use of CSS explicit positioning and/or table elements to achieve
-					particular visual layouts — Authors are strongly discouraged from utilizing such techniques. They
-					are not reliable in EPUB since many Reading Systems render content in a paginated manner rather than
-					creating a single scrolling <a>Viewport</a> and since each Reading System might define its own
+					particular visual layouts — EPUB Creators are strongly discouraged from utilizing such techniques.
+					They are not reliable in EPUB since many Reading Systems render content in a paginated manner rather
+					than creating a single scrolling <a>Viewport</a> and since each Reading System might define its own
 					pagination algorithm. If these techniques are necessary to convey the content of the publication,
 					consider including <a href="https://www.w3.org/TR/epub-33/#sec-foreign-restrictions">fallbacks</a>
 					[[EPUB-33]] (e.g., for graphic novels).</p>
@@ -586,9 +586,9 @@
 					to further facilitate access to their contents, the documents have to be accessible without
 					them.</p>
 
-				<p>Authors should always implement best practices for accessible scripting in Web documents, such as
-					provided in [[WAI-ARIA]], and reserve the use of scripting for situations in which interactivity is
-					critical to the user experience.</p>
+				<p>EPUB Creators should always implement best practices for accessible scripting in Web documents, such
+					as provided in [[WAI-ARIA]], and reserve the use of scripting for situations in which interactivity
+					is critical to the user experience.</p>
 
 			</section>
 		</section>
@@ -630,9 +630,10 @@
 			<section id="epub301">
 				<h3>EPUB 3.0.1: 2014</h3>
 				<p>The EPUB 3.0.1 revision was undertaken in 2013-14. Although introducing mostly minor fixes and
-					updates, it did see the integration of Fixed Layout Documents, which give Authors greater control
-					over presentation when a reflowable EPUB is not suitable for the content. [[EPUBPublications-301]]
-					[[EPUBContentDocs-301]] [[OCF-301]] [[EPUBMediaOverlays-301]] [[EPUBChanges-301]]</p>
+					updates, it did see the integration of Fixed Layout Documents, which give EPUB Creators greater
+					control over presentation when a reflowable EPUB is not suitable for the content.
+					[[EPUBPublications-301]] [[EPUBContentDocs-301]] [[OCF-301]] [[EPUBMediaOverlays-301]]
+					[[EPUBChanges-301]]</p>
 			</section>
 
 			<section id="epub31">
@@ -651,12 +652,12 @@
 			<section id="epub32">
 				<h3>EPUB 3.2: 2018</h3>
 				<p>The work on EPUB 3.2 was undertaken shortly after EPUB 3.1 to restore compatibility of content to
-					EPUB 3. The change of version number introduced in EPUB 3.1 meant that authors, vendors and reading
-					system developers would have to produce, distribute and consume two versions of EPUB content, but
-					the costs of this change outweighed the benefits of the new version. EPUB 3.2 instead keeps all the
-					best parts of EPUB 3.1 but returns and deprecates the removed elements so that a new version number
-					is not necessary in the Package Document. [[EPUB-32]] [[EPUBPackages-32]] [[EPUBContentDocs-32]]
-					[[OCF-32]] [[EPUBMediaOverlays-32]] [[EPUBChanges-32]]</p>
+					EPUB 3. The change of version number introduced in EPUB 3.1 meant that EPUB Creators, vendors and
+					reading system developers would have to produce, distribute and consume two versions of EPUB
+					content, but the costs of this change outweighed the benefits of the new version. EPUB 3.2 instead
+					keeps all the best parts of EPUB 3.1 but returns and deprecates the removed elements so that a new
+					version number is not necessary in the Package Document. [[EPUB-32]] [[EPUBPackages-32]]
+					[[EPUBContentDocs-32]] [[OCF-32]] [[EPUBMediaOverlays-32]] [[EPUBChanges-32]]</p>
 			</section>
 
 			<section id="epub33">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -203,10 +203,10 @@
 					</ul>
 					<p class="note" id="note-video-codecs">It is recommended that Reading Systems support at least one
 						of the H.264 [[H264]] and VP8 [[RFC6386]] video codecs, but this is not a conformance
-						requirement – a Reading System might support other video codecs, or none at all. Authors and
-						Reading System developers need to take into consideration factors such as breadth of adoption,
-						video playback quality, and technology usage royalty requirements when making a choice to
-						include or implement video in either format, or both.</p>
+						requirement &#8212; a Reading System may support other video codecs, or none at all. Reading
+						System developers need to take into consideration factors such as breadth of adoption, video
+						playback quality, and technology usage royalty requirements when making the choice to implement
+						video in either format, or both.</p>
 				</dd>
 				<dt id="sec-epub-rs-conf-a11y">Accessibility</dt>
 				<dd>
@@ -333,12 +333,12 @@
 				<section id="sec-pub-identifiers">
 					<h3>Unique Identifier</h3>
 
-					<p>Reading Systems SHOULD NOT depend on the <code>unique-identifier</code> attribute being unique to one and only one
-						EPUB Publication. Determining whether two EPUB Publications with the same Unique Identifier
-						represent different versions of the same publication, or different publications, might
-						require inspecting other metadata, such as the titles or authors.</p>
+					<p>Reading Systems SHOULD NOT depend on the <code>unique-identifier</code> attribute being unique to
+						one and only one EPUB Publication. Determining whether two EPUB Publications with the same
+						Unique Identifier represent different versions of the same publication, or different
+						publications, might require inspecting other metadata, such as the titles or authors.</p>
 				</section>
-	
+
 				<section id="metadata">
 					<h4>Metadata</h4>
 
@@ -438,9 +438,9 @@
 								supports multiple Publication Resources in the fallback chain, it MAY select the
 								resource to use based on specific <a
 									href="https://www.w3.org/TR/epub-33/#attrdef-item-properties">properties</a>
-								[[!EPUB-33]] of that resource, otherwise it SHOULD honor the Author's preferred fallback
-								order. If a Reading System does not support any resource in the fallback chain, it MUST
-								alert the reader that content could not be displayed.</p>
+								[[!EPUB-33]] of that resource, otherwise it SHOULD honor the EPUB Creator's preferred
+								fallback order. If a Reading System does not support any resource in the fallback chain,
+								it MUST alert the reader that content could not be displayed.</p>
 						</dd>
 						<dt>Manifest Fallbacks</dt>
 						<dd>
@@ -788,8 +788,8 @@
 									default rendering</a>.</p>
 						</li>
 						<li>
-							<p id="confreq-css-rs-overrides">It SHOULD respect Author CSS and user styles as defined in
-									<a href="#sec-css-rs-overrides"></a>.</p>
+							<p id="confreq-css-rs-overrides">It SHOULD respect CSS and user styles provided by the EPUB
+								Creator as defined in <a href="#sec-css-rs-overrides"></a>.</p>
 						</li>
 					</ul>
 
@@ -800,12 +800,12 @@
 				<section id="sec-css-rs-overrides">
 					<h4>Reading System Overrides</h4>
 
-					<p><a>EPUB Reading Systems</a> SHOULD apply <a>Author</a> style sheets as written to <a>EPUB Content
-							Documents</a>. If a Reading System allows, users SHOULD be able to override Author style
-						sheets as desired. EPUB Reading Systems SHOULD NOT override Author style sheets unless strictly
-						necessary.</p>
+					<p><a>EPUB Reading Systems</a> SHOULD apply <a>EPUB Creator</a> style sheets as written to <a>EPUB
+							Content Documents</a>. If a Reading System allows, users SHOULD be able to override the EPUB
+						Creator's style sheets as desired. EPUB Reading Systems SHOULD NOT override the EPUB Creator's
+						style sheets unless strictly necessary.</p>
 
-					<p>If a Reading System has to override an Author style sheet, it SHOULD do so in a way that
+					<p>If a Reading System has to override an EPUB Creator's style sheet, it SHOULD do so in a way that
 						preserves the Cascade: through a user agent style sheet, the <a
 							href="https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-OverrideAndComputed"
 								><code>getOverrideStyle</code> method</a> [[!DOM-Level-2-Style]], or [[!HTML]] <a
@@ -813,7 +813,7 @@
 								><code>style</code> attributes</a>.</p>
 
 					<p>Developers of Reading Systems are strongly encouraged to publicly document their user agent style
-						sheets and how they interact with Author style sheets.</p>
+						sheets and how they interact with EPUB Creator's style sheets.</p>
 				</section>
 			</section>
 
@@ -888,29 +888,15 @@
 									Scripted Content Documents</a> [[!EPUB-33]].</p>
 						</li>
 					</ul>
-
-					<div class="note">
-						<p>Reading Systems might render Scripted Content Documents in a manner that disables other EPUB
-							capabilities and/or provides a different rendering and user experience (e.g., by disabling
-							pagination).</p>
-						<p>Authors choosing to restrict the usage of scripting to the <a
-								href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained"
-								>container-constrained model</a> [[!EPUB-33]] will ensure a more consistent user
-							experience between scripted and non-scripted content (e.g., consistent pagination
-							behavior).</p>
-						<p>Authors are advised to use declarative techniques whenever practical to increase the
-							interoperability, longevity, and accessibility of their EPUB Publications, and avoid the
-							inclusion of scripting whenever practical.</p>
-					</div>
 				</section>
 
 				<section id="sec-scripted-content-security" class="informative">
 					<h4>Security Considerations</h4>
 
-					<p>All EPUB <a>Authors</a> and <a>EPUB Reading System</a> developers have to be aware of the
-						security issues that arise when scripted content is executed by a Reading System. As the
-						underlying scripting model employed by Reading Systems and browsers is the same, the same kinds
-						of issues encountered in Web contexts have to be taken into consideration.</p>
+					<p><a>EPUB Creators</a> and <a>Reading System</a> developers must be aware of the security issues
+						that arise when scripted content is executed by a Reading System. As the underlying scripting
+						model employed by Reading Systems and browsers is the same, the same kinds of issues encountered
+						in Web contexts have to be taken into consideration.</p>
 
 					<p>Each Reading System has to establish if the scripts in a particular document are to be trusted or
 						not. It is advised that all scripts be treated as untrusted (and potentially malicious), and
@@ -986,12 +972,6 @@
 							>potentially malicious</a> script could impact their Reading Systems. As a result, although
 						the scripting environment needs to be able to cancel the default action of any event, some
 						events either might not be passed through or might not be cancelable.</p>
-
-					<p><a>Authors</a> need to take into account the wide variety of possible Reading System
-						implementations when adding scripting functionality to their EPUB Publications (e.g., not all
-						devices have physical keyboards, and in many cases a soft keyboard is activated only for text
-						input elements). Consequently, relying on keyboard events alone is not advised; alternative ways
-						to trigger a desired action always need to be provided.</p>
 				</section>
 			</section>
 
@@ -1966,7 +1946,7 @@ partial interface Navigator {
 							<a href="https://www.w3.org/TR/2015/WD-workers-20150924/#the-workernavigator-object"
 								><code>WorkerNavigator</code> object</a> [[WebWorkers]]. Reading Systems therefore do
 						not have to expose the <code>epubReadingSystem</code> object in the scripting context of
-						Workers, and Authors cannot rely on its presence.</p>
+						Workers, and EPUB Creators cannot rely on its presence.</p>
 				</div>
 			</section>
 
@@ -2066,7 +2046,7 @@ partial interface Navigator {
 							could change in incompatible ways over time. The return value indicates support only for the
 							specified version of the feature.</p>
 
-						<p><a>Authors</a> SHOULD NOT include the <code>version</code> parameter when querying <a
+						<p><a>EPUB Creators</a> SHOULD NOT include the <code>version</code> parameter when querying <a
 								href="#app-ers-hasFeature-features">features defined in this specification</a> — these
 							features are considered versionless. If a Reading System supports a feature defined in this
 							specification, it MUST ignore any supplied <code>version</code> parameter and return a
@@ -2182,9 +2162,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					<li>10-Mar-2021: Changed restriction against using resources not listed in the Package Document to a
 						recommendation not to use. See <a href="https://github.com/w3c/epub-specs/issues/810">issue
 							810</a>.</li>
-					<li>09-March-2021: the statement on unique identifiers has been set to non-normative, following 
-						the discussion and <a href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-12-18-epub#resolution2">Working Group resolution</a>. See <a href="https://github.com/w3c/epub-specs/issues/1310">issue 1310</a>.
-					</li>
+					<li>09-March-2021: the statement on unique identifiers has been set to non-normative, following the
+						discussion and <a
+							href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-12-18-epub#resolution2"
+							>Working Group resolution</a>. See <a href="https://github.com/w3c/epub-specs/issues/1310"
+							>issue 1310</a>. </li>
 					<li>8-Mar-2021: Remove unnecessary requirement to assume default value for rendering metadata. See
 							<a href="https://github.com/w3c/epub-specs/issues/1313">issue 1313</a>.</li>
 					<li>5-Mar-2021: Added requirement for reading systems to collapse whitespace in DCMES and meta


### PR DESCRIPTION
Changes all instance of "Author" to "EPUB Creator". Can always be switched to another term if people prefer something else (it's not as clunky sounding as I thought it might be, at least). Take a look at the definition, too.

Otherwise, only a couple of other minor content moves as I found some author guidance hiding in the reading system prose:

- added some of the relevant video note text to the core media types section so you don't have to link across
- moved some note text for authoring into the relevant scripting sections
- added the paragraph on authoring in scripting event model to the core spec

The only bit of authoring guidance left in the reading system specification, at least that this change surfaced, was in the readingsystemobject appendix, but leaving it where it is for now.

Fixes #1575 

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1577.html" title="Last updated on Mar 16, 2021, 3:18 PM UTC (99b7ef6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1577/2577dab...99b7ef6.html" title="Last updated on Mar 16, 2021, 3:18 PM UTC (99b7ef6)">Diff</a>