### PR TITLE
Typos in code point references

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5794,13 +5794,13 @@ Spine:
 									<p>Private Use Area (<code>U+E000 … U+F8FF</code>)</p>
 								</li>
 								<li>
-									<p>Non characters in Arabic Presentation Forms-A (<code>U+FDDO … U+FDEF</code>)</p>
+									<p>Non characters in Arabic Presentation Forms-A (<code>U+FDD0 … U+FDEF</code>)</p>
 								</li>
 								<li>
 									<p>Specials (<code>U+FFF0 … U+FFFF</code>)</p>
 								</li>
 								<li>
-									<p>Non characters at the end of the Supplementary Planes (<code>U+1FFFE, U+1FFFFF …
+									<p>Non characters at the end of the Supplementary Planes (<code>U+1FFFE, U+1FFFF …
 											U+EFFFE, U+EFFFF</code>)</p>
 								</li>
 								<li>


### PR DESCRIPTION
Does not resolve the larger issue of #1632, however.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1636.html" title="Last updated on Apr 12, 2021, 2:18 PM UTC (ae12d2b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1636/71271b0...ae12d2b.html" title="Last updated on Apr 12, 2021, 2:18 PM UTC (ae12d2b)">Diff</a>