### PR TITLE
Clarifications for epub:type/role

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5013,8 +5013,8 @@ Spine:
 					<div class="note" id="note-page-spread-aliases">
 						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 							properties are aliases for the <a href="#page-spread-left"><code>page-spread-left</code></a>
-							and <a href="#page-spread-right"><code>page-spread-right</code></a> properties. They allow the
-							use of a single vocabulary for all fixed-layout properties. EPUB Creators can use either
+							and <a href="#page-spread-right"><code>page-spread-right</code></a> properties. They allow
+							the use of a single vocabulary for all fixed-layout properties. EPUB Creators can use either
 							property set, but older Reading Systems might only recognize the unprefixed versions. The
 							Working Group is not going to extend the <a href="#app-itemref-properties-vocab">EPUB Spine
 								Properties Vocabulary</a> to add an unprefixed <code>page-spread-center</code>
@@ -7827,10 +7827,11 @@ html.my-document-playing * {
 					domain-specific semantics in <a>EPUB Content Documents</a> and <a>Media Overlay Documents</a>, with
 					the structural information it carries complementing the underlying vocabulary.</p>
 
-				<p>The applied semantics refine the meaning of their containing elements; they do not override their
-					nature (e.g., EPUB Creators can use the attribute to indicate a [[HTML]] <code>section</code> is a
-					chapter in a work, but not to turn <code>p</code> elements into list items to avoid proper list
-					structures).</p>
+				<p>The applied semantics refine the meaning of their containing elements without changing their nature
+					for assistive technologies, as happens when using the similar <a
+						href="https://html.spec.whatwg.org/multipage/infrastructure.html#attr-aria-role"
+							><code>role</code> attribute</a> [[HTML]]. The attribute does not enhance the accessibility
+					of the content, in other words, only provides hints about the purpose.</p>
 
 				<p>Semantic metadata enriches content for use in publishing workflows and for author-defined purposes.
 					It also allows Reading Systems to learn more about the structure and content of a document (e.g., to
@@ -7871,19 +7872,6 @@ html.my-document-playing * {
 					</dd>
 				</dl>
 
-				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
-					is one or more white space-separated terms stemming from external vocabularies associated with the
-					document instance.</p>
-
-				<p>The inflected semantic MUST express a subclass of the semantic of the carrying element. In the case
-					of semantically neutral elements, such as the [[HTML]] <a
-						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element"
-							><code>div</code></a> and <a
-						href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element"
-							><code>span</code></a> elements, the inflected semantic MUST NOT attach a meaning that is
-					already conveyed by an existing element (e.g., that a <code>div</code> represents a paragraph or
-					section).</p>
-
 				<div class="note">
 					<p>Although the <code>epub:type</code> attribute is similar in nature to the <a
 							href="https://html.spec.whatwg.org/multipage/infrastructure.html#attr-aria-role"
@@ -7896,6 +7884,19 @@ html.my-document-playing * {
 							WAI-ARIA Module 1.0</a> [[DPUB-ARIA-1.0]] for more information about accessible publishing
 						roles.</p>
 				</div>
+
+				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
+					is one or more white space-separated terms stemming from external vocabularies associated with the
+					document instance.</p>
+
+				<p>The inflected semantic MUST express a subclass of the semantic of the carrying element. In the case
+					of semantically neutral elements, such as the [[HTML]] <a
+						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element"
+							><code>div</code></a> and <a
+						href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element"
+							><code>span</code></a> elements, the inflected semantic MUST NOT attach a meaning that is
+					already conveyed by an existing element (e.g., that a <code>div</code> represents a paragraph or
+					section).</p>
 
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
 					the <a href="#structure-vocab">Structural Semantics Vocabulary</a>. EPUB Creators MAY include


### PR DESCRIPTION
I've moved the note up so it's the first thing after the definition.

I also modified the second paragraph in the introduction that was already talking about epub:type in comparison to role to be more explicit about this.

Fixes #1740


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1746.html" title="Last updated on Jul 1, 2021, 11:20 AM UTC (cd3b548)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1746/7b4131f...cd3b548.html" title="Last updated on Jul 1, 2021, 11:20 AM UTC (cd3b548)">Diff</a>