### PR TITLE
Note problem of multipart titles

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1793,24 +1793,24 @@
 										elements is inconsistent. Reading Systems may ignore the additional segments or
 										combine them in unexpected ways.</p>
 
-									<aside class="example">
-										<p>The following example shows a multipart title:</p>
-										<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
+									<p>For example, the following example shows a basic multipart title:</p>
+									
+									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:title&gt;THE LORD OF THE RINGS&lt;/dc:title&gt;
     &lt;dc:title&gt;Part One: The Fellowship of the Ring&lt;/dc:title&gt;
     …
 &lt;/metadata&gt;
 </pre>
-										<p>The same title could be expressed using a single <code>dc:title</code>
-											element as follows:</p>
-										<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
+									<p>The same title could instead be expressed using a single <code>dc:title</code>
+										element as follows:</p>
+									
+									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:title&gt;
         THE LORD OF THE RINGS, Part One: The Fellowship of the Ring
     &lt;/dc:title&gt;
     …
 &lt;/metadata&gt;
 </pre>
-									</aside>
 
 									<p>Previous versions of this specification recommended using the <a
 											href="#sec-property-title-type"><code>title-type</code></a> and <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1784,24 +1784,39 @@
 									title of the EPUB Publication (i.e., the primary one Reading Systems present to
 									users).</p>
 
-								<aside class="example">
-									<p>The following example shows a multi-part title:</p>
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
+								<div class="note">
+									<p>Although it is possible to include more than one <code>title</code> element for
+										multipart titles, Reading System support for additional <code>title</code>
+										elements is inconsistent. Reading Systems may ignore the additional segments or
+										combine them in unexpected ways. EPUB Creators are therefore advised to use only
+										a single <code>title</code> element.</p>
+
+									<aside class="example">
+										<p>The following example shows a multipart title:</p>
+										<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:title&gt;THE LORD OF THE RINGS&lt;/dc:title&gt;
     &lt;dc:title&gt;Part One: The Fellowship of the Ring&lt;/dc:title&gt;
     …
 &lt;/metadata&gt;
 </pre>
-									<p>The same title could be expressed using a single <code>dc:title</code> element as
-										follows:</p>
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
+										<p>The same title could be expressed using a single <code>dc:title</code>
+											element as follows:</p>
+										<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:title&gt;
         THE LORD OF THE RINGS, Part One: The Fellowship of the Ring
     &lt;/dc:title&gt;
     …
 &lt;/metadata&gt;
 </pre>
-								</aside>
+									</aside>
+
+									<p>Previous versions of this specification recommended using the <a
+											href="#sec-property-title-type"><code>title-type</code></a> and <a
+											href="#sec-property-display-seq"><code>display-seq</code></a> properties to
+										identify and format the segments of multipart titles (see the <a
+											href="#cookbook-ex">Great Cookbooks example</a>). It is still possible to
+										add these semantics but they are also not well supported.</p>
+								</div>
 							</section>
 
 							<section id="sec-opf-dclanguage">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1784,12 +1784,14 @@
 									title of the EPUB Publication (i.e., the primary one Reading Systems present to
 									users).</p>
 
+								<p>EPUB Creators are strongly advised to use only a single <code>title</code> element to
+									ensure consistent rendering of the title in Reading Systems.</p>
+
 								<div class="note">
 									<p>Although it is possible to include more than one <code>title</code> element for
 										multipart titles, Reading System support for additional <code>title</code>
 										elements is inconsistent. Reading Systems may ignore the additional segments or
-										combine them in unexpected ways. EPUB Creators are therefore advised to use only
-										a single <code>title</code> element.</p>
+										combine them in unexpected ways.</p>
 
 									<aside class="example">
 										<p>The following example shows a multipart title:</p>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -707,9 +707,9 @@
 &lt;/metadata></pre>
 			</aside>
 			<aside class="example">
-				<p>The following example shows how the complex title "The Great Cookbooks of the World: Mon premier
-					guide de cuisson, un Mémoire. The New French Cuisine Masters, Volume Two. Special Anniversary
-					Edition" could be classified.</p>
+				<p id="cookbook-ex">The following example shows how the complex title "The Great Cookbooks of the
+					World: Mon premier guide de cuisson, un Mémoire. The New French Cuisine Masters, Volume Two.
+					Special Anniversary Edition" could be classified.</p>
 				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     &lt;dc:title id="t1" xml:lang="fr">Mon premier guide de cuisson, un Mémoire&lt;/dc:title>
     &lt;meta refines="#t1" property="title-type">main&lt;/meta>


### PR DESCRIPTION
This PR moves adds an advisement to use only a single title for consistent rendering.

The multipart title example is moved into a note and some additional context about inconsistent support is added. It also mentions the previous recommendation to use `title-type` and `display-seq` (with a pointer to the examples in the vocabulary) noting that these are still allowed but don't lead to better support.

Fixes #1527


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1580.html" title="Last updated on Mar 19, 2021, 12:03 PM UTC (3d30b31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1580/332c414...3d30b31.html" title="Last updated on Mar 19, 2021, 12:03 PM UTC (3d30b31)">Diff</a>