### PR TITLE
Merge the structure vocab's "about this vocabulary" content into parent section

### DIFF
--- a/epub33/core/vocab/structure.html
+++ b/epub33/core/vocab/structure.html
@@ -1,29 +1,26 @@
 <section id="structure-vocab">
 	<h3>Structural Semantics Vocabulary</h3>
 	
-	<section id="about" class="informative">
-		<h4>About this Vocabulary</h4>
-		
-		<p>While the EPUB Structural Semantics vocabulary is generally host language agnostic, it has been
-			constructed primarily to enable semantic inflection of elements in the HTML vocabulary.</p>
-		
-		<p>The <i>HTML usage context</i> fields indicate contexts in HTML documents where the given property is
-			considered relevant. EPUB Creators may use the properties on HTML markup elements not specifically listed,
-			but must ensure that the semantics they express represent a subset of the carrying element's
-			semantics and do not attach an existing element's meaning to a semantically neutral element.</p>
-		
-		<p>The <i>DPUB-ARIA role</i> fields indicate the [[DPUB-ARIA-1.0]] roles that can alternatively be used
-			with the [[HTML]] <code>role</code> attribute to improve accessibility. These roles may have more
-			restrictive usage contexts, however, so may not be valid wherever the <code>epub:type</code>
-			attribute is used. Refer to [[HTML-ARIA]] for more information about where the roles are
-			allowed.</p>
-		
-		<p>When processing HTML documents, Reading Systems may ignore such non-compliant properties, unless
-			their usage context is explicitly overridden or extended by the host specification.</p>
-		
-		<p>The <i>Usage Details</i> sections identify IDPF specifications that define or utilize the specified
-			properties.</p>
-	</section>
+	<p>While the EPUB Structural Semantics vocabulary is generally host language agnostic, it has been
+		constructed primarily to enable semantic inflection of elements in the HTML vocabulary.</p>
+	
+	<p>The <i>HTML usage context</i> fields indicate contexts in HTML documents where the given property is
+		considered relevant. EPUB Creators may use the properties on HTML markup elements not specifically listed,
+		but must ensure that the semantics they express represent a subset of the carrying element's
+		semantics and do not attach an existing element's meaning to a semantically neutral element.</p>
+	
+	<p>The <i>DPUB-ARIA role</i> fields indicate the [[DPUB-ARIA-1.0]] roles that can alternatively be used
+		with the [[HTML]] <code>role</code> attribute to improve accessibility. These roles may have more
+		restrictive usage contexts, however, so may not be valid wherever the <code>epub:type</code>
+		attribute is used. Refer to [[HTML-ARIA]] for more information about where the roles are
+		allowed.</p>
+	
+	<p>When processing HTML documents, Reading Systems may ignore such non-compliant properties, unless
+		their usage context is explicitly overridden or extended by the host specification.</p>
+	
+	<p>The <i>Usage Details</i> sections identify IDPF specifications that define or utilize the specified
+		properties.</p>
+	
 	<section id="partitions">
 		<h4>Document Partitions</h4>
 		<dl>


### PR DESCRIPTION
This is effectively just a missed step from https://github.com/w3c/epub-specs/pull/1541

Fixes #1760 