### PR TITLE
Add non characters at end of supplementary planes to file naming restrictions

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -965,9 +965,8 @@
 						</li>
 					</ul>
 
-					<p>Authors are encouraged to locate these resources inside the EPUB Container
-						whenever feasible to allow users access to the entire presentation regardless of
-						connectivity status.</p>
+					<p>Authors are encouraged to locate these resources inside the EPUB Container whenever feasible to
+						allow users access to the entire presentation regardless of connectivity status.</p>
 
 					<aside class="example">
 						<p>The following example shows a reference to an audio file in an <a>XHTML Content Document</a>
@@ -5692,6 +5691,10 @@ Spine:
 									<p>Specials (<code>U+FFF0 … U+FFFF</code>)</p>
 								</li>
 								<li>
+									<p>Non characters at the end of the Supplementary Planes (<code>U+1FFFE, U+1FFFFF …
+											U+EFFFE, U+EFFFF</code>)</p>
+								</li>
+								<li>
 									<p>Tags and Variation Selectors Supplement (<code>U+E0000 … U+E0FFF</code>)</p>
 								</li>
 								<li>
@@ -9021,6 +9024,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>17-Mar-2021: Include non characters at the end of the supplementary planes in list of characters
+						not allowed in file names. See <a href="https://github.com/w3c/epub-specs/issues/1538">issue
+							1538</a>.</li>
 					<li>10-Mar-2021: Require that resources referenced from an EPUB Publication not be located in the
 							<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205"
 							>issue 1205</a>.</li>


### PR DESCRIPTION
Kind of an awkward fit since it overlaps with the private use area restrictions. Rather than duplicate the code points, I've left off those last two planes and ended at U+EFFFE and U+EFFFF, but open to living with a bit of duplication.

Fixes #1538


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1579.html" title="Last updated on Mar 19, 2021, 2:18 PM UTC (ed8cf8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1579/42671d8...ed8cf8f.html" title="Last updated on Mar 19, 2021, 2:18 PM UTC (ed8cf8f)">Diff</a>