### PR TITLE
Changed NFC to UAX15

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9465,6 +9465,10 @@ EPUB/images/cover.png</pre>
 				<h3>Substantive Changes since the <a href="https://www.w3.org/TR/2021/WD-epub-33-20210525/">Previous
 						Working Draft</a></h3>
 
+					<li>31-May-2021: Require Unicode normalization and full case folding (in this order) for file name uniqueness
+						comparisons. See <a href="https://github.com/w3c/epub-specs/issues/1631">issue 1631</a> and 
+						<a href="https://github.com/w3c/epub-specs/pull/1648">pull request 1648</a>.</li>
+	
 				<!--
 					After each working draft is published:
 						- change the link/text in the section heading to refer to the published draft (use the dated URL)
@@ -9500,8 +9504,6 @@ EPUB/images/cover.png</pre>
 					<li>28-Apr-2021: Drop requirement for resources referenced from HTML <code>link</code> elements to
 						have core media type fallbacks. See <a href="https://github.com/w3c/epub-specs/issues/1312"
 							>issue 1312</a>.</li>
-					<li>24-Apr-2021: Require Unicode full case folding and NFC normalization for file name uniqueness
-						comparisons. See <a href="https://github.com/w3c/epub-specs/issues/1631">issue 1631</a>.</li>
 					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 is the recommended
 						encoding. See <a href="https://github.com/w3c/epub-specs/issues/1628">issue 1628</a>.</li>
 					<li>19-Apr-2021: The use of custom attributes in EPUB Content Documents is no longer supported. See

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5520,8 +5520,8 @@ Spine:
 							</ul>
 						</li>
 						<li>
-							<p id="ocf-fn-cn">All File Names within the same directory MUST be unique following NFC
-								normalization [[TR15]] and then full case folding [[Unicode]]. (Refer to <a
+							<p id="ocf-fn-cn">All File Names within the same directory MUST be unique following Unicode
+								normalization [[UAX15]] and then full case folding [[Unicode]]. (Refer to <a
 									href="https://www.w3.org/TR/charmod-norm/#CanonicalFoldNormalizationStep">Unicode
 									Canonical Case Fold Normalization Step</a> [[?CHARMOD-NORM]] for more
 								information.)</p>


### PR DESCRIPTION
Changing NFC to UAX15 in the file name issue. This is a reaction on:

https://github.com/w3c/epub-specs/pull/1648#issuecomment-851313841


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1692.html" title="Last updated on May 31, 2021, 2:42 PM UTC (9623962)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1692/b4bd87f...9623962.html" title="Last updated on May 31, 2021, 2:42 PM UTC (9623962)">Diff</a>