### PR TITLE
Add data-tests attributes for some existing tests as well as ReSpec test config

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -73,7 +73,11 @@
                 },
                 localBiblio: biblio,
                 preProcess:[inlineCustomCSS],
-                postProcess:[addConformanceLinks, addCautionHeaders]
+                postProcess:[addConformanceLinks, addCautionHeaders],
+				testSuiteURI: "https://github.com/w3c/epub-tests/tree/HEAD/tests/EPUBs/",
+				lint: {
+					"wpt-tests-exist": true,
+				}
             };//]]>
       </script>
 	</head>
@@ -719,28 +723,28 @@
 									<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
 								</tr>
 								<tr>
-									<td id="cmt-gif" data-test="cmt-gif">
+									<td id="cmt-gif" data-tests="cmt-gif.epub">
 										<code>image/gif</code>
 									</td>
 									<td> [[GIF]] </td>
 									<td>GIF Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-jpeg" data-test="cmt-jpeg">
+									<td id="cmt-jpeg" data-tests="cmt-jpeg.epub">
 										<code>image/jpeg</code>
 									</td>
 									<td> [[JPEG]] </td>
 									<td>JPEG Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-png" data-test="cmt-png">
+									<td id="cmt-png" data-tests="cmt-png.epub">
 										<code>image/png</code>
 									</td>
 									<td> [[PNG]] </td>
 									<td>PNG Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-svg" data-test="cmt-svg,confreq-rs-epub3-svg">
+									<td id="cmt-svg" data-tests="cmt-svg,confreq-rs-epub3-svg.epub">
 										<code>image/svg+xml</code>
 									</td>
 									<td>
@@ -749,7 +753,7 @@
 									<td>SVG documents</td>
 								</tr>
 								<tr>
-									<td id="cmt-webp" data-test="cmt-webp">
+									<td id="cmt-webp" data-tests="cmt-webp.epub">
 										<code>image/webp</code>
 									</td>
 									<td> [[WebP-Container]], [[WebP-LB]] </td>
@@ -760,21 +764,21 @@
 									<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>
 								</tr>
 								<tr>
-									<td id="cmt-mp3" data-test="cmt-mp3">
+									<td id="cmt-mp3" data-tests="cmt-mp3.epub">
 										<code>audio/mpeg</code>
 									</td>
 									<td> [[MP3]] </td>
 									<td>MP3 audio</td>
 								</tr>
 								<tr>
-									<td id="cmt-mp4-aac" data-test="cmt-mp4-aac">
+									<td id="cmt-mp4-aac" data-tests="cmt-mp4-aac.epub">
 										<code>audio/mp4</code>
 									</td>
 									<td> [[MPEG4-Audio]], [[MP4]] </td>
 									<td>AAC LC audio using MP4 container</td>
 								</tr>
 								<tr>
-									<td id="cmt-ogg-opus" data-test="cmt-ogg-opus">
+									<td id="cmt-ogg-opus" data-tests="cmt-ogg-opus.epub">
 										<code>audio/opus</code>
 									</td>
 									<td>[[RFC7845]]</td>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -719,28 +719,28 @@
 									<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
 								</tr>
 								<tr>
-									<td id="cmt-gif">
+									<td id="cmt-gif" data-test="cmt-gif">
 										<code>image/gif</code>
 									</td>
 									<td> [[GIF]] </td>
 									<td>GIF Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-jpeg">
+									<td id="cmt-jpeg" data-test="cmt-jpeg">
 										<code>image/jpeg</code>
 									</td>
 									<td> [[JPEG]] </td>
 									<td>JPEG Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-png">
+									<td id="cmt-png" data-test="cmt-png">
 										<code>image/png</code>
 									</td>
 									<td> [[PNG]] </td>
 									<td>PNG Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-svg">
+									<td id="cmt-svg" data-test="cmt-svg,confreq-rs-epub3-svg">
 										<code>image/svg+xml</code>
 									</td>
 									<td>
@@ -749,7 +749,7 @@
 									<td>SVG documents</td>
 								</tr>
 								<tr>
-									<td id="cmt-webp">
+									<td id="cmt-webp" data-test="cmt-webp">
 										<code>image/webp</code>
 									</td>
 									<td> [[WebP-Container]], [[WebP-LB]] </td>
@@ -760,21 +760,21 @@
 									<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>
 								</tr>
 								<tr>
-									<td id="cmt-mp3">
+									<td id="cmt-mp3" data-test="cmt-mp3">
 										<code>audio/mpeg</code>
 									</td>
 									<td> [[MP3]] </td>
 									<td>MP3 audio</td>
 								</tr>
 								<tr>
-									<td id="cmt-mp4-aac">
+									<td id="cmt-mp4-aac" data-test="cmt-mp4-aac">
 										<code>audio/mp4</code>
 									</td>
 									<td> [[MPEG4-Audio]], [[MP4]] </td>
 									<td>AAC LC audio using MP4 container</td>
 								</tr>
 								<tr>
-									<td id="cmt-ogg-opus">
+									<td id="cmt-ogg-opus" data-test="cmt-ogg-opus">
 										<code>audio/opus</code>
 									</td>
 									<td>[[RFC7845]]</td>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -74,10 +74,10 @@
                 localBiblio: biblio,
                 preProcess:[inlineCustomCSS],
                 postProcess:[addConformanceLinks, addCautionHeaders],
-				testSuiteURI: "https://github.com/w3c/epub-tests/tree/HEAD/tests/EPUBs/",
-				lint: {
-					"wpt-tests-exist": true,
-				}
+                testSuiteURI: "https://github.com/w3c/epub-tests/tree/HEAD/tests/EPUBs/",
+                lint: {
+                     "wpt-tests-exist": true,
+		}
             };//]]>
       </script>
 	</head>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -187,13 +187,15 @@
 			<section id="sec-epub-rs-conf-cmt">
 				<h4>Core Media Types</h4>
 
-				<p id="confreq-rs-epub3-images">If a Reading System has a <a>Viewport</a>, it MUST support the <a
+				<p id="confreq-rs-epub3-images" data-test="cmt-gif,cmt-jpg,cmt-png,cmt-svg,cmt-webp">If a Reading System has
+					a <a>Viewport</a>, it MUST support the <a
 						href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type Resources</a>
 					[[EPUB-33]].</p>
 
-				<p id="confreq-rs-epub3-mp3-aac">If it has the capability to render pre-recorded audio, it MUST support
-					the <a href="https://www.w3.org/TR/epub-33/#cmt-grp-audio">audio Core Media Type Resources</a>
-					[[EPUB-33]] and SHOULD support Media Overlays [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-mp3-aac" data-test="cmt-mp3,cmt-mp4-aac,cmt-ogg-opus">If it has the capability to
+					render pre-recorded audio, it MUST support the <a
+					href="https://www.w3.org/TR/epub-33/#cmt-grp-audio">audio Core Media Type Resources</a> [[EPUB-33]] and
+					SHOULD support Media Overlays [[EPUB-33]].</p>
 
 				<p class="note" id="note-video-codecs">It is recommended that Reading Systems support at least one of
 					the H.264 [[H264]] and VP8 [[RFC6386]] video codecs, but this is not a conformance requirement
@@ -503,8 +505,8 @@
 			<section id="sec-xhtml">
 				<h3>XHTML Content Documents</h3>
 
-				<p id="confreq-rs-epub3-xhtml" class="support">Reading Systems MUST process <a
-						href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a> [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-xhtml" class="support" data-test="confreq-rs-epub3-xhtml">Reading Systems MUST
+					process <a href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a> [[EPUB-33]].</p>
 
 				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, Reading
 					Systems MUST process XHTML Content Documents using semantics defined by the [[HTML]] specification
@@ -599,7 +601,8 @@
 
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-mathml-rs-behavior">MUST be an input-compliant renderer for <a
+								<p id="confreq-mathml-rs-behavior" data-test="confreq-mathml-rs-behavior">MUST be an
+									input-compliant renderer for <a
 										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
 									defined in the [[MATHML3]] specification.</p>
 							</li>
@@ -609,8 +612,8 @@
 										<code>annotation-xml</code> elements.</p>
 							</li>
 							<li>
-								<p id="confreq-mathml-rs-render">MUST, if it has a <a>Viewport</a>, support visual
-									rendering of Presentation MathML.</p>
+								<p id="confreq-mathml-rs-render" data-test="confreq-mathml-rs-behavior">MUST, if it has a
+									<a>Viewport</a>, support visual rendering of Presentation MathML.</p>
 							</li>
 						</ul>
 						<p class="note">Reading Systems may choose to use third-party libraries such as MathJax to
@@ -620,19 +623,19 @@
 					<section id="sec-xhtml-svg">
 						<h5>Embedded SVG</h5>
 
-						<p>Reading Systems MUST process SVG embedded in XHTML Content Documents as defined in <a
-								href="#sec-svg"></a>.</p>
+						<p id="confreq-svg-rs-embed">Reading Systems MUST process SVG embedded in XHTML Content Documents as
+							defined in <a href="#sec-svg"></a>.</p>
 
 						<section id="sec-xhtml-svg-css">
 							<h6>Embedded SVG and CSS</h6>
 
-							<p id="confreq-svg-rs-css-embed-ref">For the purposes of styling SVG embedded in XHTML
-								Content Documents <em>by reference</em>, Reading Systems MUST NOT apply CSS style rules
-								of the containing document to the referenced SVG document.</p>
+							<p id="confreq-svg-rs-css-embed-ref" data-test="confreq-svg-rs-css-embed-ref">For the purposes of
+								styling SVG embedded in XHTML Content Documents <em>by reference</em>, Reading Systems MUST
+								NOT apply CSS style rules of the containing document to the referenced SVG document.</p>
 
-							<p id="confreq-svg-rs-css-embed-inc">For the purposes of styling SVG embedded in XHTML
-								Content Documents <em>by inclusion</em>, Reading Systems MUST apply applicable CSS rules
-								of the containing document to the included SVG elements.</p>
+							<p id="confreq-svg-rs-css-embed-inc" data-test="confreq-svg-rs-css-embed-inc">For the purposes of
+								styling SVG embedded in XHTML Content Documents <em>by inclusion</em>, Reading Systems MUST
+								apply applicable CSS rules of the containing document to the included SVG elements.</p>
 
 							<div class="note">
 								<p>SVG included <em>by reference</em> is processed as a separate document, and can
@@ -657,7 +660,7 @@
 			<section id="sec-svg">
 				<h3>SVG Content Documents</h3>
 
-				<p id="confreq-rs-epub3-svg" class="support">Reading Systems MUST process <a
+				<p id="confreq-rs-epub3-svg" class="support" data-test="confreq-rs-epub3-svg">Reading Systems MUST process <a
 						href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
 
 				<p>To process SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -68,7 +68,11 @@
 				},
 				localBiblio: biblio,
 				preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
-				postProcess:[addConformanceLinks]
+				postProcess:[addConformanceLinks],
+				testSuiteURI: "https://github.com/w3c/epub-tests/tree/HEAD/tests/EPUBs/",
+				lint: {
+					"wpt-tests-exist": true,
+				}
 			};//]]></script>
 	</head>
 	<body>
@@ -187,13 +191,13 @@
 			<section id="sec-epub-rs-conf-cmt">
 				<h4>Core Media Types</h4>
 
-				<p id="confreq-rs-epub3-images" data-test="cmt-gif,cmt-jpg,cmt-png,cmt-svg,cmt-webp">If a Reading System has
-					a <a>Viewport</a>, it MUST support the <a
-						href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type Resources</a>
-					[[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-images"
+				    data-tests="cmt-gif.epub,cmt-jpg.epub,cmt-png.epub,cmt-svg.epub,cmt-webp.epub">If a Reading System has a
+				    <a>Viewport</a>, it MUST support the <a href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core
+				   	Media Type Resources</a> [[EPUB-33]].</p>
 
-				<p id="confreq-rs-epub3-mp3-aac" data-test="cmt-mp3,cmt-mp4-aac,cmt-ogg-opus">If it has the capability to
-					render pre-recorded audio, it MUST support the <a
+				<p id="confreq-rs-epub3-mp3-aac" data-tests="cmt-mp3.epub,cmt-mp4-aac.epub,cmt-ogg-opus.epub">If it has the
+					capability to render pre-recorded audio, it MUST support the <a
 					href="https://www.w3.org/TR/epub-33/#cmt-grp-audio">audio Core Media Type Resources</a> [[EPUB-33]] and
 					SHOULD support Media Overlays [[EPUB-33]].</p>
 
@@ -505,7 +509,7 @@
 			<section id="sec-xhtml">
 				<h3>XHTML Content Documents</h3>
 
-				<p id="confreq-rs-epub3-xhtml" class="support" data-test="confreq-rs-epub3-xhtml">Reading Systems MUST
+				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="confreq-rs-epub3-xhtml.epub">Reading Systems MUST
 					process <a href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a> [[EPUB-33]].</p>
 
 				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, Reading
@@ -601,14 +605,14 @@
 
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-mathml-rs-behavior" data-test="confreq-mathml-rs-behavior">MUST be an <a
+								<p id="confreq-mathml-rs-behavior" data-tests="confreq-mathml-rs-behavior.epub">MUST be an <a
 									href="https://www.w3.org/TR/MathML3/chapter7.html#sec7.2.1">input-compliant processor</a>
 									for <a href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
 									defined in the [[MATHML3]] specification.</p>
 							</li>
 							<li>
-								<p id="confreq-mathml-rs-render" data-test="confreq-mathml-rs-behavior">MUST, if it has a
-									<a>Viewport</a>, support visual rendering of Presentation MathML.</p>
+								<p id="confreq-mathml-rs-render" data-tests="confreq-mathml-rs-behavior.epub">MUST, if it has
+									a <a>Viewport</a>, support visual rendering of Presentation MathML.</p>
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
@@ -629,13 +633,15 @@
 						<section id="sec-xhtml-svg-css">
 							<h6>Embedded SVG and CSS</h6>
 
-							<p id="confreq-svg-rs-css-embed-ref" data-test="confreq-svg-rs-css-embed-ref">For the purposes of
-								styling SVG embedded in XHTML Content Documents <em>by reference</em>, Reading Systems MUST
-								NOT apply CSS style rules of the containing document to the referenced SVG document.</p>
+							<p id="confreq-svg-rs-css-embed-ref" data-tests="confreq-svg-rs-css-embed-ref.epub">For the
+								purposes of styling SVG embedded in XHTML Content Documents <em>by reference</em>, Reading
+								Systems MUST NOT apply CSS style rules of the containing document to the referenced SVG
+								document.</p>
 
-							<p id="confreq-svg-rs-css-embed-inc" data-test="confreq-svg-rs-css-embed-inc">For the purposes of
-								styling SVG embedded in XHTML Content Documents <em>by inclusion</em>, Reading Systems MUST
-								apply applicable CSS rules of the containing document to the included SVG elements.</p>
+							<p id="confreq-svg-rs-css-embed-inc" data-tests="confreq-svg-rs-css-embed-inc.epub">For the
+								purposes of styling SVG embedded in XHTML Content Documents <em>by inclusion</em>, Reading
+								Systems MUST apply applicable CSS rules of the containing document to the included SVG
+								elements.</p>
 
 							<div class="note">
 								<p>SVG included <em>by reference</em> is processed as a separate document, and can
@@ -660,8 +666,8 @@
 			<section id="sec-svg">
 				<h3>SVG Content Documents</h3>
 
-				<p id="confreq-rs-epub3-svg" class="support" data-test="confreq-rs-epub3-svg">Reading Systems MUST process <a
-						href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-svg" class="support" data-tests="confreq-rs-epub3-svg.epub">Reading Systems MUST
+					process <a href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
 
 				<p>To process SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content
 						Documents</a>, a Reading System:</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -601,19 +601,19 @@
 
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-mathml-rs-behavior" data-test="confreq-mathml-rs-behavior">MUST be an
-									input-compliant renderer for <a
-										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
+								<p id="confreq-mathml-rs-behavior" data-test="confreq-mathml-rs-behavior">MUST be an <a
+									href="https://www.w3.org/TR/MathML3/chapter7.html#sec7.2.1">input-compliant processor</a>
+									for <a href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
 									defined in the [[MATHML3]] specification.</p>
+							</li>
+							<li>
+								<p id="confreq-mathml-rs-render" data-test="confreq-mathml-rs-behavior">MUST, if it has a
+									<a>Viewport</a>, support visual rendering of Presentation MathML.</p>
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
 										href="https://www.w3.org/TR/MathML3/chapter4.html">Content MathML</a> found in
 										<code>annotation-xml</code> elements.</p>
-							</li>
-							<li>
-								<p id="confreq-mathml-rs-render" data-test="confreq-mathml-rs-behavior">MUST, if it has a
-									<a>Viewport</a>, support visual rendering of Presentation MathML.</p>
 							</li>
 						</ul>
 						<p class="note">Reading Systems may choose to use third-party libraries such as MathJax to


### PR DESCRIPTION
Adds data-tests attributes, corresponding to tests also tracked in tinyurl.com/epub-tests, for tests I have written, as well as adding one ID to a normative statement that didn't have an ID. See https://respec.org/docs/#html-attributes.

If this is acceptable, I will rename other existing tests (not written by me) to match, and add data-tests attributes for them too.

In https://github.com/w3c/epub-tests/pull/20, I will rename some tests to match the names in this PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dlazin/epub-specs/pull/1685.html" title="Last updated on May 27, 2021, 6:15 PM UTC (0b6c8a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1685/81acc27...dlazin:0b6c8a0.html" title="Last updated on May 27, 2021, 6:15 PM UTC (0b6c8a0)">Diff</a>