### PR TITLE
Remove section on custom attributes in RS spec

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -571,40 +571,6 @@
 								href="https://www.w3.org/TR/epub-33/#deprecated">deprecated</a> [[EPUB-33]]. Refer to
 							its definition in [[!EPUBContentDocs-301]] for implementation information.</p>
 					</section>
-
-					<section id="sec-xhtml-custom-attributes">
-						<h5>Custom Attributes</h5>
-
-						<p>Vendors MAY introduce functionality not defined in this specification to enhance the
-							rendering of <a>EPUB Publications</a>.</p>
-
-						<p>To facilitate this experimentation, vendors MAY define custom attributes for use in <a>XHTML
-								Content Documents</a> provided they are from a foreign namespace, which is defined as a
-							namespace [[!XML-NAMES]] that does not include either of the following domains in its URI's
-							authority component [[!RFC3986]]:</p>
-
-						<ul>
-							<li>
-								<p>
-									<code>w3.org</code>
-								</p>
-							</li>
-							<li>
-								<p>
-									<code>idpf.org</code>
-								</p>
-							</li>
-						</ul>
-
-						<p>Custom attributes, and the behaviors associated with them, MUST NOT alter the integrity of an
-							EPUB Publication.</p>
-
-						<div class="note">
-							<p>To facilitate interoperability of custom attributes across Reading Systems, vendors are
-								strongly encouraged to document any extensions they implement in
-								[[AttributeExtensions]].</p>
-						</div>
-					</section>
 				</section>
 
 				<section id="sec-xhtml-deviations">
@@ -2055,6 +2021,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>
+						16-04-2021: Removed the section on custom attributes. See <a href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution2">Working Group Resolution</a>.
+					</li>
 					<li>09-Apr-2021: Added section clarifying all the conformance requirements on
 						establishing the primary language and base direction of Publication Resources.
 						See <a href="https://github.com/w3c/epub-specs/pull/1613">pull request 1613</a>.
@@ -2119,8 +2088,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					<li>6-Nov-2020: Reading systems are now required to <a href="#confreq-rs-xml-extid">not resolve
 							external identifiers</a> in doctype declarations. See <a
 							href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
-					<li>5-Nov-2020: Generalized the restriction on <a href="#sec-xhtml-custom-attributes">custom
-							attribute namespace URIs</a> to exclude all of idpf.org and w3.org. See <a
+					<li>5-Nov-2020: Generalized the restriction on custom
+							attribute namespace URIs to exclude all of idpf.org and w3.org. See <a
 							href="https://github.com/w3c/epub-specs/issues/1388">issue 1388</a>.</li>
 					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
 						understanding and access to information. This specification now consolidates the reading system


### PR DESCRIPTION
This is the implementation of the [WG Resolution](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution2) on 2021-04-15.

Fixes #1602

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/custom-attributes-issue-1602/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/custom-attributes-issue-1602/epub33/rs/index.html)

