### PR TITLE
Update accessibility conformance identifiers to use hyphens and underscores

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -851,9 +851,8 @@
 						it MUST include a <code>conformsTo</code> property whose value MUST exactly match (i.e., both in
 						case and spacing) the following pattern:</p>
 
-					<p class="conf-pattern">EPUB Accessibility <a href="#acc-ver"><var>A11Y-VER</var></a> + WCAG <a
-							href="#wcag-ver"><var>WCAG-VER</var></a> Level <a href="#wcag-lvl"
-						><var>WCAG-LVL</var></a></p>
+					<p class="conf-pattern">EPUB-A11Y-<a href="#acc-ver"><var>A11Y-VER</var></a>_WCAG-<a
+							href="#wcag-ver"><var>WCAG-VER</var></a>-<a href="#wcag-lvl"><var>WCAG-LVL</var></a></p>
 
 					<p><i>where:</i></p>
 
@@ -861,13 +860,13 @@
 						<dt id="acc-ver"><var>A11Y-VER</var></dt>
 						<dd>
 							<p>MUST be the version number of the EPUB Accessibility specification the publication
-								conforms to. For the purpose of this specification, this value MUST be
-								<code>1.1</code>.</p>
+								conforms to, not including the decimal points. For the purpose of this specification,
+								this value MUST be <code>11</code>.</p>
 						</dd>
 						<dt id="wcag-ver"><var>WCAG-VER</var></dt>
 						<dd>
-							<p>MUST be the version number of WCAG the publication conforms to (e.g., <code>2.0</code> or
-									<code>2.1</code>).</p>
+							<p>MUST be the version number of WCAG the publication conforms to, not including the decimal
+								points (e.g., <code>20</code> for WCAG 2.0 or <code>21</code> for WCAG 2.1).</p>
 						</dd>
 						<dt id="wcag-lvl"><var>WCAG-LVL</var></dt>
 						<dd>
@@ -879,16 +878,18 @@
 					<p>The following conformance strings are valid as of publication of this document:</p>
 
 					<ul>
-						<li>EPUB Accessibility 1.1 + WCAG 2.0 Level A</li>
-						<li>EPUB Accessibility 1.1 + WCAG 2.0 Level AA</li>
-						<li>EPUB Accessibility 1.1 + WCAG 2.0 Level AAA</li>
-						<li>EPUB Accessibility 1.1 + WCAG 2.1 Level A</li>
-						<li>EPUB Accessibility 1.1 + WCAG 2.1 Level AA</li>
-						<li>EPUB Accessibility 1.1 + WCAG 2.1 Level AAA</li>
+						<li>EPUB-A11Y-11_WCAG-20-A</li>
+						<li>EPUB-A11Y-11_WCAG-20-AA</li>
+						<li>EPUB-A11Y-11_WCAG-20-AAA</li>
+						<li>EPUB-A11Y-11_WCAG-21-A</li>
+						<li>EPUB-A11Y-11_WCAG-21-AA</li>
+						<li>EPUB-A11Y-11_WCAG-21-AAA</li>
 					</ul>
 
-					<p>This list will change as new versions of WCAG are released. For new versions of [[WCAG2]], only
-						the digit after the "2." should change from the above patterns.</p>
+					<div class="note">
+						<p>The list of acceptable conformance strings will increase as new versions of WCAG are
+							released.</p>
+					</div>
 
 					<aside class="example">
 						<p>The following example shows a conformance statement for an EPUB 3 Publication that conforms
@@ -896,7 +897,7 @@
 						<pre>&lt;package …>
    &lt;metadata>
       …
-      &lt;meta property="dcterms:conformsTo">EPUB Accessibility 1.1 + WCAG 2.1 Level AA&lt;/meta>
+      &lt;meta property="dcterms:conformsTo">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
       …
    &lt;/metadata>
    …
@@ -1375,7 +1376,11 @@
 						- move all changes down to the next section
 				-->
 
-				<ul> </ul>
+				<ul>
+					<li>29-Apr-2021: Change conformance identifiers to use hyphens and dashes so they are not confused
+						for plain language strings. See <a href="https://github.com/w3c/epub-specs/issues/1455">issue
+							1455</a>.</li>
+				</ul>
 			</section>
 
 			<section id="changes-older">


### PR DESCRIPTION
Updates the identifiers per the recommendation in https://github.com/w3c/epub-specs/issues/1455#issuecomment-828940542 so that they are not confused for plain language strings.