### PR TITLE
Standardize language of dir and xml:lang definitions

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1193,8 +1193,9 @@
 								<code>dir</code>
 							</dt>
 							<dd>
-								<p>Specifies the base direction [[BIDI]] of the carrying element and its
-									descendants.</p>
+								<p>Specifies the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base
+										direction</a> [[BIDI]] of the textual content and attribute values of the
+									carrying element and its descendants</p>
 								<p>Allowed values are:</p>
 								<ul>
 									<li><code>ltr</code> &#8212; left-to-right base direction;</li>
@@ -1350,7 +1351,7 @@
 								<code>xml:lang</code>
 							</dt>
 							<dd>
-								<p>Specifies the language used in the contents and attribute values of the carrying
+								<p>Specifies the language of the textual content and attribute values of the carrying
 									element and its descendants, as defined in section <a
 										href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-lang-tag">2.12 Language
 										Identification</a> of [[XML]]. The value of each <code>xml:lang</code> attribute
@@ -9462,10 +9463,6 @@ EPUB/images/cover.png</pre>
 				<h3>Substantive Changes since the <a href="https://www.w3.org/TR/2021/WD-epub-33-20210525/">Previous
 						Working Draft</a></h3>
 
-					<li>31-May-2021: Require Unicode normalization and full case folding (in this order) for file name uniqueness
-						comparisons. See <a href="https://github.com/w3c/epub-specs/issues/1631">issue 1631</a> and 
-						<a href="https://github.com/w3c/epub-specs/pull/1648">pull request 1648</a>.</li>
-	
 				<!--
 					After each working draft is published:
 						- change the link/text in the section heading to refer to the published draft (use the dated URL)
@@ -9473,6 +9470,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>31-May-2021: Require Unicode normalization and full case folding (in this order) for file name
+						uniqueness comparisons. See <a href="https://github.com/w3c/epub-specs/issues/1631">issue 1631</a>
+						and <a href="https://github.com/w3c/epub-specs/pull/1648">pull request 1648</a>.</li>
 					<li>31-May-2021: Confirmed that SVG Content Documents do not have to be valid to the SVG
 						specification, only meet the well-formedness and ID requirements currently referenced and the
 						restrictions imposed by this specification. See <a


### PR DESCRIPTION
Implements the text change suggested in https://github.com/w3c/epub-specs/issues/1689#issuecomment-850343026


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1694.html" title="Last updated on Jun 2, 2021, 12:23 PM UTC (095b0f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1694/78f3a87...095b0f6.html" title="Last updated on Jun 2, 2021, 12:23 PM UTC (095b0f6)">Diff</a>