### PR TITLE
Attempt to fix #1299 by adding some text to CMT about track element not requiring a fallback

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -780,14 +780,21 @@
 									<th colspan="3" id="cmt-grp-video" class="tbl-group">Video</th>
 								</tr>
 								<tr>
-									<td colspan="3" id="cmt-vide-note">EPUB 3 allows any video codecs to be included
+									<td colspan="3" id="cmt-vide-note"><p>EPUB 3 allows any video codecs to be included
 										without fallbacks, although none are technically considered Core Media Type
 										Resources. Although Reading Systems are recommended to support at least one of
 										the H.264 [[?H264]] and VP8 [[?RFC6386]] video codecs, it is not a conformance
 										requirement &#8212; a Reading System might support other video codecs, or none
 										at all. EPUB Creators and need to take into consideration factors such as
 										breadth of adoption, video playback quality, and technology usage royalty
-										requirements when making a choice to include video in either format, or both.
+										requirements when making a choice to include video in either format, or both.</p>
+										
+										<p>Note that the HTML 
+										<a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">
+										<code>track</code>
+										</a> 
+										element can refer to Foreign Resources
+										such as VTT files without providing a fallback.</p>
 									</td>
 								</tr>
 								<tr>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -796,7 +796,7 @@
 										<a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">
 										<code>track</code></a> element do not require fallbacks. 
 										This allows, for example, EPUB Creators to include captions, subtitles, descriptions, etc. 
-										using VTT [[WebVTT]].</p>
+										using [[WebVTT]].</p>
 									</td>
 								</tr>
 								<tr>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -790,13 +790,16 @@
 										not a conformance requirement &#8212; a Reading System might support other video
 										codecs, or none at all. EPUB Creators must consider factors such as breadth of
 										adoption, video playback quality, and technology usage royalty requirements when
-										making a choice to include video in either format, or both. </p>
-										
-										<p>Files referenced from the HTML 
-										<a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">
-										<code>track</code></a> element do not require fallbacks. 
-										This allows, for example, EPUB Creators to include captions, subtitles, descriptions, etc. 
-										using [[WebVTT]].</p>
+										making a choice to include video in either format, or both.
+									</td>
+								</tr>
+								<tr>
+									<th colspan="3" id="cmt-grp-track" class="tbl-group">Tracks</th>
+								</tr>
+								<tr>
+									<td colspan="3" id="cmt-track-note">EPUB Creators can include any kind of audio or 
+										video track (for example, [[?WebVTT]] captions, subtitles and descriptions) without a fallback. 
+										Refer to <a href="#sec-xhtml-fallbacks"></a> for more information.
 									</td>
 								</tr>
 								<tr>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -789,12 +789,10 @@
 										breadth of adoption, video playback quality, and technology usage royalty
 										requirements when making a choice to include video in either format, or both.</p>
 										
-										<p>Note that the HTML 
+										<p>Note that EPUB Creators may include captions, subtitles, descriptions, etc. 
+										using VTT [[WebVTT]] files referenced from the HTML 
 										<a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">
-										<code>track</code>
-										</a> 
-										element can refer to Foreign Resources
-										such as VTT files without providing a fallback.</p>
+										<code>track</code></a> element without providing fallbacks.</p>
 									</td>
 								</tr>
 								<tr>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -789,10 +789,11 @@
 										breadth of adoption, video playback quality, and technology usage royalty
 										requirements when making a choice to include video in either format, or both.</p>
 										
-										<p>Note that EPUB Creators may include captions, subtitles, descriptions, etc. 
-										using VTT [[WebVTT]] files referenced from the HTML 
+										<p>Files referenced from the HTML 
 										<a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">
-										<code>track</code></a> element without providing fallbacks.</p>
+										<code>track</code></a> element do not require fallbacks. 
+										This allows, for example, EPUB Creators to include captions, subtitles, descriptions, etc. 
+										using VTT [[WebVTT]].</p>
 									</td>
 								</tr>
 								<tr>


### PR DESCRIPTION
#1299 asked for some clarification on this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dauwhe/epub-specs/pull/1657.html" title="Last updated on May 3, 2021, 9:47 PM UTC (59a8ac2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1657/1a90e58...dauwhe:59a8ac2.html" title="Last updated on May 3, 2021, 9:47 PM UTC (59a8ac2)">Diff</a>