### PR TITLE
Adding a warning on how to truncate file names

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5531,7 +5531,7 @@ Spine:
 
 					<div class="note">
 						<p>
-							If EPUB Creators dynamically integrate resources (i.e., where the naming is beyond their control), they should be aware that automatic truncation of File Names to keep them within the 255 bytes limit can lead to corruption. This is due to the difference between bytes and characters in multibyte encodings such as UTF-8; it is therefore important to avoid mid-character truncation. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of strings"</a> in [[international-specs]] for more information. </p>
+							If EPUB Creators dynamically integrate resources (i.e., where the naming is beyond their control), they should be aware that automatic truncation of File Names to keep them within the 255 bytes limit can lead to corruption. This is due to the difference between bytes and characters in multibyte encodings such as UTF-8; it is, therefore, important to avoid mid-character truncation. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of strings"</a> in [[international-specs]] for more information. </p>
 					</div>
 
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5530,7 +5530,8 @@ Spine:
 					</ul>
 
 					<div class="note">
-						<p>EPUB Creators may have to truncate File Names to keep them within the 255 bytes limit. When doing so it is important to avoid mid-character truncation due to the difference between bytes and characters in multibyte encodings such as UTF-8. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of strings"</a> in [[international-specs]] for more information. </p>
+						<p>
+							If EPUB Creators dynamically integrate resources (i.e., where the naming is beyond their control), they should be aware that automatic truncation of File Names to keep them within the 255 bytes limit can lead to corruption. This is due to the difference between bytes and characters in multibyte encodings such as UTF-8. It is therefore important to avoid mid-character truncation. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of strings"</a> in [[international-specs]] for more information. </p>
 					</div>
 
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5530,7 +5530,7 @@ Spine:
 					</ul>
 
 					<div class="note">
-						<p>EPUB Creators may have to truncate File Names to keep them within the 255 bytes range. When doing so it is important to avoid mid-character truncation due to the difference between bytes and characters in multibyte encodings such as UTF-8. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of strings"</a> in [[international-specs]] for more information. </p>
+						<p>EPUB Creators may have to truncate File Names to keep them within the 255 bytes limit. When doing so it is important to avoid mid-character truncation due to the difference between bytes and characters in multibyte encodings such as UTF-8. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of strings"</a> in [[international-specs]] for more information. </p>
 					</div>
 
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5530,7 +5530,7 @@ Spine:
 					</ul>
 
 					<div class="note">
-						<p>EPUB Creators may have to truncate File Names to keep it within the 255 bytes range. When doing so it is important to avoid mid-character truncation due to the difference between bytes and characters in multibyte encodings such as UTF-8. See section on <a data-cite="international-specs/#char_truncation">Truncating or limiting the length of strings</a> [[international-specs]] for more information. </p>
+						<p>EPUB Creators may have to truncate File Names to keep them within the 255 bytes range. When doing so it is important to avoid mid-character truncation due to the difference between bytes and characters in multibyte encodings such as UTF-8. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of strings"</a> in [[international-specs]] for more information. </p>
 					</div>
 
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5530,6 +5530,11 @@ Spine:
 					</ul>
 
 					<div class="note">
+						<p>EPUB Creators may have to truncate File Names to keep it within the 255 bytes range. When doing so it is important to avoid mid-character truncation due to the difference between bytes and characters in multibyte encodings such as UTF-8. See section on <a data-cite="international-specs/#char_truncation">Truncating or limiting the length of strings</a> [[international-specs]] for more information. </p>
+					</div>
+
+
+					<div class="note">
 						<p>Some commercial ZIP tools do not support the full Unicode range for File Names. <a>EPUB
 								Creators</a> who want to use ZIP tools that have these restrictions may find it best to
 							restrict their File Names to the [[US-ASCII]] range.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5531,7 +5531,7 @@ Spine:
 
 					<div class="note">
 						<p>
-							If EPUB Creators dynamically integrate resources (i.e., where the naming is beyond their control), they should be aware that automatic truncation of File Names to keep them within the 255 bytes limit can lead to corruption. This is due to the difference between bytes and characters in multibyte encodings such as UTF-8. It is therefore important to avoid mid-character truncation. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of strings"</a> in [[international-specs]] for more information. </p>
+							If EPUB Creators dynamically integrate resources (i.e., where the naming is beyond their control), they should be aware that automatic truncation of File Names to keep them within the 255 bytes limit can lead to corruption. This is due to the difference between bytes and characters in multibyte encodings such as UTF-8; it is therefore important to avoid mid-character truncation. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of strings"</a> in [[international-specs]] for more information. </p>
 					</div>
 
 


### PR DESCRIPTION
This is an answer to https://github.com/w3c/epub-specs/issues/1629#issuecomment-849720887 (taking also into account https://github.com/w3c/epub-specs/issues/1629#issuecomment-861472292)

Fix 1629


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1702.html" title="Last updated on Jun 17, 2021, 9:43 AM UTC (f5ec76e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1702/2b5ea19...f5ec76e.html" title="Last updated on Jun 17, 2021, 9:43 AM UTC (f5ec76e)">Diff</a>