### PR TITLE
remove custom attributes section from core spec

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3676,25 +3676,6 @@ Spine:
 						<p>Use of the <code>trigger</code> element is <a href="#deprecated">deprecated</a>. Refer to its
 							definition in [[!EPUBContentDocs-301]] for usage information.</p>
 					</section>
-
-					<section id="sec-xhtml-custom-attributes">
-						<h5>Custom Attributes</h5>
-
-						<p><a>EPUB Creators</a> MAY specify <a
-								href="https://www.w3.org/TR/epub-rs-33/#sec-xhtml-custom-attributes">custom
-								attributes</a> [[!EPUB-RS-33]] in <a>XHTML Content Documents</a> to take advantage of
-							Reading System-specific functionality not defined in this specification.</p>
-
-						<p>Custom attributes MAY be specified on any element in an XHTML Content Document.</p>
-
-						<p>When using custom attributes, the content MUST remain consumable by a user without any
-							information loss or other significant deterioration, regardless of the Reading System it is
-							rendered on.</p>
-
-						<div class="note">
-							<p>Refer to [[AttributeExtensions]] for a registry of custom attributes.</p>
-						</div>
-					</section>
 				</section>
 
 				<section id="sec-xhtml-deviations">
@@ -9406,6 +9387,8 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>19-Apr-2021: The use of custom attributes in EPUB Content Documents is no longer supported. See
+						<a href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>
 					<li>13-Apr-2021: Require path names in OCF to also be UTF-8 encoded. See <a
 							href="https://github.com/w3c/epub-specs/issues/1630">issue 1630</a>.</li>
 					<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in <a


### PR DESCRIPTION
I noticed while opening epubcheck issues that only the custom attributes section from the reading system spec was removed.

This PR also removes their use from authoring.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1644.html" title="Last updated on Apr 19, 2021, 12:53 PM UTC (b9b673e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1644/5bc4f65...b9b673e.html" title="Last updated on Apr 19, 2021, 12:53 PM UTC (b9b673e)">Diff</a>