### PR TITLE
Marked UTF-8 as the that SHOULD be used

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1091,7 +1091,7 @@
 							<p id="confreq-xml-xinc"> It MUST NOT make use of XInclude [[!XInclude]].</p>
 						</li>
 						<li>
-							<p id="confreq-xml-enc"> It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], but UTF-8 SHOULD be used.</p>
+							<p id="confreq-xml-enc">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], with UTF-8 as the RECOMMENDED encoding.</p>
 						</li>
 					</ul>
 
@@ -4051,7 +4051,7 @@ Spine:
 									href="#sec-css-prefixed"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], but UTF-8 SHOULD be used.</p>
+							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], with UTF-8 as the RECOMMENDED encoding.</p>
 						</li>
 					</ul>
 
@@ -9388,7 +9388,7 @@ EPUB/images/cover.png</pre>
 
 				<ul>
 
-					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 SHOULD be used. See <a
+					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 is the RECOMMENDED encoding. See <a
 						href="https://github.com/w3c/epub-specs/issues/1630">issue 1628</a>.</li>
 					<li>19-Apr-2021: The use of custom attributes in EPUB Content Documents is no longer supported. See
 							<a href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1091,7 +1091,7 @@
 							<p id="confreq-xml-xinc"> It MUST NOT make use of XInclude [[!XInclude]].</p>
 						</li>
 						<li>
-							<p id="confreq-xml-enc"> It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], but the use of UTF-16 is <a href="#deprecated">deprecated</a>..</p>
+							<p id="confreq-xml-enc"> It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], but UTF-8 SHOULD be used.</p>
 						</li>
 					</ul>
 
@@ -4051,7 +4051,7 @@ Spine:
 									href="#sec-css-prefixed"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], but the use of UTF-16 is <a href="#deprecated">deprecated</a>.</p>
+							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], but UTF-8 SHOULD be used.</p>
 						</li>
 					</ul>
 
@@ -9388,7 +9388,7 @@ EPUB/images/cover.png</pre>
 
 				<ul>
 
-					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been deprecated. See <a
+					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 SHOULD be used. See <a
 						href="https://github.com/w3c/epub-specs/issues/1630">issue 1628</a>.</li>
 					<li>19-Apr-2021: The use of custom attributes in EPUB Content Documents is no longer supported. See
 							<a href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1091,7 +1091,7 @@
 							<p id="confreq-xml-xinc"> It MUST NOT make use of XInclude [[!XInclude]].</p>
 						</li>
 						<li>
-							<p id="confreq-xml-enc"> It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p>
+							<p id="confreq-xml-enc"> It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], but the use of UTF-16 is <a href="#deprecated">deprecated</a>..</p>
 						</li>
 					</ul>
 
@@ -4070,7 +4070,7 @@ Spine:
 									href="#sec-css-prefixed"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]].</p>
+							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], but the use of UTF-16 is <a href="#deprecated">deprecated</a>.</p>
 						</li>
 					</ul>
 
@@ -9406,6 +9406,8 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been deprecated. See <a
+						href="https://github.com/w3c/epub-specs/issues/1630">issue 1628</a>.</li>
 					<li>13-Apr-2021: Require path names in OCF to also be UTF-8 encoded. See <a
 							href="https://github.com/w3c/epub-specs/issues/1630">issue 1630</a>.</li>
 					<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in <a


### PR DESCRIPTION
This is a PR implemented the proposed solution outlined in https://github.com/w3c/epub-specs/issues/1628#issuecomment-824540674 for issue #1628.

Merging this PR must be sanctioned by a WG resolution.

Fix #1628.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1645.html" title="Last updated on Apr 24, 2021, 5:59 AM UTC (a37806b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1645/5b6ea1a...a37806b.html" title="Last updated on Apr 24, 2021, 5:59 AM UTC (a37806b)">Diff</a>