### PR TITLE
Clarify that reading systems should process invalid file and path names

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -797,8 +797,8 @@
 					<li>
 						<p id="confreq-rs-scripted-readingsystem-object">It MUST extend the <a
 								href="https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object"
-									>navigator object</a> [[!HTML]] with the <code>epubReadingSystem</code>
-							interface defined in <a href="#app-epubReadingSystem"></a>. It also MUST support the
+								>navigator object</a> [[!HTML]] with the <code>epubReadingSystem</code> interface
+							defined in <a href="#app-epubReadingSystem"></a>. It also MUST support the
 								<code>dom-manipulation</code> and <code>layout-change</code> features defined in <a
 								href="#app-ers-hasFeature-features"></a> in container-constrained scripting
 							contexts.</p>
@@ -1110,6 +1110,12 @@
 
 				<section id="sec-container-filenames">
 					<h4>File Names</h4>
+
+					<p>Although EPUB Creators are required to follow various <a
+							href="https://www.w3.org/TR/epub-33/#sec-container-filenames">File and Path Name
+							restrictions</a> [[!EPUB-33]] for maximum interoperability, Reading Systems SHOULD attempt
+						to process File and Path Names that are not valid to these requirements. Invalid File and Path
+						Names may only be problematic on some operating systems.</p>
 
 					<p>This specification does not specify how a Reading System that is unable to represent OCF File and
 						Path Names would compensate for this incompatibility.</p>
@@ -2080,6 +2086,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>23-Apr-2021: Clarified that Reading Systems should attempt to process invalid file and path
+						names. See <a href="https://github.com/w3c/epub-specs/issues/1629">issue 1629</a></li>
 					<li>16-Apr-2021: Removed the section on custom attributes. See <a
 							href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution2"
 							>Working Group Resolution</a>.</li>


### PR DESCRIPTION
Adds the clarification that reading systems should process file and path names regardless of whether they are valid to the authoring requirements.

Fixes #1629.

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1629/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1629/epub33/rs/index.html)

