### PR TITLE
Add epub-added features to privacy and security section

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7823,9 +7823,10 @@ html.my-document-playing * {
 
 			<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
 				representing, packaging, and encoding structured and semantically enhanced Web content — including HTML,
-				CSS, SVG, and other resources — for distribution in a single-file container. This specification does not
-					<em>add</em> any new features, APIs, etc. This also means that, essentially, the security and
-				privacy issues are reliant on the features of those formats. In particular:</p>
+				CSS, SVG, JavaScript, and other resources — for distribution in a single-file container.</p>
+
+			<p>This means that, essentially, the security and privacy issues are reliant on the features of those
+				formats. In particular:</p>
 
 			<ul>
 				<li>EPUB 3 allows references to remotely hosted resources from within <a>EPUB Content Documents</a>, but
@@ -7838,10 +7839,30 @@ html.my-document-playing * {
 					could expose unexpected information if explicit author approval of metadata is not required.</li>
 			</ul>
 
-			<div class="ednote">
-				<p>The Working Group will have to address the particularity of cross-origin by addressing the question
-					of what the "origin" is for an EPUB Publication.</p>
-			</div>
+			<p>In general, EPUB 3 tries to avoid extending the underlying technologies it builds on, but it has
+				introduced some new features. These additions are not known to present any new privacy or security
+				issues:</p>
+
+			<ul>
+				<li>
+					<p><a href="#sec-xhtml-content-switch">Content switching</a> and <a href="#sec-xhtml-epub-trigger"
+							>multimedia control elements</a> (both now deprecated) only allow hiding of content and
+						script-less control of playback in HTML.</p>
+				</li>
+				<li>
+					<p>The <a href="#sec-epub-type-attribute">expression of structural semantics</a> in HTML and SVG
+						only allows the annotation of elements.</p>
+				</li>
+				<li>
+					<p>A <a href="#sec-xhtml-ssml-attrib">reformulation of SSML</a> as HTML attributes only allows the
+						expression of phonemes and pronunciation alphabets.</p>
+				</li>
+				<li>
+					<p>The <a href="https://www.w3.org/TR/epub-rs-33/#app-epubReadingSystem"
+								><code>epubReadingSystem</code> object</a> [[EPUB-RS-33]] only allows EPUB Creators to
+						query information about the current Reading System.</p>
+				</li>
+			</ul>
 		</section>
 		<section id="app-overview-unsupported" class="appendix">
 			<h2>Unsupported Features</h2>


### PR DESCRIPTION
Implements the prose in https://github.com/w3c/epub-specs/issues/1674#issue-889960154 to explain that these do not add any known issues.

Also removes the ed. note about having to figure out origin, as I assume we've got that covered now.

Fixes #1674


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1679.html" title="Last updated on May 22, 2021, 10:23 PM UTC (6ba4db2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1679/d957223...6ba4db2.html" title="Last updated on May 22, 2021, 10:23 PM UTC (6ba4db2)">Diff</a>