### PR TITLE
Removed section on presentation logic.

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -274,14 +274,6 @@
 			<p id="confreq-rs-epub-pub" class="support">Reading Systems MUST process the <a
 					href="https://www.w3.org/TR/epub-33/#sec-package-doc">Package Document</a> [[!EPUB-33]].</p>
 
-			<section id="sec-pkg-doc-presentation">
-				<h4>Presentation Logic</h4>
-
-				<p id="confreq-rendition-rs-package">Reading Systems MUST honor all presentation logic expressed through
-					the <a href="https://www.w3.org/TR/epub-33/#sec-package-def">Package Document</a> [[!EPUB-33]]
-					(e.g., the reading order, fallback chains, page progression direction and fixed layouts).</p>
-			</section>
-
 			<section id="sec-pkg-doc-relative-iris">
 				<h4>Resolving Relative IRIs</h4>
 
@@ -2055,6 +2047,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>
+						15-04-2021: Remove the reference to "presentation logic". See 
+						<a href="https://github.com/w3c/epub-specs/issues/1516">issue 1516</a> and 
+						<a href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution3">Working Group Resolution</a>.
+					</li>
 					<li>09-Apr-2021: Added section clarifying all the conformance requirements on
 						establishing the primary language and base direction of Publication Resources.
 						See <a href="https://github.com/w3c/epub-specs/pull/1613">pull request 1613</a>.


### PR DESCRIPTION
See [WG resolution](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution3).

Fixes #1516

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/remove-presentation-logic-issue-1516/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/remove-presentation-logic-issue-1516/epub33/rs/index.html)

