### PR TITLE
file URLs Should Not be used in the manifest

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1231,8 +1231,7 @@
 								<code>href</code>
 							</dt>
 							<dd>
-								<p>A <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a>
-									[[URL]] that references a resource. The <a href="https://url.spec.whatwg.org/#url-scheme-string">URL-scheme string</a> [[URL]], if present, SHOULD NOT match for <code>file</code>.</p>
+								<p>A <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a> [[URL]] that references a resource. If the value is an <a href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL</a>, it SHOULD NOT use the <code>file</code> URI scheme [[rfc8089]].</p>
 								<div class="example">
 									<pre>&lt;link rel="record"
       href="meta/9780000000001.xml" 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1232,7 +1232,7 @@
 							</dt>
 							<dd>
 								<p>A <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a>
-									[[URL]] that references a resource.</p>
+									[[URL]] that references a resource. The <a href="https://url.spec.whatwg.org/#url-scheme-string">URL-scheme string</a> [[URL]], if present, SHOULD NOT match for <code>file</code>.</p>
 								<div class="example">
 									<pre>&lt;link rel="record"
       href="meta/9780000000001.xml" 
@@ -9470,6 +9470,8 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>16-June-2021: Absolute URLs with <code>file</code> scheme SHOULD NOT be used on manifest items. 
+						See <a href="https://github.com/w3c/epub-specs/issues/1688">issue 1688</a>.</li>
 					<li>31-May-2021: Require Unicode normalization and full case folding (in this order) for file name
 						uniqueness comparisons. See <a href="https://github.com/w3c/epub-specs/issues/1631">issue 1631</a>
 						and <a href="https://github.com/w3c/epub-specs/pull/1648">pull request 1648</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1231,7 +1231,7 @@
 								<code>href</code>
 							</dt>
 							<dd>
-								<p>A <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a> [[URL]] that references a resource. If the value is an <a href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL</a>, it SHOULD NOT use the <code>file</code> URI scheme [[rfc8089]].</p>
+								<p>A <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a> [[URL]] that references a resource. If the value is an <a href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL</a>, it SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
 								<div class="example">
 									<pre>&lt;link rel="record"
       href="meta/9780000000001.xml" 


### PR DESCRIPTION
The [WG resolution](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-06-10-epub#resolution2) says "SHOULD NOT" and not "MUST NOT", so this is what the PR uses. There may be a question whether "MUST NOT" is not more appropriate here.

Fixes #1688.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1703.html" title="Last updated on Jun 17, 2021, 9:29 AM UTC (6d49760)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1703/5ce5b14...6d49760.html" title="Last updated on Jun 17, 2021, 9:29 AM UTC (6d49760)">Diff</a>