### PR TITLE
Tweaks to 1627

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4083,7 +4083,7 @@ Spine:
 							<li>
 								<p>the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
 											><code>dir</code> attribute</a> [[!HTML]] and <a
-										href="https://www.w3.org/TR/SVG2/text.html#DirectionProperty"
+										href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
 											><code>direction</code> attribute</a> [[!SVG]] for inline base
 									directionality.</p>
 							</li>
@@ -4092,7 +4092,8 @@ Spine:
 										href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element"
 											><code>bdo</code> element</a> with the <a
 										href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
-											><code>dir</code> attribute</a> [[!HTML]] and the <a href=""
+											><code>dir</code> attribute</a> [[!HTML]] and the <a
+										href="https://www.w3.org/TR/SVG/styling.html#PresentationAttributes"
 											><code>unicode-bidi</code> attribute</a> [[!SVG]] for bidirectionality.</p>
 							</li>
 						</ul>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4045,7 +4045,7 @@ Spine:
 				<section id="sec-css-req">
 					<h4>CSS Requirements</h4>
 
-					<p>A CSS style sheets has to meet the following requirements:</p>
+					<p>A CSS style sheet has to meet the following requirements:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -4053,31 +4053,50 @@ Spine:
 								exceptions:</p>
 							<ul class="conformance-list">
 								<li>
-									<p id="confreq-css-props-exc-direction">It MUST NOT use the <a
-											href="https://www.w3.org/TR/css3-writing-modes/#direction"><code>direction</code> property</a> [[!CSS-Writing-Modes-3]] for [[!HTML]] or [[!SVG]] Content Documents. Use the [[!HTML]] <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"><code>dir</code> attribute</a>, 
-											respectively the [[!SVG]] <a href="https://www.w3.org/TR/SVG2/text.html#DirectionProperty"><code>direction</code> attribute</a>, to set the 
-											inline base direction.
-									</p>
+									<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
+											href="https://www.w3.org/TR/css3-writing-modes/#direction"
+												><code>direction</code> property</a> [[!CSS-Writing-Modes-3]].</p>
 								</li>
 								<li>
-									<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT use the <a
-										href="https://www.w3.org/TR/css3-writing-modes/#unicode-bidi"><code>unicode-bidi</code> property</a> [[!CSS-Writing-Modes-3]] for [[!HTML]] Content Documents. Use the [[!HTML]] <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element"><code>bdo</code> element</a>
-										and the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"><code>dir</code> attribute</a> to control bidirectionality..
-									</p>
+									<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT include the <a
+											href="https://www.w3.org/TR/css3-writing-modes/#unicode-bidi"
+												><code>unicode-bidi</code> property</a> [[!CSS-Writing-Modes-3]].</p>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p id="confreq-css-prefixed">It MAY include the prefixed properties defined in <a href="#sec-css-prefixed"></a>.</p>
+							<p id="confreq-css-prefixed">It MAY include the prefixed properties defined in <a
+									href="#sec-css-prefixed"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p>
 						</li>
 					</ul>
 
-					<p class=note>
-						The reason of the restrictions on the <code>direction</code> and the <code>unicode-bidi</code> properties is the fact that Reading Systems may not implement, or may switch off, CSS processing.
-					</p>
+					<div class="note">
+						<p>The use of the <code>direction</code> and <code>unicode-bidi</code> properties is restricted
+							because Reading Systems may not implement, or may switch off, CSS processing. EPUB Creators
+							must use the following format-specific methods when control over these aspects of the
+							rendering is needed:</p>
+
+						<ul>
+							<li>
+								<p>the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
+											><code>dir</code> attribute</a> [[!HTML]] and <a
+										href="https://www.w3.org/TR/SVG2/text.html#DirectionProperty"
+											><code>direction</code> attribute</a> [[!SVG]] for inline base
+									directionality.</p>
+							</li>
+							<li>
+								<p>the <a
+										href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element"
+											><code>bdo</code> element</a> with the <a
+										href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
+											><code>dir</code> attribute</a> [[!HTML]] and the <a href=""
+											><code>unicode-bidi</code> attribute</a> [[!SVG]] for bidirectionality.</p>
+							</li>
+						</ul>
+					</div>
 				</section>
 
 				<section id="sec-css-prefixed">
@@ -9358,12 +9377,11 @@ EPUB/images/cover.png</pre>
 
 				<ul>
 					<ul>
-						<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in
-							<a href="#sec-css-req"></a>. 
-							See <a href="https://github.com/w3c/epub-specs/issues/1613">issue 1614</a>.
-						</li>
+						<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in <a
+								href="#sec-css-req"></a>. See <a href="https://github.com/w3c/epub-specs/issues/1613"
+								>issue 1614</a>. </li>
 					</ul>
-					</ul>
+				</ul>
 			</section>
 
 			<section id="changes-older">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9377,11 +9377,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
-					<ul>
-						<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in <a
-								href="#sec-css-req"></a>. See <a href="https://github.com/w3c/epub-specs/issues/1613"
-								>issue 1614</a>. </li>
-					</ul>
+					<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in <a
+							href="#sec-css-req"></a>. See <a href="https://github.com/w3c/epub-specs/issues/1613">issue
+							1614</a>.</li>
 				</ul>
 			</section>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -483,11 +483,11 @@
 		<section id="sec-contentdocs">
 			<h2>Content Document Processing</h2>
 
-			<p>
-				The definition of EPUB Content Documents includes various authoring restrictions to optimize the cross-compatibility of 
-				content (e.g., <a href="https://www.w3.org/TR/epub-33/#sec-css-req">prohibiting CSS for setting language and direction</a>). 
-				Unless stated otherwise in this specification, Reading Systems MAY support these restricted features.
-			</p>
+			<p>The definition of <a href="https://www.w3.org/TR/epub-33/#sec-contentdocs">EPUB Content Documents</a>
+				[[!EPUB-33]] includes various authoring restrictions to optimize the cross-compatibility of content
+				(e.g., <a href="https://www.w3.org/TR/epub-33/#sec-css-req">prohibiting CSS for setting language and
+					direction</a> [[EPUB-33]]). Unless stated otherwise in this specification, Reading Systems MAY support these
+				restricted features.</p>
 
 			<section id="sec-xhtml">
 				<h3>XHTML Content Documents</h3>
@@ -632,7 +632,8 @@
 										<code>annotation-xml</code> elements.</p>
 							</li>
 							<li>
-								<p id="confreq-mathml-rs-render">MUST, if it has a <a>Viewport</a>, support visual rendering of Presentation MathML.</p>
+								<p id="confreq-mathml-rs-render">MUST, if it has a <a>Viewport</a>, support visual
+									rendering of Presentation MathML.</p>
 							</li>
 						</ul>
 						<p class="note">Reading Systems may choose to use third-party libraries such as MathJax to
@@ -696,12 +697,12 @@
 								href="#sec-scripted-content"></a>.</p>
 					</li>
 					<li>
-						<p id="confreq-svg-rs-css">MUST, if it has a <a>Viewport</a>, support the visual rendering of SVG using CSS as defined in <a
-								href="https://www.w3.org/TR/SVG/styling.html">Styling</a> [[!SVG]] and it SHOULD support
-							all properties defined in the <a href="https://www.w3.org/TR/SVG/propidx.html">Property
-								Index</a> [[!SVG]]. In the case of embedded SVG, a Reading
-							System MUST also conform to the constraints defined in <a href="#sec-xhtml-svg-css"
-							></a>.</p>
+						<p id="confreq-svg-rs-css">MUST, if it has a <a>Viewport</a>, support the visual rendering of
+							SVG using CSS as defined in <a href="https://www.w3.org/TR/SVG/styling.html">Styling</a>
+							[[!SVG]] and it SHOULD support all properties defined in the <a
+								href="https://www.w3.org/TR/SVG/propidx.html">Property Index</a> [[!SVG]]. In the case
+							of embedded SVG, a Reading System MUST also conform to the constraints defined in <a
+								href="#sec-xhtml-svg-css"></a>.</p>
 					</li>
 					<li>
 						<p id="confreq-svg-rs-text">SHOULD support user selection and searching of text within SVG
@@ -2060,10 +2061,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
-					<li>09-Apr-2021: Added section clarifying all the conformance requirements on
-						establishing the primary language and base direction of Publication Resources.
-						See <a href="https://github.com/w3c/epub-specs/pull/1613">pull request 1613</a>.
-					</li>
+					<li>09-Apr-2021: Added section clarifying all the conformance requirements on establishing the
+						primary language and base direction of Publication Resources. See <a
+							href="https://github.com/w3c/epub-specs/pull/1613">pull request 1613</a>. </li>
 				</ul>
 			</section>
 


### PR DESCRIPTION
Having authoring guidance in the css restrictions makes the bullets a bit unwieldy, but rather than try to describe the change see what you think of this rework that puts them into the note after.

(I also made one minor change to the RS spec to add a link across to the definition of epub content documents in the "do what you want" clarification.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1635.html" title="Last updated on Apr 12, 2021, 2:10 PM UTC (e199846)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1635/ef5a530...e199846.html" title="Last updated on Apr 12, 2021, 2:10 PM UTC (e199846)">Diff</a>