### PR TITLE
Add missing element definitions

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6341,8 +6341,8 @@ Spine:
 									applied to an EPUB Publication as a whole or to its parts and can specify the
 									signing of any kind of data (i.e., not just XML).</p>
 
-								<p class="note"> The content of the <code>signatures.xml</code> file is also defined,
-									informally, through an XML schema; see <a href="#app-schema-signatures"></a> for
+								<p class="note"> The content of the <code>signatures.xml</code> file is also defined
+									informally through an XML schema. See <a href="#app-schema-signatures"></a> for
 									further details. </p>
 
 								<p>When the <code>signatures.xml</code> file is not present, no part of the container is
@@ -9292,8 +9292,10 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
-					<li>15-Mar-2021: Removed the normative dependencies on XML schemas; all schemas are considered as
-						informative. See <a href="https://github.com/w3c/epub-specs/issues/1566">issue 1566</a>.</li>
+					<li>15-Mar-2021: Removed the normative dependencies on XML schemas and added element and attribute
+						definitions for the <code>container.xml</code>, <code>encryption.xml</code> and
+							<code>signatures.xml</code> files. All schemas are considered informative. See <a
+							href="https://github.com/w3c/epub-specs/issues/1566">issue 1566</a>.</li>
 					<li>10-Mar-2021: Require that resources referenced from an EPUB Publication not be located in the
 							<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205"
 							>issue 1205</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6010,90 +6010,124 @@ Spine:
 								indicate that the resource is encrypted and provide information on how it is
 								encrypted.</p>
 
-							<p>This file is an XML document whose root element is <code
-									id="elemdef-encryption-encryption">encryption</code>. The <code>encryption</code>
-								element contains child elements of type <code>EncryptedKey</code> and
-									<code>EncryptedData</code> as defined by [[!XMLENC-CORE1]]. An <code
-									id="elemdef-encryption-EncryptedKey">EncryptedKey</code> element describes each
-								encryption key used in the container, while an <code
-									id="elemdef-encryption-EncryptedData">EncryptedData</code> element describes each
-								encrypted file. Each <code>EncryptedData</code> element refers to an
-									<code>EncryptedKey</code> element, as described in XML Encryption.</p>
+							<section id="sec-encryption.xml-encryption">
+								<h6>The <code>encryption</code> element</h6>
 
-							<p class="note"> The content of the <code>encryption.xml</code> file is also defined,
-								informally, through an XML schema; see <a href="#app-schema-encryption"></a> for further
-								details. </p>
+								<dl class="elemdef" id="elemdef-encryption">
+									<dt>Element Name</dt>
+									<dd>
+										<p>
+											<code>encryption</code>
+										</p>
+									</dd>
+									<dt>Namespace</dt>
+									<dd>
+										<p><code>urn:oasis:names:tc:opendocument:xmlns:container</code></p>
+									</dd>
+									<dt>Usage</dt>
+									<dd>
+										<p>Root element of the <code>encryption.xml</code> file.</p>
+									</dd>
+									<dt>Attributes</dt>
+									<dd>
+										<p>None</p>
+									</dd>
+									<dt>Content Model</dt>
+									<dd>
+										<p>In any order:</p>
+										<ul class="nomark">
+											<li><code>EncryptedKey</code> [1 or more]</li>
+											<li><code>EncryptedData</code> [1 or more]</li>
+										</ul>
+									</dd>
+								</dl>
 
-							<p>OCF encrypts individual files independently, trading off some security for improved
-								performance, allowing the container contents to be incrementally decrypted. Encryption
-								in this way exposes the directory structure and file naming of the whole package.</p>
+								<p>The <code>encryption</code> element contains child elements of type
+										<code>EncryptedKey</code> and <code>EncryptedData</code> as defined by
+									[[!XMLENC-CORE1]].</p>
 
-							<p>OCF uses XML Encryption [[!XMLENC-CORE1]] to provide a framework for encryption, allowing
-								a variety of algorithms to be used. XML Encryption specifies a process for encrypting
-								arbitrary data and representing the result in XML. Even though an <a>OCF Abstract
-									Container</a> might contain non-XML data, XML Encryption can be used to encrypt all
-								data in an OCF Abstract Container. OCF encryption supports only the encryption of entire
-								files within the container, not parts of files. The <code>encryption.xml</code> file, if
-								present, MUST NOT be encrypted.</p>
+								<p>An <code id="elemdef-encryption-EncryptedKey">EncryptedKey</code> element describes
+									each encryption key used in the container, while an <code
+										id="elemdef-encryption-EncryptedData">EncryptedData</code> element describes
+									each encrypted file. Each <code>EncryptedData</code> element refers to an
+										<code>EncryptedKey</code> element, as described in XML Encryption.</p>
 
-							<p>Encrypted data replaces unencrypted data in an OCF Abstract Container. For example, if an
-								image named <code>photo.jpeg</code> is encrypted, the contents of the
-									<code>photo.jpeg</code> resource SHOULD be replaced by its encrypted contents.
-								Within the ZIP directory, encrypted files SHOULD be stored rather than
-								Deflate-compressed.</p>
+								<p class="note">The content of the <code>encryption.xml</code> file is also defined
+									informally through an XML schema. See <a href="#app-schema-encryption"></a> for
+									further details.</p>
 
-							<p id="encryption-obfuscation">Note that some situations require obfuscating the storage of
-								embedded resources referenced by an <a>EPUB Publication</a> to make them more difficult
-								to extract for unrestricted use (e.g., fonts). Although obfuscation is not encryption,
-								the <code>encryption.xml</code> file is used in conjunction with the <a
-									href="#sec-resource-obfuscation">resource obfuscation algorithm</a> to identify
-								resources that need to be de-obfuscated before they can be used.</p>
+								<p>OCF encrypts individual files independently, trading off some security for improved
+									performance, allowing the container contents to be incrementally decrypted.
+									Encryption in this way exposes the directory structure and file naming of the whole
+									package.</p>
 
-							<p id="encryption-restrictions">The following files MUST NOT be encrypted, regardless of
-								whether default or specific encryption is requested:</p>
+								<p>OCF uses XML Encryption [[!XMLENC-CORE1]] to provide a framework for encryption,
+									allowing a variety of algorithms to be used. XML Encryption specifies a process for
+									encrypting arbitrary data and representing the result in XML. Even though an <a>OCF
+										Abstract Container</a> might contain non-XML data, XML Encryption can be used to
+									encrypt all data in an OCF Abstract Container. OCF encryption supports only the
+									encryption of entire files within the container, not parts of files. The
+										<code>encryption.xml</code> file, if present, MUST NOT be encrypted.</p>
 
-							<ul class="nomark">
-								<li>
-									<code>mimetype</code>
-								</li>
-								<li>
-									<code>META-INF/container.xml</code>
-								</li>
-								<li>
-									<code>META-INF/encryption.xml</code>
-								</li>
-								<li>
-									<code>META-INF/manifest.xml</code>
-								</li>
-								<li>
-									<code>META-INF/metadata.xml</code>
-								</li>
-								<li>
-									<code>META-INF/rights.xml</code>
-								</li>
-								<li>
-									<code>META-INF/signatures.xml</code>
-								</li>
-								<li>
-									<a>
-										<code>Package Document</code>
-									</a>
-								</li>
-							</ul>
+								<p>Encrypted data replaces unencrypted data in an OCF Abstract Container. For example,
+									if an image named <code>photo.jpeg</code> is encrypted, the contents of the
+										<code>photo.jpeg</code> resource SHOULD be replaced by its encrypted contents.
+									Within the ZIP directory, encrypted files SHOULD be stored rather than
+									Deflate-compressed.</p>
 
-							<p>Signed resources MAY subsequently be encrypted using the Decryption Transform for XML
-								Signature [[!XMLENC-DECRYPT]]. This feature enables an application such as an OCF agent
-								to distinguish data that was encrypted before signing from data that was encrypted after
-								signing. Only data that was encrypted after signing MUST be decrypted before computing
-								the digest used to validate the signature.</p>
+								<p id="encryption-obfuscation">Note that some situations require obfuscating the storage
+									of embedded resources referenced by an <a>EPUB Publication</a> to make them more
+									difficult to extract for unrestricted use (e.g., fonts). Although obfuscation is not
+									encryption, the <code>encryption.xml</code> file is used in conjunction with the <a
+										href="#sec-resource-obfuscation">resource obfuscation algorithm</a> to identify
+									resources that need to be de-obfuscated before they can be used.</p>
 
-							<aside class="example">
-								<p>In the following example, adapted from <a
-										href="https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/#sec-eg-Symmetric-Key"
-										>Section 2.2.1 </a> of [[!XMLENC-CORE1]] the resource <code>image.jpeg</code> is
-									encrypted using a symmetric key algorithm (AES) and the symmetric key is further
-									encrypted using an asymmetric key algorithm (RSA) with a key of John Smith.</p>
-								<pre>
+								<p id="encryption-restrictions">The following files MUST NOT be encrypted, regardless of
+									whether default or specific encryption is requested:</p>
+
+								<ul class="nomark">
+									<li>
+										<code>mimetype</code>
+									</li>
+									<li>
+										<code>META-INF/container.xml</code>
+									</li>
+									<li>
+										<code>META-INF/encryption.xml</code>
+									</li>
+									<li>
+										<code>META-INF/manifest.xml</code>
+									</li>
+									<li>
+										<code>META-INF/metadata.xml</code>
+									</li>
+									<li>
+										<code>META-INF/rights.xml</code>
+									</li>
+									<li>
+										<code>META-INF/signatures.xml</code>
+									</li>
+									<li>
+										<a>
+											<code>Package Document</code>
+										</a>
+									</li>
+								</ul>
+
+								<p>Signed resources MAY subsequently be encrypted using the Decryption Transform for XML
+									Signature [[!XMLENC-DECRYPT]]. This feature enables an application such as an OCF
+									agent to distinguish data that was encrypted before signing from data that was
+									encrypted after signing. Only data that was encrypted after signing MUST be
+									decrypted before computing the digest used to validate the signature.</p>
+
+								<aside class="example">
+									<p>In the following example, adapted from <a
+											href="https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/#sec-eg-Symmetric-Key"
+											>Section 2.2.1 </a> of [[!XMLENC-CORE1]] the resource
+											<code>image.jpeg</code> is encrypted using a symmetric key algorithm (AES)
+										and the symmetric key is further encrypted using an asymmetric key algorithm
+										(RSA) with a key of John Smith.</p>
+									<pre>
 &lt;encryption
     xmlns ="urn:oasis:names:tc:opendocument:xmlns:container"
     xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
@@ -6119,7 +6153,8 @@ Spine:
     &lt;/enc:EncryptedData&gt;
 &lt;/encryption&gt;
                     </pre>
-							</aside>
+								</aside>
+							</section>
 
 							<section id="sec-enc-compression">
 								<h6>Order of Compression and Encryption</h6>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -965,9 +965,8 @@
 						</li>
 					</ul>
 
-					<p>Authors are encouraged to locate these resources inside the EPUB Container
-						whenever feasible to allow users access to the entire presentation regardless of
-						connectivity status.</p>
+					<p>Authors are encouraged to locate these resources inside the EPUB Container whenever feasible to
+						allow users access to the entire presentation regardless of connectivity status.</p>
 
 					<aside class="example">
 						<p>The following example shows a reference to an audio file in an <a>XHTML Content Document</a>
@@ -5746,32 +5745,251 @@ Spine:
 								identifies the <a>Package Documents</a> available in the <a>OCF Abstract
 								Container</a>.</p>
 
-							<p id="elemdef-container-rootfile">Each <code>rootfile</code> element MUST identify the
-								location of a <a>Package Document</a> in its <code>full-path</code> attribute and
-								specify the media type "<code>application/oebps-package+xml</code>" in its
-									<code>media-type</code> attribute.</p>
+							<p>All [[!XML]] elements defined in this section are in the
+									<code>urn:oasis:names:tc:opendocument:xmlns:container</code> namespace
+								[[!XML-NAMES]] unless specified otherwise.</p>
 
-							<p>If more than one <code>rootfile</code> element is defined, each MUST reference a Package
-								Document that conforms to the same version of EPUB. Each Package Document represents one
-								rendering of the EPUB Publication.</p>
+							<p>The contents of this file MUST be valid to the definition in this section after removing
+								all elements and attributes from other namespaces (including all attributes and contents
+								of such elements).</p>
 
-							<p class="note">
-								The content of this file is also defined, informally, through an XML schema;
-								see <a href="#app-schema-container"></a> for further details.
-							</p>
+							<p class="note">The content of this file is also defined informally through an XML schema.
+								See <a href="#app-schema-container"></a> for further details.</p>
 
-							<div class="note">
-								<p>Although the EPUB Container provides the ability to reference more than one Package
-									Document, this specification does not define how to interpret, or select from, the
-									available options. Refer to [[EPUB-MULTI-REND-11]] for more information on how to
-									bundle more than one rendering of the content.</p>
-							</div>
+							<section id="sec-container.xml-container-elem">
+								<h6>The <code>container</code> Element</h6>
 
-							<aside class="example">
-								<p>The following example shows a sample <code>container.xml</code> for an EPUB
+								<p>The <code>container</code> element is the root element of the
+										<code>container.xml</code> file.</p>
+
+								<dl id="elemdef-container" class="elemdef">
+									<dt>Element Name</dt>
+									<dd>
+										<p>
+											<code>container</code>
+										</p>
+									</dd>
+									<dt>Usage</dt>
+									<dd>
+										<p>Root element of the <code>container.xml</code> file.</p>
+									</dd>
+									<dt>Attributes</dt>
+									<dd>
+										<dl>
+											<dt>
+												<code>version</code>
+												<code>[required]</code>
+											</dt>
+											<dd id="attrdef-container-version">This attribute MUST have the value
+													"<code>1.0</code>".</dd>
+										</dl>
+									</dd>
+									<dt>Content Model</dt>
+									<dd>
+										<p>In this order:</p>
+										<ul class="nomark">
+											<li><a href="#elemdef-rootfiles"><code>rootfiles</code></a> [exactly
+												one]</li>
+											<li><a href="#elemdef-links"><code>links</code></a> [0 or 1]</li>
+										</ul>
+									</dd>
+								</dl>
+							</section>
+
+							<section id="sec-container.xml-rootfiles-elem">
+								<h6>The <code>rootfiles</code> Element</h6>
+
+								<p>The <code>rootfiles</code> element contains a list of <a>Package Documents</a>
+									available in the <a>EPUB Container</a>.</p>
+
+								<dl id="elemdef-rootfiles" class="elemdef">
+									<dt>Element Name</dt>
+									<dd>
+										<p>
+											<code>rootfiles</code>
+										</p>
+									</dd>
+									<dt>Usage</dt>
+									<dd>
+										<p>REQUIRED first child of <a href="#elemdef-container"
+												><code>container</code></a>.</p>
+									</dd>
+									<dt>Attributes</dt>
+									<dd>
+										<p>None</p>
+									</dd>
+									<dt>Content Model</dt>
+									<dd>
+										<ul class="nomark">
+											<li><a href="#elemdef-rootfile"><code>rootfile</code></a> [1 or more]</li>
+										</ul>
+									</dd>
+								</dl>
+							</section>
+
+							<section id="sec-container.xml-rootfile-elem">
+								<h6>The <code>rootfile</code> Element</h6>
+
+								<p>Each <code>rootfile</code> element identifies the location of one <a>Package
+										Document</a> in the <a>EPUB Container</a>.</p>
+
+								<dl id="elemdef-rootfile" class="elemdef">
+									<dt>Element Name</dt>
+									<dd>
+										<p>
+											<code>rootfile</code>
+										</p>
+									</dd>
+									<dt>Usage</dt>
+									<dd>
+										<p>As child of the <a href="#elemdef-rootfiles"><code>rootfiles</code></a>
+											element. Repeatable.</p>
+									</dd>
+									<dt>Attributes</dt>
+									<dd>
+										<dl>
+											<dt>
+												<code>full-path</code>
+												<code>[required]</code>
+											</dt>
+											<dd>
+												<p>Identifies the location of a <a>Package Document</a>.</p>
+												<p>The value of the attribute MUST contain a <em>path component</em>
+													[[!RFC3986]] which MUST take the form of a <em>path-rootless</em>
+													[[!RFC3986]] only. The path components are relative to the <a>Root
+														Directory</a>.</p>
+											</dd>
+
+											<dt>
+												<code>media-type</code>
+												<code>[required]</code>
+											</dt>
+											<dd>
+												<p>Identifies the media type of the Package Document.</p>
+												<p>The value of the attribute MUST be
+														"<code>application/oebps-package+xml</code>".</p>
+											</dd>
+										</dl>
+									</dd>
+									<dt>Content Model</dt>
+									<dd>
+										<p>Empty</p>
+									</dd>
+								</dl>
+
+								<p>If more than one <code>rootfile</code> element is defined, each MUST reference a
+									Package Document that conforms to the same version of EPUB. Each Package Document
+									represents one rendering of the EPUB Publication.</p>
+
+								<div class="note">
+									<p>Although the EPUB Container provides the ability to reference more than one
+										Package Document, this specification does not define how to interpret, or select
+										from, the available options. Refer to [[EPUB-MULTI-REND-11]] for more
+										information on how to bundle more than one rendering of the content.</p>
+								</div>
+							</section>
+
+							<section id="sec-container.xml-links-elem">
+								<h6>The <code>links</code> Element</h6>
+
+								<p>The <code id="elemdef-container-links">links</code> element identifies resources
+									necessary for the processing of the <a>OCF ZIP Container</a>.</p>
+
+								<dl id="elemdef-links" class="elemdef">
+									<dt>Element Name</dt>
+									<dd>
+										<p>
+											<code>links</code>
+										</p>
+									</dd>
+									<dt>Usage</dt>
+									<dd>
+										<p>OPTIONAL second child of <a href="#elemdef-container"
+												><code>container</code></a>. Repeatable.</p>
+									</dd>
+									<dt>Attributes</dt>
+									<dd>
+										<p>None</p>
+									</dd>
+									<dt>Content Model</dt>
+									<dd>
+										<ul class="nomark">
+											<li><a href="#elemdef-link"><code>link</code></a> [1 or more]</li>
+										</ul>
+									</dd>
+								</dl>
+
+								<div class="note">
+									<p>This specification currently does not define uses for the <code>links</code>
+										element. Refer to [[EPUB-Multi-Rend-11]] for an example of its use.</p>
+								</div>
+							</section>
+
+							<section id="sec-container.xml-link-elem">
+								<h6>The <code>link</code> Element</h6>
+
+								<dl id="elemdef-link" class="elemdef">
+									<dt>Element Name</dt>
+									<dd>
+										<p>
+											<code>link</code>
+										</p>
+									</dd>
+									<dt>Usage</dt>
+									<dd>
+										<p>As child of the <a href="#elemdef-links"><code>links</code></a> element.
+											Repeatable.</p>
+									</dd>
+									<dt>Attributes</dt>
+									<dd>
+										<dl>
+											<dt>
+												<code>href</code>
+												<code>[required]</code>
+											</dt>
+											<dd>
+												<p>Identifies the location of a resource.</p>
+												<p>The value of the <code>link</code> element <code>href</code>
+													attribute MUST contain a <em>path component</em> [[!RFC3986]] which
+													MUST take the form of a <em>path-rootless</em> [[!RFC3986]] only.
+													The path component is relative to the <a>Root Directory</a>.</p>
+											</dd>
+
+											<dt>
+												<code>media-type</code>
+												<code>[optional]</code>
+											</dt>
+											<dd>
+												<p>Identifies the type and format of the referenced resource.</p>
+												<p>The value of the attribute MUST be a media type [[!RFC2046]].</p>
+											</dd>
+
+											<dt>
+												<code>rel</code>
+												<code>[required]</code>
+											</dt>
+											<dd>
+												<p>Identifies the relationship of the resource.</p>
+												<p>The value of the attribute MUST be a space-separated list of
+													tokens.</p>
+											</dd>
+										</dl>
+									</dd>
+									<dt>Content Model</dt>
+									<dd>
+										<p>Empty</p>
+									</dd>
+								</dl>
+							</section>
+
+							<section id="sec-container-container.xml-example" class="informative">
+								<h6>Container Example</h6>
+
+								<p>The following example shows a sample <code>container.xml</code> file for an EPUB
 									Publication with the root file <code>EPUB/My Crazy Life.opf</code> (the Package
 									Document):</p>
-								<pre>
+
+								<pre class="example">
 &lt;?xml version="1.0"?&gt;
 &lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
     &lt;rootfiles&gt;
@@ -5780,27 +5998,7 @@ Spine:
     &lt;/rootfiles&gt;
 &lt;/container&gt;
                     </pre>
-							</aside>
-
-							<p>The OPTIONAL <code id="elemdef-container-links">links</code> element identifies resources
-								necessary for the processing of the <a>OCF ZIP Container</a>. Each of its child <code
-									id="elemdef-container-link">link</code> elements MUST specify an <code>href</code>
-								attribute whose value identifies the location of a resource. Each <code>link</code>
-								element also MUST specify a <code>rel</code> attribute whose value identifies the
-								relationship of the resource, and MAY specify a <code>media-type</code> attribute whose
-								value MUST be a media type [[!RFC2046]] that specifies the type and format of the
-								resource referenced by the <code>link</code>.</p>
-
-							<div class="note">
-								<p>This specification currently does not define uses for the <code>links</code> element.
-									Refer to [[EPUB-Multi-Rend-11]] for an example of its use.</p>
-							</div>
-
-							<p>The value of the <code>rootfile</code> element <code>full-path</code> attribute and the
-									<code>link</code> element <code>href</code> attribute MUST contain a <em
-									class="firstterm" id="def-path-component">path component</em> [[!RFC3986]] which
-								MUST take the form of a <em class="firstterm" id="def-path-rootless">path-rootless</em>
-								[[!RFC3986]] only. The path components are relative to the <a>Root Directory</a>.</p>
+							</section>
 						</section>
 
 						<section id="sec-container-metainf-encryption.xml">
@@ -5822,11 +6020,10 @@ Spine:
 								encrypted file. Each <code>EncryptedData</code> element refers to an
 									<code>EncryptedKey</code> element, as described in XML Encryption.</p>
 
-							<p class="note">
-								The content of the <code>encryption.xml</code> file is also defined, informally, through an XML schema;
-								see <a href="#app-schema-encryption"></a> for further details.
-							</p>
-		
+							<p class="note"> The content of the <code>encryption.xml</code> file is also defined,
+								informally, through an XML schema; see <a href="#app-schema-encryption"></a> for further
+								details. </p>
+
 							<p>OCF encrypts individual files independently, trading off some security for improved
 								performance, allowing the container contents to be incrementally decrypted. Encryption
 								in this way exposes the directory structure and file naming of the whole package.</p>
@@ -6080,11 +6277,10 @@ Spine:
 								by [[!XMLDSIG-CORE1]]. Signatures can be applied to an EPUB Publication as a whole or to
 								its parts and can specify the signing of any kind of data (i.e., not just XML).</p>
 
-							<p class="note">
-								The content of the <code>signatures.xml</code> file is also defined, informally, through an XML schema;
-								see <a href="#app-schema-signatures"></a> for further details.
-							</p>
-	
+							<p class="note"> The content of the <code>signatures.xml</code> file is also defined,
+								informally, through an XML schema; see <a href="#app-schema-signatures"></a> for further
+								details. </p>
+
 							<p>When the <code>signatures.xml</code> file is not present, no part of the container is
 								digitally signed at the container level. Digital signing might exist within the <a>EPUB
 									Publication</a>.</p>
@@ -8351,9 +8547,8 @@ html.my-document-playing * {
 				<p>A non-normative schema for Package Documents is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
 						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.
-						This schema should be applied after removing all elements and attributes from other namespaces (including all
-							attributes and contents of such elements).
-					</p>
+					This schema should be applied after removing all elements and attributes from other namespaces
+					(including all attributes and contents of such elements). </p>
 
 				<p>Validation using this schema requires a processor that supports [[NVDL]], [[RelaxNG-Schema]],
 					[[ISOSchematron]] and [[XMLSCHEMA-2]].</p>
@@ -9032,9 +9227,8 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
-					<li>15-Mar-2021: Removed the normative dependencies on XML schemas; all schemas are considered as informative.
-						See <a href="https://github.com/w3c/epub-specs/issues/1566"issue 1566</a>.</li>
-
+					<li>15-Mar-2021: Removed the normative dependencies on XML schemas; all schemas are considered as
+						informative. See <a href="https://github.com/w3c/epub-specs/issues/1566">issue 1566</a>.</li>
 					<li>10-Mar-2021: Require that resources referenced from an EPUB Publication not be located in the
 							<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205"
 							>issue 1205</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6304,76 +6304,107 @@ Spine:
 							</div>
 
 							<p>The OPTIONAL <code>signatures.xml</code> file in the <code>META-INF</code> directory
-								holds digital signatures for the container and its contents. The contents of this file
-								MUST be valid to the schema in <a href="#app-schema-signatures"></a>.</p>
+								holds digital signatures for the container and its contents.</p>
 
-							<p>The root element of the <code>signatures.xml</code> file is the <code>signatures</code>
-								element. This element contains child elements of type <code>Signature</code>, as defined
-								by [[!XMLDSIG-CORE1]]. Signatures can be applied to an EPUB Publication as a whole or to
-								its parts and can specify the signing of any kind of data (i.e., not just XML).</p>
+							<section id="sec-signatures.xml-signatures">
+								<h6>The <code>signatures</code> element</h6>
 
-							<p class="note"> The content of the <code>signatures.xml</code> file is also defined,
-								informally, through an XML schema; see <a href="#app-schema-signatures"></a> for further
-								details. </p>
+								<dl class="elemdef" id="elemdef-signatures">
+									<dt>Element Name</dt>
+									<dd>
+										<p>
+											<code>signatures</code>
+										</p>
+									</dd>
+									<dt>Namespace</dt>
+									<dd>
+										<p><code>urn:oasis:names:tc:opendocument:xmlns:container</code></p>
+									</dd>
+									<dt>Usage</dt>
+									<dd>
+										<p>Root element of the <code>signature.xml</code> file.</p>
+									</dd>
+									<dt>Attributes</dt>
+									<dd>
+										<p>None</p>
+									</dd>
+									<dt>Content Model</dt>
+									<dd>
+										<ul class="nomark">
+											<li><code>Signature</code> [1 or more]</li>
+										</ul>
+									</dd>
+								</dl>
 
-							<p>When the <code>signatures.xml</code> file is not present, no part of the container is
-								digitally signed at the container level. Digital signing might exist within the <a>EPUB
-									Publication</a>.</p>
+								<p>The <code>signature</code> element contains child elements of type
+										<code>Signature</code>, as defined by [[!XMLDSIG-CORE1]]. Signatures can be
+									applied to an EPUB Publication as a whole or to its parts and can specify the
+									signing of any kind of data (i.e., not just XML).</p>
 
-							<p id="sig-container">When a data signature is created for the container, the signature
-								SHOULD be added as the last child <code>Signature</code> element of the
-									<code>signatures</code> element.</p>
+								<p class="note"> The content of the <code>signatures.xml</code> file is also defined,
+									informally, through an XML schema; see <a href="#app-schema-signatures"></a> for
+									further details. </p>
 
-							<div class="note">
-								<p>Each <code>Signature</code> in the <code>signatures.xml</code> file identifies by IRI
-									the data to which the signature applies, using the [[XMLDSIG-CORE1]]
-										<code>Manifest</code> element and its <code>Reference</code> sub-elements.
-									Individual contained files might be signed separately or together. Separately
-									signing each file creates a digest value for the resource that can be validated
-									independently. This approach might make a Signature element larger. If files are
-									signed together, the set of signed files can be listed in a single XML Signature
-										<code>Manifest</code> element and referenced by one or more
-										<code>Signature</code> elements.</p>
-							</div>
+								<p>When the <code>signatures.xml</code> file is not present, no part of the container is
+									digitally signed at the container level. Digital signing might exist within the
+										<a>EPUB Publication</a>.</p>
 
-							<p id="sig-restrictions">Any or all files in the container can be signed in their entirety,
-								except for the <code>signatures.xml</code> file since that file will contain the
-								computed signature information. Whether and how the <code>signatures.xml</code> file is
-								signed depends on the objective of the signer.</p>
+								<p id="sig-container">When a data signature is created for the container, the signature
+									SHOULD be added as the last child <code>Signature</code> element of the
+										<code>signatures</code> element.</p>
 
-							<p>If the signer wants to allow signatures to be added or removed from the container without
-								invalidating the signer's signature, the <code>signatures.xml</code> file SHOULD NOT be
-								signed.</p>
+								<div class="note">
+									<p>Each <code>Signature</code> in the <code>signatures.xml</code> file identifies by
+										IRI the data to which the signature applies, using the [[XMLDSIG-CORE1]]
+											<code>Manifest</code> element and its <code>Reference</code> sub-elements.
+										Individual contained files might be signed separately or together. Separately
+										signing each file creates a digest value for the resource that can be validated
+										independently. This approach might make a Signature element larger. If files are
+										signed together, the set of signed files can be listed in a single XML Signature
+											<code>Manifest</code> element and referenced by one or more
+											<code>Signature</code> elements.</p>
+								</div>
 
-							<p>If the signer wants any addition or removal of a signature to invalidate the signer’s
-								signature, the Enveloped Signature transform defined in <a
-									href="https://www.w3.org/TR/2008/REC-xmldsig-core-20080610/#sec-EnvelopedSignature"
-									>Section 6.6.4</a> of [[!XMLDSIG-CORE1]] can be used to sign the entire preexisting
-								signature file excluding the <code>Signature</code> being created. This transform would
-								sign all previous signatures, and it would become invalid if a subsequent signature were
-								added to the package.</p>
+								<p id="sig-restrictions">Any or all files in the container can be signed in their
+									entirety, except for the <code>signatures.xml</code> file since that file will
+									contain the computed signature information. Whether and how the
+										<code>signatures.xml</code> file is signed depends on the objective of the
+									signer.</p>
 
-							<div class="note">
-								<p>If the signer wants the removal of an existing signature to invalidate the signer’s
-									signature, but also wants to allow the addition of signatures, an XPath transform
-									could be used to sign just the existing signatures. The details of such a transform
-									are outside the scope of this specification, however.</p>
-							</div>
+								<p>If the signer wants to allow signatures to be added or removed from the container
+									without invalidating the signer's signature, the <code>signatures.xml</code> file
+									SHOULD NOT be signed.</p>
 
-							<p>The [[!XMLDSIG-CORE1]] specification does not associate any semantics with a signature;
-								an agent might include semantic information, for example, by adding information to the
-								Signature element that describes the signature. The [[!XMLDSIG-CORE1]] specification
-								describes how additional information can be added to a signature, such as by use the
-									<code>SignatureProperties</code> element.</p>
+								<p>If the signer wants any addition or removal of a signature to invalidate the signer’s
+									signature, the Enveloped Signature transform defined in <a
+										href="https://www.w3.org/TR/2008/REC-xmldsig-core-20080610/#sec-EnvelopedSignature"
+										>Section 6.6.4</a> of [[!XMLDSIG-CORE1]] can be used to sign the entire
+									preexisting signature file excluding the <code>Signature</code> being created. This
+									transform would sign all previous signatures, and it would become invalid if a
+									subsequent signature were added to the package.</p>
 
-							<aside class="example">
-								<p>The following XML expression shows the content of an example
-										<code>signatures.xml</code> file. It is based on the examples found in <a
-										href="https://www.w3.org/TR/2008/REC-xmldsig-core-20080610/#sec-Overview"
-										>Section 2</a> of [[!XMLDSIG-CORE1]]. It contains one signature, and the
-									signature applies to two resources, <code class="filename">EPUB/book.xhtml</code>
-									and <code>EPUB/images/cover.jpeg</code>, in the container.</p>
-								<pre>
+								<div class="note">
+									<p>If the signer wants the removal of an existing signature to invalidate the
+										signer’s signature, but also wants to allow the addition of signatures, an XPath
+										transform could be used to sign just the existing signatures. The details of
+										such a transform are outside the scope of this specification, however.</p>
+								</div>
+
+								<p>The [[!XMLDSIG-CORE1]] specification does not associate any semantics with a
+									signature; an agent might include semantic information, for example, by adding
+									information to the Signature element that describes the signature. The
+									[[!XMLDSIG-CORE1]] specification describes how additional information can be added
+									to a signature, such as by use the <code>SignatureProperties</code> element.</p>
+
+								<aside class="example">
+									<p>The following XML expression shows the content of an example
+											<code>signatures.xml</code> file. It is based on the examples found in <a
+											href="https://www.w3.org/TR/2008/REC-xmldsig-core-20080610/#sec-Overview"
+											>Section 2</a> of [[!XMLDSIG-CORE1]]. It contains one signature, and the
+										signature applies to two resources, <code class="filename"
+											>EPUB/book.xhtml</code> and <code>EPUB/images/cover.jpeg</code>, in the
+										container.</p>
+									<pre>
 &lt;signatures xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
     &lt;Signature Id="sig" xmlns="http://www.w3.org/2000/09/xmldsig#"&gt;
         &lt;SignedInfo&gt;
@@ -6416,7 +6447,8 @@ Spine:
     &lt;/Signature&gt; 
 &lt;/signatures&gt;
                     </pre>
-							</aside>
+								</aside>
+							</section>
 						</section>
 					</section>
 				</section>
@@ -8581,9 +8613,7 @@ html.my-document-playing * {
 
 				<p>A non-normative schema for Package Documents is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
-						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.
-					This schema should be applied after removing all elements and attributes from other namespaces
-					(including all attributes and contents of such elements). </p>
+						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.</p>
 
 				<p>Validation using this schema requires a processor that supports [[NVDL]], [[RelaxNG-Schema]],
 					[[ISOSchematron]] and [[XMLSCHEMA-2]].</p>


### PR DESCRIPTION
This merges on top of #1573 to add the missing element definitions for the container.xml, encryption.xml and signature.xml files.

This ensures there's no reliance on the schemas to normatively understand what is necessary.

The only tweak I made to the schemas section was to remove the text about removing foreign namespace elements and attributes from the container.xml file. It's back in the body plus the NVDL schema should already take care of this before dispatching to the RNC.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1578.html" title="Last updated on Mar 16, 2021, 5:12 PM UTC (6ea0595)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1578/9729102...6ea0595.html" title="Last updated on Mar 16, 2021, 5:12 PM UTC (6ea0595)">Diff</a>