### PR TITLE
Move "if it has a Viewport" for readability

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -626,8 +626,7 @@
 										<code>annotation-xml</code> elements.</p>
 							</li>
 							<li>
-								<p id="confreq-mathml-rs-render">MUST support visual rendering of Presentation MathML if
-									it has a <a>Viewport</a>.</p>
+								<p id="confreq-mathml-rs-render">MUST, if it has a <a>Viewport</a>, support visual rendering of Presentation MathML.</p>
 							</li>
 						</ul>
 						<p class="note">Reading Systems may choose to use third-party libraries such as MathJax to
@@ -691,10 +690,10 @@
 								href="#sec-scripted-content"></a>.</p>
 					</li>
 					<li>
-						<p id="confreq-svg-rs-css">MUST support the visual rendering of SVG using CSS as defined in <a
+						<p id="confreq-svg-rs-css">MUST, if it has a <a>Viewport</a>, support the visual rendering of SVG using CSS as defined in <a
 								href="https://www.w3.org/TR/SVG/styling.html">Styling</a> [[!SVG]] and it SHOULD support
 							all properties defined in the <a href="https://www.w3.org/TR/SVG/propidx.html">Property
-								Index</a> [[!SVG]] if it has a <a>Viewport</a>. In the case of embedded SVG, a Reading
+								Index</a> [[!SVG]]. In the case of embedded SVG, a Reading
 							System MUST also conform to the constraints defined in <a href="#sec-xhtml-svg-css"
 							></a>.</p>
 					</li>


### PR DESCRIPTION
This makes the second sentence easier to parse. The first is updated only to match the structure of the second.