### PR TITLE
Clarify that link element can be used with individual properties

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2586,6 +2586,17 @@
 									between them, this specification does not require Reading Systems to process linked
 									records.</p>
 							</div>
+
+							<p>In addition to full records, EPUB Creators MAY also use the <code>link</code> element to
+								identify individual metadata properties available in an alternative format.</p>
+
+							<aside class="example">
+								<p>The following example shows a link to an embedded [[HTML]] description of the EPUB
+									Publication.</p>
+								<pre>&lt;link rel="dcterms:description"
+       href="description.html"
+       media-type="text/html" /&gt;</pre>
+							</aside>
 						</section>
 					</section>
 
@@ -9416,6 +9427,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>08-May-2021: Added clarifying text that <code>link</code> element can be used to link individual
+						metadata properties in an alternative format. See <a
+							href="https://github.com/w3c/epub-specs/issues/1666">issue 1666</a>.</li>
 					<li>06-May-2021: Noted that the working group will no longer maintain the publication type and
 						collection role registries and removed dependence on the latter for validating collection types
 						(use of NMToken values remains restricted to extension specifications). The registry of


### PR DESCRIPTION
Includes an example of dcterms:description.

Fixes #1666


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1669.html" title="Last updated on May 8, 2021, 3:48 PM UTC (efdd8bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1669/3bc2855...efdd8bd.html" title="Last updated on May 8, 2021, 3:48 PM UTC (efdd8bd)">Diff</a>