### PR TITLE
Remove recommendation to use the first language tag to infer a missing ppd

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -473,9 +473,8 @@
 
 				<p>If the EPUB Creator has not specified the <code>page-progression-direction</code>, the Reading System
 					MUST assume the value of <code>default</code>. When the EPUB Creator has set the value of the
-						<code>page-progression-direction</code> to <code>default</code> (either explicitly or
-					implicitly), the Reading System SHOULD choose a default <code>page-progression-direction</code>
-					value based on the first <code>language</code> element.</p>
+						<code>page-progression-direction</code> to <code>default</code>, either explicitly or
+					implicitly, the Reading System can choose rendering direction.</p>
 
 				<p>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
 							><code>pre-paginated</code></a> XHTML Content Documents. The
@@ -2125,6 +2124,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				-->
 
 				<ul>
+					<li>09-July-2021: Removed recommendation to use the first language tag to determine an unspecified
+						page progression direction. See <a href="https://github.com/w3c/epub-specs/issues/1482">issue
+							1482</a>.</li>
 					<li>18-June-2021: Moved requirements for supporting SSML, PLS lexicons and CSS 3 Speech to the <a
 							href="https://www.w3.org/TR/epub-3-tts">EPUB 3 Text-to-Speech Support</a> note. See <a
 							href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>


### PR DESCRIPTION
It looks like the original paragraph got rewritten at some point, so I've only tweaked out the offending recommendation.

Fixes #1482 
