### PR TITLE
SSML and PLS clarifications

### DIFF
--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -435,7 +435,8 @@
 				<h3>Conformance</h3>
 
 				<p><a>Reading Systems</a> with <a>Text-to-Speech</a> (TTS) capabilities SHOULD support <a href="#ssml"
-						>SSML attributes</a> and <a href="#pls">pronunciation lexicons</a> as follows:</p>
+						>SSML attributes</a>, <a href="#pls">pronunciation lexicons</a> and <a href="#css-speech">CSS
+						Speech</a> as follows:</p>
 
 				<dl>
 					<dt>SSML</dt>
@@ -512,6 +513,12 @@
 									carries the <code>ssml:ph</code> attribute.</p>
 							</li>
 						</ul>
+					</dd>
+
+					<dt>CSS Speech</dt>
+					<dd>
+						<p>This document adds no additional requirements for Reading System support to those defined in
+							[[CSS-SPEECH-1]].</p>
 					</dd>
 				</dl>
 			</section>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -172,9 +172,9 @@
 
 				<p id="ssml-ph-text">EPUB Creators SHOULD NOT use the <code>ssml:ph</code> attribute on elements without
 					text content that a Text-to-Speech engine would normally render (e.g., on empty <code>div</code> or
-						<code>span</code> elements). The attribute is not intended for adding additional voicing only
-					for users listening to TTS playback and Reading Systems are expected to ignore the attribute if it
-					does not replace text they would normally render.</p>
+						<code>span</code> elements). The attribute is not intended to add additional voicing only for
+					TTS playback, and Reading Systems are expected to ignore the attribute if it does not replace text
+					they would normally render.</p>
 
 				<div class="note">
 					<p>The <code>ssml:ph</code> attribute does not replace attribute values that carry additional

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -178,14 +178,18 @@
 
 				<div class="note">
 					<p>The <code>ssml:ph</code> attribute does not replace attribute values that carry additional
-						textual information (e.g., <code>alt</code> and <code>aria-label</code>) or link additional
-						textual information (e.g., <code>aria-describedby</code>).</p>
+						textual information (e.g., <a
+							href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-alt"
+								><code>alt</code></a> [[HTML]] and <a href="https://www.w3.org/TR/wai-aria/#aria-label"
+								><code>aria-label</code></a> [[WAI-ARIA]]) or link additional textual information (e.g.,
+							<a href="https://www.w3.org/TR/wai-aria/#aria-describedby"><code>aria-describedby</code></a>
+						[[WAI-ARIA]]).</p>
 				</div>
 
 				<p id="ssml-ph-empty">Similarly, EPUB Creators SHOULD NOT add empty <code>ssml:ph</code> attributes to
 					try and suppress the rendering of text. Reading Systems are expected to ignore empty attributes.
 					(See the <a href="https://www.w3.org/TR/wai-aria/#aria-hidden"><code>aria-hidden</code>
-						attribute</a> [[WAI-ARIA]] for specifying that content is only for visual rendering.)</p>
+						attribute</a> [[?WAI-ARIA]] for specifying that content is only for visual rendering.)</p>
 
 				<aside class="example">
 					<p>The following example shows the pronunciation for EPUB added to HTML markup.</p>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -534,8 +534,8 @@
 				are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3ASpec-TTS">Working
-					Group's issue tracker</a>.</p>
+					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+label%3ASpec-TTS"
+					>Working Group's issue tracker</a>.</p>
 
 			<section id="changes-latest">
 				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-contentdocs.html">EPUB

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -65,8 +65,8 @@
 					common terms a TTS engine can use, while SSML provides the ability to add individual voicing for
 					specific phrases. EPUB Creators can use these technologies together or separately depending on the
 					complexity of the text. Despite these advantages, the technologies have not been adapted for easy
-					use within the XHTML and SVG formats that EPUB relies on. This document represents an attempt to
-					reformulate these technologies so that they can be authored in EPUB Content Documents.</p>
+					use within the XHTML and SVG formats that EPUB relies on. This document proposes an approach to
+					enable their authoring and rendering in EPUB Content Documents.</p>
 
 				<p>This document also covers the use of CSS Speech for improved aural rendering in EPUB. CSS Speech
 					covers a different domain than SSML and pronunciation lexicons. Instead of controlling the specific
@@ -85,13 +85,14 @@
 					in-development speech properties of the CSS Speech module [[CSS-Speech-1]].</p>
 
 				<p>Although there has been some authoring uptake of these technologies, support in Reading Systems has
-					yet to materialize to a level where these technologies are considered stable. 
-					As a consequence, these technologies are now published as a W3C Working Group Note.</p>
+					yet to materialize to a level where these technologies are considered stable. As a consequence,
+					these technologies are now published as a W3C Working Group Note.</p>
 
 				<p>EPUB Creators can continue to use these technologies in their publications, as the move to a Note
 					does not change their validity or affect backward compatibility. Developers of Reading Systems that
-					support TTS playback are also strongly encouraged to implement support. The Working Group will
-					look at standardizing any of the technologies that meet support requirements in future revisions of EPUB 3.</p>
+					support TTS playback are also strongly encouraged to implement support. The Working Group will look
+					at standardizing any of the technologies that meet support requirements in future revisions of EPUB
+					3.</p>
 
 				<div class="note">
 					<p>The <a href="https://www.w3.org/TR/spoken-html/">Specification for Spoken Presentation in
@@ -158,29 +159,54 @@
 					</dd>
 				</dl>
 
-				<p>This attribute inherits the requirements of the [[SSML]] <code>phoneme</code> element's <a
+				<p>The <code>ssml:ph</code> attribute inherits the authoring requirements of the [[SSML]]
+						<code>phoneme</code> element's <a
 						href="https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#S3.1.10"><code>ph</code></a>
-					attribute, with the following additions:</p>
+					attribute.</p>
 
-				<ul class="conformance-list">
-					<li>
-						<p id="ssml-ph-concat">When the <code>ssml:ph</code> attribute appears on an element that has
-							text node descendants, the corresponding document text to which the pronunciation applies is
-							the string that results from concatenating the descendant text nodes, in document order. The
-							specified phonetic pronunciation MUST therefore logically match the element's textual data
-							in its entirety (i.e., not just an isolated part of its content).</p>
-					</li>
-				</ul>
+				<p id="ssml-ph-concat">When the <code>ssml:ph</code> attribute appears on an element that has text node
+					descendants, the corresponding document text to which the pronunciation applies is the string that
+					results from concatenating the descendant text nodes, in document order. The specified phonetic
+					pronunciation must therefore logically match the element's textual data in its entirety (i.e., not
+					just an isolated part of its content).</p>
+
+				<p id="ssml-ph-text">EPUB Creators SHOULD NOT use the <code>ssml:ph</code> attribute on elements without
+					text content that a Text-to-Speech engine would normally render (e.g., on empty <code>div</code> or
+						<code>span</code> elements). The attribute is not intended for adding additional voicing only
+					for users listening to TTS playback and Reading Systems are expected to ignore the attribute if it
+					does not replace text they would normally render.</p>
+
+				<div class="note">
+					<p>The <code>ssml:ph</code> attribute does not replace attribute values that carry additional
+						textual information (e.g., <code>alt</code> and <code>aria-label</code>) or link additional
+						textual information (e.g., <code>arai-describedby</code>).</p>
+				</div>
+
+				<p id="ssml-ph-empty">Similarly, EPUB Creators SHOULD NOT add empty <code>ssml:ph</code> attributes to
+					try and suppress the rendering of text. Reading Systems are expected to ignore empty attributes.
+					(See the <a href="https://www.w3.org/TR/wai-aria/#aria-hidden"><code>aria-hidden</code>
+						attribute</a> [[WAI-ARIA]] for specifying that content is only for visual rendering.)</p>
 
 				<aside class="example">
 					<p>The following example shows the pronunciation for EPUB added to HTML markup.</p>
-					<pre>&lt;p>The &lt;span ssml:ph="ipʌb">EPUB&lt;/span> format &#8230;&lt;/p></pre>
+					<pre>&lt;html &#8230;
+      xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+      ssml:alphabet="ipa">
+   &#8230;
+   &lt;body>
+      &lt;h1>&lt;span ssml:ph="ipʌb">EPUB&lt;/span> 3.3&lt;/h1>
+      &#8230;
+   &lt;/body>
+&lt;/html>
+</pre>
 				</aside>
 
 				<aside class="example">
 					<p>The following example shows the pronunciation for EPUB added to SVG markup.</p>
-					<pre>&lt;text>&lt;tspan ssml:ph="ipʌb">EPUB&lt;/tspan> 3&lt;/text></pre>
-				</aside>
+					<pre>&lt;svg &#8230;
+     xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+     ssml:alphabet="ipa">
+   &lt;title>&lt;tspan ssml:ph="ipʌb">EPUB&lt;/tspan> 3&lt;/text></pre> &#8230; &lt;/svg></aside>
 			</section>
 
 			<section id="ssml-alphabet-attribute">
@@ -214,28 +240,32 @@
 					</dd>
 				</dl>
 
-				<p>This attribute inherits the requirements of the [[SSML]] <code>phoneme</code> element's <a
+				<p>The <code>ssml:alphabet</code> attribute inherits the authoring requirements of the [[SSML]]
+						<code>phoneme</code> element's <a
 						href="https://www.w3.org/TR/2010/REC-speech-synthesis11-20100907/#S3.1.10"
-						><code>alphabet</code></a> attribute, with the following addition:</p>
+						><code>alphabet</code></a> attribute.</p>
 
-				<ul class="conformance-list">
-					<li>
-						<p id="ssml-alphabet-inherit">The value of the <code>ssml:alphabet</code> attribute is inherited
-							in the document tree. The pronunciation alphabet used for each <code>ssml:ph</code>
-							attribute value is determined by locating the first occurrence of the
-								<code>ssml:alphabet</code> attribute starting with the element on which the
-								<code>ssml:ph</code> attribute appears, followed by the nearest ancestor element.</p>
-					</li>
-				</ul>
+				<p id="ssml-alphabet-inherit">The value of the <code>ssml:alphabet</code> attribute is inherited in the
+					document tree. The pronunciation alphabet used for each <code>ssml:ph</code> attribute value is
+					determined by locating the first occurrence of the <code>ssml:alphabet</code> attribute starting
+					with the element on which the <code>ssml:ph</code> attribute appears, followed by the nearest
+					ancestor element.</p>
+
+				<p>EPUB Creators SHOULD ensure that an alphabet is defined in scope for all phonemes expressed in <a
+						href="#ssml-ph-attribute"><code>ssml:ph</code> attributes</a>. Interoperability of playback
+					cannot be guaranteed in the absence of a declaration &#8212; Reading Systems may apply a default
+					alphabet, for example, or may not voice the phoneme.</p>
 
 				<aside class="example">
 					<p>The following example shows a global declaration for the x-JEITA alphabet on the root
-							<code>html</code> element. It is overriden on a paragraph in the body to switch to IPA.</p>
-					<pre>&lt;html &#8230; ssml:alphabet="x-JEITA">
+							<code>html</code> element. It is overriden in the body to switch to IPA.</p>
+					<pre>&lt;html &#8230; 
+      xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+      ssml:alphabet="x-JEITA">
    &#8230;
    &lt;body>
    	&#8230;
-   	   &lt;p ssml:alphabet="ipa">&lt;span ssml:ph="ipʌb">EPUB&lt;/span> is an &#8230;&lt;/p>
+   	   &lt;p>&lt;span ssml:alphabet="ipa" ssml:ph="ipʌb">EPUB&lt;/span> is an &#8230;&lt;/p>
    	&#8230;
    &lt;/body>
 &lt;/html></pre>
@@ -244,8 +274,10 @@
 				<aside class="example">
 					<p>The following example shows a global declaration for the x-SAMPA alphabet on the root
 							<code>svg</code> element.</p>
-					<pre>&lt;svg &#8230; ssml:alphabet="x-sampa">
-   &lt;title>&lt;span ssml:ph="ipVb">EPUB&lt;/span> Adoption Chart&lt;/title>
+					<pre>&lt;svg &#8230;
+      xmlns:ssml="http://www.w3.org/2001/10/synthesis"
+      ssml:alphabet="x-sampa">
+   &lt;title>&lt;tspan ssml:ph="ipVb">EPUB&lt;/tspan> Adoption Chart&lt;/title>
    &#8230;
 &lt;/svg></pre>
 				</aside>
@@ -408,8 +440,34 @@
 						<p>Reading Systems that support SSML:</p>
 						<ul class="conformance-list">
 							<li>
-								<p>SHOULD support the IPA alphabet [[IPA]], as expressed by the value
-									"<code>ipa</code>".</p>
+								<p id="confreq-ssml-ph">MUST process the <code>ssml:ph</code> attribute per the
+									requirements for the <a href="https://www.w3.org/TR/speech-synthesis11/#S3.1.10"
+											><code>phoneme</code> element's <code>ph</code> attribute</a> [[SSML]] with
+									the additional requirements that it:</p>
+								<ul>
+									<li>
+										<p id="confreq-ssml-ph-empty">MUST ignore <code>ssml:ph</code> attributes whose
+											value is an empty string or consists only of <a
+												href="https://infra.spec.whatwg.org/#ascii-whitespace">ASCII
+												whitespace</a> [[INFRA]].</p>
+									</li>
+									<li>
+										<p id="confreq-ssml-ph-emptytext">MUST ignore <code>ssml:ph</code> attributes on
+											elements whose descendant text content is an empty string or consists only
+											of <a href="https://infra.spec.whatwg.org/#ascii-whitespace">ASCII
+												whitespace</a> [[INFRA]].</p>
+									</li>
+									<li>
+										<p id="confreq-ssml-ph-nontext">MUST ignore <code>ssml:ph</code> attributes on
+											elements whose descendant text content represents a fallback.</p>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<p id="confreq-ssml-alphabet">MUST process the <code>ssml:alphabet</code> attribute per
+									the requirements for the <a href="https://www.w3.org/TR/speech-synthesis11/#S3.1.10"
+											><code>phoneme</code> element's <code>alphabet</code> attribute</a>
+									[[SSML]].</p>
 							</li>
 						</ul>
 					</dd>
@@ -419,22 +477,24 @@
 						<p>Reading Systems that support pronunciation lexicons:</p>
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-pls-rs-proc">MUST process PLS documents as defined in
-									[[PRONUNCIATION-LEXICON]].</p>
-								<p id="confreq-pls-rs-scope">MUST apply the supplied pronunciation instructions to all
-									text nodes in the current XHTML Content Document whose <a
-										href="https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes"
-										>language</a> [[HTML]] matches <a
+								<p id="confreq-pls-rs-proc">MUST process all linked pronunciation lexicons in an EPUB
+									Content Document as defined in [[PRONUNCIATION-LEXICON]].</p>
+							</li>
+							<li>
+								<p id="confreq-pls-rs-scope">MUST apply the supplied lexemes to all text nodes in the
+									EPUB Content Document whose language matches <a
 										href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/#S4.1">the
 										language for which the pronunciation lexicon is relevant</a>
 									[[PRONUNCIATION-LEXICON]]. [[BCP47]] defines the algorithm for matching language
 									tags.</p>
-								<p id="confreq-pls-rs-multi">MUST give precedence to the last occurrence of a rule when
-									a pronunciation rule is specified more than once for a given string target in a
-									given language (i.e., the Reading System must override the previously defined
-									pronunciation rule(s)).</p>
 							</li>
 						</ul>
+						<div class="note">
+							<p>It is not required that the Reading System use a Text-to-Speech engine that supports
+								pronunciation lexicons so long as the lexemes are processed and applied correctly. A
+								Reading System might, for example, transform the lexicon into an alternative dictionary
+								format its TTS engine supports.</p>
+						</div>
 					</dd>
 
 					<dt>SSML and Pronunciation Lexicons</dt>
@@ -443,9 +503,10 @@
 						<ul>
 							<li>
 								<p>MUST let any pronunciation instructions provided via the <a href="#ssml-ph-attribute"
-											><code>ssml:ph</code></a> attribute take precedence in cases where a
-										<code>grapheme</code> element [[PRONUNCIATION-LEXICON]] matches a text node of
-									an element that carries the <code>ssml:ph</code> attribute.</p>
+											><code>ssml:ph</code></a> attribute take precedence in cases where a <a
+										href="https://www.w3.org/TR/pronunciation-lexicon/#S4.5"><code>grapheme</code>
+										element</a> [[PRONUNCIATION-LEXICON]] matches a text node of an element that
+									carries the <code>ssml:ph</code> attribute.</p>
 							</li>
 						</ul>
 					</dd>
@@ -473,6 +534,11 @@
 				-->
 
 				<ul>
+					<li>25-June-2021: Clarified processing of <code>ssml:alphabet</code> attribute and added additional
+						requirements for the <code>ssml:ph</code> attribute to avoid its use for adding or removing text
+						vocalization. See <a href="https://github.com/w3c/epub-specs/issues/1706">issue 1706</a>.</li>
+					<li>25-June-2021: Clarified application of pronunciation lexicons. See <a
+							href="https://github.com/w3c/epub-specs/issues/1705">issue 1705</a>.</li>
 					<li>22-June-2021: Added that SSML and PLS can also be used with SVG Content Documents. See <a
 							href="https://github.com/w3c/epub-specs/issues/1710">issue 1710</a>.</li>
 				</ul>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -85,8 +85,8 @@
 					in-development speech properties of the CSS Speech module [[CSS-Speech-1]].</p>
 
 				<p>Although there has been some authoring uptake of these technologies, support in Reading Systems has
-					yet to materialize to a level where these technologies are considered stable. As a consequence,
-					these technologies are now published as a W3C Working Group Note.</p>
+					yet to materialize to a level where these technologies are considered stable. Consequently, these
+					technologies are now published as a W3C Working Group Note.</p>
 
 				<p>EPUB Creators can continue to use these technologies in their publications, as the move to a Note
 					does not change their validity or affect backward compatibility. Developers of Reading Systems that
@@ -179,7 +179,7 @@
 				<div class="note">
 					<p>The <code>ssml:ph</code> attribute does not replace attribute values that carry additional
 						textual information (e.g., <code>alt</code> and <code>aria-label</code>) or link additional
-						textual information (e.g., <code>arai-describedby</code>).</p>
+						textual information (e.g., <code>aria-describedby</code>).</p>
 				</div>
 
 				<p id="ssml-ph-empty">Similarly, EPUB Creators SHOULD NOT add empty <code>ssml:ph</code> attributes to
@@ -261,7 +261,7 @@
 
 				<aside class="example">
 					<p>The following example shows a global declaration for the x-JEITA alphabet on the root
-							<code>html</code> element. It is overriden in the body to switch to IPA.</p>
+							<code>html</code> element. It is overridden in the body to switch to IPA.</p>
 					<pre>&lt;html &#8230; 
       xmlns:ssml="http://www.w3.org/2001/10/synthesis"
       ssml:alphabet="x-JEITA">
@@ -364,7 +364,7 @@
 				<p id="confreq-cd-pls-assoc">To associate a pronunciation lexicon with an <a>XHTML Content Document</a>,
 					EPUB Creators MUST use the [[HTML]] <a
 						href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"
-						><code>link</code></a> element. Similarly, to associate a pronunciation lexison with an <a>SVG
+						><code>link</code></a> element. Similarly, to associate a pronunciation lexicon with an <a>SVG
 						Content Document</a>, EPUB Creators MUST use the [[SVG2]] <a
 						href="https://www.w3.org/TR/SVG2/struct.html#HTMLMetadataElements"><code>link</code>
 					element</a>.</p>


### PR DESCRIPTION
This PR adds some clarifications for using the SSML attributes and attaching pronunciation lexicons. In particular, that ssml:ph not be used where there isn't text and be ignored if it's empty as it's not intended to suppress voicing. It also points out the voicings are not replacements for attributes that carry textual information.

I've generally only made the requirements "should not" as it's hard to anticipate if there ever would be a legitimate outside case.

I still find the complexities of HTML and SVG markup vis-a-vis raw SSML leave us only with a basic framework, but I guess small steps are good enough until more developers try to implement these technologies. In other words, I don't anticipate doing anything more to this note myself.

Feedback welcome on the additions, of course.

Fixes #1705 
Fixes #1706 

- TTS [preview](https://cdn.statically.io/gh/w3c/epub-specs/tts/issue-1706/epub33/tts/index.html)
- TTS [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/main/epub33/tts/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/tts/issue-1706/epub33/tts/index.html)
