### PR TITLE
Remove requirement for page list to match the order of page break markers

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1794,7 +1794,7 @@
 										combine them in unexpected ways.</p>
 
 									<p>For example, the following example shows a basic multipart title:</p>
-									
+
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:title&gt;THE LORD OF THE RINGS&lt;/dc:title&gt;
     &lt;dc:title&gt;Part One: The Fellowship of the Ring&lt;/dc:title&gt;
@@ -1803,7 +1803,7 @@
 </pre>
 									<p>The same title could instead be expressed using a single <code>dc:title</code>
 										element as follows:</p>
-									
+
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:title&gt;
         THE LORD OF THE RINGS, Part One: The Fellowship of the Ring
@@ -4916,19 +4916,6 @@ Spine:
 						<p>The <code>page-list</code>
 							<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more
 							than once.</p>
-
-						<p>The page references in the <code>page-list</code>
-							<code>nav</code> element MUST be ordered such that they reflect both:</p>
-
-						<ul>
-							<li>
-								<p>the order of the <a href="#confreq-nav-a-href">referenced EPUB Content Documents</a>
-									in the <a>spine</a>; and</p>
-							</li>
-							<li>
-								<p>the order of each page within its respective EPUB Content Document.</p>
-							</li>
-						</ul>
 
 						<p>The <code>page-list</code>
 							<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
@@ -9349,15 +9336,15 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>26-Mar-2021: Removed requirement for page list ordering to reflect the order of page breaks in
+						the content. See <a href="https://github.com/w3c/epub-specs/issues/1500">issue 1500</a>.</li>
 					<li>17-Mar-2021: Include non characters at the end of the supplementary planes in list of characters
 						not allowed in file names. See <a href="https://github.com/w3c/epub-specs/issues/1538">issue
-            1538</a>.
-          </li>
+							1538</a>.</li>
 					<li>15-Mar-2021: Removed the normative dependencies on XML schemas and added element and attribute
 						definitions for the <code>container.xml</code>, <code>encryption.xml</code> and
 							<code>signatures.xml</code> files. All schemas are considered informative. See <a
 							href="https://github.com/w3c/epub-specs/issues/1566">issue 1566</a>.</li>
-
 					<li>10-Mar-2021: Require that resources referenced from an EPUB Publication not be located in the
 							<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205"
 							>issue 1205</a>.</li>


### PR DESCRIPTION
As currently recommended in #1500, this PR removes the requirement for the page list to match the order of page break markers in the content.

Assuming this is accepted by the WG, a future PR will address recommending the page list match the print sequencing in the accessibility spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1588.html" title="Last updated on Mar 28, 2021, 3:20 PM UTC (6d0b46e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1588/f3879d4...6d0b46e.html" title="Last updated on Mar 28, 2021, 3:20 PM UTC (6d0b46e)">Diff</a>