### PR TITLE
Shortened the history section

### DIFF
--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>EPUB 3 Text-to-Speech Enhancements</title>
-		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
 		<script src="../common/js/biblio.js" class="remove"></script>
 		<script src="../common/js/dfn-crossref.js" class="remove"></script>
 		<script src="../common/js/confreq-permalinks.js" class="remove"></script>
@@ -85,17 +85,13 @@
 					in-development speech properties of the CSS Speech module [[CSS-Speech-1]].</p>
 
 				<p>Although there has been some authoring uptake of these technologies, support in Reading Systems has
-					yet to materialize to a level where these technologies are considered stable under W3C process
-					requirements.</p>
-
-				<p>To ensure that EPUB 3.3 can move to a W3C Recommendation as easily as possible while also avoiding
-					any backwards compatibility issues, the W3C's EPUB 3 Working Group decided to publish these
-					technologies as a W3C Working Group Note.</p>
+					yet to materialize to a level where these technologies are considered stable. 
+					As a consequence, these technologies are now published as a W3C Working Group Note.</p>
 
 				<p>EPUB Creators can continue to use these technologies in their publications, as the move to a Note
-					does not change their validity. Developers of Reading Systems that support TTS playback are also
-					strongly encouraged to implement support. The Working Group will look at standardizing any of the
-					technologies that meet support requirements in future revisions of EPUB 3.</p>
+					does not change their validity or affect backward compatibility. Developers of Reading Systems that
+					support TTS playback are also strongly encouraged to implement support. The Working Group will
+					look at standardizing any of the technologies that meet support requirements in future revisions of EPUB 3.</p>
 
 				<div class="note">
 					<p>The <a href="https://www.w3.org/TR/spoken-html/">Specification for Spoken Presentation in


### PR DESCRIPTION
I have removed statements referring to internal W3C process cuisine...

See

* [preview](https://raw.githack.com/w3c/epub-specs/tts-history/epub33/tts/index.html)
* * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/tts/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/tts-history/epub33/tts/index.html)