### PR TITLE
Rolling back the intro remark on rendition:layout

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -937,10 +937,10 @@
 
 				<section id="layout">
 					<h4>The <code>rendition:layout</code> Property</h4>
-
-					<p>The default global value is <code>reflowable</code> if no <code>meta</code> element carrying this
-						property occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"
-								><code>metadata</code> section</a> [[!EPUB-33]].</p>
+					<p>
+						The default value <code>reflowable</code> MUST be assumed by EPUB Reading Systems as the global value if no meta element carrying this property occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code> 
+						section</a> section [[!EPUB-33]].
+					</p>
 
 					<p>When the <code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading
 						Systems MUST NOT include space between the adjacent content slots when rendering <a>Synthetic


### PR DESCRIPTION
This is the response to the (goal of the) [WG resolution](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution1). 

The resolution was not entirely accurate because #1616 was already closed, but https://github.com/w3c/epub-specs/pull/1616#pullrequestreview-629109802 referred to a prior resolution raised in #1313 and was and executed in #1562. This PR, essentially, rolls back #1562 (but in the new version of the document).

Fixes #1313

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/rendition-layout-final-version/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/rendition-layout-final-version/epub33/rs/index.html)

