### PR TITLE
Regrouped CSS and Scripting subsections in section 3

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4015,6 +4015,8 @@ Spine:
 
 			<section>
 				<h3>Common Resource Requirements</h3>
+				
+				<p>This section defines requirements for technologies usable in both XHTML and SVG Content Documents.</p>
 
 				<section id="sec-css">
 					<h3>Cascading Style Sheets (CSS)</h3>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4013,292 +4013,298 @@ Spine:
 				</section>
 			</section>
 
-			<section id="sec-css">
-				<h3>Cascading Style Sheets (CSS)</h3>
+			<section>
+				<h3>Common Resource Requirements</h3>
 
-				<section id="sec-css-intro" class="informative">
-					<h4>Introduction</h4>
+				<section id="sec-css">
+					<h3>Cascading Style Sheets (CSS)</h3>
 
-					<p>CSS is an integral part of the Open Web Platform. Readers, publishers, and document authors
-						expect CSS to "just work," as they expect HTML to just work.</p>
+					<section id="sec-css-intro" class="informative">
+						<h4>Introduction</h4>
 
-					<p>In the past, EPUB defined a profile of CSS that mandated support for certain properties and
-						provided prefixed versions of numerous other properties. Although the CSS Working Group no
-						longer recommends the use of prefixed properties, this specification maintains some prefixed
-						properties to avoid breaking existing content. But with the minor exceptions defined in this
-						section, EPUB defers to the W3C to define CSS.</p>
+						<p>CSS is an integral part of the Open Web Platform. Readers, publishers, and document authors
+							expect CSS to "just work," as they expect HTML to just work.</p>
 
-					<div class="note">
-						<p>Keep in mind that some <a>Reading Systems</a> will not support all desired features of CSS.
-							The following are known to be particularly problematic:</p>
-						<ul>
-							<li>
-								<p>Reading System-induced pagination can interact poorly with style sheets as Reading
-									Systems sometimes paginate using columns. This may result in incorrect values for
-									viewport sizes. Fixed and absolute positioning are particularly problematic.</p>
-							</li>
-							<li>
-								<p>Some types of screens will render animations and transitions poorly (e.g., those with
-									high latency).</p>
-							</li>
-						</ul>
-					</div>
-				</section>
-
-				<section id="sec-css-req">
-					<h4>CSS Requirements</h4>
-
-					<p>A CSS style sheet:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-css-props">MAY include any CSS properties, with the following exceptions:</p>
-							<ul class="conformance-list">
-								<li>
-									<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
-											href="https://www.w3.org/TR/css3-writing-modes/#direction"
-												><code>direction</code> property</a> [[CSS-Writing-Modes-3]].</p>
-								</li>
-								<li>
-									<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT include the <a
-											href="https://www.w3.org/TR/css3-writing-modes/#unicode-bidi"
-												><code>unicode-bidi</code> property</a> [[CSS-Writing-Modes-3]].</p>
-								</li>
-							</ul>
-						</li>
-						<li>
-							<p id="confreq-css-prefixed">MAY include the prefixed properties defined in <a
-									href="#sec-css-prefixed"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8 as
-								the RECOMMENDED encoding.</p>
-						</li>
-					</ul>
-
-					<div class="note">
-						<p>This specification restricts the use of the <code>direction</code> and
-								<code>unicode-bidi</code> properties because Reading Systems may not implement, or may
-							switch off, CSS processing. EPUB Creators must use the following format-specific methods
-							when they need control over these aspects of the rendering:</p>
-
-						<ul>
-							<li>
-								<p>the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
-											><code>dir</code> attribute</a> [[HTML]] and <a
-										href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
-											><code>direction</code> attribute</a> [[SVG]] for inline base
-									directionality.</p>
-							</li>
-							<li>
-								<p>the <a
-										href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element"
-											><code>bdo</code> element</a> with the <a
-										href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
-											><code>dir</code> attribute</a> [[HTML]] and the <a
-										href="https://www.w3.org/TR/SVG2/styling.html#PresentationAttributes"
-										>presentation attribute alternative</a> for <code>unicode-bidi</code> [[SVG]]
-									for bidirectionality.</p>
-							</li>
-						</ul>
-					</div>
-				</section>
-
-				<section id="sec-css-prefixed">
-					<h4>Prefixed Properties</h4>
-
-					<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to world
-						languages were not yet mature. To ensure backwards compatibility for content authored using
-						these prefixes, they have been retained in this specification. Unless otherwise noted, prefixed
-						properties and values behave exactly as their unprefixed equivalents as described in the
-						appropriate CSS specification. The prefixed properties are documented in an <a
-							href="#css-prefixes">Appendix</a>. </p>
-
-					<div class="caution">
-						<p><a>EPUB Creators</a> should use unprefixed properties and <a>Reading Systems</a> should
-							support current CSS specifications. This specification retains the widely-used prefixed
-							properties from [[EPUBContentDocs-301]], but removes support for the less-used ones. EPUB
-							Creators should use CSS-native solutions for the removed properties whenever available.</p>
-						<p>The Working Group recommends that EPUB Creators currently using these prefixed properties
-							move to unprefixed versions as soon as support allows, as the Working Group does not
-							anticipate supporting them in the next major version of EPUB.</p>
-					</div>
-
-					<p class="note">In some cases, the unprefixed versions of these properties now support additional
-						values. Reading Systems MAY support these values even with the prefixed property.</p>
-				</section>
-			</section>
-
-			<section id="sec-scripted-content">
-				<h3>Scripting</h3>
-
-				<section id="sec-scripted-support">
-					<h4>Script Inclusion</h4>
-
-					<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in the
-						respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB Content Document
-						contains scripting, this specification refers to it as a <a>Scripted Content Document</a>. This
-						label also applies to <a>XHTML Content Documents</a> when they contain instances of [[HTML]] <a
-							href="https://html.spec.whatwg.org/multipage/forms.html#forms">forms</a>.</p>
-
-					<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
-						<code>item</code> element is used to indicate that an EPUB Content Document is a <a>Scripted
-							Content Document</a>.</p>
-
-					<p>When an [[HTML]] <code>script</code> element contains a <a
-							href="https://html.spec.whatwg.org/multipage/scripting.html#data-block">data block</a>
-						[[HTML]], it does not represent scripted content.</p>
-
-					<div class="note">
-						<p>[[SVG]] does not define data blocks as of publication, but the same exclusion would apply if
-							a future update adds the concept.</p>
-					</div>
-
-					<p>EPUB Creators should note that Reading Systems are required to behave as though a unique <a
-							href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] has been assigned to each EPUB
-						Publication. In practice, this means that it is not possible for scripts to share data between
-						EPUB Publications.</p>
-
-					<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the rights
-						and restrictions that a Reading System places on it (refer to <a
-							href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content">Scripting Conformance</a>
-						[[?EPUB-RS-33]] for more information).</p>
-
-					<div class="note">
-						<p>Reading Systems may render Scripted Content Documents in a manner that disables other EPUB
-							capabilities and/or provides a different rendering and user experience (e.g., by disabling
-							pagination).</p>
-					</div>
-				</section>
-
-				<section id="sec-scripted-context">
-					<h4>Scripting Contexts</h4>
-
-					<p>EPUB 3 defines two contexts for script execution:</p>
-
-					<ul>
-						<li><a href="#sec-scripted-container-constrained">container-constrained</a> &#8212; when the
-							execution of a script occurs within an <code>iframe</code>; and</li>
-						<li><a href="#sec-scripted-spine">spine-level</a> &#8212; when the execution of a script occurs
-							directly within a <a>Top-level Content Document</a>.</li>
-					</ul>
-
-					<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference it
-						via the element's <code>src</code> attribute makes no difference to its executing context.</p>
-
-					<p>Which context EPUB Creators use for their scripts affects both what actions the scripts can
-						perform and the likelihood of support in Reading Systems, as described in the following
-						subsections.</p>
-
-					<div class="note">
-						<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference between
-							the two contexts.</p>
-					</div>
-
-					<section id="sec-scripted-container-constrained">
-						<h5>Container-Constrained Scripts</h5>
-
-						<p>A <dfn>container-constrained script</dfn> is either of the following:</p>
-
-						<ul>
-							<li>
-								<p>An instance of the [[HTML]] <a
-										href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
-											><code>script</code></a> element contained in an <a>XHTML Content
-										Document</a> that is embedded in a parent XHTML Content Document using the
-									[[HTML]] <a
-										href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
-											><code>iframe</code></a> element.</p>
-							</li>
-							<li>
-								<p>An instance of the [[SVG]] <a
-										href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
-										><code>script</code></a> element contained in an <a>SVG Content Document</a>
-									that is embedded in a parent XHTML Content Document using the [[HTML]] <a
-										href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
-											><code>iframe</code></a> element.</p>
-							</li>
-						</ul>
-
-						<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
-							instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e., the
-							one that contains the <code>iframe</code> element). It also MUST NOT contain instructions
-							for manipulating the size of its containing rectangle.</p>
-
-						<p>EPUB Creators should note that <a
-								href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content">support for
-								container-constrained scripting in Reading Systems</a> is only recommended in reflowable
-							documents [[EPUB-RS-33]]. Furthermore, Reading System support in fixed-layouts EPUBs is
-							optional.</p>
-
-						<p>EPUB Creators should ensure container-constrained scripts degrade gracefully in Reading
-							Systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
+						<p>In the past, EPUB defined a profile of CSS that mandated support for certain properties and
+							provided prefixed versions of numerous other properties. Although the CSS Working Group no
+							longer recommends the use of prefixed properties, this specification maintains some prefixed
+							properties to avoid breaking existing content. But with the minor exceptions defined in this
+							section, EPUB defers to the W3C to define CSS.</p>
 
 						<div class="note">
-							<p>EPUB Creators choosing to restrict the usage of scripting to the container-constrained
-								model will ensure a more consistent user experience between scripted and non-scripted
-								content (e.g., consistent pagination behavior).</p>
+							<p>Keep in mind that some <a>Reading Systems</a> will not support all desired features of CSS.
+								The following are known to be particularly problematic:</p>
+							<ul>
+								<li>
+									<p>Reading System-induced pagination can interact poorly with style sheets as Reading
+										Systems sometimes paginate using columns. This may result in incorrect values for
+										viewport sizes. Fixed and absolute positioning are particularly problematic.</p>
+								</li>
+								<li>
+									<p>Some types of screens will render animations and transitions poorly (e.g., those with
+										high latency).</p>
+								</li>
+							</ul>
 						</div>
 					</section>
 
-					<section id="sec-scripted-spine">
-						<h5>Spine-Level Scripts</h5>
+					<section id="sec-css-req">
+						<h4>CSS Requirements</h4>
 
-						<p>A <dfn>spine-level script</dfn> is an instance of the [[HTML]] <a
-								href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
-									><code>script</code></a> or [[SVG]] <a
-								href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
-							element contained in a <a>Top-level Content Document</a>.</p>
+						<p>A CSS style sheet:</p>
 
-						<p>EPUB Creators should note that support for spine-level scripting in Reading Systems is only
-							recommended in <a href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-fxl-support"
-								>fixed-layout documents</a> and <a
-								href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-scrolled">reflowable
-								documents set to scroll</a> [[EPUB-RS-33]]. Furthermore, Reading System support in all
-							other contexts is optional.</p>
+						<ul class="conformance-list">
+							<li>
+								<p id="confreq-css-props">MAY include any CSS properties, with the following exceptions:</p>
+								<ul class="conformance-list">
+									<li>
+										<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
+												href="https://www.w3.org/TR/css3-writing-modes/#direction"
+													><code>direction</code> property</a> [[CSS-Writing-Modes-3]].</p>
+									</li>
+									<li>
+										<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT include the <a
+												href="https://www.w3.org/TR/css3-writing-modes/#unicode-bidi"
+													><code>unicode-bidi</code> property</a> [[CSS-Writing-Modes-3]].</p>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<p id="confreq-css-prefixed">MAY include the prefixed properties defined in <a
+										href="#sec-css-prefixed"></a>.</p>
+							</li>
+							<li>
+								<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8 as
+									the RECOMMENDED encoding.</p>
+							</li>
+						</ul>
 
-						<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include spine-level
-							scripting SHOULD remain consumable by the user without any information loss or other
-							significant deterioration when scripting is disabled or not available (e.g., by employing
-							progressive enhancement techniques or <a href="#sec-scripted-fallbacks">fallbacks</a>).
-							Failing to account for non-scripted environments in Top-level Content Documents can result
-							in EPUB Publications being unreadable.</p>
+						<div class="note">
+							<p>This specification restricts the use of the <code>direction</code> and
+									<code>unicode-bidi</code> properties because Reading Systems may not implement, or may
+								switch off, CSS processing. EPUB Creators must use the following format-specific methods
+								when they need control over these aspects of the rendering:</p>
+
+							<ul>
+								<li>
+									<p>the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
+												><code>dir</code> attribute</a> [[HTML]] and <a
+											href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
+												><code>direction</code> attribute</a> [[SVG]] for inline base
+										directionality.</p>
+								</li>
+								<li>
+									<p>the <a
+											href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element"
+												><code>bdo</code> element</a> with the <a
+											href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
+												><code>dir</code> attribute</a> [[HTML]] and the <a
+											href="https://www.w3.org/TR/SVG2/styling.html#PresentationAttributes"
+											>presentation attribute alternative</a> for <code>unicode-bidi</code> [[SVG]]
+										for bidirectionality.</p>
+								</li>
+							</ul>
+						</div>
+					</section>
+
+					<section id="sec-css-prefixed">
+						<h4>Prefixed Properties</h4>
+
+						<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to world
+							languages were not yet mature. To ensure backwards compatibility for content authored using
+							these prefixes, they have been retained in this specification. Unless otherwise noted, prefixed
+							properties and values behave exactly as their unprefixed equivalents as described in the
+							appropriate CSS specification. The prefixed properties are documented in an <a
+								href="#css-prefixes">Appendix</a>. </p>
+
+						<div class="caution">
+							<p><a>EPUB Creators</a> should use unprefixed properties and <a>Reading Systems</a> should
+								support current CSS specifications. This specification retains the widely-used prefixed
+								properties from [[EPUBContentDocs-301]], but removes support for the less-used ones. EPUB
+								Creators should use CSS-native solutions for the removed properties whenever available.</p>
+							<p>The Working Group recommends that EPUB Creators currently using these prefixed properties
+								move to unprefixed versions as soon as support allows, as the Working Group does not
+								anticipate supporting them in the next major version of EPUB.</p>
+						</div>
+
+						<p class="note">In some cases, the unprefixed versions of these properties now support additional
+							values. Reading Systems MAY support these values even with the prefixed property.</p>
 					</section>
 				</section>
 
-				<section id="sec-scripted-content-events" class="informative">
-					<h4>Event Model</h4>
+				<section id="sec-scripted-content">
+					<h3>Scripting</h3>
 
-					<p><a>EPUB Creators</a> should consider the wide variety of possible Reading System implementations
-						when adding scripting functionality to their EPUB Publications (e.g., not all devices have
-						physical keyboards, and in many cases a soft keyboard is activated only for text input
-						elements). Consequently, EPUB Creators should not rely on keyboard events alone; they should
-						always provide alternative ways to trigger a desired action.</p>
+					<section id="sec-scripted-support">
+						<h4>Script Inclusion</h4>
+
+						<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in the
+							respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB Content Document
+							contains scripting, this specification refers to it as a <a>Scripted Content Document</a>. This
+							label also applies to <a>XHTML Content Documents</a> when they contain instances of [[HTML]] <a
+								href="https://html.spec.whatwg.org/multipage/forms.html#forms">forms</a>.</p>
+
+						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
+							<code>item</code> element is used to indicate that an EPUB Content Document is a <a>Scripted
+								Content Document</a>.</p>
+
+						<p>When an [[HTML]] <code>script</code> element contains a <a
+								href="https://html.spec.whatwg.org/multipage/scripting.html#data-block">data block</a>
+							[[HTML]], it does not represent scripted content.</p>
+
+						<div class="note">
+							<p>[[SVG]] does not define data blocks as of publication, but the same exclusion would apply if
+								a future update adds the concept.</p>
+						</div>
+
+						<p>EPUB Creators should note that Reading Systems are required to behave as though a unique <a
+								href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] has been assigned to each EPUB
+							Publication. In practice, this means that it is not possible for scripts to share data between
+							EPUB Publications.</p>
+
+						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the rights
+							and restrictions that a Reading System places on it (refer to <a
+								href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content">Scripting Conformance</a>
+							[[?EPUB-RS-33]] for more information).</p>
+
+						<div class="note">
+							<p>Reading Systems may render Scripted Content Documents in a manner that disables other EPUB
+								capabilities and/or provides a different rendering and user experience (e.g., by disabling
+								pagination).</p>
+						</div>
+					</section>
+
+					<section id="sec-scripted-context">
+						<h4>Scripting Contexts</h4>
+
+						<p>EPUB 3 defines two contexts for script execution:</p>
+
+						<ul>
+							<li><a href="#sec-scripted-container-constrained">container-constrained</a> &#8212; when the
+								execution of a script occurs within an <code>iframe</code>; and</li>
+							<li><a href="#sec-scripted-spine">spine-level</a> &#8212; when the execution of a script occurs
+								directly within a <a>Top-level Content Document</a>.</li>
+						</ul>
+
+						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference it
+							via the element's <code>src</code> attribute makes no difference to its executing context.</p>
+
+						<p>Which context EPUB Creators use for their scripts affects both what actions the scripts can
+							perform and the likelihood of support in Reading Systems, as described in the following
+							subsections.</p>
+
+						<div class="note">
+							<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference between
+								the two contexts.</p>
+						</div>
+
+						<section id="sec-scripted-container-constrained">
+							<h5>Container-Constrained Scripts</h5>
+
+							<p>A <dfn>container-constrained script</dfn> is either of the following:</p>
+
+							<ul>
+								<li>
+									<p>An instance of the [[HTML]] <a
+											href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
+												><code>script</code></a> element contained in an <a>XHTML Content
+											Document</a> that is embedded in a parent XHTML Content Document using the
+										[[HTML]] <a
+											href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
+												><code>iframe</code></a> element.</p>
+								</li>
+								<li>
+									<p>An instance of the [[SVG]] <a
+											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
+											><code>script</code></a> element contained in an <a>SVG Content Document</a>
+										that is embedded in a parent XHTML Content Document using the [[HTML]] <a
+											href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
+												><code>iframe</code></a> element.</p>
+								</li>
+							</ul>
+
+							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
+								instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e., the
+								one that contains the <code>iframe</code> element). It also MUST NOT contain instructions
+								for manipulating the size of its containing rectangle.</p>
+
+							<p>EPUB Creators should note that <a
+									href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content">support for
+									container-constrained scripting in Reading Systems</a> is only recommended in reflowable
+								documents [[EPUB-RS-33]]. Furthermore, Reading System support in fixed-layouts EPUBs is
+								optional.</p>
+
+							<p>EPUB Creators should ensure container-constrained scripts degrade gracefully in Reading
+								Systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
+
+							<div class="note">
+								<p>EPUB Creators choosing to restrict the usage of scripting to the container-constrained
+									model will ensure a more consistent user experience between scripted and non-scripted
+									content (e.g., consistent pagination behavior).</p>
+							</div>
+						</section>
+
+						<section id="sec-scripted-spine">
+							<h5>Spine-Level Scripts</h5>
+
+							<p>A <dfn>spine-level script</dfn> is an instance of the [[HTML]] <a
+									href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
+										><code>script</code></a> or [[SVG]] <a
+									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
+								element contained in a <a>Top-level Content Document</a>.</p>
+
+							<p>EPUB Creators should note that support for spine-level scripting in Reading Systems is only
+								recommended in <a href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-fxl-support"
+									>fixed-layout documents</a> and <a
+									href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-scrolled">reflowable
+									documents set to scroll</a> [[EPUB-RS-33]]. Furthermore, Reading System support in all
+								other contexts is optional.</p>
+
+							<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include spine-level
+								scripting SHOULD remain consumable by the user without any information loss or other
+								significant deterioration when scripting is disabled or not available (e.g., by employing
+								progressive enhancement techniques or <a href="#sec-scripted-fallbacks">fallbacks</a>).
+								Failing to account for non-scripted environments in Top-level Content Documents can result
+								in EPUB Publications being unreadable.</p>
+						</section>
+					</section>
+
+					<section id="sec-scripted-content-events" class="informative">
+						<h4>Event Model</h4>
+
+						<p><a>EPUB Creators</a> should consider the wide variety of possible Reading System implementations
+							when adding scripting functionality to their EPUB Publications (e.g., not all devices have
+							physical keyboards, and in many cases a soft keyboard is activated only for text input
+							elements). Consequently, EPUB Creators should not rely on keyboard events alone; they should
+							always provide alternative ways to trigger a desired action.</p>
+					</section>
+
+					<section id="sec-scripted-a11y">
+						<h4>Scripting Accessibility</h4>
+
+						<p id="confreq-cd-scripted-a11y">EPUB Content Documents that contain scripting SHOULD employ
+							relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable by
+							all users.</p>
+					</section>
+
+					<section id="sec-scripted-fallbacks">
+						<h4 id="confreq-cd-scripted-flbk">Scripting Fallbacks</h4>
+
+						<p id="confreq-cd-scripted-fallback">EPUB Content Documents that contain scripting MAY provide
+							fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
+							available for the [[HTML]] <a
+								href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element"
+									><code>object</code></a> and <a
+								href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element"
+									><code>canvas</code></a> elements) or, when an intrinsic fallback is not applicable, by
+							using a <a href="#sec-foreign-restrictions-manifest">manifest-level fallback</a>.</p>
+						<p id="confreq-cd-scripted-foreign-resources">EPUB Creators MUST ensure that scripts only generate
+								<a href="#sec-core-media-types">Core Media Type Resources</a> or fragments thereof.</p>
+					</section>
 				</section>
 
-				<section id="sec-scripted-a11y">
-					<h4>Scripting Accessibility</h4>
-
-					<p id="confreq-cd-scripted-a11y">EPUB Content Documents that contain scripting SHOULD employ
-						relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable by
-						all users.</p>
-				</section>
-
-				<section id="sec-scripted-fallbacks">
-					<h4 id="confreq-cd-scripted-flbk">Scripting Fallbacks</h4>
-
-					<p id="confreq-cd-scripted-fallback">EPUB Content Documents that contain scripting MAY provide
-						fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
-						available for the [[HTML]] <a
-							href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element"
-								><code>object</code></a> and <a
-							href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element"
-								><code>canvas</code></a> elements) or, when an intrinsic fallback is not applicable, by
-						using a <a href="#sec-foreign-restrictions-manifest">manifest-level fallback</a>.</p>
-					<p id="confreq-cd-scripted-foreign-resources">EPUB Creators MUST ensure that scripts only generate
-							<a href="#sec-core-media-types">Core Media Type Resources</a> or fragments thereof.</p>
-				</section>
 			</section>
+
 
 			<section id="sec-pls">
 				<h3>Pronunciation Lexicons</h3>


### PR DESCRIPTION
This is the PR corresponding to #1704.

Note that I did not touch the PLS subsection, because there is a pending PR (#1700) that might remove it altogether, and did not want to create a possible merge conflict.

Fix #1704


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1709.html" title="Last updated on Jun 18, 2021, 1:38 PM UTC (17f6b55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1709/17a81fe...17f6b55.html" title="Last updated on Jun 18, 2021, 1:38 PM UTC (17f6b55)">Diff</a>