### PR TITLE
Require Unicode full case folding and NFC normalization

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1091,7 +1091,8 @@
 							<p id="confreq-xml-xinc"> It MUST NOT make use of XInclude [[!XInclude]].</p>
 						</li>
 						<li>
-							<p id="confreq-xml-enc">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], with UTF-8 as the RECOMMENDED encoding.</p>
+							<p id="confreq-xml-enc">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], with UTF-8 as
+								the RECOMMENDED encoding.</p>
 						</li>
 					</ul>
 
@@ -4051,7 +4052,8 @@ Spine:
 									href="#sec-css-prefixed"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], with UTF-8 as the RECOMMENDED encoding.</p>
+							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], with UTF-8
+								as the RECOMMENDED encoding.</p>
 						</li>
 					</ul>
 
@@ -5816,12 +5818,11 @@ Spine:
 							</ul>
 						</li>
 						<li>
-							<p id="ocf-fn-cn">All File Names within the same directory MUST be unique following case
-								normalization as described in section 3.13 of [[!Unicode]].</p>
-						</li>
-						<li>
-							<p id="ocf-fn-an">All File Names within the same directory SHOULD be unique following NFC or
-								NFD normalization [[!TR15]].</p>
+							<p id="ocf-fn-cn">All File Names within the same directory MUST be unique following full
+								case folding [[!Unicode]] and NFC normalization [[!TR15]]. (Refer to <a
+									href="https://www.w3.org/TR/charmod-norm/#CanonicalFoldNormalizationStep">Unicode
+									Canonical Case Fold Normalization Step</a> [[CHARMOD-NORM]] for more
+								information.)</p>
 						</li>
 					</ul>
 
@@ -9387,9 +9388,10 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
-
-					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 is the RECOMMENDED encoding. See <a
-						href="https://github.com/w3c/epub-specs/issues/1630">issue 1628</a>.</li>
+					<li>24-Apr-2021: Require Unicode full case folding and NFC normalization for file name uniqueness
+						comparisons. See <a href="https://github.com/w3c/epub-specs/issues/1631">issue 1631</a>.</li>
+					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 is the recommended
+						encoding. See <a href="https://github.com/w3c/epub-specs/issues/1628">issue 1628</a>.</li>
 					<li>19-Apr-2021: The use of custom attributes in EPUB Content Documents is no longer supported. See
 							<a href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>
 					<li>13-Apr-2021: Require path names in OCF to also be UTF-8 encoded. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5819,9 +5819,9 @@ Spine:
 						</li>
 						<li>
 							<p id="ocf-fn-cn">All File Names within the same directory MUST be unique following full
-								case folding [[!Unicode]] and NFC normalization [[!TR15]]. (Refer to <a
+								case folding [[Unicode]] and NFC normalization [[TR15]]. (Refer to <a
 									href="https://www.w3.org/TR/charmod-norm/#CanonicalFoldNormalizationStep">Unicode
-									Canonical Case Fold Normalization Step</a> [[CHARMOD-NORM]] for more
+									Canonical Case Fold Normalization Step</a> [[?CHARMOD-NORM]] for more
 								information.)</p>
 						</li>
 					</ul>


### PR DESCRIPTION
Includes an informative reference to charmod-norm for more information.

Fixes #1631


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1648.html" title="Last updated on Apr 27, 2021, 3:16 PM UTC (2de6c13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1648/3b68534...2de6c13.html" title="Last updated on Apr 27, 2021, 3:16 PM UTC (2de6c13)">Diff</a>