### PR TITLE
Restructuring of the reading system specification

### DIFF
--- a/epub33/common/js/confreq-permalinks.js
+++ b/epub33/common/js/confreq-permalinks.js
@@ -1,6 +1,6 @@
 
 function addConformanceLinks() {
-    var dt = document.querySelectorAll('*[class~="conformance-list"] p[id]');
+    var dt = document.querySelectorAll('*[class~="conformance-list"] li p[id]');
     
     for (var i = 0; i < dt.length; i++) {
         

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -124,9 +124,9 @@
 
 					<p>This specification does not require <a>EPUB Reading Systems</a> to support scripting, HTML forms
 						or the HTML DOM. Reading Systems conformant with this specification are only expected to be able
-						to process a conforming <a>EPUB Content Document</a>. As <a href="#sec-scripted-content-rs-reqs"
-							>support for scripting and HTML forms</a> is not compulsory, a conformant Reading System
-						might not be a fully-conformant HTML user agent.</p>
+						to process a conforming <a>EPUB Content Document</a>. As <a href="#sec-scripted-content">support
+							for scripting and HTML forms</a> is not compulsory, a conformant Reading System might not be
+						a fully-conformant HTML user agent.</p>
 				</section>
 
 
@@ -205,7 +205,7 @@
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-rs-epub3-css">It MUST support visual rendering of <a>XHTML Content
-									Documents</a> as defined in <a href="#sec-css-rs-conf"></a>.</p>
+									Documents</a> as defined in <a href="#sec-css"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-images">It MUST support the <a
@@ -221,7 +221,7 @@
 					<p>Support for the following features is OPTIONAL:</p>
 					<ul>
 						<li>
-							<p id="confreq-fxl"><a href="#sec-fixed-layouts">Fixed-Layout Documents</a></p>
+							<p id="confreq-fxl"><a href="#sec-fxl">Fixed-Layout Documents</a></p>
 						</li>
 						<li>
 							<p id="confreq-mo"><a href="sec-media-overlays">Media Overlays</a></p>
@@ -695,7 +695,7 @@
 					</li>
 					<li>
 						<p id="confreq-svg-rs-scrpt">It MUST meet the Reading System conformance criteria defined in <a
-								href="#sec-scripted-content-rs-reqs"></a>.</p>
+								href="#sec-scripted-content"></a>.</p>
 					</li>
 					<li>
 						<p id="confreq-svg-rs-css">If it has a <a>Viewport</a>, it MUST support the visual rendering of

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -308,9 +308,10 @@
 			<section id="pkg-doc-presentation">
 				<h4>Presentation Logic</h4>
 
-				<p id="confreq-rendition-rs-package">It MUST honor all presentation logic expressed through the <a
-						href="https://www.w3.org/TR/epub-33/#sec-package-def">Package Document</a> [[!EPUB-33]] (e.g.,
-					the reading order, fallback chains, page progression direction and fixed layouts).</p>
+				<p id="confreq-rendition-rs-package"><a>Reading Systems</a> MUST honor all presentation logic expressed
+					through the <a href="https://www.w3.org/TR/epub-33/#sec-package-def">Package Document</a>
+					[[!EPUB-33]] (e.g., the reading order, fallback chains, page progression direction and fixed
+					layouts).</p>
 			</section>
 
 			<section id="dir">
@@ -1056,10 +1057,9 @@
 				<dl>
 					<dt>XHTML</dt>
 					<dd>
-						<p>In this version of this specification, <a>Reading Systems</a> MUST recognize only the width
-							and height expressions as defined in <a
+						<p><a>Reading Systems</a> MUST use the width and height expressions as defined in <a
 								href="https://www.w3.org/TR/epub-33/#sec-fxl-icb-html">Expressing in HTML</a>
-							[[!EPUB-33]].</p>
+							[[!EPUB-33]] to render <a>XHTML Content Documents</a>.</p>
 						<p>Reading Systems MUST clip XHTML content to the initial containing block (ICB) dimensions
 							declared in the <code>viewport</code>
 							<code>meta</code> tag — content positioned outside of the initial containing block will not
@@ -1646,9 +1646,10 @@
 			<h2>Security and Privacy</h2>
 
 			<div class="ednote">
-				<p>This is a very initial draft intended only as a starting point. It is inspired by the <a
-						href="https://www.w3.org/TR/pub-manifest/#security-privacy">relevant section of the Publication
-						Manifest</a> specification. It will require more work.</p>
+				<p>This section currently combines an overview of security and privacy considerations with issues
+					previously cited in the specification.</p>
+				<p>The Working Group intends to develop this section throughout the revision to further expand on the
+					issues and provide it with a more structured narrative.</p>
 			</div>
 
 			<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
@@ -1678,11 +1679,6 @@
 						><code>application/oebps-package+xml</code></a> and the <a
 					href="https://www.w3.org/TR/epub-33/#app-media-type-app-oebps-package"
 						><code>application/epub+zip</code></a> formats for further details. </p>
-
-			<div class="ednote">
-				<p>The Working Group will have to address the particularity of cross-origin by addressing the question
-					of what the "origin" is for an EPUB Publication.</p>
-			</div>
 
 			<section id="sec-scripted-content-security">
 				<h4>Scripting Considerations</h4>
@@ -2005,8 +2001,12 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>30-Mar-2021: Restructured the document to remove the rendundant conformance sections and
+						requirements that were only used as locators when this specification was combined with the
+						authoring requirements. See <a href="https://github.com/w3c/epub-specs/pull/1597">pull request
+							1597</a>.</li>
 					<li>23-Mar-2021: Added requirement to prevent top-level navigation to data URLs. See <a
-							href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a></li>
+							href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a>.</li>
 					<li>23-Mar-2021: Changed "suppressing" of non-linear content to "skipping" when traversing the spine
 						to clarify that the intention is not to remove all access to such content. See <a
 							href="https://github.com/w3c/epub-specs/issues/1480">issue 1480</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -219,7 +219,7 @@
 						</li>
 					</ul>
 					<p>Support for the following features is OPTIONAL:</p>
-					<ul>
+					<ul class="conformance-list">
 						<li>
 							<p id="confreq-fxl"><a href="#sec-fxl">Fixed-Layout Documents</a></p>
 						</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -155,11 +155,11 @@
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-rs-epub3-ocf">It MUST process the <a>EPUB Container</a> as defined in <a
-									href="#ocf"></a>.</p>
+									href="#sec-ocf"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-package">It MUST process the <a>Package Document</a> as defined in
-									<a href="#package-doc"></a>.</p>
+									<a href="#sec-package-doc"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-foreign">It MAY support an arbitrary set of <a>Foreign Resource</a> types,
@@ -182,21 +182,12 @@
 							<p class="issue" data-number="1592"></p>
 						</li>
 						<li>
-							<p id="confreq-rs-epub3-xhtml">It MUST process <a>XHTML Content Document</a> as defined in
-									<a href="#sec-xhtml-conf-rs"></a>.</p>
+							<p id="confreq-rs-epub3-xhtml">It MUST process <a>XHTML Content Documents</a> as defined in
+									<a href="#sec-xhtml"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-svg">It MUST process <a>SVG Content Documents</a> as defined in <a
 									href="#sec-svg"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-rs-epub3-css">If it has a <a>Viewport</a>, it MUST support visual rendering
-								of <a>XHTML Content Documents</a> as defined in <a href="#sec-css-rs-conf"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-rs-epub3-images">If it has a Viewport, it MUST support the <a
-									href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type
-									Resources</a> [[!EPUB-33]].</p>
 						</li>
 						<li>
 							<p id="confreq-rs-epub3-mp3-aac">If it has the capability to render pre-recorded audio, it
@@ -210,6 +201,37 @@
 								[[!EPUB-33]] in <a>XHTML Content Documents</a>.</p>
 						</li>
 					</ul>
+					<p>In addition, if a Reading System has a <a>Viewport</a>:</p>
+					<ul class="conformance-list">
+						<li>
+							<p id="confreq-rs-epub3-css">It MUST support visual rendering of <a>XHTML Content
+									Documents</a> as defined in <a href="#sec-css-rs-conf"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-rs-epub3-images">It MUST support the <a
+									href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type
+									Resources</a> [[!EPUB-33]].</p>
+						</li>
+						<li>
+							<p id="confreq-ocf-fobfus">It MUST support deobfuscation of resources as defined in <a
+									href="https://www.w3.org/TR/epub-33/#sec-resource-obfuscation"><em>Resource
+										Obfuscation</em></a> [[!EPUB-33]].</p>
+						</li>
+					</ul>
+					<p>Support for the following features is OPTIONAL:</p>
+					<ul>
+						<li>
+							<p id="confreq-fxl"><a href="#sec-fixed-layouts">Fixed-Layout Documents</a></p>
+						</li>
+						<li>
+							<p id="confreq-mo"><a href="sec-media-overlays">Media Overlays</a></p>
+						</li>
+					</ul>
+					<p id="confreq-rs-mo-ignore">If a Reading System does not support Media Overlays, it MUST ignore
+						both the <code>media-overlay</code> attribute on <a>Manifest</a>
+						<a href="https://www.w3.org/TR/epub-33/#elemdef-package-item"><code>item</code> elements</a> and
+						the manifest <code>item</code> elements where the <code>media-type</code> attribute value equals
+							<code>application/smil+xml</code>.</p>
 					<p class="note" id="note-video-codecs">It is recommended that Reading Systems support at least one
 						of the H.264 [[H264]] and VP8 [[RFC6386]] video codecs, but this is not a conformance
 						requirement &#8212; a Reading System may support other video codecs, or none at all. Reading
@@ -280,279 +302,214 @@
 					as a distributed system.</p>
 			</div>
 		</section>
-		<section id="package-doc">
+		<section id="sec-package-doc">
 			<h2>Package Document Processing</h2>
 
-			<section id="sec-package-rs-conformance">
-				<h3>Package Document Conformance</h3>
+			<section id="pkg-doc-presentation">
+				<h4>Presentation Logic</h4>
 
-				<p>An <a>EPUB Reading System</a> is conformant with this section if meets all of the following
-					criteria:</p>
+				<p id="confreq-rendition-rs-package">It MUST honor all presentation logic expressed through the <a
+						href="https://www.w3.org/TR/epub-33/#sec-package-def">Package Document</a> [[!EPUB-33]] (e.g.,
+					the reading order, fallback chains, page progression direction and fixed layouts).</p>
+			</section>
 
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-rendition-rs-package">It MUST honor all presentation logic expressed through the
-								<a href="https://www.w3.org/TR/epub-33/#sec-package-def">Package Document</a>
-							[[!EPUB-33]] (e.g., the reading order, fallback chains, page progression direction and fixed
-							layouts).</p>
-					</li>
-					<li>
-						<p id="confreq-rs-package-def">It MUST process the Package Document in conformance with all
-							Reading System conformance constraints expressed in <a href="#sec-package-def"></a>.</p>
-					</li>
-					<li>
-						<p id="confreq-rs-epub3-presentational-meta">It SHOULD process rendering metadata, as expressed
-							in <a href="#sec-package-metadata-rendering"></a>.</p>
-					</li>
-					<li>
-						<p id="confreq-rs-epub3-fxl-meta">It MUST process fixed layout metadata, as expressed in <a
-								href="#sec-fxl-props"></a>.</p>
-					</li>
-					<li>
+			<section id="dir">
+				<h4>Base Direction</h4>
+
+				<p>If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
+						<code>rtl</code>, the Reading System MUST override the bidi algorithm per <a
+						data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[!BIDI]],
+					setting the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the
+					base direction is <code>rtl</code>.</p>
+
+				<p>Otherwise the base direction is <code>auto</code>, in which case the Reading System MUST determine
+					the text's direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2"
+						>Rule P2</a> of [[!BIDI]].</p>
+			</section>
+
+			<section id="sec-pub-identifiers">
+				<h3>Unique Identifier</h3>
+
+				<p>Reading Systems SHOULD NOT depend on the <code>unique-identifier</code> attribute being unique to one
+					and only one EPUB Publication. Determining whether two EPUB Publications with the same Unique
+					Identifier represent different versions of the same publication, or different publications, might
+					require inspecting other metadata, such as the titles or authors.</p>
+			</section>
+
+			<section id="metadata">
+				<h4>Metadata</h4>
+
+				<dl class="conformance-list">
+					<dt id="conf-meta-ws">White Space</dt>
+					<dd>
+						<p>Reading Systems MUST <a
+								href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">strip and
+								collapse ASCII whitespace</a> [[!Infra]] from Dublin Core [[!DC11]] and <a
+								href="https://www.w3.org/TR/epub-33/#sec-meta-elem"><code>meta</code></a> element <a
+								href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[!EPUB-33]] before
+							processing.</p>
+					</dd>
+
+					<dt id="dc-identifier">The <code>identifier</code> element</dt>
+					<dd>
+						<p>To determine whether an <code>identifier</code> conforms to an established system or has been
+							granted by an issuing authority, Reading Systems SHOULD check for an <a
+								href="https://www.w3.org/TR/epub-33/#identifier-type"><code>identifier-type</code>
+								property</a> [[!EPUB-33]].</p>
+					</dd>
+
+					<dt id="dc-title">The <code>title</code> element</dt>
+					<dd>
+						<p id="title-order"><a>Reading Systems</a> MUST recognize the first <code>title</code> element
+							in document order as the main title of the EPUB Publication and present it to users before
+							other title elements.</p>
+						<p>This specification does not define how to process additional <code>title</code> elements.</p>
+					</dd>
+
+					<dt id="sec-opf-dclanguage">The <code>language</code> element</dt>
+					<dd>
+						<p>The language(s) of the <a>EPUB Publication</a> specified in <code>language</code> elements
+							are advisory. Reading Systems MUST use the language information associated with a resource
+							to determine its language.</p>
+					</dd>
+
+					<dt id="dc-creator">The <code>creator</code> element</dt>
+					<dd>
+						<p>When determining display priority, Reading Systems MUST use the document order of
+								<code>creator</code> elements in the <code>metadata</code> section, where the first
+								<code>creator</code> element encountered is the primary creator. If a Reading System
+							exposes creator metadata to the user, it SHOULD include all the creators listed in the
+								<code>metadata</code> section whenever possible (e.g., when not constrained by display
+							considerations).</p>
+					</dd>
+
+					<dt id="meta">The <code>meta</code> element</dt>
+					<dd>
+						<p>If a Reading System does not recognize the <code>scheme</code> attribute value, it SHOULD
+							treat the value of the element as a string.</p>
+						<p>Reading Systems SHOULD ignore all <code>meta</code> elements whose <code>property</code>
+							attributes define expressions they do not recognize. A Reading System MUST NOT fail when
+							encountering unknown expressions.</p>
+					</dd>
+
+					<dt id="conf-metadata-link">The <code>link</code> element</dt>
+					<dd>
+						<p>Retrieval of Remote Resources is OPTIONAL.</p>
+						<p>The language identified in an <code>hreflang</code> attribute is not authoritative. Language
+							information defined in a linked resource determines its language.</p>
+						<p>Reading System do not have to use or present linked resources, even if they recognize the
+							relationship defined in the <code>rel</code> attribute.</p>
+						<p id="sec-linked-records">In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
+								>linked metadata record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing the
+							metadata expressed in the Package Document and only use the information expressed in the
+							record. Reading Systems MAY compile metadata from multiple linked records; they do not have
+							to select only one record.</p>
+						<p>When it comes to resolving discrepancies and conflicts between metadata expressed in the
+							Package Document and in linked metadata records, Reading Systems MUST use the document order
+							of <code>link</code> elements in the Package Document to establish precedence (i.e.,
+							metadata in the first linked record encountered has the highest precedence and metadata in
+							the Package Document the lowest, regardless of whether the <code>link</code> elements occur
+							before, within or after the package metadata elements).</p>
+						<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
+							layout and rendering of the EPUB Publication.</p>
+					</dd>
+
+					<dt>Proprietary Metadata</dt>
+					<dd>
 						<p id="confreq-rs-epub3-fxl-conflicts">It MUST ignore proprietary metadata properties that
 							pertain to layout expressions if they conflict behaviorally with the property semantics
 							defined in <a href="#sec-fxl-props"></a>.</p>
-					</li>
-					<li>
-						<p id="confreq-rendition-rs-manifest">It SHOULD NOT use non-<a>Publication Resources</a> in the
-							rendering of an EPUB Publication due to the inherent limitations and risks involved (e.g.,
-							lack of information about the resource and how to process it, security risks from
-							remotely-hosted sources, lack of fallbacks, etc.).</p>
-					</li>
-				</ul>
+					</dd>
+				</dl>
 			</section>
 
-			<section id="sec-package-def">
-				<h3>Package Document</h3>
+			<section id="manifest">
+				<h3>Manifest</h3>
 
-				<section id="dir">
-					<h4>Base Direction</h4>
+				<p>When an <code>href</code> attribute contains a relative IRI, Reading Systems MUST use the IRI of the
+					Package Document as the base when resolving to an absolute IRI.</p>
 
-					<p>If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
-							<code>rtl</code>, the Reading System MUST override the bidi algorithm per <a
-							data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[!BIDI]],
-						setting the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if
-						the base direction is <code>rtl</code>.</p>
+				<p>Reading Systems MAY optimize the rendering depending on the properties set in the
+						<code>properties</code> attribute (e.g., disable a rendering process or use a fallback). Reading
+					Systems MUST ignore values of the <code>properties</code> attribute they do not recognize.</p>
 
-					<p>Otherwise the base direction is <code>auto</code>, in which case the Reading System MUST
-						determine the text's direction by applying the Unicode Bidi Algorithm, beginning with <a
-							data-cite="bidi#P2">Rule P2</a> of [[!BIDI]].</p>
-				</section>
+				<p id="confreq-rendition-rs-manifest">It SHOULD NOT use non-<a>Publication Resources</a> in the
+					rendering of an EPUB Publication due to the inherent limitations and risks involved (e.g., lack of
+					information about the resource and how to process it, security risks from remotely-hosted sources,
+					lack of fallbacks, etc.).</p>
 
-				<section id="sec-pub-identifiers">
-					<h3>Unique Identifier</h3>
+				<p>A Reading System that does not support the Media Type of a given Publication Resource MUST traverse
+					the fallback chain until it has identified at least one supported Publication Resource to use in
+					place of the unsupported resource. If the Reading System supports multiple Publication Resources in
+					the fallback chain, it MAY select the resource to use based on specific <a
+						href="https://www.w3.org/TR/epub-33/#attrdef-item-properties">properties</a> [[!EPUB-33]] of
+					that resource, otherwise it SHOULD honor the EPUB Creator's preferred fallback order. If a Reading
+					System does not support any resource in the fallback chain, it MUST alert the reader that content
+					could not be displayed.</p>
 
-					<p>Reading Systems SHOULD NOT depend on the <code>unique-identifier</code> attribute being unique to
-						one and only one EPUB Publication. Determining whether two EPUB Publications with the same
-						Unique Identifier represent different versions of the same publication, or different
-						publications, might require inspecting other metadata, such as the titles or authors.</p>
-				</section>
-
-				<section id="metadata">
-					<h4>Metadata</h4>
-
-					<dl class="conformance-list">
-						<dt id="conf-meta-ws">White Space</dt>
-						<dd>
-							<p>Reading Systems MUST <a
-									href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">strip and
-									collapse ASCII whitespace</a> [[!Infra]] from Dublin Core [[!DC11]] and <a
-									href="https://www.w3.org/TR/epub-33/#sec-meta-elem"><code>meta</code></a> element <a
-									href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[!EPUB-33]] before
-								processing.</p>
-						</dd>
-
-						<dt id="dc-identifier">The <code>identifier</code> element</dt>
-						<dd>
-							<p>To determine whether an <code>identifier</code> conforms to an established system or has
-								been granted by an issuing authority, Reading Systems SHOULD check for an <a
-									href="https://www.w3.org/TR/epub-33/#identifier-type"><code>identifier-type</code>
-									property</a> [[!EPUB-33]].</p>
-						</dd>
-
-
-						<dt id="dc-title">The <code>title</code> element</dt>
-						<dd>
-							<p id="title-order"><a>Reading Systems</a> MUST recognize the first <code>title</code>
-								element in document order as the main title of the EPUB Publication and present it to
-								users before other title elements.</p>
-							<p>This specification does not define how to process additional <code>title</code>
-								elements.</p>
-						</dd>
-
-						<dt id="sec-opf-dclanguage">The <code>language</code> element</dt>
-						<dd>
-							<p>The language(s) of the <a>EPUB Publication</a> specified in <code>language</code>
-								elements are advisory. Reading Systems MUST use the language information associated with
-								a resource to determine its language.</p>
-						</dd>
-
-						<dt id="dc-creator">The <code>creator</code> element</dt>
-						<dd>
-							<p>When determining display priority, Reading Systems MUST use the document order of
-									<code>creator</code> elements in the <code>metadata</code> section, where the first
-									<code>creator</code> element encountered is the primary creator. If a Reading System
-								exposes creator metadata to the user, it SHOULD include all the creators listed in the
-									<code>metadata</code> section whenever possible (e.g., when not constrained by
-								display considerations).</p>
-						</dd>
-
-						<dt id="meta">The <code>meta</code> element</dt>
-						<dd>
-							<p>If a Reading System does not recognize the <code>scheme</code> attribute value, it SHOULD
-								treat the value of the element as a string.</p>
-							<p>Reading Systems SHOULD ignore all <code>meta</code> elements whose <code>property</code>
-								attributes define expressions they do not recognize. A Reading System MUST NOT fail when
-								encountering unknown expressions.</p>
-						</dd>
-
-						<dt id="conf-metadata-link">The <code>link</code> element</dt>
-						<dd>
-							<p>Retrieval of Remote Resources is OPTIONAL.</p>
-							<p>The language identified in an <code>hreflang</code> attribute is not authoritative.
-								Language information defined in a linked resource determines its language.</p>
-							<p>Reading System do not have to use or present linked resources, even if they recognize the
-								relationship defined in the <code>rel</code> attribute.</p>
-							<p id="sec-linked-records">In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
-									>linked metadata record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing
-								the metadata expressed in the Package Document and only use the information expressed in
-								the record. Reading Systems MAY compile metadata from multiple linked records; they do
-								not have to select only one record.</p>
-							<p>When it comes to resolving discrepancies and conflicts between metadata expressed in the
-								Package Document and in linked metadata records, Reading Systems MUST use the document
-								order of <code>link</code> elements in the Package Document to establish precedence
-								(i.e., metadata in the first linked record encountered has the highest precedence and
-								metadata in the Package Document the lowest, regardless of whether the <code>link</code>
-								elements occur before, within or after the package metadata elements).</p>
-							<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
-								layout and rendering of the EPUB Publication.</p>
-						</dd>
-					</dl>
-				</section>
-
-				<section id="manifest">
-					<h3>Manifest</h3>
-					<dl class="conformance-list">
-						<dt>The <code>item</code> element</dt>
-						<dd>
-							<p>When an <code>href</code> attribute contains a relative IRI, Reading Systems MUST use the
-								IRI of the Package Document as the base when resolving to an absolute IRI.</p>
-							<p>Reading Systems MAY optimize the rendering depending on the properties set in the
-									<code>properties</code> attribute (e.g., disable a rendering process or use a
-								fallback). Reading Systems MUST ignore values of the <code>properties</code> attribute
-								they do not recognize.</p>
-						</dd>
-						<dt>Manifest Fallbacks</dt>
-						<dd>
-							<p>A Reading System that does not support the Media Type of a given Publication Resource
-								MUST traverse the fallback chain until it has identified at least one supported
-								Publication Resource to use in place of the unsupported resource. If the Reading System
-								supports multiple Publication Resources in the fallback chain, it MAY select the
-								resource to use based on specific <a
-									href="https://www.w3.org/TR/epub-33/#attrdef-item-properties">properties</a>
-								[[!EPUB-33]] of that resource, otherwise it SHOULD honor the EPUB Creator's preferred
-								fallback order. If a Reading System does not support any resource in the fallback chain,
-								it MUST alert the reader that content could not be displayed.</p>
-							<p>When <a href="https://www.w3.org/TR/epub-33/#sec-foreign-restrictions-manifest">manifest
-									fallbacks</a> [[!EPUB-33]] are provided for <a>Top-level Content Documents</a>,
-								Reading Systems MAY choose from the available options in order to find the optimal
-								version to render in a given context (e.g., by inspecting the properties attribute for
-								each).</p>
-						</dd>
-					</dl>
-				</section>
-
-				<section id="spine">
-					<h3>Spine</h3>
-
-					<dl class="conformance-list">
-						<dt id="sec-spine-elem">The <code>spine</code> element</dt>
-						<dd>
-							<p>Reading Systems MUST provide a means of rendering the EPUB Publication in the order
-								defined in the <code>spine</code>, which includes: 1) recognizing the first <a
-									href="https://www.w3.org/TR/epub-33/#linear-itemrefs">linear <code>itemref</code>
-									element</a> [[!EPUB-33]] as the beginning of the default reading order; and, 2)
-								rendering successive linear items in the order given in the <code>spine</code>.</p>
-							<p>When the <code>default</code> value of the <code>page-progression-direction</code>
-								attribute is specified, the Reading System can choose the rendering direction. The
-									<code>default</code> value MUST be assumed when the attribute is not specified. In
-								this case, the reading system SHOULD choose a default
-									<code>page-progression-direction</code> value based on the first
-									<code>language</code> element.</p>
-							<p>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
-										><code>pre-paginated</code></a> XHTML Content Documents. The
-									<code>page-progression-direction</code> attribute defines the flow direction from
-								one fixed-layout page to the next.</p>
-						</dd>
-
-						<dt id="sec-itemref-elem">The <code>itemref</code> element</dt>
-						<dd>
-							<p>When a user traverses the default reading order defined in the <a
-									href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[!EPUB-33]], a
-								Reading System MAY automatically skip <code>itemref</code> elements marked as non-linear
-								(excluding when a user specifically activates a hyperlink to such items). Reading
-								Systems MAY also provide the option for users to select whether non-linear content is
-								skipped by default or not.</p>
-							<p>Reading Systems MUST ignore all metadata properties expressed in the
-									<code>properties</code> attribute that they do not recognize.</p>
-						</dd>
-					</dl>
-				</section>
-
-				<section id="sec-collections">
-					<h3>Collections</h3>
-
-					<p>In the context of this specification, support for collections in Reading Systems is OPTIONAL.
-						Reading Systems MUST ignore <code>collection</code> elements that define unrecognized roles.</p>
-				</section>
-
+				<p>When <a href="https://www.w3.org/TR/epub-33/#sec-foreign-restrictions-manifest">manifest
+						fallbacks</a> [[!EPUB-33]] are provided for <a>Top-level Content Documents</a>, Reading Systems
+					MAY choose from the available options in order to find the optimal version to render in a given
+					context (e.g., by inspecting the properties attribute for each).</p>
 			</section>
+
+			<section id="spine">
+				<h3>Spine</h3>
+
+				<p>Reading Systems MUST provide a means of rendering the EPUB Publication in the order defined in the
+						<code>spine</code>, which includes: 1) recognizing the first primary <code>itemref</code> as the
+					beginning of the default reading order; and, 2) rendering successive primary items in the order
+					given in the <code>spine</code>.</p>
+
+				<p>When a user traverses the default reading order defined in the <a
+						href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[!EPUB-33]], a Reading System
+					MAY automatically skip <code>itemref</code> elements marked as non-linear (excluding when a user
+					specifically activates a hyperlink to such items). Reading Systems MAY also provide the option for
+					users to select whether non-linear content is skipped by default or not.</p>
+
+				<p>When the <code>default</code> value of the <code>page-progression-direction</code> attribute is
+					specified, the Reading System can choose the rendering direction. The <code>default</code> value
+					MUST be assumed when the attribute is not specified. In this case, the reading system SHOULD choose
+					a default <code>page-progression-direction</code> value based on the first <code>language</code>
+					element.</p>
+
+				<p>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
+							><code>pre-paginated</code></a> XHTML Content Documents. The
+						<code>page-progression-direction</code> attribute defines the flow direction from one
+					fixed-layout page to the next.</p>
+
+				<p>Reading Systems MUST ignore all metadata properties expressed in spine <code>itemref</code>
+					<code>properties</code> attribute that they do not recognize.</p>
+			</section>
+
+			<section id="sec-collections">
+				<h3>Collections</h3>
+
+				<p>In the context of this specification, support for collections in Reading Systems is OPTIONAL. Reading
+					Systems MUST ignore <code>collection</code> elements that define unrecognized roles.</p>
+			</section>
+
 		</section>
-		<section id="contentdocs">
+		<section id="sec-contentdocs">
 			<h2>Content Document Processing</h2>
 
 			<section id="sec-xhtml">
 				<h3>XHTML Content Documents</h3>
 
-				<section id="sec-xhtml-conf-rs">
-					<h4>XHTML Conformance</h4>
-
-					<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing
-							<a>XHTML Content Documents</a>:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-html-rs-behavior">Unless explicitly defined by this specification as
-								overridden, it MUST process XHTML Content Documents using semantics defined by the
-								[[!HTML]] specification and honor any applicable user agent conformance constraints
-								expressed therein.</p>
-						</li>
-						<li>
-							<p id="confreq-html-rs-behavior-add">It MUST meet all Reading System conformance criteria
-								defined in <a href="#sec-xhtml-extensions"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-html-rs-behavior-restr">It MUST recognize and adapt behaviorally to the
-								constraints defined in <a href="#sec-xhtml-deviations"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-html-rs-scrpt">It MUST meet the Reading System conformance criteria defined
-								in <a href="#sec-scripted-content-rs-reqs"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-html-rs-css">It MUST support visual rendering of XHTML Content Documents as
-								defined in <a href="#sec-css-rs-conf"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-html-rs-a11y">It SHOULD recognize embedded ARIA markup and support exposure
-								of any given ARIA roles, states and properties to platform accessibility APIs
-								[[!WAI-ARIA]].</p>
-						</li>
-					</ul>
-				</section>
+				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, Reading
+					Systems MUST process XHTML Content Documents using semantics defined by the [[!HTML]] specification
+					and honor any applicable user agent conformance constraints expressed therein.</p>
 
 				<section id="sec-xhtml-extensions">
 					<h4>HTML Extensions</h4>
+
+					<section id="sec-xhtml-aria">
+						<h5>ARIA</h5>
+
+						<p id="confreq-html-rs-a11y">Reading Systems SHOULD recognize embedded ARIA markup and support
+							exposure of any given ARIA roles, states and properties to platform accessibility APIs
+							[[!WAI-ARIA]].</p>
+					</section>
 
 					<section id="sec-xhtml-structural-semantics">
 						<h5>Structural Semantics</h5>
@@ -765,224 +722,124 @@
 			<section id="sec-css">
 				<h3>CSS Style Sheets</h3>
 
-				<section id="sec-css-rs-conf">
-					<h4>CSS Conformance</h4>
+				<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing CSS Style
+					Sheets:</p>
 
-					<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing CSS
-						Style Sheets:</p>
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-css-rs-support">It MUST support the official definition of CSS as described in
+							the [[!CSSSnapshot]].</p>
+					</li>
+					<li>
+						<p id="confreq-css-rs-modules">It SHOULD support all applicable modules in [[!CSSSnapshot]] that
+							have reached at least <a href="https://www.w3.org/Consortium/Process/#RecsCR">Candidate
+								Recommendation</a> status [[!W3CProcess]] (and are widely implemented).</p>
+					</li>
+					<li>
+						<p id="confreq-css-rs-fonts">It MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and
+							[[!WOFF2]] font resources referenced from <code>@font-face</code> rules.</p>
+					</li>
+					<li>
+						<p id="confreq-css-rs-prefixed">It MUST support all prefixed properties defined in <a
+								href="https://www.w3.org/TR/epub-33/#sec-css-prefixed">CSS Style Sheets — Prefixed
+								Properties</a> [[EPUB-33]].</p>
+					</li>
+					<li>
+						<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above,
+							its user agent style sheet SHOULD support the [[!HTML]] <a
+								href="https://html.spec.whatwg.org/multipage/rendering.html#rendering">suggested default
+								rendering</a>.</p>
+					</li>
+					<li>
+						<p id="confreq-css-creator-styles">It SHOULD apply <a>EPUB Creator</a> style sheets as written
+							to <a>EPUB Content Documents</a>.</p>
+					</li>
+					<li>
+						<p id="confreq-css-overrides">It SHOULD NOT override the EPUB Creator's style sheets, but SHOULD
+							do so in a way that preserves the Cascade when necessary: through a user agent style sheet,
+							the <a
+								href="https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-OverrideAndComputed"
+									><code>getOverrideStyle</code> method</a> [[!DOM-Level-2-Style]], or [[!HTML]] <a
+								href="https://html.spec.whatwg.org/multipage/dom.html#the-style-attribute"
+									><code>style</code> attributes</a>.</p>
+					</li>
+					<li>
+						<p id="confreq-css-user-styles">It SHOULD allow users to override the EPUB Creator's style
+							sheets as desired.</p>
+					</li>
+				</ul>
 
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-css-rs-support">It MUST support the official definition of CSS as described
-								in the [[!CSSSnapshot]].</p>
-						</li>
-						<li>
-							<p id="confreq-css-rs-modules">It SHOULD support all applicable modules in [[!CSSSnapshot]]
-								that have reached at least <a href="https://www.w3.org/Consortium/Process/#RecsCR"
-									>Candidate Recommendation</a> status [[!W3CProcess]] (and are widely
-								implemented).</p>
-						</li>
-						<li>
-							<p id="confreq-css-rs-fonts">It MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and
-								[[!WOFF2]] font resources referenced from <code>@font-face</code> rules.</p>
-						</li>
-						<li>
-							<p id="confreq-css-rs-prefixed">It MUST support all prefixed properties defined in <a
-									href="https://www.w3.org/TR/epub-33/#sec-css-prefixed">CSS Style Sheets — Prefixed
-									Properties</a> [[EPUB-33]].</p>
-						</li>
-						<li>
-							<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined
-								above, its user agent style sheet SHOULD support the [[!HTML]] <a
-									href="https://html.spec.whatwg.org/multipage/rendering.html#rendering">suggested
-									default rendering</a>.</p>
-						</li>
-						<li>
-							<p id="confreq-css-rs-overrides">It SHOULD respect CSS and user styles provided by the EPUB
-								Creator as defined in <a href="#sec-css-rs-overrides"></a>.</p>
-						</li>
-					</ul>
-
-					<p>Reading System developers are encouraged to implement CSS support at the level of major
-						browsers.</p>
-				</section>
-
-				<section id="sec-css-rs-overrides">
-					<h4>Reading System Overrides</h4>
-
-					<p><a>EPUB Reading Systems</a> SHOULD apply <a>EPUB Creator</a> style sheets as written to <a>EPUB
-							Content Documents</a>. If a Reading System allows, users SHOULD be able to override the EPUB
-						Creator's style sheets as desired. EPUB Reading Systems SHOULD NOT override the EPUB Creator's
-						style sheets unless strictly necessary.</p>
-
-					<p>If a Reading System has to override an EPUB Creator's style sheet, it SHOULD do so in a way that
-						preserves the Cascade: through a user agent style sheet, the <a
-							href="https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-OverrideAndComputed"
-								><code>getOverrideStyle</code> method</a> [[!DOM-Level-2-Style]], or [[!HTML]] <a
-							href="https://html.spec.whatwg.org/multipage/dom.html#the-style-attribute"
-								><code>style</code> attributes</a>.</p>
-
-					<p>Developers of Reading Systems are strongly encouraged to publicly document their user agent style
-						sheets and how they interact with EPUB Creator's style sheets.</p>
-				</section>
+				<p>Reading System developers are strongly encouraged to implement CSS support at the level of major
+					browsers and to publicly document their user agent style sheets and how they interact with EPUB
+					Creator's style sheets.</p>
 			</section>
 
 			<section id="sec-scripted-content">
 				<h3>Scripting</h3>
 
-				<section id="sec-scripted-content-rs-reqs">
-					<h4>Scripting Conformance</h4>
+				<p>A Reading System that supports scripting MUST meet the following criteria:</p>
 
-					<p>A Reading System that supports scripting MUST meet the following criteria:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-rs-scripted-reflow-support">It SHOULD support <a
-									href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained"
-									>container-constrained scripting</a> [[!EPUB-33]] in reflowable EPUB Content
-								Documents.</p>
-						</li>
-						<li>
-							<p id="confreq-rs-scripted-fxl-support">It SHOULD support <a
-									href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level scripting</a>
-								[[!EPUB-33]] in <a href="https://www.w3.org/TR/epub-33/#sec-fixed-layouts">fixed-layout
-									documents</a> [[!EPUB-33]].</p>
-						</li>
-						<li>
-							<p id="confreq-rs-scripted-scrolled">It SHOULD support spine-level scripting in reflowable
-								EPUB Content Documents that use the <a
-									href="https://www.w3.org/TR/epub-33/#flow-scrolled-doc"
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-rs-scripted-reflow-support">It SHOULD support <a
+								href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained"
+								>container-constrained scripting</a> [[!EPUB-33]] in reflowable EPUB Content
+							Documents.</p>
+					</li>
+					<li>
+						<p id="confreq-rs-scripted-fxl-support">It SHOULD support <a
+								href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level scripting</a>
+							[[!EPUB-33]] in <a href="https://www.w3.org/TR/epub-33/#sec-fixed-layouts">fixed-layout
+								documents</a> [[!EPUB-33]].</p>
+					</li>
+					<li>
+						<p id="confreq-rs-scripted-scrolled">It SHOULD support spine-level scripting in reflowable EPUB
+							Content Documents that use the <a href="https://www.w3.org/TR/epub-33/#flow-scrolled-doc"
 									>"<code>scrolled-doc</code>"</a> or <a
-									href="https://www.w3.org/TR/epub-33/#flow-scrolled-continuous"
-										>"<code>scrolled-continuous</code>"</a> [[!EPUB-33]] presentation modes defined
-								by <a href="#flow">the <code>rendition:flow</code> property</a>. Similarly, if it
-								supports spine-level scripting in reflowable EPUB Content Documents, it MUST implement
-								the "<code>scrolled-doc</code>" presentation mode and SHOULD implement the
-									"<code>scrolled-continuous</code>" presentation mode.</p>
-						</li>
-						<li>
-							<p id="confreq-rs-scripted-optional-support">It MAY support scripting in other contexts, but
-								this specification does not address such scripting. As a result, the use of scripting in
-								these contexts might not be consistent across Reading Systems.</p>
-						</li>
-						<li>
-							<p id="confreq-rs-scripted-ua">It MAY render <a>Scripted Content Documents</a> as an
-								interactive, scripted user agent according to [[!HTML]].</p>
-						</li>
-						<li>
-							<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to
-								modify the DOM of the parent Content Document or other contents in the EPUB Publication
-								and MUST NOT allow it to manipulate the size of its containing rectangle. (Note: Even if
-								a script is not container-constrained, the Reading System MAY impose restrictions on
-								modifications (see also the <a href="#feature-dom-manipulation">dom-manipulation
-									feature</a>).)</p>
-						</li>
-						<li>
-							<p id="confreq-rs-scripted-limit">It MAY place additional limitations on the capabilities
-								provided to scripts during execution (e.g., limiting networking).</p>
-						</li>
-						<li>
-							<p id="confreq-rs-scripted-readingsystem-object">It MUST implement the JavaScript
-									<code>navigator</code> extension object <code>epubReadingSystem</code> defined in <a
-									href="#app-epubReadingSystem"></a>. It also MUST support the
-									<code>dom-manipulation</code> and <code>layout-change</code> features defined in <a
-									href="#app-ers-hasFeature-features"></a> in container-constrained scripting
-								contexts.</p>
-						</li>
-					</ul>
-					<p>A Reading System that does not support scripting MUST meet the following criteria:</p>
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-rs-scripted-flbk">It MUST process fallbacks for scripted content as defined
-								in <a href="https://www.w3.org/TR/epub-33/#confreq-cd-scripted-flbk">Fallbacks for
-									Scripted Content Documents</a> [[!EPUB-33]].</p>
-						</li>
-					</ul>
-				</section>
-
-				<section id="sec-scripted-content-security" class="informative">
-					<h4>Security Considerations</h4>
-
-					<p><a>EPUB Creators</a> and <a>Reading System</a> developers must be aware of the security issues
-						that arise when scripted content is executed by a Reading System. As the underlying scripting
-						model employed by Reading Systems and browsers is the same, the same kinds of issues encountered
-						in Web contexts have to be taken into consideration.</p>
-
-					<p>Each Reading System has to establish if the scripts in a particular document are to be trusted or
-						not. It is advised that all scripts be treated as untrusted (and potentially malicious), and
-						that all vectors of attack be examined and protected against. In particular, the following need
-						to be considered:</p>
-
-					<ul>
-						<li>
-							<p>an attack against the runtime environment (e.g., stealing files from a user's hard
-								drive);</p>
-						</li>
-						<li>
-							<p>an attack against the Reading System itself (e.g., stealing a list of a user's books or
-								causing unexpected behavior);</p>
-						</li>
-						<li>
-							<p>an attack of one Content Document against another (e.g., stealing data that originated in
-								a different document);</p>
-						</li>
-						<li>
-							<p>an attack of an unencrypted script against an encrypted portion of a document (e.g., an
-								injected malicious script extracting protected content);</p>
-						</li>
-						<li>
-							<p>an attack against the local network (e.g., stealing data from a server behind a
-								firewall).</p>
-						</li>
-					</ul>
-
-					<p>The following recommendations are provided as a guide to handling untrusted scripts:</p>
-
-					<ul>
-						<li>
-							<p>Reading Systems must behave as if a unique <a href="https://url.spec.whatwg.org/#origin"
-									>origin</a> [[URL]] were allocated to each <a>EPUB Publication</a>. Adopting this
-								approach will isolate publications from each other, thereby limiting access to cookies,
-								DOM storage, etc.</p>
-							<div class="note">
-								<p>Although domain isolation is the most effective way to secure EPUB Publications in
-									Web-based Reading Systems, it is not always a realistic option. Web-based Reading
-									Systems must still maintain isolation in such cases, which may require limiting
-									access to scripting APIs that allow client-side data storage and access.</p>
-							</div>
-							<p>Reading Systems that enable scripting and network access should also include methods to
-								notify the user that network activity is occurring and/or that allow them to disable
-								it.</p>
-						</li>
-						<li>
-							<p>If a Reading System allows persistent data to be stored, that data must be treated as
-								sensitive. Scripts may save persistent data through cookies and DOM storage but Reading
-								Systems may block such attempts. Reading Systems that do allow data to be stored must
-								ensure that it is not made available to other unrelated documents (e.g., ones that could
-								have been spoofed). In particular, checking for a matching document identifier (or
-								similar metadata) is not a valid method to control access to persistent data.</p>
-							<p>Reading Systems that allow local storage should also provide methods for users to
-								inspect, disable, and delete that data. The data needs to be destroyed if the
-								corresponding EPUB Publication is deleted.</p>
-						</li>
-					</ul>
-
-					<p>Note that compliance with these recommendations does not guarantee protection from the possible
-						attacks listed above; developers have to examine each potential vulnerability within the context
-						of their Reading System.</p>
-				</section>
-
-				<section id="sec-scripted-content-events" class="informative">
-					<h4>Event Model Considerations</h4>
-
-					<p>Reading Systems need to follow the DOM Event model as per [[HTML]] and pass UI events to the
-						scripting environment before performing any default action associated with these events. Reading
-						System implementers need to ensure that scripts cannot disable critical functionality (such as
-						navigation) to constrain the extent to which a <a href="#sec-scripted-content-security"
-							>potentially malicious</a> script could impact their Reading Systems. As a result, although
-						the scripting environment needs to be able to cancel the default action of any event, some
-						events either might not be passed through or might not be cancelable.</p>
-				</section>
+								href="https://www.w3.org/TR/epub-33/#flow-scrolled-continuous"
+									>"<code>scrolled-continuous</code>"</a> [[!EPUB-33]] presentation modes defined by
+								<a href="#flow">the <code>rendition:flow</code> property</a>. Similarly, if it supports
+							spine-level scripting in reflowable EPUB Content Documents, it MUST implement the
+								"<code>scrolled-doc</code>" presentation mode and SHOULD implement the
+								"<code>scrolled-continuous</code>" presentation mode.</p>
+					</li>
+					<li>
+						<p id="confreq-rs-scripted-optional-support">It MAY support scripting in other contexts, but
+							this specification does not address such scripting. As a result, the use of scripting in
+							these contexts might not be consistent across Reading Systems.</p>
+					</li>
+					<li>
+						<p id="confreq-rs-scripted-ua">It MAY render <a>Scripted Content Documents</a> as an
+							interactive, scripted user agent according to [[!HTML]].</p>
+					</li>
+					<li>
+						<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to modify
+							the DOM of the parent Content Document or other contents in the EPUB Publication and MUST
+							NOT allow it to manipulate the size of its containing rectangle. (Note: Even if a script is
+							not container-constrained, the Reading System MAY impose restrictions on modifications (see
+							also the <a href="#feature-dom-manipulation">dom-manipulation feature</a>).)</p>
+					</li>
+					<li>
+						<p id="confreq-rs-scripted-limit">It MAY place additional limitations on the capabilities
+							provided to scripts during execution (e.g., limiting networking).</p>
+					</li>
+					<li>
+						<p id="confreq-rs-scripted-readingsystem-object">It MUST implement the JavaScript
+								<code>navigator</code> extension object <code>epubReadingSystem</code> defined in <a
+								href="#app-epubReadingSystem"></a>. It also MUST support the
+								<code>dom-manipulation</code> and <code>layout-change</code> features defined in <a
+								href="#app-ers-hasFeature-features"></a> in container-constrained scripting
+							contexts.</p>
+					</li>
+				</ul>
+				<p>A Reading System that does not support scripting MUST meet the following criteria:</p>
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-rs-scripted-flbk">It MUST process fallbacks for scripted content as defined in <a
+								href="https://www.w3.org/TR/epub-33/#confreq-cd-scripted-flbk">Fallbacks for Scripted
+								Content Documents</a> [[!EPUB-33]].</p>
+					</li>
+				</ul>
 			</section>
 
 			<section id="sec-pls-conf-rs">
@@ -1020,91 +877,54 @@
 			</section>
 		</section>
 		<section id="sec-nav">
-			<h3>Navigation Document</h3>
+			<h3>Navigation Document Processing</h3>
 
-			<section id="sec-nav-rs-conf">
-				<h4>Navigation Document Conformance</h4>
+			<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing <a>EPUB
+					Navigation Documents</a>:</p>
 
-				<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing <a>EPUB
-						Navigation Documents</a>:</p>
-
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-nav-toc-access">It MUST provide users access to the links in the <a
-								href="https://www.w3.org/TR/epub-33/#sec-nav-toc"><code>toc nav</code> element</a>
-							[[!EPUB-33]].</p>
-					</li>
-					<li>
-						<p id="confreq-nav-pagelist-access">It SHOULD provide a method to navigate to the listed page
-							breaks when a <a href="https://www.w3.org/TR/epub-33/#sec-nav-pagelist"><code>page-list
-									nav</code> element</a> [[!EPUB-33]] is present.</p>
-					</li>
-					<li>
-						<p id="confreq-nav-landmarks-access">It MAY provide users access to the links in the <a
-								href="https://www.w3.org/TR/epub-33/#sec-nav-landmarks"><code>landmarks nav</code>
-								element</a> [[!EPUB-33]] and MAY use the links to enable functionality in the
-							application.</p>
-					</li>
-					<li>
-						<p id="confreq-nav-other-access">It MAY provide access to <code>nav</code> elements that do not
-							specify an <code>epub:type</code> attribute or that <a
-								href="https://www.w3.org/TR/epub-33/#sec-nav-def-types-other">declare an unknown
-								value</a> [[!EPUB-33]].</p>
-					</li>
-					<li>
-						<p id="confreq-nav-activation">When a link to a <a>Publication Resource</a> is activated, it
-							MUST relocate the current reading position to the destination identified by that link.</p>
-					</li>
-					<li>
-						<p id="confreq-nav-spine">It MUST honor the above requirements irrespective of whether the EPUB
-							Navigation Document is part of the <a href="#sec-spine-elem">spine</a>.</p>
-					</li>
-				</ul>
-			</section>
-
-			<section id="sec-nav-def-model">
-				<h4>The <code>nav</code> Element: Restrictions</h4>
-
-				<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
-					items within <code>nav</code> elements MUST be equivalent to the <a
-						href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style: none</code>
-						property</a> [[!CSSSnapshot]]. Reading Systems MUST NOT show list item numbering on these lists
-					when presenting the Navigation Document outside of the spine, regardless of their support for
-					CSS.</p>
-			</section>
+			<ul class="conformance-list">
+				<li>
+					<p id="confreq-nav-toc-access">It MUST provide users access to the links in the <a
+							href="https://www.w3.org/TR/epub-33/#sec-nav-toc"><code>toc nav</code> element</a>
+						[[!EPUB-33]].</p>
+				</li>
+				<li>
+					<p id="confreq-nav-pagelist-access">It SHOULD provide a method to navigate to the listed page breaks
+						when a <a href="https://www.w3.org/TR/epub-33/#sec-nav-pagelist"><code>page-list nav</code>
+							element</a> [[!EPUB-33]] is present.</p>
+				</li>
+				<li>
+					<p id="confreq-nav-landmarks-access">It MAY provide users access to the links in the <a
+							href="https://www.w3.org/TR/epub-33/#sec-nav-landmarks"><code>landmarks nav</code>
+							element</a> [[!EPUB-33]] and MAY use the links to enable functionality in the
+						application.</p>
+				</li>
+				<li>
+					<p id="confreq-nav-other-access">It MAY provide access to <code>nav</code> elements that do not
+						specify an <code>epub:type</code> attribute or that <a
+							href="https://www.w3.org/TR/epub-33/#sec-nav-def-types-other">declare an unknown value</a>
+						[[!EPUB-33]].</p>
+				</li>
+				<li>
+					<p id="confreq-nav-activation">When a link to a <a>Publication Resource</a> is activated, it MUST
+						relocate the current reading position to the destination identified by that link.</p>
+				</li>
+				<li>
+					<p id="confreq-nav-spine">It MUST honor the above requirements irrespective of whether the EPUB
+						Navigation Document is part of the <a href="https://www.w3.org/TR/epub-33/#sec-spine-elem"
+							>spine</a> [[!EPUB-33]].</p>
+				</li>
+				<li>
+					<p id="confreq-nav-ol-style">It MUST NOT show list item numbering on <code>nav</code> elements when
+						presenting them outside of the spine, regardless of support for CSS, as the default display
+						style of list items is equivalent to the <a
+							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
+								none</code> property</a> [[!CSSSnapshot]].).</p>
+				</li>
+			</ul>
 		</section>
 		<section id="sec-fxl">
-			<h2>Fixed-Layout Documents</h2>
-
-			<section id="sec-fxl-rs-conf">
-				<h3>Fixed Layout Conformance</h3>
-
-				<p>A conformant <a>EPUB Reading System</a> has to meet the following criteria for processing
-						<a>Fixed-Layout Documents</a>:</p>
-
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-fxl-rs-viewport">It SHOULD allocate the full <a>Content Display Area</a> for the
-							document, as defined in <a href="#sec-fxl-viewport"></a>.</p>
-					</li>
-					<li>
-						<p id="confreq-fxl-rs-html">It MUST use the dimensions expressed in the <code>viewport</code>
-							<code>meta</code> tag to render <a>XHTML Content Documents</a>, as defined in <a
-								href="#sec-fxl-html-dimensions"></a>.</p>
-					</li>
-					<li>
-						<p id="confreq-fxl-rs-svg">It MUST use the dimensions as defined in <a
-								href="https://www.w3.org/TR/epub-33/#sec-fxl-icb-svg">Expressing the ICB in SVG</a>
-							[[!EPUB-33]] to render <a>SVG Content Documents</a>.</p>
-					</li>
-				</ul>
-
-				<div class="note">
-					<p>This specification does not define how the <a
-							href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
-							block</a> [[CSS2]] is placed within the Reading System <a>Content Display Area</a>.</p>
-				</div>
-			</section>
+			<h2>Fixed-Layout Documents Processing</h2>
 
 			<section id="sec-fxl-props">
 				<h3>Fixed-Layout Properties</h3>
@@ -1230,20 +1050,32 @@
 				</section>
 			</section>
 
-			<section id="sec-fxl-html-dimensions">
-				<h3>HTML Initial Containing Block Dimensions</h3>
+			<section id="sec-fxl-dimensions">
+				<h3>Initial Containing Block Dimensions</h3>
 
-				<p>In this version of this specification, only the width and height expressions as defined in <a
-						href="https://www.w3.org/TR/epub-33/#sec-fxl-icb-html">Expressing in HTML</a> [[!EPUB-33]] MUST
-					be recognized by <a>Reading Systems</a>.</p>
+				<dl>
+					<dt>XHTML</dt>
+					<dd>
+						<p>In this version of this specification, <a>Reading Systems</a> MUST recognize only the width
+							and height expressions as defined in <a
+								href="https://www.w3.org/TR/epub-33/#sec-fxl-icb-html">Expressing in HTML</a>
+							[[!EPUB-33]].</p>
+						<p>Reading Systems MUST clip XHTML content to the initial containing block (ICB) dimensions
+							declared in the <code>viewport</code>
+							<code>meta</code> tag — content positioned outside of the initial containing block will not
+							be visible. When the ICB aspect ratio does not match the aspect ratio of the Reading System
+								<a>Content Display Area</a>, Reading Systems MAY position the ICB inside the area to
+							accommodate the user interface; in other words, added letter-boxing space MAY appear on
+							either side (or both) of the content.</p>
+					</dd>
 
-				<p>Reading Systems MUST clip XHTML content to the initial containing block (ICB) dimensions declared in
-					the <code>viewport</code>
-					<code>meta</code> tag — content positioned outside of the initial containing block will not be
-					visible. When the ICB aspect ratio does not match the aspect ratio of the Reading System <a>Content
-						Display Area</a>, Reading Systems MAY position the ICB inside the area to accommodate the user
-					interface; in other words, added letter-boxing space MAY appear on either side (or both) of the
-					content.</p>
+					<dt>SVG</dt>
+					<dd>
+						<p id="confreq-fxl-rs-svg">Reading Systems MUST use the dimensions as defined in <a
+								href="https://www.w3.org/TR/epub-33/#sec-fxl-icb-svg">Expressing the ICB in SVG</a>
+							[[!EPUB-33]] to render <a>SVG Content Documents</a>.</p>
+					</dd>
+				</dl>
 			</section>
 
 			<section id="sec-fxl-viewport">
@@ -1255,43 +1087,26 @@
 					into the Viewport.</p>
 
 				<div class="note">
+					<p>This specification does not define how the <a
+							href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
+							block</a> [[CSS2]] is placed within the Reading System <a>Content Display Area</a>.</p>
+				</div>
+
+				<div class="note">
 					<p>The exposure of Reading System control widgets to the user is implementation-specific and not
 						included in the above behavioral expectations.</p>
 				</div>
 			</section>
 		</section>
-		<section id="ocf">
+		<section id="sec-ocf">
 			<h2>Open Container Format Processing</h2>
 
-			<section id="ocf-conformance-rs">
-				<h3>OCF Conformance</h3>
-
-				<p>An <a>EPUB Reading System</a> has to meet the following criteria:</p>
-
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-ocf-rs-abstract">It MUST process the OCF Abstract Container in conformance with
-							all Reading System conformance constraints expressed in <a href="#sec-container-abstract"
-							></a>.</p>
-					</li>
-					<li>
-						<p id="confreq-ocf-rs-zip">It MUST process the OCF ZIP Container in conformance with all Reading
-							System conformance constraints expressed in <a href="#sec-container-zip"></a>.</p>
-					</li>
-					<li>
-						<p id="confreq-ocf-fobfus">If it has a <a>Viewport</a>, it MUST support deobfuscation of
-							resources as defined in <a href="https://www.w3.org/TR/epub-33/#sec-resource-obfuscation"
-									><em>Resource Obfuscation</em></a> [[!EPUB-33]].</p>
-					</li>
-				</ul>
-
-				<div class="note">
-					<p>It is not required that an application that processes OCF Containers be a full-fledged EPUB
-						Reading System (e.g., an application might only extract the content of a container or check the
-						validity of the packaged content). In these cases, the rendering requirements for EPUB Reading
-						Systems defined in the referenced sections can be ignored.</p>
-				</div>
-			</section>
+			<div class="note">
+				<p>It is not required that an application that processes OCF Containers be a full-fledged EPUB Reading
+					System (e.g., an application might only extract the content of a container or check the validity of
+					the packaged content). In these cases, the rendering requirements for EPUB Reading Systems defined
+					in this section can be ignored.</p>
+			</div>
 
 			<section id="sec-container-abstract">
 				<h3>OCF Abstract Container</h3>
@@ -1396,347 +1211,299 @@
 				</ul>
 			</section>
 		</section>
-		<section id="mediaoverlays">
+		<section id="sec-mediaoverlays">
 			<h2>Media Overlays Processing</h2>
 
-			<section id="sec-overlays-rs-conf">
-				<h2>Media Overlays Conformance</h2>
+			<section id="sec-behaviors-loading">
+				<h4>Loading the Media Overlay</h4>
 
-				<p><a>EPUB Reading System</a> support for Media Overlays is OPTIONAL. A Reading System that supports
-					Media Overlays MUST meet the following criteria:</p>
+				<p>When an <a>EPUB Reading System</a> loads a <a>Package Document</a>, it MUST refer to the
+						<a>Manifest</a>
+					<a href="https://www.w3.org/TR/epub-33/#elemdef-package-item"><code>item</code> elements'</a>
+					[[!EPUB-33]] <code>media-overlay</code> attributes to discover the corresponding Media Overlays for
+						<a>EPUB Content Documents</a>.</p>
 
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-rs-xhtml-svg">It MUST support <a>XHTML Content Documents</a>, and it MAY support
-								<a>SVG Content Documents</a>.</p>
-						<p id="confreq-rs-render">It MUST render Media Overlay elements as described in <a
-								href="#sec-behaviors-playback"></a>.</p>
-						<p id="confreq-rs-navigation">It MUST allow user navigation while a Media Overlay is being
-							played, as discussed in <a href="#sec-rsconf-navigation"></a>.</p>
-						<p id="confreq-rs-embed">It MUST adhere to rules regarding referenced audio and video embedded
-							in the <a>EPUB Content Document</a>, as stated in <a href="#sec-embedded-media"></a>.</p>
-						<p id="confreq-rs-tts"><a>Text-to-Speech</a>-capable Reading Systems SHOULD conform to <a
-								href="#confreq-rs-epub3-tts">Reading System Text-to-Speech Conformance Requirements</a>
-							[[!EPUB-33]].</p>
-						<p id="confreq-rs-skip-escape">It SHOULD offer the skippability and escapability features
-							described in <a href="#sec-behaviors-skip-escape"></a>.</p>
-					</li>
-				</ul>
+				<p id="confreq-rs-xhtml-svg">Reading Systems MUST support playback for <a>XHTML Content Documents</a>,
+					and MAY support <a>SVG Content Documents</a>.</p>
 
-				<p>A Reading System that does not support Media Overlays MUST meet the following criteria:</p>
-
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-rs-mo-ignore">It MUST ignore both the <code>media-overlay</code> attribute on
-								<a>Manifest</a>
-							<a href="https://www.w3.org/TR/epub-33/#elemdef-package-item"><code>item</code> elements</a>
-							and the manifest <code>item</code> elements where the <code>media-type</code> attribute
-							value equals <code>application/smil+xml</code>.</p>
-					</li>
-				</ul>
+				<p>Playback MUST start at the Media Overlay element which corresponds to the desired EPUB Content
+					Document starting point. Note that the start of an EPUB Content Document MAY correspond to an
+					element at the start or in the middle of a Media Overlay. When the Media Overlay Document has
+					finished playing, the Reading System SHOULD load the next EPUB Content Document (as specified in the
+					Package Document <a>spine</a>) and also load its corresponding Media Overlay Document, provided that
+					one is given.</p>
 			</section>
 
-			<section id="sec-overlay-behaviors">
-				<h3>Playback Behaviors</h3>
+			<section id="sec-behaviors-playback">
+				<h4>Basic Playback</h4>
 
-				<section id="sec-behaviors-loading">
-					<h4>Loading the Media Overlay</h4>
+				<section id="sec-rsconf-timing-synch">
+					<h3>Timing and Synchronization</h3>
 
-					<p>When an <a>EPUB Reading System</a> loads a <a>Package Document</a>, it MUST refer to the
-							<a>Manifest</a>
-						<a href="https://www.w3.org/TR/epub-33/#elemdef-package-item"><code>item</code> elements'</a>
-						[[!EPUB-33]] <code>media-overlay</code> attributes to discover the corresponding Media Overlays
-						for <a>EPUB Content Documents</a>. Playback MUST start at the Media Overlay element which
-						corresponds to the desired EPUB Content Document starting point. Note that the start of an EPUB
-						Content Document MAY correspond to an element at the start or in the middle of a Media Overlay.
-						When the Media Overlay Document has finished playing, the Reading System SHOULD load the next
-						EPUB Content Document (as specified in the Package Document <a>spine</a>) and also load its
-						corresponding Media Overlay Document, provided that one is given.</p>
+					<p>Reading Systems MUST render immediate children of the <a
+							href="https://www.w3.org/TR/epub-33/#elemdef-smil-body"><code>body</code> element</a>
+						[[!EPUB-33]] in a sequence. A <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-seq"
+								><code>seq</code> element's</a> [[!EPUB-33]] children MUST be rendered in sequence, and
+						playback completes when the last child has finished playing. A <a
+							href="https://www.w3.org/TR/epub-33/#elemdef-smil-par"><code>par</code> element's</a>
+						[[!EPUB-33]] children MUST be rendered in parallel (with each starting at the same time), and
+						playback completes when all the children have finished playing. When the <code>body</code>
+						element's last child has finished playing, playback of the Media Overlay Document is done.</p>
 				</section>
 
-				<section id="sec-behaviors-playback">
-					<h4>Basic Playback</h4>
+				<section id="sec-rsconf-rendering-audio">
+					<h5>Rendering Audio</h5>
 
-					<section id="sec-rsconf-timing-synch">
-						<h3>Timing and Synchronization</h3>
+					<p>When presented with a Media Overlay <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"
+								><code>audio</code> element</a> [[!EPUB-33]], Reading Systems MUST play the audio
+						resource referenced by the <code>src</code> attribute, starting at the clip offset time given by
+						the <a href="https://www.w3.org/TR/epub-33/#attrdef-smil-clipBegin"><code>clipBegin</code>
+							attribute</a> [[!EPUB-33]] and ending at the clip offset time given by the <a
+							href="https://www.w3.org/TR/epub-33/#attrdef-smil-clipEnd"><code>clipEnd</code>
+							attribute</a> [[!EPUB-33]]. The following rules MUST be observed:</p>
 
-						<p>Reading Systems MUST render immediate children of the <a
-								href="https://www.w3.org/TR/epub-33/#elemdef-smil-body"><code>body</code> element</a>
-							[[!EPUB-33]] in a sequence. A <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-seq"
-									><code>seq</code> element's</a> [[!EPUB-33]] children MUST be rendered in sequence,
-							and playback completes when the last child has finished playing. A <a
-								href="https://www.w3.org/TR/epub-33/#elemdef-smil-par"><code>par</code> element's</a>
-							[[!EPUB-33]] children MUST be rendered in parallel (with each starting at the same time),
-							and playback completes when all the children have finished playing. When the
-								<code>body</code> element's last child has finished playing, playback of the Media
-							Overlay Document is done.</p>
+					<ul>
+						<li>
+							<p>If <code>clipBegin</code> is not specified, its value is assumed to be
+								"<code>0</code>".</p>
+						</li>
+						<li>
+							<p>If <code>clipEnd</code> is not specified, its value is assumed to be the full duration of
+								the physical media.</p>
+						</li>
+						<li>
+							<p>If <code>clipEnd</code> exceeds the full duration of the physical media, then its value
+								is assumed to be the full duration of the physical media.</p>
+						</li>
+					</ul>
 
-					</section>
-
-					<section id="sec-rsconf-rendering-audio">
-						<h5>Rendering Audio</h5>
-
-						<p>When presented with a Media Overlay <a
-								href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"><code>audio</code> element</a>
-							[[!EPUB-33]], Reading Systems MUST play the audio resource referenced by the
-								<code>src</code> attribute, starting at the clip offset time given by the <a
-								href="https://www.w3.org/TR/epub-33/#attrdef-smil-clipBegin"><code>clipBegin</code>
-								attribute</a> [[!EPUB-33]] and ending at the clip offset time given by the <a
-								href="https://www.w3.org/TR/epub-33/#attrdef-smil-clipEnd"><code>clipEnd</code>
-								attribute</a> [[!EPUB-33]]. The following rules MUST be observed:</p>
-
-						<ul>
-							<li>
-								<p>If <code>clipBegin</code> is not specified, its value is assumed to be
-										"<code>0</code>".</p>
-							</li>
-							<li>
-								<p>If <code>clipEnd</code> is not specified, its value is assumed to be the full
-									duration of the physical media.</p>
-							</li>
-							<li>
-								<p>If <code>clipEnd</code> exceeds the full duration of the physical media, then its
-									value is assumed to be the full duration of the physical media.</p>
-							</li>
-						</ul>
-
-						<p>User-controllable audio playback options SHOULD include timescale modification, in which the
-							playback rate is altered without distorting the pitch. The suggested range is half-speed to
-							double-speed.</p>
-
-					</section>
-
-					<section id="sec-rsconf-rendering-text">
-						<h5>Rendering EPUB Content Document Elements</h5>
-
-						<p>When presented with a Media Overlay <a
-								href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"><code>text</code> element</a>
-							[[!EPUB-33]], Reading Systems SHOULD ensure the EPUB Content Document element referenced by
-							the <code>src</code> attribute is visible in the <a>Viewport</a>. During Media Overlays
-							playback, Reading Systems with a Viewport SHOULD add the class names given by the metadata
-							properties <a href="https://www.w3.org/TR/epub-33/#active-class"
-								><code>active-class</code></a> and <a
-								href="https://www.w3.org/TR/epub-33/#playback-active-class"
-									><code>playback-active-class</code></a> [[!EPUB-33]] to the appropriate elements in
-							the EPUB Content Document. Conversely, the class names SHOULD be removed when the playback
-							state changes, as described in <a href="https://www.w3.org/TR/epub-33/#sec-docs-assoc-style"
-								>Associating Style Information</a> [[!EPUB-33]].</p>
-
-						<p>The <code>active-class</code> and <code>playback-active-class</code> metadata properties are
-							OPTIONAL, and if omitted, Reading System behavior is implementation-specific.</p>
-
-					</section>
+					<p>User-controllable audio playback options SHOULD include timescale modification, in which the
+						playback rate is altered without distorting the pitch. The suggested range is half-speed to
+						double-speed.</p>
 
 				</section>
 
-				<section id="sec-behaviors-interaction">
-					<h4>Interacting with the EPUB Content Document</h4>
+				<section id="sec-rsconf-rendering-text">
+					<h5>Rendering EPUB Content Document Elements</h5>
 
-					<section id="sec-rsconf-navigation">
-						<h5>Navigation</h5>
+					<p>When presented with a Media Overlay <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"
+								><code>text</code> element</a> [[!EPUB-33]], Reading Systems SHOULD ensure the EPUB
+						Content Document element referenced by the <code>src</code> attribute is visible in the
+							<a>Viewport</a>. During Media Overlays playback, Reading Systems with a Viewport SHOULD add
+						the class names given by the metadata properties <a
+							href="https://www.w3.org/TR/epub-33/#active-class"><code>active-class</code></a> and <a
+							href="https://www.w3.org/TR/epub-33/#playback-active-class"
+								><code>playback-active-class</code></a> [[!EPUB-33]] to the appropriate elements in the
+						EPUB Content Document. Conversely, the class names SHOULD be removed when the playback state
+						changes, as described in <a href="https://www.w3.org/TR/epub-33/#sec-docs-assoc-style"
+							>Associating Style Information</a> [[!EPUB-33]].</p>
 
-						<p>Because the Media Overlay is closely linked to the <a>EPUB Content Document</a>, it is very
-							easy for Reading Systems to locate a position in the EPUB Content Document based on the
-							current position in the Media Overlay playback. If the user pauses synchronized playback and
-							navigates to a different part of the <a>EPUB Publication</a>, synchronized playback MUST
-							resume at that point. For example, if a specific page number in the EPUB Content Document is
-							the desired location, then this same point is located in the Media Overlay and playback
-							started there.</p>
+					<p>The <code>active-class</code> and <code>playback-active-class</code> metadata properties are
+						OPTIONAL, and if omitted, Reading System behavior is implementation-specific.</p>
+				</section>
+			</section>
 
-						<p>This same approach allows for synchronizing the Media Overlay playback with user selection of
-							a navigation point in the <a>EPUB Navigation Document</a>. The Reading System loads the
-							Media Overlay for that file and finds the correct point for starting playback based on the
-							ID [[!XML]] of the navigation point target.</p>
+			<section id="sec-behaviors-interaction">
+				<h4>Interacting with the EPUB Content Document</h4>
 
-						<div class="note">
-							<p>A Media Overlay Document can be associated directly with a Navigation Document in order
-								to provide synchronized playback of its contents, regardless of whether the <a>XHTML
-									Content Document</a> in which it resides is included in the <a>spine</a>. See <a
-									href="https://www.w3.org/TR/epub-33/#sec-nav-doc"><em>EPUB Navigation
-									Document</em></a> [[!EPUB-33]] for more information.</p>
-						</div>
+				<section id="sec-rsconf-navigation">
+					<h5>Navigation</h5>
 
-						<div class="note" id="note-table-reading-mode">
-							<p>Media Overlay Document elements can be associated with EPUB Content Document structures
-								such as tables. Reading Systems need to ensure that Media Overlay playback remains
-								synchronized with user navigation of table rows and cells. The Reading System might also
-								play the corresponding table header preceding the contents of the cell.</p>
-						</div>
+					<p>Because the Media Overlay is closely linked to the <a>EPUB Content Document</a>, it is very easy
+						for Reading Systems to locate a position in the EPUB Content Document based on the current
+						position in the Media Overlay playback. If the user pauses synchronized playback and navigates
+						to a different part of the <a>EPUB Publication</a>, synchronized playback MUST resume at that
+						point. For example, if a specific page number in the EPUB Content Document is the desired
+						location, then this same point is located in the Media Overlay and playback started there.</p>
 
-					</section>
+					<p>This same approach allows for synchronizing the Media Overlay playback with user selection of a
+						navigation point in the <a>EPUB Navigation Document</a>. The Reading System loads the Media
+						Overlay for that file and finds the correct point for starting playback based on the ID [[!XML]]
+						of the navigation point target.</p>
 
-					<section id="sec-embedded-media">
-						<h5>Embedded Audio and Video</h5>
+					<div class="note">
+						<p>A Media Overlay Document can be associated directly with a Navigation Document in order to
+							provide synchronized playback of its contents, regardless of whether the <a>XHTML Content
+								Document</a> in which it resides is included in the <a>spine</a>. See <a
+								href="https://www.w3.org/TR/epub-33/#sec-nav-doc"><em>EPUB Navigation Document</em></a>
+							[[!EPUB-33]] for more information.</p>
+					</div>
 
-						<p> An <a>EPUB Content Document</a> with which a Media Overlay is associated MAY itself contain
-							embedded video and audio media, which MAY be pointed to by Media Overlay elements. Unlike
-							text and images, video and audio media have an intrinsic duration. Consequently, when a
-							Reading System renders the synchronization described by a Media Overlay, the default
-							playback behavior of audio and video media embedded within the associated EPUB Content
-							Document MUST be overridden.</p>
+					<div class="note" id="note-table-reading-mode">
+						<p>Media Overlay Document elements can be associated with EPUB Content Document structures such
+							as tables. Reading Systems need to ensure that Media Overlay playback remains synchronized
+							with user navigation of table rows and cells. The Reading System might also play the
+							corresponding table header preceding the contents of the cell.</p>
+					</div>
 
-						<p>Note that the rules below apply only to <em>referenced</em> [[!HTML]] <a
-								href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
-									><code>video</code></a> or <a
-								href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
-									><code>audio</code></a> elements within the associated EPUB Content Document. That
-							is to say, the rules apply to only those elements pointed to by <a
-								href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"><code>text</code> elements</a>
-							[[!EPUB-33]] within the Media Overlay (i.e., via the <code>src</code> attribute). Embedded
-							media that is not referenced by Media Overlay elements is not subject to these rules.</p>
-
-						<ul>
-							<li>
-								<p>All referenced audio and video media embedded within an EPUB Content Document MUST
-									have their public playback interface deactivated (typically: play/pause control,
-									time slider, volume level, etc.). This behavior is necessary to avoid interference
-									between the scheduled playback sequence defined by the Media Overlay, and the
-									arbitrary playback behavior due to user interaction or script execution. As a
-									result, when the Reading System is in playback mode, it SHOULD:</p>
-								<ul>
-									<li>
-										<p>Hide the individual video/audio UI controls from the page, which overrides
-											the default behavior defined by the [[!HTML]] <a
-												href="https://html.spec.whatwg.org/multipage/media.html#attr-media-controls"
-													><code>controls</code> attribute</a>.</p>
-									</li>
-									<li>
-										<p>Prevent scripts embedded within the EPUB Content Document from invoking the
-											JavaScript audio/video playback API (i.e., authored as part of the default
-											behavior). It is RECOMMENDED that content producers avoid publishing
-											embedded scripts dedicated to controlling the playback of embedded
-											audio/video media. The published Media Overlay can then retain full control
-											of the synchronized presentation without any risk of interference from
-											script-enabled custom behaviors.</p>
-									</li>
-								</ul>
-							</li>
-							<li>
-								<p>All referenced audio and video media embedded within an EPUB Content Document MUST be
-									initialized to their "stopped" state, and be ready to be played from the
-									zero-position within their content stream (possibly displaying the image specified
-									using the [[!HTML]] <a
-										href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
-											><code>poster</code></a> attribute). This requirement overrides the default
-									behavior defined by the [[!HTML]] <a
-										href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
-											><code>autoplay</code></a> attribute.</p>
-							</li>
-							<li>
-								<p>When an EPUB Content Document element becomes active, the CSS Style Sheet visual
-									highlighting rules apply regardless of the content type referred to by that
-									element's <code>src</code> attribute (e.g., the CSS class name defined by the <a
-										href="https://www.w3.org/TR/epub-33/#active-class"><code>active-class</code>
-										metadata property</a> [[!EPUB-33]] SHOULD be applied to visible video and audio
-									player controls within the host EPUB Content Document).</p>
-							</li>
-							<li>
-								<p>In addition to the default behavior of Media Overlay activation for textual fragments
-									and images, audio and video playback MUST be started and stopped according to the
-									duration implied by the authored Media Overlay synchronization (as per the standard
-									[[!SMIL3]] timing model). There are two possible scenarios:</p>
-								<ul>
-									<li>
-										<p>When a Media Overlay <code>text</code> element has no <a
-												href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"
-													><code>audio</code></a> [[!EPUB-33]] sibling within its <a
-												href="https://www.w3.org/TR/epub-33/#elemdef-smil-par"
-												><code>par</code></a> [[!EPUB-33]] parent container, the referenced EPUB
-											Content Document audio or video media MUST play until it ends, at which
-											point the <code>text</code> element's lifespan terminates. In this case, the
-											implicit duration of the <code>text</code> element (and by inference, of the
-											parent <code>par</code> container) is that of the referenced audio or video
-											clip.</p>
-									</li>
-									<li>
-										<p>When a Media Overlay <code>text</code> element has an <code>audio</code>
-											sibling within its <code>par</code> parent container, the playback duration
-											of the referenced EPUB Content Document audio or video media MUST be
-											constrained by the duration of the <code>audio</code> sibling. In this case,
-											the actual duration of the parent <code>par</code> container is that of the
-											child audio clip, regardless of the duration of the video or audio media
-											pointed to by the <code>text</code> element. This behavior can result in
-											embedded video or audio media ending playback prematurely (before reaching
-											its full duration), or ending before the playback of the parallel Media
-											Overlay <code>audio</code> is finished (in which case the last-played video
-											frame SHOULD remain visible until the parent <code>par</code> container
-											finally ends). This behavior is equivalent of the Media Overlay
-												<code>audio</code> element implicitly carrying the behavior of the
-											[[!SMIL3]] <a
-												href="https://www.w3.org/TR/SMIL/smil-timing.html#adef-endsync"
-													><code>endsync</code></a> attribute.</p>
-										<p>Furthermore, Reading Systems SHOULD expose user controls for the volume
-											levels of each independent audio track (i.e., from the <code>audio</code>
-											element of the Media Overlay, and from the embedded audio or video media
-											within the EPUB Content Document), so that audio output can be adjusted to
-											match listeners' requirements. Note that having overlapping audio tracks is
-											typically an authoring-time concern: content producers usually add a layer
-											of audio information over a video track for description purposes. It is
-											RECOMMENDED that overlapping audio situations are carefully examined and
-											dealt with at production stage, as Reading Systems are NOT REQUIRED to
-											handle simultaneous volume levels in any specific way.</p>
-									</li>
-								</ul>
-							</li>
-							<li>
-								<p>When a <code>text</code> element becomes inactive in the Media Overlay, and when it
-									points to embedded video or audio media, that referenced media MUST be reset to its
-									initial "stopped" state, ready to be played from the zero-position within their
-									content stream (possibly displaying the poster image specified using the [[!HTML]]
-									markup).</p>
-							</li>
-						</ul>
-
-					</section>
-
-					<section id="sec-text-to-speech">
-						<h5>Text-to-Speech</h5>
-
-						<p>When a Media Overlay <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"
-									><code>text</code> element</a> [[!EPUB-33]] with no <a
-								href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"><code>audio</code></a>
-							[[!EPUB-33]] sibling element references text within the target <a>EPUB Content Document</a>,
-							Reading Systems capable of <a>Text-to-Speech</a> (TTS) SHOULD render the referenced text
-							using TTS.</p>
-
-						<p>As per Reading System conformance requirements, the speech-related information provided in
-							the target EPUB Content Document SHOULD be used to play the audio stream as part of the
-							Media Overlay rendering. See <a href="#confreq-rs-epub3-tts">Reading System Text-to-Speech
-								Conformance Requirements</a>.</p>
-
-						<p>The Media Overlay <code>text</code> element's lifespan corresponds to the rendering time of
-							the associated speech synthesis. The implicit duration of the <code>text</code> element (and
-							by inference, of the parent <code>par</code> element) is therefore determined by the
-							execution of the Text-to-Speech engine, and cannot be known at authoring time (factors like
-							speech rate, pauses and other prosody parameters influence the audio output).</p>
-
-					</section>
 				</section>
 
-				<section id="sec-behaviors-skip-escape">
-					<h4>Skippability and Escapability</h4>
+				<section id="sec-embedded-media">
+					<h5>Embedded Audio and Video</h5>
 
-					<section id="sec-skippability">
-						<h5>Skippability</h5>
+					<p> An <a>EPUB Content Document</a> with which a Media Overlay is associated MAY itself contain
+						embedded video and audio media, which MAY be pointed to by Media Overlay elements. Unlike text
+						and images, video and audio media have an intrinsic duration. Consequently, when a Reading
+						System renders the synchronization described by a Media Overlay, the default playback behavior
+						of audio and video media embedded within the associated EPUB Content Document MUST be
+						overridden.</p>
 
-						<p>Reading Systems SHOULD use the semantic information provided by Media Overlay elements' <a
-								href="#sec-structural-semantics"><code>epub:type</code> attribute</a> to determine when
-							to offer users the option of skippable features.</p>
-					</section>
+					<p>Note that the rules below apply only to <em>referenced</em> [[!HTML]] <a
+							href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
+								><code>video</code></a> or <a
+							href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
+								><code>audio</code></a> elements within the associated EPUB Content Document. That is to
+						say, the rules apply to only those elements pointed to by <a
+							href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"><code>text</code> elements</a>
+						[[!EPUB-33]] within the Media Overlay (i.e., via the <code>src</code> attribute). Embedded media
+						that is not referenced by Media Overlay elements is not subject to these rules.</p>
 
-					<section id="sec-escapability">
-						<h5>Escapability</h5>
+					<ul>
+						<li>
+							<p>All referenced audio and video media embedded within an EPUB Content Document MUST have
+								their public playback interface deactivated (typically: play/pause control, time slider,
+								volume level, etc.). This behavior is necessary to avoid interference between the
+								scheduled playback sequence defined by the Media Overlay, and the arbitrary playback
+								behavior due to user interaction or script execution. As a result, when the Reading
+								System is in playback mode, it SHOULD:</p>
+							<ul>
+								<li>
+									<p>Hide the individual video/audio UI controls from the page, which overrides the
+										default behavior defined by the [[!HTML]] <a
+											href="https://html.spec.whatwg.org/multipage/media.html#attr-media-controls"
+												><code>controls</code> attribute</a>.</p>
+								</li>
+								<li>
+									<p>Prevent scripts embedded within the EPUB Content Document from invoking the
+										JavaScript audio/video playback API (i.e., authored as part of the default
+										behavior). It is RECOMMENDED that content producers avoid publishing embedded
+										scripts dedicated to controlling the playback of embedded audio/video media. The
+										published Media Overlay can then retain full control of the synchronized
+										presentation without any risk of interference from script-enabled custom
+										behaviors.</p>
+								</li>
+							</ul>
+						</li>
+						<li>
+							<p>All referenced audio and video media embedded within an EPUB Content Document MUST be
+								initialized to their "stopped" state, and be ready to be played from the zero-position
+								within their content stream (possibly displaying the image specified using the [[!HTML]]
+									<a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
+										><code>poster</code></a> attribute). This requirement overrides the default
+								behavior defined by the [[!HTML]] <a
+									href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
+										><code>autoplay</code></a> attribute.</p>
+						</li>
+						<li>
+							<p>When an EPUB Content Document element becomes active, the CSS Style Sheet visual
+								highlighting rules apply regardless of the content type referred to by that element's
+									<code>src</code> attribute (e.g., the CSS class name defined by the <a
+									href="https://www.w3.org/TR/epub-33/#active-class"><code>active-class</code>
+									metadata property</a> [[!EPUB-33]] SHOULD be applied to visible video and audio
+								player controls within the host EPUB Content Document).</p>
+						</li>
+						<li>
+							<p>In addition to the default behavior of Media Overlay activation for textual fragments and
+								images, audio and video playback MUST be started and stopped according to the duration
+								implied by the authored Media Overlay synchronization (as per the standard [[!SMIL3]]
+								timing model). There are two possible scenarios:</p>
+							<ul>
+								<li>
+									<p>When a Media Overlay <code>text</code> element has no <a
+											href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"
+											><code>audio</code></a> [[!EPUB-33]] sibling within its <a
+											href="https://www.w3.org/TR/epub-33/#elemdef-smil-par"><code>par</code></a>
+										[[!EPUB-33]] parent container, the referenced EPUB Content Document audio or
+										video media MUST play until it ends, at which point the <code>text</code>
+										element's lifespan terminates. In this case, the implicit duration of the
+											<code>text</code> element (and by inference, of the parent <code>par</code>
+										container) is that of the referenced audio or video clip.</p>
+								</li>
+								<li>
+									<p>When a Media Overlay <code>text</code> element has an <code>audio</code> sibling
+										within its <code>par</code> parent container, the playback duration of the
+										referenced EPUB Content Document audio or video media MUST be constrained by the
+										duration of the <code>audio</code> sibling. In this case, the actual duration of
+										the parent <code>par</code> container is that of the child audio clip,
+										regardless of the duration of the video or audio media pointed to by the
+											<code>text</code> element. This behavior can result in embedded video or
+										audio media ending playback prematurely (before reaching its full duration), or
+										ending before the playback of the parallel Media Overlay <code>audio</code> is
+										finished (in which case the last-played video frame SHOULD remain visible until
+										the parent <code>par</code> container finally ends). This behavior is equivalent
+										of the Media Overlay <code>audio</code> element implicitly carrying the behavior
+										of the [[!SMIL3]] <a
+											href="https://www.w3.org/TR/SMIL/smil-timing.html#adef-endsync"
+												><code>endsync</code></a> attribute.</p>
+									<p>Furthermore, Reading Systems SHOULD expose user controls for the volume levels of
+										each independent audio track (i.e., from the <code>audio</code> element of the
+										Media Overlay, and from the embedded audio or video media within the EPUB
+										Content Document), so that audio output can be adjusted to match listeners'
+										requirements. Note that having overlapping audio tracks is typically an
+										authoring-time concern: content producers usually add a layer of audio
+										information over a video track for description purposes. It is RECOMMENDED that
+										overlapping audio situations are carefully examined and dealt with at production
+										stage, as Reading Systems are NOT REQUIRED to handle simultaneous volume levels
+										in any specific way.</p>
+								</li>
+							</ul>
+						</li>
+						<li>
+							<p>When a <code>text</code> element becomes inactive in the Media Overlay, and when it
+								points to embedded video or audio media, that referenced media MUST be reset to its
+								initial "stopped" state, ready to be played from the zero-position within their content
+								stream (possibly displaying the poster image specified using the [[!HTML]] markup).</p>
+						</li>
+					</ul>
 
-						<p>Reading Systems SHOULD allow escaping of nested structures. Reading Systems MUST determine
-							the start of nested structures by the value of the <a href="#sec-structural-semantics"
-									><code>epub:type</code> attribute</a> and SHOULD offer users the option to skip
-							playback of that structure and resume with whatever content comes after it.</p>
-					</section>
+				</section>
+
+				<section id="sec-text-to-speech">
+					<h5>Text-to-Speech</h5>
+
+					<p>When a Media Overlay <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"><code>text</code>
+							element</a> [[!EPUB-33]] with no <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"
+								><code>audio</code></a> [[!EPUB-33]] sibling element references text within the target
+							<a>EPUB Content Document</a>, Reading Systems capable of <a>Text-to-Speech</a> (TTS) SHOULD
+						render the referenced text using TTS.</p>
+
+					<p>As per Reading System conformance requirements, the speech-related information provided in the
+						target EPUB Content Document SHOULD be used to play the audio stream as part of the Media
+						Overlay rendering. See <a href="#confreq-rs-epub3-tts">Reading System Text-to-Speech Conformance
+							Requirements</a>.</p>
+
+					<p>The Media Overlay <code>text</code> element's lifespan corresponds to the rendering time of the
+						associated speech synthesis. The implicit duration of the <code>text</code> element (and by
+						inference, of the parent <code>par</code> element) is therefore determined by the execution of
+						the Text-to-Speech engine, and cannot be known at authoring time (factors like speech rate,
+						pauses and other prosody parameters influence the audio output).</p>
+
+				</section>
+			</section>
+
+			<section id="sec-behaviors-skip-escape">
+				<h4>Skippability and Escapability</h4>
+
+				<section id="sec-skippability">
+					<h5>Skippability</h5>
+
+					<p>Reading Systems SHOULD use the semantic information provided by Media Overlay elements' <a
+							href="#sec-structural-semantics"><code>epub:type</code> attribute</a> to determine when to
+						offer users the option of skippable features.</p>
+				</section>
+
+				<section id="sec-escapability">
+					<h5>Escapability</h5>
+
+					<p>Reading Systems SHOULD allow escaping of nested structures. Reading Systems MUST determine the
+						start of nested structures by the value of the <a href="#sec-structural-semantics"
+								><code>epub:type</code> attribute</a> and SHOULD offer users the option to skip playback
+						of that structure and resume with whatever content comes after it.</p>
 				</section>
 			</section>
 		</section>
 		<section id="sec-structural-semantics">
-			<h2>Expressing Structural Semantics</h2>
+			<h2>Processing Structural Semantics</h2>
 
 			<p>A Reading System has to process the <code>epub:type</code> attribute as follows:</p>
 
@@ -1762,131 +1529,117 @@
 				value conflicts with an element's native behavior, the behavior associated with the element MUST be
 				given precedence.</p>
 		</section>
-		<section id="vocabs">
-			<h2>Vocabularies</h2>
+		<section id="sec-vocab-assoc">
+			<h2>Vocabulary Association Mechanisms</h2>
 
-			<section id="sec-vocab-assoc">
-				<h3>Vocabulary Association Mechanisms</h3>
+			<dl class="conformance-list">
+				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
+				<dd>
+					<p>Reading Systems MUST resolve all reserved prefixes used in Package Documents using their
+						predefined URIs unless a local <a href="#sec-prefix-attr">prefix</a> is declared. Reading
+						Systems MUST use locally overridden prefixes in the <code>prefix</code> attribute when
+						encountered.</p>
+					<p>As changes to the reserved prefixes and updates to Reading Systems are not always going happen in
+						synchrony, Reading Systems MUST NOT fail when encountering unrecognized prefixes (i.e., not
+						reserved and not declared using the <code>prefix</code> attribute).</p>
+				</dd>
 
-				<dl class="conformance-list">
-					<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
+				<dt id="sec-prefix-attr">The <code>prefix</code> attribute</dt>
+				<dd>
+					<p>If the <code>prefix</code> attribute includes a declaration for a <a
+							href="#sec-metadata-reserved-prefixes">predefined prefix</a>, Reading Systems MUST use the
+						URI mapping defined in the <code>prefix</code> attribute, regardless of whether of it maps to
+						the same URI as the predefined prefix.</p>
+				</dd>
+
+				<dt id="sec-property-datatype">The <code>property</code> Data Type</dt>
+				<dd>
+					<p>A Reading System MUST use the following rules to create an IRI [[!RFC3987]] from a property:</p>
+					<ul>
+						<li>
+							<p>If the property consists only of a reference, the IRI is obtained by concatenating the
+								IRI stem associated with the <a href="https://www.w3.org/TR/epub-33/#sec-default-vocab"
+									>default vocabulary</a> [[!EPUB-33]] to the reference.</p>
+						</li>
+						<li>
+							<p>If the property consists of a prefix and reference, the IRI is obtained by concatenating
+								the IRI stem associated with the prefix to the reference. If no matching prefix has been
+								defined, the property is invalid and MUST be ignored.</p>
+						</li>
+					</ul>
+					<p>The resulting IRI MUST be valid to [[!RFC3987]]. Reading Systems do not have to resolve this IRI,
+						however.</p>
+				</dd>
+			</dl>
+		</section>
+		<section id="sec-package-metadata-rendering">
+			<h3>Package Rendering Metadata Processing</h3>
+
+			<p id="confreq-rs-epub3-presentational-meta">Reading Systems SHOULD process the rendering metadata expressed
+				in the following sections.</p>
+
+			<section id="flow">
+				<h5>The <code>rendition:flow</code> Property</h5>
+
+				<p>If a Reading System supports the specified rendering, it SHOULD use that method to handle overflow
+					content, but MAY provide the option for users to override the requested rendering.</p>
+
+				<p>The default global value is <code>auto</code> if no <code>meta</code> element carrying this property
+					occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code>
+						section</a> [[!EPUB-33]]. Reading Systems MAY support only this default value.</p>
+
+				<p>If a Reading Systems supports the <a href="#layout"><code>rendition:layout</code></a> property, it
+					MUST ignore the <code>rendition:flow</code> property when it has been set on a spine item that also
+					specifies the <a href="#layout"><code>rendition:layout</code></a> value
+					<code>pre-paginated</code>.</p>
+
+				<p>The <code>rendition:flow</code> property values have the following processing requirements:</p>
+
+				<dl class="variablelist">
+					<dt id="paginated">paginated</dt>
 					<dd>
-						<p>Reading Systems MUST resolve all reserved prefixes used in Package Documents using their
-							predefined URIs unless a local <a href="#sec-prefix-attr">prefix</a> is declared. Reading
-							Systems MUST use locally overridden prefixes in the <code>prefix</code> attribute when
-							encountered.</p>
-						<p>As changes to the reserved prefixes and updates to Reading Systems are not always going
-							happen in synchrony, Reading Systems MUST NOT fail when encountering unrecognized prefixes
-							(i.e., not reserved and not declared using the <code>prefix</code> attribute).</p>
+						<p>The Reading System SHOULD dynamically paginate all overflow content.</p>
 					</dd>
-
-					<dt id="sec-prefix-attr">The <code>prefix</code> attribute</dt>
+					<dt id="scrolled-continuous">scrolled-continuous</dt>
 					<dd>
-						<p>If the <code>prefix</code> attribute includes a declaration for a <a
-								href="#sec-metadata-reserved-prefixes">predefined prefix</a>, Reading Systems MUST use
-							the URI mapping defined in the <code>prefix</code> attribute, regardless of whether of it
-							maps to the same URI as the predefined prefix.</p>
+						<p>The Reading System SHOULD render all Content Documents such that overflow content is
+							scrollable, and the EPUB Publication SHOULD be presented as one continuous scroll from spine
+							item to spine item (except where <a
+								href="https://www.w3.org/TR/epub-33/#layout-property-flow-overrides">locally
+								overridden</a> [[!EPUB-33]]).</p>
 					</dd>
-
-					<dt id="sec-property-datatype">The <code>property</code> Data Type</dt>
+					<dt id="scrolled-doc">scrolled-doc</dt>
 					<dd>
-						<p>A Reading System MUST use the following rules to create an IRI [[!RFC3987]] from a
-							property:</p>
-						<ul>
-							<li>
-								<p>If the property consists only of a reference, the IRI is obtained by concatenating
-									the IRI stem associated with the <a
-										href="https://www.w3.org/TR/epub-33/#sec-default-vocab">default vocabulary</a>
-									[[!EPUB-33]] to the reference.</p>
-							</li>
-							<li>
-								<p>If the property consists of a prefix and reference, the IRI is obtained by
-									concatenating the IRI stem associated with the prefix to the reference. If no
-									matching prefix has been defined, the property is invalid and MUST be ignored.</p>
-							</li>
-						</ul>
-						<p>The resulting IRI MUST be valid to [[!RFC3987]]. Reading Systems do not have to resolve this
-							IRI, however.</p>
+						<p>The Reading System SHOULD render all Content Documents such that overflow content is
+							scrollable, and each spine item SHOULD be presented as a separate scrollable document.</p>
+					</dd>
+					<dt id="auto">auto</dt>
+					<dd>
+						<p>The Reading System MAY render overflow content using its default method or a user preference,
+							whichever is applicable.</p>
 					</dd>
 				</dl>
+
+				<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction is defined
+					relative to the block flow direction of the root element of the XHTML Content Document referenced by
+					the <a href="https://www.w3.org/TR/epub-33/#elemdef-spine-itemref"><code>itemref</code> element</a>
+					[[!EPUB-33]]. The scroll direction is vertical if the block flow direction is downward
+					(top-to-bottom). It is horizontal if the block flow direction of the root element is rightward
+					(left-to-right) or leftward (right-to-left).</p>
 			</section>
 
-			<section id="sec-package-metadata-rendering">
-				<h3>Package Rendering Metadata</h3>
+			<section id="align-x-center">
+				<h5>The <code>rendition:align-x-center</code> Property</h5>
 
-				<section id="sec-package-metadata-general">
-					<h4>General Properties</h4>
+				<p>When the <a href="#align-x-center"><code>rendition:align-x-center</code> property</a> is set on a
+					spine item, Reading Systems SHOULD render the content centered horizontally within the
+						<a>Viewport</a> or spread, as applicable. This property does not affect the rendering of the
+					spine item, only the placement of the resulting content box.</p>
 
-					<section id="flow">
-						<h5>The <code>rendition:flow</code> Property</h5>
+				<p>For reflowable content, Reading Systems that support this property MUST center each virtual page.</p>
 
-						<p>If a Reading System supports the specified rendering, it SHOULD use that method to handle
-							overflow content, but MAY provide the option for users to override the requested
-							rendering.</p>
-
-						<p>The default global value is <code>auto</code> if no <code>meta</code> element carrying this
-							property occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"
-									><code>metadata</code> section</a> [[!EPUB-33]]. Reading Systems MAY support only
-							this default value.</p>
-
-						<p>If a Reading Systems supports the <a href="#layout"><code>rendition:layout</code></a>
-							property, it MUST ignore the <code>rendition:flow</code> property when it has been set on a
-							spine item that also specifies the <a href="#layout"><code>rendition:layout</code></a> value
-								<code>pre-paginated</code>.</p>
-
-						<p>The <code>rendition:flow</code> property values have the following processing
-							requirements:</p>
-
-						<dl class="variablelist">
-							<dt id="paginated">paginated</dt>
-							<dd>
-								<p>The Reading System SHOULD dynamically paginate all overflow content.</p>
-							</dd>
-							<dt id="scrolled-continuous">scrolled-continuous</dt>
-							<dd>
-								<p>The Reading System SHOULD render all Content Documents such that overflow content is
-									scrollable, and the EPUB Publication SHOULD be presented as one continuous scroll
-									from spine item to spine item (except where <a
-										href="https://www.w3.org/TR/epub-33/#layout-property-flow-overrides">locally
-										overridden</a> [[!EPUB-33]]).</p>
-							</dd>
-							<dt id="scrolled-doc">scrolled-doc</dt>
-							<dd>
-								<p>The Reading System SHOULD render all Content Documents such that overflow content is
-									scrollable, and each spine item SHOULD be presented as a separate scrollable
-									document.</p>
-							</dd>
-							<dt id="auto">auto</dt>
-							<dd>
-								<p>The Reading System MAY render overflow content using its default method or a user
-									preference, whichever is applicable.</p>
-							</dd>
-						</dl>
-
-						<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction is
-							defined relative to the block flow direction of the root element of the XHTML Content
-							Document referenced by the <a href="https://www.w3.org/TR/epub-33/#elemdef-spine-itemref"
-									><code>itemref</code> element</a> [[!EPUB-33]]. The scroll direction is vertical if
-							the block flow direction is downward (top-to-bottom). It is horizontal if the block flow
-							direction of the root element is rightward (left-to-right) or leftward (right-to-left).</p>
-					</section>
-
-					<section id="align-x-center">
-						<h5>The <code>rendition:align-x-center</code> Property</h5>
-
-						<p>When the <a href="#align-x-center"><code>rendition:align-x-center</code> property</a> is set
-							on a spine item, Reading Systems SHOULD render the content centered horizontally within the
-								<a>Viewport</a> or spread, as applicable. This property does not affect the rendering of
-							the spine item, only the placement of the resulting content box.</p>
-
-						<p>For reflowable content, Reading Systems that support this property MUST center each virtual
-							page.</p>
-
-						<p>This version of this specification does not define a default rendering behavior when this
-							property is not supported or specified. Reading Systems MAY render spine items by their own
-							design.</p>
-					</section>
-				</section>
+				<p>This version of this specification does not define a default rendering behavior when this property is
+					not supported or specified. Reading Systems MAY render spine items by their own design.</p>
 			</section>
 		</section>
 		<section id="sec-security-privacy">
@@ -1930,6 +1683,89 @@
 				<p>The Working Group will have to address the particularity of cross-origin by addressing the question
 					of what the "origin" is for an EPUB Publication.</p>
 			</div>
+
+			<section id="sec-scripted-content-security">
+				<h4>Scripting Considerations</h4>
+
+				<p><a>EPUB Creators</a> and <a>Reading System</a> developers must be aware of the security issues that
+					arise when scripted content is executed by a Reading System. As the underlying scripting model
+					employed by Reading Systems and browsers is the same, the same kinds of issues encountered in Web
+					contexts have to be taken into consideration.</p>
+
+				<p>Each Reading System has to establish if the scripts in a particular document are to be trusted or
+					not. It is advised that all scripts be treated as untrusted (and potentially malicious), and that
+					all vectors of attack be examined and protected against. In particular, the following need to be
+					considered:</p>
+
+				<ul>
+					<li>
+						<p>an attack against the runtime environment (e.g., stealing files from a user's hard
+							drive);</p>
+					</li>
+					<li>
+						<p>an attack against the Reading System itself (e.g., stealing a list of a user's books or
+							causing unexpected behavior);</p>
+					</li>
+					<li>
+						<p>an attack of one Content Document against another (e.g., stealing data that originated in a
+							different document);</p>
+					</li>
+					<li>
+						<p>an attack of an unencrypted script against an encrypted portion of a document (e.g., an
+							injected malicious script extracting protected content);</p>
+					</li>
+					<li>
+						<p>an attack against the local network (e.g., stealing data from a server behind a
+							firewall).</p>
+					</li>
+				</ul>
+
+				<p>The following recommendations are provided as a guide to handling untrusted scripts:</p>
+
+				<ul>
+					<li>
+						<p>Reading Systems must behave as if a unique <a href="https://url.spec.whatwg.org/#origin"
+								>origin</a> [[URL]] were allocated to each <a>EPUB Publication</a>. Adopting this
+							approach will isolate publications from each other, thereby limiting access to cookies, DOM
+							storage, etc.</p>
+						<div class="note">
+							<p>Although domain isolation is the most effective way to secure EPUB Publications in
+								Web-based Reading Systems, it is not always a realistic option. Web-based Reading
+								Systems must still maintain isolation in such cases, which may require limiting access
+								to scripting APIs that allow client-side data storage and access.</p>
+						</div>
+						<p>Reading Systems that enable scripting and network access should also include methods to
+							notify the user that network activity is occurring and/or that allow them to disable it.</p>
+					</li>
+					<li>
+						<p>If a Reading System allows persistent data to be stored, that data must be treated as
+							sensitive. Scripts may save persistent data through cookies and DOM storage but Reading
+							Systems may block such attempts. Reading Systems that do allow data to be stored must ensure
+							that it is not made available to other unrelated documents (e.g., ones that could have been
+							spoofed). In particular, checking for a matching document identifier (or similar metadata)
+							is not a valid method to control access to persistent data.</p>
+						<p>Reading Systems that allow local storage should also provide methods for users to inspect,
+							disable, and delete that data. The data needs to be destroyed if the corresponding EPUB
+							Publication is deleted.</p>
+					</li>
+				</ul>
+
+				<p>Note that compliance with these recommendations does not guarantee protection from the possible
+					attacks listed above; developers have to examine each potential vulnerability within the context of
+					their Reading System.</p>
+			</section>
+
+			<section id="sec-scripted-content-events">
+				<h4>Event Model Considerations</h4>
+
+				<p>Reading Systems need to follow the DOM Event model as per [[HTML]] and pass UI events to the
+					scripting environment before performing any default action associated with these events. Reading
+					System implementers need to ensure that scripts cannot disable critical functionality (such as
+					navigation) to constrain the extent to which a <a href="#sec-scripted-content-security">potentially
+						malicious</a> script could impact their Reading Systems. As a result, although the scripting
+					environment needs to be able to cancel the default action of any event, some events either might not
+					be passed through or might not be cancelable.</p>
+			</section>
 		</section>
 		<section id="app-epubReadingSystem" class="appendix">
 			<h2>JavaScript <dfn>epubReadingSystem</dfn> Object</h2>


### PR DESCRIPTION
This PR also sprung out of last week's telecon as I noticed that the spine discussion was split between elements only because that's the way the core spec was structured. There's no need to break topics like that along element lines.

From there, I noticed other quirks of pulling out the RS requirements that could stand for improvement:

I've removed all the "conformance" sections that were embedded within each subsection. I've either integrated these without the headings if they're the only thing in the section and contain actual requirements, or deleted them if all they contained were pointers to other sections (most of these lists were just helpful locators to where actual requirements were listed when the specs were merged so devs didn't have to read everything). Some of these statements were confusingly half-true (e.g., you "must" support scripting as defined in the scripting section when the scripting section doesn't actually require support for scripting).

Some of the other notable changes include:

- I've grouped three bullets in the main conformance section that all began with "if it has a viewport".
- I've noted that support for fixed layouts and media overlays is optional in the main conformance section (we used to say that support for fixed layout metadata is required, but this was never true as reading systems default to conformance, so I removed that statement)
- The support for "presentation logic" bullet in the package document conformance I've added as a subsection since I couldn't find any other place for it. It still needs to be returned to for #1516 
- The only bullet in the xhtml conformance section that wasn't redundant was support for ARIA. I've added this to the extensions section as a new section (HTML allows ARIA attributes but I can't find that it requires exposing them).
- I merged the requirements for handling author/user css changes with the conformance bullets and dropped the subsectioning.
- I've moved the informative section on scripting security to the security section at the end. These will likely need better integration in the future, though.

Also, the media overlays conformance section had one bullet that wasn't just a pointer to a subsection, but it was a bit confusing in that it says that xhtml content documents have to be supported and SVG may. I've made the obvious assumption this refers to playback, not support for the formats and worked this bullet into the loading section.

Long story short, the intention is only to simplify the spec by removing the unnecessary pointers and subsectioning. Actual requirements that have to be conformed to should all remain.