### PR TITLE
Clarify that a primary itemref is one with linear="yes"

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3146,10 +3146,11 @@ Spine:
 								which might, for example, be presented in a popup window or omitted from an aural
 								rendering.</p>
 
-							<p>The <a>spine</a> MUST contain at least one <code>itemref</code> whose <code>linear</code>
-								attribute value is either explicitly or implicitly set to "<code>yes</code>". An
-									<code>itemref</code> that omits the <code>linear</code> attribute is assumed to have
-								the value "<code>yes</code>".</p>
+							<p id="linear-itemrefs">The <a>spine</a> MUST contain at least one linear
+									<code>itemref</code> element &#8212; whose <code>linear</code> attribute value is
+								either explicitly or implicitly set to "<code>yes</code>". An <code>itemref</code> that
+								omits the <code>linear</code> attribute is assumed to have the value
+								"<code>yes</code>".</p>
 
 							<p>EPUB Creators MUST provide a means of accessing all non-linear content (e.g., hyperlinks
 								in the content or from the <a href="#sec-nav">EPUB Navigation Document</a>).</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -179,7 +179,6 @@
 								System affordance such as a context menu. If a Reading System does not use a top-level
 								browsing context for <a>Top-level Content Documents</a>, it MUST also prevent data URLs
 								from opening as though they are Top-level Content Documents.</p>
-
 							<p class="issue" data-number="1592"></p>
 						</li>
 						<li>
@@ -470,10 +469,10 @@
 						<dt id="sec-spine-elem">The <code>spine</code> element</dt>
 						<dd>
 							<p>Reading Systems MUST provide a means of rendering the EPUB Publication in the order
-								defined in the <code>spine</code>, which includes: 1) recognizing the first primary
-									<code>itemref</code> (i.e., whose <code>linear</code> attribute value is
-									"<code>yes</code>") as the beginning of the default reading order; and, 2) rendering
-								successive primary items in the order given in the <code>spine</code>.</p>
+								defined in the <code>spine</code>, which includes: 1) recognizing the first <a
+									href="https://www.w3.org/TR/epub-33/#linear-itemrefs">linear <code>itemref</code>
+									element</a> [[!EPUB-33]] as the beginning of the default reading order; and, 2)
+								rendering successive linear items in the order given in the <code>spine</code>.</p>
 							<p>When the <code>default</code> value of the <code>page-progression-direction</code>
 								attribute is specified, the Reading System can choose the rendering direction. The
 									<code>default</code> value MUST be assumed when the attribute is not specified. In

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -471,8 +471,9 @@
 						<dd>
 							<p>Reading Systems MUST provide a means of rendering the EPUB Publication in the order
 								defined in the <code>spine</code>, which includes: 1) recognizing the first primary
-									<code>itemref</code> as the beginning of the default reading order; and, 2)
-								rendering successive primary items in the order given in the <code>spine</code>.</p>
+									<code>itemref</code> (i.e., whose <code>linear</code> attribute value is
+									"<code>yes</code>") as the beginning of the default reading order; and, 2) rendering
+								successive primary items in the order given in the <code>spine</code>.</p>
 							<p>When the <code>default</code> value of the <code>page-progression-direction</code>
 								attribute is specified, the Reading System can choose the rendering direction. The
 									<code>default</code> value MUST be assumed when the attribute is not specified. In


### PR DESCRIPTION
This is a minor edit from the call yesterday. There's an assumption that anyone reading the RS spec will understand that a "primary" itemref is one whose linear attribute is "yes". This just makes that point explicit in a parenthetical.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1594.html" title="Last updated on Mar 27, 2021, 8:03 PM UTC (4dd1fd8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1594/493b1ce...4dd1fd8.html" title="Last updated on Mar 27, 2021, 8:03 PM UTC (4dd1fd8)">Diff</a>