### PR TITLE
Remove statement that reading systems support xml:base

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1116,12 +1116,9 @@
 					<p>The above constraints apply regardless of whether the given Publication Resource is a <a>Core
 							Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
 
-
 					<div class="note">
-						<p>Although EPUB Reading Systems are <a
-								href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-xml-base">required to support</a>
-							[[EPUB-RS-33]] the XML `base` attribute [[XMLBase]], [[HTML]] and [[SVG]] are removing
-							support. EPUB Creators should avoid using this feature.</p>
+						<p>[[HTML]] and [[SVG]] are removing support for the XML `base` attribute [[XMLBase]]. EPUB
+							Creators should avoid using this feature.</p>
 					</div>
 				</section>
 			</section>


### PR DESCRIPTION
Minor rewrite of the note discouraging authors from using xml:base in html and svg. The requirement to support was removed from the RS specification, so the claim that reading systems have to support the attribute isn't true and there isn't a destination for the link.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1758.html" title="Last updated on Jul 12, 2021, 11:34 AM UTC (b536bd9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1758/607cf25...b536bd9.html" title="Last updated on Jul 12, 2021, 11:34 AM UTC (b536bd9)">Diff</a>