### PR TITLE
Add note not to wait on development of v. 1.1

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -72,7 +72,14 @@
 				Publications. It also specifies accessibility metadata requirements for the discoverability of EPUB
 				Publications.</p>
 		</section>
-		<section id="sotd"></section>
+		<section id="sotd">
+			<div class="ednote">
+				<p>Publishers not currently producing accessible content are encouraged to begin updating their
+					production processes to meet the requirements of [[EPUB-A11Y-10]] while this specification is being
+					developed. Content that meets the requirements of that version will typically also meet the
+					requirements of this specification with few changes necessary.</p>
+			</div>
+		</section>
 		<section id="intro">
 			<h2>Introduction</h2>
 


### PR DESCRIPTION
@avneeshsingh I've added an editor's note to the status section to address the concern you've raised about publishers holding off on creating accessible content until this revision is done. It reads:

> Publishers not currently producing accessible content are encouraged to begin updating their production processes to meet the requirements of [EPUB-A11Y-10] while this specification is being developed. Content that meets the requirements of that version will typically also meet the requirements of this specification with few changes necessary.

Let me know if this is sufficient.