### PR TITLE
File names: normalization followed by case folding

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5516,8 +5516,8 @@ Spine:
 							</ul>
 						</li>
 						<li>
-							<p id="ocf-fn-cn">All File Names within the same directory MUST be unique following full
-								case folding [[Unicode]] and NFC normalization [[TR15]]. (Refer to <a
+							<p id="ocf-fn-cn">All File Names within the same directory MUST be unique following 
+								NFC normalization [[TR15]] and then case folding [[Unicode]]. (Refer to <a
 									href="https://www.w3.org/TR/charmod-norm/#CanonicalFoldNormalizationStep">Unicode
 									Canonical Case Fold Normalization Step</a> [[?CHARMOD-NORM]] for more
 								information.)</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5517,7 +5517,7 @@ Spine:
 						</li>
 						<li>
 							<p id="ocf-fn-cn">All File Names within the same directory MUST be unique following 
-								NFC normalization [[TR15]] and then case folding [[Unicode]]. (Refer to <a
+								NFC normalization [[TR15]] and then full case folding [[Unicode]]. (Refer to <a
 									href="https://www.w3.org/TR/charmod-norm/#CanonicalFoldNormalizationStep">Unicode
 									Canonical Case Fold Normalization Step</a> [[?CHARMOD-NORM]] for more
 								information.)</p>


### PR DESCRIPTION
This is to answer https://github.com/w3c/epub-specs/pull/1648#issuecomment-846389747.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1680.html" title="Last updated on May 24, 2021, 8:19 AM UTC (fa63575)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1680/d957223...fa63575.html" title="Last updated on May 24, 2021, 8:19 AM UTC (fa63575)">Diff</a>