### PR TITLE
Various editorial cleanup

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -65,7 +65,7 @@
 		<section id="sec-overview">
 			<h2>Overview</h2>
 
-			<section id="sec-purpose-scope" class="informative">
+			<section id="sec-purpose-scope">
 				<h3>Purpose and Scope</h3>
 
 				<p>This document, EPUB Accessibility Techniques, provides guidance on how to meet the
@@ -1531,7 +1531,7 @@
 				</section>
 			</section>
 		</section>
-		<section id="change-log" class="appendix informative">
+		<section id="change-log" class="appendix">
 			<h2>Change Log</h2>
 
 			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1531,7 +1531,7 @@
 				</section>
 			</section>
 		</section>
-		<section id="change-log">
+		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
 
 			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -143,7 +143,7 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This document uses the following terminology defined in EPUB 3 [[!EPUB-3]]:</p>
+				<p>This document uses the following terminology defined in EPUB 3 [[EPUB-3]]:</p>
 
 				<ul>
 					<li>
@@ -168,7 +168,7 @@
 
 				<p>In addition, it uses the definition of <a
 						href="https://www.w3.org/TR/WCAG2/#dfn-assistive-technologies">assistive technology</a> as
-					defined in [[!WCAG2]].</p>
+					defined in [[WCAG2]].</p>
 
 				<div class="note">
 					<p>An assistive technology is not always a separate application from a Reading System. Reading
@@ -287,7 +287,7 @@
 					web accessibility techniques.</p>
 
 				<p>The primary source for the production of accessible web content is the W3C Web Content Accessibility
-					Guidelines (WCAG) [[!WCAG2]]. This document leverages the extensive work done in WCAG to establish
+					Guidelines (WCAG) [[WCAG2]]. This document leverages the extensive work done in WCAG to establish
 					benchmarks for accessible content, and the same four high-level content principles — perceivable,
 					operable, understandable, and robust — are central to creating EPUB Publications that are
 					accessible.</p>
@@ -337,19 +337,19 @@
 				<section id="sec-wcag-conf">
 					<h4>WCAG Conformance Requirements</h4>
 
-					<p>An EPUB Publication has to meet the following requirements to conform to this specification:</p>
+					<p>To conform to this specification, an EPUB Publication:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-wcag-20">It MUST meet the requirements of WCAG 2.0 [[!WCAG20]], but it is
+							<p id="confreq-wcag-20">MUST meet the requirements of WCAG 2.0 [[WCAG20]], but it is
 								strongly RECOMMENDED that it conform to the <a href="https://www.w3.org/TR/WCAG2/"
 									>latest recommended version</a>.</p>
 						</li>
 
 						<li>
-							<p id="confreq-wcag-a">It MUST meet the requirements of <a
+							<p id="confreq-wcag-a">MUST meet the requirements of <a
 									href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a>, but it is strongly RECOMMENDED
-								that it meet <a href="https://www.w3.org/TR/WCAG2/#cc1">Level AA</a> [[!WCAG2]].</p>
+								that it meet <a href="https://www.w3.org/TR/WCAG2/#cc1">Level AA</a> [[WCAG2]].</p>
 						</li>
 					</ul>
 
@@ -396,10 +396,10 @@
 						<h5>Page and Publication</h5>
 
 						<p>The WCAG <a href="https://www.w3.org/TR/WCAG2/#wcag-2-layers-of-guidance">principles</a>
-							[[!WCAG2]] focus on the evaluation of individual web pages, but an EPUB Publication more
+							[[WCAG2]] focus on the evaluation of individual web pages, but an EPUB Publication more
 							closely resembles what WCAG refers to as a <a
 								href="https://www.w3.org/TR/WCAG2/#dfn-set-of-web-pages">set of web pages</a>: "[a]
-							collection of Web pages that share a common purpose" [[!WCAG2]].</p>
+							collection of Web pages that share a common purpose" [[WCAG2]].</p>
 
 						<p>Consequently, when evaluating the accessibility of an EPUB Publication, individual pages — or
 							Content Documents, as they are known in EPUB 3 — cannot be reviewed in isolation. Rather,
@@ -415,14 +415,14 @@
 							Document within it.</p>
 
 						<p>More information about applying these guidelines to EPUB Publications is available in the
-							EPUB Accessibility Techniques [[EPUB-A11Y-TECH-11]].</p>
+							EPUB Accessibility Techniques [[?EPUB-A11Y-TECH-11]].</p>
 					</section>
 
 					<section id="sec-wcag-application">
 						<h5>Applying the Conformance Criteria</h5>
 
 						<p>When evaluating an EPUB Publication, the WCAG <a
-								href="https://www.w3.org/TR/WCAG2/#conformance-reqs">conformance criteria</a> [[!WCAG2]]
+								href="https://www.w3.org/TR/WCAG2/#conformance-reqs">conformance criteria</a> [[WCAG2]]
 							are applied as follows:</p>
 
 						<ul>
@@ -431,21 +431,21 @@
 
 							<li>EPUB Creators MUST NOT use EPUB's fallback mechanisms to provide a <a
 									href="https://www.w3.org/TR/WCAG2/#dfn-conforming-alternate-version">conforming
-									alternate version</a> [[!WCAG2]], as there is no reliable way for users to access
+									alternate version</a> [[WCAG2]], as there is no reliable way for users to access
 								such fallbacks. If fallbacks are used, both the primary content and its fallback(s) MUST
 								meet the requirements for the conformance level claimed. EPUB-specific fallback
 								mechanisms include <a
 									href="https://www.w3.org/TR/epub/#sec-foreign-restrictions-manifest">manifest
-									fallbacks</a> [[!EPUB-3]], <a href="https://www.w3.org/TR/epub/#sec-opf-bindings"
-									>bindings</a> [[!EPUB-3]] and content switching via the <a
+									fallbacks</a> [[EPUB-3]], <a href="https://www.w3.org/TR/epub/#sec-opf-bindings"
+									>bindings</a> [[EPUB-3]] and content switching via the <a
 									href="https://www.w3.org/TR/epub/#sec-xhtml-content-switch"><code>epub:switch</code>
-									element</a> [[!EPUB-3]].</li>
+									element</a> [[EPUB-3]].</li>
 
 							<li>When determining compliance with the "<a href="https://www.w3.org/TR/WCAG2/#cc2">Full
-									Pages</a>" requirement [[!WCAG2]] (i.e., that parts of a page cannot be excluded
-								when making a conformance claim), the entirety of each EPUB Content Document MUST
-								achieve the conformance level <em>and</em> every Content Document in the EPUB
-								Publication MUST meet the stated conformance level.</li>
+									Pages</a>" requirement [[WCAG2]] (i.e., that parts of a page cannot be excluded when
+								making a conformance claim), the entirety of each EPUB Content Document MUST achieve the
+								conformance level <em>and</em> every Content Document in the EPUB Publication MUST meet
+								the stated conformance level.</li>
 						</ul>
 					</section>
 				</section>
@@ -619,7 +619,7 @@
 											the source whether they are reproduced or not.</li>
 									</ul>
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
-										of the content (e.g., EPUB 3 Media Overlays [[EPUB-3]]), EPUB Creators MUST
+										of the content (e.g., EPUB 3 Media Overlays [[?EPUB-3]]), EPUB Creators MUST
 										identify the page numbers in the markup that controls the playback.</p>
 								</dd>
 							</dl>
@@ -710,7 +710,7 @@
 										SHOULD be ordered such that they reflect both:</p>
 									<ul>
 										<li>the order of the referenced EPUB Content Documents in the <a
-												href="https://www.w3.org/TR/epub/#dfn-spine">spine</a> [[!EPUB-3]];
+												href="https://www.w3.org/TR/epub/#dfn-spine">spine</a> [[EPUB-3]];
 											and</li>
 										<li>the order of each element within its respective EPUB Content Document.</li>
 									</ul>
@@ -887,7 +887,7 @@
 						<li>EPUB Accessibility 1.1 + WCAG 2.1 Level AAA</li>
 					</ul>
 
-					<p>This list will change as new versions of WCAG are released. For new versions of [[!WCAG2]], only
+					<p>This list will change as new versions of WCAG are released. For new versions of [[WCAG2]], only
 						the digit after the "2." should change from the above patterns.</p>
 
 					<aside class="example">
@@ -1094,7 +1094,7 @@
 		<section id="sec-opt-pubs">
 			<h2>Optimized Publications</h2>
 
-			<p>Although WCAG [[!WCAG2]] provides a general set of guidelines for making content broadly accessible,
+			<p>Although WCAG [[WCAG2]] provides a general set of guidelines for making content broadly accessible,
 				conformant content is not always optimal for specific user groups. Conversely, content optimized for a
 				specific need or reading modality is often not conformant to WCAG because it is not designed for a broad
 				audience.</p>
@@ -1108,8 +1108,8 @@
 				achieve a WCAG conformance level does not make it any less accessible to the intended audience.</p>
 
 			<p>An EPUB Publication that has been optimized MUST identify the standard or guidelines the content adheres
-				to in a <code>conformsTo</code> property in accordance with [[!DCTERMS]]. The value of this property
-				MUST be a URL in accordance with [[!URL]] that references the standard or guidelines it follows.</p>
+				to in a <code>conformsTo</code> property in accordance with [[DCTERMS]]. The value of this property MUST
+				be a URL in accordance with [[URL]] that references the standard or guidelines it follows.</p>
 
 			<aside class="example">
 				<p>The following example shows a conformance statement for an EPUB 3 Publication that conforms to the
@@ -1355,7 +1355,7 @@
 				</section>
 			</section>
 		</section>
-		<section id="change-log">
+		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
 
 			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3958,20 +3958,20 @@ Spine:
 											content</a> or exactly one [[HTML]] <a
 											href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element"
 												><code>body</code> element</a>.</p>
-									<p class="note">MUST NOT, in the case of <a href="#sec-xhtml-svg">embedded SVGs</a>,
-										include a <code>body</code> element &#8212; see the <a
+									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
+											<code>body</code> element is not permitted per the <a
 											href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#svg-0"
 											>restrictions on SVG</a> defined in [[HTML]].</p>
 								</li>
 								<li>
-									<p id="confreq-svg-foreignObject-xhtml-frag">Its content MUST be a valid document
-										fragment that conforms to the XHTML Content Document model defined in <a
+									<p id="confreq-svg-foreignObject-xhtml-frag">MUST contain a valid document fragment
+										that conforms to the XHTML Content Document model defined in <a
 											href="#sec-xhtml-req"></a>.</p>
 								</li>
 								<li>
-									<p id="confreq-svg-foreignObject-reqext">Its <code>requiredExtensions</code>
-										attribute, if given, MUST be set to
-										"<code>http://www.idpf.org/2007/ops</code>".</p>
+									<p id="confreq-svg-foreignObject-reqext">MUST have its
+											<code>requiredExtensions</code> attribute, when set, specify the value
+											"<code>http://www.idpf.org/2007/ops</code>".</p>
 								</li>
 							</ul>
 						</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -89,7 +89,7 @@
 		<section id="sec-introduction">
 			<h2>Introduction</h2>
 
-			<section id="sec-intro-overview">
+			<section id="sec-intro-overview" class="informative">
 				<h3>Overview</h3>
 
 				<p>EPUB 3 has been widely adopted as the format for digital books (ebooks), and this revision continues
@@ -104,13 +104,13 @@
 
 				<ul>
 					<li>
-						<p><a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3 Reading Systems</a> [[!EPUB-RS-33]] —
+						<p><a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3 Reading Systems</a> [[EPUB-RS-33]] —
 							defines the processing requirements for <a>EPUB Reading Systems</a> — the applications that
 							consume EPUB Publications and present their content to users.</p>
 					</li>
 					<li>
-						<p><a href="http://www.w3.org/TR/epub-a11y-11">EPUB Accessibility</a> [[!EPUB-A11Y-11]] —
-							defines accessibility conformance and discovery requirements for EPUB Publications.</p>
+						<p><a href="http://www.w3.org/TR/epub-a11y-11">EPUB Accessibility</a> [[EPUB-A11Y-11]] — defines
+							accessibility conformance and discovery requirements for EPUB Publications.</p>
 					</li>
 				</ul>
 
@@ -457,7 +457,7 @@
 						<p>Examples of resources that are not Publication Resources include those identified by the
 							Package Document <a href="#sec-link-elem"><code>link</code> element</a> and those identified
 							in outbound hyperlinks that resolve to <a>Remote Resources</a> (e.g., referenced from the
-								<code>href</code> attribute of an [[!HTML]] <a
+								<code>href</code> attribute of an [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
 									><code>a</code></a> element).</p>
 					</dd>
@@ -485,7 +485,7 @@
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> that includes scripting or an <a>XHTML Content Document</a>
-							that contains [[!HTML]] <a href="https://html.spec.whatwg.org/multipage/forms.html#forms"
+							that contains [[HTML]] <a href="https://html.spec.whatwg.org/multipage/forms.html#forms"
 								>forms</a>.</p>
 						<p>Refer to <a href="#sec-scripted-content"></a> for more information.</p>
 					</dd>
@@ -545,11 +545,11 @@
 							Document</dfn>
 					</dt>
 					<dd>
-						<p>An <a>EPUB Content Document</a> that conforms to the profile of [[!HTML]] defined in <a
+						<p>An <a>EPUB Content Document</a> that conforms to the profile of [[HTML]] defined in <a
 								href="#sec-xhtml"></a>.</p>
 						<p>XHTML Content Documents use the <a
 								href="https://html.spec.whatwg.org/multipage/xhtml.html#xhtml">XHTML syntax</a> defined
-							in [[!HTML]].</p>
+							in [[HTML]].</p>
 					</dd>
 				</dl>
 			</section>
@@ -569,7 +569,7 @@
 				<section id="sec-shorthands-ns">
 					<h4>Namespaces</h4>
 
-					<p>For convenience, the following namespace prefixes [[!XML-NAMES]] are used in this specification
+					<p>For convenience, the following namespace prefixes [[XML-NAMES]] are used in this specification
 						without explicitly being declared. To use any of these prefixes in an <a>EPUB Content
 							Document</a>, a declaration is REQUIRED.</p>
 
@@ -604,36 +604,35 @@
 			<section id="sec-epub-conf">
 				<h3>Conformance Criteria</h3>
 
-				<p>The minimal requirements for an EPUB Publication are that:</p>
+				<p>EPUB Publications:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-package">It MUST define at least one rendering of its content as follows:</p>
+						<p id="confreq-package">MUST define at least one rendering of its content as follows:</p>
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-package-doc">It MUST contain a <a>Package Document</a> that conforms to
-										<a href="#sec-package-doc"></a> and meet all <a>Publication Resource</a>
+								<p id="confreq-package-doc">MUST contain a <a>Package Document</a> that conforms to <a
+										href="#sec-package-doc"></a> and meet all <a>Publication Resource</a>
 									requirements for the Package Document.</p>
 							</li>
 							<li>
-								<p id="confreq-nav">It MUST contain an <a>EPUB Navigation Document</a> that conforms to
-										<a href="#sec-nav-doc"></a>.</p>
+								<p id="confreq-nav">MUST contain an <a>EPUB Navigation Document</a> that conforms to <a
+										href="#sec-nav-doc"></a>.</p>
 							</li>
 						</ul>
 					</li>
 					<li>
-						<p id="confreq-res-location">Its Publication Resources MUST adhere to the requirements in <a
-								href="#sec-publication-resources"></a>.</p>
+						<p id="confreq-a11y">SHOULD conform to the accessibility requirements defined in
+							[[EPUB-A11Y-11]].</p>
 					</li>
 					<li>
-						<p id="confreq-a11y">It SHOULD conform to the accessibility requirements defined in
-							[[!EPUB-A11Y-11]].</p>
-					</li>
-					<li>
-						<p id="confreq-ocf">It MUST be packaged in an <a>EPUB Container</a> as defined in <a
+						<p id="confreq-ocf">MUST be packaged in an <a>EPUB Container</a> as defined in <a
 								href="#sec-ocf"></a>.</p>
 					</li>
 				</ul>
+
+				<p id="confreq-res-location">In addition, all Publication Resources MUST adhere to the requirements in
+						<a href="#sec-publication-resources"></a>.</p>
 
 				<p>Specific conformance details are covered in the rest of this specification.</p>
 			</section>
@@ -644,7 +643,7 @@
 				<section id="sec-core-media-types">
 					<h4>Core Media Types</h4>
 
-					<section id="sec-cmt-intro">
+					<section id="sec-cmt-intro" class="informative">
 						<h5>Introduction</h5>
 
 						<p>An <a>EPUB Publication</a> typically consists of many <a>Publication Resources</a>. These
@@ -685,14 +684,14 @@
 					<section id="sec-cmt-supported">
 						<h5>Supported Media Types</h5>
 
-						<p><a>Publication Resources</a> that conform to the following MIME media type [[!RFC2046]]
+						<p><a>Publication Resources</a> that conform to the following MIME media type [[RFC2046]]
 							specifications can be included in an EPUB Publication without fallbacks.</p>
 
 						<p>The columns in the following table represent the following information:</p>
 
 						<ul>
 							<li>
-								<p><strong>Media Type</strong>—The MIME media type [[!RFC2046]] used to represent the
+								<p><strong>Media Type</strong>—The MIME media type [[RFC2046]] used to represent the
 									given Publication Resource in the <a href="#sec-manifest-elem">manifest</a>.</p>
 								<p>If more than one media type is listed, the first one is the preferred media type. The
 									preferred media type is strongly encouraged for all new EPUB Publications.</p>
@@ -719,21 +718,21 @@
 									<td id="cmt-gif">
 										<code>image/gif</code>
 									</td>
-									<td> [[!GIF]] </td>
+									<td> [[GIF]] </td>
 									<td>GIF Images</td>
 								</tr>
 								<tr>
 									<td id="cmt-jpeg">
 										<code>image/jpeg</code>
 									</td>
-									<td> [[!JPEG]] </td>
+									<td> [[JPEG]] </td>
 									<td>JPEG Images</td>
 								</tr>
 								<tr>
 									<td id="cmt-png">
 										<code>image/png</code>
 									</td>
-									<td> [[!PNG]] </td>
+									<td> [[PNG]] </td>
 									<td>PNG Images</td>
 								</tr>
 								<tr>
@@ -749,7 +748,7 @@
 									<td id="cmt-webp">
 										<code>image/webp</code>
 									</td>
-									<td> [[!WebP-Container]], [[!WebP-LB]] </td>
+									<td> [[WebP-Container]], [[WebP-LB]] </td>
 									<td>WebP Images</td>
 								</tr>
 
@@ -760,21 +759,21 @@
 									<td id="cmt-mp3">
 										<code>audio/mpeg</code>
 									</td>
-									<td> [[!MP3]] </td>
+									<td> [[MP3]] </td>
 									<td>MP3 audio</td>
 								</tr>
 								<tr>
 									<td id="cmt-mp4-aac">
 										<code>audio/mp4</code>
 									</td>
-									<td> [[!MPEG4-Audio]], [[!MP4]] </td>
+									<td> [[MPEG4-Audio]], [[MP4]] </td>
 									<td>AAC LC audio using MP4 container</td>
 								</tr>
 								<tr>
 									<td id="cmt-ogg-opus">
 										<code>audio/opus</code>
 									</td>
-									<td>[[!RFC7845]]</td>
+									<td>[[RFC7845]]</td>
 									<td>OPUS audio using OGG container</td>
 								</tr>
 								<tr>
@@ -784,7 +783,7 @@
 									<td colspan="3" id="cmt-vide-note">EPUB 3 allows any video codecs to be included
 										without fallbacks, although none are technically considered Core Media Type
 										Resources. Although Reading Systems are recommended to support at least one of
-										the H.264 [[H264]] and VP8 [[RFC6386]] video codecs, it is not a conformance
+										the H.264 [[?H264]] and VP8 [[?RFC6386]] video codecs, it is not a conformance
 										requirement &#8212; a Reading System might support other video codecs, or none
 										at all. EPUB Creators and need to take into consideration factors such as
 										breadth of adoption, video playback quality, and technology usage royalty
@@ -810,7 +809,7 @@
 									<td colspan="3" id="cmt-font-note"> EPUB 3 allows any font resource to be included
 										without a fallback, as CSS already defines fallback rules for fonts. Refer to
 										the <a href="https://www.w3.org/TR/epub-rs-33/#confreq-css-rs-fonts">Reading
-											System support requirements for fonts</a> [[!EPUB-RS-33]] for more
+											System support requirements for fonts</a> [[EPUB-RS-33]] for more
 										information.</td>
 								</tr>
 								<tr>
@@ -819,7 +818,7 @@
 										<br />
 										<code>application/font-sfnt</code>
 									</td>
-									<td>[[!TrueType]] </td>
+									<td>[[TrueType]] </td>
 									<td>TrueType fonts</td>
 								</tr>
 								<tr>
@@ -830,7 +829,7 @@
 										<br />
 										<code>application/vnd.ms-opentype</code>
 									</td>
-									<td>[[!OpenType]]</td>
+									<td>[[OpenType]]</td>
 									<td>OpenType fonts</td>
 
 								</tr>
@@ -840,14 +839,14 @@
 										<br />
 										<code>application/font-woff</code>
 									</td>
-									<td> [[!WOFF]] </td>
+									<td> [[WOFF]] </td>
 									<td>WOFF fonts</td>
 								</tr>
 								<tr>
 									<td id="cmt-woff2">
 										<code>font/woff2</code>
 									</td>
-									<td> [[!WOFF2]] </td>
+									<td> [[WOFF2]] </td>
 									<td>WOFF2 fonts</td>
 								</tr>
 								<tr>
@@ -863,7 +862,7 @@
 									</td>
 									<td><a>XHTML Content Documents</a> that use the <a
 											href="https://html.spec.whatwg.org/multipage/xhtml.html#xhtml">XHTML
-											syntax</a> [[!HTML]]. </td>
+											syntax</a> [[HTML]]. </td>
 								</tr>
 								<tr>
 									<td id="cmt-js">
@@ -871,14 +870,14 @@
 										<br />
 										<code>text/javascript</code>
 									</td>
-									<td> [[!RFC4329]] </td>
+									<td> [[RFC4329]] </td>
 									<td>Scripts.</td>
 								</tr>
 								<tr>
 									<td id="cmt-ncx">
 										<code>application/x-dtbncx+xml</code>
 									</td>
-									<td> [[!OPF-201]] </td>
+									<td> [[OPF-201]] </td>
 									<td>The <a href="#legacy">legacy</a> NCX.</td>
 								</tr>
 
@@ -895,7 +894,7 @@
 									<td id="cmt-pls">
 										<code>application/pls+xml</code>
 									</td>
-									<td> [[!PRONUNCIATION-LEXICON]] </td>
+									<td> [[PRONUNCIATION-LEXICON]] </td>
 									<td><a>Text-to-Speech</a> (TTS) Pronunciation lexicons</td>
 								</tr>
 							</tbody>
@@ -919,9 +918,9 @@
 						<p id="confreq-foreign-no-fallback">Foreign Resources MAY be included in an EPUB Publication
 							without a fallback provided they are not referenced from <a href="#sec-itemref-elem">spine
 									<code>itemref</code> elements</a> or directly rendered in their native format in
-							EPUB Content Documents (e.g., via [[!HTML]] <a
+							EPUB Content Documents (e.g., via [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/embedded-content.html#embedded-content"
-								>embedded content</a> and [[!SVG]] <a
+								>embedded content</a> and [[SVG]] <a
 								href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"><code>image</code></a> and
 								<a href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
 									><code>foreignObject</code></a> elements).</p>
@@ -939,7 +938,7 @@
 
 						<ul>
 							<li>
-								<p>intrinsic fallback mechanisms provided by the host format (e.g., [[HTML]] elements
+								<p>intrinsic fallback mechanisms provided by the host format (e.g., [[?HTML]] elements
 									often provide the ability to reference more than one media type or to display an
 									alternate embedded message when a media type cannot be rendered); or</p>
 							</li>
@@ -951,11 +950,11 @@
 						<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback chains
 							to Core Media Type Resources. They are used to create fallbacks for Foreign Resources in the
 								<a href="#sec-spine-elem">spine</a> and when intrinsic fallback capabilities are not
-							available (e.g., for the [[!HTML]] <a
+							available (e.g., for the [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"
 									><code>img</code></a> element).</p>
 
-						<p>Refer to the [[!HTML]] and [[!SVG]] specifications for the intrinsic fallback capabilities
+						<p>Refer to the [[HTML]] and [[SVG]] specifications for the intrinsic fallback capabilities
 							their elements provide.</p>
 					</section>
 				</section>
@@ -1015,14 +1014,14 @@
 				<section id="sec-data-urls">
 					<h4>Data URLs</h4>
 
-					<p>The <a href="https://tools.ietf.org/html/rfc2397"><code>data:</code> URL scheme</a> [[!RFC2397]]
+					<p>The <a href="https://tools.ietf.org/html/rfc2397"><code>data:</code> URL scheme</a> [[RFC2397]]
 						is used to encode resources directly into a URL string. The advantage of this scheme is that it
 						allows a resource to be embedded within another, avoiding the need for an external file.</p>
 
 					<p><a>EPUB Creators</a> MAY use data URLs in EPUB Publications provided their use does not result in
 						a <a>Top-level Content Document</a> or <a
 							href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context"
-							>top-level browsing context</a> [[!HTML]]. This restriction applies to data URLs used in the
+							>top-level browsing context</a> [[HTML]]. This restriction applies to data URLs used in the
 						following scenarios:</p>
 
 					<ul>
@@ -1031,17 +1030,17 @@
 									<a>spine</a>;</p>
 						</li>
 						<li>
-							<p>in the <code>href</code> attribute on [[!HTML]] or [[!SVG]] <code>a</code> elements
-								(except when inside an <a
+							<p>in the <code>href</code> attribute on [[HTML]] or [[SVG]] <code>a</code> elements (except
+								when inside an <a
 									href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
-										><code>iframe</code> element</a> [[!HTML]]);</p>
+										><code>iframe</code> element</a> [[HTML]]);</p>
 						</li>
 						<li>
-							<p>in the <code>href</code> attribute on [[!HTML]] <code>area</code> elements (except when
+							<p>in the <code>href</code> attribute on [[HTML]] <code>area</code> elements (except when
 								inside an <code>iframe</code> element);</p>
 						</li>
 						<li>
-							<p>in calls to [[!ECMASCRIPT]] <code>window.open</code> or <code>document.open</code>.</p>
+							<p>in calls to [[ECMASCRIPT]] <code>window.open</code> or <code>document.open</code>.</p>
 						</li>
 					</ul>
 
@@ -1064,34 +1063,34 @@
 				<section id="sec-xml-constraints">
 					<h4>XML Conformance</h4>
 
-					<p>Any <a>Publication Resource</a> that is an XML-Based Media Type has to meet the following
-						constraints:</p>
+					<p>Any <a>Publication Resource</a> that is an XML-Based Media Type:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-xml-wellformed"> It MUST be a conformant XML 1.0 Document as defined in <a
+							<p id="confreq-xml-wellformed">MUST be a conformant XML 1.0 Document as defined in <a
 									href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#Conformance">Conformance of
-									Documents</a> [[!XML-NAMES]].</p>
+									Documents</a> [[XML-NAMES]].</p>
 						</li>
 						<li>
-							<p id="confreq-xml-identifiers">It MAY only specify a <a
+							<p id="confreq-xml-identifiers">MAY only specify a <a
 									href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-doctype">document type
 									declaration</a> that references an <a
 									href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">external
 									identifier</a> appropriate for its media type &#8212; as defined in <a
 									href="#app-identifiers-allowed"></a> &#8212; or that omits external identifiers
-								[[!XML]].</p>
+								[[XML]].</p>
 						</li>
 						<li>
-							<p id="confreq-xml-entities">It MUST NOT contain <a
+							<p id="confreq-xml-entities">MUST NOT contain <a
 									href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-extent">external entity</a>
-								declarations in the internal DTD subset [[!XML]].</p>
+								declarations in the internal DTD subset [[XML]].</p>
 						</li>
 						<li>
-							<p id="confreq-xml-xinc"> It MUST NOT make use of XInclude [[!XInclude]].</p>
+							<p id="confreq-xml-xinc">MUST NOT make use of XInclude [[XInclude]].</p>
 						</li>
 						<li>
-							<p id="confreq-xml-enc">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], with UTF-8 as the RECOMMENDED encoding.</p>
+							<p id="confreq-xml-enc">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8 as the
+								RECOMMENDED encoding.</p>
 						</li>
 					</ul>
 
@@ -1162,9 +1161,8 @@
 				<section id="sec-package-def">
 					<h4>Package Document Definition</h4>
 
-					<p>All [[!XML]] elements defined in this section are in the
-							<code>http://www.idpf.org/2007/opf</code> namespace [[!XML-NAMES]] unless otherwise
-						specified.</p>
+					<p>All [[XML]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
+						namespace [[XML-NAMES]] unless otherwise specified.</p>
 
 					<p>When an element defined in this section has mandatory text content, that content is referred to
 						as the value of the element in the explanatory descriptions.</p>
@@ -1180,7 +1178,7 @@
 								<code>dir</code>
 							</dt>
 							<dd>
-								<p>Specifies the base direction [[!BIDI]] of the carrying element and its
+								<p>Specifies the base direction [[BIDI]] of the carrying element and its
 									descendants.</p>
 								<p>Allowed values are:</p>
 								<ul>
@@ -1217,7 +1215,7 @@
 								<code>href</code>
 							</dt>
 							<dd>
-								<p>An absolute or relative IRI reference [[!RFC3987]] to a resource.</p>
+								<p>An absolute or relative IRI reference [[RFC3987]] to a resource.</p>
 								<div class="example">
 									<pre>&lt;link rel="record"
       href="meta/9780000000001.xml" 
@@ -1230,7 +1228,7 @@
 								<code>id</code>
 							</dt>
 							<dd>
-								<p>The ID [[!XML]] of the element, which MUST be unique within the document scope.</p>
+								<p>The ID [[XML]] of the element, which MUST be unique within the document scope.</p>
 								<div class="example">
 									<pre>&lt;dc:identifier id="pub-id"&gt;urn:isbn:97800000000001&lt;/dc:identifier&gt;</pre>
 								</div>
@@ -1260,7 +1258,7 @@
 								<code>media-type</code>
 							</dt>
 							<dd>
-								<p>A media type [[!RFC2046]] that specifies the type and format of the referenced
+								<p>A media type [[RFC2046]] that specifies the type and format of the referenced
 									resource.</p>
 								<div class="example">
 									<pre>&lt;link rel="record"
@@ -1294,7 +1292,7 @@
 							<dd>
 								<p>Establishes an association between the current expression and the element or resource
 									identified by its value. The value of the attribute must be a relative IRI
-									[[!RFC3987]] that references the resource or element being described.</p>
+									[[RFC3987]] that references the resource or element being described.</p>
 								<aside class="example">
 									<p>The following example shows the <code>refines</code> element used to indicate a
 										creator is the illustrator.</p>
@@ -1337,9 +1335,9 @@
 								<p>Specifies the language used in the contents and attribute values of the carrying
 									element and its descendants, as defined in section <a
 										href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-lang-tag">2.12 Language
-										Identification</a> of [[!XML]]. The value of each <code>xml:lang</code>
-									attribute MUST be a <a href="https://tools.ietf.org/html/bcp47#section-2.2.9"
-										>well-formed language tag</a> [[!BCP47]].</p>
+										Identification</a> of [[XML]]. The value of each <code>xml:lang</code> attribute
+									MUST be a <a href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed
+										language tag</a> [[BCP47]].</p>
 								<div class="example">
 									<pre>&lt;package … xml:lang="ja"&gt;
 	…
@@ -1500,7 +1498,7 @@
 						</div>
 
 						<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an
-							IDREF [[!XML]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"
+							IDREF [[XML]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"
 									><code>dc:identifier</code></a> element that provides the preferred, or primary,
 							identifier.</p>
 
@@ -1614,18 +1612,18 @@
 
 							<p>The Package Document is not designed to provide complex metadata encoding capabilities.
 								If more detailed information about an EPUB Publication is needed, metadata records
-								(e.g., that conform to an international standard such as [[!ONIX]] or are created for
+								(e.g., that conform to an international standard such as [[ONIX]] or are created for
 								custom purposes) can be associated using the <a href="#sec-link-elem"
 									><code>link</code></a> element. This approach allows the metadata to be processed in
 								its native form, avoiding the potential problems and information loss caused by
 								translating to use the minimal Package Document structure.</p>
 
 							<p id="core-metadata-reqs">In keeping with this philosophy, the Package Document only has
-								the following minimal metadata requirements: it MUST contain the [[!DCTERMS]] <a
+								the following minimal metadata requirements: it MUST contain the [[DCTERMS]] <a
 									href="#sec-opf-dcidentifier"><code>title</code></a>, <a
 									href="#elemdef-opf-dcidentifier"><code>identifier</code></a>, and <a
 									href="#elemdef-opf-dclanguage"><code>language</code></a> elements together with the
-								[[!DCTERMS]] <a href="#last-modified-date"><code>modified</code> property</a>. All other
+								[[DCTERMS]] <a href="#last-modified-date"><code>modified</code> property</a>. All other
 								metadata is OPTIONAL.</p>
 
 							<aside class="example">
@@ -1658,21 +1656,21 @@
 						<section id="sec-metadata-values">
 							<h5>Metadata Values</h5>
 
-							<p>The Dublin Core elements [[!DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code>
+							<p>The Dublin Core elements [[DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code>
 									element</a> have mandatory <a
 									href="https://dom.spec.whatwg.org/#concept-child-text-content">child text
-									content</a> [[!DOM]]. That content is referred to as the <dfn>value</dfn> of the
+									content</a> [[DOM]]. That content is referred to as the <dfn>value</dfn> of the
 								element in their descriptions.</p>
 
 							<p>These elements MUST have non-empty values after <a
 									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
-									>leading and trailing ASCII whitespace</a> [[!Infra]] is stripped (i.e., they must
+									>leading and trailing ASCII whitespace</a> [[Infra]] is stripped (i.e., they must
 								consist of at least one non-whitespace character).</p>
 
 							<p>Whitespace within these element values are not significant. Sequences of one or more
 								whitespace characters are <a
 									href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">collapsed
-									to a single space</a> [[!Infra]] during processing .</p>
+									to a single space</a> [[Infra]] during processing .</p>
 						</section>
 
 						<section id="sec-opf-dcmes-required">
@@ -1681,7 +1679,7 @@
 							<section id="sec-opf-dcidentifier">
 								<h6>The <code>identifier</code> Element</h6>
 
-								<p>The [[!DCTERMS]] <code>identifier</code> element contains an identifier such as a
+								<p>The [[DCTERMS]] <code>identifier</code> element contains an identifier such as a
 										<abbr title="Universally Unique Identifier">UUID</abbr>, <abbr
 										title="Digital Object Identfier">DOI</abbr> or <abbr
 										title="International Standard Book Number">ISBN</abbr>.</p>
@@ -1772,7 +1770,7 @@
 							<section id="sec-opf-dctitle">
 								<h6>The <code>title</code> Element</h6>
 
-								<p>The [[!DCTERMS]] <code>title</code> element represents an instance of a name for the
+								<p>The [[DCTERMS]] <code>title</code> element represents an instance of a name for the
 										<a>EPUB Publication</a>.</p>
 
 								<dl id="elemdef-opf-dctitle" class="elemdef">
@@ -1884,7 +1882,7 @@
 							<section id="sec-opf-dclanguage">
 								<h6>The <code>language</code> Element</h6>
 
-								<p>The [[!DCTERMS]] <code>language</code> element specifies the language of the content
+								<p>The [[DCTERMS]] <code>language</code> element specifies the language of the content
 									of the <a>EPUB Publication</a>.</p>
 
 								<dl id="elemdef-opf-dclanguage" class="elemdef">
@@ -1923,7 +1921,7 @@
 								<p>The <code>metadata</code> section MUST contain at least one <code>language</code>
 									element. The <a>value</a> of each <code>language</code> element MUST be a <a
 										href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
-										tag</a> [[!BCP47]].</p>
+										tag</a> [[BCP47]].</p>
 
 								<aside class="example">
 									<p>The following example shows an <a>EPUB Publication</a> is in U.S. English.</p>
@@ -1953,7 +1951,7 @@
 							<section id="sec-opf-dcmes-optional-def">
 								<h6>General Definition</h6>
 
-								<p>All [[!DCTERMS]] elements except for <a href="#sec-opf-dcidentifier"
+								<p>All [[DCTERMS]] elements except for <a href="#sec-opf-dcidentifier"
 											><code>identifier</code></a>, <a href="#sec-opf-dclanguage"
 											><code>language</code></a>, and <a href="#sec-opf-dctitle"
 											><code>title</code></a> are designated as OPTIONAL. These elements conform
@@ -2010,14 +2008,14 @@
 									</dd>
 								</dl>
 
-								<p>This specification does not modify the [[!DCTERMS]] element definitions except as
+								<p>This specification does not modify the [[DCTERMS]] element definitions except as
 									noted in the following sections.</p>
 							</section>
 
 							<section id="sec-opf-dccontributor">
 								<h6>The <code>contributor</code> Element</h6>
 
-								<p>The [[!DCTERMS]] <code>contributor</code> element is used to represent the name of a
+								<p>The [[DCTERMS]] <code>contributor</code> element is used to represent the name of a
 									person, organization, etc. that played a secondary role in the creation of the
 									content.</p>
 
@@ -2029,7 +2027,7 @@
 							<section id="sec-opf-dccreator">
 								<h6>The <code>creator</code> Element</h6>
 
-								<p>The [[!DCTERMS]] <code>creator</code> element represents the name of a person,
+								<p>The [[DCTERMS]] <code>creator</code> element represents the name of a person,
 									organization, etc. responsible for the creation of the content. The <a href="#role"
 											><code>role</code> property</a> can be <a href="#subexpression">associated
 										with the element</a> to indicate the function the creator played.</p>
@@ -2092,14 +2090,14 @@
 							<section id="sec-opf-dcdate">
 								<h6>The <code>date</code> Element</h6>
 
-								<p>The [[!DCTERMS]] <code>date</code> element MUST only be used to define the
-									publication date of the <a>EPUB Publication</a>. The publication date is not the
-									same as the <a href="#last-modified-date">last modified date</a> (the last time the
-									EPUB Publication was changed).</p>
+								<p>The [[DCTERMS]] <code>date</code> element MUST only be used to define the publication
+									date of the <a>EPUB Publication</a>. The publication date is not the same as the <a
+										href="#last-modified-date">last modified date</a> (the last time the EPUB
+									Publication was changed).</p>
 
-								<p>It is RECOMMENDED that the date string conform to [[!ISO8601]], particularly the
-									subset expressed in W3C Date and Time Formats [[!DateTime]], as such strings are
-									both human and machine readable.</p>
+								<p>It is RECOMMENDED that the date string conform to [[ISO8601]], particularly the
+									subset expressed in W3C Date and Time Formats [[DateTime]], as such strings are both
+									human and machine readable.</p>
 
 								<aside class="example">
 									<p>The following example shows a publication date.</p>
@@ -2112,7 +2110,7 @@
 								</aside>
 
 								<p>Additional dates SHOULD be expressed using the specialized date properties available
-									in the [[!DCTERMS]] vocabulary, or similar.</p>
+									in the [[DCTERMS]] vocabulary, or similar.</p>
 
 								<p>Only one <code>date</code> element is allowed.</p>
 							</section>
@@ -2120,7 +2118,7 @@
 							<section id="sec-opf-dcsubject">
 								<h6>The <code>subject</code> Element</h6>
 
-								<p>The [[!DCTERMS]] <code>subject</code> element identifies the subject of the EPUB
+								<p>The [[DCTERMS]] <code>subject</code> element identifies the subject of the EPUB
 									Publication. The <a>value</a> of the element SHOULD be the human-readable heading or
 									label, but MAY be the code value if the subject taxonomy does not provide a separate
 									descriptive label.</p>
@@ -2156,12 +2154,12 @@
 							<section id="sec-opf-dctype">
 								<h6>The <code>type</code> Element</h6>
 
-								<p>The [[!DCTERMS]] <code>type</code> element is used to indicate that the EPUB
+								<p>The [[DCTERMS]] <code>type</code> element is used to indicate that the EPUB
 									Publication is of a specialized type (e.g., annotations or a dictionary packaged in
 									EPUB format).</p>
 
 								<p>An informative registry of specialized EPUB Publication types for use with this
-									element is maintained in the [[TypesRegistry]], but EPUB Creators MAY use any text
+									element is maintained in the [[?TypesRegistry]], but EPUB Creators MAY use any text
 									string as a <a>value</a>.</p>
 							</section>
 						</section>
@@ -2268,13 +2266,13 @@
 								MAY be used to refine the meaning of other subexpressions, thereby creating chains of
 								information.</p>
 
-							<p class="note">All the DCMES [[!DCTERMS]] elements represent primary expressions, and
-								permit refinement by meta element subexpressions.</p>
+							<p class="note">All the DCMES [[DCTERMS]] elements represent primary expressions, and permit
+								refinement by meta element subexpressions.</p>
 
 							<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a
 									href="#sec-default-vocab">default vocabulary</a> for use with the
 									<code>property</code> attribute. If the attribute's value does not include a prefix,
-								the following IRI [[!RFC3987]] stem MUST be used to generate the resulting IRI:
+								the following IRI [[RFC3987]] stem MUST be used to generate the resulting IRI:
 									<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
 
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
@@ -2310,9 +2308,9 @@
 							<h5>Last Modified Date</h5>
 
 							<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one
-								[[!DCTERMS]] <code>modified</code> property containing the last modification date. The
-									<a>value</a> of this property MUST be an [[!XMLSCHEMA-2]] dateTime conformant date
-								of the form: <code>CCYY-MM-DDThh:mm:ssZ</code></p>
+								[[DCTERMS]] <code>modified</code> property containing the last modification date. The
+									<a>value</a> of this property MUST be an [[XMLSCHEMA-2]] dateTime conformant date of
+								the form: <code>CCYY-MM-DDThh:mm:ssZ</code></p>
 
 							<p>The last modification date MUST be expressed in Coordinated Universal Time (UTC) and MUST
 								be terminated by the "<code>Z</code>" (Zulu) time zone indicator.</p>
@@ -2434,8 +2432,8 @@
 								NOT be listed in the <a href="#sec-manifest-elem">manifest</a>. A linked resource MAY be
 								embedded in a Publication Resource that is listed in the manifest, however, in which
 								case it MUST be a <a href="#sec-core-media-types">Core Media Type Resource</a> (e.g., an
-									<a>EPUB Content Document</a> could contain a metadata record serialized as
-								[[RDFA-CORE]] or [[JSON-LD]]).</p>
+									<a>EPUB Content Document</a> could contain a metadata record serialized as RDFa
+								[[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]]).</p>
 
 							<aside class="example">
 								<p>The following example shows a reference to a metadata record embedded in a
@@ -2481,7 +2479,7 @@
 							<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the
 								language of the linked resource. The value MUST be a <a
 									href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language tag</a>
-								[[!BCP47]].</p>
+								[[BCP47]].</p>
 
 							<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated
 								list of <a href="#sec-property-datatype">property</a> values that establish the
@@ -2513,7 +2511,7 @@
 							<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a
 									href="#sec-default-vocab">default vocabulary</a> for the <code>rel</code> and
 									<code>properties</code> attributes. If any of these attributes' values do not
-								include a prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the
+								include a prefix, the following IRI [[RFC3987]] stem MUST be used to generate the
 								resulting IRI for them: <code>http://idpf.org/epub/vocab/package/link/#</code></p>
 
 							<p><a>EPUB Creators</a> MAY add relationships and properties from other vocabularies as
@@ -2541,7 +2539,7 @@
 								Reading Systems are not required to process these records.</p>
 
 							<p>When a Reading System <a href="https://www.w3.org/TR/epub-rs-33/#sec-linked-records"
-									>processes linked records</a> [[!EPUB-RS-33]], the document order of
+									>processes linked records</a> [[EPUB-RS-33]], the document order of
 									<code>link</code> elements is used to determine which has the highest priority in
 								the case of conflicts (i.e., first in document order has the highest priority).</p>
 
@@ -2713,10 +2711,10 @@
 							</dl>
 
 							<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the IRI
-								[[!RFC3987]] provided in its <code>href</code> attribute. The IRI MAY be absolute or
+								[[RFC3987]] provided in its <code>href</code> attribute. The IRI MAY be absolute or
 								relative, but each IRI MUST be unique within the <code>manifest</code> scope after <a
 									href="https://www.w3.org/TR/epub-rs-33/#sec-pkg-doc-relative-iris">resolution to an
-									absolute IRI</a> [[!EPUB-RS-33]].</p>
+									absolute IRI</a> [[EPUB-RS-33]].</p>
 
 							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
 								element MUST conform to the applicable specification(s) as inferred from the MIME media
@@ -2724,7 +2722,7 @@
 								attribute</a>. <a>Core Media Type Resources</a> MUST use the media type designated in <a
 									href="#sec-cmt-supported"></a>.</p>
 
-							<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[!XML]]
+							<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[XML]]
 								that identifies a fallback for the Publication Resource referenced from the
 									<code>item</code> element. Fallbacks MAY be provided for <a>Core Media Type
 									Resources</a> (e.g., to provide a static alternative to a <a>Scripted Content
@@ -2734,7 +2732,7 @@
 							<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
 									Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
 									<code>properties</code> attribute. If any of the attribute's values do not include a
-								prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the resulting IRI
+								prefix, the following IRI [[RFC3987]] stem MUST be used to generate the resulting IRI
 								for them: <code>http://idpf.org/epub/vocab/package/item/#</code></p>
 
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
@@ -2747,7 +2745,7 @@
 								using the <code>nav</code> property.</p>
 
 							<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF
-								[[!XML]] that identifies the <a>Media Overlay Document</a> for the resource described by
+								[[XML]] that identifies the <a>Media Overlay Document</a> for the resource described by
 								this <code>item</code>. Refer to <a href="#sec-docs-package"></a> for more
 								information.</p>
 
@@ -2852,8 +2850,8 @@ Manifest:
 								<p>The following example shows a link to the same audio file, but in this case the file
 									is not listed in the manifest (hyperlinked Remote Resources are not Publication
 									Resources). The audio file would only be listed in the manifest if the EPUB Creator
-									has also referenced it from an [[HTML]] embedded content element, as above (i.e., in
-									a context where it is used as a Publication Resource).</p>
+									has also referenced it from an [[?HTML]] embedded content element, as above (i.e.,
+									in a context where it is used as a Publication Resource).</p>
 								<pre>XHTML:
 &lt;a href="http://www.example.com/book/audio/ch01.mp4"&gt;Go to audio file&lt;/a&gt;
 
@@ -2885,7 +2883,7 @@ Spine:
 
 							<p>Foreign Resources MAY be referenced in contexts in which an intrinsic fallback cannot be
 								provided (e.g., directly from <a>spine</a>
-								<a href="#elemdef-spine-itemref"><code>itemref</code> elements</a>; from [[!HTML]]
+								<a href="#elemdef-spine-itemref"><code>itemref</code> elements</a>; from [[HTML]]
 									<code>img</code>, <code>iframe</code> and <code>link</code> elements in <a>XHTML
 									Content Documents</a>; and from <code>@import</code> rules in CSS Style Sheets).
 								Manifest fallbacks MUST be provided in such cases.</p>
@@ -2893,7 +2891,7 @@ Spine:
 							<p>Manifest fallbacks are provided using the <a href="#attrdef-item-fallback"
 										><code>fallback</code> attribute</a> on the <a>manifest</a>
 								<a href="#elemdef-package-item"><code>item</code></a> element that represents the
-								Publication Resource. The <code>fallback</code> attribute's IDREF [[!XML]] value MUST
+								Publication Resource. The <code>fallback</code> attribute's IDREF [[XML]] value MUST
 								resolve to another <code>item</code> in the <code>manifest</code>. This fallback
 									<code>item</code> MAY itself specify another fallback <code>item</code>, and so
 								on.</p>
@@ -2938,7 +2936,7 @@ Spine:
 							<p>The <code>bindings</code> element defines a set of custom handlers for media types not
 								supported by this specification. Its use is <a href="#deprecated">deprecated</a>.</p>
 
-							<p>Refer to [[!EPUBPublications-301]] for more information about this element.</p>
+							<p>Refer to [[EPUBPublications-301]] for more information about this element.</p>
 						</section>
 					</section>
 
@@ -3013,7 +3011,7 @@ Spine:
 								Publication Resources in the <code>spine</code> MUST themselves be listed in the
 									<code>spine</code>, where hyperlinking is defined to be any linking mechanism that
 								requires the user to navigate away from the current resource. Common hyperlinking
-								mechanisms include the <code>href</code> attribute of the [[!HTML]] <a
+								mechanisms include the <code>href</code> attribute of the [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
 										><code>a</code></a> and <a
 									href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element"
@@ -3032,7 +3030,7 @@ Spine:
 									resources).</p>
 							</div>
 
-							<p>Embedded Publication Resources (e.g., via the [[!HTML]] <a
+							<p>Embedded Publication Resources (e.g., via the [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
 										><code>iframe</code></a> element) do not have to be listed in the
 									<code>spine</code>.</p>
@@ -3051,8 +3049,8 @@ Spine:
 								allow the application of alternate style sheets).</p>
 
 							<p>The <a href="#legacy">legacy</a>
-								<code>toc</code> attribute takes an IDREF [[!XML]] that identifies the manifest item
-								that represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
+								<code>toc</code> attribute takes an IDREF [[XML]] that identifies the manifest item that
+								represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
 						</section>
 
 						<section id="sec-itemref-elem">
@@ -3117,10 +3115,9 @@ Spine:
 							</dl>
 
 							<p id="attrdef-itemref-idref">Each <code>itemref</code> element MUST reference the ID
-								[[!XML]] of a unique <a href="#elemdef-package-item"><code>item</code></a> in the
-									<a>manifest</a> via the IDREF [[!XML]] in its <code>idref</code> attribute (i.e.,
-								two or more <code>itemref</code> elements cannot reference the same
-								<code>item</code>).</p>
+								[[XML]] of a unique <a href="#elemdef-package-item"><code>item</code></a> in the
+									<a>manifest</a> via the IDREF [[XML]] in its <code>idref</code> attribute (i.e., two
+								or more <code>itemref</code> elements cannot reference the same <code>item</code>).</p>
 
 							<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a)
 								an <a>EPUB Content Document</a> or b) another type of <a>Publication Resource</a> which,
@@ -3167,7 +3164,7 @@ Spine:
 							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
 									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>
 								for the <code>properties</code> attribute. If any of the attribute's values do not
-								include a prefix, the following IRI [[!RFC3987]] stem MUST be used to generate the
+								include a prefix, the following IRI [[RFC3987]] stem MUST be used to generate the
 								resulting IRI for them: <code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
 
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
@@ -3280,9 +3277,9 @@ Spine:
 								identifies all conformant <code>collection</code> elements. The role of each
 									<code>collection</code> element in the Package Document MUST be identified in its
 									<code>role</code> attribute, whose value MUST be one or more NMTOKENs
-								[[!XMLSCHEMA-2]] and/or absolute IRIs [[!RFC3987]]. The use of NMTOKEN values is
-								reserved for roles not defined in EPUB, which are maintained in the [[!RoleRegistry]].
-								NMTOKEN values not defined in the registry are not valid. No roles are defined in this
+								[[XMLSCHEMA-2]] and/or absolute IRIs [[RFC3987]]. The use of NMTOKEN values is reserved
+								for roles not defined in EPUB, which are maintained in the [[RoleRegistry]]. NMTOKEN
+								values not defined in the registry are not valid. No roles are defined in this
 								section.</p>
 
 							<p>Third parties MAY define custom roles for the <code>collection</code> element, but such
@@ -3390,37 +3387,37 @@ Spine:
 							<h6>The <code>meta</code> Element</h6>
 
 							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
-										><code>meta</code> element</a> [[!OPF-201]] is a <a href="#legacy">legacy</a>
+										><code>meta</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a>
 								feature that previously provided a means of including generic metadata. It is replaced
 								in EPUB 3 by the updated <a href="#sec-meta-elem"><code>meta</code> element</a>, which
 								uses different attributes and requires text content.</p>
 
 							<p>For more information about the <code>meta</code> element, refer to its definition in
-								[[!OPF-201]].</p>
+								[[OPF-201]].</p>
 						</section>
 
 						<section id="sec-opf2-guide">
 							<h6>The <code>guide</code> Element</h6>
 
 							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
-										><code>guide</code> element</a> [[!OPF-201]] is a <a href="#legacy">legacy</a>
+										><code>guide</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a>
 								feature that previously provided machine-processable navigation to key structures. It is
 								replaced in EPUB 3 by <a href="#sec-nav-landmarks">landmarks</a> in the <a>EPUB
 									Navigation Document</a>.</p>
 
 							<p>For more information about the <code>guide</code> element, refer to its definition in
-								[[!OPF-201]].</p>
+								[[OPF-201]].</p>
 						</section>
 
 						<section id="sec-opf2-ncx">
 							<h6>NCX</h6>
 
 							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a>
-								[[!OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the
-								table of contents. It is replaced in EPUB 3 by the <a href="#sec-nav">EPUB Navigation
+								[[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table
+								of contents. It is replaced in EPUB 3 by the <a href="#sec-nav">EPUB Navigation
 									Document</a>.</p>
 
-							<p>For more information about the NCX, refer to its definition in [[!OPF-201]].</p>
+							<p>For more information about the NCX, refer to its definition in [[OPF-201]].</p>
 						</section>
 					</section>
 				</section>
@@ -3432,39 +3429,39 @@ Spine:
 			<section id="sec-xhtml">
 				<h3>XHTML Content Documents</h3>
 
-				<section id="sec-xhtml-intro">
+				<section id="sec-xhtml-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>This section defines a profile of [[!HTML]] for creating XHTML Content Documents. An instance of
+					<p>This section defines a profile of [[HTML]] for creating XHTML Content Documents. An instance of
 						an XML document that conforms to this profile is a <a>Core Media Type Resource</a> and is
 						referred to in this specification as an <a>XHTML Content Document</a>.</p>
-
-					<p>Unless otherwise specified, this specification inherits all definitions of semantics, structure,
-						and processing behaviors from the [[!HTML]] specification.</p>
 				</section>
 
 				<section id="sec-xhtml-req">
 					<h4>XHTML Requirements</h4>
 
-					<p>An XHTML Content Document has to meet the following basic requirements:</p>
+					<p>An XHTML Content Document:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-cd-html-docprops-syntax">It MUST be an [[!HTML]] document that conforms to
-								the <a href="https://html.spec.whatwg.org/multipage/xhtml.html#xhtml">XHTML</a>
-								syntax.</p>
+							<p id="confreq-cd-html-docprops-syntax">MUST be an [[HTML]] document that conforms to the <a
+									href="https://html.spec.whatwg.org/multipage/xhtml.html#xhtml">XHTML</a> syntax.</p>
 						</li>
 						<li>
-							<p id="confreq-cd-html-docprops-html">It MUST conform to the conformance criteria for all
-								document constructs defined by [[!HTML]] unless explicitly overridden in <a
+							<p id="confreq-cd-html-docprops-html">MUST conform to the conformance criteria for all
+								document constructs defined by [[HTML]] unless explicitly overridden in <a
 									href="#sec-xhtml-deviations"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-cd-html-docprops-schema">It MAY include extensions to the [[!HTML]] grammar
-								as defined in <a href="#sec-xhtml-extensions"></a>, and MUST conform to all content
+							<p id="confreq-cd-html-docprops-schema">MAY include extensions to the [[HTML]] grammar as
+								defined in <a href="#sec-xhtml-extensions"></a>, and MUST conform to all content
 								conformance constraints defined therein.</p>
 						</li>
 					</ul>
+
+					<p>Unless specified otherwise, XHTML Content Documents inherit all definitions of semantics,
+						structure, and processing behaviors from the [[HTML]] specification.</p>
+
 					<div class="note">
 						<p>The recommendation that EPUB Publications follow the accessibility requirements in
 							[[EPUB-A11Y-11]] applies to XHTML Content Documents. See <a href="#confreq-a11y"
@@ -3475,7 +3472,7 @@ Spine:
 				<section id="sec-xhtml-extensions">
 					<h4>HTML Extensions</h4>
 
-					<p>This section defines EPUB 3 <a>XHTML Content Document</a> extensions to the underlying [[!HTML]]
+					<p>This section defines EPUB 3 <a>XHTML Content Document</a> extensions to the underlying [[HTML]]
 						document model.</p>
 
 					<div class="note">
@@ -3492,7 +3489,7 @@ Spine:
 								<a>XHTML Content Documents</a> to express <a href="#sec-structural-semantics-intro"
 								>structural semantics</a>.</p>
 
-						<p>As the [[!HTML]] <a
+						<p>As the [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element"
 									><code>head</code> element</a> contains metadata for the document, structural
 							semantics expressed on this element or any descendant of it have no meaning.</p>
@@ -3501,11 +3498,11 @@ Spine:
 					<section id="sec-xhtml-rdfa">
 						<h5>RDFa</h5>
 
-						<p>The [[!HTML-RDFA]] specification defines a set of attributes that MAY be used in <a>XHTML
+						<p>The [[HTML-RDFA]] specification defines a set of attributes that MAY be used in <a>XHTML
 								Content Documents</a> to semantically enrich the content. The use of these attributes
-							MUST conform to the requirements defined in [[!HTML-RDFA]].</p>
+							MUST conform to the requirements defined in [[HTML-RDFA]].</p>
 
-						<p>The [[!HTML-RDFA]] specification defines changes to the [[!HTML]] content model when RDFa
+						<p>The [[HTML-RDFA]] specification defines changes to the [[HTML]] content model when RDFa
 							attributes are used. This modified content model is valid in XHTML Content Documents.</p>
 
 						<div class="note">
@@ -3521,22 +3518,19 @@ Spine:
 					<section id="sec-xhtml-ssml-attrib">
 						<h5>SSML Attributes</h5>
 
-						<section id="sec-cd-ssml-intro">
+						<section id="sec-cd-ssml-intro" class="informative">
 							<h6>Introduction</h6>
 
-							<p>The W3C Speech Synthesis Markup Language [[!SSML]] is a language used for assisting
+							<p>The W3C Speech Synthesis Markup Language [[SSML]] is a language used for assisting
 									<a>Text-to-Speech</a> (TTS) engines in generating synthetic speech. Although SSML is
 								designed as a standalone document type, it also defines semantics suitable for use
 								within other markup languages.</p>
 
-							<p>This specification recasts the [[!SSML]] <a
+							<p>This specification recasts the [[SSML]] <a
 									href="https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#S3.1.10"
 										><code>phoneme</code> element</a> as two attributes — <code>ssml:ph</code> and
 									<code>ssml:alphabet</code> — and makes them available within XHTML Content
 								Documents.</p>
-
-							<p>Reading Systems with <a>Text-to-Speech</a> (TTS) capabilities SHOULD support the SSML
-								Attributes as defined below.</p>
 
 							<div class="note">
 								<p>For more information on EPUB 3 features related to synthetic speech, refer to <a
@@ -3581,8 +3575,8 @@ Spine:
 								</dd>
 							</dl>
 
-							<p>This attribute inherits all the semantics of the [[!SSML]] <code>phoneme</code> element
-									<a href="https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#S3.1.10"
+							<p>This attribute inherits all the semantics of the [[SSML]] <code>phoneme</code> element <a
+									href="https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#S3.1.10"
 										><code>ph</code></a> attribute, with the following addition:</p>
 
 							<ul class="conformance-list">
@@ -3629,8 +3623,8 @@ Spine:
 								</dd>
 							</dl>
 
-							<p>This attribute inherits all the semantics of the [[!SSML]] <code>phoneme</code> element
-									<a href="https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#S3.1.10"
+							<p>This attribute inherits all the semantics of the [[SSML]] <code>phoneme</code> element <a
+									href="https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#S3.1.10"
 										><code>alphabet</code></a> attribute, with the following addition:</p>
 
 							<ul class="conformance-list">
@@ -3663,7 +3657,7 @@ Spine:
 							scripting capabilities of the <a>EPUB Reading System</a>.</p>
 
 						<p>Use of the <code>switch</code> element is <a href="#deprecated">deprecated</a>. Refer to its
-							definition in [[!EPUBContentDocs-301]] for usage information.</p>
+							definition in [[EPUBContentDocs-301]] for usage information.</p>
 					</section>
 
 					<section id="sec-xhtml-epub-trigger">
@@ -3674,21 +3668,21 @@ Spine:
 							non-scripted contexts.</p>
 
 						<p>Use of the <code>trigger</code> element is <a href="#deprecated">deprecated</a>. Refer to its
-							definition in [[!EPUBContentDocs-301]] for usage information.</p>
+							definition in [[EPUBContentDocs-301]] for usage information.</p>
 					</section>
 				</section>
 
 				<section id="sec-xhtml-deviations">
 					<h4>HTML Deviations and Constraints</h4>
 
-					<p>This section defines deviations from, and constraints on, the underlying [[!HTML]] document model
+					<p>This section defines deviations from, and constraints on, the underlying [[HTML]] document model
 						applicable to EPUB 3 <a>XHTML Content Documents</a>.</p>
 
 					<section id="sec-xhtml-mathml">
 						<h5>Embedded MathML</h5>
 
 						<p>XHTML Content Documents support embedded [[MATHML3]]. Occurrences of MathML markup MUST
-							conform to the constraints expressed in the MathML specification [[!MATHML3]], with the
+							conform to the constraints expressed in the MathML specification [[MATHML3]], with the
 							following additional restrictions:</p>
 
 						<dl class="conformance-list">
@@ -3714,7 +3708,7 @@ Spine:
 							<dt id="math-deprecated">Deprecated MathML</dt>
 							<dd>
 								<p id="confreq-mathml-deprecated">Elements and attributes marked as deprecated in
-									[[!MATHML3]] MUST NOT be included within MathML markup in XHTML Content
+									[[MATHML3]] MUST NOT be included within MathML markup in XHTML Content
 									Documents.</p>
 							</dd>
 						</dl>
@@ -3734,7 +3728,7 @@ Spine:
 
 						<p><a>XHTML Content Documents</a> support the embedding of <a
 								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
-								fragments</a> [[!SVG]] <em>by reference</em> (embedding via reference, for example, from
+								fragments</a> [[SVG]] <em>by reference</em> (embedding via reference, for example, from
 							an <code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
 							direct inclusion of the <code>svg</code> element in the XHTML Content Document).</p>
 
@@ -3757,10 +3751,10 @@ Spine:
 							<dt>Private Use Characters and Embedded Fonts</dt>
 							<dd>
 								<p id="confreq-html-unicode-pua">Any included characters that map to a code point within
-									one of the Private Use Area (PUA) ranges as defined in [[!Unicode]] MUST occur
-									within a string that is styled or attributed in a manner that includes a reference
-									to an embedded font [[!CSS-Fonts-3]] that contains an appropriate glyph for that
-									code point.</p>
+									one of the Private Use Area (PUA) ranges as defined in [[Unicode]] MUST occur within
+									a string that is styled or attributed in a manner that includes a reference to an
+									embedded font [[CSS-Fonts-3]] that contains an appropriate glyph for that code
+									point.</p>
 							</dd>
 						</dl>
 					</section>
@@ -3782,12 +3776,12 @@ Spine:
 						<section id="sec-xhtml-deviations-embed">
 							<h6>The <code>embed</code> Element</h6>
 
-							<p id="confreq-html-vocab-embed">Since the [[!HTML]] <a
+							<p id="confreq-html-vocab-embed">Since the [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element"
 										><code>embed</code></a> element does not include intrinsic facilities to provide
 								fallback content for Reading Systems that do not support scripting, <a>EPUB Creators</a>
 								are discouraged from using the element when the referenced resource includes scripting.
-								The [[!HTML]] <a
+								The [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element"
 										><code>object</code> element</a> can be used instead, as it includes intrinsic
 								fallback capabilities.</p>
@@ -3800,7 +3794,7 @@ Spine:
 						<p id="confreq-resources-cd-fallback">Foreign Resources MAY be referenced from elements that
 							have intrinsic fallback mechanisms, where an intrinsic fallback method is the capability to
 							offer an alternative presentation if the foreign resource is not supported. For example,
-							most [[!HTML]] <a
+							most [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/embedded-content.html#embedded-content"
 								>embedded content elements</a> provide options for alternative rendering, such as
 							allowing multiple sources to be specified or allowing embedded HTML content for when a
@@ -3808,7 +3802,7 @@ Spine:
 							be provided via the given element's intrinsic fallback mechanism when a Foreign Resource is
 							referenced.</p>
 
-						<p id="confreq-resources-cd-fallback-media">[[!HTML]] <a
+						<p id="confreq-resources-cd-fallback-media">[[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a> MAY
 							be embedded within the <a
 								href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
@@ -3819,7 +3813,7 @@ Spine:
 							fallback Core Media Type Resource.</p>
 
 						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that can be associated
-							with to the [[!HTML]] <a
+							with to the [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"
 									><code>img</code> element</a>, the following fallback conditions apply to its
 							use:</p>
@@ -3846,7 +3840,7 @@ Spine:
 									>manifest fallbacks</a> are defined.</li>
 						</ul>
 
-						<p>The following [[!HTML]] elements can refer to <a href="#sec-core-media-types">Foreign
+						<p>The following [[HTML]] elements can refer to <a href="#sec-core-media-types">Foreign
 								Resources</a> without having to provide a fallback Core Media Type Resource:</p>
 
 						<ul>
@@ -3890,7 +3884,7 @@ Spine:
 				<h3>SVG Content Documents</h3>
 
 				<div class="caution">
-					<p>Some features of [[!SVG]] are not fully supported in <a>Reading Systems</a> or supported across
+					<p>Some features of [[SVG]] are not fully supported in <a>Reading Systems</a> or supported across
 						all platforms on which Reading Systems run. When utilizing such features, <a>EPUB Creators</a>
 						need to consider the inherent risks in terms of the potential impact on interoperability and
 						document longevity.</p>
@@ -3922,17 +3916,17 @@ Spine:
 				<section id="sec-svg-req">
 					<h4>SVG Requirements</h4>
 
-					<p>An SVG Content Document has to meet the following requirements:</p>
+					<p>An SVG Content Document:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-cd-svg-docprops-schema">It MUST be an <a
+							<p id="confreq-cd-svg-docprops-schema">MUST be an <a
 									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles">SVG
-									document fragment</a> [[!SVG]] and conform to all content conformance constraints
+									document fragment</a> [[SVG]] and conform to all content conformance constraints
 								expressed in <a href="#sec-svg-restrictions"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-svg-structural-semantics">It MAY specify the <a href="#attrdef-epub-type"
+							<p id="confreq-svg-structural-semantics">MAY specify the <a href="#attrdef-epub-type"
 										><code>epub:type</code></a> attribute for expressing <a
 									href="#app-structural-semantics">structural semantics</a> and use all applicable <a
 									href="#sec-vocab-assoc">vocabulary association mechanisms</a>.</p>
@@ -3954,19 +3948,18 @@ Spine:
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-svg-foreignObject">The [[!SVG]] <a
+							<p id="confreq-svg-foreignObject">The [[SVG]] <a
 									href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
-										><code>foreignObject</code></a> element MUST adhere to the following
-								criteria:</p>
+										><code>foreignObject</code></a> element:</p>
 							<ul class="conformance-list">
 								<li>
-									<p id="confreq-svg-foreignObject-xhtml-content">It MUST contain either [[!HTML]] <a
+									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[HTML]] <a
 											href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow
-											content</a> or exactly one [[!HTML]] <a
+											content</a> or exactly one [[HTML]] <a
 											href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element"
 												><code>body</code> element</a>.</p>
-									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
-											<code>body</code> element is not permitted per the <a
+									<p class="note">MUST NOT, in the case of <a href="#sec-xhtml-svg">embedded SVGs</a>,
+										include a <code>body</code> element &#8212; see the <a
 											href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#svg-0"
 											>restrictions on SVG</a> defined in [[HTML]].</p>
 								</li>
@@ -3983,7 +3976,7 @@ Spine:
 							</ul>
 						</li>
 						<li>
-							<p id="confreq-svg-title">The [[!SVG]] <a
+							<p id="confreq-svg-title">The [[SVG]] <a
 									href="https://www.w3.org/TR/SVG/struct.html#TitleElement"><code>title</code></a>
 								element MUST contain only valid <a href="#sec-xhtml-req">XHTML Content Document Phrasing
 									content</a>.</p>
@@ -4027,31 +4020,31 @@ Spine:
 				<section id="sec-css-req">
 					<h4>CSS Requirements</h4>
 
-					<p>A CSS style sheet has to meet the following requirements:</p>
+					<p>A CSS style sheet:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-css-props">It MAY include any CSS properties, with the following
-								exceptions:</p>
+							<p id="confreq-css-props">MAY include any CSS properties, with the following exceptions:</p>
 							<ul class="conformance-list">
 								<li>
 									<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
 											href="https://www.w3.org/TR/css3-writing-modes/#direction"
-												><code>direction</code> property</a> [[!CSS-Writing-Modes-3]].</p>
+												><code>direction</code> property</a> [[CSS-Writing-Modes-3]].</p>
 								</li>
 								<li>
 									<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT include the <a
 											href="https://www.w3.org/TR/css3-writing-modes/#unicode-bidi"
-												><code>unicode-bidi</code> property</a> [[!CSS-Writing-Modes-3]].</p>
+												><code>unicode-bidi</code> property</a> [[CSS-Writing-Modes-3]].</p>
 								</li>
 							</ul>
 						</li>
 						<li>
-							<p id="confreq-css-prefixed">It MAY include the prefixed properties defined in <a
+							<p id="confreq-css-prefixed">MAY include the prefixed properties defined in <a
 									href="#sec-css-prefixed"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-css-encoding">It MUST be encoded in UTF-8 or UTF-16 [[!Unicode]], with UTF-8 as the RECOMMENDED encoding.</p>
+							<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8 as
+								the RECOMMENDED encoding.</p>
 						</li>
 					</ul>
 
@@ -4064,9 +4057,9 @@ Spine:
 						<ul>
 							<li>
 								<p>the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
-											><code>dir</code> attribute</a> [[!HTML]] and <a
+											><code>dir</code> attribute</a> [[HTML]] and <a
 										href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
-											><code>direction</code> attribute</a> [[!SVG]] for inline base
+											><code>direction</code> attribute</a> [[SVG]] for inline base
 									directionality.</p>
 							</li>
 							<li>
@@ -4074,9 +4067,9 @@ Spine:
 										href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element"
 											><code>bdo</code> element</a> with the <a
 										href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
-											><code>dir</code> attribute</a> [[!HTML]] and the <a
+											><code>dir</code> attribute</a> [[HTML]] and the <a
 										href="https://www.w3.org/TR/SVG2/styling.html#PresentationAttributes"
-										>presentation attribute alternative</a> for <code>unicode-bidi</code> [[!SVG]]
+										>presentation attribute alternative</a> for <code>unicode-bidi</code> [[SVG]]
 									for bidirectionality.</p>
 							</li>
 						</ul>
@@ -4089,7 +4082,7 @@ Spine:
 					<div class="caution">
 						<p><a>EPUB Creators</a> are strongly encouraged to use unprefixed properties and <a>Reading
 								Systems</a> to support current CSS specifications. The widely-used prefixed properties
-							from [[!EPUBContentDocs-301]] have been retained, but support for the other properties has
+							from [[EPUBContentDocs-301]] have been retained, but support for the other properties has
 							been removed. EPUB Creators are advised to use CSS-native solutions for the removed
 							properties where and when they are available.</p>
 						<p>EPUB Creators currently using these prefixed properties are advised to move to unprefixed
@@ -4101,11 +4094,11 @@ Spine:
 						<h5>CSS Writing Modes</h5>
 
 						<p>The following table lists the <code>-epub-</code> prefixed properties for
-							[[!CSS-Writing-Modes-3]]. The Value column indicates the value the property accepts. The
+							[[CSS-Writing-Modes-3]]. The Value column indicates the value the property accepts. The
 							Prior EPUB Mapping column indicates values/properties that were used in previous versions of
 							EPUB 3. An asterisk (*) denotes that the older property or value is now deprecated. The
 							final column describes how to implement the prefixed property based on
-							[[!CSS-Writing-Modes-3-20151215]].</p>
+							[[CSS-Writing-Modes-3-20151215]].</p>
 
 						<table>
 							<thead>
@@ -4113,7 +4106,7 @@ Spine:
 									<th>Property</th>
 									<th>Value</th>
 									<th>Prior EPUB Mapping</th>
-									<th>Mapping to [[!CSS-Writing-Modes-3-20151215]]</th>
+									<th>Mapping to [[CSS-Writing-Modes-3-20151215]]</th>
 								</tr>
 							</thead>
 							<tbody>
@@ -4314,7 +4307,7 @@ Spine:
 								<tr>
 									<th>Property</th>
 									<th>Value</th>
-									<th>Mapping to [[!CSS-Text-3-20160119]]</th>
+									<th>Mapping to [[CSS-Text-3-20160119]]</th>
 								</tr>
 							</thead>
 							<tbody>
@@ -4385,7 +4378,7 @@ Spine:
 								<tr>
 									<th>Property</th>
 									<th>Value</th>
-									<th>Mapping to [[!CSS-Text-Decor-3]]</th>
+									<th>Mapping to [[CSS-Text-Decor-3]]</th>
 								</tr>
 							</thead>
 							<tbody>
@@ -4441,7 +4434,7 @@ Spine:
 						</table>
 						<p>Property value syntax defined in <a
 								href="https://www.w3.org/TR/css-values/#component-combinators">Component value
-								combinators</a> [[!CSS-Values-3]].</p>
+								combinators</a> [[CSS-Values-3]].</p>
 					</section>
 				</section>
 			</section>
@@ -4453,10 +4446,10 @@ Spine:
 					<h4>Script Inclusion</h4>
 
 					<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in the
-						respective underlying specifications ([[!HTML]] and [[!SVG]]). When an EPUB Content Document
+						respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB Content Document
 						contains scripting, it is referred to in this specification as a <a>Scripted Content
 							Document</a>. This label also applies to <a>XHTML Content Documents</a> when they contain
-						instances of [[!HTML]] <a href="https://html.spec.whatwg.org/multipage/forms.html#forms"
+						instances of [[HTML]] <a href="https://html.spec.whatwg.org/multipage/forms.html#forms"
 							>forms</a>.</p>
 
 					<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
@@ -4480,7 +4473,7 @@ Spine:
 					<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the rights
 						and restrictions that a Reading System places on it (refer to <a
 							href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content">Scripting Conformance</a>
-						[[EPUB-RS-33]] for more information).</p>
+						[[?EPUB-RS-33]] for more information).</p>
 
 					<div class="note">
 						<p>Reading Systems may render Scripted Content Documents in a manner that disables other EPUB
@@ -4520,19 +4513,19 @@ Spine:
 
 						<ul>
 							<li>
-								<p>An instance of the [[!HTML]] <a
+								<p>An instance of the [[HTML]] <a
 										href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
 											><code>script</code></a> element contained in an <a>XHTML Content
 										Document</a> that is embedded in a parent XHTML Content Document using the
-									[[!HTML]] <a
+									[[HTML]] <a
 										href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
 											><code>iframe</code></a> element.</p>
 							</li>
 							<li>
-								<p>An instance of the [[!SVG]] <a
+								<p>An instance of the [[SVG]] <a
 										href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
 										><code>script</code></a> element contained in an <a>SVG Content Document</a>
-									that is embedded in a parent XHTML Content Document using the [[!HTML]] <a
+									that is embedded in a parent XHTML Content Document using the [[HTML]] <a
 										href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
 											><code>iframe</code></a> element.</p>
 							</li>
@@ -4562,9 +4555,9 @@ Spine:
 					<section id="sec-scripted-spine">
 						<h5>Spine-Level Scripts</h5>
 
-						<p>A <dfn>spine-level script</dfn> is an instance of the [[!HTML]] <a
+						<p>A <dfn>spine-level script</dfn> is an instance of the [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
-									><code>script</code></a> or [[!SVG]] <a
+									><code>script</code></a> or [[SVG]] <a
 								href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 							element contained in a <a>Top-level Content Document</a>.</p>
 
@@ -4598,7 +4591,7 @@ Spine:
 					<h4>Scripting Accessibility</h4>
 
 					<p id="confreq-cd-scripted-a11y">EPUB Content Documents that contain scripting SHOULD employ
-						relevant [[!WAI-ARIA]] accessibility techniques to ensure that the content remains consumable by
+						relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable by
 						all users.</p>
 				</section>
 
@@ -4607,7 +4600,7 @@ Spine:
 
 					<p id="confreq-cd-scripted-fallback">EPUB Content Documents that contain scripting MAY provide
 						fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
-						available for the [[!HTML]] <a
+						available for the [[HTML]] <a
 							href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element"
 								><code>object</code></a> and <a
 							href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element"
@@ -4629,7 +4622,7 @@ Spine:
 					XHTML Content Document MAY contain zero or more PLS document associations.</p>
 
 				<p id="confreq-cd-pls-assoc">A PLS Document MUST be associated with the <a>XHTML Content Document</a> to
-					which it applies using the [[!HTML]] <a
+					which it applies using the [[HTML]] <a
 						href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"
 						><code>link</code></a> element with its <code>rel</code> attribute set to
 						"<code>pronunciation</code>" and its <code>type</code> attribute set to the media type
@@ -4638,7 +4631,7 @@ Spine:
 				<p id="confreq-cd-pls-assoc-lang">The <code>link</code> element <code>hreflang</code> attribute SHOULD
 					be specified on each <code>link</code>, and its value MUST match <a
 						href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/#S4.1">the language for
-						which the pronunciation lexicon is relevant</a> [[!PRONUNCIATION-LEXICON]] when specified.</p>
+						which the pronunciation lexicon is relevant</a> [[PRONUNCIATION-LEXICON]] when specified.</p>
 
 				<aside class="example">
 					<p>The following example shows two <abbr title="Pronunciation Lexicon Specification">PLS</abbr>
@@ -4657,7 +4650,7 @@ Spine:
 				<p id="confreq-cd-pls-docprops-schema">PLS Documents MUST be valid to the RELAX NG schema available at
 					the URI <a href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
 							><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng</code></a>
-					[[!PRONUNCIATION-LEXICON]].</p>
+					[[PRONUNCIATION-LEXICON]].</p>
 
 				<p id="confreq-cd-pls-fileprops-name">PLS Documents SHOULD use the file extension <code class="filename"
 						>.pls</code>.</p>
@@ -4835,17 +4828,17 @@ Spine:
 						</li>
 						<li>
 							<p id="confreq-nav-a-href">The IRI reference provided in the <code>href</code> attribute of
-								the <code>a</code> element MUST adhere to the following requirements:</p>
+								the <code>a</code> element:</p>
 							<ul class="conformance-list">
 								<li>
-									<p id="confreq-nav-a-href-default">In the case of the <a href="#sec-nav-toc"
+									<p id="confreq-nav-a-href-default">MUST, in the case of the <a href="#sec-nav-toc"
 												><code>toc nav</code></a>, <a href="#sec-nav-landmarks"><code>landmarks
 												nav</code></a> and <a href="#sec-nav-pagelist"><code>page-list
-												nav</code></a>, it MUST resolve to a <a>Top-level Content Document</a>
-										or fragment therein.</p>
+												nav</code></a>, resolve to a <a>Top-level Content Document</a> or
+										fragment therein.</p>
 								</li>
 								<li>
-									<p id="confreq-nav-a-href-other">For all other <code>nav</code> types, it MAY also
+									<p id="confreq-nav-a-href-other">MAY, for all other <code>nav</code> types, also
 										reference <a>Remote Resources</a>.</p>
 								</li>
 							</ul>
@@ -4897,7 +4890,7 @@ Spine:
 					<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
 						items within <code>nav</code> elements is equivalent to the <a
 							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
-								none</code> property</a> [[!CSSSnapshot]]. <a>EPUB Creators</a> MAY specify alternative
+								none</code> property</a> [[CSSSnapshot]]. <a>EPUB Creators</a> MAY specify alternative
 						list styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
 								><code>spine</code></a>.</p>
 				</section>
@@ -5080,9 +5073,9 @@ Spine:
 						dedicated navigation user interface.</p>
 
 					<p> While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
-							property</a> [[!CSSSnapshot]] can be used to control the visual rendering of EPUB Navigation
+							property</a> [[CSSSnapshot]] can be used to control the visual rendering of EPUB Navigation
 						Documents in Reading Systems with <a>Viewports</a>, not all Reading Systems provide such an
-						interface. To control rendering across all Reading Systems, EPUB Creators MUST use the [[!HTML]]
+						interface. To control rendering across all Reading Systems, EPUB Creators MUST use the [[HTML]]
 							<a href="https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute"
 								><code>hidden</code></a> attribute to indicate which (if any) portions of the navigation
 						data are excluded from rendering in the content flow. The <code>hidden</code> attribute has no
@@ -5431,7 +5424,7 @@ Spine:
 
 							<dt id="spread-portrait">spread-portrait</dt>
 							<dd>The <code>spread-portrait</code> property is <a href="#deprecated">deprecated</a>. Refer
-								to its definition in [[!EPUBPublications-301]] for more information.</dd>
+								to its definition in [[EPUBPublications-301]] for more information.</dd>
 						</dl>
 
 						<p>Only one of these overrides is allowed on any given spine item.</p>
@@ -5537,11 +5530,11 @@ Spine:
 					<h4>Viewport Dimensions (Deprecated)</h4>
 
 					<p>The <code>rendition:viewport</code> property allows <a>EPUB Creators</a> to express the CSS
-						initial containing block (ICB) [[!CSS2]] for XHTML and SVG Content Documents whose
+						initial containing block (ICB) [[CSS2]] for XHTML and SVG Content Documents whose
 							<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
 
 					<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its definition in
-						[[!EPUBPublications-301]] for more information.</p>
+						[[EPUBPublications-301]] for more information.</p>
 				</section>
 			</section>
 
@@ -5553,15 +5546,15 @@ Spine:
 
 				<p id="confreg-fxl-icb">Fixed-Layout Documents specify their <a
 						href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
-						block</a> [[!CSS2]] in the manner applicable to their format:</p>
+						block</a> [[CSS2]] in the manner applicable to their format:</p>
 
 				<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
 					<dt id="sec-fxl-icb-html">Expressing in XHTML</dt>
 					<dd>
 						<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
 								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-								containing block</a> [[!CSS2]] dimensions MUST be expressed in a <code>viewport</code>
-							<code>meta</code> tag using the syntax defined in [[!CSS-Device-Adapt-1]].</p>
+								containing block</a> [[CSS2]] dimensions MUST be expressed in a <code>viewport</code>
+							<code>meta</code> tag using the syntax defined in [[CSS-Device-Adapt-1]].</p>
 						<aside class="example">
 							<p>The following example shows a <code>viewport</code>
 								<code>meta</code> tag.</p>
@@ -5576,9 +5569,9 @@ Spine:
 
 					<dt id="sec-fxl-icb-svg">Expressing in SVG</dt>
 					<dd>
-						<p>For SVG <a>Fixed-Layout Documents</a>, the initial containing block [[!CSS2]] dimensions MUST
+						<p>For SVG <a>Fixed-Layout Documents</a>, the initial containing block [[CSS2]] dimensions MUST
 							be expressed using the <a href="http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
-									><code>viewBox</code> attribute</a> [[!SVG]].</p>
+									><code>viewBox</code> attribute</a> [[SVG]].</p>
 						<aside class="example">
 							<p>The following example shows a <code>viewBox</code> attribute declaration for an SVG
 								Content Document with an aspect ratio of 844 pixels wide by 1200 pixels high.</p>
@@ -5683,7 +5676,7 @@ Spine:
 					<h4>Relative IRIs for Referencing Other Components</h4>
 
 					<p>Files within the <a>OCF Abstract Container</a> MUST reference each other via relative IRI
-						references ([[!RFC3987]] and [[!RFC3986]]).</p>
+						references ([[RFC3987]] and [[RFC3986]]).</p>
 
 					<aside class="example">
 						<p>The following example shows how a file named <code>image1.jpg</code> in the same directory as
@@ -5694,13 +5687,13 @@ Spine:
                 </pre>
 					</aside>
 
-					<p>For relative IRI references, the Base IRI [[!RFC3986]] is determined by the relevant language
+					<p>For relative IRI references, the Base IRI [[RFC3986]] is determined by the relevant language
 						specifications for the given file formats. For example, CSS defines how relative IRI references
-						work in the context of CSS style sheets and property declarations [[!CSSSnapshot]].</p>
+						work in the context of CSS style sheets and property declarations [[CSSSnapshot]].</p>
 
 					<div class="note">
-						<p>Some language specifications reference Requests For Comments [[RFC]] that preceded
-							[[RFC3987]], in which case the earlier RFC applies for content in that language.</p>
+						<p>Some language specifications reference Requests For Comments that preceded [[RFC3987]], in
+							which case the earlier RFC applies for content in that language.</p>
 					</div>
 
 					<p>Unlike most language specifications, the Base IRIs for all files within the <code>META-INF</code>
@@ -5738,7 +5731,7 @@ Spine:
 
 					<ul class="conformance-list">
 						<li>
-							<p id="ocf-fn-encoding">Path and File Names MUST be UTF-8 [[!Unicode]] encoded.</p>
+							<p id="ocf-fn-encoding">Path and File Names MUST be UTF-8 [[Unicode]] encoded.</p>
 						</li>
 						<li>
 							<p id="ocf-fn-length">File Names MUST NOT exceed 255 bytes.</p>
@@ -5748,7 +5741,7 @@ Spine:
 								Container MUST NOT exceed 65535 bytes.</p>
 						</li>
 						<li>
-							<p id="ocf-fn-chars">File Names MUST NOT use the following [[!Unicode]] characters, as these
+							<p id="ocf-fn-chars">File Names MUST NOT use the following [[Unicode]] characters, as these
 								characters might not be supported consistently across commonly used operating
 								systems:</p>
 							<ul>
@@ -5817,11 +5810,11 @@ Spine:
 						</li>
 						<li>
 							<p id="ocf-fn-cn">All File Names within the same directory MUST be unique following case
-								normalization as described in section 3.13 of [[!Unicode]].</p>
+								normalization as described in section 3.13 of [[Unicode]].</p>
 						</li>
 						<li>
 							<p id="ocf-fn-an">All File Names within the same directory SHOULD be unique following NFC or
-								NFD normalization [[!TR15]].</p>
+								NFD normalization [[TR15]].</p>
 						</li>
 					</ul>
 
@@ -5859,9 +5852,9 @@ Spine:
 								identifies the <a>Package Documents</a> available in the <a>OCF Abstract
 								Container</a>.</p>
 
-							<p>All [[!XML]] elements defined in this section are in the
-									<code>urn:oasis:names:tc:opendocument:xmlns:container</code> namespace
-								[[!XML-NAMES]] unless specified otherwise.</p>
+							<p>All [[XML]] elements defined in this section are in the
+									<code>urn:oasis:names:tc:opendocument:xmlns:container</code> namespace [[XML-NAMES]]
+								unless specified otherwise.</p>
 
 							<p>The contents of this file MUST be valid to the definition in this section after removing
 								all elements and attributes from other namespaces (including all attributes and contents
@@ -5969,8 +5962,8 @@ Spine:
 											<dd>
 												<p>Identifies the location of a <a>Package Document</a>.</p>
 												<p>The value of the attribute MUST contain a <em>path component</em>
-													[[!RFC3986]] which MUST take the form of a <em>path-rootless</em>
-													[[!RFC3986]] only. The path components are relative to the <a>Root
+													[[RFC3986]] which MUST take the form of a <em>path-rootless</em>
+													[[RFC3986]] only. The path components are relative to the <a>Root
 														Directory</a>.</p>
 											</dd>
 
@@ -6064,9 +6057,9 @@ Spine:
 											<dd>
 												<p>Identifies the location of a resource.</p>
 												<p>The value of the <code>link</code> element <code>href</code>
-													attribute MUST contain a <em>path component</em> [[!RFC3986]] which
-													MUST take the form of a <em>path-rootless</em> [[!RFC3986]] only.
-													The path component is relative to the <a>Root Directory</a>.</p>
+													attribute MUST contain a <em>path component</em> [[RFC3986]] which
+													MUST take the form of a <em>path-rootless</em> [[RFC3986]] only. The
+													path component is relative to the <a>Root Directory</a>.</p>
 											</dd>
 
 											<dt>
@@ -6075,7 +6068,7 @@ Spine:
 											</dt>
 											<dd>
 												<p>Identifies the type and format of the referenced resource.</p>
-												<p>The value of the attribute MUST be a media type [[!RFC2046]].</p>
+												<p>The value of the attribute MUST be a media type [[RFC2046]].</p>
 											</dd>
 
 											<dt>
@@ -6158,7 +6151,7 @@ Spine:
 
 								<p>The <code>encryption</code> element contains child elements of type
 										<code>EncryptedKey</code> and <code>EncryptedData</code> as defined by
-									[[!XMLENC-CORE1]].</p>
+									[[XMLENC-CORE1]].</p>
 
 								<p>An <code id="elemdef-encryption-EncryptedKey">EncryptedKey</code> element describes
 									each encryption key used in the container, while an <code
@@ -6175,7 +6168,7 @@ Spine:
 									Encryption in this way exposes the directory structure and file naming of the whole
 									package.</p>
 
-								<p>OCF uses XML Encryption [[!XMLENC-CORE1]] to provide a framework for encryption,
+								<p>OCF uses XML Encryption [[XMLENC-CORE1]] to provide a framework for encryption,
 									allowing a variety of algorithms to be used. XML Encryption specifies a process for
 									encrypting arbitrary data and representing the result in XML. Even though an <a>OCF
 										Abstract Container</a> might contain non-XML data, XML Encryption can be used to
@@ -6229,7 +6222,7 @@ Spine:
 								</ul>
 
 								<p>Signed resources MAY subsequently be encrypted using the Decryption Transform for XML
-									Signature [[!XMLENC-DECRYPT]]. This feature enables an application such as an OCF
+									Signature [[XMLENC-DECRYPT]]. This feature enables an application such as an OCF
 									agent to distinguish data that was encrypted before signing from data that was
 									encrypted after signing. Only data that was encrypted after signing MUST be
 									decrypted before computing the digest used to validate the signature.</p>
@@ -6237,10 +6230,10 @@ Spine:
 								<aside class="example">
 									<p>In the following example, adapted from <a
 											href="https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/#sec-eg-Symmetric-Key"
-											>Section 2.2.1 </a> of [[!XMLENC-CORE1]] the resource
-											<code>image.jpeg</code> is encrypted using a symmetric key algorithm (AES)
-										and the symmetric key is further encrypted using an asymmetric key algorithm
-										(RSA) with a key of John Smith.</p>
+											>Section 2.2.1 </a> of [[XMLENC-CORE1]] the resource <code>image.jpeg</code>
+										is encrypted using a symmetric key algorithm (AES) and the symmetric key is
+										further encrypted using an asymmetric key algorithm (RSA) with a key of John
+										Smith.</p>
 									<pre>
 &lt;encryption
     xmlns ="urn:oasis:names:tc:opendocument:xmlns:container"
@@ -6378,7 +6371,7 @@ Spine:
 								directory, if present, MUST be used for container-level metadata.</p>
 
 							<p>If the <code>metadata.xml</code> file is present, its contents SHOULD be only
-								namespace-qualified elements [[!XML-NAMES]]. The file SHOULD contain the root element
+								namespace-qualified elements [[XML-NAMES]]. The file SHOULD contain the root element
 									<code>metadata</code> in the namespace
 									<code>http://www.idpf.org/2013/metadata</code>, but other root elements are allowed
 								for backwards compatibility. Reading Systems SHOULD ignore <code>metadata.xml</code>
@@ -6398,7 +6391,7 @@ Spine:
 
 							<p>This version of the OCF specification does not require a specific format for DRM
 								information, but a future version might. The contents of the <code>rights.xml</code>
-								SHOULD be only namespace-qualified elements [[!XML-NAMES]] to avoid collision with a
+								SHOULD be only namespace-qualified elements [[XML-NAMES]] to avoid collision with a
 								future format.</p>
 
 							<p>When the <code>rights.xml</code> file is not present, no part of the container is rights
@@ -6451,7 +6444,7 @@ Spine:
 								</dl>
 
 								<p>The <code>signature</code> element contains child elements of type
-										<code>Signature</code>, as defined by [[!XMLDSIG-CORE1]]. Signatures can be
+										<code>Signature</code>, as defined by [[XMLDSIG-CORE1]]. Signatures can be
 									applied to an EPUB Publication as a whole or to its parts and can specify the
 									signing of any kind of data (i.e., not just XML).</p>
 
@@ -6492,7 +6485,7 @@ Spine:
 								<p>If the signer wants any addition or removal of a signature to invalidate the signer’s
 									signature, the Enveloped Signature transform defined in <a
 										href="https://www.w3.org/TR/2008/REC-xmldsig-core-20080610/#sec-EnvelopedSignature"
-										>Section 6.6.4</a> of [[!XMLDSIG-CORE1]] can be used to sign the entire
+										>Section 6.6.4</a> of [[XMLDSIG-CORE1]] can be used to sign the entire
 									preexisting signature file excluding the <code>Signature</code> being created. This
 									transform would sign all previous signatures, and it would become invalid if a
 									subsequent signature were added to the package.</p>
@@ -6504,17 +6497,17 @@ Spine:
 										such a transform are outside the scope of this specification, however.</p>
 								</div>
 
-								<p>The [[!XMLDSIG-CORE1]] specification does not associate any semantics with a
+								<p>The [[XMLDSIG-CORE1]] specification does not associate any semantics with a
 									signature; an agent might include semantic information, for example, by adding
 									information to the Signature element that describes the signature. The
-									[[!XMLDSIG-CORE1]] specification describes how additional information can be added
-									to a signature, such as by use the <code>SignatureProperties</code> element.</p>
+									[[XMLDSIG-CORE1]] specification describes how additional information can be added to
+									a signature, such as by use the <code>SignatureProperties</code> element.</p>
 
 								<aside class="example">
 									<p>The following XML expression shows the content of an example
 											<code>signatures.xml</code> file. It is based on the examples found in <a
 											href="https://www.w3.org/TR/2008/REC-xmldsig-core-20080610/#sec-Overview"
-											>Section 2</a> of [[!XMLDSIG-CORE1]]. It contains one signature, and the
+											>Section 2</a> of [[XMLDSIG-CORE1]]. It contains one signature, and the
 										signature applies to two resources, <code class="filename"
 											>EPUB/book.xhtml</code> and <code>EPUB/images/cover.jpeg</code>, in the
 										container.</p>
@@ -6596,7 +6589,7 @@ Spine:
 				<section id="sec-zip-container-zipreqs">
 					<h4>ZIP File Requirements</h4>
 
-					<p>An <a>OCF ZIP Container</a> uses the ZIP format as specified by [[!ZIP]], but with the following
+					<p>An <a>OCF ZIP Container</a> uses the ZIP format as specified by [[ZIP]], but with the following
 						constraints and clarifications:</p>
 
 					<ul class="conformance-list">
@@ -6606,7 +6599,7 @@ Spine:
 						</li>
 						<li>
 							<p id="confreq-zip-mult">OCF ZIP Containers MUST NOT use the features in the ZIP application
-								note [[!ZIP]] that allow ZIP files to be spanned across multiple storage media or be
+								note [[ZIP]] that allow ZIP files to be spanned across multiple storage media or be
 								split into multiple files.</p>
 						</li>
 						<li>
@@ -6615,7 +6608,7 @@ Spine:
 						</li>
 						<li>
 							<p id="confreq-zip-64">OCF ZIP Containers MAY use the ZIP64 extensions defined as "Version
-								1" in section V, subsection G of the application note [[!ZIP]] and SHOULD use only those
+								1" in section V, subsection G of the application note [[ZIP]] and SHOULD use only those
 								extensions when the content requires them.</p>
 						</li>
 						<li>
@@ -6625,7 +6618,7 @@ Spine:
 						</li>
 						<li>
 							<p id="confreq-zip-utf8">OCF ZIP Containers MUST encode File System Names using UTF-8
-								[[!Unicode]].</p>
+								[[Unicode]].</p>
 						</li>
 					</ul>
 
@@ -6653,8 +6646,8 @@ Spine:
 					<p>The first file in the <a>OCF ZIP Container</a> MUST be the <code>mimetype</code> file, which
 						meets the following requirements: </p>
 					<ul>
-						<li>The contents of the <code>mimetype</code> file MUST be the MIME media type [[!RFC2046]]
-							string <code>application/epub+zip</code> encoded in US-ASCII [[!US-ASCII]].</li>
+						<li>The contents of the <code>mimetype</code> file MUST be the MIME media type [[RFC2046]]
+							string <code>application/epub+zip</code> encoded in US-ASCII [[US-ASCII]].</li>
 						<li>The <code>mimetype</code> file MUST NOT contain any leading or trailing padding or white
 							space.</li>
 						<li>The <code>mimetype</code> file MUST NOT begin with the Unicode byte order mark U+FEFF.</li>
@@ -6722,12 +6715,12 @@ Spine:
 
 					<p>All white space characters, as defined in <a
 							href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-common-syn">section 2.3 of the XML
-							1.0 specification</a> [[!XML]], MUST be removed from this identifier — specifically, the
+							1.0 specification</a> [[XML]], MUST be removed from this identifier — specifically, the
 						Unicode code points <code>U+0020</code>, <code>U+0009</code>, <code>U+000D</code> and
 							<code>U+000A</code>.</p>
 
 					<p>A SHA-1 digest of the UTF-8 representation of the resulting string SHOULD be generated as
-						specified by the Secure Hash Standard [[!FIPS-180-4]]. This digest is then directly used as the
+						specified by the Secure Hash Standard [[FIPS-180-4]]. This digest is then directly used as the
 						key for the algorithm.</p>
 				</section>
 
@@ -6872,21 +6865,21 @@ store destination as source in ocf
 				<section id="sec-overlay-req">
 					<h4>Media Overlay Document Requirements</h4>
 
-					<p>A <a>Media Overlay Document</a> has to meet the following requirements:</p>
+					<p>A <a>Media Overlay Document</a>:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-mo-docprops-schema">It MUST be valid to the Media Overlays schema as defined
-								in <a href="#app-schema-overlays"></a> and conform to all content conformance
+							<p id="confreq-mo-docprops-schema">MUST be valid to the Media Overlays schema as defined in
+									<a href="#app-schema-overlays"></a> and conform to all content conformance
 								constraints expressed in <a href="#sec-overlays-def"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-mo-docprops-references">It MAY refer to more than one EPUB Content Document,
-								but an EPUB Content Document MUST NOT be referenced by more than one Media Overlay
+							<p id="confreq-mo-docprops-references">MAY refer to more than one EPUB Content Document, but
+								an EPUB Content Document MUST NOT be referenced by more than one Media Overlay
 								Document.</p>
 						</li>
 						<li>
-							<p id="confreq-mo-docprops-semantics">It SHOULD use <a href="#sec-docs-structural-semantic"
+							<p id="confreq-mo-docprops-semantics">SHOULD use <a href="#sec-docs-structural-semantic"
 									>semantic markup</a> where appropriate.</p>
 						</li>
 					</ul>
@@ -6895,8 +6888,8 @@ store destination as source in ocf
 				<section id="sec-overlays-def">
 					<h3>Media Overlay Document Definition</h3>
 
-					<p>All elements [[!XML]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
-						namespace [[!XML-NAMES]] unless otherwise specified.</p>
+					<p>All elements [[XML]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
+						namespace [[XML-NAMES]] unless otherwise specified.</p>
 
 					<section id="sec-smil-smil-elem">
 						<h5>The <code>smil</code> Element</h5>
@@ -6922,7 +6915,7 @@ store destination as source in ocf
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>Specifies the version number of the [[!SMIL3]] specification to which the
+										<p>Specifies the version number of the [[SMIL3]] specification to which the
 											Media Overlay adheres.</p>
 										<p>This attribute MUST have the value "<code>3.0</code>".</p>
 									</dd>
@@ -6931,7 +6924,7 @@ store destination as source in ocf
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										<p>The ID [[XML]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 									<dt id="attrdef-smil-prefix">
@@ -7078,7 +7071,7 @@ store destination as source in ocf
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										<p>The ID [[XML]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 									<dt id="attrdef-body-textref">
@@ -7086,9 +7079,9 @@ store destination as source in ocf
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
+										<p>The relative IRI reference [[RFC3987]] of the corresponding EPUB Content
 											Document, including a fragment identifier that references the specific
-											element as per the [[!XPTRSH]].</p>
+											element as per the [[XPTRSH]].</p>
 									</dd>
 								</dl>
 							</dd>
@@ -7156,7 +7149,7 @@ store destination as source in ocf
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										<p>The ID [[XML]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 									<dt id="attrdef-seq-textref">
@@ -7164,9 +7157,9 @@ store destination as source in ocf
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
+										<p>The relative IRI reference [[RFC3987]] of the corresponding EPUB Content
 											Document, including a fragment identifier that references the specific
-											element as per the [[!XPTRSH]].</p>
+											element as per the [[XPTRSH]].</p>
 										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
 											information.</p>
 									</dd>
@@ -7235,7 +7228,7 @@ store destination as source in ocf
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										<p>The ID [[XML]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 								</dl>
@@ -7296,16 +7289,16 @@ store destination as source in ocf
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>The relative IRI reference [[!RFC3987]] of the corresponding EPUB Content
+										<p>The relative IRI reference [[RFC3987]] of the corresponding EPUB Content
 											Document, including a fragment identifier that references the specific
-											element as per the [[!XPTRSH]].</p>
+											element as per the [[XPTRSH]].</p>
 									</dd>
 									<dt>
 										<code>id</code>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										<p>The ID [[XML]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 								</dl>
@@ -7345,7 +7338,7 @@ store destination as source in ocf
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[!XML]] of the element, which MUST be unique within the document
+										<p>The ID [[XML]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 									<dt>
@@ -7353,7 +7346,7 @@ store destination as source in ocf
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>The relative or absolute IRI reference [[!RFC3987]] of an audio file. The
+										<p>The relative or absolute IRI reference [[RFC3987]] of an audio file. The
 											audio file MUST be one of the audio formats listed in the <a
 												href="#sec-core-media-types">Core Media Type Resources</a> table.</p>
 									</dd>
@@ -7364,9 +7357,8 @@ store destination as source in ocf
 									<dd>
 										<p>A clock value that specifies the offset into the physical media corresponding
 											to the start point of an audio clip.</p>
-										<p>MUST be a [[!SMIL3]] <a
-												href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">clock
-											value</a>.</p>
+										<p>MUST be a [[SMIL3]] <a href="https://www.w3.org/TR/SMIL/smil-timing.html#q22"
+												>clock value</a>.</p>
 										<p>See <a href="#clock-examples"></a>.</p>
 									</dd>
 									<dt id="attrdef-smil-clipEnd">
@@ -7376,9 +7368,8 @@ store destination as source in ocf
 									<dd>
 										<p>A clock value that specifies the offset into the physical media corresponding
 											to the end point of an audio clip.</p>
-										<p>MUST be a [[!SMIL3]] <a
-												href="https://www.w3.org/TR/SMIL/smil-timing.html#q22">clock
-											value</a>.</p>
+										<p>MUST be a [[SMIL3]] <a href="https://www.w3.org/TR/SMIL/smil-timing.html#q22"
+												>clock value</a>.</p>
 										<p>See <a href="#clock-examples"></a>.</p>
 										<p>The chronological offset of the terminating position MUST be after the
 											starting offset specified in the <code>clipBegin</code> attribute.</p>
@@ -7497,7 +7488,7 @@ store destination as source in ocf
 							containers to be retained in the Media Overlay Document.</p>
 
 						<p>The <code>seq</code> element MUST contain an <a href="#attrdef-body-textref"
-									><code>epub:textref</code> attribute</a>. The IRI [[!RFC3987]] value of this
+									><code>epub:textref</code> attribute</a>. The IRI [[RFC3987]] value of this
 							attribute MUST reference the corresponding structural element in an EPUB Content Document.
 							As <code>seq</code> elements do not provide synchronization instructions, this attribute
 							allows a Reading System to still match the element to a location in the text.</p>
@@ -7630,7 +7621,7 @@ store destination as source in ocf
 						<p>Any <a>EPUB Content Document</a> associated with a Media Overlay MAY contain embedded media
 							such as video, audio, and images. The Media Overlay <a href="#elemdef-smil-text"
 									><code>text</code> element</a> MAY be used in such instances to reference the
-							embedded media by its ID [[!XML]] value.</p>
+							embedded media by its ID [[XML]] value.</p>
 
 						<p>When a <code>text</code> element references embedded media that contains audio, the <a
 								href="#elemdef-smil-audio"><code>audio</code></a> sibling element is OPTIONAL.</p>
@@ -7665,7 +7656,7 @@ store destination as source in ocf
 						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
 							>skippability and escapability</a> and <a
 							href="https://www.w3.org/TR/epub-rs-33/#note-table-reading-mode">table reading mode</a>
-						[[EPUB-RS-33]].</p>
+						[[?EPUB-RS-33]].</p>
 
 					<aside class="example">
 						<p>The following example shows the semantic markup for a Media Overlay containing a figure.</p>
@@ -7708,7 +7699,7 @@ store destination as source in ocf
 					<p>EPUB Creators MUST define exactly one CSS class name in each property they define. Each property
 						MUST define a <a href="https://www.w3.org/TR/CSS2/syndata.html#characters">valid CSS class
 							name</a> not including any <a href="https://www.w3.org/TR/CSS2/selector.html">selectors</a>
-						[[!CSS2]]. This specification <strong>does not</strong> reserve names for use with these
+						[[CSS2]]. This specification <strong>does not</strong> reserve names for use with these
 						properties.</p>
 
 					<p>EPUB Creators MAY define any CSS properties for the specified CSS classes. EPUB Creators only
@@ -7781,8 +7772,8 @@ html.my-document-playing * {
 						<p>If an <a>EPUB Content Document</a> is wholly or partially referenced by a Media Overlay, then
 							its <a>manifest</a>
 							<a href="#elemdef-package-item"><code>item</code> element</a> MUST specify a
-								<code>media-overlay</code> attribute. The attribute MUST reference the ID [[!XML]] of
-							the manifest <code>item</code> for the corresponding Media Overlay Document.</p>
+								<code>media-overlay</code> attribute. The attribute MUST reference the ID [[XML]] of the
+							manifest <code>item</code> for the corresponding Media Overlay Document.</p>
 
 						<p>The <code>media-overlay</code> attribute MUST only be specified on manifest <code>item</code>
 							elements that reference <a>EPUB Content Documents</a>.</p>
@@ -8049,7 +8040,7 @@ html.my-document-playing * {
 					associated with an audio Media Overlay. Unlike traditional XHTML Content Documents, however,
 						<a>Reading Systems</a> have to present the EPUB Navigation Document to users even when it is not
 					included in the <a>spine</a> (see <a href="https://www.w3.org/TR/epub-rs-33/#sec-nav">Navigation
-						Document Processing</a> [[EPUB-RS-33]]). As a result, the method in which an associated Media
+						Document Processing</a> [[?EPUB-RS-33]]). As a result, the method in which an associated Media
 					Overlay behaves can change depending on the context:</p>
 
 				<ul>
@@ -8195,9 +8186,9 @@ html.my-document-playing * {
 
 			<p>The following table lists the <a aria-label="public identifiers"
 					href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-pubid">public </a> and <a
-					href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-sysid">system identifiers</a> [[!XML]] allowed
+					href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-sysid">system identifiers</a> [[XML]] allowed
 				in <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-doctype">document type declarations</a>.
-				[[!XML]]</p>
+				[[XML]]</p>
 
 			<p>These external identifiers MAY be used only in <a>Publication Resources</a> with the listed media types
 				specified in their <a href="#sec-manifest-elem">manifest</a> declarations. (Refer to <a
@@ -8247,7 +8238,7 @@ html.my-document-playing * {
 				</tbody>
 			</table>
 		</section>
-		<section id="app-structural-semantics">
+		<section id="app-structural-semantics" class="appendix">
 			<h2>Expressing Structural Semantics</h2>
 
 			<section id="sec-structural-semantics-intro">
@@ -8298,7 +8289,7 @@ html.my-document-playing * {
 					<dd>
 						<p>A white space-separated list of <a href="#sec-property-datatype">property</a> values, with
 							restrictions as defined in <a href="#sec-vocab-assoc"></a>.</p>
-						<p>White space is the set of characters as defined in [[!XML]].</p>
+						<p>White space is the set of characters as defined in [[XML]].</p>
 					</dd>
 				</dl>
 
@@ -8307,7 +8298,7 @@ html.my-document-playing * {
 					document instance.</p>
 
 				<p>The inflected semantic MUST express a subclass of the semantic of the carrying element. In the case
-					of semantically neutral elements, such as the [[!HTML]] <a
+					of semantically neutral elements, such as the [[HTML]] <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element"
 							><code>div</code></a> and <a
 						href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element"
@@ -8336,7 +8327,7 @@ html.my-document-playing * {
 
 				<aside class="example" id="ex.epubtype.note">
 					<p>The following example shows how a preamble could be marked up with the <code>epub:type</code>
-						attribute on its containing [[!HTML]] <code>section</code> element.</p>
+						attribute on its containing [[HTML]] <code>section</code> element.</p>
 					<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
     …
@@ -8349,7 +8340,7 @@ html.my-document-playing * {
 
 				<aside class="example" id="ex.epubtype.gloss">
 					<p>The following example shows the <code>epub:type</code> attribute used to add glossary semantics
-						on an [[!HTML]] definition list.</p>
+						on an [[HTML]] definition list.</p>
 					<pre>
 &lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
     …
@@ -8383,7 +8374,7 @@ html.my-document-playing * {
 			<section id="sec-vocab-assoc">
 				<h3>Vocabulary Association Mechanisms</h3>
 
-				<section id="sec-vocab-assoc-intro">
+				<section id="sec-vocab-assoc-intro" class="informative">
 					<h4>Introduction</h4>
 
 					<p>EPUB defines a formal method of referencing terms and properties defined in metadata and semantic
@@ -8418,7 +8409,7 @@ html.my-document-playing * {
 				<section id="sec-property-datatype">
 					<h4>The <var>property</var> Data Type</h4>
 
-					<p>The <var>property</var> data type is a compact means of expressing an IRI [[!RFC3987]] and
+					<p>The <var>property</var> data type is a compact means of expressing an IRI [[RFC3987]] and
 						consists of an OPTIONAL prefix separated from a reference by a colon.</p>
 
 					<table class="productionset">
@@ -8455,11 +8446,11 @@ html.my-document-playing * {
 								<code>=</code>
 							</td>
 							<td>? irelative-ref ? ;</td>
-							<td>/* as defined in [[!RFC3987]] */<br /></td>
+							<td>/* as defined in [[RFC3987]] */<br /></td>
 						</tr>
 					</table>
 
-					<p>The <var>property</var> data type is derived from the CURIE data type defined in [[!RDFA-CORE]]
+					<p>The <var>property</var> data type is derived from the CURIE data type defined in [[RDFA-CORE]]
 						and represents a subset of CURIEs.</p>
 
 					<aside class="example">
@@ -8627,18 +8618,18 @@ html.my-document-playing * {
 					</div>
 
 					<p>Note that for <a href="#sec-xhtml-svg">embedded SVG</a>, prefixes MUST be declared on the
-						[[!HTML]] root <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element"
+						[[HTML]] root <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element"
 								><code>html</code> element</a>.</p>
 
 					<p>To avoid conflicts, the <code>prefix</code> attribute MUST NOT be used to declare a prefix that
 						maps to the <a href="#sec-default-vocab">default vocabulary</a>.</p>
 
 					<p>The prefix '_' MUST NOT be declared as it is reserved for future compatibility with RDFa
-						[[!RDFA-CORE]] processing.</p>
+						[[RDFA-CORE]] processing.</p>
 
 					<p>For future compatibility with alternative serializations of the Package Document, a prefix for
-						the Dublin Core <em>/elements/1.1/</em> namespace [[!DCTERMS]] MUST NOT be declared in the
-							<code>prefix</code> attribute. <a>EPUB Creators</a> MUST use only the [[!DCTERMS]] elements
+						the Dublin Core <em>/elements/1.1/</em> namespace [[DCTERMS]] MUST NOT be declared in the
+							<code>prefix</code> attribute. <a>EPUB Creators</a> MUST use only the [[DCTERMS]] elements
 							<a href="#sec-pkg-metadata">allowed in the Package Document metadata</a>.</p>
 				</section>
 
@@ -8819,7 +8810,7 @@ html.my-document-playing * {
 				</div>
 			</section>
 		</section>
-		<section id="app-examples" class="appendix infomative">
+		<section id="app-examples" class="appendix informative">
 			<h2>Detailed Examples</h2>
 
 			<section id="scripted-contexts-example">
@@ -9261,7 +9252,7 @@ EPUB/images/cover.png</pre>
 					Format (OCF).</p>
 
 				<p>An <a>OCF ZIP Container</a>, or <a>EPUB Container</a>, file is a container technology based on the
-					[[!ZIP]] archive format. It is used to encapsulate the EPUB Publication. OCF and its related
+					[[ZIP]] archive format. It is used to encapsulate the EPUB Publication. OCF and its related
 					standards are maintained and defined by the <a href="https://www.w3.org">World Wide Web
 						Consortium</a> (W3C).</p>
 
@@ -9366,7 +9357,7 @@ EPUB/images/cover.png</pre>
 				</dl>
 			</section>
 		</section>
-		<section id="change-log">
+		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
 
 			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance
@@ -9388,8 +9379,8 @@ EPUB/images/cover.png</pre>
 
 				<ul>
 
-					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 is the RECOMMENDED encoding. See <a
-						href="https://github.com/w3c/epub-specs/issues/1630">issue 1628</a>.</li>
+					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 is the RECOMMENDED
+						encoding. See <a href="https://github.com/w3c/epub-specs/issues/1630">issue 1628</a>.</li>
 					<li>19-Apr-2021: The use of custom attributes in EPUB Content Documents is no longer supported. See
 							<a href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>
 					<li>13-Apr-2021: Require path names in OCF to also be UTF-8 encoded. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -604,7 +604,7 @@
 			<section id="sec-epub-conf">
 				<h3>Conformance Criteria</h3>
 
-				<p>EPUB Publications:</p>
+				<p>An EPUB Publication:</p>
 
 				<ul class="conformance-list">
 					<li>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -144,16 +144,16 @@
 					the overall interoperability of Multiple-Rendition Publications.</p>
 
 				<p>Some of the <a href="#rendition-selection-attr">Rendition selection attributes</a> defined in this
-					specification share common names with Package Document elements and properties [[!EPUB-33]] as they
+					specification share common names with Package Document elements and properties [[EPUB-33]] as they
 					are designed to reflect that information for selection purposes.</p>
 
 				<p>Despite this commonality, this specification does not enforce equivalence between the Rendition
-					selection properties expressed on a <code>rootfile</code> element [[!EPUB-33]] and the metadata
+					selection properties expressed on a <code>rootfile</code> element [[EPUB-33]] and the metadata
 					expressed in the corresponding Package Document, as direct equivalence is not always possible.</p>
 
 				<p>For example, a multilingual EPUB Publication will define more than one <a
 						href="https://www.w3.org/TR/epub-33/#sec-opf-dclanguage">DCMES <code>language</code> element</a>
-					[[!EPUB-33]] &#8212; one for each language &#8212; but for Rendition selection only the primary
+					[[EPUB-33]] &#8212; one for each language &#8212; but for Rendition selection only the primary
 					language is defined. Likewise, the language defined in the Package Document could include a specific
 					region code, but for selection purposes the EPUB Creator might identify only the language code.</p>
 
@@ -164,7 +164,7 @@
 
 				<p>The selection properties defined in the <a
 						href="https://www.w3.org/TR/epub-33/#sec-container-metainf-container.xml"
-							><code>container.xml</code> file</a> [[!EPUB-33]] have no rendering behaviors attached to
+							><code>container.xml</code> file</a> [[EPUB-33]] have no rendering behaviors attached to
 					them, either. For example, indicating that a Rendition is fixed layout in the <a href="#layout-attr"
 							><code>rendition:layout</code> attribute</a> does not trigger fixed layout rendering
 					behaviors within the specified Rendition.</p>
@@ -176,7 +176,7 @@
 			<section id="terminology">
 				<h3>Terminology</h3>
 
-				<p>The following terms used in this document are defined in [[!EPUB-33]]:</p>
+				<p>The following terms used in this document are defined in [[EPUB-33]]:</p>
 
 				<ul>
 					<li><a href="https://www.w3.org/TR/epub-33/#dfn-epub-container">EPUB Container</a></li>
@@ -202,15 +202,15 @@
 						<p>The <a href="https://www.w3.org/TR/epub-33/#sec-container-metainf-container.xml"
 									><code>container.xml</code> file</a> located in the child <a
 								href="https://www.w3.org/TR/epub-33/#sec-container-metainf"><code>META-INF</code>
-								directory</a> of the EPUB Container Root Directory [[!EPUB-33]]. Each <a>Rendition</a>
-							in the Container is identified by a <code>rootfile</code> element [[!EPUB-33]].</p>
+								directory</a> of the EPUB Container Root Directory [[EPUB-33]]. Each <a>Rendition</a> in
+							the Container is identified by a <code>rootfile</code> element [[EPUB-33]].</p>
 					</dd>
 
 					<dt><dfn>Default Rendition</dfn></dt>
 					<dd>
 						<p>The <a>Rendition</a> listed in the first <code>rootfile</code> element in the <a
 								href="https://www.w3.org/TR/epub-33/#sec-container-metainf-container.xml"
-									><code>container.xml</code> file</a> [[!EPUB-33]].</p>
+									><code>container.xml</code> file</a> [[EPUB-33]].</p>
 					</dd>
 
 					<dt><dfn>Multiple-Rendition Publication</dfn></dt>
@@ -239,10 +239,10 @@
 
 			<p>Each Rendition of an <a>EPUB Publication</a> MUST meet the <a
 					href="https://www.w3.org/TR/epub-33/#sec-epub-conf">requirements for EPUB Publications</a>
-				[[!EPUB-33]].</p>
+				[[EPUB-33]].</p>
 
 			<p>The Package Document for each Rendition MUST be listed in the <code>container.xml</code> file
-				[[!EPUB-33]], where the first Package Document listed represents the <a>Default Rendition</a>.</p>
+				[[EPUB-33]], where the first Package Document listed represents the <a>Default Rendition</a>.</p>
 
 			<aside class="example">
 				<p>The following example shows SVG and XHTML Renditions bundled in the same container:</p>
@@ -259,7 +259,7 @@
 			</aside>
 
 			<p>Each Rendition of the EPUB Publication SHOULD only list the <a>Publication Resources</a> necessary for
-				its rendering in its Package Document <a>manifest</a> [[!EPUB-33]]. Renditions MAY reference the same
+				its rendering in its Package Document <a>manifest</a> [[EPUB-33]]. Renditions MAY reference the same
 				Publication Resources.</p>
 
 			<div class="note">
@@ -293,31 +293,31 @@
 					<p>To ensure consistency of metadata at the Publication and <a>Rendition</a> levels, this
 						specification defines the content model of the root <code>metadata</code> element in the <a
 							href="https://www.w3.org/TR/epub-33/#sec-container-metainf-metadata.xml"
-								><code>metadata.xml</code> file</a> [[!EPUB-33]] to be the same as the Package Document
+								><code>metadata.xml</code> file</a> [[EPUB-33]] to be the same as the Package Document
 							<a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code>
-							element</a> [[!EPUB-33]], with the following differences in syntax and semantics:</p>
+							element</a> [[EPUB-33]], with the following differences in syntax and semantics:</p>
 
 					<ul>
-						<li>A <code>dc:identifier</code> element [[!DCTERMS]] MUST contain the <a
+						<li>A <code>dc:identifier</code> element [[DCTERMS]] MUST contain the <a
 								href="https://www.w3.org/TR/epub-33/#sec-opf-dcidentifier">unique identifier</a>
-							[[!EPUB-33]] for the EPUB Publication.</li>
-						<li>A <code>meta</code> element [[!EPUB-33]] MUST contain the last modified date, expressed
-							using the <code>dcterms:modified</code> property [[!DCTERMS]]. The value of the property
-							MUST conform to the pattern and rules defined in <a
+							[[EPUB-33]] for the EPUB Publication.</li>
+						<li>A <code>meta</code> element [[EPUB-33]] MUST contain the last modified date, expressed using
+							the <code>dcterms:modified</code> property [[DCTERMS]]. The value of the property MUST
+							conform to the pattern and rules defined in <a
 								href="https://www.w3.org/TR/epub-33/#sec-metadata-last-modified">Last Modified Date</a>
-							[[!EPUB-33]]. Only one <code>dcterms:modified</code> property without a <a
+							[[EPUB-33]]. Only one <code>dcterms:modified</code> property without a <a
 								href="https://www.w3.org/TR/epub-33/#attrdef-refines"><code>refines</code> attribute</a>
-							[[!EPUB-33]] is allowed.</li>
+							[[EPUB-33]] is allowed.</li>
 						<li>All other metadata is OPTIONAL.</li>
 						<li>The obsolete <a href="https://www.w3.org/TR/epub-33/#sec-opf2-meta">OPF2 <code>meta</code>
-								element</a> [[!EPUB-33]] is not allowed.</li>
+								element</a> [[EPUB-33]] is not allowed.</li>
 						<li>The <code>meta</code> and <code>link</code> elements are defined in the same namespace as
 							the <code>metadata</code> root element: <code class="uri"><a
 									href="http://www.idpf.org/2013/metadata"
 								>http://www.idpf.org/2013/metadata</a></code></li>
 						<li>In order to enable the full expression of metadata in the <code>metadata.xml</code> file,
 							all attributes allowed on the <a href="https://www.w3.org/TR/epub-33/#sec-package-elem"
-									><code>package</code> element</a> [[!EPUB-33]] are allowed on the root <code
+									><code>package</code> element</a> [[EPUB-33]] are allowed on the root <code
 								class="markup">metadata</code> element.</li>
 					</ul>
 
@@ -355,8 +355,8 @@
 						<h4>Resource Obfuscation</h4>
 
 						<p>The <a href="https://www.w3.org/TR/epub-33/#obfus-algorithm">resource obfuscation
-								algorithm</a> [[!EPUB-33]] depends on creating an <a
-								href="https://www.w3.org/TR/epub-33/#obfus-keygen">obfuscation key</a> [[!EPUB-33]] from
+								algorithm</a> [[EPUB-33]] depends on creating an <a
+								href="https://www.w3.org/TR/epub-33/#obfus-keygen">obfuscation key</a> [[EPUB-33]] from
 							the <a>Unique Identifier</a> for the EPUB Publication.</p>
 
 						<p>For compatibility reasons, and due to the complexities of being able to share resources
@@ -376,11 +376,11 @@
 
 					<p>This specification inherits the mechanisms for associating vocabularies defined in <a
 							href="https://www.w3.org/TR/epub-33/#sec-vocab-assoc">Vocabulary Association Mechanisms</a>
-						[[!EPUB-33]] as they relate to the Package Document metadata, with only the following
+						[[EPUB-33]] as they relate to the Package Document metadata, with only the following
 						modification: the <code>prefix</code> attribute MAY be attached only to the root
 							<code>metadata</code> element.</p>
 
-					<p><a href="https://www.w3.org/TR/epub-33/#sec-reserved-vocabs">Reserved prefixes</a> [[!EPUB-33]]
+					<p><a href="https://www.w3.org/TR/epub-33/#sec-reserved-vocabs">Reserved prefixes</a> [[EPUB-33]]
 						for metadata attribute expressions are adopted without change.</p>
 				</section>
 			</section>
@@ -412,32 +412,28 @@
 			<section id="rendition-selection-pub-confomance">
 				<h3>Content Conformance</h3>
 
-				<p>A Container Document MUST meet all of the following criteria:</p>
+				<p>A Container Document:</p>
 
 				<ul class="conformancelist">
-					<li id="confreq-container">It MUST be valid to the definition and requirements for the
+					<li id="confreq-container">MUST be valid to the definition and requirements for the
 							<code>container.xml</code> file specified in <a
 							href="https://www.w3.org/TR/epub-33/#sec-container-metainf-container.xml">Container –
-							META-INF/container.xml</a> [[!EPUB-33]].</li>
-					<li id="confreq-selection-attr">It MAY include any of the selection attributes defined in <a
+							META-INF/container.xml</a> [[EPUB-33]].</li>
+					<li id="confreq-selection-attr">MAY include any of the selection attributes defined in <a
 							href="#rendition-selection-attr">Rendition Selection Attributes</a>.</li>
-					<li id="confreq-selection-min">Inclusion of selection attributes is OPTIONAL on the <a
+					<li id="confreq-selection-default">MAY Include selection attributes on the <a
 							href="https://www.w3.org/TR/epub-33/#elemdef-container-rootfile"><code>rootfile</code>
-							element</a> [[!EPUB-33]] for the <a>Default Rendition</a>, but it SHOULD include at least
-						one selection attribute ‒ in addition to the OPTIONAL label ‒ on each subsequent
-							<code>rootfile</code> element.</li>
+							element</a> [[EPUB-33]] for the <a>Default Rendition</a></li>
+					<li id="confreq-selection-min">SHOULD include at least one selection attribute ‒ in addition to the
+						OPTIONAL label ‒ on each subsequent <code>rootfile</code> element.</li>
 				</ul>
 			</section>
 
 			<section id="rendition-selection-rs-conformance">
 				<h3>Reading System Conformance</h3>
 
-				<p>An EPUB Reading System MUST meet all of the following criteria for <a>Rendition</a> selection:</p>
-
-				<ul class="conformancelist">
-					<li id="confreq-rs-processing">It SHOULD determine the Rendition to present to a user as defined in
-							<a href="#rendition-selection-proc-model"></a>.</li>
-				</ul>
+				<p>An EPUB Reading System SHOULD determine the Rendition to present to a user as defined in <a
+						href="#rendition-selection-proc-model"></a>.</p>
 			</section>
 
 			<section id="rendition-selection-attr">
@@ -479,22 +475,22 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on Container Document <code>rootfile</code> elements
-									[[!EPUB-33]].</p>
+									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
 							</dt>
 							<dd>
-								<p>A CSS 3 media query [[!MediaQueries]], where the media type, if specified, MUST only
+								<p>A CSS 3 media query [[MediaQueries]], where the media type, if specified, MUST only
 									be the value "<code>all</code>".</p>
 							</dd>
 						</dl>
 					</div>
 
-					<p>As per [[!MediaQueries]], the media query in this attribute MUST evaluate to true in order for
-						the given Rendition to be selected for rendering. Media queries that evaluate to "not all” per
-							<a href="http://www.w3.org/TR/css3-mediaqueries/#error-handling">3.1 Error Handling</a>
-						[[!MediaQueries]] SHOULD be treated as false for the purposes of Rendition selection (i.e., the
+					<p>As per [[MediaQueries]], the media query in this attribute MUST evaluate to true in order for the
+						given Rendition to be selected for rendering. Media queries that evaluate to "not all” per <a
+							href="http://www.w3.org/TR/css3-mediaqueries/#error-handling">3.1 Error Handling</a>
+						[[MediaQueries]] SHOULD be treated as false for the purposes of Rendition selection (i.e., the
 						given Rendition is not a valid match).</p>
 
 					<aside class="example">
@@ -545,7 +541,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on Container Document <code>rootfile</code> elements
-									[[!EPUB-33]].</p>
+									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -559,7 +555,7 @@
 
 					<p>When specified, the value of this attribute MUST match the <a
 							href="https://www.w3.org/TR/epub-33/#property-layout-global">global rendition:layout
-							setting</a> [[!EPUB-33]] for the referenced Rendition.</p>
+							setting</a> [[EPUB-33]] for the referenced Rendition.</p>
 
 					<p>If a user layout preference is defined in the Reading System, the attribute evaluates to true if
 						the preference matches the specified value, otherwise it evaluates to false. If no user
@@ -613,13 +609,13 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on Container Document <code>rootfile</code> elements
-									[[!EPUB-33]].</p>
+									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
 							</dt>
 							<dd>
-								<p>MUST contain a valid language code conforming to [[!RFC5646]].</p>
+								<p>MUST contain a valid language code conforming to [[RFC5646]].</p>
 							</dd>
 						</dl>
 					</div>
@@ -631,7 +627,7 @@
 
 					<p>If a user language preference is defined in the Reading System, the attribute evaluates to true
 						if the preference matches the specified value, otherwise it evaluates to false. Several matching
-						schemes are defined in Section 3 of [[!RFC4647]]. Reading systems can use the most appropriate
+						schemes are defined in Section 3 of [[RFC4647]]. Reading systems can use the most appropriate
 						matching scheme. If no user preference is defined, the Reading System SHOULD ignore the
 						attribute when selecting from the available Renditions.</p>
 
@@ -661,7 +657,7 @@
 					<h4>The <code>rendition:accessMode</code> attribute</h4>
 
 					<p>The <code>rendition:accessMode</code> attribute identifies the way in which intellectual content
-						is communicated in a <a>Rendition</a>, and is based on the [[!ISO24751-3]] "Access Mode"
+						is communicated in a <a>Rendition</a>, and is based on the [[ISO24751-3]] "Access Mode"
 						property.</p>
 
 					<div class="elem-synopsis" id="attrdef-accessMode">
@@ -687,7 +683,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on Container Document <code>rootfile</code> elements
-									[[!EPUB-33]].</p>
+									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -747,7 +743,7 @@
 				<section id="label-attr">
 					<h4>The <code>rendition:label</code> attribute</h4>
 
-					<p>The <code>rendition:label</code> attribute allows each <code>rootfile</code> element [[!EPUB-33]]
+					<p>The <code>rendition:label</code> attribute allows each <code>rootfile</code> element [[EPUB-33]]
 						to be annotated with a human-readable name.</p>
 
 					<div class="elem-synopsis" id="attrdef-label">
@@ -773,7 +769,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on Container Document <code>rootfile</code> elements
-									[[!EPUB-33]].</p>
+									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -825,7 +821,7 @@
 					viewport size).</p>
 
 				<p>When a change condition is triggered, the Reading System SHOULD evaluate the <code>rootfile</code>
-					elements [[!EPUB-33]] in the Container Document as follows, starting with the last
+					elements [[EPUB-33]] in the Container Document as follows, starting with the last
 						<code>rootfile</code> entry:</p>
 
 				<ul>
@@ -904,25 +900,18 @@
 
 				<p>An EPUB Publication MAY include an EPUB Rendition Mapping Document.</p>
 
-				<p>A conformant EPUB Rendition Mapping Document MUST meet all of the following criteria:</p>
-
-				<p class="bridgehead">Document Properties</p>
+				<p>A conformant EPUB Rendition Mapping Document:</p>
 
 				<ul class="conformancelist">
-					<li id="confreq-map-xhtml">It MUST conform to all content conformance constraints for XHTML Content
+					<li id="confreq-map-xhtml">MUST conform to all content conformance constraints for XHTML Content
 						Documents as defined in <a
 							href="http://www.idpf.org/epub/301/spec/epub-contentdocs.html#sec-xhtml-conf-content">XHTML
-							Content Documents — Content Conformance</a> [[!EPUB-33]].</li>
-					<li id="confreq-map-content-model">It MUST conform to all content conformance constraints specific
-						for EPUB Rendition Mapping Documents expressed in <a href="#rendition-mapping-doc-def">EPUB
+							Content Documents — Content Conformance</a> [[EPUB-33]].</li>
+					<li id="confreq-map-content-model">MUST conform to all content conformance constraints specific for
+						EPUB Rendition Mapping Documents expressed in <a href="#rendition-mapping-doc-def">EPUB
 							Rendition Mapping Document Definition</a>.</li>
-				</ul>
-
-				<p class="bridgehead">Publication</p>
-
-				<ul class="conformancelist">
-					<li id="confreq-map-unlisted">It MUST NOT be listed in the Package Document manifest of any of the
-						EPUB Publication's Renditions.</li>
+					<li id="confreq-map-unlisted">MUST NOT be listed in the Package Document manifest of any of the EPUB
+						Publication's Renditions.</li>
 				</ul>
 			</section>
 
@@ -931,10 +920,10 @@
 
 				<p>Reading Systems SHOULD support the use of Rendition Mapping Documents to switch between content. </p>
 
-				<p>If a Reading System supports mapping, it MUST meet all of the following criteria:</p>
+				<p>A Reading System that supports mapping:</p>
 
 				<ul class="conformancelist">
-					<li id="confreq-rs-remap">When a change in Renditions occurs, it MUST locate the current position in
+					<li id="confreq-rs-remap">MUST, when a change in Renditions occurs, locate the current position in
 						the Rendition Mapping Document and load the matching position in the new Rendition.</li>
 				</ul>
 			</section>
@@ -951,7 +940,7 @@
 					<h4>XHTML Content Document: Restrictions</h4>
 
 					<p>The Rendition Mapping Document is a compliant XHTML Content Document, but with the following
-						restrictions on the [[!HTML]] content model:</p>
+						restrictions on the [[HTML]] content model:</p>
 
 					<ul>
 						<li>No attributes are allowed on the <code>html</code>, <code>head</code>, <code>body</code>,
@@ -967,7 +956,7 @@
 							ignore all other <code>meta</code> elements.</li>
 						<li>The <code>body</code> element MUST include exactly one <code>nav</code> element child whose
 								<code>epub:type</code> attribute specifies the value "<code>resource-map</code>", and
-							MAY include one or more optional <code>nav</code> elements. No other [[!HTML]] content is
+							MAY include one or more optional <code>nav</code> elements. No other [[HTML]] content is
 							allowed as a child of the <code>body</code>.</li>
 					</ul>
 				</section>
@@ -1019,11 +1008,11 @@
 					<p>Each list item in the unordered list MUST identify an EPUB Content Document, or a fragment
 						therein, for one of the Renditions ‒ defined in a child <code>a</code> element. Each of these
 						links MUST reference a <a href="https://www.w3.org/TR/epub-33/#sec-itemref-elem">linear
-							Top-level Content Document</a> [[!EPUB-33]].</p>
+							Top-level Content Document</a> [[EPUB-33]].</p>
 
 					<p>Each <code>a</code> element MUST specify which Rendition it refers to either 1) by including an
 							<a href="http://www.idpf.org/epub/linking/cfi/#sec-intra-cfis">Intra-Publication CFI</a>
-						[[!EPUBCFI-11]] in its <code>href</code> attribute, or 2) by providing the relative path to the
+						[[EPUBCFI-11]] in its <code>href</code> attribute, or 2) by providing the relative path to the
 						Package Document for the Rendition as the value of an <code>epub:rendition</code> attribute.</p>
 
 					<p>If the <code>epub:rendition</code> attribute is used to specify the target Rendition, any
@@ -1132,7 +1121,7 @@
 
 					<p>The location of the Rendition Mapping Document is identified in the Container Document using a <a
 							href="https://www.w3.org/TR/epub-33/#sec-container.xml-link-elem"><code>link</code>
-							element</a> [[!EPUB-33]], where:</p>
+							element</a> [[EPUB-33]], where:</p>
 
 					<ul>
 						<li>the <code>href</code> attribute MUST reference the location of the Rendition Mapping
@@ -1247,7 +1236,7 @@
 						>http://www.idpf.org/epub/renditions/multiple/schema/epub-rendition-mapping.rnc</a>.</p>
 			</section>
 		</section>
-		<section id="change-log">
+		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
 
 			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -84,7 +84,7 @@
 		<section id="sec-introduction">
 			<h2>Introduction</h2>
 
-			<section id="sec-intro-overview">
+			<section id="sec-intro-overview" class="informative">
 				<h3>Overview</h3>
 
 				<p>The EPUB 3 standard is separated into two distinct concerns: the authoring of <a>EPUB
@@ -153,15 +153,15 @@
 			<h3>Publication Resource Processing</h3>
 
 			<p id="confreq-rs-epub-pub-res" class="support">Reading Systems MUST process <a
-					href="https://www.w3.org/TR/epub-33/#sec-package-doc">Publication Resources</a> [[!EPUB-33]].</p>
+					href="https://www.w3.org/TR/epub-33/#sec-package-doc">Publication Resources</a> [[EPUB-33]].</p>
 
 			<section id="sec-epub-rs-conf-foreign-res">
 				<h4>Foreign Resources</h4>
 
 				<p id="confreq-rs-foreign">Reading Systems MAY support an arbitrary set of <a>Foreign Resource</a>
 					types, and MUST process fallbacks for unsupported Foreign Resources as defined in <a
-						href="https://www.w3.org/TR/epub-33/#sec-foreign-restrictions">Foreign Resources</a>
-					[[!EPUB-33]] if not.</p>
+						href="https://www.w3.org/TR/epub-33/#sec-foreign-restrictions">Foreign Resources</a> [[EPUB-33]]
+					if not.</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-remote-res">
@@ -169,13 +169,13 @@
 
 				<p id="confreq-rs-remote">Reading Systems SHOULD support <a>remote resources</a>, as defined in <a
 						href="https://www.w3.org/TR/epub-33/#sec-resource-locations">Resource Locations</a>
-					[[!EPUB-33]].</p>
+					[[EPUB-33]].</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-data-urls">
 				<h4>Data URLs</h4>
 
-				<p id="confreq-rs-data-urls">Reading Systems MUST prevent data URLs [[!RFC2397]] from opening in <a
+				<p id="confreq-rs-data-urls">Reading Systems MUST prevent data URLs [[RFC2397]] from opening in <a
 						href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level
 						browsing contexts</a> [[HTML]], except when initiated through a Reading System affordance such
 					as a context menu. If a Reading System does not use a top-level browsing context for <a>Top-level
@@ -189,11 +189,11 @@
 
 				<p id="confreq-rs-epub3-images">If a Reading System has a <a>Viewport</a>, it MUST support the <a
 						href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type Resources</a>
-					[[!EPUB-33]].</p>
+					[[EPUB-33]].</p>
 
 				<p id="confreq-rs-epub3-mp3-aac">If it has the capability to render pre-recorded audio, it MUST support
 					the <a href="https://www.w3.org/TR/epub-33/#cmt-grp-audio">audio Core Media Type Resources</a>
-					[[!EPUB-33]] and SHOULD support Media Overlays [[!EPUB-33]].</p>
+					[[EPUB-33]] and SHOULD support Media Overlays [[EPUB-33]].</p>
 
 				<p class="note" id="note-video-codecs">It is recommended that Reading Systems support at least one of
 					the H.264 [[H264]] and VP8 [[RFC6386]] video codecs, but this is not a conformance requirement
@@ -211,21 +211,21 @@
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-rs-xml-nval">a <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#proc-types"
-								>conformant non-validating processor</a> [[!XML]].</p>
+								>conformant non-validating processor</a> [[XML]].</p>
 					</li>
 					<li>
 						<p id="confreq-rs-xml-ns">a <a
 								href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#ProcessorConformance"
-								>conformant processor</a> as defined in [[!XML-NAMES]].</p>
+								>conformant processor</a> as defined in [[XML-NAMES]].</p>
 					</li>
 					<li>
-						<p id="confreq-rs-xml-base">a conformant application as defined by [[!XMLBase]].</p>
+						<p id="confreq-rs-xml-base">a conformant application as defined by [[XMLBase]].</p>
 					</li>
 				</ul>
 
 				<p id="confreq-rs-xml-extid">In addition, when processing XML documents, it MUST NOT resolve <a
 						href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">external identifiers</a>
-					[[!XML]].</p>
+					[[XML]].</p>
 			</section>
 
 			<section id="sec-epub-rs-i18n">
@@ -238,12 +238,12 @@
 					<li> the <code>xml:lang</code> attribute for all XML documents like the <a
 							href="https://www.w3.org/TR/epub-33/#attrdef-xml-lang">Package Document</a> or the <a
 							href="https://www.w3.org/TR/epub-33/#sec-overlay-docs">Media Overlay
-						Document</a> [[!EPUB-33]]. </li>
+						Document</a> [[EPUB-33]]. </li>
 
 					<li> the <code>xml:lang</code> and <code>lang</code> attributes for <a
 							href="https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes"
-							>XHTML</a> [[!HTML]] or <a href="https://www.w3.org/TR/SVG/struct.html#LangSpaceAttrs"
-							>SVG</a> [[!SVG]]. </li>
+							>XHTML</a> [[HTML]] or <a href="https://www.w3.org/TR/SVG/struct.html#LangSpaceAttrs"
+							>SVG</a> [[SVG]]. </li>
 				</ul>
 
 				<p> Similarly, a Reading System MUST process, for all <a
@@ -252,13 +252,12 @@
 
 				<ul>
 					<li> the <code>dir</code> attribute for the <a href="https://www.w3.org/TR/epub-33/#attrdef-dir"
-							>Package Document</a> [[!EPUB-33]]. (See also <a href="#sec-pkg-doc-base-dir"></a> for
+							>Package Document</a> [[EPUB-33]]. (See also <a href="#sec-pkg-doc-base-dir"></a> for
 						further details.) </li>
 					<li> the <code>dir</code> attribute for <a
-							href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
-						>XHTML</a> [[!HTML]]. </li>
+							href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute">XHTML</a> [[HTML]]. </li>
 					<li> the <code>direction</code> attribute for <a
-							href="https://www.w3.org/TR/SVG2/text.html#DirectionProperty">SVG</a> [[!SVG]]. </li>
+							href="https://www.w3.org/TR/SVG2/text.html#DirectionProperty">SVG</a> [[SVG]]. </li>
 				</ul>
 
 				<p> In the absence of this information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume
@@ -272,13 +271,13 @@
 			<h2>Package Document Processing</h2>
 
 			<p id="confreq-rs-epub-pub" class="support">Reading Systems MUST process the <a
-					href="https://www.w3.org/TR/epub-33/#sec-package-doc">Package Document</a> [[!EPUB-33]].</p>
+					href="https://www.w3.org/TR/epub-33/#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
 
 			<section id="sec-pkg-doc-relative-iris">
 				<h4>Resolving Relative IRIs</h4>
 
-				<p>To obtain an absolute IRI reference from a relative IRI reference [[!RFC3987]] in the Package
-					Document, Reading Systems MUST use the Base IRI [[!RFC3986]] of the Package Document.</p>
+				<p>To obtain an absolute IRI reference from a relative IRI reference [[RFC3987]] in the Package
+					Document, Reading Systems MUST use the Base IRI [[RFC3986]] of the Package Document.</p>
 
 				<p>The Base IRI of the Package Document is the combination of the Base IRI of the <a>EPUB Container</a>
 					together with the path to Package Document (relative to the <a>Root Directory</a>) when an EPUB
@@ -293,13 +292,13 @@
 
 				<p>If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
 						<code>rtl</code>, Reading Systems MUST override the bidi algorithm per <a
-						data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[!BIDI]],
+						data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]],
 					setting the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the
 					base direction is <code>rtl</code>.</p>
 
 				<p>Otherwise the base direction is <code>auto</code>, in which case Reading Systems MUST determine the
 					text's direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule
-						P2</a> of [[!BIDI]].</p>
+						P2</a> of [[BIDI]].</p>
 			</section>
 
 			<section id="sec-pkg-doc-pub-identifiers">
@@ -319,9 +318,9 @@
 					<dd>
 						<p>Reading Systems MUST <a
 								href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">strip and
-								collapse ASCII whitespace</a> [[!Infra]] from Dublin Core [[!DC11]] and <a
+								collapse ASCII whitespace</a> [[Infra]] from Dublin Core [[DC11]] and <a
 								href="https://www.w3.org/TR/epub-33/#sec-meta-elem"><code>meta</code></a> element <a
-								href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[!EPUB-33]] before
+								href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[EPUB-33]] before
 							processing.</p>
 					</dd>
 
@@ -330,7 +329,7 @@
 						<p>To determine whether an <code>identifier</code> conforms to an established system or has been
 							granted by an issuing authority, Reading Systems SHOULD check for an <a
 								href="https://www.w3.org/TR/epub-33/#identifier-type"><code>identifier-type</code>
-								property</a> [[!EPUB-33]].</p>
+								property</a> [[EPUB-33]].</p>
 					</dd>
 
 					<dt id="dc-title">The <code>title</code> element</dt>
@@ -384,7 +383,7 @@
 							resource, a Reading System must only use the language information associated with the
 							resource to determine its language, not the metadata included in the link to the resource. </p>
 						<p id="sec-linked-records"> In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
-								>linked metadata record</a> [[!EPUB-33]], Reading Systems MUST NOT skip processing the
+								>linked metadata record</a> [[EPUB-33]], Reading Systems MUST NOT skip processing the
 							metadata expressed in the Package Document and only use the information expressed in the
 							record. Reading Systems may compile metadata from multiple linked records; they do not have
 							to select only one record.</p>
@@ -426,13 +425,13 @@
 					the fallback chain until it has identified at least one supported Publication Resource to use in
 					place of the unsupported resource. If the Reading System supports multiple Publication Resources in
 					the fallback chain, it MAY select the resource to use based on specific <a
-						href="https://www.w3.org/TR/epub-33/#attrdef-item-properties">properties</a> [[!EPUB-33]] of
-					that resource, otherwise it SHOULD honor the EPUB Creator's preferred fallback order. If a Reading
-					System does not support any resource in the fallback chain, it MUST alert the reader that content
-					could not be displayed.</p>
+						href="https://www.w3.org/TR/epub-33/#attrdef-item-properties">properties</a> [[EPUB-33]] of that
+					resource, otherwise it SHOULD honor the EPUB Creator's preferred fallback order. If a Reading System
+					does not support any resource in the fallback chain, it MUST alert the reader that content could not
+					be displayed.</p>
 
 				<p>When <a href="https://www.w3.org/TR/epub-33/#sec-foreign-restrictions-manifest">manifest
-						fallbacks</a> [[!EPUB-33]] are provided for <a>Top-level Content Documents</a>, Reading Systems
+						fallbacks</a> [[EPUB-33]] are provided for <a>Top-level Content Documents</a>, Reading Systems
 					MAY choose from the available options in order to find the optimal version to render in a given
 					context (e.g., by inspecting the properties attribute for each).</p>
 			</section>
@@ -446,8 +445,8 @@
 					given in the <code>spine</code>.</p>
 
 				<p>When a user traverses the default reading order defined in the <a
-						href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[!EPUB-33]], a Reading System
-					MAY automatically skip <code>itemref</code> elements marked as non-linear (excluding when a user
+						href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[EPUB-33]], a Reading System MAY
+					automatically skip <code>itemref</code> elements marked as non-linear (excluding when a user
 					specifically activates a hyperlink to such items). Reading Systems MAY also provide the option for
 					users to select whether non-linear content is skipped by default or not.</p>
 
@@ -477,19 +476,19 @@
 			<h2>Content Document Processing</h2>
 
 			<p>The definition of <a href="https://www.w3.org/TR/epub-33/#sec-contentdocs">EPUB Content Documents</a>
-				[[!EPUB-33]] includes various authoring restrictions to optimize the cross-compatibility of content
+				[[EPUB-33]] includes various authoring restrictions to optimize the cross-compatibility of content
 				(e.g., <a href="https://www.w3.org/TR/epub-33/#sec-css-req">prohibiting CSS for setting language and
-					direction</a> [[EPUB-33]]). Unless stated otherwise in this specification, Reading Systems MAY
+					direction</a> [[?EPUB-33]]). Unless stated otherwise in this specification, Reading Systems MAY
 				support these restricted features.</p>
 
 			<section id="sec-xhtml">
 				<h3>XHTML Content Documents</h3>
 
 				<p id="confreq-rs-epub3-xhtml" class="support">Reading Systems MUST process <a
-						href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a> [[!EPUB-33]].</p>
+						href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a> [[EPUB-33]].</p>
 
 				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, Reading
-					Systems MUST process XHTML Content Documents using semantics defined by the [[!HTML]] specification
+					Systems MUST process XHTML Content Documents using semantics defined by the [[HTML]] specification
 					and honor any applicable user agent conformance constraints expressed therein.</p>
 
 				<section id="sec-xhtml-extensions">
@@ -500,7 +499,7 @@
 
 						<p id="confreq-html-rs-a11y">Reading Systems SHOULD recognize embedded ARIA markup and support
 							exposure of any given ARIA roles, states and properties to platform accessibility APIs
-							[[!WAI-ARIA]].</p>
+							[[WAI-ARIA]].</p>
 					</section>
 
 					<section id="sec-xhtml-structural-semantics">
@@ -508,7 +507,7 @@
 
 						<p id="confreq-rs-epubtype-head">In addition to the requirements in <a
 								href="#sec-structural-semantics"></a>, a Reading System MUST ignore semantics expressed
-							on the [[!HTML]] <a
+							on the [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element"
 									><code>head</code></a> element or its descendants.</p>
 					</section>
@@ -518,7 +517,7 @@
 
 						<p>Reading System support for the <a
 								href="https://www.w3.org/TR/2015/REC-rdfa-core-20150317/#s_model">attribute processing
-								model</a> [[!RDFA-CORE]] is OPTIONAL.</p>
+								model</a> [[RDFA-CORE]] is OPTIONAL.</p>
 					</section>
 
 					<section id="sec-xhtml-microdata">
@@ -526,7 +525,7 @@
 
 						<p>Reading System support for the <a href="https://www.w3.org/TR/microdata/#encoding-microdata"
 								>attribute processing model</a> is OPTIONAL, as is the <a
-								href="https://www.w3.org/TR/microdata/#json">conversion to JSON</a> [[!Microdata]].</p>
+								href="https://www.w3.org/TR/microdata/#json">conversion to JSON</a> [[Microdata]].</p>
 					</section>
 
 					<section id="sec-xhtml-ssml-attrib">
@@ -534,21 +533,21 @@
 
 						<p id="confreq-rs-epub3-ssml">Reading Systems with <a>Text-to-Speech</a> (TTS) capabilities
 							SHOULD support <a href="https://www.w3.org/TR/epub-33/#sec-xhtml-ssml-attrib">SSML
-								attributes</a> [[!EPUB-33]].</p>
+								attributes</a> [[EPUB-33]].</p>
 
 						<dl class="conformance-list">
 							<dt id="sec-cd-ssml-ph-attrib">The <code>ssml:ph</code> attribute</dt>
 							<dd>
 								<p>Reading Systems that support the SSML Attributes and <a
-										href="https://www.w3.org/TR/epub-33/#sec-pls">PLS documents</a> [[!EPUB-33]]
-									MUST honor the defined <a href="#confreq-pls-rs-casc">precedence rules</a> for these
-									two constructs.</p>
+										href="https://www.w3.org/TR/epub-33/#sec-pls">PLS documents</a> [[EPUB-33]] MUST
+									honor the defined <a href="#confreq-pls-rs-casc">precedence rules</a> for these two
+									constructs.</p>
 							</dd>
 
 							<dt id="sec-cd-ssml-alphabet-attrib">The <code>ssml:alphabet</code> attribute</dt>
 							<dd>
 								<p>Reading Systems that support the <a href="#sec-xhtml-ssml-attrib">SSML Attributes</a>
-									feature of this specification SHOULD support the IPA alphabet [[!IPA]], as expressed
+									feature of this specification SHOULD support the IPA alphabet [[IPA]], as expressed
 									by the value "<code>ipa</code>".</p>
 							</dd>
 						</dl>
@@ -558,7 +557,7 @@
 						<h5>Content Switching (Deprecated)</h5>
 
 						<p>Use of the <code>switch</code> element is <a href="https://www.w3.org/TR/epub-33/#deprecated"
-								>deprecated</a> [[EPUB-33]]. Refer to its definition in [[!EPUBContentDocs-301]] for
+								>deprecated</a> [[EPUB-33]]. Refer to its definition in [[EPUBContentDocs-301]] for
 							implementation information.</p>
 					</section>
 
@@ -567,7 +566,7 @@
 
 						<p>Use of the <code>trigger</code> element is <a
 								href="https://www.w3.org/TR/epub-33/#deprecated">deprecated</a> [[EPUB-33]]. Refer to
-							its definition in [[!EPUBContentDocs-301]] for implementation information.</p>
+							its definition in [[EPUBContentDocs-301]] for implementation information.</p>
 					</section>
 				</section>
 
@@ -583,7 +582,7 @@
 							<li>
 								<p id="confreq-mathml-rs-behavior">MUST be an input-compliant renderer for <a
 										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
-									defined in the [[!MATHML3]] specification.</p>
+									defined in the [[MATHML3]] specification.</p>
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
@@ -630,7 +629,7 @@
 					<section id="sec-xhtml-forms">
 						<h5>Form Submission</h5>
 
-						<p>Reading System support for the submission of [[!HTML]] forms is OPTIONAL. A Reading System
+						<p>Reading System support for the submission of [[HTML]] forms is OPTIONAL. A Reading System
 							might, for example, prevent form submissions by limiting access to networking.</p>
 					</section>
 				</section>
@@ -640,7 +639,7 @@
 				<h3>SVG Content Documents</h3>
 
 				<p id="confreq-rs-epub3-svg" class="support">Reading Systems MUST process <a
-						href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[!EPUB-33]].</p>
+						href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
 
 				<p>To process SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content
 						Documents</a>, a Reading System:</p>
@@ -648,7 +647,7 @@
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-svg-rs-behavior">MUST process SVG Content Documents using semantics defined by
-							the [[!SVG]] specification, and honor any applicable user agent conformance constraints
+							the [[SVG]] specification, and honor any applicable user agent conformance constraints
 							expressed therein, unless explicitly defined by this specification as overridden.</p>
 					</li>
 					<li>
@@ -658,9 +657,9 @@
 					<li>
 						<p id="confreq-svg-rs-css">MUST, if it has a <a>Viewport</a>, support the visual rendering of
 							SVG using CSS as defined in <a href="https://www.w3.org/TR/SVG/styling.html">Styling</a>
-							[[!SVG]] and it SHOULD support all properties defined in the <a
-								href="https://www.w3.org/TR/SVG/propidx.html">Property Index</a> [[!SVG]]. In the case
-							of embedded SVG, a Reading System MUST also conform to the constraints defined in <a
+							[[SVG]] and it SHOULD support all properties defined in the <a
+								href="https://www.w3.org/TR/SVG/propidx.html">Property Index</a> [[SVG]]. In the case of
+							embedded SVG, a Reading System MUST also conform to the constraints defined in <a
 								href="#sec-xhtml-svg-css"></a>.</p>
 					</li>
 					<li>
@@ -682,22 +681,22 @@
 
 				<p id="confreq-rs-epub3-css" class="support">If a Reading System has a <a>Viewport</a>, it MUST support
 					the <a href="https://www.w3.org/TR/epub-33/#sec-css">visual rendering of XHTML Content Documents via
-						CSS</a> [[!EPUB-33]].</p>
+						CSS</a> [[EPUB-33]].</p>
 
 				<p>To support CSS, a Reading System:</p>
 
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-css-rs-support">MUST support the official definition of CSS as described in the
-							[[!CSSSnapshot]].</p>
+							[[CSSSnapshot]].</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-modules">SHOULD support all applicable modules in [[!CSSSnapshot]] that
+						<p id="confreq-css-rs-modules">SHOULD support all applicable modules in [[CSSSnapshot]] that
 							have reached at least <a href="https://www.w3.org/Consortium/Process/#RecsCR">Candidate
-								Recommendation</a> status [[!W3CProcess]] (and are widely implemented).</p>
+								Recommendation</a> status [[W3CProcess]] (and are widely implemented).</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-fonts">MUST support [[!TrueType]], [[!OpenType]], [[!WOFF]] and [[!WOFF2]]
+						<p id="confreq-css-rs-fonts">MUST support [[TrueType]], [[OpenType]], [[WOFF]] and [[WOFF2]]
 							font resources referenced from <code>@font-face</code> rules.</p>
 					</li>
 					<li>
@@ -714,7 +713,7 @@
 							so in a way that preserves the Cascade when necessary: through a user agent style sheet, the
 								<a
 								href="https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-OverrideAndComputed"
-									><code>getOverrideStyle</code> method</a> [[!DOM-Level-2-Style]], or [[!HTML]] <a
+									><code>getOverrideStyle</code> method</a> [[DOM-Level-2-Style]], or [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/dom.html#the-style-attribute"
 									><code>style</code> attributes</a>.</p>
 					</li>
@@ -725,7 +724,7 @@
 				</ul>
 
 				<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above, a Reading
-					System's user agent style sheet SHOULD support the [[!HTML]] <a
+					System's user agent style sheet SHOULD support the [[HTML]] <a
 						href="https://html.spec.whatwg.org/multipage/rendering.html#rendering">suggested default
 						rendering</a>.</p>
 
@@ -734,14 +733,14 @@
 					Creator's style sheets.</p>
 
 				<p id="confreq-rs-epub3-speech">Reading Systems with <a>Text-to-Speech</a> (TTS) capabilities SHOULD
-					support [[!CSS3-Speech]].</p>
+					support [[CSS3-Speech]].</p>
 			</section>
 
 			<section id="sec-scripted-content">
 				<h3>Scripting</h3>
 
 				<p id="confreq-rs-scripted" class="support">Reading Systems SHOULD support <a
-						href="https://www.w3.org/TR/epub-33/#sec-scripted-content">scripting</a> [[!EPUB-33]].</p>
+						href="https://www.w3.org/TR/epub-33/#sec-scripted-content">scripting</a> [[EPUB-33]].</p>
 
 				<p>Reading System support for scripting depends on the context in which it is used:</p>
 
@@ -749,22 +748,22 @@
 					<li>
 						<p id="confreq-rs-scripted-reflow-support">Reading Systems SHOULD support <a
 								href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained"
-								>container-constrained scripting</a> [[!EPUB-33]] in reflowable EPUB Content
+								>container-constrained scripting</a> [[EPUB-33]] in reflowable EPUB Content
 							Documents.</p>
 					</li>
 					<li>
 						<p id="confreq-rs-scripted-fxl-support">Reading Systems SHOULD support <a
 								href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level scripting</a>
-							[[!EPUB-33]] in <a href="https://www.w3.org/TR/epub-33/#sec-fixed-layouts">fixed-layout
-								documents</a> [[!EPUB-33]].</p>
+							[[EPUB-33]] in <a href="https://www.w3.org/TR/epub-33/#sec-fixed-layouts">fixed-layout
+								documents</a> [[EPUB-33]].</p>
 					</li>
 					<li>
 						<p id="confreq-rs-scripted-scrolled">Reading Systems SHOULD support spine-level scripting in
 							reflowable EPUB Content Documents that use the <a
 								href="https://www.w3.org/TR/epub-33/#flow-scrolled-doc">"<code>scrolled-doc</code>"</a>
 							or <a href="https://www.w3.org/TR/epub-33/#flow-scrolled-continuous"
-									>"<code>scrolled-continuous</code>"</a> [[!EPUB-33]] presentation modes defined by
-								<a href="#flow">the <code>rendition:flow</code> property</a>. Similarly, if it supports
+									>"<code>scrolled-continuous</code>"</a> [[EPUB-33]] presentation modes defined by <a
+								href="#flow">the <code>rendition:flow</code> property</a>. Similarly, if it supports
 							spine-level scripting in reflowable EPUB Content Documents, it MUST implement the
 								"<code>scrolled-doc</code>" presentation mode and SHOULD implement the
 								"<code>scrolled-continuous</code>" presentation mode.</p>
@@ -781,7 +780,7 @@
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-rs-scripted-ua">It MAY render <a>Scripted Content Documents</a> as an
-							interactive, scripted user agent according to [[!HTML]].</p>
+							interactive, scripted user agent according to [[HTML]].</p>
 					</li>
 					<li>
 						<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to modify
@@ -797,8 +796,8 @@
 					<li>
 						<p id="confreq-rs-scripted-readingsystem-object">It MUST extend the <a
 								href="https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object"
-									>navigator object</a> [[!HTML]] with the <code>epubReadingSystem</code>
-							interface defined in <a href="#app-epubReadingSystem"></a>. It also MUST support the
+								>navigator object</a> [[HTML]] with the <code>epubReadingSystem</code> interface defined
+							in <a href="#app-epubReadingSystem"></a>. It also MUST support the
 								<code>dom-manipulation</code> and <code>layout-change</code> features defined in <a
 								href="#app-ers-hasFeature-features"></a> in container-constrained scripting
 							contexts.</p>
@@ -812,7 +811,7 @@
 				<p id="confreq-rs-scripted-flbk">If a Reading System does not support scripting, it MUST process
 					fallbacks for scripted content as defined in <a
 						href="https://www.w3.org/TR/epub-33/#confreq-cd-scripted-flbk">Fallbacks for Scripted Content
-						Documents</a> [[!EPUB-33]].</p>
+						Documents</a> [[EPUB-33]].</p>
 			</section>
 
 			<section id="sec-pls">
@@ -820,28 +819,28 @@
 
 				<p id="sec-pls-conf-rs" class="support">Reading Systems with Text-to-Speech (TTS) capabilities SHOULD
 					support <a href="https://www.w3.org/TR/epub-33/#sec-pls"><abbr
-							title="Pronunciation Lexicon Specification">PLS</abbr> lexicons</a> [[!EPUB-33]].</p>
+							title="Pronunciation Lexicon Specification">PLS</abbr> lexicons</a> [[EPUB-33]].</p>
 
 				<p>To support PLS lexicons, a Reading System:</p>
 
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-pls-rs-proc">MUST process PLS documents as defined in
-							[[!PRONUNCIATION-LEXICON]].</p>
+							[[PRONUNCIATION-LEXICON]].</p>
 						<p id="confreq-pls-rs-scope">MUST apply the supplied pronunciation instructions to all text
 							nodes in the current XHTML Content Document whose <a
 								href="https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes"
-								>language</a> [[!HTML]] matches <a
+								>language</a> [[HTML]] matches <a
 								href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/#S4.1">the language
-								for which the pronunciation lexicon is relevant</a> [[!PRONUNCIATION-LEXICON]]. The
-							algorithm for matching language tags is defined in [[!BCP47]].</p>
+								for which the pronunciation lexicon is relevant</a> [[PRONUNCIATION-LEXICON]]. The
+							algorithm for matching language tags is defined in [[BCP47]].</p>
 						<p id="confreq-pls-rs-multi">MUST give precedence to the last occurrence of a rule when a
 							pronunciation rule is specified more than once for a given string target in a given language
 							(i.e., the Reading System must override the previously-defined pronunciation rule(s)).</p>
 						<p id="confreq-pls-rs-casc">MUST let any pronunciation instructions provided via the <a
 								href="#sec-cd-ssml-ph-attrib"><code>ssml:ph</code></a> attribute take precedence in
-							cases where a <code>grapheme</code> element [[!PRONUNCIATION-LEXICON]] matches a text node
-							of an element that carries the <code>ssml:ph</code> attribute [[!SSML]] (for Reading Systems
+							cases where a <code>grapheme</code> element [[PRONUNCIATION-LEXICON]] matches a text node of
+							an element that carries the <code>ssml:ph</code> attribute [[SSML]] (for Reading Systems
 							that also support <a href="#sec-xhtml-ssml-attrib">SSML Attributes</a>).</p>
 					</li>
 				</ul>
@@ -851,7 +850,7 @@
 			<h3>Navigation Document Processing</h3>
 
 			<p id="sec-nav-rs-conf" class="support">Reading Systems MUST process <a
-					href="https://www.w3.org/TR/epub-33/#sec-nav">EPUB Navigation Documents</a> [[!EPUB-33]].</p>
+					href="https://www.w3.org/TR/epub-33/#sec-nav">EPUB Navigation Documents</a> [[EPUB-33]].</p>
 
 			<p>To process the EPUB Navigation Document, a Reading System:</p>
 
@@ -859,24 +858,24 @@
 				<li>
 					<p id="confreq-nav-toc-access">MUST provide users access to the links in the <a
 							href="https://www.w3.org/TR/epub-33/#sec-nav-toc"><code>toc nav</code> element</a>
-						[[!EPUB-33]].</p>
+						[[EPUB-33]].</p>
 				</li>
 				<li>
 					<p id="confreq-nav-pagelist-access">SHOULD provide a method to navigate to the listed page breaks
 						when a <a href="https://www.w3.org/TR/epub-33/#sec-nav-pagelist"><code>page-list nav</code>
-							element</a> [[!EPUB-33]] is present.</p>
+							element</a> [[EPUB-33]] is present.</p>
 				</li>
 				<li>
 					<p id="confreq-nav-landmarks-access">MAY provide users access to the links in the <a
 							href="https://www.w3.org/TR/epub-33/#sec-nav-landmarks"><code>landmarks nav</code>
-							element</a> [[!EPUB-33]] and MAY use the links to enable functionality in the
+							element</a> [[EPUB-33]] and MAY use the links to enable functionality in the
 						application.</p>
 				</li>
 				<li>
 					<p id="confreq-nav-other-access">MAY provide access to <code>nav</code> elements that do not specify
 						an <code>epub:type</code> attribute or that <a
 							href="https://www.w3.org/TR/epub-33/#sec-nav-def-types-other">declare an unknown value</a>
-						[[!EPUB-33]].</p>
+						[[EPUB-33]].</p>
 				</li>
 				<li>
 					<p id="confreq-nav-activation">MUST relocate the current reading position to the destination
@@ -887,20 +886,20 @@
 						presenting them outside of the spine, regardless of support for CSS, as the default display
 						style of list items is equivalent to the <a
 							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
-								none</code> property</a> [[!CSSSnapshot]].).</p>
+								none</code> property</a> [[CSSSnapshot]].).</p>
 				</li>
 			</ul>
 
 			<p id="confreq-nav-spine">Reading Systems MUST honor the above requirements irrespective of whether the EPUB
 				Navigation Document is part of the <a href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a>
-				[[!EPUB-33]].</p>
+				[[EPUB-33]].</p>
 
 		</section>
 		<section id="sec-fixed-layouts">
 			<h2>Fixed-Layout Documents Processing</h2>
 
 			<p id="confreq-rs-epub3-fxl" class="support">Reading Systems MUST support the rendering of <a
-					href="https://www.w3.org/TR/epub-33/#sec-fixed-layouts">Fixed-Layout Documents</a> [[!EPUB-33]].</p>
+					href="https://www.w3.org/TR/epub-33/#sec-fixed-layouts">Fixed-Layout Documents</a> [[EPUB-33]].</p>
 
 			<section id="sec-fxl-props">
 				<h3>Fixed-Layout Properties</h3>
@@ -910,7 +909,7 @@
 					<p> The default value <code>reflowable</code> MUST be assumed by EPUB Reading Systems as the global
 						value if no meta element carrying this property occurs in the <a
 							href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code> section</a>
-						section [[!EPUB-33]]. </p>
+						section [[EPUB-33]]. </p>
 
 					<p>When the <code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading
 						Systems MUST NOT include space between the adjacent content slots when rendering <a>Synthetic
@@ -927,7 +926,7 @@
 						<dd>
 							<p>Reading Systems MUST produce exactly one page per spine <a
 									href="https://www.w3.org/TR/epub-33/#elemdef-spine-itemref"><code>itemref</code></a>
-								[[!EPUB-33]] when rendering.</p>
+								[[EPUB-33]] when rendering.</p>
 						</dd>
 					</dl>
 				</section>
@@ -994,7 +993,7 @@
 
 					<p>The <code>rendition:page-spread-*</code> properties MUST take precedence over whatever value of
 						the <a href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-								><code>page-break-before</code> property</a> [[!CSSSnapshot]] has been set for an
+								><code>page-break-before</code> property</a> [[CSSSnapshot]] has been set for an
 							<a>XHTML Content Document</a>.</p>
 
 					<div class="note">
@@ -1006,9 +1005,9 @@
 
 					<p>When a <a href="#def-layout-reflowable">reflowable</a> spine item follows a <a
 							href="#def-layout-pre-paginated">pre-paginated</a> one, the reflowable one SHOULD start on
-						the next page (as defined by the <a
+						the next page &#8212; as defined by the <a
 							href="https://www.w3.org/TR/epub-33/#attrdef-spine-page-progression-direction"
-								><code>page-progression-direction</code></a> [[EPUB-33]]) when it lacks a
+								><code>page-progression-direction</code></a> [[EPUB-33]] &#8212; when it lacks a
 							<code>rendition:page-spread-*</code> property value. If the reflowable spine item has a
 							<code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by inserting a
 						blank page).</p>
@@ -1034,7 +1033,7 @@
 					<dd>
 						<p>Reading Systems MUST use the width and height expressions as defined in <a
 								href="https://www.w3.org/TR/epub-33/#sec-fxl-icb-html">Expressing in HTML</a>
-							[[!EPUB-33]] to render <a>XHTML Content Documents</a>.</p>
+							[[EPUB-33]] to render <a>XHTML Content Documents</a>.</p>
 						<p>Reading Systems MUST clip XHTML content to the initial containing block (ICB) dimensions
 							declared in the <code>viewport</code>
 							<code>meta</code> tag — content positioned outside of the initial containing block will not
@@ -1048,7 +1047,7 @@
 					<dd>
 						<p id="confreq-fxl-rs-svg">Reading Systems MUST use the dimensions as defined in <a
 								href="https://www.w3.org/TR/epub-33/#sec-fxl-icb-svg">Expressing the ICB in SVG</a>
-							[[!EPUB-33]] to render <a>SVG Content Documents</a>.</p>
+							[[EPUB-33]] to render <a>SVG Content Documents</a>.</p>
 					</dd>
 				</dl>
 			</section>
@@ -1077,7 +1076,7 @@
 			<h2>Open Container Format Processing</h2>
 
 			<p id="confreq-rs-epub3-ocf" class="support">Reading Systems MUST process the <a
-					href="https://www.w3.org/TR/epub-33/#sec-ocf">EPUB Container</a> [[!EPUB-33]].</p>
+					href="https://www.w3.org/TR/epub-33/#sec-ocf">EPUB Container</a> [[EPUB-33]].</p>
 
 			<div class="note">
 				<p>It is not required that an application that processes OCF Containers be a full-fledged Reading System
@@ -1092,15 +1091,14 @@
 				<section id="sec-container-iri">
 					<h4>Relative IRIs for Referencing Other Components</h4>
 
-					<p>For relative IRI references, Reading Systems MUST determine the Base IRI [[!RFC3986]] according
-						to the relevant language specifications for the given file formats. For example, CSS defines how
+					<p>For relative IRI references, Reading Systems MUST determine the Base IRI [[RFC3986]] according to
+						the relevant language specifications for the given file formats. For example, CSS defines how
 						relative IRI references work in the context of CSS style sheets and property declarations
-						[[!CSSSnapshot]].</p>
+						[[CSSSnapshot]].</p>
 
 					<div class="note">
-						<p>Some language specifications reference Requests For Comments [[RFC]] that preceded
-							[[RFC3987]], in which case the earlier RFC applies for content in that particular
-							language.</p>
+						<p>Some language specifications reference Requests For Comments that preceded [[RFC3987]], in
+							which case the earlier RFC applies for content in that particular language.</p>
 					</div>
 
 					<p>Unlike most language specifications, Reading Systems MUST use the <a>Root Directory</a> of the
@@ -1132,7 +1130,7 @@
 							<p>Reading Systems MUST NOT fail when encountering configuration files in the <code
 									class="filename">META-INF</code> directory not listed in <a
 									href="https://www.w3.org/TR/epub-33/#sec-container-metainf-files">Reserved Files</a>
-								[[!EPUB-33]].</p>
+								[[EPUB-33]].</p>
 						</dd>
 					</dl>
 				</section>
@@ -1193,27 +1191,27 @@
 
 				<p id="confreq-ocf-fobfus">Reading Systems MUST support deobfuscation of resources as defined in <a
 						href="https://www.w3.org/TR/epub-33/#sec-resource-obfuscation"><em>Resource Obfuscation</em></a>
-					[[!EPUB-33]].</p>
+					[[EPUB-33]].</p>
 			</section>
 		</section>
 		<section id="sec-media-overlays">
 			<h2>Media Overlays Processing</h2>
 
 			<p id="confreq-rs-epub3-mo" class="support">Reading Systems MAY support <a
-					href="https://www.w3.org/TR/epub-33/#sec-media-overlays">Media Overlays</a> [[!EPUB-33]].</p>
+					href="https://www.w3.org/TR/epub-33/#sec-media-overlays">Media Overlays</a> [[EPUB-33]].</p>
 
 			<p>If a Reading System does not support Media Overlays, it MUST ignore both the <code>media-overlay</code>
 				attribute on <a>Manifest</a>
-				<a href="https://www.w3.org/TR/epub-33/#elemdef-package-item"><code>item</code> elements</a>
-				[[!EPUB-33]] and the manifest <code>item</code> elements where the <code>media-type</code> attribute
-				value equals <code>application/smil+xml</code>.</p>
+				<a href="https://www.w3.org/TR/epub-33/#elemdef-package-item"><code>item</code> elements</a> [[EPUB-33]]
+				and the manifest <code>item</code> elements where the <code>media-type</code> attribute value equals
+					<code>application/smil+xml</code>.</p>
 
 			<section id="sec-behaviors-loading">
 				<h4>Loading the Media Overlay</h4>
 
 				<p>When a Reading System loads a <a>Package Document</a>, it MUST refer to the <a>Manifest</a>
 					<a href="https://www.w3.org/TR/epub-33/#elemdef-package-item"><code>item</code> elements'</a>
-					[[!EPUB-33]] <code>media-overlay</code> attributes to discover the corresponding Media Overlays for
+					[[EPUB-33]] <code>media-overlay</code> attributes to discover the corresponding Media Overlays for
 						<a>EPUB Content Documents</a>.</p>
 
 				<p id="confreq-rs-xhtml-svg">Reading Systems MUST support playback for <a>XHTML Content Documents</a>,
@@ -1235,11 +1233,11 @@
 
 					<p>Reading Systems MUST render immediate children of the <a
 							href="https://www.w3.org/TR/epub-33/#elemdef-smil-body"><code>body</code> element</a>
-						[[!EPUB-33]] in a sequence. A <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-seq"
-								><code>seq</code> element's</a> [[!EPUB-33]] children MUST be rendered in sequence, and
+						[[EPUB-33]] in a sequence. A <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-seq"
+								><code>seq</code> element's</a> [[EPUB-33]] children MUST be rendered in sequence, and
 						playback completes when the last child has finished playing. A <a
 							href="https://www.w3.org/TR/epub-33/#elemdef-smil-par"><code>par</code> element's</a>
-						[[!EPUB-33]] children MUST be rendered in parallel (with each starting at the same time), and
+						[[EPUB-33]] children MUST be rendered in parallel (with each starting at the same time), and
 						playback completes when all the children have finished playing. When the <code>body</code>
 						element's last child has finished playing, playback of the Media Overlay Document is done.</p>
 				</section>
@@ -1248,12 +1246,12 @@
 					<h5>Rendering Audio</h5>
 
 					<p>When presented with a Media Overlay <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"
-								><code>audio</code> element</a> [[!EPUB-33]], Reading Systems MUST play the audio
+								><code>audio</code> element</a> [[EPUB-33]], Reading Systems MUST play the audio
 						resource referenced by the <code>src</code> attribute, starting at the clip offset time given by
 						the <a href="https://www.w3.org/TR/epub-33/#attrdef-smil-clipBegin"><code>clipBegin</code>
-							attribute</a> [[!EPUB-33]] and ending at the clip offset time given by the <a
+							attribute</a> [[EPUB-33]] and ending at the clip offset time given by the <a
 							href="https://www.w3.org/TR/epub-33/#attrdef-smil-clipEnd"><code>clipEnd</code>
-							attribute</a> [[!EPUB-33]]. The following rules MUST be observed:</p>
+							attribute</a> [[EPUB-33]]. The following rules MUST be observed:</p>
 
 					<ul>
 						<li>
@@ -1280,16 +1278,16 @@
 					<h5>Rendering EPUB Content Document Elements</h5>
 
 					<p>When presented with a Media Overlay <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"
-								><code>text</code> element</a> [[!EPUB-33]], Reading Systems SHOULD ensure the EPUB
+								><code>text</code> element</a> [[EPUB-33]], Reading Systems SHOULD ensure the EPUB
 						Content Document element referenced by the <code>src</code> attribute is visible in the
 							<a>Viewport</a>. During Media Overlays playback, Reading Systems with a Viewport SHOULD add
 						the class names given by the metadata properties <a
 							href="https://www.w3.org/TR/epub-33/#active-class"><code>active-class</code></a> and <a
 							href="https://www.w3.org/TR/epub-33/#playback-active-class"
-								><code>playback-active-class</code></a> [[!EPUB-33]] to the appropriate elements in the
+								><code>playback-active-class</code></a> [[EPUB-33]] to the appropriate elements in the
 						EPUB Content Document. Conversely, the class names SHOULD be removed when the playback state
 						changes, as described in <a href="https://www.w3.org/TR/epub-33/#sec-docs-assoc-style"
-							>Associating Style Information</a> [[!EPUB-33]].</p>
+							>Associating Style Information</a> [[EPUB-33]].</p>
 
 					<p>The <code>active-class</code> and <code>playback-active-class</code> metadata properties are
 						OPTIONAL, and if omitted, Reading System behavior is implementation-specific.</p>
@@ -1311,7 +1309,7 @@
 
 					<p>This same approach allows for synchronizing the Media Overlay playback with user selection of a
 						navigation point in the <a>EPUB Navigation Document</a>. The Reading System loads the Media
-						Overlay for that file and finds the correct point for starting playback based on the ID [[!XML]]
+						Overlay for that file and finds the correct point for starting playback based on the ID [[XML]]
 						of the navigation point target.</p>
 
 					<div class="note">
@@ -1319,7 +1317,7 @@
 							provide synchronized playback of its contents, regardless of whether the <a>XHTML Content
 								Document</a> in which it resides is included in the <a>spine</a>. See <a
 								href="https://www.w3.org/TR/epub-33/#sec-nav-doc"><em>EPUB Navigation Document</em></a>
-							[[!EPUB-33]] for more information.</p>
+							[[EPUB-33]] for more information.</p>
 					</div>
 
 					<div class="note" id="note-table-reading-mode">
@@ -1341,14 +1339,14 @@
 						of audio and video media embedded within the associated EPUB Content Document MUST be
 						overridden.</p>
 
-					<p>Note that the rules below apply only to <em>referenced</em> [[!HTML]] <a
+					<p>Note that the rules below apply only to <em>referenced</em> [[HTML]] <a
 							href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
 								><code>video</code></a> or <a
 							href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
 								><code>audio</code></a> elements within the associated EPUB Content Document. That is to
 						say, the rules apply to only those elements pointed to by <a
 							href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"><code>text</code> elements</a>
-						[[!EPUB-33]] within the Media Overlay (i.e., via the <code>src</code> attribute). Embedded media
+						[[EPUB-33]] within the Media Overlay (i.e., via the <code>src</code> attribute). Embedded media
 						that is not referenced by Media Overlay elements is not subject to these rules.</p>
 
 					<ul>
@@ -1362,7 +1360,7 @@
 							<ul>
 								<li>
 									<p>Hide the individual video/audio UI controls from the page, which overrides the
-										default behavior defined by the [[!HTML]] <a
+										default behavior defined by the [[HTML]] <a
 											href="https://html.spec.whatwg.org/multipage/media.html#attr-media-controls"
 												><code>controls</code> attribute</a>.</p>
 								</li>
@@ -1380,10 +1378,10 @@
 						<li>
 							<p>All referenced audio and video media embedded within an EPUB Content Document MUST be
 								initialized to their "stopped" state, and be ready to be played from the zero-position
-								within their content stream (possibly displaying the image specified using the [[!HTML]]
+								within their content stream (possibly displaying the image specified using the [[HTML]]
 									<a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
 										><code>poster</code></a> attribute). This requirement overrides the default
-								behavior defined by the [[!HTML]] <a
+								behavior defined by the [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
 										><code>autoplay</code></a> attribute.</p>
 						</li>
@@ -1392,21 +1390,21 @@
 								highlighting rules apply regardless of the content type referred to by that element's
 									<code>src</code> attribute (e.g., the CSS class name defined by the <a
 									href="https://www.w3.org/TR/epub-33/#active-class"><code>active-class</code>
-									metadata property</a> [[!EPUB-33]] SHOULD be applied to visible video and audio
+									metadata property</a> [[EPUB-33]] SHOULD be applied to visible video and audio
 								player controls within the host EPUB Content Document).</p>
 						</li>
 						<li>
 							<p>In addition to the default behavior of Media Overlay activation for textual fragments and
 								images, audio and video playback MUST be started and stopped according to the duration
-								implied by the authored Media Overlay synchronization (as per the standard [[!SMIL3]]
+								implied by the authored Media Overlay synchronization (as per the standard [[SMIL3]]
 								timing model). There are two possible scenarios:</p>
 							<ul>
 								<li>
 									<p>When a Media Overlay <code>text</code> element has no <a
 											href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"
-											><code>audio</code></a> [[!EPUB-33]] sibling within its <a
+											><code>audio</code></a> [[EPUB-33]] sibling within its <a
 											href="https://www.w3.org/TR/epub-33/#elemdef-smil-par"><code>par</code></a>
-										[[!EPUB-33]] parent container, the referenced EPUB Content Document audio or
+										[[EPUB-33]] parent container, the referenced EPUB Content Document audio or
 										video media MUST play until it ends, at which point the <code>text</code>
 										element's lifespan terminates. In this case, the implicit duration of the
 											<code>text</code> element (and by inference, of the parent <code>par</code>
@@ -1425,7 +1423,7 @@
 										finished (in which case the last-played video frame SHOULD remain visible until
 										the parent <code>par</code> container finally ends). This behavior is equivalent
 										of the Media Overlay <code>audio</code> element implicitly carrying the behavior
-										of the [[!SMIL3]] <a
+										of the [[SMIL3]] <a
 											href="https://www.w3.org/TR/SMIL/smil-timing.html#adef-endsync"
 												><code>endsync</code></a> attribute.</p>
 									<p>Furthermore, Reading Systems SHOULD expose user controls for the volume levels of
@@ -1445,7 +1443,7 @@
 							<p>When a <code>text</code> element becomes inactive in the Media Overlay, and when it
 								points to embedded video or audio media, that referenced media MUST be reset to its
 								initial "stopped" state, ready to be played from the zero-position within their content
-								stream (possibly displaying the poster image specified using the [[!HTML]] markup).</p>
+								stream (possibly displaying the poster image specified using the [[HTML]] markup).</p>
 						</li>
 					</ul>
 
@@ -1455,8 +1453,8 @@
 					<h5>Text-to-Speech</h5>
 
 					<p>When a Media Overlay <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"><code>text</code>
-							element</a> [[!EPUB-33]] with no <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"
-								><code>audio</code></a> [[!EPUB-33]] sibling element references text within the target
+							element</a> [[EPUB-33]] with no <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"
+								><code>audio</code></a> [[EPUB-33]] sibling element references text within the target
 							<a>EPUB Content Document</a>, Reading Systems capable of <a>Text-to-Speech</a> (TTS) SHOULD
 						render the referenced text using TTS.</p>
 
@@ -1500,7 +1498,7 @@
 			<h2>Processing Structural Semantics</h2>
 
 			<p id="confreq-rs-epub-epub-type" class="support">Reading Systems MAY support <a
-					href="https://www.w3.org/TR/epub-33/#app-structural-semantics">structural semantics</a> [[!EPUB-33]]
+					href="https://www.w3.org/TR/epub-33/#app-structural-semantics">structural semantics</a> [[EPUB-33]]
 				in <a>EPUB Content Documents</a>.</p>
 
 			<p>When processing the <code>epub:type</code> attribute, a Reading System:</p>
@@ -1532,7 +1530,7 @@
 
 			<p id="confreq-res-epub-vocab-assoc" class="support">Reading Systems MUST support <a
 					href="https://www.w3.org/TR/epub-33/#sec-vocab-assoc">vocabulary association mechanisms</a>
-				[[!EPUB-33]].</p>
+				[[EPUB-33]].</p>
 
 			<dl class="conformance-list">
 				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
@@ -1556,12 +1554,12 @@
 
 				<dt id="sec-property-datatype">The <code>property</code> Data Type</dt>
 				<dd>
-					<p>A Reading System MUST use the following rules to create an IRI [[!RFC3987]] from a property:</p>
+					<p>A Reading System MUST use the following rules to create an IRI [[RFC3987]] from a property:</p>
 					<ul>
 						<li>
 							<p>If the property consists only of a reference, the IRI is obtained by concatenating the
 								IRI stem associated with the <a href="https://www.w3.org/TR/epub-33/#sec-default-vocab"
-									>default vocabulary</a> [[!EPUB-33]] to the reference.</p>
+									>default vocabulary</a> [[EPUB-33]] to the reference.</p>
 						</li>
 						<li>
 							<p>If the property consists of a prefix and reference, the IRI is obtained by concatenating
@@ -1569,7 +1567,7 @@
 								defined, the property is invalid and MUST be ignored.</p>
 						</li>
 					</ul>
-					<p>The resulting IRI MUST be valid to [[!RFC3987]]. Reading Systems do not have to resolve this IRI,
+					<p>The resulting IRI MUST be valid to [[RFC3987]]. Reading Systems do not have to resolve this IRI,
 						however.</p>
 				</dd>
 			</dl>
@@ -1579,7 +1577,7 @@
 
 			<p id="confreq-rs-epub3-presentational-meta" class="support">Reading Systems SHOULD process the <a
 					href="https://www.w3.org/TR/epub-33/#sec-rendering-general">general package rendering properties</a>
-				[[!EPUB-33]].</p>
+				[[EPUB-33]].</p>
 
 			<section id="flow">
 				<h5>The <code>rendition:flow</code> Property</h5>
@@ -1589,7 +1587,7 @@
 
 				<p>The default global value is <code>auto</code> if no <code>meta</code> element carrying this property
 					occurs in the <a href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code>
-						section</a> [[!EPUB-33]]. Reading Systems MAY support only this default value.</p>
+						section</a> [[EPUB-33]]. Reading Systems MAY support only this default value.</p>
 
 				<p>If a Reading Systems supports the <a href="#layout"><code>rendition:layout</code></a> property, it
 					MUST ignore the <code>rendition:flow</code> property when it has been set on a spine item that also
@@ -1609,7 +1607,7 @@
 							scrollable, and the EPUB Publication SHOULD be presented as one continuous scroll from spine
 							item to spine item (except where <a
 								href="https://www.w3.org/TR/epub-33/#layout-property-flow-overrides">locally
-								overridden</a> [[!EPUB-33]]).</p>
+								overridden</a> [[EPUB-33]]).</p>
 					</dd>
 					<dt id="scrolled-doc">scrolled-doc</dt>
 					<dd>
@@ -1626,7 +1624,7 @@
 				<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction MUST be
 					defined relative to the block flow direction of the root element of the XHTML Content Document
 					referenced by the <a href="https://www.w3.org/TR/epub-33/#elemdef-spine-itemref"
-							><code>itemref</code> element</a> [[!EPUB-33]]. The scroll direction MUST be vertical if the
+							><code>itemref</code> element</a> [[EPUB-33]]. The scroll direction MUST be vertical if the
 					block flow direction is downward (top-to-bottom). It MUST be horizontal if the block flow direction
 					of the root element is rightward (left-to-right) or leftward (right-to-left).</p>
 			</section>
@@ -1850,7 +1848,7 @@
 
 				<p>This specification extends the the <a
 						href="https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object"
-							><dfn>Navigator</dfn> object</a> [[!HTML]] as follows.</p>
+							><dfn>Navigator</dfn> object</a> [[HTML]] as follows.</p>
 
 				<pre class="idl">[Exposed=(Window)]
 interface EpubReadingSystem {
@@ -1891,10 +1889,10 @@ partial interface Navigator {
 				<p>Reading Systems MUST expose the <code>epubReadingSystem</code> object on the <code>navigator</code>
 					object of all loaded Scripted Content Documents, including any nested <a
 						href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained">container-constrained
-						scripting contexts</a> [[!EPUB-33]]. Reading Systems MUST ensure that the
+						scripting contexts</a> [[EPUB-33]]. Reading Systems MUST ensure that the
 						<code>epubReadingSystem</code> object is available no later than when the <a
 						href="https://html.spec.whatwg.org/multipage/parsing.html#the-end"><code>DOMContentLoaded</code>
-						event is triggered</a> [[!HTML]].</p>
+						event is triggered</a> [[HTML]].</p>
 
 				<div class="note">
 					<p>Reading systems implementations might create cloned instances of the
@@ -1945,7 +1943,7 @@ partial interface Navigator {
 							</td>
 							<td>Use of the <code>layoutStyle</code> property is <a
 									href="https://www.w3.org/TR/epub-33/#deprecated">deprecated</a> [[EPUB-33]]. Refer
-								to its definition in [[!EPUBContentDocs-301]] for usage information.</td>
+								to its definition in [[EPUBContentDocs-301]] for usage information.</td>
 						</tr>
 					</tbody>
 				</table>
@@ -2006,7 +2004,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 									</td>
 									<td>Scripts MAY make structural changes to the document’s DOM (applies to <a
 											href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level
-											scripting</a> [[!EPUB-33]] only).</td>
+											scripting</a> [[EPUB-33]] only).</td>
 								</tr>
 								<tr>
 									<td id="feature-layout-changes">
@@ -2014,7 +2012,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 									</td>
 									<td>Scripts MAY modify attributes and CSS styles that affect content layout (applies
 										to <a href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level
-											scripting</a> [[!EPUB-33]] only).</td>
+											scripting</a> [[EPUB-33]] only).</td>
 								</tr>
 								<tr>
 									<td id="feature-touch-events">
@@ -2043,7 +2041,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 									</td>
 									<td>Indicates whether the Reading System supports <a
 											href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level
-											scripting</a> [[!EPUB-33]] (e.g., so a <a
+											scripting</a> [[EPUB-33]] (e.g., so a <a
 											href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained"
 											>container-constrained script</a> [[EPUB-33]] can determine whether any
 										actions that depend on scripting support in a <a>Top-level Content Document</a>
@@ -2059,7 +2057,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				</section>
 			</section>
 		</section>
-		<section id="change-log">
+		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
 
 			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance


### PR DESCRIPTION
This PR makes the following editorial changes:

- harmonizes referencing of specifications with the new respec rules and fixes some references incorrectly picked up as normative due to the change
- reformats the conformance lists so they match what we did for the reading systems specification (i.e., start each list item with a normative keyword)
- adds informative classes to a number of sections that were missing them (including all change logs)
- moves a statement about inheriting all semantics, etc. from the HTML spec to the xhtml conformance section (was in a "normative" introduction)
- adds explicit appendix classes to backmatter sections that were missing them
- removes a made-up reference to "[RFC]" for the term "Request for Comments"
- updates a reference to JSON-LD 1.0 to 1.1

- Reading Systems: [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/ref-cleanup/epub33/rs/index.html) | [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/ref-cleanup/epub33/rs/index.html)
- Accessibility: [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/ref-cleanup/epub33/a11y/index.html) | [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/ref-cleanup/epub33/a11y/index.html)
- A11y Techniques: [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/ref-cleanup/epub33/a11y-tech/index.html) | [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/ref-cleanup/epub33/a11y-tech/index.html)
- Multiple Renditions: [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/ref-cleanup/epub33/multi-rend/index.html) | [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/multi-rend/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/ref-cleanup/epub33/multi-rend/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1649.html" title="Last updated on Apr 26, 2021, 7:05 PM UTC (e9c7817)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1649/70ae53c...e9c7817.html" title="Last updated on Apr 26, 2021, 7:05 PM UTC (e9c7817)">Diff</a>