### PR TITLE
Add path names to the utf-8 encoding requirement

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9359,7 +9359,10 @@ EPUB/images/cover.png</pre>
 						- move all changes down to the next section
 				-->
 
-				<ul> </ul>
+				<ul>
+					<li>13-Apr-2021: Require path names in OCF to also be UTF-8 encoded. See <a
+							href="https://github.com/w3c/epub-specs/issues/1630">issue 1630</a>.</li>
+				</ul>
 			</section>
 
 			<section id="changes-older">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5738,7 +5738,7 @@ Spine:
 
 					<ul class="conformance-list">
 						<li>
-							<p id="ocf-fn-encoding">File Names MUST be UTF-8 [[!Unicode]] encoded.</p>
+							<p id="ocf-fn-encoding">Path and File Names MUST be UTF-8 [[!Unicode]] encoded.</p>
 						</li>
 						<li>
 							<p id="ocf-fn-length">File Names MUST NOT exceed 255 bytes.</p>
@@ -9359,8 +9359,7 @@ EPUB/images/cover.png</pre>
 						- move all changes down to the next section
 				-->
 
-				<ul>
-				</ul>
+				<ul> </ul>
 			</section>
 
 			<section id="changes-older">


### PR DESCRIPTION
Fixes #1630


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1638.html" title="Last updated on Apr 16, 2021, 5:32 PM UTC (e16582f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1638/625c6af...e16582f.html" title="Last updated on Apr 16, 2021, 5:32 PM UTC (e16582f)">Diff</a>