### PR TITLE
Editorial rewrites of the linked resource and foreign resource paras

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -920,15 +920,24 @@
 					<section id="sec-foreign-restrictions">
 						<h5>Foreign Resources</h5>
 
-						<p id="confreq-foreign-no-fallback">EPUB Creators MAY include Foreign Resources without a
-							fallback provided they do not reference them from <a href="#sec-itemref-elem">spine
-									<code>itemref</code> elements</a> or directly render them in their native format in
-							EPUB Content Documents (e.g., via [[HTML]] <a
-								href="https://html.spec.whatwg.org/multipage/embedded-content.html#embedded-content"
-								>embedded content</a> and [[SVG]] <a
-								href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"><code>image</code></a> and
-								<a href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
-									><code>foreignObject</code></a> elements).</p>
+						<p id="confreq-foreign-no-fallback">EPUB Creators MAY include Foreign Resources without
+							fallbacks provided they:</p>
+
+						<ul>
+							<li>
+								<p>do not reference the resources from <a href="#sec-itemref-elem">spine
+											<code>itemref</code> elements</a>; and</p>
+							</li>
+							<li>
+								<p>do not embed them directly in EPUB Content Documents (e.g., via [[?HTML]] <a
+										href="https://html.spec.whatwg.org/multipage/embedded-content.html#embedded-content"
+										>embedded content</a> and [[?SVG]] <a
+										href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"
+										><code>image</code></a> and <a
+										href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
+											><code>foreignObject</code></a> elements).</p>
+							</li>
+						</ul>
 
 						<p class="note">This exception allows EPUB Creators to include resources in the <a>EPUB
 								Container</a> that are not for use by EPUB Reading Systems. The primary case for this
@@ -2440,12 +2449,26 @@
 								more <code>link</code> elements, each of which identifies the location of a linked
 								resource in its REQUIRED <code>href</code> attribute</p>
 
-							<p id="linked-res-manifest">Linked resources are not <a>Publication Resources</a>. EPUB
-								Creators MUST NOT list them in the <a href="#sec-manifest-elem">manifest</a>. EPUB
-								Creators MUST use linked resources that are <a href="#sec-core-media-types">Core Media
-									Type Resources</a> to embed them in Publication Resources listed in the manifest
-								(e.g., an <a>EPUB Content Document</a> could contain a metadata record serialized as
-								RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]]).</p>
+							<p id="linked-res-manifest">Linked Resources are <a>Publication Resources</a> only when they
+								are:</p>
+
+							<ul>
+								<li>
+									<p>referenced from the <a href="#sec-spine-elem">spine</a>; or</p>
+								</li>
+								<li>
+									<p>included or embedded in an EPUB Content Document (e.g., a metadata record
+										serialized as RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]] embedded in an
+										[[HTML]] <a
+											href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
+												><code>script</code> element</a>).</p>
+								</li>
+							</ul>
+
+							<p>In all other cases (e.g., when linking to standalone [[?ONIX]] or [[?XMP]] records), the
+								linked resources are not Publication Resources (i.e., are not subject to <a
+									href="#sec-core-media-type">Core Media Type requirements</a>) and EPUB Creators MUST
+								NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
 
 							<aside class="example">
 								<p>The following example shows a reference to a metadata record embedded in a
@@ -5013,8 +5036,8 @@ Spine:
 					<div class="note" id="note-page-spread-aliases">
 						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 							properties are aliases for the <a href="#page-spread-left"><code>page-spread-left</code></a>
-							and <a href="#page-spread-right"><code>page-spread-right</code></a> properties. They allow the
-							use of a single vocabulary for all fixed-layout properties. EPUB Creators can use either
+							and <a href="#page-spread-right"><code>page-spread-right</code></a> properties. They allow
+							the use of a single vocabulary for all fixed-layout properties. EPUB Creators can use either
 							property set, but older Reading Systems might only recognize the unprefixed versions. The
 							Working Group is not going to extend the <a href="#app-itemref-properties-vocab">EPUB Spine
 								Properties Vocabulary</a> to add an unprefixed <code>page-spread-center</code>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2467,8 +2467,8 @@
 
 							<p>In all other cases (e.g., when linking to standalone [[?ONIX]] or [[?XMP]] records), the
 								linked resources are not Publication Resources (i.e., are not subject to <a
-									href="#sec-core-media-type">Core Media Type requirements</a>) and EPUB Creators MUST
-								NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
+									href="#sec-core-media-types">Core Media Type requirements</a>) and EPUB Creators
+								MUST NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
 
 							<aside class="example">
 								<p>The following example shows a reference to a metadata record embedded in a


### PR DESCRIPTION
Implements the suggested rewrite in #1728 and #1730.

The only change I made from the proposed text is in the rewrite for linked resources. It's redundant to say that publication resources are subject to CMT requirements so I stripped that sentence.

Fixes #1728 
Fixes #1730


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1747.html" title="Last updated on Jul 1, 2021, 1:49 PM UTC (04bc5aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1747/7b4131f...04bc5aa.html" title="Last updated on Jul 1, 2021, 1:49 PM UTC (04bc5aa)">Diff</a>