### PR TITLE
Add caution formatting

### DIFF
--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -334,3 +334,14 @@ p.support {
 	background-color: rgb(255,255,230);
 	padding: 0.7rem;
 }
+
+p.caution, div.caution {
+	padding: 0.5rem;
+	border-left: 0.5rem solid rgb(255,140,0);
+	background-color: rgb(254,236,207);
+}
+
+div.caution-title > span {
+	color: rgb(140,40,0);
+	text-transform: uppercase;
+}

--- a/epub33/common/js/add-caution-hd.js
+++ b/epub33/common/js/add-caution-hd.js
@@ -1,0 +1,25 @@
+
+function addCautionHeaders() {
+	var cautions = document.querySelectorAll('div.caution');
+	
+	for (var i = 0; i < cautions.length; i++) {
+		
+		cautions[i].setAttribute('id', 'caution-'+i);
+		
+		// find current parent heading level for setting aria-level on caution heading
+		var parent_section = cautions[i].closest('section');
+		var parent_hd = parent_section.querySelector('h2,h3,h4,h5,h6');
+		var parent_num = parent_hd.localName.replace('h','');
+		
+		var caution_hd = document.createElement('div');
+			caution_hd.setAttribute('role', 'heading');
+			caution_hd.setAttribute('aria-level', parent_num+1);
+			caution_hd.setAttribute('class','caution-title marker');
+		
+		var caution_label = document.createElement('span');
+			caution_label.appendChild(document.createTextNode('Caution'));
+		
+		caution_hd.appendChild(caution_label);
+		cautions[i].prepend(caution_hd);
+	} 
+}

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7,6 +7,7 @@
 		<script src="../common/js/biblio.js" class="remove"></script>
 		<script src="../common/js/confreq-permalinks.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/add-caution-hd.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
             var respecConfig = {
@@ -72,7 +73,7 @@
                 },
                 localBiblio: biblio,
                 preProcess:[inlineCustomCSS],
-                postProcess:[addConformanceLinks]
+                postProcess:[addConformanceLinks, addCautionHeaders]
             };//]]>
       </script>
 	</head>
@@ -206,7 +207,7 @@
 						track of the various changes to HTML and the technologies it references to ensure they keep
 						their processes up to date.</p>
 
-					<div class="warning">
+					<div class="caution">
 						<p>As HTML evolves, it is possible that features that were valid in previous versions could
 							become obsolete or be removed. In general, however, features are typically only removed if
 							serious issues with them arise (e.g., lack of support in browsers, security issues).</p>
@@ -790,17 +791,16 @@
 										not a conformance requirement &#8212; a Reading System might support other video
 										codecs, or none at all. EPUB Creators must consider factors such as breadth of
 										adoption, video playback quality, and technology usage royalty requirements when
-										making a choice to include video in either format, or both.
-									</td>
+										making a choice to include video in either format, or both. </td>
 								</tr>
 								<tr>
 									<th colspan="3" id="cmt-grp-track" class="tbl-group">Tracks</th>
 								</tr>
 								<tr>
-									<td colspan="3" id="cmt-track-note">EPUB Creators can include any kind of audio or 
-										video track (for example, [[?WebVTT]] captions, subtitles and descriptions) without a fallback. 
-										Refer to <a href="#sec-xhtml-fallbacks"></a> for more information.
-									</td>
+									<td colspan="3" id="cmt-track-note">EPUB Creators can include any kind of audio or
+										video track (for example, [[?WebVTT]] captions, subtitles and descriptions)
+										without a fallback. Refer to <a href="#sec-xhtml-fallbacks"></a> for more
+										information. </td>
 								</tr>
 								<tr>
 									<th colspan="3" id="cmt-grp-text" class="tbl-group">Style</th>
@@ -4079,28 +4079,27 @@ Spine:
 
 				<section id="sec-css-prefixed">
 					<h4>Prefixed Properties</h4>
-					
-					<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to 
-					world languages were not yet mature. To ensure backwards compatibility for content authored 
-					using these prefixes, they have been retained in this specification. Unless otherwise noted, 
-					prefixed properties and values behave exactly as their unprefixed equivalents as described in
-					the appropriate CSS specification. The prefixed properties are documented 
-					in an <a href="#css-prefixes">Appendix</a>.
-					</p>
+
+					<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to world
+						languages were not yet mature. To ensure backwards compatibility for content authored using
+						these prefixes, they have been retained in this specification. Unless otherwise noted, prefixed
+						properties and values behave exactly as their unprefixed equivalents as described in the
+						appropriate CSS specification. The prefixed properties are documented in an <a
+							href="#css-prefixes">Appendix</a>. </p>
 
 					<div class="caution">
 						<p><a>EPUB Creators</a> are strongly encouraged to use unprefixed properties and <a>Reading
-							Systems</a> are encouraged to support current CSS specifications. The widely-used prefixed properties
-							from [[EPUBContentDocs-301]] have been retained, but support for the other properties has
-							been removed. EPUB Creators are advised to use CSS-native solutions for the removed
-							properties where and when they are available.</p>
+								Systems</a> are encouraged to support current CSS specifications. The widely-used
+							prefixed properties from [[EPUBContentDocs-301]] have been retained, but support for the
+							other properties has been removed. EPUB Creators are advised to use CSS-native solutions for
+							the removed properties where and when they are available.</p>
 						<p>EPUB Creators currently using these prefixed properties are advised to move to unprefixed
 							versions as soon as support allows, as these properties are not anticipated to be supported
 							in the next major version of EPUB.</p>
 					</div>
-					
-					<p class="note">In some cases, the unprefixed versions of these properties now support
-						additional values. Reading Systems MAY support these values even with the prefixed property.</p>
+
+					<p class="note">In some cases, the unprefixed versions of these properties now support additional
+						values. Reading Systems MAY support these values even with the prefixed property.</p>
 
 				</section>
 			</section>
@@ -8296,10 +8295,12 @@ html.my-document-playing * {
 				<section id="sec-reserved-prefixes">
 					<h4>Reserved Prefixes</h4>
 
-					<p class="warning">Although reserved prefixes are an authoring convenience, reliance on them can
-						lead to interoperability issues. Validation tools will often reject new prefixes until their
-						developers update them to the latest version of the specification, for example. Consequently,
-						EPUB Creators should declare all prefixes they use to avoid such issues.</p>
+					<div class="caution">
+						<p>Although reserved prefixes are an authoring convenience, reliance on them can lead to
+							interoperability issues. Validation tools will often reject new prefixes until their
+							developers update them to the latest version of the specification, for example.
+							Consequently, EPUB Creators should declare all prefixes they use to avoid such issues.</p>
+					</div>
 
 					<p><a>EPUB Creators</a> MAY use reserved prefixes in attributes that expect a <a
 							href="#sec-property-datatype"><var>property</var> value</a> without declaring them in a <a
@@ -8401,390 +8402,359 @@ html.my-document-playing * {
 
 			<div data-include="vocab/structure.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 		</section>
-		
 		<section id="css-prefixes" class="appendix">
-		<h2>Prefixed CSS Properties</h2>
-		<p>This appendix describes the prefixed CSS properties supported by EPUB. </p>
-					<section id="sec-css-prefixed-writing-modes">
-						<h5>CSS Writing Modes</h5>
+			<h2>Prefixed CSS Properties</h2>
+			<p>This appendix describes the prefixed CSS properties supported by EPUB. </p>
+			<section id="sec-css-prefixed-writing-modes">
+				<h5>CSS Writing Modes</h5>
 
-						<p>This section describes the <code>-epub-</code> prefixed properties for
-							[[CSS-Writing-Modes-3]].</p>
+				<p>This section describes the <code>-epub-</code> prefixed properties for [[CSS-Writing-Modes-3]].</p>
 
-						<section id="sec-css-prefixed-writing-modes-text-orientation">
-							<h6>The <code>-epub-text-orientation</code> Property</h6>
-							<p>This is a prefixed version of the CSS <code>text-orientation</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-orientation</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											mixed | upright | sideways | sideways-right
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							
-							<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>.
-								User agents MUST interpret these values according to the following table:
-							</p>
-							
-							<table class="data">
-								<thead>
-									<tr>
-										<th>Deprecated value</th>
-										<th>Value to be used</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td><code>vertical-right</code></td>
-										<td><code>mixed</code></td>
-									</tr>
-									<tr>
-										<td><code>rotate-right</code></td>
-										<td><code>sideways</code></td>
-									</tr>
-									<tr>
-										<td><code>rotate-normal</code></td>
-										<td><code>sideways</code></td>
-									</tr>
-								</tbody>
-							
-							</table>
-						</section>
-						
-						<section id="sec-css-prefixed-writing-modes-writing-mode">
-							<h6>The <code>-epub-writing-mode</code> Property</h6>
-							<p>This is a prefixed version of the CSS <code>writing-mode</code> property, 
-							with the same syntax and behavior.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-writing-mode</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											horizontal-tb | vertical-rl | vertical-lr
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						
-						<section id="sec-css-prefixed-writing-modes-text-combine">
-							<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code> Properties</h6>
-							
-							<p>These are prefixed versions of <code>text-combine-upright</code>, 
-							although <code>-epub-text-combine</code> is deprecated. See the table below for how 
-							values of both properties translate to unprefixed CSS.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-combine-horizontal</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											none | all
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-combine</dfn> (deprecated)
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											none | horizontal | horizontal &lt;number&gt; 
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							<p>The following table shows how to map from the prefixed versions to the current CSS versions.</p>
-							<table class="data">
-								<thead>
-									<tr>
-										<th>Prefixed version</th>
-										<th>CSS equivalent</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td><code>-epub-text-combine-horizontal: none</code></td>
-										<td><code>text-combine-upright: none</code></td>
-									</tr>
-									<tr>
-										<td><code>-epub-text-combine-horizontal: all</code></td>
-										<td><code>text-combine-upright: all</code></td>
-									</tr>
-									<tr>
-										<td><code>-epub-text-combine: none</code></td>
-										<td><code>text-combine-upright: none</code></td>
-									</tr>
-									<tr>
-										<td><code>-epub-text-combine: horizontal</code></td>
-										<td><code>text-combine-upright: all</code></td>
-									</tr>
-									<tr>
-										<td><code>-epub-text-combine: horizontal &lt;number&gt;</code></td>
-										<td>Error</td>
-									</tr>
-								</tbody>
-							
-							</table>
-						</section>
-					</section>
+				<section id="sec-css-prefixed-writing-modes-text-orientation">
+					<h6>The <code>-epub-text-orientation</code> Property</h6>
+					<p>This is a prefixed version of the CSS <code>text-orientation</code> property.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-text-orientation</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> mixed | upright | sideways | sideways-right </td>
+							</tr>
+						</tbody>
+					</table>
 
-					<section id="sec-css-prefixed-text">
-						<h5>CSS Text Level 3</h5>
-						<p>This section describes the <code>-epub-</code> prefixed properties 
-						(and one prefixed value) for [[CSS-Text-3]].</p>
-						<section id="sec-css-prefixed-text-epub-hyphens">
-						<h6>The <code>-epub-hyphens</code> Property</h6>
-						<p>This is a prefixed version of the <code>hyphens</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-hyphens</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											none | manual | auto | all
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							<p class="note">The <code>all</code> value is no longer supported in CSS.</p>
-						</section>
-						<section id="sec-css-prefixed-text-epub-line-break">
-						<h6>The <code>-epub-line-break</code> Property</h6>
-						<p>This is a prefixed version of the <code>line-break</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-line-break</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											auto | loose | normal | strict
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-epub-text-align-last">
-						<h6>The <code>-epub-text-align-last</code> Property</h6>
-						<p>This is a prefixed version of the <code>text-align-last</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-align-last</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											auto | start | end | left | right | center | justify
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-epub-word-break">
-						<h6>The <code>-epub-word-break</code> Property</h6>
-						<p>This is a prefixed version of the <code>word-break</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-word-break</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											normal | keep-all | break-all
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-text-transform">
-						<h6>The <code>text-transform</code> Property</h6>
-						<p>This is a prefixed value for the <code>text-transform</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>text-transform</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											-epub-fullwidth
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							<p>The following table describes the equivalent value in CSS.</p>
-							<table class="data">
-								<thead>
-									<tr>
-										<th>EPUB version</th>
-										<th>CSS equivalent</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td><code>text-transform: -epub-fullwidth</code></td>
-										<td><code>text-transform: full-width</code></td>
-									</tr>
-								</tbody>
-							
-							</table>
-						</section>
-					</section>
+					<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>. User
+						agents MUST interpret these values according to the following table: </p>
 
-					<section id="sec-css-prefixed-text-decoration">
-						<h5>CSS Text Decoration Level 3</h5>
-						<p>This section describes the <code>-epub-</code> prefixed properties for
-							[[CSS-Text-Decor-3]].</p>
-						
-						<section id="sec-css-prefixed-text-epub-text-emphasis-color">
-						<h6>The <code>-epub-text-emphasis-color</code> Property</h6>
-						<p>This is a prefixed version of the <code>text-emphasis-color</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-emphasis-color</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											&lt;color&gt;
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-epub-text-emphasis-position">
-						<h6>The <code>-epub-text-emphasis-position</code> Property</h6>
-						<p>This is a prefixed version of the <code>text-emphasis-position</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-emphasis-position</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											[ over | under ] &amp;&amp; [ right | left ]
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-epub-text-emphasis-style">
-						<h6>The <code>-epub-text-emphasis-style</code> Property</h6>
-						<p>This is a prefixed version of the <code>text-emphasis-style</code> property.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-emphasis-style</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | &lt;string&gt;
-										</td>
-									</tr>
-								</tbody>
-							</table>
-						</section>
-						<section id="sec-css-prefixed-text-epub-text-underline-position">
-						<h6>The <code>-epub-text-underline-position</code> Property</h6>
-						<p>This is a prefixed version of the <code>text-underline-position</code> property.
-						One value is no longer supported by CSS.</p>
-							<table class="def propdef">
-								<tbody>
-									<tr>
-										<th>Name: </th>
-										<td>
-											<dfn>-epub-text-underline-position</dfn>
-										</td>
-									</tr>
-									<tr class="value">
-										<th>Value:</th>
-										<td>
-											auto | [ under || [ left | right ] ] | alphabetic
-										</td>
-									</tr>
-								</tbody>
-							</table>
-							<p>The following table describes the equivalent value in CSS.</p>
-							<table class="data">
-								<thead>
-									<tr>
-										<th>EPUB version</th>
-										<th>CSS equivalent</th>
-									</tr>
-								</thead>
-								<tbody>
-									<tr>
-										<td><code>-epub-text-underline-position: alphabetic</code></td>
-										<td><code>text-underline-position: auto</code></td>
-									</tr>
-								</tbody>
-							
-							</table>
-						</section>		
-					</section>
+					<table class="data">
+						<thead>
+							<tr>
+								<th>Deprecated value</th>
+								<th>Value to be used</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>vertical-right</code></td>
+								<td><code>mixed</code></td>
+							</tr>
+							<tr>
+								<td><code>rotate-right</code></td>
+								<td><code>sideways</code></td>
+							</tr>
+							<tr>
+								<td><code>rotate-normal</code></td>
+								<td><code>sideways</code></td>
+							</tr>
+						</tbody>
+
+					</table>
+				</section>
+
+				<section id="sec-css-prefixed-writing-modes-writing-mode">
+					<h6>The <code>-epub-writing-mode</code> Property</h6>
+					<p>This is a prefixed version of the CSS <code>writing-mode</code> property, with the same syntax
+						and behavior.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-writing-mode</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> horizontal-tb | vertical-rl | vertical-lr </td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section id="sec-css-prefixed-writing-modes-text-combine">
+					<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>
+						Properties</h6>
+
+					<p>These are prefixed versions of <code>text-combine-upright</code>, although
+							<code>-epub-text-combine</code> is deprecated. See the table below for how values of both
+						properties translate to unprefixed CSS.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-text-combine-horizontal</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> none | all </td>
+							</tr>
+						</tbody>
+					</table>
+
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-text-combine</dfn> (deprecated) </td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> none | horizontal | horizontal &lt;number&gt; </td>
+							</tr>
+						</tbody>
+					</table>
+					<p>The following table shows how to map from the prefixed versions to the current CSS versions.</p>
+					<table class="data">
+						<thead>
+							<tr>
+								<th>Prefixed version</th>
+								<th>CSS equivalent</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>-epub-text-combine-horizontal: none</code></td>
+								<td><code>text-combine-upright: none</code></td>
+							</tr>
+							<tr>
+								<td><code>-epub-text-combine-horizontal: all</code></td>
+								<td><code>text-combine-upright: all</code></td>
+							</tr>
+							<tr>
+								<td><code>-epub-text-combine: none</code></td>
+								<td><code>text-combine-upright: none</code></td>
+							</tr>
+							<tr>
+								<td><code>-epub-text-combine: horizontal</code></td>
+								<td><code>text-combine-upright: all</code></td>
+							</tr>
+							<tr>
+								<td><code>-epub-text-combine: horizontal &lt;number&gt;</code></td>
+								<td>Error</td>
+							</tr>
+						</tbody>
+
+					</table>
+				</section>
+			</section>
+
+			<section id="sec-css-prefixed-text">
+				<h5>CSS Text Level 3</h5>
+				<p>This section describes the <code>-epub-</code> prefixed properties (and one prefixed value) for
+					[[CSS-Text-3]].</p>
+				<section id="sec-css-prefixed-text-epub-hyphens">
+					<h6>The <code>-epub-hyphens</code> Property</h6>
+					<p>This is a prefixed version of the <code>hyphens</code> property.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-hyphens</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> none | manual | auto | all </td>
+							</tr>
+						</tbody>
+					</table>
+					<p class="note">The <code>all</code> value is no longer supported in CSS.</p>
+				</section>
+				<section id="sec-css-prefixed-text-epub-line-break">
+					<h6>The <code>-epub-line-break</code> Property</h6>
+					<p>This is a prefixed version of the <code>line-break</code> property.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-line-break</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> auto | loose | normal | strict </td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+				<section id="sec-css-prefixed-text-epub-text-align-last">
+					<h6>The <code>-epub-text-align-last</code> Property</h6>
+					<p>This is a prefixed version of the <code>text-align-last</code> property.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-text-align-last</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> auto | start | end | left | right | center | justify </td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+				<section id="sec-css-prefixed-text-epub-word-break">
+					<h6>The <code>-epub-word-break</code> Property</h6>
+					<p>This is a prefixed version of the <code>word-break</code> property.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-word-break</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> normal | keep-all | break-all </td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+				<section id="sec-css-prefixed-text-text-transform">
+					<h6>The <code>text-transform</code> Property</h6>
+					<p>This is a prefixed value for the <code>text-transform</code> property.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>text-transform</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> -epub-fullwidth </td>
+							</tr>
+						</tbody>
+					</table>
+					<p>The following table describes the equivalent value in CSS.</p>
+					<table class="data">
+						<thead>
+							<tr>
+								<th>EPUB version</th>
+								<th>CSS equivalent</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>text-transform: -epub-fullwidth</code></td>
+								<td><code>text-transform: full-width</code></td>
+							</tr>
+						</tbody>
+
+					</table>
+				</section>
+			</section>
+
+			<section id="sec-css-prefixed-text-decoration">
+				<h5>CSS Text Decoration Level 3</h5>
+				<p>This section describes the <code>-epub-</code> prefixed properties for [[CSS-Text-Decor-3]].</p>
+
+				<section id="sec-css-prefixed-text-epub-text-emphasis-color">
+					<h6>The <code>-epub-text-emphasis-color</code> Property</h6>
+					<p>This is a prefixed version of the <code>text-emphasis-color</code> property.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-text-emphasis-color</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> &lt;color&gt; </td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+				<section id="sec-css-prefixed-text-epub-text-emphasis-position">
+					<h6>The <code>-epub-text-emphasis-position</code> Property</h6>
+					<p>This is a prefixed version of the <code>text-emphasis-position</code> property.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-text-emphasis-position</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> [ over | under ] &amp;&amp; [ right | left ] </td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+				<section id="sec-css-prefixed-text-epub-text-emphasis-style">
+					<h6>The <code>-epub-text-emphasis-style</code> Property</h6>
+					<p>This is a prefixed version of the <code>text-emphasis-style</code> property.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-text-emphasis-style</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ]
+									] | &lt;string&gt; </td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+				<section id="sec-css-prefixed-text-epub-text-underline-position">
+					<h6>The <code>-epub-text-underline-position</code> Property</h6>
+					<p>This is a prefixed version of the <code>text-underline-position</code> property. One value is no
+						longer supported by CSS.</p>
+					<table class="def propdef">
+						<tbody>
+							<tr>
+								<th>Name: </th>
+								<td>
+									<dfn>-epub-text-underline-position</dfn>
+								</td>
+							</tr>
+							<tr class="value">
+								<th>Value:</th>
+								<td> auto | [ under || [ left | right ] ] | alphabetic </td>
+							</tr>
+						</tbody>
+					</table>
+					<p>The following table describes the equivalent value in CSS.</p>
+					<table class="data">
+						<thead>
+							<tr>
+								<th>EPUB version</th>
+								<th>CSS equivalent</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>-epub-text-underline-position: alphabetic</code></td>
+								<td><code>text-underline-position: auto</code></td>
+							</tr>
+						</tbody>
+
+					</table>
+				</section>
+			</section>
 		</section>
-		
-		
 		<section id="app-schemas" class="appendix informative">
 			<h2>Schemas</h2>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -208,9 +208,9 @@
 						their processes up to date.</p>
 
 					<div class="caution">
-						<p>As HTML evolves, it is possible that features that were valid in previous versions could
-							become obsolete or be removed. In general, however, features are typically only removed if
-							serious issues with them arise (e.g., lack of support in browsers, security issues).</p>
+						<p>As HTML evolves, it is possible that previously-valid features may become obsolete or be
+							removed. In general, however, the removal of features typically only occurs when serious
+							issues arise with them (e.g., lack of support in browsers, security issues).</p>
 					</div>
 
 					<p>The <a href="#sec-xhtml">XHTML profile defined by this specification</a> inherits all definitions
@@ -233,10 +233,10 @@
 						their processes up to date.</p>
 
 					<div class="caution">
-						<p>As SVG evolves, features that were valid in previous versions could become obsolete or be
-							removed. The Working Group anticipates that the W3C will make any such changes carefully to
-							ensure minimal disruption for EPUB Creators, but in the case of a backwards-incompatible
-							revision the Working Group could revisit the use of an undated reference.</p>
+						<p>As SVG evolves, features previously-valid features may become obsolete or be removed. The
+							Working Group anticipates the W3C will make any such changes carefully to ensure minimal
+							disruption, but in the case of a backwards-incompatible revision the Working Group could
+							revisit the use of an undated reference.</p>
 					</div>
 				</section>
 
@@ -3885,10 +3885,9 @@ Spine:
 				<h3>SVG Content Documents</h3>
 
 				<div class="caution">
-					<p>Some features of [[SVG]] are not fully supported in <a>Reading Systems</a> or supported across
-						all platforms on which Reading Systems run. When utilizing such features, <a>EPUB Creators</a>
-						should consider the inherent risks in terms of the potential impact on interoperability and
-						document longevity.</p>
+					<p><a>Reading Systems</a> may not support all the features of [[SVG]] or supported them across all
+						platforms that Reading Systems run on. When utilizing such features, <a>EPUB Creators</a> should
+						consider the inherent risks on interoperability and document longevity.</p>
 				</div>
 
 				<section id="sec-svg-intro" class="informative">
@@ -4088,19 +4087,17 @@ Spine:
 							href="#css-prefixes">Appendix</a>. </p>
 
 					<div class="caution">
-						<p><a>EPUB Creators</a> are strongly encouraged to use unprefixed properties and <a>Reading
-								Systems</a> are encouraged to support current CSS specifications. The widely-used
-							prefixed properties from [[EPUBContentDocs-301]] have been retained, but support for the
-							other properties has been removed. EPUB Creators are advised to use CSS-native solutions for
-							the removed properties where and when they are available.</p>
-						<p>EPUB Creators currently using these prefixed properties are advised to move to unprefixed
-							versions as soon as support allows, as these properties are not anticipated to be supported
-							in the next major version of EPUB.</p>
+						<p><a>EPUB Creators</a> should use unprefixed properties and <a>Reading Systems</a> should
+							support current CSS specifications. This specification retains the widely-used prefixed
+							properties from [[EPUBContentDocs-301]], but removes support for the less-used ones. EPUB
+							Creators should use CSS-native solutions for the removed properties whenever available.</p>
+						<p>The Working Group recommends that EPUB Creators currently using these prefixed properties
+							move to unprefixed versions as soon as support allows, as the Working Group does not
+							anticipate supporting them in the next major version of EPUB.</p>
 					</div>
 
 					<p class="note">In some cases, the unprefixed versions of these properties now support additional
 						values. Reading Systems MAY support these values even with the prefixed property.</p>
-
 				</section>
 			</section>
 
@@ -8296,10 +8293,10 @@ html.my-document-playing * {
 					<h4>Reserved Prefixes</h4>
 
 					<div class="caution">
-						<p>Although reserved prefixes are an authoring convenience, reliance on them can lead to
-							interoperability issues. Validation tools will often reject new prefixes until their
-							developers update them to the latest version of the specification, for example.
-							Consequently, EPUB Creators should declare all prefixes they use to avoid such issues.</p>
+						<p>Although reserved prefixes are an authoring convenience, EPUB Creators should avoid relying
+							on them as they may cause interoperability issues. Validation tools will often reject new
+							prefixes until their developers update the tools to the latest version of the specification,
+							for example. EPUB Creators should declare all prefixes they use to avoid such issues.</p>
 					</div>
 
 					<p><a>EPUB Creators</a> MAY use reserved prefixes in attributes that expect a <a


### PR DESCRIPTION
Basically mimics notes but in an orange scheme.

Fixes #1660


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1661.html" title="Last updated on May 4, 2021, 8:18 PM UTC (fba588a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1661/010a52f...fba588a.html" title="Last updated on May 4, 2021, 8:18 PM UTC (fba588a)">Diff</a>