### PR TITLE
Add additional linking to the cover-image definition

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2785,6 +2785,12 @@
 							<p>EPUB Creators MUST declare all applicable descriptive metadata properties for each
 								Publication Resource in this attribute.</p>
 
+							<p>EPUB Creators MUST declare all applicable descriptive metadata properties for each
+								Publication Resource in this attribute (e.g., if the resource is the <a
+									href="#sec-cover-image">cover image</a>, contains <a href="#sec-scripted"
+									>scripting</a>, or references <a href="#sec-remote-resources">remote
+								resources</a>).</p>
+
 							<p>EPUB Creators MUST declare exactly one <code>item</code> as the <a>EPUB Navigation
 									Document</a> using the <code>nav</code> property.</p>
 
@@ -3441,6 +3447,14 @@ Spine:
 
 							<p>For more information about the <code>meta</code> element, refer to its definition in
 								[[OPF-201]].</p>
+
+							<div class="note">
+								<p>The [[OPF-201]] <code>meta</code> element is retained in EPUB 3 primarily so that
+									EPUB Creators can identify the cover image for compatibility with EPUB 2 Reading
+									Systems. In EPUB 3, the cover image must be identified using the <a
+										href="#sec-cover-image"><code>cover-image</code> property</a> on the <a
+										href="#sec-item-elem">manifest <code>item</code></a> for the image.</p>
+							</div>
 						</section>
 
 						<section id="sec-opf2-guide">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2783,9 +2783,6 @@
 									href="#sec-vocab-assoc"></a>.</p>
 
 							<p>EPUB Creators MUST declare all applicable descriptive metadata properties for each
-								Publication Resource in this attribute.</p>
-
-							<p>EPUB Creators MUST declare all applicable descriptive metadata properties for each
 								Publication Resource in this attribute (e.g., if the resource is the <a
 									href="#sec-cover-image">cover image</a>, contains <a href="#sec-scripted"
 									>scripting</a>, or references <a href="#sec-remote-resources">remote


### PR DESCRIPTION
Per #1731, this PR adds some examples of what the manifest item properties identify, including the cover image.

It also adds a note to the opf2 meta element section explaining that it is retained for identifying covers in epub 2 but that the cover-image property must be used in epub 3.

Hopefully, that should be plenty of guidance in the right direction.

Fixes #1731


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1748.html" title="Last updated on Jul 1, 2021, 2:28 PM UTC (2c45d42)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1748/b355364...2c45d42.html" title="Last updated on Jul 1, 2021, 2:28 PM UTC (2c45d42)">Diff</a>