### PR TITLE
Add new section clarifying the requirements for data urls

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -440,16 +440,25 @@
 							not render as intended by the <a>EPUB Creator</a>. Examples of Publication Resources include
 							the <a>Package Document</a>, <a>EPUB Content Document</a>, CSS Style Sheets, audio, video,
 							images, embedded fonts, and scripts.</p>
-						<p>Publication Resources are listed in the Package Document <a href="#sec-manifest-elem"
-								>manifest</a> and bundled in the <a>EPUB Container</a> file unless specified otherwise
-							in <a href="#sec-resource-locations"></a>.</p>
+						<p>Publication Resources are typically listed in the Package Document <a
+								href="#sec-manifest-elem">manifest</a> and bundled in the <a>EPUB Container</a>, with
+							two exceptions:</p>
+						<ul>
+							<li>
+								<p>resources encoded as <a href="#sec-data-urls">data URLs</a> are not required to be
+									listed in the manifest; and</p>
+							</li>
+							<li>
+								<p>resources listed in <a href="#sec-resource-locations"></a> may be located outside the
+									EPUB Container.</p>
+							</li>
+						</ul>
 						<p>Examples of resources that are not Publication Resources include those identified by the
 							Package Document <a href="#sec-link-elem"><code>link</code> element</a> and those identified
 							in outbound hyperlinks that resolve to <a>Remote Resources</a> (e.g., referenced from the
 								<code>href</code> attribute of an [[!HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
-									><code>a</code></a> element). Resources represented by <a href="#sec-data-urls">data
-								URLs</a> are also not Publication Resources.</p>
+									><code>a</code></a> element).</p>
 					</dd>
 					<dt>
 						<dfn id="dfn-remote-resource" data-lt="Remote Resources">Remote Resource</dfn>
@@ -1010,14 +1019,38 @@
 						allows a resource to be embedded within another, avoiding the need for an external file.</p>
 
 					<p><a>EPUB Creators</a> MAY use data URLs in EPUB Publications provided their use does not result in
-						a <a>Top-Level Content Document</a> or open a new browser instance (e.g., they cannot be used in
-						manifest <code>item</code> elements that are referenced from the <a>spine</a>, in [[HTML]] or
-						[[SVG]] <code>a</code> elements (except when inside an <code>iframe</code>), or in calls to
-						[[ECMASCRIPT]] <code>window.open</code> or <code>document.open</code>).</p>
+						a <a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context"
+							>top-level browsing context</a> [[!HTML]]. This restriction applies to data URLs used in the
+						following scenarios:</p>
 
-					<p>This restriction on their use is to prevent security issues (i.e., phishing scams) and also to
-						ensure that <a>Reading Systems</a> can determine where to take a user next (i.e., because such
-						resources will typically not be listed in the spine).</p>
+					<ul>
+						<li>
+							<p>in manifest <a href="#sec-item-elem"><code>item</code> elements</a> referenced from the
+									<a>spine</a>;</p>
+						</li>
+						<li>
+							<p>in the <code>href</code> attribute on [[!HTML]] or [[!SVG]] <code>a</code> elements
+								(except when inside an <a
+									href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
+										><code>iframe</code> element</a> [[!HTML]]);</p>
+						</li>
+						<li>
+							<p>in the <code>href</code> attribute on [[!HTML]] <code>area</code> elements (except when
+								inside an <code>iframe</code> element);</p>
+						</li>
+						<li>
+							<p>in calls to [[!ECMASCRIPT]] <code>window.open</code> or <code>document.open</code>.</p>
+						</li>
+					</ul>
+
+					<div class="note">
+						<p>The list of prohibited uses for data URLs is subject to change as the respective standards
+							that allow their use evolve.</p>
+					</div>
+
+					<p>This restriction on their use is to prevent security issues and also to ensure that <a>Reading
+							Systems</a> can determine where to take a user next (i.e., because these resources are not
+						be listed in the spine).</p>
 
 					<p>Resources represented as data URLs are not Publication Resources so are exempt from the
 						requirement to be listed in the <a>manifest</a>.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1019,7 +1019,8 @@
 						allows a resource to be embedded within another, avoiding the need for an external file.</p>
 
 					<p><a>EPUB Creators</a> MAY use data URLs in EPUB Publications provided their use does not result in
-						a <a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context"
+						a <a>Top-level Content Document</a> or <a
+							href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context"
 							>top-level browsing context</a> [[!HTML]]. This restriction applies to data URLs used in the
 						following scenarios:</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2893,8 +2893,8 @@ Spine:
 									href="#confreq-cd-scripted-flbk">fallbacks for scripted content</a>.</p>
 
 							<div class="note">
-								<p>As it is not possible to use manifest fallbacks for resources represented using <a
-										href="#sec-data-urls">data URLs</a>. Foreign resources can only be represented
+								<p>As it is not possible to use manifest fallbacks for resources represented in <a
+										href="#sec-data-urls">data URLs</a>, Foreign Resources can only be represented
 									as data URLs where an intrinsic fallback mechanism is available.</p>
 							</div>
 						</section>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -448,7 +448,8 @@
 							in outbound hyperlinks that resolve to <a>Remote Resources</a> (e.g., referenced from the
 								<code>href</code> attribute of an [[!HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
-									><code>a</code></a> element).</p>
+									><code>a</code></a> element). Resources represented by <a href="#sec-data-urls">data
+								URLs</a> are also not Publication Resources.</p>
 					</dd>
 					<dt>
 						<dfn id="dfn-remote-resource" data-lt="Remote Resources">Remote Resource</dfn>
@@ -999,6 +1000,30 @@
 									><code>remote-resources</code> property</a> on the <a>manifest</a>
 							<a href="#sec-item-elem"><code>item</code> element</a>.</p>
 					</div>
+				</section>
+
+				<section id="sec-data-urls">
+					<h4>Data URLs</h4>
+
+					<p>The <a href="https://tools.ietf.org/html/rfc2397"><code>data:</code> URL scheme</a> [[!RFC2397]]
+						is used to encode resources directly into a URL string. The advantage of this scheme is that it
+						allows a resource to be embedded within another, avoiding the need for an external file.</p>
+
+					<p><a>EPUB Creators</a> MAY use data URLs in EPUB Publications provided their use does not result in
+						a <a>Top-Level Content Document</a> or open a new browser instance (e.g., they cannot be used in
+						manifest <code>item</code> elements that are referenced from the <a>spine</a>, in [[HTML]] or
+						[[SVG]] <code>a</code> elements (except when inside an <code>iframe</code>), or in calls to
+						[[ECMASCRIPT]] <code>window.open</code> or <code>document.open</code>).</p>
+
+					<p>This restriction on their use is to prevent security issues (i.e., phishing scams) and also to
+						ensure that <a>Reading Systems</a> can determine where to take a user next (i.e., because such
+						resources will typically not be listed in the spine).</p>
+
+					<p>Resources represented as data URLs are not Publication Resources so are exempt from the
+						requirement to be listed in the <a>manifest</a>.</p>
+
+					<p>Data URLs MUST encode Core Media Types or be used where a fallback to one is provided (i.e., they
+						are subject to the <a href="sec-foreign-restrictions">foreign resource restrictions</a>).</p>
 				</section>
 
 				<section id="sec-xml-constraints">
@@ -1794,7 +1819,7 @@
 										combine them in unexpected ways.</p>
 
 									<p>For example, the following example shows a basic multipart title:</p>
-									
+
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:title&gt;THE LORD OF THE RINGS&lt;/dc:title&gt;
     &lt;dc:title&gt;Part One: The Fellowship of the Ring&lt;/dc:title&gt;
@@ -1803,7 +1828,7 @@
 </pre>
 									<p>The same title could instead be expressed using a single <code>dc:title</code>
 										element as follows:</p>
-									
+
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:title&gt;
         THE LORD OF THE RINGS, Part One: The Fellowship of the Ring
@@ -2820,7 +2845,6 @@ Manifest:
 Spine:
 &lt;itemref idref="audio01" linear="no"/&gt;</pre>
 							</aside>
-
 						</section>
 
 						<section id="sec-foreign-restrictions-manifest">
@@ -2867,6 +2891,12 @@ Spine:
 							<p>Fallbacks MAY also be provided for <a>Top-Level Content Documents</a> that are EPUB
 								Content Documents. An example of when this feature can be utilized is when providing <a
 									href="#confreq-cd-scripted-flbk">fallbacks for scripted content</a>.</p>
+
+							<div class="note">
+								<p>As it is not possible to use manifest fallbacks for resources represented using <a
+										href="#sec-data-urls">data URLs</a>. Foreign resources can only be represented
+									as data URLs where an intrinsic fallback mechanism is available.</p>
+							</div>
 						</section>
 
 						<section id="sec-opf-bindings">
@@ -9349,10 +9379,11 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>23-Mar-2021: Clarified the requirements for the use of data URLs in EPUB Publications. See <a
+							href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a></li>
 					<li>17-Mar-2021: Include non characters at the end of the supplementary planes in list of characters
 						not allowed in file names. See <a href="https://github.com/w3c/epub-specs/issues/1538">issue
-            1538</a>.
-          </li>
+							1538</a>.</li>
 					<li>15-Mar-2021: Removed the normative dependencies on XML schemas and added element and attribute
 						definitions for the <code>container.xml</code>, <code>encryption.xml</code> and
 							<code>signatures.xml</code> files. All schemas are considered informative. See <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -175,8 +175,10 @@
 						<li>
 							<p id="confreq-rs-data-urls">It MUST prevent data URLs [[!RFC2397]] from opening in <a
 									href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context"
-									>top-level browsing contexts</a> [[HTML]], except when initiated through the user
-									interface of the Reading System (e.g., a context menu).</p>
+									>top-level browsing contexts</a> [[HTML]], except when initiated through a Reading
+								System affordance such as a context menu. If a Reading System does not use a top-level
+								browsing context for <a>Top-level Content Documents</a>, it MUST also prevent data URLs
+								from opening as though they are Top-level Content Documents.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-xhtml">It MUST process <a>XHTML Content Document</a> as defined in

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -173,11 +173,10 @@
 								[[!EPUB-33]].</p>
 						</li>
 						<li>
-							<p id="confreq-rs-data-urls">It MUST prevent attemps at top-level navigation to data URLs
-								[[!RFC2397]]. (Examples of top-level navigation include loading resources not in the
-								spine as though they are <a>Top-Level Content Documents</a> and opening <a
+							<p id="confreq-rs-data-urls">It MUST prevent data URLs [[!RFC2397]] from opening in <a
 									href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context"
-									>top-level browsing contexts</a> [[HTML]])</p>
+									>top-level browsing contexts</a> [[HTML]], except when initiated through the user
+									interface of the Reading System (e.g., a context menu).</p>
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-xhtml">It MUST process <a>XHTML Content Document</a> as defined in

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -173,6 +173,13 @@
 								[[!EPUB-33]].</p>
 						</li>
 						<li>
+							<p id="confreq-rs-data-urls">It MUST prevent attemps at top-level navigation to data URLs
+								[[!RFC2397]]. (Examples of top-level navigation include loading resources not in the
+								spine as though they are <a>Top-Level Content Documents</a> and opening <a
+									href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context"
+									>top-level browsing contexts</a> [[HTML]])</p>
+						</li>
+						<li>
 							<p id="confreq-rs-epub3-xhtml">It MUST process <a>XHTML Content Document</a> as defined in
 									<a href="#sec-xhtml-conf-rs"></a>.</p>
 						</li>
@@ -2159,6 +2166,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>23-Mar-2021: Added requirement to prevent top-level navigation to data URLs. See <a
+							href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a></li>
 					<li>10-Mar-2021: Changed restriction against using resources not listed in the Package Document to a
 						recommendation not to use. See <a href="https://github.com/w3c/epub-specs/issues/810">issue
 							810</a>.</li>


### PR DESCRIPTION
The issue appears a little more nuanced than we've discussed so far - top-level navigation is being restricted, but you can still link to data URLs within an iframe, for example. I've tried to craft the new section to also make this distinction.

It's also possible to use data URLs in the package document along with the various content formats, so I put the new section under publication resources. It's either forbidden or pointless to use them in the manifest, but you could, for example, embed a resource in a `link` element.

I've also noted they are subject to the foreign resource restrictions, so that limits what you can use and where.

The one complexity is how reading systems restrict top-level navigation to data URLs. I don't know that this is something we can, or should, try to be too specific about. While it's possible you might disable hyperlinks with a data scheme, that wouldn't stop scripts from opening such content. I was reading some of the bug trackers for this and it sounds like browsers may only prevent the resource from loading in the spawned window, not restrict the event that triggered it.

As a result, I've only given a very general requirement to prevent data URLs from loading, but open to alternative wording if someone knows a better way to phrase this.

Fixes #1564 


- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1564/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1564/epub33/rs/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1582.html" title="Last updated on Mar 26, 2021, 3:25 PM UTC (3913551)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1582/5e73f5b...3913551.html" title="Last updated on Mar 26, 2021, 3:25 PM UTC (3913551)">Diff</a>