### PR TITLE
Group non characters in character restrictions

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5795,14 +5795,23 @@ Spine:
 									<p>Private Use Area (<code>U+E000 … U+F8FF</code>)</p>
 								</li>
 								<li>
-									<p>Non characters in Arabic Presentation Forms-A (<code>U+FDD0 … U+FDEF</code>)</p>
+									<p>All Unicode Non Characters, specifically:</p>
+									<ul>
+										<li>
+											<p>The 32 in Arabic Presentation Forms-A (<code>U+FDD0 … U+FDEF</code>)</p>
+										</li>
+										<li>
+											<p>The last two code points of the Basic Multilingual Plane
+													(<code>U+FFFE</code> and <code>U+FFFF</code></p>
+										</li>
+										<li>
+											<p>The last two code points at the end of the Supplementary Planes
+													(<code>U+1FFFE, U+1FFFF … U+EFFFE, U+EFFFF</code>)</p>
+										</li>
+									</ul>
 								</li>
 								<li>
 									<p>Specials (<code>U+FFF0 … U+FFFF</code>)</p>
-								</li>
-								<li>
-									<p>Non characters at the end of the Supplementary Planes (<code>U+1FFFE, U+1FFFF …
-											U+EFFFE, U+EFFFF</code>)</p>
 								</li>
 								<li>
 									<p>Tags and Variation Selectors Supplement (<code>U+E0000 … U+E0FFF</code>)</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5798,7 +5798,8 @@ Spine:
 									<p>All Unicode Non Characters, specifically:</p>
 									<ul>
 										<li>
-											<p>The 32 in Arabic Presentation Forms-A (<code>U+FDD0 … U+FDEF</code>)</p>
+											<p>The 32 contiguous characters in the Basic Multilingual Plane
+													(<code>U+FDD0 … U+FDEF</code>)</p>
 										</li>
 										<li>
 											<p>The last two code points of the Basic Multilingual Plane

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5803,7 +5803,7 @@ Spine:
 										</li>
 										<li>
 											<p>The last two code points of the Basic Multilingual Plane
-													(<code>U+FFFE</code> and <code>U+FFFF</code></p>
+													(<code>U+FFFE</code> and <code>U+FFFF</code>)</p>
 										</li>
 										<li>
 											<p>The last two code points at the end of the Supplementary Planes


### PR DESCRIPTION
As I mentioned on the call yesterday, would it make sense to group all the non characters together like in this PR so it's clearer what we're restricting?

There's some overlap with the subsequent character restrictions, but that's hardly consequential.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1647.html" title="Last updated on Apr 25, 2021, 5:58 PM UTC (164b4af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1647/5b6ea1a...164b4af.html" title="Last updated on Apr 25, 2021, 5:58 PM UTC (164b4af)">Diff</a>