### PR TITLE
Change to using URL standard

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8197,8 +8197,9 @@ html.my-document-playing * {
 							href="#sec-property-datatype"><var>property</var> value</a> is expected. EPUB Creators MUST
 						NOT add a prefix to terms and properties from a default vocabulary.</p>
 
-					<p>EPUB Creators MUST NOT assign a prefix to the URLs associated with these vocabularies using the
-							<a href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
+					<p>EPUB Creators MUST NOT assign a prefix to the <a
+							href="https://url.spec.whatwg.org/#concept-base-url">base URLs</a> [[URL]] associated with
+						these vocabularies using the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
 
 					<div class="note">
 						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2733,7 +2733,7 @@
 									href="https://url.spec.whatwg.org/#absolute-url-string">absolute-</a> or <a
 									href="https://url.spec.whatwg.org/#relative-url-string">relative-URL string</a>
 								[[URL]], but they MUST ensure each URL is unique within the <code>manifest</code> scope
-								after <a href="https://www.w3.org/TR/epub-rs-33/#sec-pkg-doc-relative-iris">resolution
+								after <a href="https://www.w3.org/TR/epub-rs-33/#sec-pkg-doc-relative-urls">resolution
 									to an absolute URL</a> [[EPUB-RS-33]].</p>
 
 							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5402,10 +5402,9 @@ Spine:
 						OCF Abstract Container and not relative to the <code>META-INF</code> directory.</p>
 
 					<p>All <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-							>relative-URL-with-fragment strings</a> [[URL]] MUST identify resources within the OCF
-						Abstract Container (i.e., at or below the Root Directory) after <a
-							href="https://url.spec.whatwg.org/#concept-url-parser">parsing to URL records</a>
-						[[URL]].</p>
+							>relative-URL-with-fragment strings</a> [[URL]] MUST, after <a
+							href="https://url.spec.whatwg.org/#concept-url-parser">parsing to URL records</a> [[URL]],
+						identify resources within the OCF Abstract Container (i.e., at or below the Root Directory).</p>
 				</section>
 
 				<section id="sec-container-filenames">
@@ -9436,6 +9435,8 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>12-May-2021: Changed all references to URIs/IRIs to URLs and references to RFCs 3986 and 3987 to
+						the URL standard. See <a href="https://github.com/w3c/epub-specs/issues/808">issue 808</a>.</li>
 					<li>06-May-2021: Noted that the working group will no longer maintain the publication type and
 						collection role registries and removed dependence on the latter for validating collection types
 						(use of NMToken values remains restricted to extension specifications). The registry of

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6756,7 +6756,7 @@ store destination as source in ocf
 										<p>Identifies an associated fragment of an EPUB Content Document.</p>
 										<p>The value MUST be a <a
 												href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-												>relative-URL-with-fragment string</a> [[URL]] with a non-null <a
+												>relative-URL-with-fragment string</a> [[URL]] with a <a
 												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
 									</dd>
 								</dl>
@@ -6835,7 +6835,7 @@ store destination as source in ocf
 										<p>Identifies an associated fragment of an EPUB Content Document.</p>
 										<p>The value MUST be a <a
 												href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-												>relative-URL-with-fragment string</a> [[URL]] with a non-null <a
+												>relative-URL-with-fragment string</a> [[URL]] with a <a
 												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
 										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
 											information.</p>
@@ -6969,7 +6969,7 @@ store destination as source in ocf
 										<p>Identifies the associated fragment of an EPUB Content Document.</p>
 										<p>The value MUST be a <a
 												href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-												>relative-URL-with-fragment string</a> [[URL]] with a non-null <a
+												>relative-URL-with-fragment string</a> [[URL]] with a <a
 												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
 									</dd>
 									<dt>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5369,11 +5369,11 @@ Spine:
                 </pre>
 					</aside>
 
-					<p>For <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-							>relative-URL-with-fragment strings</a> [[URL]], the <a
-							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] is determined by
-						the relevant language specifications for the given file formats. For example, CSS defines how
-						relative URL references work in the context of CSS style sheets and property declarations
+					<p>The relevant language specification for a given file format determines the <a
+							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] used to parse <a
+							href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+							>relative-URL-with-fragment strings</a> [[URL]]. For example, CSS defines how relative URL
+						references work in the context of CSS style sheets and property declarations
 						[[CSSSnapshot]].</p>
 
 					<div class="note">
@@ -5402,8 +5402,10 @@ Spine:
 						OCF Abstract Container and not relative to the <code>META-INF</code> directory.</p>
 
 					<p>All <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-							>relative-URL-with-fragment strings</a> [[URL]] references MUST resolve to resources within
-						the OCF Abstract Container (i.e., at or below the Root Directory).</p>
+							>relative-URL-with-fragment strings</a> [[URL]] MUST identify resources within the OCF
+						Abstract Container (i.e., at or below the Root Directory) after <a
+							href="https://url.spec.whatwg.org/#concept-url-parser">parsing to URL records</a>
+						[[URL]].</p>
 				</section>
 
 				<section id="sec-container-filenames">
@@ -6752,10 +6754,11 @@ store destination as source in ocf
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-												>relative-URL-with-fragment string</a> [[URL]] of the corresponding EPUB
-											Content Document, which MUST have a <a href="#sec-media-overlays-fragids"
-												>fragment identifier</a> that references the specific content.</p>
+										<p>Identifies an associated fragment of an EPUB Content Document.</p>
+										<p>The value MUST be a <a
+												href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+												>relative-URL-with-fragment string</a> [[URL]] with a non-null <a
+												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
 									</dd>
 								</dl>
 							</dd>
@@ -6830,10 +6833,11 @@ store destination as source in ocf
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>The <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-												>relative-URL-with-fragment string</a> [[URL]] of the corresponding EPUB
-											Content Document, which MUST have a <a href="#sec-media-overlays-fragids"
-												>fragment identifier</a> that references the specific content.</p>
+										<p>Identifies an associated fragment of an EPUB Content Document.</p>
+										<p>The value MUST be a <a
+												href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+												>relative-URL-with-fragment string</a> [[URL]] with a non-null <a
+												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
 										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
 											information.</p>
 									</dd>
@@ -6963,10 +6967,11 @@ store destination as source in ocf
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>The <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-												>relative-URL-with-fragment string</a> [[URL]] of the corresponding EPUB
-											Content Document, which MUST have a <a href="#sec-media-overlays-fragids"
-												>fragment identifier</a> that references the specific content.</p>
+										<p>Identifies the associated fragment of an EPUB Content Document.</p>
+										<p>The value MUST be a <a
+												href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+												>relative-URL-with-fragment string</a> [[URL]] with a non-null <a
+												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
 									</dd>
 									<dt>
 										<code>id</code>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1303,7 +1303,7 @@
 							</dt>
 							<dd>
 								<p>Establishes an association between the current expression and the element or resource
-									identified by its value. EPUB Creators MUST use, as the value, a <a
+									identified by its value. EPUB Creators MUST use as the value a <a
 										href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
 										>relative-URL-with-fragment string</a> [[URL]] that references the resource or
 									element they are describing.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1140,8 +1140,8 @@
 								metadata.</p>
 						</li>
 						<li>
-							<p>A <a href="#sec-manifest-elem">manifest</a> — identifies via IRI [[RFC3987]], and
-								describes via MIME media type [[RFC4839]], the set of <a>Publication Resources</a>.</p>
+							<p>A <a href="#sec-manifest-elem">manifest</a> — identifies via URL [[URL]], and describes
+								via MIME media type [[RFC4839]], the set of <a>Publication Resources</a>.</p>
 						</li>
 						<li>
 							<p>A <a href="#sec-spine-elem">spine</a> — an ordered sequence of ID references to top-level
@@ -1226,7 +1226,8 @@
 								<code>href</code>
 							</dt>
 							<dd>
-								<p>An absolute or relative IRI reference [[RFC3987]] to a resource.</p>
+								<p>A <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a>
+									[[URL]] that references a resource.</p>
 								<div class="example">
 									<pre>&lt;link rel="record"
       href="meta/9780000000001.xml" 
@@ -1302,8 +1303,10 @@
 							</dt>
 							<dd>
 								<p>Establishes an association between the current expression and the element or resource
-									identified by its value. The value of the attribute must be a relative IRI
-									[[RFC3987]] that references the resource or element being described.</p>
+									identified by its value. EPUB Creators MUST use, as the value, a <a
+										href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+										>relative-URL-with-fragment string</a> [[URL]] that references the resource or
+									element they are describing.</p>
 								<aside class="example">
 									<p>The following example shows the <code>refines</code> element used to indicate a
 										creator is the illustrator.</p>
@@ -2151,7 +2154,7 @@
 								</aside>
 
 								<aside class="example">
-									<p>The following example shows the use of an IRI for the scheme.</p>
+									<p>The following example shows the use of a URL for the scheme.</p>
 									<pre>&lt;dc:subject id="sbj01"&gt;Number Theory&lt;/dc:subject&gt;
 &lt;meta refines="#sbj01" property="authority">http://www.ams.org/msc/msc2010.html&lt;/meta>
 &lt;meta refines="#sbj01" property="term">11&lt;/meta></pre>
@@ -2290,9 +2293,7 @@
 
 							<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a
 									href="#sec-default-vocab">default vocabulary</a> for use with the
-									<code>property</code> attribute. If the attribute's value does not include a prefix,
-								the following IRI [[RFC3987]] stem MUST be used to generate the resulting IRI:
-									<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
+									<code>property</code> attribute.</p>
 
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
 									href="#sec-vocab-assoc"></a>.</p>
@@ -2492,8 +2493,8 @@
 
 							<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
 									attribute</a> is OPTIONAL when a linked resource is located outside the EPUB
-								Container, as more than one media type could be served from the same IRI. EPUB Creators
-								MUST specify the attribute for all <a>Local Resources</a>.</p>
+								Container, as more than one media type could be served from the same URL [[URL]]. EPUB
+								Creators MUST specify the attribute for all <a>Local Resources</a>.</p>
 
 							<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the
 								language of the linked resource. The value MUST be a <a
@@ -2529,9 +2530,7 @@
 
 							<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a
 									href="#sec-default-vocab">default vocabulary</a> for the <code>rel</code> and
-									<code>properties</code> attributes. If any of these attributes' values do not
-								include a prefix, the following IRI [[RFC3987]] stem MUST be used to generate the
-								resulting IRI for them: <code>http://idpf.org/epub/vocab/package/link/#</code></p>
+									<code>properties</code> attributes.</p>
 
 							<p><a>EPUB Creators</a> MAY add relationships and properties from other vocabularies as
 								defined in <a href="#sec-vocab-assoc"></a>.</p>
@@ -2647,9 +2646,9 @@
 
 							<div class="note">
 								<p>This specification supports internationalized resource naming, so elements and
-									attributes that reference Publication Resources accept IRIs as their value. For
-									compatibility with older Reading Systems that only accept URIs, EPUB Creators should
-									restrict resource names to the ASCII character set.</p>
+									attributes that reference Publication Resources accept URLs [[URL]] as their value.
+									For compatibility with older Reading Systems that only accept URIs, EPUB Creators
+									should restrict resource names to the ASCII character set.</p>
 							</div>
 						</section>
 
@@ -2729,11 +2728,13 @@
 								</dd>
 							</dl>
 
-							<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the IRI
-								[[RFC3987]] in its <code>href</code> attribute. EPUB Creators MAY use absolute or
-								relative IRIs, but they MUST ensure each IRI is unique within the <code>manifest</code>
-								scope after <a href="https://www.w3.org/TR/epub-rs-33/#sec-pkg-doc-relative-iris"
-									>resolution to an absolute IRI</a> [[EPUB-RS-33]].</p>
+							<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL
+								[[URL]] in its <code>href</code> attribute. EPUB Creators MAY use <a
+									href="https://url.spec.whatwg.org/#absolute-url-string">absolute-</a> or <a
+									href="https://url.spec.whatwg.org/#relative-url-string">relative-URL string</a>
+								[[URL]], but they MUST ensure each URL is unique within the <code>manifest</code> scope
+								after <a href="https://www.w3.org/TR/epub-rs-33/#sec-pkg-doc-relative-iris">resolution
+									to an absolute URL</a> [[EPUB-RS-33]].</p>
 
 							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
 								element MUST conform to the applicable specification(s) as inferred from the MIME media
@@ -2750,9 +2751,7 @@
 
 							<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
 									Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
-									<code>properties</code> attribute. If any of the attribute's values do not include a
-								prefix, the following IRI [[RFC3987]] stem MUST be used to generate the resulting IRI
-								for them: <code>http://idpf.org/epub/vocab/package/item/#</code></p>
+									<code>properties</code> attribute.</p>
 
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
 									href="#sec-vocab-assoc"></a>.</p>
@@ -3182,9 +3181,7 @@ Spine:
 
 							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
 									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>
-								for the <code>properties</code> attribute. If any of the attribute's values do not
-								include a prefix, the following IRI [[RFC3987]] stem MUST be used to generate the
-								resulting IRI for them: <code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
+								for the <code>properties</code> attribute.</p>
 
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
 									href="#sec-vocab-assoc"></a>.</p>
@@ -3295,16 +3292,21 @@ Spine:
 							<p id="attrdef-collection-role">Each specialization MUST define a role value that uniquely
 								identifies all conformant <code>collection</code> elements. EPUB Creators MUST identify
 								the role of each <code>collection</code> element in its <code>role</code> attribute,
-								whose value MUST be one or more NMTOKENs [[XMLSCHEMA-2]] and/or absolute IRIs
-								[[RFC3987]].</p>
+								whose value MUST be one or more NMTOKENs [[XMLSCHEMA-2]] and/or <a
+									href="https://url.spec.whatwg.org/#absolute-url-with-fragment-string"
+									>absolute-URL-with-fragment strings</a> [[URL]].</p>
 
 							<p>This specification reserves the use of NMTOKEN values for roles defined in EPUB
 								specifications. NMTOKEN values not defined by a recognized specification are not valid.
 								This section does not define any roles.</p>
 
 							<p>Third parties MAY define custom roles for the <code>collection</code> element, but they
-								MUST identify such roles using absolute IRIs. Custom roles MUST NOT incorporate the
-								string "<code>idpf.org</code>" in the host component of their identifying IRI.</p>
+								MUST identify such roles using <a
+									href="https://url.spec.whatwg.org/#absolute-url-with-fragment-string"
+									>absolute-URL-with-fragment strings</a> [[URL]]. Custom roles MUST NOT incorporate
+								the string "<code>idpf.org</code>" in the <a
+									href="https://url.spec.whatwg.org/#concept-host">host component</a> [[URL]] of their
+								identifying URL.</p>
 
 
 							<div class="note">
@@ -4499,8 +4501,8 @@ Spine:
 								rendering of the link label.</p>
 						</li>
 						<li>
-							<p id="confreq-nav-a-href">The IRI reference provided in the <code>href</code> attribute of
-								the <code>a</code> element:</p>
+							<p id="confreq-nav-a-href">The URL [[URL]] reference provided in the <code>href</code>
+								attribute of the <code>a</code> element:</p>
 							<ul class="conformance-list">
 								<li>
 									<p id="confreq-nav-a-href-default">MUST, in the case of the <a href="#sec-nav-toc"
@@ -5352,32 +5354,37 @@ Spine:
 				</section>
 
 				<section id="sec-container-iri">
-					<h4>Relative IRIs for Referencing Other Components</h4>
+					<h4>Relative URLs for Referencing Other Components</h4>
 
-					<p>Files within the <a>OCF Abstract Container</a> MUST reference each other via relative IRI
-						references ([[RFC3987]] and [[RFC3986]]).</p>
+					<p>Files within the <a>OCF Abstract Container</a> MUST reference each other via <a
+							href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+							>relative-URL-with-fragment strings</a> [[URL]].</p>
 
 					<aside class="example">
-						<p>The following example shows how a file named <code>image1.jpg</code> in the same directory as
-							an <a>XHTML Content Document</a> is referenced from an [[HTML]] <code>img</code>
-							element.</p>
+						<p>The following example shows how to reference, from an [[HTML]] <code>img</code> element, a
+							file named <code>image1.jpg</code> in the same directory as an <a>XHTML Content
+							Document</a>.</p>
 						<pre>
 &lt;img src="image1.jpg" alt="…" /&gt;
                 </pre>
 					</aside>
 
-					<p>For relative IRI references, the Base IRI [[RFC3986]] is determined by the relevant language
-						specifications for the given file formats. For example, CSS defines how relative IRI references
-						work in the context of CSS style sheets and property declarations [[CSSSnapshot]].</p>
+					<p>For <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+							>relative-URL-with-fragment strings</a> [[URL]], the <a
+							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] is determined by
+						the relevant language specifications for the given file formats. For example, CSS defines how
+						relative URL references work in the context of CSS style sheets and property declarations
+						[[CSSSnapshot]].</p>
 
 					<div class="note">
-						<p>Some language specifications reference Requests For Comments that preceded [[RFC3987]], in
-							which case the earlier RFC applies for content in that language.</p>
+						<p>Some language specifications reference <a href="https://tools.ietf.org/rfc/index">Requests
+								For Comments</a> that preceded [[URL]], in which case the earlier RFC applies for
+							content in that language.</p>
 					</div>
 
-					<p>Unlike most language specifications, the Base IRIs for all files within the <code>META-INF</code>
-						directory use the <a>Root Directory</a> of the OCF Abstract Container as the default Base
-						IRI.</p>
+					<p>Unlike most language specifications, the <a href="https://url.spec.whatwg.org/#concept-base-url"
+							>base URL</a> [[URL]] for all files within the <code>META-INF</code> directory is the
+							<a>Root Directory</a> of the OCF Abstract Container.</p>
 
 					<p>For example, if <code>META-INF/container.xml</code> has the following content:</p>
 
@@ -5394,8 +5401,9 @@ Spine:
 					<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the root directory for the
 						OCF Abstract Container and not relative to the <code>META-INF</code> directory.</p>
 
-					<p>All relative IRI references MUST resolve to resources within the OCF Abstract Container (i.e., at
-						or below the Root Directory).</p>
+					<p>All <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+							>relative-URL-with-fragment strings</a> [[URL]] references MUST resolve to resources within
+						the OCF Abstract Container (i.e., at or below the Root Directory).</p>
 				</section>
 
 				<section id="sec-container-filenames">
@@ -5644,10 +5652,10 @@ Spine:
 											</dt>
 											<dd>
 												<p>Identifies the location of a <a>Package Document</a>.</p>
-												<p>The value of the attribute MUST contain a <em>path component</em>
-													[[RFC3986]] which MUST take the form of a <em>path-rootless</em>
-													[[RFC3986]] only. The path components are relative to the <a>Root
-														Directory</a>.</p>
+												<p>The value of the attribute MUST be a <a
+														href="https://url.spec.whatwg.org/#path-relative-scheme-less-url-string"
+														>path-relative-scheme-less-URL string</a> [[URL]]. The path is
+													relative to the <a>Root Directory</a>.</p>
 											</dd>
 
 											<dt>
@@ -5740,9 +5748,10 @@ Spine:
 											<dd>
 												<p>Identifies the location of a resource.</p>
 												<p>The value of the <code>link</code> element <code>href</code>
-													attribute MUST contain a <em>path component</em> [[RFC3986]] which
-													MUST take the form of a <em>path-rootless</em> [[RFC3986]] only. The
-													path component is relative to the <a>Root Directory</a>.</p>
+													attribute MUST be a <a
+														href="https://url.spec.whatwg.org/#path-relative-scheme-less-url-string"
+														>path-relative-scheme-less-URL string</a> [[URL]]. The path is
+													relative to the <a>Root Directory</a>.</p>
 											</dd>
 
 											<dt>
@@ -6140,7 +6149,7 @@ Spine:
 
 								<div class="note">
 									<p>Each <code>Signature</code> in the <code>signatures.xml</code> file identifies by
-										IRI the data to which the signature applies, using the [[XMLDSIG-CORE1]]
+										URL [[URL]] the data to which the signature applies, using the [[XMLDSIG-CORE1]]
 											<code>Manifest</code> element and its <code>Reference</code> sub-elements.
 										EPUB Creator may sign individual container files separately or together.
 										Separately signing each file creates a digest value for the resource that
@@ -6743,9 +6752,10 @@ store destination as source in ocf
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The relative IRI reference [[RFC3987]] of the corresponding EPUB Content
-											Document, including a <a href="#sec-media-overlays-fragids">fragment
-												identifier</a> that references the specific content.</p>
+										<p>The <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+												>relative-URL-with-fragment string</a> [[URL]] of the corresponding EPUB
+											Content Document, which MUST have a <a href="#sec-media-overlays-fragids"
+												>fragment identifier</a> that references the specific content.</p>
 									</dd>
 								</dl>
 							</dd>
@@ -6820,9 +6830,10 @@ store destination as source in ocf
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>The relative IRI reference [[RFC3987]] of the corresponding EPUB Content
-											Document, including a <a href="#sec-media-overlays-fragids">fragment
-												identifier</a> that references the specific content.</p>
+										<p>The <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+												>relative-URL-with-fragment string</a> [[URL]] of the corresponding EPUB
+											Content Document, which MUST have a <a href="#sec-media-overlays-fragids"
+												>fragment identifier</a> that references the specific content.</p>
 										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
 											information.</p>
 									</dd>
@@ -6952,9 +6963,10 @@ store destination as source in ocf
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>The relative IRI reference [[RFC3987]] of the corresponding EPUB Content
-											Document, including a <a href="#sec-media-overlays-fragids">fragment
-												identifier</a> that references the specific content.</p>
+										<p>The <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+												>relative-URL-with-fragment string</a> [[URL]] of the corresponding EPUB
+											Content Document, which MUST have a <a href="#sec-media-overlays-fragids"
+												>fragment identifier</a> that references the specific content.</p>
 									</dd>
 									<dt>
 										<code>id</code>
@@ -7009,9 +7021,11 @@ store destination as source in ocf
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>The relative or absolute IRI reference [[RFC3987]] of an audio file. The
-											audio file MUST be one of the audio formats listed in the <a
-												href="#sec-core-media-types">Core Media Type Resources</a> table.</p>
+										<p>The <a href="https://url.spec.whatwg.org/#relative-url-string">relative-</a>
+											or <a href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL
+												string</a> [[URL]] reference to an audio file. The audio file MUST be
+											one of the audio formats listed in the <a href="#sec-core-media-types">Core
+												Media Type Resources</a> table.</p>
 									</dd>
 									<dt id="attrdef-smil-clipBegin">
 										<code>clipBegin</code>
@@ -7079,7 +7093,7 @@ store destination as source in ocf
 						presentation.</p>
 
 					<p>The <code>text</code> element <code>src</code> attribute references the associated phrase,
-						sentence, or other segment of the EPUB Content Document by its IRI reference. The
+						sentence, or other segment of the EPUB Content Document by its URL [[URL]] reference. The
 							<code>audio</code> element <code>src</code> attribute similarly references the location of
 						the corresponding audio clip and adds the OPTIONAL <a href="#attrdef-smil-clipBegin"
 								><code>clipBegin</code></a> and <a href="#attrdef-smil-clipEnd"><code>clipEnd</code></a>
@@ -8070,17 +8084,17 @@ html.my-document-playing * {
 							semantics</a>, for example, while the <code>property</code> and <code>rel</code> attributes
 						use the data type to define properties and relationships in the <a>Package Document</a>.</p>
 
-					<p>A <var>property</var> value is like a CURIE [[RDFA-CORE]] &#8212; it represents an IRI
-						[[RFC3987]] in compact form. The expression consists of a prefix and a reference, where the
-						prefix — whether literal or implied — is a shorthand mapping of an IRI that typically resolves
-						to a term vocabulary. When a Reading System converts the prefix to its IRI representation and
-						combines with the reference, the resulting IRI normally resolves to a fragment within that
-						vocabulary that contains human- and/or machine-readable information about the term.</p>
+					<p>A <var>property</var> value is like a CURIE [[RDFA-CORE]] &#8212; it represents a URL [[URL]] in
+						compact form. The expression consists of a prefix and a reference, where the prefix — whether
+						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
+						vocabulary. When a Reading System converts the prefix to its URL representation and combines
+						with the reference, the resulting URL normally resolves to a fragment within that vocabulary
+						that contains human- and/or machine-readable information about the term.</p>
 
 					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> data type
 						also defines a <a href="#sec-default-vocab">default vocabulary</a>. Terms and properties
 						referenced from the default vocabularies do not include a prefix as the mapping <a>Reading
-							Systems</a> use to map to a IRI is predefined.</p>
+							Systems</a> use to map to a URL is predefined.</p>
 
 					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
 						terms and properties, EPUB Creators only need to declare a <a href="#sec-prefix-attr"
@@ -8095,8 +8109,8 @@ html.my-document-playing * {
 				<section id="sec-property-datatype">
 					<h4>The <var>property</var> Data Type</h4>
 
-					<p>The <var>property</var> data type is a compact means of expressing an IRI [[RFC3987]] and
-						consists of an OPTIONAL prefix separated from a reference by a colon.</p>
+					<p>The <var>property</var> data type is a compact means of expressing a URL [[URL]] and consists of
+						an OPTIONAL prefix separated from a reference by a colon.</p>
 
 					<table class="productionset">
 						<caption>(EBNF productions <a
@@ -8131,8 +8145,9 @@ html.my-document-playing * {
 							<td>
 								<code>=</code>
 							</td>
-							<td>? irelative-ref ? ;</td>
-							<td>/* as defined in [[RFC3987]] */<br /></td>
+							<td>? <a href="https://url.spec.whatwg.org/#path-relative-scheme-less-url-string"
+									>path-relative-scheme-less-URL string</a> [[URL]] ? ;</td>
+							<td>/* as defined in [[URL]] */<br /></td>
 						</tr>
 					</table>
 
@@ -8146,12 +8161,12 @@ html.my-document-playing * {
 					</aside>
 
 					<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-datatype">processing</a>
-						[[EPUB-RS-33]], this property would expand to the following IRI:</p>
+						[[EPUB-RS-33]], this property would expand to the following URL:</p>
 
 					<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
 
 					<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
-							prefix</a> that maps to the IRI "<code>http://purl.org/dc/terms/</code>".</p>
+							prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
 
 					<p>When an EPUB Creator omits a prefix from a <var>property</var> value, the expressed reference
 						represents a term from the <a href="#sec-default-vocab">default vocabulary</a> for that
@@ -8167,7 +8182,7 @@ html.my-document-playing * {
 
 						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
 
-						<p>when the IRI for the vocabulary is concatenated with the reference.</p>
+						<p>when the URL for the vocabulary is concatenated with the reference.</p>
 					</aside>
 
 					<p>An empty string does not represent a valid <var>property</var> value, even though it is valid to
@@ -8182,7 +8197,7 @@ html.my-document-playing * {
 							href="#sec-property-datatype"><var>property</var> value</a> is expected. EPUB Creators MUST
 						NOT add a prefix to terms and properties from a default vocabulary.</p>
 
-					<p>EPUB Creators MUST NOT assign a prefix to the IRIs associated with these vocabularies using the
+					<p>EPUB Creators MUST NOT assign a prefix to the URLs associated with these vocabularies using the
 							<a href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
 
 					<div class="note">
@@ -8199,7 +8214,7 @@ html.my-document-playing * {
 							href="#sec-property-datatype"><var>property</var> values</a>.</p>
 
 					<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
-						prefix-to-IRI mappings of the form:</p>
+						prefix-to-URL mappings of the form:</p>
 
 					<table class="productionset">
 						<caption>(EBNF productions <a
@@ -8349,7 +8364,7 @@ html.my-document-playing * {
 								<thead>
 									<tr>
 										<th>Prefix</th>
-										<th>IRI</th>
+										<th>URL</th>
 									</tr>
 								</thead>
 								<tbody>
@@ -8398,7 +8413,7 @@ html.my-document-playing * {
 								<thead>
 									<tr>
 										<th>Prefix</th>
-										<th>IRI</th>
+										<th>URL</th>
 									</tr>
 								</thead>
 								<tbody>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9435,6 +9435,8 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>12-May-2021: Clarified that manifest items must not contain fragment identifiers. See <a
+							href="https://github.com/w3c/epub-specs/issues/1303">issue 1303</a>.</li>
 					<li>12-May-2021: Changed all references to URIs/IRIs to URLs and references to RFCs 3986 and 3987 to
 						the URL standard. See <a href="https://github.com/w3c/epub-specs/issues/808">issue 808</a>.</li>
 					<li>06-May-2021: Noted that the working group will no longer maintain the publication type and

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4322,7 +4322,7 @@ Spine:
 				</aside>
 
 				<p id="confreq-cd-pls-docprops-schema">PLS Documents MUST be valid to the RELAX NG schema available at
-					the URI <a href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
+					the URL <a href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
 							><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng</code></a>
 					[[PRONUNCIATION-LEXICON]].</p>
 
@@ -8187,7 +8187,7 @@ html.my-document-playing * {
 
 						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
 
-						<p>when the URL for the vocabulary is concatenated with the reference.</p>
+						<p>when the prefix URL for the vocabulary is concatenated with the reference.</p>
 					</aside>
 
 					<p>An empty string does not represent a valid <var>property</var> value, even though it is valid to
@@ -8202,9 +8202,8 @@ html.my-document-playing * {
 							href="#sec-property-datatype"><var>property</var> value</a> is expected. EPUB Creators MUST
 						NOT add a prefix to terms and properties from a default vocabulary.</p>
 
-					<p>EPUB Creators MUST NOT assign a prefix to the <a
-							href="https://url.spec.whatwg.org/#concept-base-url">base URLs</a> [[URL]] associated with
-						these vocabularies using the <a href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
+					<p>EPUB Creators MUST NOT assign a prefix to the URLs associated with these vocabularies using the
+							<a href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
 
 					<div class="note">
 						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -1,18 +1,15 @@
 <section id="app-item-properties-vocab" class="vocab">
 	<h3>Manifest Properties Vocabulary</h3>
-	
 	<p>The properties in this vocabulary are usable in the manifest <a href="#sec-item-elem"><code>item</code>
 			element's</a>
 		<a href="#attrdef-item-properties"><code>properties</code> attribute</a>.</p>
-	
 	<p>The <strong>Applies to</strong> field indicates which Publication Resource type(s) the given property MAY
 		be specified on, the <strong>Cardinality</strong> field indicates the number of times the property MUST
 		appear within the Package Document scope, and the <strong>Usage</strong> field indicates usage
 		conditions.</p>
-	
-	<p>Properties without a prefix are referenceable using the base IRI
+	<p>Properties without a prefix are referenceable using the <a
+			href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
 			<code>http://idpf.org/epub/vocab/package/item/#</code>.</p>
-	
 	<section id="sec-cover-image">
 		<h4>cover-image</h4>
 		<table id="cover-image">
@@ -45,7 +42,6 @@
 			</tbody>
 		</table>
 	</section>
-	
 	<section id="sec-mathml">
 		<h4>mathml</h4>
 		<table id="mathml">
@@ -80,7 +76,6 @@
 			</tbody>
 		</table>
 	</section>
-	
 	<section id="sec-nav-prop">
 		<h4>nav</h4>
 		<table id="nav">
@@ -114,7 +109,6 @@
 			</tbody>
 		</table>
 	</section>
-	
 	<section id="sec-remote-resources">
 		<h4>remote-resources</h4>
 		<table id="remote-resources">
@@ -153,7 +147,6 @@
 			</tbody>
 		</table>
 	</section>
-	
 	<section id="sec-scripted">
 		<h4>scripted</h4>
 		<table id="scripted">
@@ -189,7 +182,6 @@
 			</tbody>
 		</table>
 	</section>
-	
 	<section id="sec-svg-prop">
 		<h4>svg</h4>
 		<table id="svg">
@@ -228,7 +220,6 @@
 			</tbody>
 		</table>
 	</section>
-	
 	<section id="sec-switch">
 		<h4>switch</h4>
 		<table id="switch">
@@ -264,10 +255,8 @@
 			</tbody>
 		</table>
 	</section>
-	
 	<section id="manifest-item-properties-recursive">
 		<h4>Usage</h4>
-		
 		<p>The <code>mathml</code>, <code>remote-resources</code>, <code>scripted</code> and <code>switch</code>
 			properties MUST be specified whenever the resource referenced by an <code>item</code> matches their
 			respective definitions. These properties do not apply recursively to content included into a
@@ -276,7 +265,6 @@
 				<code>item</code>
 			<code>properties</code> attribute will have the <code>scripted</code> value. </p>
 	</section>
-	
 	<section id="examples-item-properties">
 		<h4>Examples</h4>
 		<figure class="example" id="example-item-properties-nav">

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -1,15 +1,19 @@
 <section id="app-item-properties-vocab" class="vocab">
 	<h3>Manifest Properties Vocabulary</h3>
+	
 	<p>The properties in this vocabulary are usable in the manifest <a href="#sec-item-elem"><code>item</code>
 			element's</a>
 		<a href="#attrdef-item-properties"><code>properties</code> attribute</a>.</p>
+	
 	<p>The <strong>Applies to</strong> field indicates which Publication Resource type(s) the given property MAY
 		be specified on, the <strong>Cardinality</strong> field indicates the number of times the property MUST
 		appear within the Package Document scope, and the <strong>Usage</strong> field indicates usage
 		conditions.</p>
-	<p>Properties without a prefix are referenceable using the <a
-			href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
-			<code>http://idpf.org/epub/vocab/package/item/#</code>.</p>
+	
+	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
+		href="#sec-default-vocab">referencing these properties</a> is
+		<code>http://idpf.org/epub/vocab/package/item/#</code>.</p>
+	
 	<section id="sec-cover-image">
 		<h4>cover-image</h4>
 		<table id="cover-image">

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -10,8 +10,7 @@
 		appear within the Package Document scope, and the <strong>Usage</strong> field indicates usage
 		conditions.</p>
 	
-	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
-		href="#sec-default-vocab">referencing these properties</a> is
+	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 		<code>http://idpf.org/epub/vocab/package/item/#</code>.</p>
 	
 	<section id="sec-cover-image">

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -6,9 +6,9 @@
 				><code>itemref</code> element's</a>
 		<a href="#attrdef-itemref-properties"><code>properties</code> attribute</a>.</p>
 
-	<p>Properties are referenceable using the <a
-		href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
-			<code>http://idpf.org/epub/vocab/package/itemref/#</code>.</p>
+	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
+		href="#sec-default-vocab">referencing these properties</a> is
+		<code>http://idpf.org/epub/vocab/package/itemref/#</code>.</p>
 
 	<section id="sec-page-spread-left">
 		<h4>page-spread-left</h4>

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -6,8 +6,7 @@
 				><code>itemref</code> element's</a>
 		<a href="#attrdef-itemref-properties"><code>properties</code> attribute</a>.</p>
 
-	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
-		href="#sec-default-vocab">referencing these properties</a> is
+	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 		<code>http://idpf.org/epub/vocab/package/itemref/#</code>.</p>
 
 	<section id="sec-page-spread-left">

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -6,7 +6,8 @@
 				><code>itemref</code> element's</a>
 		<a href="#attrdef-itemref-properties"><code>properties</code> attribute</a>.</p>
 
-	<p>Properties are referenceable using the base IRI
+	<p>Properties are referenceable using the <a
+		href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
 			<code>http://idpf.org/epub/vocab/package/itemref/#</code>.</p>
 
 	<section id="sec-page-spread-left">

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -6,15 +6,18 @@
 				><code>link</code> element's</a>
 		<code>rel</code> and <code>properties</code> attributes.</p>
 	
-	<p><a href="#sec-link-properties">Link properties</a> without a prefix are referenceable using the
-		<a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
+	<p>The
+		<a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
+			href="#sec-default-vocab">referencing these properties</a> is
 		<code>http://idpf.org/epub/vocab/package/link/#</code>.</p>
 	
 	<section id="sec-link-rel">
 		<h4>Link Relationships</h4>
+		
 		<p>The following values can be used in the <code>link</code> element <a href="#attrdef-link-rel"
 					><code>rel</code> attribute</a> to establish the relationship of the resource referenced in
 			the <a href="#attrdef-href"><code>href</code> attribute</a>.</p>
+		
 		<section id="sec-acquire">
 			<h5>acquire</h5>
 			<table id="acquire">

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -6,9 +6,7 @@
 				><code>link</code> element's</a>
 		<code>rel</code> and <code>properties</code> attributes.</p>
 	
-	<p>The
-		<a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
-			href="#sec-default-vocab">referencing these properties</a> is
+	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 		<code>http://idpf.org/epub/vocab/package/link/#</code>.</p>
 	
 	<section id="sec-link-rel">

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -7,7 +7,8 @@
 		<code>rel</code> and <code>properties</code> attributes.</p>
 	
 	<p><a href="#sec-link-properties">Link properties</a> without a prefix are referenceable using the
-		base IRI <code>http://idpf.org/epub/vocab/package/link/#</code>.</p>
+		<a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
+		<code>http://idpf.org/epub/vocab/package/link/#</code>.</p>
 	
 	<section id="sec-link-rel">
 		<h4>Link Relationships</h4>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -16,8 +16,7 @@
 		times the property MAY be attached to another property, and the <strong>Extends</strong> field
 		identifies the properties it MAY be attached to.</p>
 	
-	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
-		href="#sec-default-vocab">referencing these properties</a> is
+	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 		<code>http://idpf.org/epub/vocab/package/meta/#</code>.</p>
 	
 	<section id="sec-property-alternate-script">

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -1,20 +1,25 @@
 <section id="app-meta-property-vocab" class="vocab">
 	<h3>Meta Properties Vocabulary</h3>
+	
 	<p>The properties in this vocabulary are usable in the <a href="#sec-meta-elem"><code>meta</code>
 			element's</a>
 		<code>property</code> attribute.</p>
+	
 	<p>Unless indicated otherwise in its "Extends" field, the properties defined in this section are used to
 		define <a href="#subexpression">subexpressions</a>: in other words, a <code><a href="#elemdef-meta"
 				>meta</a></code> element carrying a property defined in this section MUST have a <code><a
 				href="#attrdef-refines">refines</a></code> attribute referencing a resource or expression being
 		augmented.</p>
+	
 	<p>In each property definition, the <strong>Allowed values</strong> field indicates the expected type of
 		value (using [[!XMLSCHEMA-2]] datatypes), the <strong>Cardinality</strong> field indicates the number of
 		times the property MAY be attached to another property, and the <strong>Extends</strong> field
 		identifies the properties it MAY be attached to.</p>
-	<p>Properties without a prefix are referenceable using the <a
-		href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
-			<code>http://idpf.org/epub/vocab/package/meta/#</code>.</p>
+	
+	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
+		href="#sec-default-vocab">referencing these properties</a> is
+		<code>http://idpf.org/epub/vocab/package/meta/#</code>.</p>
+	
 	<section id="sec-property-alternate-script">
 		<h5>alternate-script</h5>
 		<table id="alternate-script">
@@ -86,79 +91,96 @@
 						<ul>
 							<li>
 								<p>one of the following case-insensitive reserved authority values:</p>
-								
 								<dl id="authorities">
-									<dt id="aat"><a href="http://www.getty.edu/research/tools/vocabularies/aat/index.html">AAT</a></dt>
+									<dt id="aat">
+										<a
+											href="http://www.getty.edu/research/tools/vocabularies/aat/index.html"
+											>AAT</a>
+									</dt>
 									<dd>
 										<p>The Getty Art and Architecture Taxonomy.</p>
 									</dd>
-									
-									<dt id="bic"><a href="http://www.bic.org.uk/7/BIC-Standard-Subject-Categories/">BIC</a></dt>
+									<dt id="bic">
+										<a href="http://www.bic.org.uk/7/BIC-Standard-Subject-Categories/"
+											>BIC</a>
+									</dt>
 									<dd>
 										<p>The main UK subject scheme for the book supply chain.</p>
 									</dd>
-									
-									<dt id="bisac"><a href="http://bisg.org/page/BISACSubjectCodes">BISAC</a></dt>
+									<dt id="bisac">
+										<a href="http://bisg.org/page/BISACSubjectCodes">BISAC</a>
+									</dt>
 									<dd>
 										<p>The main US subject scheme for the book supply chain.</p>
 									</dd>
-									
-									<dt id="clc"><a href="http://clc.nlc.gov.cn/">CLC</a></dt>
+									<dt id="clc">
+										<a href="http://clc.nlc.gov.cn/">CLC</a>
+									</dt>
 									<dd>
 										<p>The main subject classification scheme used in China.</p>
 									</dd>
-									
-									<dt id="ddc"><a href="https://www.oclc.org/dewey/features/summaries.en.html">DDC</a></dt>
+									<dt id="ddc">
+										<a href="https://www.oclc.org/dewey/features/summaries.en.html">DDC</a>
+									</dt>
 									<dd>
 										<p>The Dewey Decimal Classification system.</p>
 									</dd>
-									
-									<dt id="clil"><a href="http://clil.centprod.com/information/detailDoc.html?docId=34">CLIL</a></dt>
+									<dt id="clil">
+										<a href="http://clil.centprod.com/information/detailDoc.html?docId=34"
+											>CLIL</a>
+									</dt>
 									<dd>
 										<p>The main French subject scheme for the book supply chain.</p>
 									</dd>
-									
-									<dt id="eurovoc"><a href="http://eurovoc.europa.eu/">EuroVoc</a></dt>
+									<dt id="eurovoc">
+										<a href="http://eurovoc.europa.eu/">EuroVoc</a>
+									</dt>
 									<dd>
 										<p>The European multilingual thesaurus.</p>
 									</dd>
-									
-									<dt id="medtop"><a href="https://iptc.org/standards/media-topics/">MEDTOP</a></dt>
+									<dt id="medtop">
+										<a href="https://iptc.org/standards/media-topics/">MEDTOP</a>
+									</dt>
 									<dd>
 										<p>IPTC Media Topics classification scheme for the news industry.</p>
 									</dd>
-									
-									<dt id="lcsh"><a href="http://id.loc.gov/authorities/subjects.html">LCSH</a></dt>
+									<dt id="lcsh">
+										<a href="http://id.loc.gov/authorities/subjects.html">LCSH</a>
+									</dt>
 									<dd>
 										<p>Library of Congress Subject Headings.</p>
 									</dd>
-									
-									<dt id="ndc"><a href="http://www.jla.or.jp/">NDC</a></dt>
+									<dt id="ndc">
+										<a href="http://www.jla.or.jp/">NDC</a>
+									</dt>
 									<dd>
 										<p>The main Japanese subject scheme.</p>
 									</dd>
-									
-									<dt id="thema"><a href="http://www.editeur.org/151/thema/">Thema</a></dt>
+									<dt id="thema">
+										<a href="http://www.editeur.org/151/thema/">Thema</a>
+									</dt>
 									<dd>
-										<p>The international subject scheme for the book supply chain, providing codes that work across many
-											languages.</p>
+										<p>The international subject scheme for the book supply chain, providing
+											codes that work across many languages.</p>
 									</dd>
-									
-									<dt id="udc"><a href="http://www.udcc.org/">UDC</a></dt>
+									<dt id="udc">
+										<a href="http://www.udcc.org/">UDC</a>
+									</dt>
 									<dd>
 										<p>The Universal Decimal Classification system.</p>
 									</dd>
-									
-									<dt id="wgs"><a href="http://info.vlb.de/files/wgsneuversion2_0.pdf">WGS</a></dt>
+									<dt id="wgs">
+										<a href="http://info.vlb.de/files/wgsneuversion2_0.pdf">WGS</a>
+									</dt>
 									<dd>
 										<p>The main German subject scheme for the book supply chain.</p>
 									</dd>
 								</dl>
 							</li>
 							<li>
-								<p>an <a href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL string</a>
-									[[URL]] that identifies the scheme. The URL SHOULD refer to a resource that provides
-									more information about the scheme.</p>
+								<p>an <a href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL
+										string</a> [[URL]] that identifies the scheme. The URL SHOULD refer to a
+									resource that provides more information about the scheme.</p>
 							</li>
 						</ul>
 					</td>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -12,7 +12,8 @@
 		value (using [[!XMLSCHEMA-2]] datatypes), the <strong>Cardinality</strong> field indicates the number of
 		times the property MAY be attached to another property, and the <strong>Extends</strong> field
 		identifies the properties it MAY be attached to.</p>
-	<p>Properties without a prefix are referenceable using the base IRI
+	<p>Properties without a prefix are referenceable using the <a
+		href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
 			<code>http://idpf.org/epub/vocab/package/meta/#</code>.</p>
 	<section id="sec-property-alternate-script">
 		<h5>alternate-script</h5>
@@ -155,8 +156,9 @@
 								</dl>
 							</li>
 							<li>
-								<p>an absolute IRI [[!RFC3987]] that identifies the scheme. The IRI SHOULD refer
-									to a resource that provides more information about the scheme.</p>
+								<p>an <a href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL string</a>
+									[[URL]] that identifies the scheme. The URL SHOULD refer to a resource that provides
+									more information about the scheme.</p>
 							</li>
 						</ul>
 					</td>

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -5,8 +5,8 @@
 			element's</a>
 		<code>property</code> attribute.</p>
 	
-	<p>The base IRI for referencing this vocabulary is
-		<code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>
+	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for referencing
+		this vocabulary is <code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>
 	
 	<p>The prefix "<code>media:</code>" is <a href="#sec-metadata-reserved-prefixes">reserved for use</a> with
 		properties in this vocabulary and does not have to be declared in the Package Document.</p>

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -5,8 +5,9 @@
 			element's</a>
 		<code>property</code> attribute.</p>
 	
-	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for referencing
-		this vocabulary is <code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>
+	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
+		href="#sec-default-vocab">referencing these properties</a> is
+		<code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>
 	
 	<p>The prefix "<code>media:</code>" is <a href="#sec-metadata-reserved-prefixes">reserved for use</a> with
 		properties in this vocabulary and does not have to be declared in the Package Document.</p>

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -5,8 +5,7 @@
 			element's</a>
 		<code>property</code> attribute.</p>
 	
-	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
-		href="#sec-default-vocab">referencing these properties</a> is
+	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 		<code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>
 	
 	<p>The prefix "<code>media:</code>" is <a href="#sec-metadata-reserved-prefixes">reserved for use</a> with

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -10,8 +10,9 @@
 			System</a>). If a Reading System supports the desired rendering, these properties enable the
 		user to be presented the content as the EPUB Creator optimally designed it.</p>
 	
-	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for referencing
-		these properties is <code>http://www.idpf.org/vocab/rendition/#</code>.</p>
+	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
+		href="#sec-default-vocab">referencing these properties</a> is
+		<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
 	
 	<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved for
 		use</a> with the package rendering properties and does not have to be declared in the

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -10,8 +10,8 @@
 			System</a>). If a Reading System supports the desired rendering, these properties enable the
 		user to be presented the content as the EPUB Creator optimally designed it.</p>
 	
-	<p>The base IRI for referencing these properties is
-		<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
+	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for referencing
+		these properties is <code>http://www.idpf.org/vocab/rendition/#</code>.</p>
 	
 	<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved for
 		use</a> with the package rendering properties and does not have to be declared in the

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -10,8 +10,7 @@
 			System</a>). If a Reading System supports the desired rendering, these properties enable the
 		user to be presented the content as the EPUB Creator optimally designed it.</p>
 	
-	<p>The <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] for <a
-		href="#sec-default-vocab">referencing these properties</a> is
+	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 		<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
 	
 	<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved for

--- a/epub33/core/vocab/structure.html
+++ b/epub33/core/vocab/structure.html
@@ -1,20 +1,26 @@
 <section id="structure-vocab">
 	<h3>Structural Semantics Vocabulary</h3>
+	
 	<section id="about" class="informative">
 		<h4>About this Vocabulary</h4>
+		
 		<p>While the EPUB Structural Semantics vocabulary is generally host language agnostic, it has been
 			constructed primarily to enable semantic inflection of elements in the HTML vocabulary.</p>
+		
 		<p>The <i>HTML usage context</i> fields indicate contexts in HTML documents where the given property is
 			considered relevant. EPUB Creators may use the properties on HTML markup elements not specifically listed,
 			but must ensure that the semantics they express represent a subset of the carrying element's
 			semantics and do not attach an existing element's meaning to a semantically neutral element.</p>
+		
 		<p>The <i>DPUB-ARIA role</i> fields indicate the [[DPUB-ARIA-1.0]] roles that can alternatively be used
 			with the [[HTML]] <code>role</code> attribute to improve accessibility. These roles may have more
 			restrictive usage contexts, however, so may not be valid wherever the <code>epub:type</code>
 			attribute is used. Refer to [[HTML-ARIA]] for more information about where the roles are
 			allowed.</p>
+		
 		<p>When processing HTML documents, Reading Systems may ignore such non-compliant properties, unless
 			their usage context is explicitly overridden or extended by the host specification.</p>
+		
 		<p>The <i>Usage Details</i> sections identify IDPF specifications that define or utilize the specified
 			properties.</p>
 	</section>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -1016,7 +1016,7 @@
 						Package Document for the Rendition as the value of an <code>epub:rendition</code> attribute.</p>
 
 					<p>If the <code>epub:rendition</code> attribute is used to specify the target Rendition, any
-						fragment identifier scheme MAY be used within the URI value of the <code>href</code> attribute
+						fragment identifier scheme MAY be used within the URL value of the <code>href</code> attribute
 						of <code>a</code> elements (e.g., unique identifier, or W3C Media Fragment).</p>
 
 					<div class="note">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -377,9 +377,10 @@
 							attributes define expressions they do not recognize. A Reading System MUST NOT fail when
 							encountering unknown expressions.</p>
 						<p>If the <code>property</code> attribute's value does not include a prefix, Reading Systems
-							MUST use the following <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a>
-							[[URL]] to generate the resulting URL:
-								<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
+							MUST <a href="https://url.spec.whatwg.org/#concept-url-parser">parse</a> the value to a <a
+								href="https://url.spec.whatwg.org/#concept-url">URL</a> using the <a
+								href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
+								"<code>http://idpf.org/epub/vocab/package/meta/#</code>".</p>
 					</dd>
 
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
@@ -404,9 +405,10 @@
 						<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
 							layout and rendering of the EPUB Publication.</p>
 						<p>If any of the <code>rel</code> or <code>properties</code> attributes' values do not include a
-							prefix, Reading Systems MUST use the following <a
-								href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] to generate
-							the resulting URL: <code>http://idpf.org/epub/vocab/package/link/#</code></p>
+							prefix, Reading Systems MUST <a href="https://url.spec.whatwg.org/#concept-url-parser"
+								>parse</a> the unprefixed values to <a href="https://url.spec.whatwg.org/#concept-url"
+								>URLs</a> using the <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a>
+							[[URL]] "<code>http://idpf.org/epub/vocab/package/link/#</code>".</p>
 					</dd>
 
 					<dt>Proprietary Metadata</dt>
@@ -422,10 +424,11 @@
 				<h3>Manifest</h3>
 
 				<p>When an <code>href</code> attribute contains a <a
-						href="https://url.spec.whatwg.org/#relative-url-string">relative-URL string</a> [[URL]], Reading
-					Systems MUST use the URL of the Package Document as the <a
-						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] when resolving to an
-						<a href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL string</a> [[URL]].</p>
+						href="https://url.spec.whatwg.org/#relative-url-string">relative-URL string</a>, Reading Systems
+					MUST use the URL of the Package Document as the <a
+						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> when <a
+						href="https://url.spec.whatwg.org/#concept-url-parser">parsing</a> to a <a
+						href="https://url.spec.whatwg.org/#concept-url">URL record</a> [[URL]].</p>
 
 				<p>Reading Systems MAY optimize the rendering depending on the properties set in the
 						<code>properties</code> attribute (e.g., disable a rendering process or use a fallback). Reading
@@ -453,9 +456,11 @@
 				<p>Reading Systems MUST terminate the fallback chain at the first reference to a manifest item it has
 					already encountered.</p>
 
-				<p>If any of the <code>property</code> attribute's values do not include a prefix, Reading Systems MUST
-					use the following <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] to
-					generate the resulting URL: <code>http://idpf.org/epub/vocab/package/item/#</code></p>
+				<p>If any of the <code>properties</code> attribute's values do not include a prefix, Reading Systems
+					MUST <a href="https://url.spec.whatwg.org/#concept-url-parser">parse</a> the unprefix values to <a
+						href="https://url.spec.whatwg.org/#concept-url">URLs</a> using the <a
+						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
+						"<code>http://idpf.org/epub/vocab/package/item/#</code>".</p>
 			</section>
 
 			<section id="sec-pkg-doc-spine">
@@ -483,9 +488,11 @@
 						<code>page-progression-direction</code> attribute defines the flow direction from one
 					fixed-layout page to the next.</p>
 
-				<p>If any of the spine <code>itemref</code> attribute's values do not include a prefix, Reading Systems
-					MUST use the following <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
-					to generate the resulting URL: <code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
+				<p>If any of the <code>properties</code> attribute's values do not include a prefix, Reading Systems
+					MUST <a href="https://url.spec.whatwg.org/#concept-url-parser">parse</a> the unprefixes values to <a
+						href="https://url.spec.whatwg.org/#concept-url">URLs</a> using the <a
+						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
+						"<code>http://idpf.org/epub/vocab/package/itemref/#</code>".</p>
 
 				<p>Reading Systems MUST ignore all metadata properties expressed in spine <code>itemref</code>
 					<code>properties</code> attribute that they do not recognize.</p>
@@ -1618,23 +1625,25 @@
 
 				<dt id="sec-property-datatype">The <code>property</code> Data Type</dt>
 				<dd>
-					<p>A Reading System MUST use the following rules to create a URL [[URL]] from a property:</p>
+					<p>A Reading System MUST use the following rules to create a <a
+							href="https://url.spec.whatwg.org/#concept-url">URL</a> [[URL]] from a property:</p>
 					<ul>
 						<li>
-							<p>If the property consists only of a reference, obtain the URL by concatenating the <a
-									href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] associated
-								with the <a href="https://www.w3.org/TR/epub-33/#sec-default-vocab">default
-									vocabulary</a> [[EPUB-33]] to the reference.</p>
+							<p>If the property consists only of a reference, obtain the URL by concatenating the base
+								URL associated with the <a href="https://www.w3.org/TR/epub-33/#sec-default-vocab"
+									>default vocabulary</a> [[EPUB-33]] to the reference.</p>
 						</li>
 						<li>
 							<p>If the property consists of a prefix and reference, obtain the URL by concatenating the
-									<a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
-								associated with the prefix to the reference. If the EPUB Creator has not defined a
-								matching prefix, the property is invalid and the Reading System MUST ignore it.</p>
+								base URL associated with the prefix to the reference. If the EPUB Creator has not
+								defined a matching prefix, the property is invalid and the Reading System MUST ignore
+								it.</p>
 						</li>
 					</ul>
 					<p>The result MUST be a <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a>
-						[[URL]]. Reading Systems do not have to resolve this URL, however.</p>
+						[[URL]]. Reading Systems do not have to <a
+							href="https://url.spec.whatwg.org/#concept-url-parser">parse this URL</a> [[URL]] or attempt
+						to retrieve the referenced resource, however.</p>
 				</dd>
 			</dl>
 		</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1113,7 +1113,7 @@
 							>relative-URL-with-fragment strings</a> [[URL]], Reading Systems MUST determine the <a
 							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] according to the
 						relevant language specifications for the given file formats. For example, CSS defines how
-						relative IRI references work in the context of CSS style sheets and property declarations
+						relative URL references work in the context of CSS style sheets and property declarations
 						[[CSSSnapshot]].</p>
 
 					<div class="note">
@@ -1634,7 +1634,7 @@
 						</li>
 					</ul>
 					<p>The result MUST be valid a <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL
-							string</a> [[URL]]. Reading Systems do not have to resolve this IRI, however.</p>
+							string</a> [[URL]]. Reading Systems do not have to resolve this URL, however.</p>
 				</dd>
 			</dl>
 		</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -274,22 +274,18 @@
 			<p id="confreq-rs-epub-pub" class="support">Reading Systems MUST process the <a
 					href="https://www.w3.org/TR/epub-33/#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
 
-			<section id="sec-pkg-doc-relative-iris">
-				<h4>Resolving Relative URLs</h4>
+			<section id="sec-pkg-doc-relative-urls">
+				<h4>Parsing Relative URLs</h4>
 
-				<p>To obtain an <a href="https://url.spec.whatwg.org/#absolute-url-with-fragment-string"
-						>absolute-URL-with-fragment string</a> [[URL]] from a <a
-						href="https://url.spec.whatwg.org/#relative-url-with-fragment-string">relative-URL-with-fragment
-						string</a> [[URL]] in the Package Document, Reading Systems MUST use the <a
-						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] of the Package
-					Document.</p>
+				<p>To parse <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+						>relative-URL-with-fragment strings</a> [[URL]] in the Package Document, Reading Systems MUST
+					use the URL of the Package Document as the <a href="https://url.spec.whatwg.org/#concept-base-url"
+						>base URL</a> [[URL]].</p>
 
-				<p>The base URL of the Package Document is the combination of the base URL of the <a>EPUB Container</a>
-					together with the path to Package Document (relative to the <a>Root Directory</a>) when an EPUB
-					Publication is zipped.</p>
-
-				<p>This specification does not require a specific URL scheme for referencing the path to the Package
-					Document within the EPUB Container.</p>
+				<p>When an EPUB Publication is zipped, the base URL of the Package Document is obtained from the URL of
+					the <a>EPUB Container</a> together with a fragment identifier that specifies the path to Package
+					Document (relative to the <a>Root Directory</a>). This specification does not require a specific URL
+					scheme for referencing the path to the Package Document within the EPUB Container.</p>
 			</section>
 
 			<section id="sec-pkg-doc-base-dir">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -377,10 +377,8 @@
 							attributes define expressions they do not recognize. A Reading System MUST NOT fail when
 							encountering unknown expressions.</p>
 						<p>If the <code>property</code> attribute's value does not include a prefix, Reading Systems
-							MUST <a href="https://url.spec.whatwg.org/#concept-url-parser">parse</a> the value to a <a
-								href="https://url.spec.whatwg.org/#concept-url">URL</a> using the <a
-								href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
-								"<code>http://idpf.org/epub/vocab/package/meta/#</code>".</p>
+							MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to <a
+								href="#sec-property-datatype">expand the value</a>.</p>
 					</dd>
 
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
@@ -405,10 +403,9 @@
 						<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
 							layout and rendering of the EPUB Publication.</p>
 						<p>If any of the <code>rel</code> or <code>properties</code> attributes' values do not include a
-							prefix, Reading Systems MUST <a href="https://url.spec.whatwg.org/#concept-url-parser"
-								>parse</a> the unprefixed values to <a href="https://url.spec.whatwg.org/#concept-url"
-								>URLs</a> using the <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a>
-							[[URL]] "<code>http://idpf.org/epub/vocab/package/link/#</code>".</p>
+							prefix, Reading Systems MUST use the prefix URL
+								"<code>http://idpf.org/epub/vocab/package/link/#</code>" to <a
+								href="#sec-property-datatype">expand the values</a>.</p>
 					</dd>
 
 					<dt>Proprietary Metadata</dt>
@@ -457,10 +454,8 @@
 					already encountered.</p>
 
 				<p>If any of the <code>properties</code> attribute's values do not include a prefix, Reading Systems
-					MUST <a href="https://url.spec.whatwg.org/#concept-url-parser">parse</a> the unprefix values to <a
-						href="https://url.spec.whatwg.org/#concept-url">URLs</a> using the <a
-						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
-						"<code>http://idpf.org/epub/vocab/package/item/#</code>".</p>
+					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/item/#</code>" to <a
+						href="#sec-property-datatype">expand the values</a>.</p>
 			</section>
 
 			<section id="sec-pkg-doc-spine">
@@ -489,10 +484,8 @@
 					fixed-layout page to the next.</p>
 
 				<p>If any of the <code>properties</code> attribute's values do not include a prefix, Reading Systems
-					MUST <a href="https://url.spec.whatwg.org/#concept-url-parser">parse</a> the unprefixes values to <a
-						href="https://url.spec.whatwg.org/#concept-url">URLs</a> using the <a
-						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
-						"<code>http://idpf.org/epub/vocab/package/itemref/#</code>".</p>
+					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
+						href="#sec-property-datatype">expand the values</a>.</p>
 
 				<p>Reading Systems MUST ignore all metadata properties expressed in spine <code>itemref</code>
 					<code>properties</code> attribute that they do not recognize.</p>
@@ -1607,9 +1600,9 @@
 				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
 				<dd>
 					<p>Reading Systems MUST resolve all reserved prefixes used in Package Documents using their
-						predefined URIs unless the EPUB Creator declares a local <a href="#sec-prefix-attr">prefix</a>.
-						Reading Systems MUST use locally overridden prefixes in the <code>prefix</code> attribute when
-						encountered.</p>
+						predefined URLs unless the EPUB Creator declares a local <a href="#sec-prefix-attr">prefix</a>.
+						Reading Systems MUST use the URLs defined for locally overridden prefixes (using the
+							<code>prefix</code> attribute) when encountered.</p>
 					<p>As changes to the reserved prefixes and updates to Reading Systems are not always going happen in
 						synchrony, Reading Systems MUST NOT fail when encountering unrecognized prefixes (i.e., not
 						reserved and not declared using the <code>prefix</code> attribute).</p>
@@ -1619,31 +1612,30 @@
 				<dd>
 					<p>If the <code>prefix</code> attribute includes a declaration for a <a
 							href="#sec-metadata-reserved-prefixes">predefined prefix</a>, Reading Systems MUST use the
-						URI mapping defined in the <code>prefix</code> attribute, regardless of whether of it maps to
-						the same URI as the predefined prefix.</p>
+						URL mapping defined in the <code>prefix</code> attribute, regardless of whether of it maps to
+						the same URL as the predefined prefix.</p>
 				</dd>
 
-				<dt id="sec-property-datatype">The <code>property</code> Data Type</dt>
+				<dt id="sec-property-datatype">Expanding <code>property</code> Data Types</dt>
 				<dd>
-					<p>A Reading System MUST use the following rules to create a <a
-							href="https://url.spec.whatwg.org/#concept-url">URL</a> [[URL]] from a property:</p>
+					<p>Reading Systems MUST expand <code>property</code> values as follows:</p>
 					<ul>
 						<li>
-							<p>If the property consists only of a reference, obtain the URL by concatenating the base
-								URL associated with the <a href="https://www.w3.org/TR/epub-33/#sec-default-vocab"
-									>default vocabulary</a> [[EPUB-33]] to the reference.</p>
+							<p>If the property consists only of a reference, concatenate the prefix URL associated with
+								the <a href="https://www.w3.org/TR/epub-33/#sec-default-vocab">default vocabulary</a>
+								[[EPUB-33]] to the reference.</p>
 						</li>
 						<li>
-							<p>If the property consists of a prefix and reference, obtain the URL by concatenating the
-								base URL associated with the prefix to the reference. If the EPUB Creator has not
-								defined a matching prefix, the property is invalid and the Reading System MUST ignore
-								it.</p>
+							<p>If the property consists of a prefix and reference, concatenate the URL defined for the
+								prefix to the reference. If the EPUB Creator has not defined a matching prefix, and it
+								is not a <a href="#sec-reserved-prefixes">reserved prefix</a> [[EPUB-33]], the property
+								is invalid and Reading Systems MUST ignore it.</p>
 						</li>
 					</ul>
 					<p>The result MUST be a <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a>
-						[[URL]]. Reading Systems do not have to <a
-							href="https://url.spec.whatwg.org/#concept-url-parser">parse this URL</a> [[URL]] or attempt
-						to retrieve the referenced resource, however.</p>
+						[[URL]]. If the resulting URL string is not valid, Reading Systems MUST ignore the property.</p>
+					<p>Reading Systems do not have to <a href="https://url.spec.whatwg.org/#concept-url-parser">parse
+							the resulting URL</a> [[URL]] or attempt to dereference the resource.</p>
 				</dd>
 			</dl>
 		</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1627,9 +1627,13 @@
 								is not a <a href="#sec-reserved-prefixes">reserved prefix</a> [[EPUB-33]], the property
 								is invalid and Reading Systems MUST ignore it.</p>
 						</li>
+						<li>
+							<p>If the property consists only of a prefix (i.e., there is no reference after the colon),
+								the property is invalid and Reading Systems MUST ignore it.</p>
+						</li>
 					</ul>
 					<p>The result MUST be a <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a>
-						[[URL]]. If the resulting URL string is not valid, Reading Systems MUST ignore the property.</p>
+						[[URL]]. If the process results in an invalid URL, Reading Systems MUST ignore the property.</p>
 					<p>Reading Systems do not have to <a href="https://url.spec.whatwg.org/#concept-url-parser">parse
 							the resulting URL</a> [[URL]] or attempt to dereference the resource.</p>
 				</dd>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1624,8 +1624,9 @@
 						<li>
 							<p>If the property consists of a prefix and reference, concatenate the URL defined for the
 								prefix to the reference. If the EPUB Creator has not defined a matching prefix, and it
-								is not a <a href="#sec-reserved-prefixes">reserved prefix</a> [[EPUB-33]], the property
-								is invalid and Reading Systems MUST ignore it.</p>
+								is not a <a href="https://www.w3.org/TR/epub-33/#sec-reserved-prefixes">reserved
+									prefix</a> [[EPUB-33]], the property is invalid and Reading Systems MUST ignore
+								it.</p>
 						</li>
 						<li>
 							<p>If the property consists only of a prefix (i.e., there is no reference after the colon),

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1633,8 +1633,8 @@
 								matching prefix, the property is invalid and the Reading System MUST ignore it.</p>
 						</li>
 					</ul>
-					<p>The result MUST be valid a <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL
-							string</a> [[URL]]. Reading Systems do not have to resolve this URL, however.</p>
+					<p>The result MUST be a <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a>
+						[[URL]]. Reading Systems do not have to resolve this URL, however.</p>
 				</dd>
 			</dl>
 		</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -275,16 +275,20 @@
 					href="https://www.w3.org/TR/epub-33/#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
 
 			<section id="sec-pkg-doc-relative-iris">
-				<h4>Resolving Relative IRIs</h4>
+				<h4>Resolving Relative URLs</h4>
 
-				<p>To obtain an absolute IRI reference from a relative IRI reference [[RFC3987]] in the Package
-					Document, Reading Systems MUST use the Base IRI [[RFC3986]] of the Package Document.</p>
+				<p>To obtain an <a href="https://url.spec.whatwg.org/#absolute-url-with-fragment-string"
+						>absolute-URL-with-fragment string</a> [[URL]] from a <a
+						href="https://url.spec.whatwg.org/#relative-url-with-fragment-string">relative-URL-with-fragment
+						string</a> [[URL]] in the Package Document, Reading Systems MUST use the <a
+						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] of the Package
+					Document.</p>
 
-				<p>The Base IRI of the Package Document is the combination of the Base IRI of the <a>EPUB Container</a>
+				<p>The base URL of the Package Document is the combination of the base URL of the <a>EPUB Container</a>
 					together with the path to Package Document (relative to the <a>Root Directory</a>) when an EPUB
 					Publication is zipped.</p>
 
-				<p>This specification does not require a specific IRI scheme for referencing the path to the Package
+				<p>This specification does not require a specific URL scheme for referencing the path to the Package
 					Document within the EPUB Container.</p>
 			</section>
 
@@ -372,6 +376,10 @@
 						<p>Reading Systems SHOULD ignore all <code>meta</code> elements whose <code>property</code>
 							attributes define expressions they do not recognize. A Reading System MUST NOT fail when
 							encountering unknown expressions.</p>
+						<p>If the <code>property</code> attribute's value does not include a prefix, Reading Systems
+							MUST use the following <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a>
+							[[URL]] to generate the resulting URL:
+								<code>http://idpf.org/epub/vocab/package/meta/#</code></p>
 					</dd>
 
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
@@ -395,6 +403,10 @@
 							before, within or after the package metadata elements).</p>
 						<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
 							layout and rendering of the EPUB Publication.</p>
+						<p>If any of the <code>rel</code> or <code>properties</code> attributes' values do not include a
+							prefix, Reading Systems MUST use the following <a
+								href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] to generate
+							the resulting URL: <code>http://idpf.org/epub/vocab/package/link/#</code></p>
 					</dd>
 
 					<dt>Proprietary Metadata</dt>
@@ -409,8 +421,11 @@
 			<section id="sec-pkg-doc-manifest">
 				<h3>Manifest</h3>
 
-				<p>When an <code>href</code> attribute contains a relative IRI, Reading Systems MUST use the IRI of the
-					Package Document as the base when resolving to an absolute IRI.</p>
+				<p>When an <code>href</code> attribute contains a <a
+						href="https://url.spec.whatwg.org/#relative-url-string">relative-URL string</a> [[URL]], Reading
+					Systems MUST use the URL of the Package Document as the <a
+						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] when resolving to an
+						<a href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL string</a> [[URL]].</p>
 
 				<p>Reading Systems MAY optimize the rendering depending on the properties set in the
 						<code>properties</code> attribute (e.g., disable a rendering process or use a fallback). Reading
@@ -437,6 +452,10 @@
 
 				<p>Reading Systems MUST terminate the fallback chain at the first reference to a manifest item it has
 					already encountered.</p>
+
+				<p>If any of the <code>property</code> attribute's values do not include a prefix, Reading Systems MUST
+					use the following <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] to
+					generate the resulting URL: <code>http://idpf.org/epub/vocab/package/item/#</code></p>
 			</section>
 
 			<section id="sec-pkg-doc-spine">
@@ -463,6 +482,10 @@
 							><code>pre-paginated</code></a> XHTML Content Documents. The
 						<code>page-progression-direction</code> attribute defines the flow direction from one
 					fixed-layout page to the next.</p>
+
+				<p>If any of the spine <code>itemref</code> attribute's values do not include a prefix, Reading Systems
+					MUST use the following <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
+					to generate the resulting URL: <code>http://idpf.org/epub/vocab/package/itemref/#</code></p>
 
 				<p>Reading Systems MUST ignore all metadata properties expressed in spine <code>itemref</code>
 					<code>properties</code> attribute that they do not recognize.</p>
@@ -1084,21 +1107,24 @@
 				<h3>OCF Abstract Container</h3>
 
 				<section id="sec-container-iri">
-					<h4>Relative IRIs for Referencing Other Components</h4>
+					<h4>Relative URLs for Referencing Other Components</h4>
 
-					<p>For relative IRI references, Reading Systems MUST determine the Base IRI [[RFC3986]] according to
-						the relevant language specifications for the given file formats. For example, CSS defines how
+					<p>For <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+							>relative-URL-with-fragment strings</a> [[URL]], Reading Systems MUST determine the <a
+							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] according to the
+						relevant language specifications for the given file formats. For example, CSS defines how
 						relative IRI references work in the context of CSS style sheets and property declarations
 						[[CSSSnapshot]].</p>
 
 					<div class="note">
-						<p>Some language specifications reference Requests For Comments that preceded [[RFC3987]], in
-							which case the earlier RFC applies for content in that particular language.</p>
+						<p>Some language specifications reference <a href="https://tools.ietf.org/rfc/index">Requests
+								For Comments</a> that preceded [[URL]], in which case the earlier RFC applies for
+							content in that particular language.</p>
 					</div>
 
 					<p>Unlike most language specifications, Reading Systems MUST use the <a>Root Directory</a> of the
-						OCF Abstract Container as the default Base IRI as the Base IRI for all files within the
-							<code>META-INF</code> directory.</p>
+						OCF Abstract Container as the <a href="https://url.spec.whatwg.org/#concept-base-url">base
+							URL</a> [[URL]] for all files within the <code>META-INF</code> directory.</p>
 				</section>
 
 				<section id="sec-container-filenames">
@@ -1334,7 +1360,8 @@
 					<p>The <code>active-class</code> and <code>playback-active-class</code> metadata properties are
 						OPTIONAL, and if omitted, Reading System behavior is implementation-specific.</p>
 
-					<p>Reading System behavior when a <a href="#sec-media-overlays-fragids">fragment identifier</a>
+					<p>Reading System behavior when a <a
+							href="https://www.w3.org/TR/epub-33/#sec-media-overlays-fragids">fragment identifier</a>
 						[[EPUB-33]] does not reference an element is also implementation-specific.</p>
 				</section>
 			</section>
@@ -1591,22 +1618,23 @@
 
 				<dt id="sec-property-datatype">The <code>property</code> Data Type</dt>
 				<dd>
-					<p>A Reading System MUST use the following rules to create an IRI [[RFC3987]] from a property:</p>
+					<p>A Reading System MUST use the following rules to create a URL [[URL]] from a property:</p>
 					<ul>
 						<li>
-							<p>If the property consists only of a reference, obtain the IRI by concatenating the IRI
-								stem associated with the <a href="https://www.w3.org/TR/epub-33/#sec-default-vocab"
-									>default vocabulary</a> [[EPUB-33]] to the reference.</p>
+							<p>If the property consists only of a reference, obtain the URL by concatenating the <a
+									href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] associated
+								with the <a href="https://www.w3.org/TR/epub-33/#sec-default-vocab">default
+									vocabulary</a> [[EPUB-33]] to the reference.</p>
 						</li>
 						<li>
-							<p>If the property consists of a prefix and reference, obtain the IRI by concatenating the
-								IRI stem associated with the prefix to the reference. If the EPUB Creator has not
-								defined a matching prefix, the property is invalid and the Reading System MUST ignore
-								it.</p>
+							<p>If the property consists of a prefix and reference, obtain the URL by concatenating the
+									<a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
+								associated with the prefix to the reference. If the EPUB Creator has not defined a
+								matching prefix, the property is invalid and the Reading System MUST ignore it.</p>
 						</li>
 					</ul>
-					<p>The resulting IRI MUST be valid to [[RFC3987]]. Reading Systems do not have to resolve this IRI,
-						however.</p>
+					<p>The result MUST be valid a <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL
+							string</a> [[URL]]. Reading Systems do not have to resolve this IRI, however.</p>
 				</dd>
 			</dl>
 		</section>
@@ -2146,7 +2174,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<h3>Substantive Changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
 					3.2</a></h3>
 				<ul>
-					<li>01-Apr-2021: Added section clarifying how absolute IRIs are created from relative in the Package
+					<li>01-Apr-2021: Added section clarifying how absolute URLs are created from relative in the Package
 						Document. See <a href="https://github.com/w3c/epub-specs/pull/1468">pull request 1468</a>.</li>
 					<li>30-Mar-2021: Restructured the document to remove the rendundant conformance sections and
 						requirements that were only used as locators when this specification was combined with the

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2145,6 +2145,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>12-May-2021: Added additional requirement that Reading Systems ignore property values that
+						expand to invalid URL strings and property values with empty references. See <a
+							href="https://github.com/w3c/epub-specs/issues/1673">issue 1673</a>.</li>
+					<li>12-May-2021: Changed all references to URIs/IRIs to URLs and references to RFCs 3986 and 3987 to
+						the URL standard. See <a href="https://github.com/w3c/epub-specs/issues/808">issue 808</a>.</li>
 					<li>06-May-2021: Recommend that Reading Systems support references to HTML target elements and SVG
 						fragment identifiers in <code>textref</code> attributes and the <code>text</code> element's
 							<code>src</code> attribute. Support for other fragment identifier schemes is optional. See


### PR DESCRIPTION
I've updated the authoring and reading system specifications to use the URL standard terminology.

There are a number of changes in this PR, but they basically all break down along these lines:

- relative IRI has become "relative-URL string" where it doesn't seem to make sense to allow fragment identifiers (manifest item and media overlays audio src)
- relative IRI has become "relative-URL-with-fragment string" for all other cases
- same changes as above for absolute IRIs
- where we hadn't broken our relative from absolute, I went with "valid URL string"
- base IRI has become base URL

The one tough case was in ocf, where the rootfile and link elements required the IRI be "a path component [RFC3986] which MUST take the form of a path-rootless [RFC3986] only". My best interpretation of this is that it is the equivalent of the URL standard's "path-relative-scheme-less-URL string".

I've also used this definition for the property datatype definition to replace irelative-ref in the ebnf.

Please let me know if you think I've made a mistake with any of these.

Otherwise, I've moved a few more passively expressed reading system requirements over to the proper document. These were all related to creating URLs from the default vocabulary base URLs. Reading systems are the ones that create these expanded URLs.

Fixes #808 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-808/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-808/epub33/rs/index.html)

EDIT: Also fixes #1673 by adding requirement for reading systems to ignore properties that expand to invalid URL strings and also prefixes without a referent.

EDIT 2: Also fixes #1303 by restricting manifest items to fragment-less URLs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1670.html" title="Last updated on May 14, 2021, 12:12 PM UTC (039d181)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1670/0f951c6...039d181.html" title="Last updated on May 14, 2021, 12:12 PM UTC (039d181)">Diff</a>