### PR TITLE
Simplify MathML language

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -599,18 +599,18 @@
 
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-mathml-rs-behavior">MUST be an input-compliant renderer for <a
+								<p id="confreq-mathml-rs-behavior">MUST process <a
 										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
 									defined in the [[MATHML3]] specification.</p>
+							</li>
+							<li>
+								<p id="confreq-mathml-rs-render">MUST, if it has a <a>Viewport</a>, support visual
+									rendering of Presentation MathML.</p>
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
 										href="https://www.w3.org/TR/MathML3/chapter4.html">Content MathML</a> found in
 										<code>annotation-xml</code> elements.</p>
-							</li>
-							<li>
-								<p id="confreq-mathml-rs-render">MUST, if it has a <a>Viewport</a>, support visual
-									rendering of Presentation MathML.</p>
 							</li>
 						</ul>
 						<p class="note">Reading Systems may choose to use third-party libraries such as MathJax to

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -599,9 +599,10 @@
 
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-mathml-rs-behavior">MUST process <a
-										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
-									defined in the [[MATHML3]] specification.</p>
+								<p id="confreq-mathml-rs-behavior">MUST be an <a
+										href="https://www.w3.org/TR/MathML3/chapter7.html#sec7.2.1">input-compliant
+									processor</a> for <a href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation
+									MathML</a>, as defined in the [[MATHML3]] specification.</p>
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-render">MUST, if it has a <a>Viewport</a>, support visual


### PR DESCRIPTION
Simplifies MathML language to avoid confusion over what "input-compliant" means, or "render" in the context of a non-visual reading system. This makes the MathML section more consistent with the SVG and CSS sections, which say:
* MUST process SVG embedded in XHTML Content Documents as defined in § 4.2 SVG Content Documents.
* MUST support the official definition of CSS as described in the [CSSSnapshot].

This also moves Presentation MathML rendering up one bullet to keep both Presentation MathML requirements together and help clarify that rendering only applies to visual RSes.