### PR TITLE
Add terminology sections to RS and TTS specs

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -117,6 +117,15 @@
 				</div>
 			</section>
 
+			<section id="sec-terminology">
+				<h3>Terminology</h3>
+
+				<p>This specification uses terminology defined in EPUB 3.3 [[EPUB-33]]. These terms appear capitalized
+					wherever used.</p>
+
+				<p>Only the first instance of a term in a section links to its definition.</p>
+			</section>
+
 			<section id="conformance"></section>
 
 			<section id="sec-intro-relations" class="informative">

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -107,6 +107,25 @@
 				</div>
 			</section>
 
+			<section id="sec-terminology">
+				<h3>Terminology</h3>
+
+				<p>This specification uses terminology defined in EPUB 3.3 [[EPUB-33]]. These terms appear capitalized
+					wherever used.</p>
+
+				<p>Only the first instance of a term in a section links to its definition.</p>
+
+				<p>In addition, this specification defines the following terms:</p>
+
+				<dl>
+					<dt><dfn>Text-to-Speech</dfn></dt>
+					<dd>
+						<p>The rendering of the textual content of an <a>EPUB Publication</a> by a <a>Reading System</a>
+							as artificial human speech using a synthesized voice.</p>
+					</dd>
+				</dl>
+			</section>
+
 			<section id="conformance"></section>
 		</section>
 		<section id="ssml">


### PR DESCRIPTION
Noticed that these two were missing the sections, so added some basic prose noting that we're using terms from epub 3.3.

Also added a definition of tts to the note to get rid of the respec errors.