### PR TITLE
Update guidance around roles and epub:type

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -756,7 +756,7 @@
 						these requirements. For complete details, refer to <a href="https://www.w3.org/TR/html-aria/"
 							>ARIA in HTML</a> [[HTML-ARIA]].</p>
 
-					<p>EPUB Creators only have to use ARIA roles for interactive controls per <a
+					<p>EPUB Creators only have to use ARIA roles for user interface components per <a
 							href="https://www.w3.org/TR/WCAG/#name-role-value">success criterion 4.1.2</a> (i.e., they
 						are not required to add roles to landmarks and other document structures to conform).</p>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1549,7 +1549,11 @@
 						- move all changes down to the next section
 				-->
 
-				<ul> </ul>
+				<ul>
+					<li>25-May-2021: Updated the section on ARIA roles to make clear that the <code>epub:type</code>
+						attribute does not have to be used in coordination, nor that roles are required where
+							<code>epub:type</code> is used.</li>
+				</ul>
 			</section>
 
 			<section id="changes-older">

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -729,13 +729,15 @@
 				<h3>Semantics</h3>
 
 				<section class="suppress-numbering" id="sem-001">
-					<h4>SEM-001: Include ARIA and EPUB semantics</h4>
+					<h4>SEM-001: Use ARIA roles in content</h4>
 
 					<p>The [[WAI-ARIA-1.1]] <a href="https://www.w3.org/TR/wai-aria-1.1/#roles"><code>role</code>
-							attribute</a> is used to provide additional semantic information about the host markup to
-						Assistive Technologies. The use of roles allows Assistive Technologies to automatically scan the
-						markup and compile a list of <a href="#sem-003">landmarks</a> for users, enabling quick access
-						to key features of the content. EPUB Creators can attach this attribute to any element.</p>
+							attribute</a> describes the purpose of an element so that Assistive Technologies can present
+						it to users as they are expected to interact with it. For example, the use of roles allows
+						Assistive Technologies to present custom form controls to users (e.g., so that a
+							<code>div</code> element scripted to function like a button is accessible as a button to
+						Assistive Technology users). Roles also allow Assistive Technologies to compile a list of <a
+							href="#sem-003">landmarks</a> in a page, enabling quick access to key features.</p>
 
 					<aside class="example">
 						<p>The following example shows a generic landmark role. The name to use for this landmark is
@@ -748,39 +750,48 @@
 &lt;/section&gt;</pre>
 					</aside>
 
-					<p>The <code>role</code> attribute is similar in nature to the <a
-							href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
-						><code>type</code> attribute</a> [[EPUB-3]], which provides additional semantic information to
-						enable EPUB Reading System behaviors.</p>
+					<p>Although EPUB Creators can attach the <code>role</code> attribute to any element, there are
+						strict rules on which roles are allowed on which elements. As the improper use of roles can
+						break content, or make it less accessible, it is important that EPUB Creators always follow
+						these requirements. For complete details, refer to <a href="https://www.w3.org/TR/html-aria/"
+							>ARIA in HTML</a> [[HTML-ARIA]].</p>
 
-					<aside class="example">
-						<p>The following example shows the <code>epub:type</code> attribute used to provide additional
-							semantic information.</p>
-						<pre>&lt;section epub:type="learning-objectives"&gt;
-   &lt;h2&gt;Objectives&lt;h2&gt;
-   …
-&lt;/section&gt;</pre>
-					</aside>
+					<p>EPUB Creators only have to use ARIA roles for interactive controls per <a
+							href="https://www.w3.org/TR/WCAG/#name-role-value">success criterion 4.1.2</a> (i.e., they
+						are not required to add roles to landmarks and other document structures to conform).</p>
 
-					<p>The key difference between these attributes is that the <code>role</code> attribute bridges
-						accessibility while the <code>type</code> attribute provides hooks to enable Reading System
-						behaviors. Omitting roles lessens the accessibility for users of Assistive Technologies, in
-						other words, while omitting types diminishes certain functionality in Reading Systems (e.g.,
-						pop-up footnotes or special presentations of the content).</p>
+					<section id="sem-001-epub-type">
+						<h5>Note on <code>epub:type</code></h5>
 
-					<p>Since each attribute offers different advantages, it is recommended that both be used whenever
-						applicable to provide the best reading experience for all readers.</p>
+						<div class="note">
+							<p>The following guidance is only for EPUB Content Documents. The <code>type</code>
+								attribute is the only means of adding structural information to Media Overlay Documents
+								so that features like lists and tables can be navigated more efficiently. It is also
+								required in the EPUB Navigation Document to identify key structures.</p>
+						</div>
 
-					<p>It is often the case that the attributes will have corresponding semantics. In these situations,
-						it is recommended that both attributes be attached to an element.</p>
+						<p>Although the <code>role</code> attribute may seem similar in nature to the <a
+								href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
+								><code>type</code> attribute</a> [[EPUB-3]], their target uses in EPUB Content Documents
+							do not overlap.</p>
 
-					<aside class="example">
-						<p>The following example shows a footnote identified in both the <code>epub:type</code> and
-								<code>role</code> attributes.</p>
-						<pre>&lt;aside epub:type="footnote" role="doc-footnote"&gt;
-   …
-&lt;/aside&gt;</pre>
-					</aside>
+						<p>The key difference between these attributes is that the <code>role</code> attribute bridges
+							accessibility in content while the <code>type</code> attribute provides hooks to enable
+							Reading System behaviors. Omitting roles lessens the accessibility for users of Assistive
+							Technologies, in other words, while omitting types diminishes certain functionality in
+							Reading Systems (e.g., pop-up footnotes or special presentations of the content).</p>
+
+						<p>Since each attribute offers different advantages, it is not necessary that they be used
+							together. Due to the lack of restrictions on where EPUB Creators can use the
+								<code>type</code> attribute, pairing the attributes may cause accessibility issues
+							(e.g., putting roles on the [[HTML]] <code>body</code> element).</p>
+
+						<p>For EPUB Creators looking to move from the <code>type</code> attribute to using ARIA roles,
+							the <a href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA Role
+								Authoring Guide</a> guide details notable authoring differences between the two
+							attributes. It also includes a mapping table of semantics in the EPUB Structural Semantics
+							Vocabulary to equivalent ARIA roles in [[DPUB-ARIA-1.0]] and [[WAI-ARIA-1.1]].</p>
+					</section>
 
 					<section class="suppress-numbering" id="sec-sem-001-res">
 						<h5>Helpful Resources</h5>
@@ -795,21 +806,8 @@
 										<code>role</code> attribute.</p>
 							</li>
 							<li>
-								<p>The EPUB Structural Semantics Vocabulary [[EPUB-SSV]] provides the default values
-									that can be used with the <code>type</code> attribute, but the attribute is
-									extensible to allow semantics from other vocabularies.</p>
-							</li>
-						</ul>
-
-						<p>The following documents explain the application of ARIA roles for EPUB Creators already
-							familiar with the use of the EPUB 3 <code>type</code> attribute for semantic inflection:</p>
-
-						<ul>
-							<li>
-								<p><a href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA
-										Role Authoring Guide</a> — guide to notable authoring differences between the
-									two attributes plus a mapping table of semantics in the EPUB Structural Semantics
-									Vocabulary to equivalent ARIA roles in [[DPUB-ARIA-1.0]] and [[WAI-ARIA-1.1]].</p>
+								<p>The ARIA in HTML [[HTML-ARIA]] specification details which roles are allowed on which
+									HTML elements.</p>
 							</li>
 						</ul>
 					</section>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -729,88 +729,39 @@
 				<h3>Semantics</h3>
 
 				<section class="suppress-numbering" id="sem-001">
-					<h4>SEM-001: Use ARIA roles in content</h4>
+					<h4>SEM-001: ARIA roles and <code>epub:type</code></h4>
 
-					<p>The [[WAI-ARIA-1.1]] <a href="https://www.w3.org/TR/wai-aria-1.1/#roles"><code>role</code>
-							attribute</a> describes the purpose of an element so that Assistive Technologies can present
-						it to users as they are expected to interact with it. For example, the use of roles allows
-						Assistive Technologies to present custom form controls to users (e.g., so that a
-							<code>div</code> element scripted to function like a button is accessible as a button to
-						Assistive Technology users). Roles also allow Assistive Technologies to compile a list of <a
-							href="#sem-003">landmarks</a> in a page, enabling quick access to key features.</p>
+					<div class="note">
+						<p>The following guidance is only for EPUB Content Documents. The <code>type</code> attribute is
+							the only means of adding structural information to Media Overlay Documents so that features
+							like lists and tables can be navigated more efficiently. It is also required in the EPUB
+							Navigation Document to identify key structures.</p>
+					</div>
 
-					<aside class="example">
-						<p>The following example shows a generic landmark role. The name to use for this landmark is
-							specified by the [[WAI-ARIA-1.1]] <a
-								href="https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby"
-								><code>aria-labelledby</code> attribute</a>.</p>
-						<pre>&lt;section role="region" aria-labelledby="puz01"&gt;
-   &lt;h2 id="puz01"&gt;Puzzles and Games&lt;h2&gt;
-   …
-&lt;/section&gt;</pre>
-					</aside>
+					<p>Although the <code>role</code> attribute may seem similar in nature to the <a
+							href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
+						><code>type</code> attribute</a> [[EPUB-3]], their target uses in EPUB Content Documents do not
+						overlap.</p>
 
-					<p>Although EPUB Creators can attach the <code>role</code> attribute to any element, there are
-						strict rules on which roles are allowed on which elements. As the improper use of roles can
-						break content, or make it less accessible, it is important that EPUB Creators always follow
-						these requirements. For complete details, refer to <a href="https://www.w3.org/TR/html-aria/"
-							>ARIA in HTML</a> [[HTML-ARIA]].</p>
+					<p>The key difference between these attributes is that the <code>role</code> attribute bridges
+						accessibility in content while the <code>type</code> attribute provides hooks to enable Reading
+						System behaviors. Omitting roles lessens the accessibility for users of Assistive Technologies,
+						in other words, while omitting types diminishes certain functionality in Reading Systems (e.g.,
+						pop-up footnotes or special presentations of the content).</p>
 
-					<p>EPUB Creators only have to use ARIA roles for user interface components per <a
-							href="https://www.w3.org/TR/WCAG/#name-role-value">success criterion 4.1.2</a> (i.e., they
-						are not required to add roles to landmarks and other document structures to conform).</p>
+					<p>Since each attribute offers different advantages, it is not necessary that they be used together.
+						Due to the lack of restrictions on where EPUB Creators can use the <code>type</code> attribute,
+						pairing the attributes may cause accessibility issues (e.g., putting roles on the [[HTML]]
+							<code>body</code> element).</p>
 
-					<section id="sem-001-epub-type">
-						<h5>Note on <code>epub:type</code></h5>
+					<p>In particular, the use of the <code>type</code> attribute is not a means of satisyfing
+						requirements for ARIA roles in WCAG.</p>
 
-						<div class="note">
-							<p>The following guidance is only for EPUB Content Documents. The <code>type</code>
-								attribute is the only means of adding structural information to Media Overlay Documents
-								so that features like lists and tables can be navigated more efficiently. It is also
-								required in the EPUB Navigation Document to identify key structures.</p>
-						</div>
-
-						<p>Although the <code>role</code> attribute may seem similar in nature to the <a
-								href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
-								><code>type</code> attribute</a> [[EPUB-3]], their target uses in EPUB Content Documents
-							do not overlap.</p>
-
-						<p>The key difference between these attributes is that the <code>role</code> attribute bridges
-							accessibility in content while the <code>type</code> attribute provides hooks to enable
-							Reading System behaviors. Omitting roles lessens the accessibility for users of Assistive
-							Technologies, in other words, while omitting types diminishes certain functionality in
-							Reading Systems (e.g., pop-up footnotes or special presentations of the content).</p>
-
-						<p>Since each attribute offers different advantages, it is not necessary that they be used
-							together. Due to the lack of restrictions on where EPUB Creators can use the
-								<code>type</code> attribute, pairing the attributes may cause accessibility issues
-							(e.g., putting roles on the [[HTML]] <code>body</code> element).</p>
-
-						<p>For EPUB Creators looking to move from the <code>type</code> attribute to using ARIA roles,
-							the <a href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA Role
-								Authoring Guide</a> guide details notable authoring differences between the two
-							attributes. It also includes a mapping table of semantics in the EPUB Structural Semantics
-							Vocabulary to equivalent ARIA roles in [[DPUB-ARIA-1.0]] and [[WAI-ARIA-1.1]].</p>
-					</section>
-
-					<section class="suppress-numbering" id="sec-sem-001-res">
-						<h5>Helpful Resources</h5>
-
-						<p>The following documents list the semantics that are available for use with each
-							attribute:</p>
-
-						<ul>
-							<li>
-								<p>The Digital Publishing WAI-ARIA Module [[DPUB-ARIA-1.0]] provides a set of core
-									publishing roles, but any roles from [[WAI-ARIA-1.1]] can be used in the
-										<code>role</code> attribute.</p>
-							</li>
-							<li>
-								<p>The ARIA in HTML [[HTML-ARIA]] specification details which roles are allowed on which
-									HTML elements.</p>
-							</li>
-						</ul>
-					</section>
+					<p>For EPUB Creators looking to move from the <code>type</code> attribute to using ARIA roles, the
+							<a href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA Role
+							Authoring Guide</a> guide details notable authoring differences between the two attributes.
+						It also includes a mapping table of semantics in the EPUB Structural Semantics Vocabulary to
+						equivalent ARIA roles in [[DPUB-ARIA-1.0]] and [[WAI-ARIA-1.1]].</p>
 				</section>
 
 				<section class="suppress-numbering" id="sem-002">


### PR DESCRIPTION
This PR tries to better match the SEM-001 technique to what we now recommend and validate - namely that role and epub:type do not have to appear together.

I've made the section focus on the use of ARIA role and noted that roles are only a requirement for user interface components.

The epub:type explanation is now in a separate subsection.

Suggestions on how to improve the text welcome.

- Techniques [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/a11y-epub-type/epub33/a11y-tech/index.html)
- Techniques [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/main/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/a11y-epub-type/epub33/a11y-tech/index.html)
