### PR TITLE
Remove the explicit list of implementations from the media type specs

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9182,43 +9182,7 @@ EPUB/images/cover.png</pre>
 					</dd>
 					<dt>Applications which use this media type:</dt>
 					<dd>
-						<p>This media type is in wide use for the distribution of ebooks in the EPUB format. The
-							following list of applications is not exhaustive.</p>
-						<ul>
-							<li>
-								<p>Adobe Digital Editions</p>
-							</li>
-							<li>
-								<p>Aldiko</p>
-							</li>
-							<li>
-								<p>Azardi</p>
-							</li>
-							<li>
-								<p>Apple iBooks</p>
-							</li>
-							<li>
-								<p>Barnes &amp; Noble Nook</p>
-							</li>
-							<li>
-								<p>Bluefire Reader</p>
-							</li>
-							<li>
-								<p>Calibre</p>
-							</li>
-							<li>
-								<p>Google Play Books</p>
-							</li>
-							<li>
-								<p>Kobo</p>
-							</li>
-							<li>
-								<p>Microsoft Edge</p>
-							</li>
-							<li>
-								<p>Readium</p>
-							</li>
-						</ul>
+						<p>This media type is in wide use for the distribution of ebooks in the EPUB format.</p>
 					</dd>
 					<dt>Additional information:</dt>
 					<dd>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9182,43 +9182,7 @@ EPUB/images/cover.png</pre>
 					</dd>
 					<dt>Applications which use this media type:</dt>
 					<dd>
-						<p>This media type is in wide use for the distribution of ebooks in the EPUB format. The
-							following list of applications is not exhaustive.</p>
-						<ul>
-							<li>
-								<p>Adobe Digital Editions</p>
-							</li>
-							<li>
-								<p>Aldiko</p>
-							</li>
-							<li>
-								<p>Azardi</p>
-							</li>
-							<li>
-								<p>Apple iBooks</p>
-							</li>
-							<li>
-								<p>Barnes &amp; Noble Nook</p>
-							</li>
-							<li>
-								<p>Bluefire Reader</p>
-							</li>
-							<li>
-								<p>Calibre</p>
-							</li>
-							<li>
-								<p>Google Play Books</p>
-							</li>
-							<li>
-								<p>Kobo</p>
-							</li>
-							<li>
-								<p>Microsoft Edge</p>
-							</li>
-							<li>
-								<p>Readium</p>
-							</li>
-						</ul>
+						<p>This media type is in wide use for the distribution of ebooks in the EPUB format.</p>
 					</dd>
 					<dt>Additional information:</dt>
 					<dd>
@@ -9330,21 +9294,7 @@ EPUB/images/cover.png</pre>
 					</dd>
 					<dt>Applications that use this media type:</dt>
 					<dd>
-						<p>This media type is in wide use for the distribution of ebooks in the EPUB format. The
-							following list of applications is not exhaustive.</p>
-						<ul>
-							<li>Adobe Digital Editions</li>
-							<li>Aldiko</li>
-							<li>Azardi</li>
-							<li>Apple iBooks</li>
-							<li>Barnes &amp; Noble NOOK</li>
-							<li>Bluefire Reader</li>
-							<li>Calibre</li>
-							<li>Google Play Books</li>
-							<li>Kobo</li>
-							<li>Microsoft Edge</li>
-							<li>Readium</li>
-						</ul>
+						<p>This media type is in wide use for the distribution of ebooks in the EPUB format.</p>
 					</dd>
 					<dt>Additional information:</dt>
 					<dd>


### PR DESCRIPTION
These lists become quickly outdated and serve no visible purpose...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1617.html" title="Last updated on Apr 6, 2021, 12:08 PM UTC (a616422)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1617/6d45491...a616422.html" title="Last updated on Apr 6, 2021, 12:08 PM UTC (a616422)">Diff</a>