### PR TITLE
Add "relationship to url" section

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -257,6 +257,18 @@
 					<p>This specification relies on a subset of [[SMIL3]], from which the Media Overlays elements and
 						attributes defined in <a href="#sec-overlays-def"></a> are derived.</p>
 				</section>
+
+				<section id="sec-overview-relations-url">
+					<h4>Relationship to URL</h4>
+
+					<p>This specification refers to the [[URL]] standard for terminology and processing related to URLs
+						expressed in EPUB Publications. It is anticipated that new and revised Web formats will adopt
+						this standard, but until then this may put this specification in conflict with the internal
+						requirements for some formats (e.g., valid relative paths), specifically with respect to the use
+						of internationalized URLs. If a format does not allow internationalized URLs (i.e., URLs must
+						conform to [[RFC3986]] or earlier), that requirement takes precedence within those
+						resources.</p>
+				</section>
 			</section>
 
 			<section id="sec-terminology">
@@ -5234,9 +5246,7 @@ Spine:
 						<p>The following example shows how to reference, from an [[HTML]] <code>img</code> element, a
 							file named <code>image1.jpg</code> in the same directory as an <a>XHTML Content
 							Document</a>.</p>
-						<pre>
-&lt;img src="image1.jpg" alt="…" /&gt;
-                </pre>
+						<pre>&lt;img src="image1.jpg" alt="…" /&gt;</pre>
 					</aside>
 
 					<p>The relevant language specification for a given file format determines the <a
@@ -5245,12 +5255,6 @@ Spine:
 							>relative-URL-with-fragment strings</a> [[URL]]. For example, CSS defines how relative URL
 						references work in the context of CSS style sheets and property declarations
 						[[CSSSnapshot]].</p>
-
-					<div class="note">
-						<p>Some language specifications reference <a href="https://www.ietf.org/standards/rfcs/"
-								>Requests For Comments</a> that preceded [[URL]], in which case the earlier RFC applies
-							for content in that language.</p>
-					</div>
 
 					<p>Unlike most language specifications, the <a href="https://url.spec.whatwg.org/#concept-base-url"
 							>base URL</a> [[URL]] for all files within the <code>META-INF</code> directory is the
@@ -9343,6 +9347,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>09-July-2021: Added the "Relationship to URL" section to explain the use of URL standard
+						terminology in this document relative to resource formats that do not reference it. See <a
+							href="https://github.com/w3c/epub-specs/issues/1726">issue 1726</a>.</li>
 					<li>05-July-2021: Removed the section on private use area characters from the XHTML restrictions.
 						The issues are more complex than what is covered and not in scope of EPUB to define. See <a
 							href="https://github.com/w3c/epub-specs/issues/1732">issue 1732</a>.</li>


### PR DESCRIPTION
Replaces the OCF note that was explaining that we don't override and allow IRIs in formats that don't allow IRIs.

Fixes #1726


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1755.html" title="Last updated on Jul 9, 2021, 1:34 PM UTC (0781fc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1755/d707b80...0781fc6.html" title="Last updated on Jul 9, 2021, 1:34 PM UTC (0781fc6)">Diff</a>