### PR TITLE
Allow use of ssml and pls in svg content documents

### DIFF
--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -183,7 +183,7 @@
 
 				<aside class="example">
 					<p>The following example shows the pronunciation for EPUB added to SVG markup.</p>
-					<pre>&lt;text>&lt;tspan ssml:ph="ipʌb">EPUB&lt;/span> 3&lt;/text></pre>
+					<pre>&lt;text>&lt;tspan ssml:ph="ipʌb">EPUB&lt;/tspan> 3&lt;/text></pre>
 				</aside>
 			</section>
 

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -122,7 +122,7 @@
 				<p>This specification recasts the [[SSML]] <a
 						href="https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#S3.1.10"><code>phoneme</code>
 						element</a> as two attributes — <code>ssml:ph</code> and <code>ssml:alphabet</code> — and makes
-					them available within XHTML Content Documents.</p>
+					them available within <a>EPUB Content Documents</a>.</p>
 
 				<p>The attributes allow EPUB Creators to specify the proper phonetic pronunciation for uncommon terms
 					that a TTS engine is likely to mispronounce, as well as to disambiguate heteronyms.</p>
@@ -149,9 +149,9 @@
 					</dd>
 					<dt>Usage</dt>
 					<dd>
-						<p><a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">Global
-								attribute</a>. EPUB Creators MAY specify on all elements with which they can logically
-							associate a phonetic equivalent (e.g., elements that contain textual information).</p>
+						<p>EPUB Creators MAY specify on any element in EPUB Content Documents with which they can
+							logically associate a phonetic equivalent (i.e., that has descendant text content that a
+							Text-to-Speech engine would otherwise render).</p>
 						<p>EPUB Creators MUST NOT specify the attribute on a descendant of an element that already
 							carries this attribute.</p>
 					</dd>
@@ -162,9 +162,9 @@
 					</dd>
 				</dl>
 
-				<p>This attribute inherits all the semantics of the [[SSML]] <code>phoneme</code> element <a
+				<p>This attribute inherits the requirements of the [[SSML]] <code>phoneme</code> element's <a
 						href="https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#S3.1.10"><code>ph</code></a>
-					attribute, with the following addition:</p>
+					attribute, with the following additions:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -177,8 +177,13 @@
 				</ul>
 
 				<aside class="example">
-					<p>The following example shows the pronunciation for EPUB.</p>
-					<pre>&lt;span ssml:ph="ipʌb">EPUB&lt;/span></pre>
+					<p>The following example shows the pronunciation for EPUB added to HTML markup.</p>
+					<pre>&lt;p>The &lt;span ssml:ph="ipʌb">EPUB&lt;/span> format &#8230;&lt;/p></pre>
+				</aside>
+
+				<aside class="example">
+					<p>The following example shows the pronunciation for EPUB added to SVG markup.</p>
+					<pre>&lt;text>&lt;tspan ssml:ph="ipʌb">EPUB&lt;/span> 3&lt;/text></pre>
 				</aside>
 			</section>
 
@@ -203,17 +208,17 @@
 					</dd>
 					<dt>Usage</dt>
 					<dd>
-						<p><a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">Global
-								attribute</a>. EPUB Creators MAY specify on any element.</p>
+						<p>EPUB Creators MAY specify on any element in an EPUB Content Document that can contain
+							descendant text content.</p>
 					</dd>
 					<dt>Value</dt>
 					<dd>
-						<p>The name of the pronunciation alphabet used in the value of <a href="#attrdef-ssml-ph"
-									><code>ssml:ph</code></a> (inherited).</p>
+						<p>The name of the pronunciation alphabet used to express the value of the <a
+								href="#attrdef-ssml-ph"><code>ssml:ph</code> attribute</a>.</p>
 					</dd>
 				</dl>
 
-				<p>This attribute inherits all the semantics of the [[SSML]] <code>phoneme</code> element <a
+				<p>This attribute inherits the requirements of the [[SSML]] <code>phoneme</code> element's <a
 						href="https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#S3.1.10"
 						><code>alphabet</code></a> attribute, with the following addition:</p>
 
@@ -234,10 +239,19 @@
    &#8230;
    &lt;body>
    	&#8230;
-   	   &lt;p ssml:alphabet="ipa">&lt;span ssml:ph="ipʌb">EPUB&lt;/span> &#8230;&lt;/p>
+   	   &lt;p ssml:alphabet="ipa">&lt;span ssml:ph="ipʌb">EPUB&lt;/span> is an &#8230;&lt;/p>
    	&#8230;
    &lt;/body>
 &lt;/html></pre>
+				</aside>
+
+				<aside class="example">
+					<p>The following example shows a global declaration for the x-SAMPA alphabet on the root
+							<code>svg</code> element.</p>
+					<pre>&lt;svg &#8230; ssml:alphabet="x-sampa">
+   &lt;title>&lt;span ssml:ph="ipVb">EPUB&lt;/span> Adoption Chart&lt;/title>
+   &#8230;
+&lt;/svg></pre>
 				</aside>
 
 				<div class="note">
@@ -264,11 +278,12 @@
 					the SSML attributes. It is a much more efficient way of defining pronunciations for words with only
 					a single pronunciation, or where a particular pronunciation is predominant.</p>
 
-				<p>EPUB Creators use the <a
+				<p>EPUB Creators can use the [[HTML]] <a
 						href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"><code>link</code>
-						element</a> to associate one or more lexicons with an <a>XHTML Content Document</a>. Reading
-					Systems can then process the XHTML to extract the list of lexicons to use and initiate
-					text-to-speech playback with these resources.</p>
+						element</a> and [[SVG2]] <a href="https://www.w3.org/TR/SVG2/struct.html#HTMLMetadataElements"
+							><code>link</code> element</a> to associate one or more lexicons with their respective
+						<a>EPUB Content Document</a> type. When Reading Systems process the documents, they can identify
+					the linked lexicons and use them to initiate text-to-speech playback.</p>
 			</section>
 
 			<section id="pls-lexicon-conformance">
@@ -310,17 +325,22 @@
 			</section>
 
 			<section id="pls-publication-requirements">
-				<h3>Associating with XHTML Content Documents</h3>
+				<h3>Associating with EPUB Content Documents</h3>
 
-				<p id="confreq-cd-pls-xht">EPUB Creators MAY associate zero or more PLS Documents with an <a>XHTML
-						Content Document</a>.</p>
+				<p id="confreq-cd-pls-xht">EPUB Creators MAY associate zero or more pronunciation lexicons
+					[[PRONUNCIATION-LEXICON]] with an <a>EPUB Content Document</a>.</p>
 
-				<p id="confreq-cd-pls-assoc">To associate a PLS Document with an <a>XHTML Content Document</a>, EPUB
-					Creators MUST use the [[HTML]] <a
+				<p id="confreq-cd-pls-assoc">To associate a pronunciation lexicon with an <a>XHTML Content Document</a>,
+					EPUB Creators MUST use the [[HTML]] <a
 						href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"
-						><code>link</code></a> element with its <code>rel</code> attribute set to
-						"<code>pronunciation</code>" and its <code>type</code> attribute set to the media type
-						"<code>application/pls+xml</code>".</p>
+						><code>link</code></a> element. Similarly, to associate a pronunciation lexison with an <a>SVG
+						Content Document</a>, EPUB Creators MUST use the [[SVG2]] <a
+						href="https://www.w3.org/TR/SVG2/struct.html#HTMLMetadataElements"><code>link</code>
+					element</a>.</p>
+
+				<p>For both types of EPUB Content Document, the <code>link</code> element MUST have its <code>rel</code>
+					attribute set to "<code>pronunciation</code>" and its <code>type</code> attribute set to the media
+					type "<code>application/pls+xml</code>".</p>
 
 				<p id="confreq-cd-pls-assoc-lang">EPUB Creators SHOULD specify the <code>link</code> element
 						<code>hreflang</code> attribute on each <code>link</code>, and its value MUST match <a
@@ -328,8 +348,8 @@
 						which the pronunciation lexicon is relevant</a> [[PRONUNCIATION-LEXICON]] when specified.</p>
 
 				<aside class="example">
-					<p>The following example shows two <abbr title="Pronunciation Lexicon Specification">PLS</abbr>
-						documents (one for Chinese and one for Mongolian) associated with an XHTML Content Document.</p>
+					<p>The following example shows two pronunciation lexicons (one for Chinese and one for Mongolian)
+						associated with an XHTML Content Document.</p>
 					<pre>
 &lt;html … &gt;    
     &lt;head&gt;
@@ -436,5 +456,43 @@
 				</dl>
 			</section>
 		</section>
+		<section id="change-log" class="appendix informative">
+			<h2>Change Log</h2>
+
+			<p>Note that this change log only identifies substantive changes &#8212; those that affect conformance or
+				are similarly noteworthy.</p>
+
+			<p>For a list of all issues addressed during the revision, refer to the <a
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3ASpec-TTS">Working
+					Group's issue tracker</a>.</p>
+
+			<section id="changes-latest">
+				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-contentdocs.html">EPUB
+						Content Documents 3.2</a></h3>
+
+				<!--
+					After each working draft is published:
+						- change the link/text in the section heading to refer to the published draft (use the dated URL)
+						- move all changes down to the next section
+				-->
+
+				<ul>
+					<li>22-June-2021: Added that SSML and PLS can also be used with SVG Content Documents. See <a
+							href="https://github.com/w3c/epub-specs/issues/1710">issue 1710</a>.</li>
+				</ul>
+			</section>
+
+			<!-- 
+			<section id="changes-older">
+				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-contentdocs.html">EPUB
+					Content Documents 3.2</a></h3>
+				
+				<ul>
+				</ul>
+			</section>
+			-->
+		</section>
+		<div data-include="../common/acknowledgements-core.html" data-oninclude="fixIncludes"
+			data-include-replace="true"></div>
 	</body>
 </html>


### PR DESCRIPTION
The changes are generally straightforward with the exception of what elements the SSML attributes are allowed on. The original wording for ssml:ph, for example, made it global and then limited it to only where it represents a phonetic pronunciation.

This doesn't make as much sense for SVG as it looks like only text, textPath, tspan, title and desc can contain text.

I know we have this for HTML, though, because it would otherwise require an evolving list of where it's allowed. I'm tempted to say we should at least limit the attribute to "palpable content" in HTML, but then it doesn't even make sense on all of those elements (audio, video, img, form elements, iframe, etc.). It also misses the title element, but that's an easy add.

I've largely kept the original wording, as I suppose we can't try to solve every possible authoring sin. Maybe we can address the authoring pitfalls of using ssml:ph on root elements, or the body, or elements without text in another PR without normatively disallowing.

But I'd be open to a format-specific restriction list like:

> EPUB Creators MAY specify on:
> 
> -  In XHTML Content Documents, the `title` element and any palpable content [[HTML]] with which they can logically associate a phonetic equivalent (i.e., that has descendant text content that a Text-to-Speech engine would otherwise render).
> - In SVG Content Docments, the `title`, `desc`, 'text`, `textPath`, and `tspan` elements [[SVG2]].

(We should probably add some reading system restrictions, like ignoring ssml:ph if the element it is on doesn't have any text that would be voiced, but for another PR.)

Fixes #1710 

- TTS [preview](https://cdn.statically.io/gh/w3c/epub-specs/tts/issue-1710/epub33/tts/index.html)
- TTS [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/main/epub33/tts/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/tts/issue-1710/epub33/tts/index.html)
