### PR TITLE
Clarify that digital publications must not identify themselves as their pagination source

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -540,13 +540,18 @@
 									<p>Including a recognizable identifier for the statically paginated source, such as
 										its ISBN or ISSN, ensures that users can determine which version the pagination
 										corresponds to.</p>
+									<p>If EPUB Creators insert pagination as a navigation aid for digital-only
+										publications, they must not specify a source (i.e., do not identify the current
+										publication as the source of its own pagination).</p>
 								</dd>
 
 								<dt id="sec-page-src-conf">Meeting this Objective</dt>
 
 								<dd>
-									<p>EPUB Creators MUST identify the source of the pagination in the Package Document
-										metadata.</p>
+									<p>When an EPUB Publication includes <a href="#sec-page-breaks">page break
+											markers</a> and/or a <a href="#sec-page-list">page list</a> that correspond
+										to a statically-paginated version of the publication, EPUB Creators MUST
+										identify that source in the Package Document metadata.</p>
 								</dd>
 							</dl>
 						</section>
@@ -1378,7 +1383,11 @@
 						- move all changes down to the next section
 				-->
 
-				<ul> </ul>
+				<ul>
+					<li>9-June-2021: Clarified that a pagination source must not be specified when page break markers
+						and/or a page list are included in a digital-only publication. See <a
+							href="https://github.com/w3c/epub-specs/issues/1599">issue 1599</a>.</li>
+				</ul>
 			</section>
 
 			<section id="changes-older">


### PR DESCRIPTION
This fixes #1599 as far as the specification goes.

Figuring out an accessibilityFeature value is a change for the schema.org vocabulary.