### PR TITLE
Drop requirement that HTML link elements have fallbacks per #1312

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3847,8 +3847,7 @@ Spine:
 							<li>
 								<p id="confreq-resources-cd-fallback-link"><a
 										href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"
-											><code>link</code></a> — when its <code>rel</code> attribute has <a
-										href="#confreq-cd-pls-assoc">the value "<code>pronunciation</code>"</a></p>
+											><code>link</code></a></p>
 							</li>
 							<li>
 								<p id="confreq-resources-cd-fallback-track">


### PR DESCRIPTION
In the past, publication resources referenced by HTML `link` elements had to have fallbacks unless they were a PLS document. This has lead to some strange issues with validations of documents including page templates, for example.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dauwhe/epub-specs/pull/1651.html" title="Last updated on Apr 28, 2021, 2:57 PM UTC (fa08d1a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1651/f430175...dauwhe:fa08d1a.html" title="Last updated on Apr 28, 2021, 2:57 PM UTC (fa08d1a)">Diff</a>