### PR TITLE
Clarify that there isn't a single presentation model for non-linear content

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3146,6 +3146,16 @@ Spine:
 								which might, for example, be presented in a popup window or omitted from an aural
 								rendering.</p>
 
+							<p>Specifying that content is non-linear does not require Reading Systems to present it in a
+								specific way, however; it is only a hint to the purpose. Reading Systems may present
+								non-linear content where it occurs in the spine, for example, or skip it until users
+								reach the end of the spine.</p>
+
+							<div class="note">
+								<p>EPUB Creators should list non-linear content at the end of the spine except when it
+									makes sense for users to encounter it between linear spine items.</p>
+							</div>
+
 							<p>The <a>spine</a> MUST contain at least one <code>itemref</code> whose <code>linear</code>
 								attribute value is either explicitly or implicitly set to "<code>yes</code>". An
 									<code>itemref</code> that omits the <code>linear</code> attribute is assumed to have

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3148,7 +3148,7 @@ Spine:
 
 							<p>Specifying that content is non-linear does not require Reading Systems to present it in a
 								specific way, however; it is only a hint to the purpose. Reading Systems may present
-								non-linear content where it occurs in the spine, for example, or skip it until users
+								non-linear content where it occurs in the spine, for example, or may skip it until users
 								reach the end of the spine.</p>
 
 							<div class="note">


### PR DESCRIPTION
This PR also arises from the last telecon. It notes that setting linear=no does not require reading systems to behave in a specific way and adds a note that non-linear content should be listed at the end of the spine unless it makes sense to occur between linear items.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1595.html" title="Last updated on Mar 28, 2021, 3:19 PM UTC (212f0ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1595/493b1ce...212f0ad.html" title="Last updated on Mar 28, 2021, 3:19 PM UTC (212f0ad)">Diff</a>