### PR TITLE
Move registries to notes

### DIFF
--- a/epub33/common/js/biblio.js
+++ b/epub33/common/js/biblio.js
@@ -3,14 +3,6 @@ var biblio = {
 		"title": "EPUB Accessibility Frequently Asked Questions",
 		"href": "http://www.idpf.org/epub/guides/a11y-faq"
 	},
-	"AttributeExtensions": {
-		"title": "EPUB Custom Attribute Extensions for Content Documents",
-		"href": "http://www.idpf.org/epub/extensions/attributes"
-	},
-	"AuthorityRegistry": {
-		"title": "EPUB Subject Authorities Registry",
-		"href": "http://www.idpf.org/epub/registries/authorities/"
-	},
 	"CSSSnapshot": {
 		"title": "CSS Snapshot",
 		"href": "https://www.w3.org/TR/CSS/"
@@ -354,14 +346,6 @@ var biblio = {
 		"title": "Request for Comments",
 		"href": "https://www.ietf.org/standards/rfcs/"
 	},
-	"RoleExtensions": {
-		"title": "EPUB Collection Element Role Extensions",
-		"href": "http://www.idpf.org/epub/extensions/roles"
-	},
-	"RoleRegistry": {
-		"title": "EPUB Collection Roles Registry",
-		"href": "http://www.idpf.org/epub/registries/roles"
-	},
 	"SHA-1": {
 		"title": "Federal Information Processing Standards Publication 180-3: Secure Hash Standard (SHS)",
 		"href": "http://csrc.nist.gov/publications/fips/fips180-3/fips180-3_final.pdf",
@@ -386,10 +370,6 @@ var biblio = {
 		"href": "https://developer.apple.com/fonts/TrueType-Reference-Manual/",
 		"publisher": "Apple",
 		"date": "2002"
-	},
-	"TypesRegistry": {
-		"title": "EPUB Publication Types Registry",
-		"href": "http://www.idpf.org/epub/vocab/package/types"
 	},
 	"US-ASCII": {
 		"title": "&quot;Coded Character Set - 7-bit American Standard Code for Information Interchange&quot;, ANSI X3.4, 1986."

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9391,6 +9391,11 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>06-May-2021: Noted that the working group will no longer maintain the publication type and
+						collection role registries and removed dependence on the latter for validating collection types
+						(use of NMToken values remains restricted to extension specifications). The registry of
+						authority codes is now integrated into the property definition. See <a
+							href="https://github.com/w3c/epub-specs/pull/1664">pull request 1664</a>.</li>
 					<li>28-Apr-2021: Drop requirement for resources referenced from HTML <code>link</code> elements to
 						have core media type fallbacks. See <a href="https://github.com/w3c/epub-specs/issues/1312"
 							>issue 1312</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2167,9 +2167,16 @@
 									Publication is of a specialized type (e.g., annotations or a dictionary packaged in
 									EPUB format).</p>
 
-								<p>An informative registry of specialized EPUB Publication types for use with this
-									element is maintained in the [[?TypesRegistry]], but EPUB Creators MAY use any text
-									string as a <a>value</a>.</p>
+								<p>EPUB Creators MAY use any text string as a <a>value</a>.</p>
+
+								<div class="note">
+									<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB
+										3 Working Group maintained an <a
+											href="http://www.idpf.org/epub/vocab/package/types">informative registry of
+											specialized EPUB Publication types</a> for use with this element. This
+										Working Group no longer maintains this registry and does not anticipate
+										developing new specialized publication types.</p>
+								</div>
 							</section>
 						</section>
 
@@ -3282,22 +3289,27 @@ Spine:
 								presented below).</p>
 
 							<p id="attrdef-collection-role">Each specialization MUST define a role value that uniquely
-								identifies all conformant <code>collection</code> elements. The role of each
-									<code>collection</code> element in the Package Document MUST be identified in its
-									<code>role</code> attribute, whose value MUST be one or more NMTOKENs
-								[[XMLSCHEMA-2]] and/or absolute IRIs [[RFC3987]]. The use of NMTOKEN values is reserved
-								for roles not defined in EPUB, which are maintained in the [[RoleRegistry]]. NMTOKEN
-								values not defined in the registry are not valid. This section does not define any
-								roles.</p>
+								identifies all conformant <code>collection</code> elements. EPUB Creators MUST identify
+								the role of each <code>collection</code> element in its <code>role</code> attribute,
+								whose value MUST be one or more NMTOKENs [[XMLSCHEMA-2]] and/or absolute IRIs
+								[[RFC3987]].</p>
+
+							<p>This specification reserves the use of NMTOKEN values for roles defined in EPUB
+								specifications. NMTOKEN values not defined by a recognized specification are not valid.
+								This section does not define any roles.</p>
 
 							<p>Third parties MAY define custom roles for the <code>collection</code> element, but they
 								MUST identify such roles using absolute IRIs. Custom roles MUST NOT incorporate the
 								string "<code>idpf.org</code>" in the host component of their identifying IRI.</p>
 
+
 							<div class="note">
-								<p>To facilitate interoperability of custom roles across Reading Systems, implementers
-									are strongly encouraged to document their use of the <code>collection</code> element
-									in [[RoleExtensions]].</p>
+								<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
+									Working Group maintained both a <a href="http://www.idpf.org/epub/registries/roles"
+										>registry of role extensions</a> and a list of <a
+										href="http://www.idpf.org/epub/extensions/roles">custom extension roles</a>.
+									This Working Group no longer maintains these registries and does not anticipate
+									defining new types of collections.</p>
 							</div>
 
 							<p id="elemdef-collection-metadata">The OPTIONAL <code>metadata</code> element child of
@@ -9228,11 +9240,8 @@ EPUB/images/cover.png</pre>
 							</dd>
 							<dt>Fragment Identifiers:</dt>
 							<dd>
-								<p>A registry of linking schemes is maintained at <a class="uri"
-										href="http://www.idpf.org/epub/linking/"
-											><code>http://www.idpf.org/epub/linking/</code></a>. Some of these schemes
-									define custom fragment identifiers that resolve to
-										<code>application/oebps-package+xml</code> documents.</p>
+								<p>EPUB Canonical Fragment Identifiers are custom fragment identifiers that can resolve
+									to <code>application/oebps-package+xml</code> documents.</p>
 							</dd>
 						</dl>
 					</dd>
@@ -9340,11 +9349,9 @@ EPUB/images/cover.png</pre>
 							</dd>
 							<dt>Fragment identifiers:</dt>
 							<dd>
-								<p>A registry of linking schemes is maintained at <a
-										href="http://www.idpf.org/epub/linking/"
-											><code>http://www.idpf.org/epub/linking/</code></a>. Some of these schemes
-									define custom fragment identifiers that resolve to <code>application/epub+zip</code>
-									and <code>application/oebps-package+xml</code> documents.</p>
+								<p>EPUB Canonical Fragment Identifiers are custom fragment identifiers that can resolve
+									to <code>application/epub+zip</code> and <code>application/oebps-package+xml</code>
+									documents.</p>
 							</dd>
 						</dl>
 					</dd>
@@ -9407,8 +9414,8 @@ EPUB/images/cover.png</pre>
 					3.2</a></h3>
 
 				<ul>
-					<li>04-May-2021: Removed requirements around SVG <code>requiredExtensions</code> attribute. See 
-						<a href="https://github.com/w3c/epub-specs/issues/1087">issue 1087</a>.</li>
+					<li>04-May-2021: Removed requirements around SVG <code>requiredExtensions</code> attribute. See <a
+							href="https://github.com/w3c/epub-specs/issues/1087">issue 1087</a>.</li>
 					<li>26-Mar-2021: Removed requirement for page list ordering to reflect the order of page breaks in
 						the content. See <a href="https://github.com/w3c/epub-specs/issues/1500">issue 1500</a>.</li>
 					<li>26-Mar-2021: Allowed <code>creator</code> and <code>contributor</code> elements to have multiple

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -1,789 +1,825 @@
-
 <section id="app-meta-property-vocab" class="vocab">
 	<h3>Meta Properties Vocabulary</h3>
-
 	<p>The properties in this vocabulary are usable in the <a href="#sec-meta-elem"><code>meta</code>
 			element's</a>
 		<code>property</code> attribute.</p>
-
-	<p>Unless indicated otherwise in its "Extends" field, the properties defined in this section are used to define
-			<a href="#subexpression">subexpressions</a>: in other words, a <code><a href="#elemdef-meta"
-			>meta</a></code> element carrying a property defined in this section MUST have a <code><a
+	<p>Unless indicated otherwise in its "Extends" field, the properties defined in this section are used to
+		define <a href="#subexpression">subexpressions</a>: in other words, a <code><a href="#elemdef-meta"
+				>meta</a></code> element carrying a property defined in this section MUST have a <code><a
 				href="#attrdef-refines">refines</a></code> attribute referencing a resource or expression being
 		augmented.</p>
-
-	<p>In each property definition, the <strong>Allowed values</strong> field indicates the expected type of value
-		(using [[!XMLSCHEMA-2]] datatypes), the <strong>Cardinality</strong> field indicates the number of times the
-		property MAY be attached to another property, and the <strong>Extends</strong> field identifies the
-		properties it MAY be attached to.</p>
-
+	<p>In each property definition, the <strong>Allowed values</strong> field indicates the expected type of
+		value (using [[!XMLSCHEMA-2]] datatypes), the <strong>Cardinality</strong> field indicates the number of
+		times the property MAY be attached to another property, and the <strong>Extends</strong> field
+		identifies the properties it MAY be attached to.</p>
 	<p>Properties without a prefix are referenceable using the base IRI
-		<code>http://idpf.org/epub/vocab/package/meta/#</code>.</p>
-	
+			<code>http://idpf.org/epub/vocab/package/meta/#</code>.</p>
 	<section id="sec-property-alternate-script">
-			<h5>alternate-script</h5>
-
-			<table id="alternate-script">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>alternate-script</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>alternate-script</code> property provides an alternate expression of the
-								associated property value in a language and script identified by the
-									<code>xml:lang</code> attribute.</p>
-							<p>This property is typically attached to <code>creator</code> and <code>title</code>
-								properties for internationalization purposes.</p>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>xsd:string</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or more</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>All properties.</td>
-					</tr>
-				</tbody>
-			</table>
-			<aside class="example">
-				<p>The following example shows the author name in English and alternatively in Japanese.</p>
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:creator id="creator">Haruki Murakami&lt;/dc:creator>
-    &lt;meta refines="#creator" property="alternate-script" xml:lang="ja">村上 春樹&lt;/meta>
-    …
+		<h5>alternate-script</h5>
+		<table id="alternate-script">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>alternate-script</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>alternate-script</code> property provides an alternate expression of the
+							associated property value in a language and script identified by the
+								<code>xml:lang</code> attribute.</p>
+						<p>This property is typically attached to <code>creator</code> and <code>title</code>
+							properties for internationalization purposes.</p>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<code>xsd:string</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or more</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>All properties.</td>
+				</tr>
+			</tbody>
+		</table>
+		<aside class="example">
+			<p>The following example shows the author name in English and alternatively in Japanese.</p>
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+…
+&lt;dc:creator id="creator">Haruki Murakami&lt;/dc:creator>
+&lt;meta refines="#creator" property="alternate-script" xml:lang="ja">村上 春樹&lt;/meta>
+…
 &lt;/metadata></pre>
-			</aside>
-		</section>
-
-		<section id="sec-property-authority">
-			<h5>authority</h5>
-
-			<table id="authority">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>authority</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>authority</code> property identifies the system or scheme the referenced
-								element's value is drawn from.</p>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<ul>
-								<li>
-									<p>a <a href="http://idpf.org/epub/registries/authorities/">reserved authority
-											value</a> [[!AuthorityRegistry]] (case-insensitive); or</p>
-								</li>
-								<li>
-									<p>an absolute IRI [[!RFC3987]] that identifies the scheme. The IRI SHOULD refer to
-										a resource that provides more information about the scheme.</p>
-								</li>
-							</ul>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>
-							<a href="#sec-opf-dcsubject"><code>subject</code></a>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-			<aside class="example">
-				<p>The following example shows a BISAC subject heading.</p>
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:subject id="subject01"&gt;FICTION / Occult &amp;amp; Supernatural&lt;/dc:subject&gt;
-    &lt;meta refines="#subject01" property="authority">BISAC&lt;/meta>
-    …
+		</aside>
+	</section>
+	<section id="sec-property-authority">
+		<h5>authority</h5>
+		<table id="authority">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>authority</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>authority</code> property identifies the system or scheme the referenced
+							element's value is drawn from.</p>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<ul>
+							<li>
+								<p>one of the following case-insensitive reserved authority values:</p>
+								
+								<dl id="authorities">
+									<dt id="aat"><a href="http://www.getty.edu/research/tools/vocabularies/aat/index.html">AAT</a></dt>
+									<dd>
+										<p>The Getty Art and Architecture Taxonomy.</p>
+									</dd>
+									
+									<dt id="bic"><a href="http://www.bic.org.uk/7/BIC-Standard-Subject-Categories/">BIC</a></dt>
+									<dd>
+										<p>The main UK subject scheme for the book supply chain.</p>
+									</dd>
+									
+									<dt id="bisac"><a href="http://bisg.org/page/BISACSubjectCodes">BISAC</a></dt>
+									<dd>
+										<p>The main US subject scheme for the book supply chain.</p>
+									</dd>
+									
+									<dt id="clc"><a href="http://clc.nlc.gov.cn/">CLC</a></dt>
+									<dd>
+										<p>The main subject classification scheme used in China.</p>
+									</dd>
+									
+									<dt id="ddc"><a href="https://www.oclc.org/dewey/features/summaries.en.html">DDC</a></dt>
+									<dd>
+										<p>The Dewey Decimal Classification system.</p>
+									</dd>
+									
+									<dt id="clil"><a href="http://clil.centprod.com/information/detailDoc.html?docId=34">CLIL</a></dt>
+									<dd>
+										<p>The main French subject scheme for the book supply chain.</p>
+									</dd>
+									
+									<dt id="eurovoc"><a href="http://eurovoc.europa.eu/">EuroVoc</a></dt>
+									<dd>
+										<p>The European multilingual thesaurus.</p>
+									</dd>
+									
+									<dt id="medtop"><a href="https://iptc.org/standards/media-topics/">MEDTOP</a></dt>
+									<dd>
+										<p>IPTC Media Topics classification scheme for the news industry.</p>
+									</dd>
+									
+									<dt id="lcsh"><a href="http://id.loc.gov/authorities/subjects.html">LCSH</a></dt>
+									<dd>
+										<p>Library of Congress Subject Headings.</p>
+									</dd>
+									
+									<dt id="ndc"><a href="http://www.jla.or.jp/">NDC</a></dt>
+									<dd>
+										<p>The main Japanese subject scheme.</p>
+									</dd>
+									
+									<dt id="thema"><a href="http://www.editeur.org/151/thema/">Thema</a></dt>
+									<dd>
+										<p>The international subject scheme for the book supply chain, providing codes that work across many
+											languages.</p>
+									</dd>
+									
+									<dt id="udc"><a href="http://www.udcc.org/">UDC</a></dt>
+									<dd>
+										<p>The Universal Decimal Classification system.</p>
+									</dd>
+									
+									<dt id="wgs"><a href="http://info.vlb.de/files/wgsneuversion2_0.pdf">WGS</a></dt>
+									<dd>
+										<p>The main German subject scheme for the book supply chain.</p>
+									</dd>
+								</dl>
+							</li>
+							<li>
+								<p>an absolute IRI [[!RFC3987]] that identifies the scheme. The IRI SHOULD refer
+									to a resource that provides more information about the scheme.</p>
+							</li>
+						</ul>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or one</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>
+						<a href="#sec-opf-dcsubject">
+							<code>subject</code>
+						</a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		<aside class="example">
+			<p>The following example shows a BISAC subject heading.</p>
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+…
+&lt;dc:subject id="subject01"&gt;FICTION / Occult &amp;amp; Supernatural&lt;/dc:subject&gt;
+&lt;meta refines="#subject01" property="authority">BISAC&lt;/meta>
+…
 &lt;/metadata></pre>
-			</aside>
-		</section>
-
-		<section id="sec-property-belongs-to-collection">
-			<h5>belongs-to-collection</h5>
-
-			<table id="belongs-to-collection">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
+		</aside>
+	</section>
+	<section id="sec-property-belongs-to-collection">
+		<h5>belongs-to-collection</h5>
+		<table id="belongs-to-collection">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>belongs-to-collection</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>belongs-to-collection</code> property identifies the name of a collection
+							to which the EPUB Publication belongs. An EPUB Publication MAY belong to one or more
+							collections.</p>
+						<p>It is also possible chain these properties using the <a href="#attrdef-refines"
+									><code>refines</code> attribute</a> to indicate that one collection is
+							itself a member of another collection.</p>
+						<p>To allow Reading System to organize collections and avoid naming collisions (e.g.,
+							unrelated collections might share a similar name, or different editions of a
+							collection could be released), an identifier SHOULD be provided that uniquely
+							identifies the instance of the collection. The <code>dcterms:identifier</code>
+							property must carry this identifier.</p>
+						<p>The collection MAY more precisely define its nature by attaching a <a
+								href="#collection-type"><code>collection-type</code></a> property.</p>
+						<p>The position of the EPUB Publication within the collection MAY be provided by
+							attaching a <a href="#group-position"><code>group-position</code> property</a>.</p>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<code>xsd:string</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or more</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>Applies to the EPUB Publication and can refine other instances of itself.</td>
+				</tr>
+			</tbody>
+		</table>
+		<aside class="example">
+			<p>The following example shows that the publication belongs to the Harry Potter set of books.</p>
+			<pre>&lt;metadata&gt;
+…
+&lt;meta property="belongs-to-collection" id="c02"&gt;Harry Potter&lt;/meta&gt;
+&lt;meta refines="#c02" property="collection-type"&gt;set&lt;/meta&gt;
+…
+&lt;/metadata></pre>
+		</aside>
+	</section>
+	<section id="sec-property-collection-type">
+		<h5>collection-type</h5>
+		<table id="collection-type">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>collection-type</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>collection-type</code> property indicates the form or nature of a
+							collection.</p>
+						<p>When the <code>collection-type</code> value is drawn from a code list or other formal
+							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
+							be attached to identify its source.</p>
+						<p>When a scheme is not specified, Reading Systems SHOULD recognize the following
+							collection type values:</p>
+						<dl>
+							<dt>
+								<code>series</code>
+							</dt>
+							<dd>
+								<p>A sequence of related works that are formally identified as a group,
+									typically open-ended with works issued individually over time.</p>
+							</dd>
+							<dt>
+								<code>set</code>
+							</dt>
+							<dd>
+								<p>A finite collection of works that together constitute a single intellectual
+									unit, typically issued together and able to be sold as a unit.</p>
+							</dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<code>xsd:string</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or one</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>
+						<a href="#belongs-to-collection">
 							<code>belongs-to-collection</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>belongs-to-collection</code> property identifies the name of a collection to
-								which the EPUB Publication belongs. An EPUB Publication MAY belong to one or more
-								collections.</p>
-							<p>It is also possible chain these properties using the <a href="#attrdef-refines"
-										><code>refines</code> attribute</a> to indicate that one collection is itself a
-								member of another collection.</p>
-							<p>To allow Reading System to organize collections and avoid naming collisions (e.g.,
-								unrelated collections might share a similar name, or different editions of a collection
-								could be released), an identifier SHOULD be provided that uniquely identifies the
-								instance of the collection. The <code>dcterms:identifier</code> property must carry this
-								identifier.</p>
-							<p>The collection MAY more precisely define its nature by attaching a <a
-									href="#collection-type"><code>collection-type</code></a> property.</p>
-							<p>The position of the EPUB Publication within the collection MAY be provided by attaching a
-									<a href="#group-position"><code>group-position</code> property</a>.</p>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>xsd:string</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or more</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>Applies to the EPUB Publication and can refine other instances of itself.</td>
-					</tr>
-				</tbody>
-			</table>
-			<aside class="example">
-				<p>The following example shows that the publication belongs to the Harry Potter set of books.</p>
-				<pre>&lt;metadata&gt;
-    …
-    &lt;meta property="belongs-to-collection" id="c02"&gt;Harry Potter&lt;/meta&gt;
-    &lt;meta refines="#c02" property="collection-type"&gt;set&lt;/meta&gt;
-    …
+						</a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		<aside class="example">
+			<p>The following examples shows that a publication belongs to the series The New French Cuisine
+				Masters.</p>
+			<pre>&lt;metadata>
+…
+&lt;meta property="belongs-to-collection" id="c01"&gt;
+The New French Cuisine Masters
+&lt;/meta&gt;
+&lt;meta refines="#c01" property="collection-type"&gt;series&lt;/meta&gt;
+…
 &lt;/metadata></pre>
-			</aside>
-
-		</section>
-
-		<section id="sec-property-collection-type">
-			<h5>collection-type</h5>
-
-			<table id="collection-type">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>collection-type</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>collection-type</code> property indicates the form or nature of a
-								collection.</p>
-							<p>When the <code>collection-type</code> value is drawn from a code list or other formal
-								enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD be
-								attached to identify its source.</p>
-							<p>When a scheme is not specified, Reading Systems SHOULD recognize the following collection
-								type values:</p>
-							<dl>
-								<dt>
-									<code>series</code>
-								</dt>
-								<dd>
-									<p>A sequence of related works that are formally identified as a group, typically
-										open-ended with works issued individually over time.</p>
-								</dd>
-								<dt>
-									<code>set</code>
-								</dt>
-								<dd>
-									<p>A finite collection of works that together constitute a single intellectual unit,
-										typically issued together and able to be sold as a unit.</p>
-								</dd>
-							</dl>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>xsd:string</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>
-							<a href="#belongs-to-collection">
-								<code>belongs-to-collection</code>
-							</a>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-			<aside class="example">
-				<p>The following examples shows that a publication belongs to the series The New French Cuisine
-					Masters.</p>
-				<pre>&lt;metadata>
-    …
-    &lt;meta property="belongs-to-collection" id="c01"&gt;
-        The New French Cuisine Masters
-    &lt;/meta&gt;
-    &lt;meta refines="#c01" property="collection-type"&gt;series&lt;/meta&gt;
-    …
+		</aside>
+	</section>
+	<section id="sec-property-display-seq">
+		<h5>display-seq</h5>
+		<table id="display-seq">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>display-seq</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>display-seq</code> property indicates the numeric position in which to
+							display the current property relative to identical metadata properties.</p>
+						<p>This property only applies where precedence rules have not already been defined
+							(e.g., precedence is given to <a href="#sec-opf-dccreator">creators</a> based on
+							their appearance in document order).</p>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<code>xsd:unsignedInt</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or one</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>All properties.</td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
+	<section id="sec-property-file-as">
+		<h5>file-as</h5>
+		<table id="file-as">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>file-as</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>The <code>file-as</code> property provides the normalized form of the associated
+						property for sorting.</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<code>xsd:string</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or one</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>All properties.</td>
+				</tr>
+			</tbody>
+		</table>
+		<aside class="example">
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+…
+&lt;dc:creator id="creator01">Lewis Carroll&lt;/dc:creator>
+&lt;meta refines="#creator01" property="file-as">Carroll, Lewis&lt;/meta>
+…
 &lt;/metadata></pre>
-			</aside>
-		</section>
-
-		<section id="sec-property-display-seq">
-			<h5>display-seq</h5>
-
-			<table id="display-seq">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>display-seq</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>display-seq</code> property indicates the numeric position in which to display
-								the current property relative to identical metadata properties.</p>
-							<p>This property only applies where precedence rules have not already been defined (e.g.,
-								precedence is given to <a href="#sec-opf-dccreator">creators</a> based on their
-								appearance in document order).</p>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>xsd:unsignedInt</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>All properties.</td>
-					</tr>
-				</tbody>
-			</table>
-		</section>
-
-		<section id="sec-property-file-as">
-			<h5>file-as</h5>
-
-			<table id="file-as">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>file-as</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>The <code>file-as</code> property provides the normalized form of the associated property
-							for sorting.</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>xsd:string</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>All properties.</td>
-					</tr>
-				</tbody>
-			</table>
-			<aside class="example">
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:creator id="creator01">Lewis Carroll&lt;/dc:creator>
-    &lt;meta refines="#creator01" property="file-as">Carroll, Lewis&lt;/meta>
-    …
+		</aside>
+	</section>
+	<section id="sec-property-group-position">
+		<h5>group-position</h5>
+		<table id="group-position">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>group-position</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>group-position</code> property indicates the numeric position in which the
+							EPUB Publication is ordered relative to other works belonging to the same group
+							(whether all EPUB Publications or not).</p>
+						<p>The <code>group-position</code> property can be attached to any metadata property
+							that establishes the group but is typically associated with the <a
+								href="#belongs-to-collection"><code>belongs-to-collection</code>
+							property</a>.</p>
+						<p>An EPUB Publication can belong to more than one group.</p>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td> A single <code>xsd:unsignedInt</code> or series of decimal-separated numbers (e.g.,
+							<code>1</code> or <code>2.2.1</code>). </td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or one</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>All properties.</td>
+				</tr>
+			</tbody>
+		</table>
+		<aside class="example">
+			<p>The following examples shows that a publication is second in the Lord of the Rings set of
+				books.</p>
+			<pre>&lt;metadata>
+…
+&lt;meta property="belongs-to-collection" id="c01"&gt;
+The Lord of the Rings
+&lt;/meta&gt;
+&lt;meta refines="#c01" property="collection-type"&gt;set&lt;/meta&gt;
+&lt;meta refines="#c01" property="group-position"&gt;2&lt;/meta&gt;
+…
 &lt;/metadata></pre>
-			</aside>
-		</section>
-
-		<section id="sec-property-group-position">
-			<h5>group-position</h5>
-
-			<table id="group-position">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>group-position</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>group-position</code> property indicates the numeric position in which the EPUB
-								Publication is ordered relative to other works belonging to the same group (whether all
-								EPUB Publications or not).</p>
-							<p>The <code>group-position</code> property can be attached to any metadata property that
-								establishes the group but is typically associated with the <a
-									href="#belongs-to-collection"><code>belongs-to-collection</code> property</a>.</p>
-							<p>An EPUB Publication can belong to more than one group.</p>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td> A single <code>xsd:unsignedInt</code> or series of decimal-separated numbers (e.g.,
-								<code>1</code> or <code>2.2.1</code>). </td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>All properties.</td>
-					</tr>
-				</tbody>
-			</table>
-			<aside class="example">
-				<p>The following examples shows that a publication is second in the Lord of the Rings set of books.</p>
-				<pre>&lt;metadata>
-    …
-    &lt;meta property="belongs-to-collection" id="c01"&gt;
-        The Lord of the Rings
-    &lt;/meta&gt;
-    &lt;meta refines="#c01" property="collection-type"&gt;set&lt;/meta&gt;
-    &lt;meta refines="#c01" property="group-position"&gt;2&lt;/meta&gt;
-    …
+		</aside>
+		<aside class="example">
+			<p>The following example uses a decimal-separated value for <code>group-position</code>, in this
+				case volume 98, issue 4 of a periodical.</p>
+			<pre>&lt;metadata&gt;
+…
+&lt;meta property="belongs-to-collection" id="cygnus-x-1">Physical Review D&lt;/meta>
+&lt;meta refines="#cygnus-x-1" property="collection-type">series&lt;/meta>
+&lt;meta refines="#cygnus-x-1" property="group-position">98.4&lt;/meta>
+…
 &lt;/metadata></pre>
-			</aside>
-
-
-			<aside class="example">
-				<p>The following example uses a decimal-separated value for <code>group-position</code>, in this case
-					volume 98, issue 4 of a periodical.</p>
-				<pre>&lt;metadata&gt;
-    …
-    &lt;meta property="belongs-to-collection" id="cygnus-x-1">Physical Review D&lt;/meta>
-    &lt;meta refines="#cygnus-x-1" property="collection-type">series&lt;/meta>
-    &lt;meta refines="#cygnus-x-1" property="group-position">98.4&lt;/meta>
-    …
+		</aside>
+	</section>
+	<section id="sec-property-identifier-type">
+		<h5>identifier-type</h5>
+		<table id="identifier-type">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>identifier-type</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>identifier-type</code> property indicates the form or nature of an
+								<code>identifier</code>.</p>
+						<p>When the <code>identifier-type</code> value is drawn from a code list or other formal
+							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
+							be attached to identify its source.</p>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<code>xsd:string</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or one</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>
+						<a href="#sec-opf-dcidentifier"><code>identifier</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>source</code></a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		<aside class="example">
+			<p>The following example shows how to indicate that an identifier is an ISBN using the ONIX code
+				list 5 numeric value.</p>
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+…
+&lt;dc:identifier id="isbn-id">urn:isbn:9780101010101&lt;/dc:identifier>
+&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
+…
 &lt;/metadata></pre>
-			</aside>
-
-
-		</section>
-
-		<section id="sec-property-identifier-type">
-			<h5>identifier-type</h5>
-
-			<table id="identifier-type">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>identifier-type</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>identifier-type</code> property indicates the form or nature of an
-									<code>identifier</code>.</p>
-							<p>When the <code>identifier-type</code> value is drawn from a code list or other formal
-								enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD be
-								attached to identify its source.</p>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>xsd:string</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>
-							<a href="#sec-opf-dcidentifier"><code>identifier</code></a>,
-							<a href="#sec-opf-dcmes-optional-def"><code>source</code></a>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-			<aside class="example">
-				<p>The following example shows how to indicate that an identifier is an ISBN using the ONIX code list 5
-					numeric value.</p>
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:identifier id="isbn-id">urn:isbn:9780101010101&lt;/dc:identifier>
-    &lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
-    …
-&lt;/metadata></pre>
-			</aside>
-		</section>
-
-		<section id="sec-property-meta-auth">
-			<h5>meta-auth (Deprecated)</h5>
-
-			<p id="meta-auth">Use of the <code>meta-auth</code> property is <a href="#deprecated">deprecated</a>.</p>
-			
-			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
-		</section>
-
-		<section id="sec-property-role">
-			<h5>role</h5>
-
-			<table id="role">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>role</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>role</code> property describes the role of a <code>creator</code>,
+		</aside>
+	</section>
+	<section id="sec-property-meta-auth">
+		<h5>meta-auth (Deprecated)</h5>
+		<p id="meta-auth">Use of the <code>meta-auth</code> property is <a href="#deprecated"
+			>deprecated</a>.</p>
+		<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
+	</section>
+	<section id="sec-property-role">
+		<h5>role</h5>
+		<table id="role">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>role</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>role</code> property describes the role of a <code>creator</code>,
 								<code>contributor</code> or <code>publisher</code> in the creation of an EPUB
-								Publication.</p>
-							<p>When the <code>role</code> value is drawn from a code list or other formal enumeration,
-								the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD be attached to
-								identify its source.</p>
-							<p>When attaching multiple roles to an individual or organization, the importance of the
-								roles should match the document order of their containing <code>meta</code> elements
-								(i.e., the first <code>meta</code> element encountered should contain the most important
-								role).</p>	
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>xsd:string</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or more</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>
-							<a href="#sec-opf-dccontributor"><code>contributor</code></a>,
-							<a href="#sec-opf-dccreator"><code>creator</code></a>,
-							<a href="#sec-opf-dcmes-optional-def"><code>publisher</code></a>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-			<aside class="example">
-				<p>The following example uses the MARC Relators vocabulary to differentiate the author from the
-					illustrator of a work.</p>
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:creator id="creator01">Lewis Carroll&lt;/dc:creator>
-    &lt;meta refines="#creator01" property="role" scheme="marc:relators">aut&lt;/meta>
-    
-    &lt;dc:creator id="creator02">John Tenniel&lt;/dc:creator>
-    &lt;meta refines="#creator02" property="role" scheme="marc:relators">ill&lt;/meta>
-    …
+							Publication.</p>
+						<p>When the <code>role</code> value is drawn from a code list or other formal
+							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
+							be attached to identify its source.</p>
+						<p>When attaching multiple roles to an individual or organization, the importance of the
+							roles should match the document order of their containing <code>meta</code> elements
+							(i.e., the first <code>meta</code> element encountered should contain the most
+							important role).</p>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<code>xsd:string</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or more</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>
+						<a href="#sec-opf-dccontributor"><code>contributor</code></a>, <a
+							href="#sec-opf-dccreator"><code>creator</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>publisher</code></a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		<aside class="example">
+			<p>The following example uses the MARC Relators vocabulary to differentiate the author from the
+				illustrator of a work.</p>
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+…
+&lt;dc:creator id="creator01">Lewis Carroll&lt;/dc:creator>
+&lt;meta refines="#creator01" property="role" scheme="marc:relators">aut&lt;/meta>
+
+&lt;dc:creator id="creator02">John Tenniel&lt;/dc:creator>
+&lt;meta refines="#creator02" property="role" scheme="marc:relators">ill&lt;/meta>
+…
 &lt;/metadata></pre>
-			</aside>
-			<aside class="example">
-				<p>The following example shows that an individual was both the author and
-					illustrator of a work.</p>
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:creator id="creator01">Maurice Sendak&lt;/dc:creator>
-    &lt;meta refines="#creator01" property="role" scheme="marc:relators">aut&lt;/meta>
-    &lt;meta refines="#creator01" property="role" scheme="marc:relators">ill&lt;/meta>
-    …
+		</aside>
+		<aside class="example">
+			<p>The following example shows that an individual was both the author and illustrator of a work.</p>
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+…
+&lt;dc:creator id="creator01">Maurice Sendak&lt;/dc:creator>
+&lt;meta refines="#creator01" property="role" scheme="marc:relators">aut&lt;/meta>
+&lt;meta refines="#creator01" property="role" scheme="marc:relators">ill&lt;/meta>
+…
 &lt;/metadata></pre>
-			</aside>
-		</section>
+		</aside>
+	</section>
+	<section id="sec-property-source-of">
+		<h5>source-of</h5>
+		<table id="source-of">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>source-of</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>source-of</code> property indicates a unique aspect of an adapted source
+							resource that has been retained in the <a>EPUB Publication</a>. </p>
+						<p>This specification defines the <code>pagination</code> value to indicate that the
+							referenced <code>dc:source</code> element is the source of the <a
+								href="http://www.idpf.org/epub/vocab/structure/#pagebreak"
+									><code>pagebreak</code> properties</a> defined in the content.</p>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<code>pagination</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or one</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>
+						<a href="#sec-opf-dcmes-optional-def">
+							<code>dc:source</code>
+						</a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		<p class="note"> See [[EPUB-A11Y-TECH-11]] for information on how to provide accessible page navigation. </p>
+		<aside class="example">
+			<p>The following example shows the ISBN identifier for an EPUB Publication together with the source
+				ISBN identifier for the print work it was derived from.</p>
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+…
+&lt;dc:identifier id="isbn-id">urn:isbn:9780101010101&lt;/dc:identifier>
+&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
 
-		<section id="sec-property-source-of">
-			<h5>source-of</h5>
-
-			<table id="source-of">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>source-of</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>source-of</code> property indicates a unique aspect of an adapted source
-								resource that has been retained in the <a>EPUB Publication</a>. </p>
-							<p>This specification defines the <code>pagination</code> value to indicate that the
-								referenced <code>dc:source</code> element is the source of the <a
-									href="http://www.idpf.org/epub/vocab/structure/#pagebreak"><code>pagebreak</code>
-									properties</a> defined in the content.</p>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>pagination</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>
-							<a href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-			<p class="note"> See [[EPUB-A11Y-TECH-11]] for information on how to provide accessible page
-				navigation. </p>
-			<aside class="example">
-				<p>The following example shows the ISBN identifier for an EPUB Publication together with the source ISBN
-					identifier for the print work it was derived from.</p>
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:identifier id="isbn-id">urn:isbn:9780101010101&lt;/dc:identifier>
-    &lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
-    
-    &lt;dc:source id="src-id">urn:isbn:9780375704024&lt;/dc:source>
-    &lt;meta refines="#src-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
-    &lt;meta refines="#src-id" property="source-of">pagination&lt;/meta>
-    …
+&lt;dc:source id="src-id">urn:isbn:9780375704024&lt;/dc:source>
+&lt;meta refines="#src-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
+&lt;meta refines="#src-id" property="source-of">pagination&lt;/meta>
+…
 &lt;/metadata></pre>
-			</aside>
-		</section>
-
-		<section id="sec-property-term">
-			<h5>term</h5>
-
-			<table id="term">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>term</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>term</code> property provides a subject code.</p>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>xsd:string</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>
-							<a href="#sec-opf-dcsubject"><code>subject</code></a>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-			<aside class="example">
-				<p>The following example shows a BISAC code for a subject heading.</p>
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:subject id="subject01"&gt;FICTION / Occult &amp;amp; Supernatural&lt;/dc:subject&gt;
-    &lt;meta refines="#subject01" property="authority">BISAC&lt;/meta>
-    &lt;meta refines="#subject01" property="term">FIC024000&lt;/meta>
-    …
+		</aside>
+	</section>
+	<section id="sec-property-term">
+		<h5>term</h5>
+		<table id="term">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>term</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>term</code> property provides a subject code.</p>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<code>xsd:string</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or one</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>
+						<a href="#sec-opf-dcsubject">
+							<code>subject</code>
+						</a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		<aside class="example">
+			<p>The following example shows a BISAC code for a subject heading.</p>
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+…
+&lt;dc:subject id="subject01"&gt;FICTION / Occult &amp;amp; Supernatural&lt;/dc:subject&gt;
+&lt;meta refines="#subject01" property="authority">BISAC&lt;/meta>
+&lt;meta refines="#subject01" property="term">FIC024000&lt;/meta>
+…
 &lt;/metadata></pre>
-			</aside>
-		</section>
-
-		<section id="sec-property-title-type">
-			<h5>title-type</h5>
-
-			<table id="title-type">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>title-type</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>
-							<p>The <code>title-type</code> property indicates the form or nature of a
+		</aside>
+	</section>
+	<section id="sec-property-title-type">
+		<h5>title-type</h5>
+		<table id="title-type">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>title-type</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>title-type</code> property indicates the form or nature of a
 								<code>title</code>.</p>
-							<p>When the <code>title-type</code> value is drawn from a code list or other formal
-								enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD be
-								attached to identify its source. When a scheme is not specified, Reading Systems <span
-									class="rfc2119">should</span> recognize the following title type values:
-									<code>main</code>, <code>subtitle</code>, <code class="value">short</code>,
-									<code>collection</code>, <code class="value">edition</code> and
-									<code>expanded</code>. </p>
-						</td>
-					</tr>
-					<tr>
-						<th>Allowed value(s):</th>
-						<td>
-							<code>xsd:string</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>zero or one</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>
-							<a href="#sec-opf-dctitle"><code>title</code></a>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-			<aside class="example">
-				<p>The following example shows how to identify different title types.</p>
+						<p>When the <code>title-type</code> value is drawn from a code list or other formal
+							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
+							be attached to identify its source. When a scheme is not specified, Reading Systems
+								<span class="rfc2119">should</span> recognize the following title type values:
+								<code>main</code>, <code>subtitle</code>, <code class="value">short</code>,
+								<code>collection</code>, <code class="value">edition</code> and
+								<code>expanded</code>. </p>
+					</td>
+				</tr>
+				<tr>
+					<th>Allowed value(s):</th>
+					<td>
+						<code>xsd:string</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>zero or one</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Extends:</th>
+					<td>
+						<a href="#sec-opf-dctitle">
+							<code>title</code>
+						</a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		<aside class="example">
+			<p>The following example shows how to identify different title types.</p>
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+…
+&lt;dc:title id="t1">A Dictionary of Modern English Usage&lt;/dc:title>
+&lt;meta refines="#t1" property="title-type">main&lt;/meta>
 
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:title id="t1">A Dictionary of Modern English Usage&lt;/dc:title>
-    &lt;meta refines="#t1" property="title-type">main&lt;/meta>
-    
-    &lt;dc:title id="t2">First Edition&lt;/dc:title>
-    &lt;meta refines="#t2" property="title-type">edition&lt;/meta>
-    
-    &lt;dc:title id="t3">Fowler's&lt;/dc:title>
-    &lt;meta refines="#t3" property="title-type">short&lt;/meta>
-    …
-&lt;/metadata></pre>
-			</aside>
-			<aside class="example">
-				<p id="cookbook-ex">The following example shows how the complex title "The Great Cookbooks of the
-					World: Mon premier guide de cuisson, un Mémoire. The New French Cuisine Masters, Volume Two.
-					Special Anniversary Edition" could be classified.</p>
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    &lt;dc:title id="t1" xml:lang="fr">Mon premier guide de cuisson, un Mémoire&lt;/dc:title>
-    &lt;meta refines="#t1" property="title-type">main&lt;/meta>
-    &lt;meta refines="#t1" property="display-seq">2&lt;/meta>
-    
-    &lt;dc:title id="t2">The Great Cookbooks of the World&lt;/dc:title>
-    &lt;meta refines="#t2" property="title-type">collection&lt;/meta>
-    &lt;meta refines="#t2" property="display-seq">1&lt;/meta>
-    
-    &lt;dc:title id="t3">The New French Cuisine Masters&lt;/dc:title>
-    &lt;meta refines="#t3" property="title-type">collection&lt;/meta>
-    &lt;meta refines="#t3" property="display-seq">3&lt;/meta>
-    
-    &lt;dc:title id="t4">Special Anniversary Edition&lt;/dc:title>
-    &lt;meta refines="#t4" property="title-type">edition&lt;/meta>
-    &lt;meta refines="#t4" property="display-seq">4&lt;/meta>
-    
-    &lt;dc:title id="t5">The Great Cookbooks of the World: 
-        Mon premier guide de cuisson, un Mémoire. 
-        The New French Cuisine Masters, Volume Two. 
-        Special Anniversary Edition&lt;/dc:title>
-    &lt;meta refines="#t5" property="title-type">expanded&lt;/meta>
-    …
-&lt;/metadata></pre>
-			</aside>
-		</section>
+&lt;dc:title id="t2">First Edition&lt;/dc:title>
+&lt;meta refines="#t2" property="title-type">edition&lt;/meta>
 
-		<section id="sec-property-examples">
-			<h5>Examples</h5>
-
-			<aside class="example">
-				<p>The following example represents a typical set of refined metadata an <a>EPUB Publication</a> might contain.</p>
-				<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    
-    &lt;dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier>
-    
-    &lt;dc:identifier id="isbn-id">urn:isbn:9780101010101&lt;/dc:identifier>
-    &lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
-    
-    &lt;dc:source id="src-id">urn:isbn:9780375704024&lt;/dc:source>
-    &lt;meta refines="#src-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
-    
-    &lt;dc:title id="title">Norwegian Wood&lt;/dc:title>
-    &lt;meta refines="#title" property="title-type">main&lt;/meta>
-    
-    &lt;dc:language>en&lt;/dc:language>
-    
-    &lt;dc:creator id="creator">Haruki Murakami&lt;/dc:creator>
-    &lt;meta refines="#creator" property="role" scheme="marc:relators" id="role">aut&lt;/meta>
-    &lt;meta refines="#creator" property="alternate-script" xml:lang="ja">村上 春樹&lt;/meta>
-    &lt;meta refines="#creator" property="file-as">Murakami, Haruki&lt;/meta>
-    
-    &lt;meta property="dcterms:modified">2011-01-01T12:00:00Z&lt;/meta>
-    
+&lt;dc:title id="t3">Fowler's&lt;/dc:title>
+&lt;meta refines="#t3" property="title-type">short&lt;/meta>
+…
 &lt;/metadata></pre>
-			</aside>
-		</section>
+		</aside>
+		<aside class="example">
+			<p id="cookbook-ex">The following example shows how the complex title "The Great Cookbooks of the
+				World: Mon premier guide de cuisson, un Mémoire. The New French Cuisine Masters, Volume Two.
+				Special Anniversary Edition" could be classified.</p>
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+&lt;dc:title id="t1" xml:lang="fr">Mon premier guide de cuisson, un Mémoire&lt;/dc:title>
+&lt;meta refines="#t1" property="title-type">main&lt;/meta>
+&lt;meta refines="#t1" property="display-seq">2&lt;/meta>
+
+&lt;dc:title id="t2">The Great Cookbooks of the World&lt;/dc:title>
+&lt;meta refines="#t2" property="title-type">collection&lt;/meta>
+&lt;meta refines="#t2" property="display-seq">1&lt;/meta>
+
+&lt;dc:title id="t3">The New French Cuisine Masters&lt;/dc:title>
+&lt;meta refines="#t3" property="title-type">collection&lt;/meta>
+&lt;meta refines="#t3" property="display-seq">3&lt;/meta>
+
+&lt;dc:title id="t4">Special Anniversary Edition&lt;/dc:title>
+&lt;meta refines="#t4" property="title-type">edition&lt;/meta>
+&lt;meta refines="#t4" property="display-seq">4&lt;/meta>
+
+&lt;dc:title id="t5">The Great Cookbooks of the World: 
+Mon premier guide de cuisson, un Mémoire. 
+The New French Cuisine Masters, Volume Two. 
+Special Anniversary Edition&lt;/dc:title>
+&lt;meta refines="#t5" property="title-type">expanded&lt;/meta>
+…
+&lt;/metadata></pre>
+		</aside>
+	</section>
+	<section id="sec-property-examples">
+		<h5>Examples</h5>
+		<aside class="example">
+			<p>The following example represents a typical set of refined metadata an <a>EPUB Publication</a>
+				might contain.</p>
+			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+&lt;dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier>
+
+&lt;dc:identifier id="isbn-id">urn:isbn:9780101010101&lt;/dc:identifier>
+&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
+
+&lt;dc:source id="src-id">urn:isbn:9780375704024&lt;/dc:source>
+&lt;meta refines="#src-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
+
+&lt;dc:title id="title">Norwegian Wood&lt;/dc:title>
+&lt;meta refines="#title" property="title-type">main&lt;/meta>
+
+&lt;dc:language>en&lt;/dc:language>
+
+&lt;dc:creator id="creator">Haruki Murakami&lt;/dc:creator>
+&lt;meta refines="#creator" property="role" scheme="marc:relators" id="role">aut&lt;/meta>
+&lt;meta refines="#creator" property="alternate-script" xml:lang="ja">村上 春樹&lt;/meta>
+&lt;meta refines="#creator" property="file-as">Murakami, Haruki&lt;/meta>
+
+&lt;meta property="dcterms:modified">2011-01-01T12:00:00Z&lt;/meta>
+
+&lt;/metadata></pre>
+		</aside>
 	</section>
 </section>


### PR DESCRIPTION
An attempt to do away with formally referencing the old idpf registries so we don't have to port them forward.

I've noted the obsolescence of the old IDPF registries without fully removing the links to them. (I don't believe we need references if we're only providing a link to where they were defined. @iherman?)

The only registry with values that weren't purely informative/repetitive was for the authority property. I've integrated these into the definition.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1664.html" title="Last updated on May 7, 2021, 12:24 PM UTC (86e46e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1664/821c764...86e46e7.html" title="Last updated on May 7, 2021, 12:24 PM UTC (86e46e7)">Diff</a>