### PR TITLE
Handled the mega-issue 1612

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -337,9 +337,10 @@
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
 					<dd>
 						<p>Retrieval of Remote Resources is OPTIONAL.</p>
-						<p>The language identified in an <code>hreflang</code> attribute is not authoritative. Language
-							information defined in a linked resource determines its language.</p>
-						<p>Reading System do not have to use or present linked resources, even if they recognize the
+						<p>The language identified in an <code>hreflang</code> is purely advisory.
+							Upon fetching the resource, a Reading System must only use the language information associated with the resource to determine its language, not metadata included in the link to the resource.
+						</p>
+						<p>Reading Systems do not have to use or present linked resources, even if they recognize the
 							relationship defined in the <code>rel</code> attribute.</p>
 						<p id="sec-linked-records">In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
 								>linked metadata record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing the
@@ -409,9 +410,9 @@
 					specifically activates a hyperlink to such items). Reading Systems MAY also provide the option for
 					users to select whether non-linear content is skipped by default or not.</p>
 
-				<p>When the <code>default</code> value of the <code>page-progression-direction</code> attribute is
-					specified, the Reading System can choose the rendering direction. The <code>default</code> value
-					MUST be assumed when the attribute is not specified. In this case, the reading system SHOULD choose
+				<p>If the <code>page-progression-direction</code> is not specified, the value of <code>default</code>
+					MUST be assumed. When the value of the <code>page-progression-direction</code> is set to 
+					<code>default</code> (either explicitly or implicitly) the Reading System SHOULD choose
 					a default <code>page-progression-direction</code> value based on the first <code>language</code>
 					element.</p>
 
@@ -898,9 +899,9 @@
 				<section id="layout">
 					<h4>The <code>rendition:layout</code> Property</h4>
 
-					<p>The default global value is <code>reflowable</code> if no <code>meta</code> element carrying this
-						property occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"
-								><code>metadata</code> section</a> [[!EPUB-33]].</p>
+					<p>If no <code>meta</code> element carrying this
+						property occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code> 
+						section</a> [[!EPUB-33]], then the Reading System MUST assume the value <code>reflowable</code>.</p>
 
 					<p>When the <code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading
 						Systems MUST NOT include space between the adjacent content slots when rendering <a>Synthetic
@@ -982,7 +983,7 @@
 						reflowable content, and they only apply when the Reading System is creating Synthetic
 						Spreads.</p>
 
-					<p>The <code>rendition:page-spread-*</code> properties take precedence over whatever value of the <a
+					<p>The <code>rendition:page-spread-*</code> properties MUST take precedence over whatever value of the <a
 							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
 								><code>page-break-before</code> property</a> [[!CSSSnapshot]] has been set for an
 							<a>XHTML Content Document</a>.</p>
@@ -1614,11 +1615,11 @@
 					</dd>
 				</dl>
 
-				<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction is defined
+				<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction MUST be defined
 					relative to the block flow direction of the root element of the XHTML Content Document referenced by
 					the <a href="https://www.w3.org/TR/epub-33/#elemdef-spine-itemref"><code>itemref</code> element</a>
-					[[!EPUB-33]]. The scroll direction is vertical if the block flow direction is downward
-					(top-to-bottom). It is horizontal if the block flow direction of the root element is rightward
+					[[!EPUB-33]]. The scroll direction MUST be vertical if the block flow direction is downward
+					(top-to-bottom). It MUST be horizontal if the block flow direction of the root element is rightward
 					(left-to-right) or leftward (right-to-left).</p>
 			</section>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -336,23 +336,32 @@
 
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
 					<dd>
-						<p>Retrieval and support of Remote Resources is OPTIONAL.</p>
+						<p>Retrieval and support of linked resources is OPTIONAL.</p>
 
-						<p>The language identified in an <code>hreflang</code> is purely advisory.
+						<!-- <p>Reading System may use support linked resources, even if they recognize the
+							relationship defined in the <code>rel</code> attribute.
+						</p> -->
+
+						<p>
+							The language identified in an <code>hreflang</code> is purely advisory.
 							Upon fetching the resource, a Reading System must only use the language information associated with the resource to determine its language, not the metadata included in the link to the resource.
 						</p>
-						<p id="sec-linked-records">In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
-								>linked metadata record</a> [[!EPUB-33]], Reading Systems must not skip processing the
+
+						<p id="sec-linked-records">
+							In the case of a <a href="https://www.w3.org/TR/epub-33/#record">linked metadata 
+							record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing the
 							metadata expressed in the Package Document and only use the information expressed in the
 							record. Reading Systems may compile metadata from multiple linked records; they do not have
 							to select only one record.</p>
+
 						<p>When it comes to resolving discrepancies and conflicts between metadata expressed in the
-							Package Document and in linked metadata records, Reading Systems must use the document order
+							Package Document and in linked metadata records, Reading Systems MUST use the document order
 							of <code>link</code> elements in the Package Document to establish precedence (i.e.,
 							metadata in the first linked record encountered has the highest precedence and metadata in
 							the Package Document the lowest, regardless of whether the <code>link</code> elements occur
 							before, within or after the package metadata elements).</p>
-						<p>Reading Systems must ignore any instructions contained in linked resources related to the
+
+						<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
 							layout and rendering of the EPUB Publication.</p>
 					</dd>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -337,9 +337,9 @@
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
 					<dd>
 						<p>Retrieval of Remote Resources is OPTIONAL.</p>
-						<p>The language identified in an <code>hreflang</code> is purely advisory.
-							Upon fetching the resource, a Reading System must only use the language information associated with the resource to determine its language, not metadata included in the link to the resource.
-						</p>
+						<p>The language identified in an <code>hreflang</code> is purely advisory. Upon fetching the
+							resource, a Reading System must only use the language information associated with the
+							resource to determine its language, not metadata included in the link to the resource. </p>
 						<p>Reading Systems do not have to use or present linked resources, even if they recognize the
 							relationship defined in the <code>rel</code> attribute.</p>
 						<p id="sec-linked-records">In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
@@ -411,9 +411,9 @@
 					users to select whether non-linear content is skipped by default or not.</p>
 
 				<p>If the <code>page-progression-direction</code> is not specified, the value of <code>default</code>
-					MUST be assumed. When the value of the <code>page-progression-direction</code> is set to 
-					<code>default</code> (either explicitly or implicitly) the Reading System SHOULD choose
-					a default <code>page-progression-direction</code> value based on the first <code>language</code>
+					MUST be assumed. When the value of the <code>page-progression-direction</code> is set to
+						<code>default</code> (either explicitly or implicitly) the Reading System SHOULD choose a
+					default <code>page-progression-direction</code> value based on the first <code>language</code>
 					element.</p>
 
 				<p>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
@@ -459,17 +459,11 @@
 					<section id="sec-xhtml-structural-semantics">
 						<h5>Structural Semantics</h5>
 
-						<p>In addition to the requirements in <a href="#sec-structural-semantics"></a>, a Reading System
-							has to process the <code>epub:type</code> attribute as follows in XHTML Content
-							Documents:</p>
-
-						<ul class="conformance-list">
-							<li>
-								<p id="confreq-rs-epubtype-head">It MUST ignore semantics expressed on the [[!HTML]] <a
-										href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element"
-											><code>head</code></a> element or its descendants.</p>
-							</li>
-						</ul>
+						<p id="confreq-rs-epubtype-head">In addition to the requirements in <a
+								href="#sec-structural-semantics"></a>, a Reading System MUST ignore semantics expressed
+							on the [[!HTML]] <a
+								href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element"
+									><code>head</code></a> element or its descendants.</p>
 					</section>
 
 					<section id="sec-xhtml-rdfa">
@@ -570,22 +564,22 @@
 					<section id="sec-xhtml-mathml">
 						<h3>MathML</h3>
 
-						<p>A Reading System has to support MathML embedded in XHTML Content Documents as follows:</p>
+						<p>To support MathML embedded in XHTML Content Documents, a Reading System:</p>
 
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-mathml-rs-behavior">It MUST be an input-compliant renderer for <a
+								<p id="confreq-mathml-rs-behavior">MUST be an input-compliant renderer for <a
 										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
 									defined in the [[!MATHML3]] specification.</p>
 							</li>
 							<li>
-								<p id="confreq-mathml-rs-anno">It MAY support rendering of <a
+								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
 										href="https://www.w3.org/TR/MathML3/chapter4.html">Content MathML</a> found in
 										<code>annotation-xml</code> elements.</p>
 							</li>
 							<li>
-								<p id="confreq-mathml-rs-render">If it has a <a>Viewport</a>, it MUST support visual
-									rendering of Presentation MathML.</p>
+								<p id="confreq-mathml-rs-render">MUST support visual rendering of Presentation MathML if
+									it has a <a>Viewport</a>.</p>
 							</li>
 						</ul>
 						<p class="note">Reading Systems may choose to use third-party libraries such as MathJax to
@@ -635,33 +629,33 @@
 				<p id="confreq-rs-epub3-svg" class="support">Reading Systems MUST process <a
 						href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[!EPUB-33]].</p>
 
-				<p>A Reading System has to process SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in
-						XHTML Content Documents</a> as follows:</p>
+				<p>To process SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content
+						Documents</a>, a Reading System:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-svg-rs-behavior">Unless explicitly defined by this specification as overridden,
-							it MUST process SVG Content Documents using semantics defined by the [[!SVG]] specification
-							and honor any applicable user agent conformance constraints expressed therein.</p>
+						<p id="confreq-svg-rs-behavior">MUST process SVG Content Documents using semantics defined by
+							the [[!SVG]] specification, and honor any applicable user agent conformance constraints
+							expressed therein, unless explicitly defined by this specification as overridden.</p>
 					</li>
 					<li>
-						<p id="confreq-svg-rs-scrpt">It MUST meet the Reading System conformance criteria defined in <a
+						<p id="confreq-svg-rs-scrpt">MUST meet the conformance criteria defined in <a
 								href="#sec-scripted-content"></a>.</p>
 					</li>
 					<li>
-						<p id="confreq-svg-rs-css">If it has a <a>Viewport</a>, it MUST support the visual rendering of
-							SVG using CSS as defined in <a href="https://www.w3.org/TR/SVG/styling.html">Styling</a>
-							[[!SVG]], and it SHOULD support all properties defined in the <a
-								href="https://www.w3.org/TR/SVG/propidx.html">Property Index</a> [[!SVG]]. In the case
-							of embedded SVG, it MUST also conform to the constraints defined in <a
-								href="#sec-xhtml-svg-css"></a>.</p>
+						<p id="confreq-svg-rs-css">MUST support the visual rendering of SVG using CSS as defined in <a
+								href="https://www.w3.org/TR/SVG/styling.html">Styling</a> [[!SVG]] and it SHOULD support
+							all properties defined in the <a href="https://www.w3.org/TR/SVG/propidx.html">Property
+								Index</a> [[!SVG]] if it has a <a>Viewport</a>. In the case of embedded SVG, a Reading
+							System MUST also conform to the constraints defined in <a href="#sec-xhtml-svg-css"
+							></a>.</p>
 					</li>
 					<li>
-						<p id="confreq-svg-rs-text">It SHOULD support user selection and searching of text within SVG
+						<p id="confreq-svg-rs-text">SHOULD support user selection and searching of text within SVG
 							elements.</p>
 					</li>
 					<li>
-						<p id="confreq-svg-rs-reqdExt">It MUST recognize the value
+						<p id="confreq-svg-rs-reqdExt">MUST recognize the value
 								"<code>http://www.idpf.org/2007/ops</code>" of the <code>requiredExtensions</code>
 							attribute as representing the occurrence of XHTML Content Document fragments (e.g., when the
 							attribute is included on the <code>foreignObject</code> element or children of the
@@ -677,51 +671,50 @@
 					the <a href="https://www.w3.org/TR/epub-33/#sec-css">visual rendering of XHTML Content Documents via
 						CSS</a> [[!EPUB-33]].</p>
 
-				<p>A Reading System that supports CSS has to process it as follows:</p>
+				<p>To support CSS, a Reading System:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-css-rs-support">It MUST support the official definition of CSS as described in
-							the [[!CSSSnapshot]].</p>
+						<p id="confreq-css-rs-support">MUST support the official definition of CSS as described in the
+							[[!CSSSnapshot]].</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-modules">It SHOULD support all applicable modules in [[!CSSSnapshot]] that
+						<p id="confreq-css-rs-modules">SHOULD support all applicable modules in [[!CSSSnapshot]] that
 							have reached at least <a href="https://www.w3.org/Consortium/Process/#RecsCR">Candidate
 								Recommendation</a> status [[!W3CProcess]] (and are widely implemented).</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-fonts">It MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and
-							[[!WOFF2]] font resources referenced from <code>@font-face</code> rules.</p>
+						<p id="confreq-css-rs-fonts">MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and [[!WOFF2]]
+							font resources referenced from <code>@font-face</code> rules.</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-prefixed">It MUST support all prefixed properties defined in <a
+						<p id="confreq-css-rs-prefixed">MUST support all prefixed properties defined in <a
 								href="https://www.w3.org/TR/epub-33/#sec-css-prefixed">CSS Style Sheets — Prefixed
 								Properties</a> [[EPUB-33]].</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above,
-							its user agent style sheet SHOULD support the [[!HTML]] <a
-								href="https://html.spec.whatwg.org/multipage/rendering.html#rendering">suggested default
-								rendering</a>.</p>
+						<p id="confreq-css-creator-styles">SHOULD apply <a>EPUB Creator</a> style sheets as written to
+								<a>EPUB Content Documents</a>.</p>
 					</li>
 					<li>
-						<p id="confreq-css-creator-styles">It SHOULD apply <a>EPUB Creator</a> style sheets as written
-							to <a>EPUB Content Documents</a>.</p>
-					</li>
-					<li>
-						<p id="confreq-css-overrides">It SHOULD NOT override the EPUB Creator's style sheets, but SHOULD
-							do so in a way that preserves the Cascade when necessary: through a user agent style sheet,
-							the <a
+						<p id="confreq-css-overrides">SHOULD NOT override the EPUB Creator's style sheets, but SHOULD do
+							so in a way that preserves the Cascade when necessary: through a user agent style sheet, the
+								<a
 								href="https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-OverrideAndComputed"
 									><code>getOverrideStyle</code> method</a> [[!DOM-Level-2-Style]], or [[!HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/dom.html#the-style-attribute"
 									><code>style</code> attributes</a>.</p>
 					</li>
 					<li>
-						<p id="confreq-css-user-styles">It SHOULD allow users to override the EPUB Creator's style
-							sheets as desired.</p>
+						<p id="confreq-css-user-styles">SHOULD allow users to override the EPUB Creator's style sheets
+							as desired.</p>
 					</li>
 				</ul>
+
+				<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above, a Reading
+					System's user agent style sheet SHOULD support the [[!HTML]] <a
+						href="https://html.spec.whatwg.org/multipage/rendering.html#rendering">suggested default
+						rendering</a>.</p>
 
 				<p>Reading System developers are strongly encouraged to implement CSS support at the level of major
 					browsers and to publicly document their user agent style sheets and how they interact with EPUB
@@ -811,29 +804,27 @@
 					support <a href="https://www.w3.org/TR/epub-33/#sec-pls"><abbr
 							title="Pronunciation Lexicon Specification">PLS</abbr> lexicons</a> [[!EPUB-33]].</p>
 
-				<p>A Reading System that supports PLS lexicons has to process them as follows:</p>
+				<p>To support PLS lexicons, a Reading System:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-pls-rs-sptts">Reading Systems with <a>Text-to-Speech</a> (TTS) capabilities
-							SHOULD support [[!PRONUNCIATION-LEXICON]].</p>
-						<p id="confreq-pls-rs-proc">It MUST process PLS documents as defined in
+						<p id="confreq-pls-rs-proc">MUST process PLS documents as defined in
 							[[!PRONUNCIATION-LEXICON]].</p>
-						<p id="confreq-pls-rs-scope">It MUST apply the supplied pronunciation instructions to all text
+						<p id="confreq-pls-rs-scope">MUST apply the supplied pronunciation instructions to all text
 							nodes in the current XHTML Content Document whose <a
 								href="https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes"
 								>language</a> [[!HTML]] matches <a
 								href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/#S4.1">the language
 								for which the pronunciation lexicon is relevant</a> [[!PRONUNCIATION-LEXICON]]. The
 							algorithm for matching language tags is defined in [[!BCP47]].</p>
-						<p id="confreq-pls-rs-multi">When a pronunciation rule is specified more than once for a given
-							string target in a given language, it MUST give precedence to the last occurrence of the
-							rule in such a way that any previously-defined pronunciation rule gets overridden.</p>
-						<p id="confreq-pls-rs-casc">If it also supports <a href="#sec-xhtml-ssml-attrib">SSML
-								Attributes</a>, it MUST let any pronunciation instructions provided via the <a
+						<p id="confreq-pls-rs-multi">MUST give precedence to the last occurrence of a rule when a
+							pronunciation rule is specified more than once for a given string target in a given language
+							(i.e., the Reading System must override the previously-defined pronunciation rule(s)).</p>
+						<p id="confreq-pls-rs-casc">MUST let any pronunciation instructions provided via the <a
 								href="#sec-cd-ssml-ph-attrib"><code>ssml:ph</code></a> attribute take precedence in
 							cases where a <code>grapheme</code> element [[!PRONUNCIATION-LEXICON]] matches a text node
-							of an element that carries the <code>ssml:ph</code> attribute [[!SSML]].</p>
+							of an element that carries the <code>ssml:ph</code> attribute [[!SSML]] (for Reading Systems
+							that also support <a href="#sec-xhtml-ssml-attrib">SSML Attributes</a>).</p>
 					</li>
 				</ul>
 			</section>
@@ -844,48 +835,48 @@
 			<p id="sec-nav-rs-conf" class="support">Reading Systems MUST process <a
 					href="https://www.w3.org/TR/epub-33/#sec-nav">EPUB Navigation Documents</a> [[!EPUB-33]].</p>
 
-			<p>A Reading System has to process EPUB Navigation Documents as follows:</p>
+			<p>To process the EPUB Navigation Document, a Reading System:</p>
 
 			<ul class="conformance-list">
 				<li>
-					<p id="confreq-nav-toc-access">It MUST provide users access to the links in the <a
+					<p id="confreq-nav-toc-access">MUST provide users access to the links in the <a
 							href="https://www.w3.org/TR/epub-33/#sec-nav-toc"><code>toc nav</code> element</a>
 						[[!EPUB-33]].</p>
 				</li>
 				<li>
-					<p id="confreq-nav-pagelist-access">It SHOULD provide a method to navigate to the listed page breaks
+					<p id="confreq-nav-pagelist-access">SHOULD provide a method to navigate to the listed page breaks
 						when a <a href="https://www.w3.org/TR/epub-33/#sec-nav-pagelist"><code>page-list nav</code>
 							element</a> [[!EPUB-33]] is present.</p>
 				</li>
 				<li>
-					<p id="confreq-nav-landmarks-access">It MAY provide users access to the links in the <a
+					<p id="confreq-nav-landmarks-access">MAY provide users access to the links in the <a
 							href="https://www.w3.org/TR/epub-33/#sec-nav-landmarks"><code>landmarks nav</code>
 							element</a> [[!EPUB-33]] and MAY use the links to enable functionality in the
 						application.</p>
 				</li>
 				<li>
-					<p id="confreq-nav-other-access">It MAY provide access to <code>nav</code> elements that do not
-						specify an <code>epub:type</code> attribute or that <a
+					<p id="confreq-nav-other-access">MAY provide access to <code>nav</code> elements that do not specify
+						an <code>epub:type</code> attribute or that <a
 							href="https://www.w3.org/TR/epub-33/#sec-nav-def-types-other">declare an unknown value</a>
 						[[!EPUB-33]].</p>
 				</li>
 				<li>
-					<p id="confreq-nav-activation">When a link to a <a>Publication Resource</a> is activated, it MUST
-						relocate the current reading position to the destination identified by that link.</p>
+					<p id="confreq-nav-activation">MUST relocate the current reading position to the destination
+						identified by an activated link when the link is to a <a>Publication Resource</a>.</p>
 				</li>
 				<li>
-					<p id="confreq-nav-spine">It MUST honor the above requirements irrespective of whether the EPUB
-						Navigation Document is part of the <a href="https://www.w3.org/TR/epub-33/#sec-spine-elem"
-							>spine</a> [[!EPUB-33]].</p>
-				</li>
-				<li>
-					<p id="confreq-nav-ol-style">It MUST NOT show list item numbering on <code>nav</code> elements when
+					<p id="confreq-nav-ol-style">MUST NOT show list item numbering on <code>nav</code> elements when
 						presenting them outside of the spine, regardless of support for CSS, as the default display
 						style of list items is equivalent to the <a
 							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
 								none</code> property</a> [[!CSSSnapshot]].).</p>
 				</li>
 			</ul>
+
+			<p id="confreq-nav-spine">Reading Systems MUST honor the above requirements irrespective of whether the EPUB
+				Navigation Document is part of the <a href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a>
+				[[!EPUB-33]].</p>
+
 		</section>
 		<section id="sec-fixed-layouts">
 			<h2>Fixed-Layout Documents Processing</h2>
@@ -899,9 +890,9 @@
 				<section id="layout">
 					<h4>The <code>rendition:layout</code> Property</h4>
 
-					<p>If no <code>meta</code> element carrying this
-						property occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code> 
-						section</a> [[!EPUB-33]], then the Reading System MUST assume the value <code>reflowable</code>.</p>
+					<p>If no <code>meta</code> element carrying this property occurs in the <a
+							href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code> section</a>
+						[[!EPUB-33]], then the Reading System MUST assume the value <code>reflowable</code>.</p>
 
 					<p>When the <code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading
 						Systems MUST NOT include space between the adjacent content slots when rendering <a>Synthetic
@@ -983,8 +974,8 @@
 						reflowable content, and they only apply when the Reading System is creating Synthetic
 						Spreads.</p>
 
-					<p>The <code>rendition:page-spread-*</code> properties MUST take precedence over whatever value of the <a
-							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
+					<p>The <code>rendition:page-spread-*</code> properties MUST take precedence over whatever value of
+						the <a href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
 								><code>page-break-before</code> property</a> [[!CSSSnapshot]] has been set for an
 							<a>XHTML Content Document</a>.</p>
 
@@ -1494,30 +1485,29 @@
 					href="https://www.w3.org/TR/epub-33/#app-structural-semantics">structural semantics</a> [[!EPUB-33]]
 				in <a>EPUB Content Documents</a>.</p>
 
-			<p>A Reading System that supports structural semantics has to process the <code>epub:type</code> attribute
-				as follows:</p>
+			<p>When processing the <code>epub:type</code> attribute, a Reading System:</p>
 
 			<ul class="conformance-list">
 				<li>
-					<p id="confreq-rs-epubtype-beh">It MAY associate behaviors with none, some or all of the terms
-						defined in the <a href="https://www.w3.org/TR/epub-33/#sec-epub-type-attribute">default
-							vocabulary</a> [[EPUB-33]].</p>
+					<p id="confreq-rs-epubtype-beh">MAY associate behaviors with none, some or all of the terms defined
+						in the <a href="https://www.w3.org/TR/epub-33/#sec-epub-type-attribute">default vocabulary</a>
+						[[EPUB-33]].</p>
 				</li>
 				<li>
-					<p id="confreq-rs-epubtype-oth">It MAY associate behaviors with terms from other vocabularies.</p>
+					<p id="confreq-rs-epubtype-oth">MAY associate behaviors with terms from other vocabularies.</p>
 				</li>
 				<li>
-					<p id="confreq-rs-epubtype-ign">It MUST ignore terms that it does not recognize.</p>
+					<p id="confreq-rs-epubtype-ign">MUST ignore terms that it does not recognize.</p>
 				</li>
 				<li>
-					<p id="confreq-rs-epubtype-conflict">It MUST <a href="#confreq-rs-epubtype-prec">ignore structural
+					<p id="confreq-rs-epubtype-conflict">MUST <a href="#confreq-rs-epubtype-prec">ignore structural
 							semantics</a> that conflict with the carrying element.</p>
 				</li>
 			</ul>
 
-			<p id="confreq-rs-epubtype-prec">When Reading System behavior associated with a given <code>epub:type</code>
-				value conflicts with an element's native behavior, the behavior associated with the element MUST be
-				given precedence.</p>
+			<p id="confreq-rs-epubtype-prec">When the Reading System behavior associated with a given
+					<code>epub:type</code> value conflicts with an element's native behavior, the behavior associated
+				with the element MUST be given precedence.</p>
 		</section>
 		<section id="sec-vocab-assoc">
 			<h2>Vocabulary Association Mechanisms</h2>
@@ -1615,12 +1605,12 @@
 					</dd>
 				</dl>
 
-				<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction MUST be defined
-					relative to the block flow direction of the root element of the XHTML Content Document referenced by
-					the <a href="https://www.w3.org/TR/epub-33/#elemdef-spine-itemref"><code>itemref</code> element</a>
-					[[!EPUB-33]]. The scroll direction MUST be vertical if the block flow direction is downward
-					(top-to-bottom). It MUST be horizontal if the block flow direction of the root element is rightward
-					(left-to-right) or leftward (right-to-left).</p>
+				<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction MUST be
+					defined relative to the block flow direction of the root element of the XHTML Content Document
+					referenced by the <a href="https://www.w3.org/TR/epub-33/#elemdef-spine-itemref"
+							><code>itemref</code> element</a> [[!EPUB-33]]. The scroll direction MUST be vertical if the
+					block flow direction is downward (top-to-bottom). It MUST be horizontal if the block flow direction
+					of the root element is rightward (left-to-right) or leftward (right-to-left).</p>
 			</section>
 
 			<section id="align-x-center">
@@ -1836,7 +1826,7 @@ partial interface Navigator {
 				<div class="note">
 					<p>Reading systems implementations might create cloned instances of the
 							<code>epubReadingSystem</code> object in Scripted Content Documents for technical
-						feasibility reasons. In such cases, the Reading System has to ensure that the object’s state —
+						feasibility reasons. In such cases, the Reading System has to ensure that the object's state —
 						as reflected by the values of its properties and methods — is consistently maintained across all
 						copied instances.</p>
 				</div>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -336,24 +336,25 @@
 
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
 					<dd>
-						<p>Retrieval of Remote Resources is OPTIONAL.</p>
+						<p>Retrieval and support of Remote Resources is OPTIONAL.</p>
+
 						<p>The language identified in an <code>hreflang</code> is purely advisory.
-							Upon fetching the resource, a Reading System must only use the language information associated with the resource to determine its language, not metadata included in the link to the resource.
+							Upon fetching the resource, a Reading System must only use the language information associated with the resource to determine its language, not the metadata included in the link to the resource.
 						</p>
-						<p>Reading Systems do not have to use or present linked resources, even if they recognize the
-							relationship defined in the <code>rel</code> attribute.</p>
+						<!-- <p>Reading Systems do not have to use or present linked resources, even if they recognize the
+							relationship defined in the <code>rel</code> attribute.</p> -->
 						<p id="sec-linked-records">In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
-								>linked metadata record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing the
+								>linked metadata record</a> [[!EPUB-33]], Reading Systems must not skip processing the
 							metadata expressed in the Package Document and only use the information expressed in the
-							record. Reading Systems MAY compile metadata from multiple linked records; they do not have
+							record. Reading Systems may compile metadata from multiple linked records; they do not have
 							to select only one record.</p>
 						<p>When it comes to resolving discrepancies and conflicts between metadata expressed in the
-							Package Document and in linked metadata records, Reading Systems MUST use the document order
+							Package Document and in linked metadata records, Reading Systems must use the document order
 							of <code>link</code> elements in the Package Document to establish precedence (i.e.,
 							metadata in the first linked record encountered has the highest precedence and metadata in
 							the Package Document the lowest, regardless of whether the <code>link</code> elements occur
 							before, within or after the package metadata elements).</p>
-						<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
+						<p>Reading Systems must ignore any instructions contained in linked resources related to the
 							layout and rendering of the EPUB Publication.</p>
 					</dd>
 
@@ -410,9 +411,8 @@
 					specifically activates a hyperlink to such items). Reading Systems MAY also provide the option for
 					users to select whether non-linear content is skipped by default or not.</p>
 
-				<p>If the <code>page-progression-direction</code> is not specified, the value of <code>default</code>
-					MUST be assumed. When the value of the <code>page-progression-direction</code> is set to 
-					<code>default</code> (either explicitly or implicitly) the Reading System SHOULD choose
+				<p>If the <code>page-progression-direction</code> is not specified, the Reading System MUST assume the value of <code>default</code>. When the value of the <code>page-progression-direction</code> is set to 
+					<code>default</code> (either explicitly or implicitly), the Reading System SHOULD choose
 					a default <code>page-progression-direction</code> value based on the first <code>language</code>
 					element.</p>
 
@@ -899,9 +899,12 @@
 				<section id="layout">
 					<h4>The <code>rendition:layout</code> Property</h4>
 
-					<p>If no <code>meta</code> element carrying this
+					<p>
+						The default global value is reflowable if no meta element carrying this property occurs in the metadata section [EPUB-33].
+					</p>
+					<!-- <p>If no <code>meta</code> element carrying this
 						property occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code> 
-						section</a> [[!EPUB-33]], then the Reading System MUST assume the value <code>reflowable</code>.</p>
+						section</a> [[!EPUB-33]], the Reading System MUST assume the value <code>reflowable</code>.</p> -->
 
 					<p>When the <code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading
 						Systems MUST NOT include space between the adjacent content slots when rendering <a>Synthetic


### PR DESCRIPTION
Quoting from #1612

> 1. `The language identified in an hreflang attribute is not authoritative. Language information defined in a linked resource determines its language.` (also discussed in https://github.com/w3c/epub-specs/issues/1601). This seems like two normative statements — hreflang SHOULD NOT be used? and resource language MUST be used? https://w3c.github.io/epub-specs/epub33/rs/#conf-metadata-link

I change the text, mostly using the way the HTML standard defines the similar attribute. Hopefully that is now clearer

> 2. `Reading System [note: should be plural] do not have to use or present linked resources, even if they recognize the relationship defined in the rel attribute.` Same section as above.

Set to plural.

> 3. `When the default value of the page-progression-direction attribute is specified, the Reading System can choose the rendering direction. The default value MUST be assumed when the attribute is not specified.` I think the second statement only makes sense if the first is also MUST. (Otherwise we're requiring RSes to use `default`, but not requiring that `default` do anything.) https://w3c.github.io/epub-specs/epub33/rs/#sec-pkg-doc-spine

I have re-written the text, hopefully it is clearer and also accurate...

> 4. `In addition to the requirements in § 9. Processing Structural Semantics, a Reading System has to process the epub:type attribute as follows in XHTML Content Documents: It MUST ignore semantics expressed on the [HTML] head element or its descendants.` Should "has to" become MUST? If so, there are ~10 instances of "has to" in the spec that should change in sync ... but that suggests this wording may be intentional. https://w3c.github.io/epub-specs/epub33/rs/#sec-xhtml-structural-semantics

I am not sure. The real normative statement is in the bullet item. I leave this to @mattgarrish, this is a generic styling issue...

> 5. `The default global value is reflowable if no meta element carrying this property occurs in the metadata section [EPUB-33].` This feels as if it should be rephrased to address the RS: "If no meta element... the RS MUST apply a global default..." If so, there are ~4 intances of "default global value" in the spec that should change in sync. https://w3c.github.io/epub-specs/epub33/rs/#layout

I agree it is more readable. For now, I have re-written it in this section; if reviewers agree this is a better choice, the other instances will have to be changed, too. 

> 6. `The rendition:page-spread-* properties take precedence over whatever value of the page-break-before property [CSSSnapshot] has been set for an XHTML Content Document.` Seems like it could have a MUST. https://w3c.github.io/epub-specs/epub33/rs/#page-spread

Yep.

> 7. `For the rendition:flow-scrolled-continuous property, the scroll direction is defined relative to the block flow direction of the root element of the XHTML Content Document referenced by the itemref element [EPUB-33]. The scroll direction is vertical if the block flow direction is downward (top-to-bottom). It is horizontal if the block flow direction of the root element is rightward (left-to-right) or leftward (right-to-left).` This seems like maybe 2 or 3 normative statements. https://w3c.github.io/epub-specs/epub33/rs/#flow

Changed.

Fix #1612 

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/editorial/issue-1612/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/editorial/issue-1612/epub33/rs/index.html)
