### PR TITLE
Add note about the problem accessing resources

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9302,6 +9302,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>28-June-2021: Added a note discouraging EPUB Creators from referencing resources outside the
+						directory containing the Package Document to avoid interoperability issues. See <a
+							href="https://github.com/w3c/epub-specs/issues/1687">issue 1687</a></li>
 					<li>18-June-2021: Moved requirements for authoring SSML, PLS lexicons and CSS 3 Speech to the <a
 							href="https://www.w3.org/TR/epub-3-tts">EPUB 3 Text-to-Speech Enhancements</a> note. The
 						ability to use these technologies in EPUB 3 Publications remains unchanged. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1216,7 +1216,10 @@
 								<code>href</code>
 							</dt>
 							<dd>
-								<p>A <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL string</a> [[URL]] that references a resource. If the value is an <a href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL</a>, it SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
+								<p>A <a href="https://url.spec.whatwg.org/#valid-url-string">valid URL
+									string</a> [[URL]] that references a resource. If the value is an <a
+										href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL</a>, it
+									SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
 								<div class="example">
 									<pre>&lt;link rel="record"
       href="meta/9780000000001.xml" 
@@ -3863,8 +3866,9 @@ Spine:
 
 			<section>
 				<h3>Common Resource Requirements</h3>
-				
-				<p>This section defines requirements for technologies usable in both XHTML and SVG Content Documents.</p>
+
+				<p>This section defines requirements for technologies usable in both XHTML and SVG Content
+					Documents.</p>
 
 				<section id="sec-css">
 					<h3>Cascading Style Sheets (CSS)</h3>
@@ -3882,17 +3886,18 @@ Spine:
 							section, EPUB defers to the W3C to define CSS.</p>
 
 						<div class="note">
-							<p>Keep in mind that some <a>Reading Systems</a> will not support all desired features of CSS.
-								The following are known to be particularly problematic:</p>
+							<p>Keep in mind that some <a>Reading Systems</a> will not support all desired features of
+								CSS. The following are known to be particularly problematic:</p>
 							<ul>
 								<li>
-									<p>Reading System-induced pagination can interact poorly with style sheets as Reading
-										Systems sometimes paginate using columns. This may result in incorrect values for
-										viewport sizes. Fixed and absolute positioning are particularly problematic.</p>
+									<p>Reading System-induced pagination can interact poorly with style sheets as
+										Reading Systems sometimes paginate using columns. This may result in incorrect
+										values for viewport sizes. Fixed and absolute positioning are particularly
+										problematic.</p>
 								</li>
 								<li>
-									<p>Some types of screens will render animations and transitions poorly (e.g., those with
-										high latency).</p>
+									<p>Some types of screens will render animations and transitions poorly (e.g., those
+										with high latency).</p>
 								</li>
 							</ul>
 						</div>
@@ -3905,7 +3910,8 @@ Spine:
 
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-css-props">MAY include any CSS properties, with the following exceptions:</p>
+								<p id="confreq-css-props">MAY include any CSS properties, with the following
+									exceptions:</p>
 								<ul class="conformance-list">
 									<li>
 										<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
@@ -3924,16 +3930,16 @@ Spine:
 										href="#sec-css-prefixed"></a>.</p>
 							</li>
 							<li>
-								<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8 as
-									the RECOMMENDED encoding.</p>
+								<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8
+									as the RECOMMENDED encoding.</p>
 							</li>
 						</ul>
 
 						<div class="note">
 							<p>This specification restricts the use of the <code>direction</code> and
-									<code>unicode-bidi</code> properties because Reading Systems may not implement, or may
-								switch off, CSS processing. EPUB Creators must use the following format-specific methods
-								when they need control over these aspects of the rendering:</p>
+									<code>unicode-bidi</code> properties because Reading Systems may not implement, or
+								may switch off, CSS processing. EPUB Creators must use the following format-specific
+								methods when they need control over these aspects of the rendering:</p>
 
 							<ul>
 								<li>
@@ -3950,8 +3956,8 @@ Spine:
 											href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
 												><code>dir</code> attribute</a> [[HTML]] and the <a
 											href="https://www.w3.org/TR/SVG2/styling.html#PresentationAttributes"
-											>presentation attribute alternative</a> for <code>unicode-bidi</code> [[SVG]]
-										for bidirectionality.</p>
+											>presentation attribute alternative</a> for <code>unicode-bidi</code>
+										[[SVG]] for bidirectionality.</p>
 								</li>
 							</ul>
 						</div>
@@ -3960,25 +3966,27 @@ Spine:
 					<section id="sec-css-prefixed">
 						<h4>Prefixed Properties</h4>
 
-						<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to world
-							languages were not yet mature. To ensure backwards compatibility for content authored using
-							these prefixes, they have been retained in this specification. Unless otherwise noted, prefixed
-							properties and values behave exactly as their unprefixed equivalents as described in the
-							appropriate CSS specification. The prefixed properties are documented in an <a
+						<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to
+							world languages were not yet mature. To ensure backwards compatibility for content authored
+							using these prefixes, they have been retained in this specification. Unless otherwise noted,
+							prefixed properties and values behave exactly as their unprefixed equivalents as described
+							in the appropriate CSS specification. The prefixed properties are documented in an <a
 								href="#css-prefixes">Appendix</a>. </p>
 
 						<div class="caution">
 							<p><a>EPUB Creators</a> should use unprefixed properties and <a>Reading Systems</a> should
 								support current CSS specifications. This specification retains the widely-used prefixed
-								properties from [[EPUBContentDocs-301]], but removes support for the less-used ones. EPUB
-								Creators should use CSS-native solutions for the removed properties whenever available.</p>
+								properties from [[EPUBContentDocs-301]], but removes support for the less-used ones.
+								EPUB Creators should use CSS-native solutions for the removed properties whenever
+								available.</p>
 							<p>The Working Group recommends that EPUB Creators currently using these prefixed properties
 								move to unprefixed versions as soon as support allows, as the Working Group does not
 								anticipate supporting them in the next major version of EPUB.</p>
 						</div>
 
-						<p class="note">In some cases, the unprefixed versions of these properties now support additional
-							values. Reading Systems MAY support these values even with the prefixed property.</p>
+						<p class="note">In some cases, the unprefixed versions of these properties now support
+							additional values. Reading Systems MAY support these values even with the prefixed
+							property.</p>
 					</section>
 				</section>
 
@@ -3988,10 +3996,11 @@ Spine:
 					<section id="sec-scripted-support">
 						<h4>Script Inclusion</h4>
 
-						<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in the
-							respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB Content Document
-							contains scripting, this specification refers to it as a <a>Scripted Content Document</a>. This
-							label also applies to <a>XHTML Content Documents</a> when they contain instances of [[HTML]] <a
+						<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in
+							the respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB Content
+							Document contains scripting, this specification refers to it as a <a>Scripted Content
+								Document</a>. This label also applies to <a>XHTML Content Documents</a> when they
+							contain instances of [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/forms.html#forms">forms</a>.</p>
 
 						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
@@ -4003,24 +4012,24 @@ Spine:
 							[[HTML]], it does not represent scripted content.</p>
 
 						<div class="note">
-							<p>[[SVG]] does not define data blocks as of publication, but the same exclusion would apply if
-								a future update adds the concept.</p>
+							<p>[[SVG]] does not define data blocks as of publication, but the same exclusion would apply
+								if a future update adds the concept.</p>
 						</div>
 
 						<p>EPUB Creators should note that Reading Systems are required to behave as though a unique <a
-								href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] has been assigned to each EPUB
-							Publication. In practice, this means that it is not possible for scripts to share data between
-							EPUB Publications.</p>
+								href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] has been assigned to each
+							EPUB Publication. In practice, this means that it is not possible for scripts to share data
+							between EPUB Publications.</p>
 
-						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the rights
-							and restrictions that a Reading System places on it (refer to <a
+						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
+							rights and restrictions that a Reading System places on it (refer to <a
 								href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content">Scripting Conformance</a>
 							[[?EPUB-RS-33]] for more information).</p>
 
 						<div class="note">
-							<p>Reading Systems may render Scripted Content Documents in a manner that disables other EPUB
-								capabilities and/or provides a different rendering and user experience (e.g., by disabling
-								pagination).</p>
+							<p>Reading Systems may render Scripted Content Documents in a manner that disables other
+								EPUB capabilities and/or provides a different rendering and user experience (e.g., by
+								disabling pagination).</p>
 						</div>
 					</section>
 
@@ -4032,20 +4041,21 @@ Spine:
 						<ul>
 							<li><a href="#sec-scripted-container-constrained">container-constrained</a> &#8212; when the
 								execution of a script occurs within an <code>iframe</code>; and</li>
-							<li><a href="#sec-scripted-spine">spine-level</a> &#8212; when the execution of a script occurs
-								directly within a <a>Top-level Content Document</a>.</li>
+							<li><a href="#sec-scripted-spine">spine-level</a> &#8212; when the execution of a script
+								occurs directly within a <a>Top-level Content Document</a>.</li>
 						</ul>
 
-						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference it
-							via the element's <code>src</code> attribute makes no difference to its executing context.</p>
+						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference
+							it via the element's <code>src</code> attribute makes no difference to its executing
+							context.</p>
 
 						<p>Which context EPUB Creators use for their scripts affects both what actions the scripts can
 							perform and the likelihood of support in Reading Systems, as described in the following
 							subsections.</p>
 
 						<div class="note">
-							<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference between
-								the two contexts.</p>
+							<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference
+								between the two contexts.</p>
 						</div>
 
 						<section id="sec-scripted-container-constrained">
@@ -4066,31 +4076,32 @@ Spine:
 								<li>
 									<p>An instance of the [[SVG]] <a
 											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
-											><code>script</code></a> element contained in an <a>SVG Content Document</a>
-										that is embedded in a parent XHTML Content Document using the [[HTML]] <a
+												><code>script</code></a> element contained in an <a>SVG Content
+											Document</a> that is embedded in a parent XHTML Content Document using the
+										[[HTML]] <a
 											href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
 												><code>iframe</code></a> element.</p>
 								</li>
 							</ul>
 
 							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
-								instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e., the
-								one that contains the <code>iframe</code> element). It also MUST NOT contain instructions
-								for manipulating the size of its containing rectangle.</p>
+								instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e.,
+								the one that contains the <code>iframe</code> element). It also MUST NOT contain
+								instructions for manipulating the size of its containing rectangle.</p>
 
 							<p>EPUB Creators should note that <a
 									href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content">support for
-									container-constrained scripting in Reading Systems</a> is only recommended in reflowable
-								documents [[EPUB-RS-33]]. Furthermore, Reading System support in fixed-layouts EPUBs is
-								optional.</p>
+									container-constrained scripting in Reading Systems</a> is only recommended in
+								reflowable documents [[EPUB-RS-33]]. Furthermore, Reading System support in
+								fixed-layouts EPUBs is optional.</p>
 
 							<p>EPUB Creators should ensure container-constrained scripts degrade gracefully in Reading
 								Systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
 
 							<div class="note">
-								<p>EPUB Creators choosing to restrict the usage of scripting to the container-constrained
-									model will ensure a more consistent user experience between scripted and non-scripted
-									content (e.g., consistent pagination behavior).</p>
+								<p>EPUB Creators choosing to restrict the usage of scripting to the
+									container-constrained model will ensure a more consistent user experience between
+									scripted and non-scripted content (e.g., consistent pagination behavior).</p>
 							</div>
 						</section>
 
@@ -4103,38 +4114,39 @@ Spine:
 									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 								element contained in a <a>Top-level Content Document</a>.</p>
 
-							<p>EPUB Creators should note that support for spine-level scripting in Reading Systems is only
-								recommended in <a href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-fxl-support"
+							<p>EPUB Creators should note that support for spine-level scripting in Reading Systems is
+								only recommended in <a
+									href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-fxl-support"
 									>fixed-layout documents</a> and <a
 									href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-scrolled">reflowable
-									documents set to scroll</a> [[EPUB-RS-33]]. Furthermore, Reading System support in all
-								other contexts is optional.</p>
+									documents set to scroll</a> [[EPUB-RS-33]]. Furthermore, Reading System support in
+								all other contexts is optional.</p>
 
-							<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include spine-level
-								scripting SHOULD remain consumable by the user without any information loss or other
-								significant deterioration when scripting is disabled or not available (e.g., by employing
-								progressive enhancement techniques or <a href="#sec-scripted-fallbacks">fallbacks</a>).
-								Failing to account for non-scripted environments in Top-level Content Documents can result
-								in EPUB Publications being unreadable.</p>
+							<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include
+								spine-level scripting SHOULD remain consumable by the user without any information loss
+								or other significant deterioration when scripting is disabled or not available (e.g., by
+								employing progressive enhancement techniques or <a href="#sec-scripted-fallbacks"
+									>fallbacks</a>). Failing to account for non-scripted environments in Top-level
+								Content Documents can result in EPUB Publications being unreadable.</p>
 						</section>
 					</section>
 
 					<section id="sec-scripted-content-events" class="informative">
 						<h4>Event Model</h4>
 
-						<p><a>EPUB Creators</a> should consider the wide variety of possible Reading System implementations
-							when adding scripting functionality to their EPUB Publications (e.g., not all devices have
-							physical keyboards, and in many cases a soft keyboard is activated only for text input
-							elements). Consequently, EPUB Creators should not rely on keyboard events alone; they should
-							always provide alternative ways to trigger a desired action.</p>
+						<p><a>EPUB Creators</a> should consider the wide variety of possible Reading System
+							implementations when adding scripting functionality to their EPUB Publications (e.g., not
+							all devices have physical keyboards, and in many cases a soft keyboard is activated only for
+							text input elements). Consequently, EPUB Creators should not rely on keyboard events alone;
+							they should always provide alternative ways to trigger a desired action.</p>
 					</section>
 
 					<section id="sec-scripted-a11y">
 						<h4>Scripting Accessibility</h4>
 
 						<p id="confreq-cd-scripted-a11y">EPUB Content Documents that contain scripting SHOULD employ
-							relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable by
-							all users.</p>
+							relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable
+							by all users.</p>
 					</section>
 
 					<section id="sec-scripted-fallbacks">
@@ -4146,10 +4158,11 @@ Spine:
 								href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element"
 									><code>object</code></a> and <a
 								href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element"
-									><code>canvas</code></a> elements) or, when an intrinsic fallback is not applicable, by
-							using a <a href="#sec-foreign-restrictions-manifest">manifest-level fallback</a>.</p>
-						<p id="confreq-cd-scripted-foreign-resources">EPUB Creators MUST ensure that scripts only generate
-								<a href="#sec-core-media-types">Core Media Type Resources</a> or fragments thereof.</p>
+									><code>canvas</code></a> elements) or, when an intrinsic fallback is not applicable,
+							by using a <a href="#sec-foreign-restrictions-manifest">manifest-level fallback</a>.</p>
+						<p id="confreq-cd-scripted-foreign-resources">EPUB Creators MUST ensure that scripts only
+							generate <a href="#sec-core-media-types">Core Media Type Resources</a> or fragments
+							thereof.</p>
 					</section>
 				</section>
 
@@ -5170,6 +5183,15 @@ Spine:
 						descendant from the Root Directory, provided they are not within the <code>META-INF</code>
 						directory. EPUB Creators MUST NOT reference files in the <code>META-INF</code> directory from an
 						EPUB Publication.</p>
+
+					<div class="note">
+						<p>Some Reading Systems do not provide access to resources outside the directory where the
+							Package Document is stored. EPUB Creators should therefore place all resources at or below
+							the directory containing the Package Document to avoid interoperability issues.</p>
+						<p>This problem is more commonly encountered when <a
+								href="https://www.w3.org/TR/epub-multi-rend-11/#container">creating multiple
+								renditions</a> [[EPUB-MULTI-REND]] of the publication.</p>
+					</div>
 				</section>
 
 				<section id="sec-container-iri">
@@ -5333,8 +5355,13 @@ Spine:
 					</ul>
 
 					<div class="note">
-						<p>
-							If EPUB Creators dynamically integrate resources (i.e., where the naming is beyond their control), they should be aware that automatic truncation of File Names to keep them within the 255 bytes limit can lead to corruption. This is due to the difference between bytes and characters in multibyte encodings such as UTF-8; it is, therefore, important to avoid mid-character truncation. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of strings"</a> in [[international-specs]] for more information. </p>
+						<p> If EPUB Creators dynamically integrate resources (i.e., where the naming is beyond their
+							control), they should be aware that automatic truncation of File Names to keep them within
+							the 255 bytes limit can lead to corruption. This is due to the difference between bytes and
+							characters in multibyte encodings such as UTF-8; it is, therefore, important to avoid
+							mid-character truncation. See the section on <a
+								data-cite="international-specs/#char_truncation">"Truncating or limiting the length of
+								strings"</a> in [[international-specs]] for more information. </p>
 					</div>
 
 
@@ -9279,7 +9306,7 @@ EPUB/images/cover.png</pre>
 							href="https://www.w3.org/TR/epub-3-tts">EPUB 3 Text-to-Speech Enhancements</a> note. The
 						ability to use these technologies in EPUB 3 Publications remains unchanged. See <a
 							href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
-					<li>16-June-2021: Absolute URLs with <code>file</code> scheme SHOULD NOT be used on manifest items. 
+					<li>16-June-2021: Absolute URLs with <code>file</code> scheme SHOULD NOT be used on manifest items.
 						See <a href="https://github.com/w3c/epub-specs/issues/1688">issue 1688</a>.</li>
 					<li>11-June-2021: The section on adding PLS lexicons to HTML has been removed due to a lack of
 						real-world support. It is still valid to link lexicon files and fallbacks are not required, but

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -263,13 +263,35 @@
 				Publication Resources.</p>
 
 			<div class="note">
-				<p>If the Package Documents for each Rendition are stored in separate directories, as shown in the <a
-						href="#sep-dir">preceding example</a>, Reading Systems may prevent one Rendition from accessing
-					the resources of another (i.e., to prevent publications from trying to reach outside the EPUB
-					Container, referencing the parent directory or above of a Package Document may be forbidden).</p>
+				<p>Renditions may not be able to access resources stored in sibling directories on all Reading Systems
+					(i.e., some Reading Systems do not provide access outside the directory a Rendition's Package
+					Document is stored in).</p>
+
+				<p>For example, given the following directory structure (all resources except the Package Documents
+					omitted for clarity):</p>
+
+				<pre>/META-INF
+/Rendition1
+   - rendition1.opf
+/Rendition2
+   - rendition2.opf
+/Shared</pre>
+
+				<p>Resources in the "<code>Rendition1</code>" directory may not be able to access resources in either
+						"<code>Rendition2</code>" or "<code>Shared</code>".</p>
 
 				<p>To share resources between Renditions, it is recommended that the Package Documents be located in a
 					common directory and the resources for each Rendition stored in separate subdirectories.</p>
+
+				<p>Restructuring the previous example as follows would allow shared access to all resources:</p>
+
+				<pre class="prettyprint">/META-INF
+/EPUB
+   /Rendition1
+   /Rendition2
+   /Shared
+   - rendition1.opf
+   - rendition2.opf</pre>
 			</div>
 		</section>
 		<section id="sec-metadata">
@@ -1247,8 +1269,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<section id="changes-latest">
-				<h3>Substantive changes since the previous <a href="https://www.w3.org/TR/2021/NOTE-epub-multi-rend-11-20210525/"
-						>Draft Note</a></h3>
+				<h3>Substantive changes since the previous <a
+						href="https://www.w3.org/TR/2021/NOTE-epub-multi-rend-11-20210525/">Draft Note</a></h3>
 
 				<!--
 					After each working draft is published:


### PR DESCRIPTION
I've added a short note about the problem to the OCF section per the resolution in #1687 and also expanded on the note in the multiple renditions spec since that's really where this issue would come into play.

Fixes #1687 


- Multiple Renditions [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1687/epub33/multi-rend/index.html)
- Multiple Renditions [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/main/epub33/multi-rend/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1687/epub33/multi-rend/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1724.html" title="Last updated on Jun 30, 2021, 9:41 PM UTC (65de0c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1724/c273d8e...65de0c7.html" title="Last updated on Jun 30, 2021, 9:41 PM UTC (65de0c7)">Diff</a>