### PR TITLE
Complete rewrite of section on prefixed CSS properties

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4092,11 +4092,12 @@ Spine:
 					<section id="sec-css-prefixed-writing-modes">
 						<h5>CSS Writing Modes</h5>
 
-						<p>The following lists the <code>-epub-</code> prefixed properties for
-							[[CSS-Writing-Modes-3]]. .</p>
+						<p>This section describes the <code>-epub-</code> prefixed properties for
+							[[CSS-Writing-Modes-3]].</p>
 
 						<section id="sec-css-prefixed-writing-modes-text-orientation">
 							<h6><code>-epub-text-orientation</code></h6>
+							<p>This is a prefixed version of the CSS <code>text-orientation</code> property.</p>
 							<table class="def propdef">
 								<tbody>
 									<tr>
@@ -4145,6 +4146,8 @@ Spine:
 						
 						<section id="sec-css-prefixed-writing-modes-writing-mode">
 							<h6><code>-epub-writing-mode</code></h6>
+							<p>This is a prefixed version of the CSS <code>writing-mode</code> property, 
+							with the same syntax and behavior.</p>
 							<table class="def propdef">
 								<tbody>
 									<tr>
@@ -4164,11 +4167,9 @@ Spine:
 						</section>
 						
 						<section id="sec-css-prefixed-writing-modes-text-combine">
-							<h6><code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>(Deprecated)</h6>
+							<h6><code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>(deprecated)</h6>
 							
-							<p>The <code>-epub-text-combine</code> property is deprecated. Authors should use 
-							<code>text-combine-upright</code>, although <code>-epub-text-combine-horizontal</code>
-							is still supported.</p>
+							<p>These properties no longer exist in CSS, having been replaced with <code>text-combine-upright</code>.</p>
 							<table class="def propdef">
 								<tbody>
 									<tr>
@@ -4185,7 +4186,57 @@ Spine:
 									</tr>
 								</tbody>
 							</table>
-		
+							<p>The <code>-epub-text-combine</code> property is deprecated. Authors should use 
+							<code>text-combine-upright</code>, although <code>-epub-text-combine-horizontal</code>
+							is still supported.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-combine</dfn> (deprecated)
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											none | horizontal | horizontal &lt;number&gt; 
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							<p>The following table shows how to map from the prefixed versions to the current CSS version.</p>
+							<table class="data">
+								<thead>
+									<tr>
+										<th>Prefixed version</th>
+										<th>Version to be used</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td><code>-epub-text-combine-horizontal: none</code></td>
+										<td><code>text-combine-upright: none</code></td>
+									</tr>
+									<tr>
+										<td><code>-epub-text-combine-horizontal: all</code></td>
+										<td><code>text-combine-upright: all</code></td>
+									</tr>
+									<tr>
+										<td><code>-epub-text-combine: none</code></td>
+										<td><code>text-combine-upright: none</code></td>
+									</tr>
+									<tr>
+										<td><code>-epub-text-combine: horizontal</code></td>
+										<td><code>text-combine-upright: all</code></td>
+									</tr>
+									<tr>
+										<td><code>-epub-text-combine: horizontal &lt;number&gt;</code></td>
+										<td>Error</td>
+									</tr>
+								</tbody>
+							
+							</table>
 						</section>
 					</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4096,7 +4096,7 @@ Spine:
 							[[CSS-Writing-Modes-3]].</p>
 
 						<section id="sec-css-prefixed-writing-modes-text-orientation">
-							<h6><code>-epub-text-orientation</code></h6>
+							<h6>The <code>-epub-text-orientation</code> Property</h6>
 							<p>This is a prefixed version of the CSS <code>text-orientation</code> property.</p>
 							<table class="def propdef">
 								<tbody>
@@ -4145,7 +4145,7 @@ Spine:
 						</section>
 						
 						<section id="sec-css-prefixed-writing-modes-writing-mode">
-							<h6><code>-epub-writing-mode</code></h6>
+							<h6>The <code>-epub-writing-mode</code> Property</h6>
 							<p>This is a prefixed version of the CSS <code>writing-mode</code> property, 
 							with the same syntax and behavior.</p>
 							<table class="def propdef">
@@ -4167,7 +4167,7 @@ Spine:
 						</section>
 						
 						<section id="sec-css-prefixed-writing-modes-text-combine">
-							<h6><code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>(deprecated)</h6>
+							<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>(deprecated) Properties</h6>
 							
 							<p>These properties no longer exist in CSS, having been replaced with <code>text-combine-upright</code>.</p>
 							<table class="def propdef">
@@ -4242,73 +4242,124 @@ Spine:
 
 					<section id="sec-css-prefixed-text">
 						<h5>CSS Text Level 3</h5>
-						<table>
-							<thead>
-								<tr>
-									<th>Property</th>
-									<th>Value</th>
-									<th>Mapping to [[CSS-Text-3-20160119]]</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>
-										<code>-epub-hyphens</code>
-									</td>
-									<td>
-										<code>none | manual | auto</code>
-									</td>
-									<td>No Change</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-hyphens</code>
-									</td>
-									<td>
-										<code>all</code>
-									</td>
-									<td>Not Supported</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-line-break</code>
-									</td>
-									<td>
-										<code>auto | loose | normal | strict</code>
-									</td>
-									<td>No Change</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-align-last</code>
-									</td>
-									<td>
-										<code>auto | start | end | left | right | center | justify</code>
-									</td>
-									<td>No Change</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-word-break</code>
-									</td>
-									<td>
-										<code>normal | keep-all | break-all</code>
-									</td>
-									<td>No Change</td>
-								</tr>
-								<tr>
-									<td>
-										<code>text-transform</code>
-									</td>
-									<td>
-										<code>-epub-fullwidth</code>
-									</td>
-									<td>
-										<code>text-transform: full-width</code>
-									</td>
-								</tr>
-							</tbody>
-						</table>
+						
+						<section id="sec-css-prefixed-text-epub-hyphens">
+						<h6>The <code>-epub-hyphens</code> Property</h6>
+						<p>This is a prefixed version of the <code>hyphens</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-hyphens</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											none | manual | auto | all
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							<p class="note">The <code>auto</code> value is no longer supported in CSS.</p>
+						</section>
+						<section id="sec-css-prefixed-text-epub-line-break">
+						<h6>The <code>-epub-line-break</code> Property</h6>
+						<p>This is a prefixed version of the <code>line-break</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-linebreak</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											auto | loose | normal | strict
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-epub-text-align-last">
+						<h6>The <code>-epub-text-align-last</code> Property</h6>
+						<p>This is a prefixed version of the <code>text-align-last</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-align-last</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											auto | start | end | left | right | center | justify
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-epub-word-break">
+						<h6>The <code>-epub-word-break</code> Property</h6>
+						<p>This is a prefixed version of the <code>word-break</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-word-break</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											normal | keep-all | break-all
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-text-transform">
+						<h6>The <code>text-transform</code> Property</h6>
+						<p>This is a prefixed value for the <code>text-transform</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>text-transform</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											-epub-fullwidth
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							<p>The following table describes the equivalent value in CSS.</p>
+							<table class="data">
+								<thead>
+									<tr>
+										<th>EPUB version</th>
+										<th>Version to be used</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td><code>text-transform: -epub-fullwidth</code></td>
+										<td><code>text-transform: full-width</code></td>
+									</tr>
+								</tbody>
+							
+							</table>
+						</section>
 					</section>
 
 					<section id="sec-css-prefixed-text-decoration">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4095,6 +4095,9 @@ Spine:
 							versions as soon as support allows, as these properties are not anticipated to be supported
 							in the next major version of EPUB.</p>
 					</div>
+					
+					<p class="note">In some cases, the unprefixed versions of these properties now support
+						additional values. Reading Systems MAY support these values even with the prefixed property.</p>
 
 					<section id="sec-css-prefixed-writing-modes">
 						<h5>CSS Writing Modes</h5>
@@ -4174,9 +4177,11 @@ Spine:
 						</section>
 						
 						<section id="sec-css-prefixed-writing-modes-text-combine">
-							<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code> (deprecated) Properties</h6>
+							<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code> Properties</h6>
 							
-							<p>These properties no longer exist in CSS, having been replaced with <code>text-combine-upright</code>.</p>
+							<p>These are prefixed versions of <code>text-combine-upright</code>, 
+							although <code>-epub-text-combine</code> is deprecated. See the table below for how 
+							values of both properties translate to unprefixed CSS.</p>
 							<table class="def propdef">
 								<tbody>
 									<tr>
@@ -4193,9 +4198,7 @@ Spine:
 									</tr>
 								</tbody>
 							</table>
-							<p>The <code>-epub-text-combine</code> property is deprecated. Authors should use 
-							<code>text-combine-upright</code>, although <code>-epub-text-combine-horizontal</code>
-							is still supported.</p>
+							
 							<table class="def propdef">
 								<tbody>
 									<tr>
@@ -4212,7 +4215,7 @@ Spine:
 									</tr>
 								</tbody>
 							</table>
-							<p>The following table shows how to map from the prefixed versions to the current CSS version.</p>
+							<p>The following table shows how to map from the prefixed versions to the current CSS versions.</p>
 							<table class="data">
 								<thead>
 									<tr>
@@ -4279,7 +4282,7 @@ Spine:
 									<tr>
 										<th>Name: </th>
 										<td>
-											<dfn>-epub-linebreak</dfn>
+											<dfn>-epub-line-break</dfn>
 										</td>
 									</tr>
 									<tr class="value">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4210,7 +4210,7 @@ Spine:
 								<thead>
 									<tr>
 										<th>Prefixed version</th>
-										<th>Version to be used</th>
+										<th>CSS equivalent</th>
 									</tr>
 								</thead>
 								<tbody>
@@ -4348,7 +4348,7 @@ Spine:
 								<thead>
 									<tr>
 										<th>EPUB version</th>
-										<th>Version to be used</th>
+										<th>CSS equivalent</th>
 									</tr>
 								</thead>
 								<tbody>
@@ -4364,68 +4364,104 @@ Spine:
 
 					<section id="sec-css-prefixed-text-decoration">
 						<h5>CSS Text Decoration Level 3</h5>
-						<table>
-							<thead>
-								<tr>
-									<th>Property</th>
-									<th>Value</th>
-									<th>Mapping to [[CSS-Text-Decor-3]]</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>
-										<code>-epub-text-emphasis-color</code>
-									</td>
-									<td>
-										<code>&lt;color&gt;</code>
-									</td>
-									<td>No Change</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-emphasis-position </code>
-									</td>
-									<td>
-										<code>[ over | under ] &amp;&amp; [ right | left ]</code>
-									</td>
-									<td>No Change</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-emphasis-style</code>
-									</td>
-									<td>
-										<code>none | [ [ filled | open ] || [ dot | circle | double-circle | triangle |
-											sesame ] ] | &lt;string&gt;</code>
-									</td>
-									<td>No Change</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-underline-position</code>
-									</td>
-									<td>
-										<code>auto | [ under || [ left | right ] ]</code>
-									</td>
-									<td>No Change</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-underline-position</code>
-									</td>
-									<td>
-										<code>alphabetic</code>
-									</td>
-									<td>
-										<code>text-underline-position: auto</code>
-									</td>
-								</tr>
-							</tbody>
-						</table>
-						<p>Property value syntax defined in <a
-								href="https://www.w3.org/TR/css-values/#component-combinators">Component value
-								combinators</a> [[CSS-Values-3]].</p>
+						
+						<section id="sec-css-prefixed-text-epub-text-emphasis-color">
+						<h6>The <code>-epub-text-emphasis-color</code> Property</h6>
+						<p>This is a prefixed value for the <code>text-emphasis-color</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-emphasis-color</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											&lt;color&gt;
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-epub-text-emphasis-position">
+						<h6>The <code>-epub-text-emphasis-position</code> Property</h6>
+						<p>This is a prefixed value for the <code>text-emphasis-position</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-emphasis-position</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											[ over | under ] &amp;&amp; [ right | left ]
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-epub-text-emphasis-style">
+						<h6>The <code>-epub-text-emphasis-style</code> Property</h6>
+						<p>This is a prefixed value for the <code>text-emphasis-style</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-emphasis-style</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | &lt;string&gt;
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-epub-text-underline-position">
+						<h6>The <code>-epub-text-underline-position</code> Property</h6>
+						<p>This is a prefixed value for the <code>text-underline-position</code> property.
+						One value is no longer supported by CSS.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-underline-position</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											auto | [ under || [ left | right ] ] | alphabetic
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							<p>The following table describes the equivalent value in CSS.</p>
+							<table class="data">
+								<thead>
+									<tr>
+										<th>EPUB version</th>
+										<th>CSS equivalent</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td><code>-epub-text-underline-position: alphabetic</code></td>
+										<td><code>text-underline-position: auto</code></td>
+									</tr>
+								</tbody>
+							
+							</table>
+						</section>
 					</section>
 				</section>
 			</section>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4092,211 +4092,101 @@ Spine:
 					<section id="sec-css-prefixed-writing-modes">
 						<h5>CSS Writing Modes</h5>
 
-						<p>The following table lists the <code>-epub-</code> prefixed properties for
-							[[CSS-Writing-Modes-3]]. The Value column indicates the value the property accepts. The
-							Prior EPUB Mapping column indicates values/properties that were used in previous versions of
-							EPUB 3. An asterisk (*) denotes that the older property or value is now deprecated. The
-							final column describes how to implement the prefixed property based on
-							[[CSS-Writing-Modes-3-20151215]].</p>
+						<p>The following lists the <code>-epub-</code> prefixed properties for
+							[[CSS-Writing-Modes-3]]. .</p>
 
-						<table>
-							<thead>
-								<tr>
-									<th>Property</th>
-									<th>Value</th>
-									<th>Prior EPUB Mapping</th>
-									<th>Mapping to [[CSS-Writing-Modes-3-20151215]]</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>
-										<code>-epub-text-orientation</code>
-									</td>
-									<td>
-										<code>upright</code>
-									</td>
-									<td>
-										<code>upright</code>
-									</td>
-									<td>
-										<code>upright</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-orientation</code>
-									</td>
-									<td>
-										<code>mixed</code>
-									</td>
-									<td>
-										<code>vertical-right</code>
-										<span aria-label="deprecated">*</span>
-									</td>
-									<td>
-										<code>mixed</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-orientation</code>
-									</td>
-									<td>
-										<code>sideways-right</code>
-									</td>
-									<td>
-										<code>sideways-right</code>
-									</td>
-									<td>
-										<code>sideways</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-orientation</code>
-									</td>
-									<td>
-										<code>sideways-right</code>
-									</td>
-									<td>
-										<code>rotate-right</code>
-										<span aria-label="deprecated">*</span>
-									</td>
-									<td>
-										<code>sideways</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-orientation</code>
-									</td>
-									<td>
-										<code>sideways</code>
-									</td>
-									<td>
-										<code>rotate-normal</code>
-										<span aria-label="deprecated">*</span>
-									</td>
-									<td>
-										<code>sideways</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-orientation</code>
-									</td>
-									<td>
-										<code>sideways</code>
-									</td>
-									<td>
-										<code>sideways</code>
-									</td>
-									<td>
-										<code>sideways</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-orientation</code>
-									</td>
-									<td>
-										<code>mixed</code>
-									</td>
-									<td>
-										<code>mixed</code>
-									</td>
-									<td>
-										<code>mixed</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-writing-mode</code>
-									</td>
-									<td>
-										<code>horizontal-tb</code>
-									</td>
-									<td>
-										<code>horizontal-tb</code>
-									</td>
-									<td>
-										<code>horizontal-tb</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-writing-mode</code>
-									</td>
-									<td>
-										<code>vertical-rl</code>
-									</td>
-									<td>
-										<code>vertical-rl</code>
-									</td>
-									<td>
-										<code>vertical-rl</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-writing-mode</code>
-									</td>
-									<td>
-										<code>vertical-lr</code>
-									</td>
-									<td>
-										<code>vertical-lr</code>
-									</td>
-									<td>
-										<code>vertical-lr</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-combine</code>
-										<span aria-label="deprecated">*</span>
-									</td>
-									<td>
-										<code>-epub-text-combine-horizontal: none</code>
-									</td>
-									<td>
-										<code>none</code>
-									</td>
-									<td>
-										<code>text-combine-upright: none</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-combine</code>
-										<span aria-label="deprecated">*</span>
-									</td>
-									<td>
-										<code>-epub-text-combine-horizontal: all</code>
-									</td>
-									<td>
-										<code>horizontal</code>
-									</td>
-									<td>
-										<code>text-combine-upright: all</code>
-									</td>
-								</tr>
-								<tr>
-									<td>
-										<code>-epub-text-combine</code>
-										<span aria-label="deprecated">*</span>
-									</td>
-									<td>Error</td>
-									<td>
-										<code>horizontal &lt;number&gt;</code>
-									</td>
-									<td>
-										<code>text-combine-upright: digits &lt;number&gt;</code>
-									</td>
-								</tr>
-							</tbody>
-						</table>
+						<section id="sec-css-prefixed-writing-modes-text-orientation">
+							<h6><code>-epub-text-orientation</code></h6>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-orientation</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											mixed | upright | sideways | sideways-right
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							
+							<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>.
+								User agents MUST interpret these values according to the following table:
+							</p>
+							
+							<table class="data">
+								<thead>
+									<tr>
+										<th>Deprecated value</th>
+										<th>Value to be used</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td><code>vertical-right</code></td>
+										<td><code>mixed</code></td>
+									</tr>
+									<tr>
+										<td><code>rotate-right</code></td>
+										<td><code>sideways</code></td>
+									</tr>
+									<tr>
+										<td><code>rotate-normal</code></td>
+										<td><code>sideways</code></td>
+									</tr>
+								</tbody>
+							
+							</table>
+						</section>
+						
+						<section id="sec-css-prefixed-writing-modes-writing-mode">
+							<h6><code>-epub-writing-mode</code></h6>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-writing-mode</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											horizontal-tb | vertical-rl | vertical-lr
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						
+						<section id="sec-css-prefixed-writing-modes-text-combine">
+							<h6><code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>(Deprecated)</h6>
+							
+							<p>The <code>-epub-text-combine</code> property is deprecated. Authors should use 
+							<code>text-combine-upright</code>, although <code>-epub-text-combine-horizontal</code>
+							is still supported.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-combine-horizontal</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											none | all
+										</td>
+									</tr>
+								</tbody>
+							</table>
+		
+						</section>
 					</section>
 
 					<section id="sec-css-prefixed-text">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4080,7 +4080,9 @@ Spine:
 					
 					<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to 
 					world languages were not yet mature. To ensure backwards compatibility for content authored 
-					using these prefixes, they have been retained in this specification.
+					using these prefixes, they have been retained in this specification. Unless otherwise noted, 
+					prefixed properties and values behave exactly as their unprefixed equivalents as described in
+					the appropriate CSS specification. 
 					</p>
 
 					<div class="caution">
@@ -4291,7 +4293,7 @@ Spine:
 						</section>
 						<section id="sec-css-prefixed-text-epub-text-align-last">
 						<h6>The <code>-epub-text-align-last</code> Property</h6>
-						<p>This is a prefixed version of the <code>text-align-last</code> property</p>
+						<p>This is a prefixed version of the <code>text-align-last</code> property.</p>
 							<table class="def propdef">
 								<tbody>
 									<tr>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4077,10 +4077,15 @@ Spine:
 
 				<section id="sec-css-prefixed">
 					<h4>Prefixed Properties</h4>
+					
+					<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to 
+					world languages were not yet mature. To ensure backwards compatibility for content authored 
+					using these prefixes, they have been retained in this specification.
+					</p>
 
 					<div class="caution">
 						<p><a>EPUB Creators</a> are strongly encouraged to use unprefixed properties and <a>Reading
-								Systems</a> to support current CSS specifications. The widely-used prefixed properties
+							Systems</a> are encouraged to support current CSS specifications. The widely-used prefixed properties
 							from [[EPUBContentDocs-301]] have been retained, but support for the other properties has
 							been removed. EPUB Creators are advised to use CSS-native solutions for the removed
 							properties where and when they are available.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4075,7 +4075,8 @@ Spine:
 					world languages were not yet mature. To ensure backwards compatibility for content authored 
 					using these prefixes, they have been retained in this specification. Unless otherwise noted, 
 					prefixed properties and values behave exactly as their unprefixed equivalents as described in
-					the appropriate CSS specification. 
+					the appropriate CSS specification. The prefixed properties are documented 
+					in an <a href="#css-prefixes">Appendix</a>.
 					</p>
 
 					<div class="caution">
@@ -4092,380 +4093,6 @@ Spine:
 					<p class="note">In some cases, the unprefixed versions of these properties now support
 						additional values. Reading Systems MAY support these values even with the prefixed property.</p>
 
-					<section id="sec-css-prefixed-writing-modes">
-						<h5>CSS Writing Modes</h5>
-
-						<p>This section describes the <code>-epub-</code> prefixed properties for
-							[[CSS-Writing-Modes-3]].</p>
-
-						<section id="sec-css-prefixed-writing-modes-text-orientation">
-							<h6>The <code>-epub-text-orientation</code> Property</h6>
-							<p>This is a prefixed version of the CSS <code>text-orientation</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-orientation</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											mixed | upright | sideways | sideways-right
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							
-							<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>.
-								User agents MUST interpret these values according to the following table:
-							</p>
-							
-							<table class="data">
-								<thead>
-									<tr>
-										<th>Deprecated value</th>
-										<th>Value to be used</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td><code>vertical-right</code></td>
-										<td><code>mixed</code></td>
-									</tr>
-									<tr>
-										<td><code>rotate-right</code></td>
-										<td><code>sideways</code></td>
-									</tr>
-									<tr>
-										<td><code>rotate-normal</code></td>
-										<td><code>sideways</code></td>
-									</tr>
-								</tbody>
-							
-							</table>
-						</section>
-						
-						<section id="sec-css-prefixed-writing-modes-writing-mode">
-							<h6>The <code>-epub-writing-mode</code> Property</h6>
-							<p>This is a prefixed version of the CSS <code>writing-mode</code> property, 
-							with the same syntax and behavior.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-writing-mode</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											horizontal-tb | vertical-rl | vertical-lr
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						
-						<section id="sec-css-prefixed-writing-modes-text-combine">
-							<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code> Properties</h6>
-							
-							<p>These are prefixed versions of <code>text-combine-upright</code>, 
-							although <code>-epub-text-combine</code> is deprecated. See the table below for how 
-							values of both properties translate to unprefixed CSS.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-combine-horizontal</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											none | all
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-combine</dfn> (deprecated)
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											none | horizontal | horizontal &lt;number&gt; 
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							<p>The following table shows how to map from the prefixed versions to the current CSS versions.</p>
-							<table class="data">
-								<thead>
-									<tr>
-										<th>Prefixed version</th>
-										<th>CSS equivalent</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td><code>-epub-text-combine-horizontal: none</code></td>
-										<td><code>text-combine-upright: none</code></td>
-									</tr>
-									<tr>
-										<td><code>-epub-text-combine-horizontal: all</code></td>
-										<td><code>text-combine-upright: all</code></td>
-									</tr>
-									<tr>
-										<td><code>-epub-text-combine: none</code></td>
-										<td><code>text-combine-upright: none</code></td>
-									</tr>
-									<tr>
-										<td><code>-epub-text-combine: horizontal</code></td>
-										<td><code>text-combine-upright: all</code></td>
-									</tr>
-									<tr>
-										<td><code>-epub-text-combine: horizontal &lt;number&gt;</code></td>
-										<td>Error</td>
-									</tr>
-								</tbody>
-							
-							</table>
-						</section>
-					</section>
-
-					<section id="sec-css-prefixed-text">
-						<h5>CSS Text Level 3</h5>
-						
-						<section id="sec-css-prefixed-text-epub-hyphens">
-						<h6>The <code>-epub-hyphens</code> Property</h6>
-						<p>This is a prefixed version of the <code>hyphens</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-hyphens</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											none | manual | auto | all
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							<p class="note">The <code>all</code> value is no longer supported in CSS.</p>
-						</section>
-						<section id="sec-css-prefixed-text-epub-line-break">
-						<h6>The <code>-epub-line-break</code> Property</h6>
-						<p>This is a prefixed version of the <code>line-break</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-line-break</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											auto | loose | normal | strict
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-epub-text-align-last">
-						<h6>The <code>-epub-text-align-last</code> Property</h6>
-						<p>This is a prefixed version of the <code>text-align-last</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-align-last</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											auto | start | end | left | right | center | justify
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-epub-word-break">
-						<h6>The <code>-epub-word-break</code> Property</h6>
-						<p>This is a prefixed version of the <code>word-break</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-word-break</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											normal | keep-all | break-all
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-text-transform">
-						<h6>The <code>text-transform</code> Property</h6>
-						<p>This is a prefixed value for the <code>text-transform</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>text-transform</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											-epub-fullwidth
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							<p>The following table describes the equivalent value in CSS.</p>
-							<table class="data">
-								<thead>
-									<tr>
-										<th>EPUB version</th>
-										<th>CSS equivalent</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td><code>text-transform: -epub-fullwidth</code></td>
-										<td><code>text-transform: full-width</code></td>
-									</tr>
-								</tbody>
-							
-							</table>
-						</section>
-					</section>
-
-					<section id="sec-css-prefixed-text-decoration">
-						<h5>CSS Text Decoration Level 3</h5>
-						
-						<section id="sec-css-prefixed-text-epub-text-emphasis-color">
-						<h6>The <code>-epub-text-emphasis-color</code> Property</h6>
-						<p>This is a prefixed value for the <code>text-emphasis-color</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-emphasis-color</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											&lt;color&gt;
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-epub-text-emphasis-position">
-						<h6>The <code>-epub-text-emphasis-position</code> Property</h6>
-						<p>This is a prefixed value for the <code>text-emphasis-position</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-emphasis-position</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											[ over | under ] &amp;&amp; [ right | left ]
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-epub-text-emphasis-style">
-						<h6>The <code>-epub-text-emphasis-style</code> Property</h6>
-						<p>This is a prefixed value for the <code>text-emphasis-style</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-emphasis-style</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | &lt;string&gt;
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-epub-text-underline-position">
-						<h6>The <code>-epub-text-underline-position</code> Property</h6>
-						<p>This is a prefixed value for the <code>text-underline-position</code> property.
-						One value is no longer supported by CSS.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-underline-position</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											auto | [ under || [ left | right ] ] | alphabetic
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							<p>The following table describes the equivalent value in CSS.</p>
-							<table class="data">
-								<thead>
-									<tr>
-										<th>EPUB version</th>
-										<th>CSS equivalent</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td><code>-epub-text-underline-position: alphabetic</code></td>
-										<td><code>text-underline-position: auto</code></td>
-									</tr>
-								</tbody>
-							
-							</table>
-						</section>
-					</section>
 				</section>
 			</section>
 
@@ -8755,6 +8382,390 @@ html.my-document-playing * {
 
 			<div data-include="vocab/structure.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 		</section>
+		
+		<section id="css-prefixes" class="appendix">
+		<h2>Prefixed CSS Properties</h2>
+		<p>This appendix describes the prefixed CSS properties supported by EPUB. </p>
+					<section id="sec-css-prefixed-writing-modes">
+						<h5>CSS Writing Modes</h5>
+
+						<p>This section describes the <code>-epub-</code> prefixed properties for
+							[[CSS-Writing-Modes-3]].</p>
+
+						<section id="sec-css-prefixed-writing-modes-text-orientation">
+							<h6>The <code>-epub-text-orientation</code> Property</h6>
+							<p>This is a prefixed version of the CSS <code>text-orientation</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-orientation</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											mixed | upright | sideways | sideways-right
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							
+							<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>.
+								User agents MUST interpret these values according to the following table:
+							</p>
+							
+							<table class="data">
+								<thead>
+									<tr>
+										<th>Deprecated value</th>
+										<th>Value to be used</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td><code>vertical-right</code></td>
+										<td><code>mixed</code></td>
+									</tr>
+									<tr>
+										<td><code>rotate-right</code></td>
+										<td><code>sideways</code></td>
+									</tr>
+									<tr>
+										<td><code>rotate-normal</code></td>
+										<td><code>sideways</code></td>
+									</tr>
+								</tbody>
+							
+							</table>
+						</section>
+						
+						<section id="sec-css-prefixed-writing-modes-writing-mode">
+							<h6>The <code>-epub-writing-mode</code> Property</h6>
+							<p>This is a prefixed version of the CSS <code>writing-mode</code> property, 
+							with the same syntax and behavior.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-writing-mode</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											horizontal-tb | vertical-rl | vertical-lr
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						
+						<section id="sec-css-prefixed-writing-modes-text-combine">
+							<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code> Properties</h6>
+							
+							<p>These are prefixed versions of <code>text-combine-upright</code>, 
+							although <code>-epub-text-combine</code> is deprecated. See the table below for how 
+							values of both properties translate to unprefixed CSS.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-combine-horizontal</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											none | all
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-combine</dfn> (deprecated)
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											none | horizontal | horizontal &lt;number&gt; 
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							<p>The following table shows how to map from the prefixed versions to the current CSS versions.</p>
+							<table class="data">
+								<thead>
+									<tr>
+										<th>Prefixed version</th>
+										<th>CSS equivalent</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td><code>-epub-text-combine-horizontal: none</code></td>
+										<td><code>text-combine-upright: none</code></td>
+									</tr>
+									<tr>
+										<td><code>-epub-text-combine-horizontal: all</code></td>
+										<td><code>text-combine-upright: all</code></td>
+									</tr>
+									<tr>
+										<td><code>-epub-text-combine: none</code></td>
+										<td><code>text-combine-upright: none</code></td>
+									</tr>
+									<tr>
+										<td><code>-epub-text-combine: horizontal</code></td>
+										<td><code>text-combine-upright: all</code></td>
+									</tr>
+									<tr>
+										<td><code>-epub-text-combine: horizontal &lt;number&gt;</code></td>
+										<td>Error</td>
+									</tr>
+								</tbody>
+							
+							</table>
+						</section>
+					</section>
+
+					<section id="sec-css-prefixed-text">
+						<h5>CSS Text Level 3</h5>
+						<p>This section describes the <code>-epub-</code> prefixed properties for
+							[[CSS-Text-3]].</p>
+						<section id="sec-css-prefixed-text-epub-hyphens">
+						<h6>The <code>-epub-hyphens</code> Property</h6>
+						<p>This is a prefixed version of the <code>hyphens</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-hyphens</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											none | manual | auto | all
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							<p class="note">The <code>all</code> value is no longer supported in CSS.</p>
+						</section>
+						<section id="sec-css-prefixed-text-epub-line-break">
+						<h6>The <code>-epub-line-break</code> Property</h6>
+						<p>This is a prefixed version of the <code>line-break</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-line-break</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											auto | loose | normal | strict
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-epub-text-align-last">
+						<h6>The <code>-epub-text-align-last</code> Property</h6>
+						<p>This is a prefixed version of the <code>text-align-last</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-align-last</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											auto | start | end | left | right | center | justify
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-epub-word-break">
+						<h6>The <code>-epub-word-break</code> Property</h6>
+						<p>This is a prefixed version of the <code>word-break</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-word-break</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											normal | keep-all | break-all
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-text-transform">
+						<h6>The <code>text-transform</code> Property</h6>
+						<p>This is a prefixed value for the <code>text-transform</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>text-transform</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											-epub-fullwidth
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							<p>The following table describes the equivalent value in CSS.</p>
+							<table class="data">
+								<thead>
+									<tr>
+										<th>EPUB version</th>
+										<th>CSS equivalent</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td><code>text-transform: -epub-fullwidth</code></td>
+										<td><code>text-transform: full-width</code></td>
+									</tr>
+								</tbody>
+							
+							</table>
+						</section>
+					</section>
+
+					<section id="sec-css-prefixed-text-decoration">
+						<h5>CSS Text Decoration Level 3</h5>
+						<p>This section describes the <code>-epub-</code> prefixed properties for
+							[[CSS-Text-Decoration-3]].</p>
+						
+						<section id="sec-css-prefixed-text-epub-text-emphasis-color">
+						<h6>The <code>-epub-text-emphasis-color</code> Property</h6>
+						<p>This is a prefixed version of the <code>text-emphasis-color</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-emphasis-color</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											&lt;color&gt;
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-epub-text-emphasis-position">
+						<h6>The <code>-epub-text-emphasis-position</code> Property</h6>
+						<p>This is a prefixed version of the <code>text-emphasis-position</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-emphasis-position</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											[ over | under ] &amp;&amp; [ right | left ]
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-epub-text-emphasis-style">
+						<h6>The <code>-epub-text-emphasis-style</code> Property</h6>
+						<p>This is a prefixed version of the <code>text-emphasis-style</code> property.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-emphasis-style</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | &lt;string&gt;
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</section>
+						<section id="sec-css-prefixed-text-epub-text-underline-position">
+						<h6>The <code>-epub-text-underline-position</code> Property</h6>
+						<p>This is a prefixed version of the <code>text-underline-position</code> property.
+						One value is no longer supported by CSS.</p>
+							<table class="def propdef">
+								<tbody>
+									<tr>
+										<th>Name: </th>
+										<td>
+											<dfn>-epub-text-underline-position</dfn>
+										</td>
+									</tr>
+									<tr class="value">
+										<th>Value:</th>
+										<td>
+											auto | [ under || [ left | right ] ] | alphabetic
+										</td>
+									</tr>
+								</tbody>
+							</table>
+							<p>The following table describes the equivalent value in CSS.</p>
+							<table class="data">
+								<thead>
+									<tr>
+										<th>EPUB version</th>
+										<th>CSS equivalent</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td><code>-epub-text-underline-position: alphabetic</code></td>
+										<td><code>text-underline-position: auto</code></td>
+									</tr>
+								</tbody>
+							
+							</table>
+						</section>		
+					</section>
+		</section>
+		
+		
 		<section id="app-schemas" class="appendix informative">
 			<h2>Schemas</h2>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4272,7 +4272,7 @@ Spine:
 									</tr>
 								</tbody>
 							</table>
-							<p class="note">The <code>auto</code> value is no longer supported in CSS.</p>
+							<p class="note">The <code>all</code> value is no longer supported in CSS.</p>
 						</section>
 						<section id="sec-css-prefixed-text-epub-line-break">
 						<h6>The <code>-epub-line-break</code> Property</h6>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4167,7 +4167,7 @@ Spine:
 						</section>
 						
 						<section id="sec-css-prefixed-writing-modes-text-combine">
-							<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>(deprecated) Properties</h6>
+							<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code> (deprecated) Properties</h6>
 							
 							<p>These properties no longer exist in CSS, having been replaced with <code>text-combine-upright</code>.</p>
 							<table class="def propdef">
@@ -4286,7 +4286,7 @@ Spine:
 						</section>
 						<section id="sec-css-prefixed-text-epub-text-align-last">
 						<h6>The <code>-epub-text-align-last</code> Property</h6>
-						<p>This is a prefixed version of the <code>text-align-last</code> property.</p>
+						<p>This is a prefixed version of the <code>text-align-last</code> property</p>
 							<table class="def propdef">
 								<tbody>
 									<tr>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8539,8 +8539,8 @@ html.my-document-playing * {
 
 					<section id="sec-css-prefixed-text">
 						<h5>CSS Text Level 3</h5>
-						<p>This section describes the <code>-epub-</code> prefixed properties for
-							[[CSS-Text-3]].</p>
+						<p>This section describes the <code>-epub-</code> prefixed properties 
+						(and one prefixed value) for [[CSS-Text-3]].</p>
 						<section id="sec-css-prefixed-text-epub-hyphens">
 						<h6>The <code>-epub-hyphens</code> Property</h6>
 						<p>This is a prefixed version of the <code>hyphens</code> property.</p>
@@ -8663,7 +8663,7 @@ html.my-document-playing * {
 					<section id="sec-css-prefixed-text-decoration">
 						<h5>CSS Text Decoration Level 3</h5>
 						<p>This section describes the <code>-epub-</code> prefixed properties for
-							[[CSS-Text-Decoration-3]].</p>
+							[[CSS-Text-Decor-3]].</p>
 						
 						<section id="sec-css-prefixed-text-epub-text-emphasis-color">
 						<h6>The <code>-epub-text-emphasis-color</code> Property</h6>


### PR DESCRIPTION
This attempts to address #1389 and #1390.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dauwhe/epub-specs/pull/1655.html" title="Last updated on May 3, 2021, 7:42 PM UTC (37d5191)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1655/1a90e58...dauwhe:37d5191.html" title="Last updated on May 3, 2021, 7:42 PM UTC (37d5191)">Diff</a>