### PR TITLE
Allow multiples roles for creator, contributor and publisher

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2023,7 +2023,6 @@
 								<p>The requirements for the <code>contributor</code> element are identical to those for
 									the <a href="#sec-opf-dccreator"><code>creator</code> element</a> in all other
 									respects.</p>
-
 							</section>
 
 							<section id="sec-opf-dccreator">
@@ -2164,7 +2163,6 @@
 									element is maintained in the [[TypesRegistry]], but EPUB Creators MAY use any text
 									string as a <a>value</a>.</p>
 							</section>
-
 						</section>
 
 						<section id="sec-meta-elem">
@@ -9413,8 +9411,12 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>26-Mar-2021: Allowed <code>creator</code> and <code>contributor</code> elements to have multiple
+						roles and allowed roles for <code>publisher</code>. See <a
+							href="https://github.com/w3c/epub-specs/issues/1129">issue 1129</a> and <a
+							href="https://github.com/w3c/epub-specs/issues/1583">issue 1583</a></li>
 					<li>23-Mar-2021: Clarified the requirements for the use of data URLs in EPUB Publications. See <a
-							href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a></li>
+							href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a>.</li>
 					<li>17-Mar-2021: Include non characters at the end of the supplementary planes in list of characters
 						not allowed in file names. See <a href="https://github.com/w3c/epub-specs/issues/1538">issue
 							1538</a>.</li>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -6,7 +6,7 @@
 			element's</a>
 		<code>property</code> attribute.</p>
 
-	<p>Unless indicated otherwise in its “Extends” field, the properties defined in this section are used to define
+	<p>Unless indicated otherwise in its "Extends" field, the properties defined in this section are used to define
 			<a href="#subexpression">subexpressions</a>: in other words, a <code><a href="#elemdef-meta"
 			>meta</a></code> element carrying a property defined in this section MUST have a <code><a
 				href="#attrdef-refines">refines</a></code> attribute referencing a resource or expression being
@@ -112,7 +112,7 @@
 					<tr>
 						<th>Extends:</th>
 						<td>
-							<code>subject</code>
+							<a href="#sec-opf-dcsubject"><code>subject</code></a>
 						</td>
 					</tr>
 				</tbody>
@@ -454,7 +454,8 @@
 					<tr>
 						<th>Extends:</th>
 						<td>
-							<code>identifier</code>, <code>source</code>
+							<a href="#sec-opf-dcidentifier"><code>identifier</code></a>,
+							<a href="#sec-opf-dcmes-optional-def"><code>source</code></a>
 						</td>
 					</tr>
 				</tbody>
@@ -493,12 +494,16 @@
 					<tr>
 						<th>Description:</th>
 						<td>
-							<p>The <code>role</code> property describes the nature of work performed by a
-									<code>creator</code> or <code>contributor</code> (e.g., that the person is the
-								author or editor of a work).</p>
+							<p>The <code>role</code> property describes the role of a <code>creator</code>,
+								<code>contributor</code> or <code>publisher</code> in the creation of an EPUB
+								Publication.</p>
 							<p>When the <code>role</code> value is drawn from a code list or other formal enumeration,
 								the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD be attached to
 								identify its source.</p>
+							<p>When attaching multiple roles to an individual or organization, the importance of the
+								roles should match the document order of their containing <code>meta</code> elements
+								(i.e., the first <code>meta</code> element encountered should contain the most important
+								role).</p>	
 						</td>
 					</tr>
 					<tr>
@@ -510,13 +515,15 @@
 					<tr>
 						<th>Cardinality:</th>
 						<td>
-							<code>zero or one</code>
+							<code>zero or more</code>
 						</td>
 					</tr>
 					<tr>
 						<th>Extends:</th>
 						<td>
-							<code>contributor</code>, <code>creator</code>
+							<a href="#sec-opf-dccontributor"><code>contributor</code></a>,
+							<a href="#sec-opf-dccreator"><code>creator</code></a>,
+							<a href="#sec-opf-dcmes-optional-def"><code>publisher</code></a>
 						</td>
 					</tr>
 				</tbody>
@@ -531,6 +538,17 @@
     
     &lt;dc:creator id="creator02">John Tenniel&lt;/dc:creator>
     &lt;meta refines="#creator02" property="role" scheme="marc:relators">ill&lt;/meta>
+    …
+&lt;/metadata></pre>
+			</aside>
+			<aside class="example">
+				<p>The following example shows that an individual was both the author and
+					illustrator of a work.</p>
+				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    …
+    &lt;dc:creator id="creator01">Maurice Sendak&lt;/dc:creator>
+    &lt;meta refines="#creator01" property="role" scheme="marc:relators">aut&lt;/meta>
+    &lt;meta refines="#creator01" property="role" scheme="marc:relators">ill&lt;/meta>
     …
 &lt;/metadata></pre>
 			</aside>
@@ -573,7 +591,7 @@
 					<tr>
 						<th>Extends:</th>
 						<td>
-							<code>dc:source</code>
+							<a href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>
 						</td>
 					</tr>
 				</tbody>
@@ -628,7 +646,7 @@
 					<tr>
 						<th>Extends:</th>
 						<td>
-							<code>subject</code>
+							<a href="#sec-opf-dcsubject"><code>subject</code></a>
 						</td>
 					</tr>
 				</tbody>
@@ -685,7 +703,7 @@
 					<tr>
 						<th>Extends:</th>
 						<td>
-							<code>title</code>
+							<a href="#sec-opf-dctitle"><code>title</code></a>
 						</td>
 					</tr>
 				</tbody>


### PR DESCRIPTION
This PR updates the cardinality of the `role` property to zero or more and also allows it on `publisher`.

I've added non-normative guidance about ordering the roles by document order for importance. I don't believe we resolved to formalize this or require reading systems to follow it, but let me know if I misunderstood here. It's in the role description as I couldn't find a better location for all three instances (contributor inherits its definition from creator but publisher isn't called out separately).

It also makes a few minor fixes to the meta vocabulary I spotted (some stylized quotes and a lack of consistent linking of the extends values).

Fixes #1129 
Fixes #1583


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1591.html" title="Last updated on Mar 26, 2021, 4:10 PM UTC (d23e52f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1591/e19934c...d23e52f.html" title="Last updated on Mar 26, 2021, 4:10 PM UTC (d23e52f)">Diff</a>