### PR TITLE
remove requirement that reading systems are conforming xml:base processors

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -218,9 +218,6 @@
 								href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#ProcessorConformance"
 								>conformant processor</a> as defined in [[XML-NAMES]].</p>
 					</li>
-					<li>
-						<p id="confreq-rs-xml-base">a conformant application as defined by [[XMLBase]].</p>
-					</li>
 				</ul>
 
 				<p id="confreq-rs-xml-extid">In addition, when processing XML documents, it MUST NOT resolve <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2140,6 +2140,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<h3>Substantive Changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
 					3.2</a></h3>
 				<ul>
+					<li>20-May-2021: Removed requirement for reading systems to be conformant 
+					xml:base processors. See <a href="https://github.com/w3c/epub-specs/pull/1678">pull request 1678</a>.</li>
 					<li>01-Apr-2021: Added section clarifying how absolute IRIs are created from relative in the Package
 						Document. See <a href="https://github.com/w3c/epub-specs/pull/1468">pull request 1468</a>.</li>
 					<li>30-Mar-2021: Restructured the document to remove the rendundant conformance sections and


### PR DESCRIPTION
Fix for #1456 