### PR TITLE
Restore the custom attribute sections

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3603,14 +3603,6 @@ Spine:
 						<p>When using custom attributes, the content MUST remain consumable by a user without any
 							information loss or other significant deterioration, regardless of the Reading System it is
 							rendered on.</p>
-
-						<div class="note">
-							<p>Custom attributes are usually defined in a Reading System-specific manner and are not
-								intended for use by Reading Systems other than the one that they have been defined for.
-								For generic extensions that are to be used by multiple independent Reading Systems,
-								future versions of this specification should be extended to provide the feature
-								explicitly.</p>
-						</div>
 					</section>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3589,6 +3589,29 @@ Spine:
 						<p>Use of the <code>trigger</code> element is <a href="#deprecated">deprecated</a>. Refer to its
 							definition in [[EPUBContentDocs-301]] for usage information.</p>
 					</section>
+
+					<section id="sec-xhtml-custom-attributes">
+						<h5>Custom Attributes</h5>
+
+						<p><a>EPUB Creators</a> MAY specify <a
+								href="https://www.w3.org/TR/epub-rs-33/#sec-xhtml-custom-attributes">custom
+								attributes</a> [[EPUB-RS-33]] in <a>XHTML Content Documents</a> to take advantage of
+								<a>Reading System</a>-specific functionality not defined in this specification.</p>
+
+						<p>Custom attributes MAY be specified on any element in an XHTML Content Document.</p>
+
+						<p>When using custom attributes, the content MUST remain consumable by a user without any
+							information loss or other significant deterioration, regardless of the Reading System it is
+							rendered on.</p>
+
+						<div class="note">
+							<p>Custom attributes are usually defined in a Reading System-specific manner and are not
+								intended for use by Reading Systems other than the one that they have been defined for.
+								For generic extensions that are to be used by multiple independent Reading Systems,
+								future versions of this specification should be extended to provide the feature
+								explicitly.</p>
+						</div>
+					</section>
 				</section>
 
 				<section id="sec-xhtml-deviations">
@@ -9343,6 +9366,9 @@ EPUB/images/cover.png</pre>
 				-->
 
 				<ul>
+					<li>09-July-2021: Restored the custom attributes section due to known usage but without reference to
+						the attribute registry. See <a href="https://github.com/w3c/epub-specs/issues/1602">issue
+							1602</a>.</li>
 					<li>05-July-2021: Removed the section on private use area characters from the XHTML restrictions.
 						The issues are more complex than what is covered and not in scope of EPUB to define. See <a
 							href="https://github.com/w3c/epub-specs/issues/1732">issue 1732</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -588,6 +588,14 @@
 
 						<p>Custom attributes, and the behaviors associated with them, MUST NOT alter the integrity of an
 							EPUB Publication.</p>
+						
+						<div class="note">
+							<p>Custom attributes are usually defined in a Reading System-specific manner and are not
+								intended for use by Reading Systems other than the one that they have been defined for.
+								For generic extensions that are to be used by multiple independent Reading Systems,
+								future versions of this specification should be extended to provide the feature
+								explicitly.</p>
+						</div>
 					</section>
 				</section>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -594,6 +594,12 @@
 							<li><code>idpf.org</code></li>
 						</ul>
 
+						<p class="note">
+							Note that this restriction also disallows the usage of custom attributes without a namespace prefix 
+							(e.g., <code>&lt;p foo=""&gt;…&lt;/p&gt;</code>). Indeed, such attributes are considered to be part of
+							the default namespace, i.e., either the XHTML or SVG namespaces, which are both in the <code>w3.org</code> domain.
+						</p>
+
 						<p>Custom attributes, and the behaviors associated with them, MUST NOT alter the integrity of an
 							EPUB Publication.</p>
 						

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -569,6 +569,26 @@
 								href="https://www.w3.org/TR/epub-33/#deprecated">deprecated</a> [[EPUB-33]]. Refer to
 							its definition in [[EPUBContentDocs-301]] for implementation information.</p>
 					</section>
+
+					<section id="sec-xhtml-custom-attributes">
+						<h5>Custom Attributes</h5>
+
+						<p>Vendors MAY introduce functionality not defined in this specification to enhance the
+							rendering of <a>EPUB Publications</a>.</p>
+
+						<p>To facilitate this experimentation, vendors MAY define custom attributes for use in <a>XHTML
+								Content Documents</a> provided they are from a foreign namespace, which is defined as a
+							namespace [[XML-NAMES]] that does not incorporate either of the following strings in its <a
+								href="https://url.spec.whatwg.org/#concept-domain">domain</a> [[URL]]:</p>
+
+						<ul>
+							<li><code>w3.org</code></li>
+							<li><code>idpf.org</code></li>
+						</ul>
+
+						<p>Custom attributes, and the behaviors associated with them, MUST NOT alter the integrity of an
+							EPUB Publication.</p>
+					</section>
 				</section>
 
 				<section id="sec-xhtml-deviations">
@@ -2125,6 +2145,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>09-July-2021: Restored the custom attributes section due to known usage but without reference to
+						the attribute registry. See <a href="https://github.com/w3c/epub-specs/issues/1602">issue
+							1602</a>.</li>
 					<li>18-June-2021: Moved requirements for supporting SSML, PLS lexicons and CSS 3 Speech to the <a
 							href="https://www.w3.org/TR/epub-3-tts">EPUB 3 Text-to-Speech Support</a> note. See <a
 							href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>


### PR DESCRIPTION
Also adds @iherman's suggested text about rs-specific nature of the attributes. I've made this a note, though, as it's more describing future process.

Only other change was to use "domain" instead of "authority component" in the part about the restricted strings so we can reference the URL standard instead of RFC3186.

Fixes #1602

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1602/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1602/epub33/rs/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1756.html" title="Last updated on Aug 15, 2021, 7:18 AM UTC (7c2e047)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1756/e674219...7c2e047.html" title="Last updated on Aug 15, 2021, 7:18 AM UTC (7c2e047)">Diff</a>