### PR TITLE
Adds ssml prefix declarations to examples

### DIFF
--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -174,13 +174,26 @@
 
 				<aside class="example">
 					<p>The following example shows the pronunciation for EPUB added to HTML markup.</p>
-					<pre>&lt;p>The &lt;span ssml:ph="ipʌb">EPUB&lt;/span> format &#8230;&lt;/p></pre>
+					<pre>&lt;html &#8230;
+      xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+      ssml:alphabet="ipa">
+   &#8230;
+   &lt;body>
+      &lt;h1>&lt;span ssml:ph="ipʌb">EPUB&lt;/span> 3.3&lt;/h1>
+      &#8230;
+   &lt;/body>
+&lt;/html>
+</pre>
 				</aside>
 
 				<aside class="example">
 					<p>The following example shows the pronunciation for EPUB added to SVG markup.</p>
-					<pre>&lt;text>&lt;tspan ssml:ph="ipʌb">EPUB&lt;/tspan> 3&lt;/text></pre>
-				</aside>
+					<pre>&lt;svg &#8230;
+     xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+     ssml:alphabet="ipa">
+   &lt;title>&lt;tspan ssml:ph="ipʌb">EPUB&lt;/tspan> 3&lt;/text></pre>
+   &#8230;
+&lt;/svg></aside>
 			</section>
 
 			<section id="ssml-alphabet-attribute">
@@ -230,12 +243,14 @@
 
 				<aside class="example">
 					<p>The following example shows a global declaration for the x-JEITA alphabet on the root
-							<code>html</code> element. It is overriden on a paragraph in the body to switch to IPA.</p>
-					<pre>&lt;html &#8230; ssml:alphabet="x-JEITA">
+							<code>html</code> element. It is overriden in the body to switch to IPA.</p>
+					<pre>&lt;html &#8230; 
+      xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+      ssml:alphabet="x-JEITA">
    &#8230;
    &lt;body>
    	&#8230;
-   	   &lt;p ssml:alphabet="ipa">&lt;span ssml:ph="ipʌb">EPUB&lt;/span> is an &#8230;&lt;/p>
+   	   &lt;p>&lt;span ssml:alphabet="ipa" ssml:ph="ipʌb">EPUB&lt;/span> is an &#8230;&lt;/p>
    	&#8230;
    &lt;/body>
 &lt;/html></pre>
@@ -244,8 +259,10 @@
 				<aside class="example">
 					<p>The following example shows a global declaration for the x-SAMPA alphabet on the root
 							<code>svg</code> element.</p>
-					<pre>&lt;svg &#8230; ssml:alphabet="x-sampa">
-   &lt;title>&lt;span ssml:ph="ipVb">EPUB&lt;/span> Adoption Chart&lt;/title>
+					<pre>&lt;svg &#8230;
+      xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+      ssml:alphabet="x-sampa">
+   &lt;title>&lt;tspan ssml:ph="ipVb">EPUB&lt;/tspan> Adoption Chart&lt;/title>
    &#8230;
 &lt;/svg></pre>
 				</aside>


### PR DESCRIPTION
No point in having an authoring shorthand section for one prefix that is central to the document.