### PR TITLE
Clarify TTS is not about AT

### DIFF
--- a/epub33/common/js/biblio.js
+++ b/epub33/common/js/biblio.js
@@ -395,5 +395,17 @@ var biblio = {
 		"title": "XPointer Shorthand Notation",
 		"href": "https://www.w3.org/TR/2003/REC-xptr-framework-20030325/",
 		"date": "25 March 2003"
+	},
+	
+	
+	
+	// TEMP ENTRIES
+	"EPUB-TTS-10": {
+		"authors":[
+			"Matt Garrish"
+		],
+		"title": "EPUB 3 Text-to-Speech Enhancements 1.0",
+		"href": "https://www.w3.org/TR/epub-tts-10",
+		"publisher": "W3C"
 	}
 }

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -518,11 +518,6 @@
 					<dd>
 						<p>The rendering of two adjacent pages simultaneously on a device screen.</p>
 					</dd>
-					<dt><dfn id="dfn-text-to-speech">Text-to-Speech</dfn> (TTS)</dt>
-					<dd>
-						<p>The rendering of the textual content of an <a>EPUB Publication</a> as artificial human speech
-							using a synthesized voice.</p>
-					</dd>
 					<dt>
 						<dfn id="dfn-top-level-content-document" data-lt="Top-level Content Documents">Top-level Content
 							Document</dfn>
@@ -6794,7 +6789,7 @@ store destination as source in ocf
 								<p>The <a href="#elemdef-smil-audio"><code>audio</code> element</a> is OPTIONAL only if
 									its sibling <a href="#elemdef-smil-text"><code>text</code> element</a> refers to
 									audio or video media (see <a href="#sec-audio-video"></a>), or to textual content
-									intended for rendering via <a>Text-to-Speech</a> (TTS).</p>
+									intended for rendering via <a href="#sec-tts">text-to-speech</a>.</p>
 							</dd>
 						</dl>
 					</section>
@@ -6865,8 +6860,8 @@ store destination as source in ocf
 							<dd>
 								<p>A REQUIRED child of the <a href="#elemdef-smil-par"><code>par</code> element</a>
 									unless its sibling <a href="#elemdef-smil-text"><code>text</code> element</a> refers
-									to audio or video media, or to textual content intended for rendering via
-										<a>Text-to-Speech</a> (TTS), in which case it is OPTIONAL (see <a
+									to audio or video media, or to textual content intended for rendering via <a
+										href="#sec-tts">text-to-speech</a>, in which case it is OPTIONAL (see <a
 										href="#sec-audio-video"></a>).</p>
 							</dd>
 							<dt>Attributes</dt>
@@ -7197,12 +7192,17 @@ store destination as source in ocf
 					<section id="sec-tts">
 						<h5>Text-to-Speech Rendering</h5>
 
-						<p>This specification allows the use of <a>Text-to-Speech</a> (TTS) in addition to pre-recorded
-							audio clips. When a Media Overlay <a href="#elemdef-smil-text"><code>text</code> element</a>
-							with no sibling <a href="#elemdef-smil-audio"><code>audio</code> element</a> references an
-							element within the target <a>EPUB Content Document</a>, the contents of the referenced
-							fragment MUST be appropriate for rendering via TTS. For example, it could be a textual EPUB
-							Content Document element or contain a text fallback.</p>
+						<p>This specification allows the use of text-to-speech (TTS) &#8212; the rendering of the
+							textual content of an <a>EPUB Publication</a> as artificial human speech using a synthesized
+							voice &#8212; in addition to pre-recorded audio clips.</p>
+
+						<p>A Media Overlay <a href="#elemdef-smil-par"><code>par</code> element</a> MAY omit an <a
+								href="#elemdef-smil-audio"><code>audio</code> element</a> when its <a
+								href="#elemdef-smil-text"><code>text</code> element</a> references a <a
+								href="#sec-audio-video">non-media element</a>. In these cases, Reading Systems are
+							expected to render the referenced fragment via TTS, so EPUB Creators MUST ensure the
+							fragment is appropriate for TTS rendering (e.g., contains a textual EPUB Content Document
+							element or has a text fallback).</p>
 					</section>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7203,6 +7203,11 @@ store destination as source in ocf
 							expected to render the referenced fragment via TTS, so EPUB Creators MUST ensure the
 							fragment is appropriate for TTS rendering (e.g., contains a textual EPUB Content Document
 							element or has a text fallback).</p>
+
+						<div class="note">
+							<p>See <a>EPUB 3 Text-to-Speech Support</a> [[EPUB-3-TTS]] for more information about using
+								TTS technologies in EPUB Publications.</p>
+						</div>
 					</section>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7205,7 +7205,7 @@ store destination as source in ocf
 							element or has a text fallback).</p>
 
 						<div class="note">
-							<p>See <a>EPUB 3 Text-to-Speech Support</a> [[EPUB-3-TTS]] for more information about using
+							<p>See <a>EPUB 3 Text-to-Speech Support</a> [[EPUB-TTS-10]] for more information about using
 								TTS technologies in EPUB Publications.</p>
 						</div>
 					</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1488,8 +1488,8 @@
 					<p>When a Media Overlay <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-text"><code>text</code>
 							element</a> [[EPUB-33]] with no <a href="https://www.w3.org/TR/epub-33/#elemdef-smil-audio"
 								><code>audio</code></a> [[EPUB-33]] sibling element references text within the target
-							<a>EPUB Content Document</a>, Reading Systems capable of <a>Text-to-Speech</a> (TTS) SHOULD
-						render the referenced text using TTS.</p>
+							<a>EPUB Content Document</a>, Reading Systems capable of text-to-speech (TTS) playback
+						SHOULD render the referenced text using TTS.</p>
 
 					<p>Reading Systems SHOULD use the speech-related information provided in the target EPUB Content
 						Document to play the audio stream as part of the Media Overlay rendering.</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1495,7 +1495,7 @@
 						Document to play the audio stream as part of the Media Overlay rendering.</p>
 
 					<div class="note">
-						<p>See <a>EPUB 3 Text-to-Speech Support</a> [[EPUB-3-TTS]] for more information about supporting
+						<p>See <a>EPUB 3 Text-to-Speech Support</a> [[EPUB-TTS-10]] for more information about supporting
 							TTS technologies in EPUB Publications.</p>
 					</div>
 

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -63,15 +63,19 @@
 
 				<p>SSML and pronunciation lexicons provide enhanced speech rendering. Lexicons are like dictionaries of
 					common terms a TTS engine can use, while SSML provides the ability to add individual voicing for
-					specific phrases. EPUB Creators can use these technologies together or separately depending on the
-					complexity of the text. Despite these advantages, the technologies have not been adapted for easy
-					use within the XHTML and SVG formats that EPUB relies on. This document proposes an approach to
+					specific phrases. <a>EPUB Creators</a> can use these technologies together or separately depending
+					on the complexity of the text. Despite these advantages, the technologies have not been adapted for
+					easy use within the XHTML and SVG formats that EPUB relies on. This document proposes an approach to
 					enable their authoring and rendering in EPUB Content Documents.</p>
 
 				<p>This document also covers the use of CSS Speech for improved aural rendering in EPUB. CSS Speech
 					covers a different domain than SSML and pronunciation lexicons. Instead of controlling the specific
 					voicing of words and phrases, these properties allow EPUB Creators to aspects of the aural playback
 					itself &#8212; what text to render, at what volume, with what preferred voice, etc.</p>
+
+				<p>This document covers the use of these technologies for rendering by <a>EPUB Reading Systems</a>.
+					Although it is anticipated that general assistive technologies such as screen readers could take
+					advantage of the technologies, use by them is out of scope.</p>
 			</section>
 
 			<section id="background" class="informative">


### PR DESCRIPTION
This PR fixes #1727 by merging the TTS definition into the media overlays section and pointing the two links to it. It also adds a link to the tts note to the authoring document and adds a paragraph that AT support is not specifically in scope in the tts note's overview.

Reviewing the media overlays section, I got a bit confused by the similarity between the embedded media and tts section -- that both talk about their respective behaviour initiating when an `audio` element isn't present. I assume for TTS we're talking about references to non-media elements, so tweaked the paragraph to that effect, but if you could have a look @marisademeglio and see if it reads properly, I'd appreciate it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1744.html" title="Last updated on Jul 1, 2021, 11:01 AM UTC (5a9a25a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1744/c273d8e...5a9a25a.html" title="Last updated on Jul 1, 2021, 11:01 AM UTC (5a9a25a)">Diff</a>