### PR TITLE
Update svg conformance reference

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3953,10 +3953,10 @@ Spine:
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-cd-svg-docprops-schema">MUST be an <a
-									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles">SVG
-									document fragment</a> [[SVG]] and conform to all content conformance constraints
-								expressed in <a href="#sec-svg-restrictions"></a>.</p>
+							<p id="confreq-cd-svg-docprops-schema">MUST be a <a
+									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles"
+									>conforming SVG stand-alone file</a> [[SVG]] and conform to all content conformance
+								constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-svg-structural-semantics">MAY specify the <a href="#attrdef-epub-type"
@@ -7295,19 +7295,16 @@ store destination as source in ocf
 
 					<section id="sec-media-overlays-fragids">
 						<h5>Referencing Document Fragments</h5>
-
 						<p>The <code>epub:textref</code> attribute and the <a href="#elemdef-smil-text"
 									><code>text</code> element's</a>
 							<code>src</code> attribute both require a fragment identifier that references a specific
 							fragment (e.g., an element or text string) of the associated <a>EPUB Content
-							Document</a>.</p>
-
-						<p>For XHTML and SVG Content Documents, the fragment SHOULD be a reference to a <a
+							Document</a>.</p>3 <p>For XHTML and SVG Content Documents, the fragment SHOULD be a
+							reference to a <a
 								href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#target-element"
 								>target element</a> [[HTML]] or an <a
 								href="https://www.w3.org/TR/SVG2/linking.html#SVGFragmentIdentifiers">SVG Fragment
 								Identifier</a> [[SVG]], respectively.</p>
-
 						<p>EPUB Creators MAY use other fragment identifier schemes, but Reading Systems may not support
 							such identifiers.</p>
 					</section>
@@ -9471,7 +9468,12 @@ EPUB/images/cover.png</pre>
 						- move all changes down to the next section
 				-->
 
-				<ul> </ul>
+				<ul>
+					<li>31-May-2021: Confirmed that SVG Content Documents do not have to be valid to the SVG
+						specification, only meet the well-formedness and ID requirements currently referenced and the
+						restrictions imposed by this specification. See <a
+							href="https://github.com/w3c/epub-specs/issues/1323">issue 1323</a>.</li>
+				</ul>
 			</section>
 
 			<section id="changes-older">


### PR DESCRIPTION
Although we've agreed not to change the current SVG link, the use of "SVG document fragment" is no longer correct. I've updated this to "conforming SVG stand-alone file" to match the SVG specification term.

Also adds a change log note that confirms that validity is not required, as this is a significant non-change.

Fixes #1323


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1693.html" title="Last updated on May 31, 2021, 12:55 PM UTC (df6cd30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1693/aa118bd...df6cd30.html" title="Last updated on May 31, 2021, 12:55 PM UTC (df6cd30)">Diff</a>