### PR TITLE
Move fallback chain requirements to manifest fallback section

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -432,6 +432,9 @@
 									<code>properties</code> attribute (e.g., disable a rendering process or use a
 								fallback). Reading Systems MUST ignore values of the <code>properties</code> attribute
 								they do not recognize.</p>
+						</dd>
+						<dt>Manifest Fallbacks</dt>
+						<dd>
 							<p>A Reading System that does not support the Media Type of a given Publication Resource
 								MUST traverse the fallback chain until it has identified at least one supported
 								Publication Resource to use in place of the unsupported resource. If the Reading System
@@ -441,9 +444,6 @@
 								[[!EPUB-33]] of that resource, otherwise it SHOULD honor the EPUB Creator's preferred
 								fallback order. If a Reading System does not support any resource in the fallback chain,
 								it MUST alert the reader that content could not be displayed.</p>
-						</dd>
-						<dt>Manifest Fallbacks</dt>
-						<dd>
 							<p>When <a href="https://www.w3.org/TR/epub-33/#sec-foreign-restrictions-manifest">manifest
 									fallbacks</a> [[!EPUB-33]] are provided for <a>Top-level Content Documents</a>,
 								Reading Systems MAY choose from the available options in order to find the optimal


### PR DESCRIPTION
This is just a minor editorial shuffle. While looking at #1464, I noticed some of the manifest fallback processing requirements were still under the item element heading.

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1464/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1464/epub33/rs/index.html)
