### PR TITLE
Clarifies that meaningful sequence applies to spreads

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -559,55 +559,25 @@
 				<h3>Content Access</h3>
 
 				<section class="suppress-numbering" id="access-001">
-					<h4>ACCESS-001: Ensure linear reading order of the publication</h4>
+					<h4>ACCESS-001: Ensure meaningful order of content across spreads</h4>
 
-					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#meaningful-sequence">Success Criterion
-						1.3.2</a> specifies that each Web page have a meaningful order, but the content of an EPUB
-						Publication typically spans multiple documents. It is consequently essential not only that each
-						EPUB Content Document has a meaningful order, but that the order is meaningful from document to
-						document.</p>
+					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#meaningful-sequence">Success Criterion 1.3.2</a>
+						specifies that each Web page have a meaningful order (i.e., that the visual presentation of the
+						content match the underlying markup).</p>
 
-					<p>EPUB Creators need to ensure that all EPUB Content Documents are included in the <a
-							href="https://www.w3.org/TR/epub/#sec-spine-elem">spine</a> [[EPUB-3]] and put in sequence
-						so that the reading order is preserved.</p>
+					<p>As EPUB allows two documents to be rendered together in a <a
+							href="https://www.w3.org/TR/epub/#spread">synthetic spread</a> [[EPUB-3]], the order of
+						content within a single document cannot always be evaluated in isolation. Content may span
+						visually from one document to the next. For example, a sidebar might span the bottom of two
+						pages.</p>
 
-					<aside class="example">
-						<p>The following example shows the linear progression of chapter references in an EPUB
-							spine.</p>
-						<pre>&lt;package …&gt;
-   …
-   &lt;manifest&gt;
-      …
-      &lt;item id="chap01" href="xhtml/chapter01.xhtml" …/&gt;
-      &lt;item id="chap02" href="xhtml/chapter02.xhtml" …/&gt;
-      &lt;item id="chap03" href="xhtml/chapter03.xhtml" …/&gt;
-      …
-   &lt;/manifest&gt;
-   &lt;spine&gt;
-      …
-      &lt;itemref idref="chap01"/&gt;
-      &lt;itemref idref="chap02"/&gt;
-      &lt;itemref idref="chap03"/&gt;
-      …
-   &lt;/spine&gt;
-&lt;/package&gt;</pre>
-					</aside>
-
-					<p>EPUB Creators also need to ensure that they identify whether items in the spine contain primary
-						or supplementary information using the <a
-							href="https://www.w3.org/TR/epub/#attrdef-itemref-linear"><code>linear</code>
-						attribute</a> [[EPUB-3]] so that the Reading System can optimally present such content.</p>
-
-					<aside class="example">
-						<p>The following example shows a non-linear answer key between two chapters.</p>
-						<pre>&lt;spine&gt;
-   …
-   &lt;itemref idref="chap01"/&gt;
-   &lt;itemref idref="answers01" linear="no"/&gt;
-   &lt;itemref idref="chap02"/&gt;
-   …
-&lt;/spine&gt;</pre>
-					</aside>
+					<p>Ordering each document separately by the visual display will lead to users of assistive
+						technologies encountering gaps between the start and end of the spanned text. If the markup
+						cannot be arranged to provide a more logical reading experience (e.g., the beginning of the
+						spanned content at the end of the first page followed by the conclusion at the start of the
+						next), another means of satisfying this criteria will be necessary to avoid failure (e.g., a
+						hyperlink could be provided to allow a user to jump from the break point on the first page to
+						the continuation on the next).</p>
 				</section>
 
 				<section class="suppress-numbering" id="access-002">
@@ -1501,6 +1471,9 @@
 				-->
 
 				<ul>
+					<li>10-June-2021: Clarified the technique on meaningful sequence that it applies to content that
+						spans pages in a spread and is not about ordering documents in the spine. See <a
+							href="https://github.com/w3c/epub-specs/issues/1695">issue 1695</a>.</li>
 					<li>25-May-2021: Updated the section on ARIA roles to make clear that the <code>epub:type</code>
 						attribute does not have to be used in coordination, nor that roles are required where
 							<code>epub:type</code> is used.</li>


### PR DESCRIPTION
I've rewritten the [access-001 technique](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1695/epub33/a11y-tech/index.html#access-001) to make it more specific to synthetic spreads, as this is where I see our issue lying. The order of content in the separate documents still has to make sense as a unit, or there has to be a way to follow the text.

Fixes #1695 

- Techniques [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1695/epub33/a11y-tech/index.html)
- Techniques [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/main/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1695/epub33/a11y-tech/index.html)
