### PR TITLE
Combine dual change log sections

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -54,7 +54,7 @@
 				},
 				localBiblio: biblio,
 				preProcess:[addConformanceLinks]
-			};</script> 
+			};</script>
 	</head>
 	<body>
 		<section id="abstract">
@@ -1453,49 +1453,32 @@
 		<section id="change-log" class="appendix">
 			<h2>Change Log</h2>
 
-			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance
-				of EPUB Publications or are similarly noteworthy.</p>
+			<p>Note that this change log only identifies substantive changes since <a
+					href="http://idpf.org/epub/a11y/techniques/">EPUB Accessibility Techniques 1.0</a> &#8212; those
+				that affect the conformance of EPUB Publications or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+label%3ASpec-AccessibilityTechs+label%3AAccessibility11+"
 					>working group's issue tracker</a>.</p>
 
-			<section id="changes-latest">
-				<h3>Substantive changes since the previous <a
-						href="https://www.w3.org/TR/2021/NOTE-epub-a11y-tech-11-20210525/">Draft Note</a></h3>
-
-				<!--
-					After each working draft is published:
-						- change the link/text in the section heading to refer to the published draft (use the dated URL)
-						- move all changes down to the next section
-				-->
-
-				<ul> </ul>
-			</section>
-
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/techniques/">EPUB Accessibility
-						Techniques 1.0</a></h3>
-				<ul>
-					<li>10-June-2021: Clarified the technique on meaningful sequence that it applies to content that
-						spans pages in a spread and is not about ordering documents in the spine. See <a
-							href="https://github.com/w3c/epub-specs/issues/1695">issue 1695</a>.</li>
-					<li>25-May-2021: Updated the section on ARIA roles to make clear that the <code>epub:type</code>
-						attribute does not have to be used in coordination, nor that roles are required where
-							<code>epub:type</code> is used.</li>
-					<li>13-Apr-2021: Added an example of using the <code>source-of</code> property in EPUB 3 to identify
-						which <code>dc:source</code> element is the source of pagination. See <a
-							href="https://github.com/w3c/epub-specs/issues/1600">issue 1600</a>.</li>
-					<li>19-Feb-2021: References to WCAG 2.0 have been updated to undated references to WCAG 2 (except
-						where WCAG 2.0 is explicitly mentioned for conformance).</li>
-					<li>08-Jan-2021: Added technique recommending the <a href="#access-003">order of the table of
-							contents</a> match the linear reading order of content.</li>
-					<li>16-Nov-2020: The techniques for <a href="#meta-007">accessibility controls</a> and <a
-							href="#meta-006">APIs</a> have been replaced with descriptions of why these properties are
-						not necessary to set. See <a href="https://github.com/w3c/epub-specs/issues/1286">issue
-						1286</a>.</li>
-				</ul>
-			</section>
+			<ul>
+				<li>10-June-2021: Clarified the technique on meaningful sequence that it applies to content that spans
+					pages in a spread and is not about ordering documents in the spine. See <a
+						href="https://github.com/w3c/epub-specs/issues/1695">issue 1695</a>.</li>
+				<li>25-May-2021: Updated the section on ARIA roles to make clear that the <code>epub:type</code>
+					attribute does not have to be used in coordination, nor that roles are required where
+						<code>epub:type</code> is used.</li>
+				<li>13-Apr-2021: Added an example of using the <code>source-of</code> property in EPUB 3 to identify
+					which <code>dc:source</code> element is the source of pagination. See <a
+						href="https://github.com/w3c/epub-specs/issues/1600">issue 1600</a>.</li>
+				<li>19-Feb-2021: References to WCAG 2.0 have been updated to undated references to WCAG 2 (except where
+					WCAG 2.0 is explicitly mentioned for conformance).</li>
+				<li>08-Jan-2021: Added technique recommending the <a href="#access-003">order of the table of
+						contents</a> match the linear reading order of content.</li>
+				<li>16-Nov-2020: The techniques for <a href="#meta-007">accessibility controls</a> and <a
+						href="#meta-006">APIs</a> have been replaced with descriptions of why these properties are not
+					necessary to set. See <a href="https://github.com/w3c/epub-specs/issues/1286">issue 1286</a>.</li>
+			</ul>
 		</section>
 		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
 		></div>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -56,7 +56,7 @@
 				localBiblio: biblio,
 				preProcess:[inlineCustomCSS],
 				postProcess:[addConformanceLinks]
-			};</script> 
+			};</script>
 		<style>
 			.conf-pattern {
 				margin-left: 3rem;
@@ -1404,70 +1404,55 @@
 		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
 
-			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance
-				of EPUB Publications or are similarly noteworthy.</p>
+			<p>Note that this change log only identifies substantive changes since <a href="http://idpf.org/epub/a11y/"
+					>EPUB Accessibility 1.0</a> &#8212; those that affect the conformance of EPUB Publications or are
+				similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+label%3ASpec-Accessibility+label%3AAccessibility11"
 					>working group's issue tracker</a>.</p>
 
-			<section id="changes-latest">
-				<h3>Substantive changes since the <a href="https://www.w3.org/TR/2021/WD-epub-a11y-11-20210712/"
-						>Previous Working Draft</a></h3>
-
-				<!--
-					After each working draft is published:
-						- change the link/text in the section heading to refer to the published draft (use the dated URL)
-						- move all changes down to the next section
-				-->
-
-				<ul> </ul>
-			</section>
-
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="http://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
-				<ul>
-					<li>09-June-2021: Clarified that a pagination source must not be specified when page break markers
-						and/or a page list are included in a digital-only publication. See <a
-							href="https://github.com/w3c/epub-specs/issues/1599">issue 1599</a>.</li>
-					<li>29-Apr-2021: Change conformance identifiers to use hyphens and dashes so they are not confused
-						for plain language strings. See <a href="https://github.com/w3c/epub-specs/issues/1455">issue
-							1455</a>.</li>
-					<li>26-Mar-2021: Added informative section detailing when to re-evaluate EPUB Publications. See <a
-							href="https://github.com/w3c/epub-specs/issues/1470">issue 1470</a>.</li>
-					<li>12-Mar-2021: Changed the distribution section to informative but added a note that the
-						requirements must be followed where required by law (e.g., in the EU). See <a
-							href="https://github.com/w3c/epub-specs/issues/1487">issue 1487</a>.</li>
-					<li>08-Mar-2021: Add objective for the sequence of <code>par</code> and <code>seq</code> elements in
-						media overlay documents to reflect a logical reading order. See <a
-							href="https://github.com/w3c/epub-specs/issues/1556">issue 1556</a>.</li>
-					<li>05-Mar-2021: Added recommendation that page markers be included for all pages of content
-						reproduced from source and best practice to include markers for all pages in the source. See <a
-							href="https://github.com/w3c/epub-specs/issues/1502">issue 1502</a>.</li>
-					<li>05-Mar-2021: Added recommendation that page list include links to all pages of content
-						reproduced from source and best practice to include links to all pages in the source. See <a
-							href="https://github.com/w3c/epub-specs/issues/1503">issue 1503</a>.</li>
-					<li>05-Mar-2021: Restructured the EPUB Requirements section to split out the individual objectives
-						that were grouped together under the Page Navigation and Media Overlays headings. See <a
-							href="https://github.com/w3c/epub-specs/issues/1458">issue 1458</a>.</li>
-					<li>25-Feb-2021: Replaced the IDPF URLs used to report conformance to the 1.0 specification with
-						more flexible text strings. See <a href="https://github.com/w3c/epub-specs/issues/1455">issue
-							1455</a>.</li>
-					<li>19-Feb-2021: References to WCAG 2.0 have been updated to undated references to WCAG 2 (except
-						where WCAG 2.0 is explicitly mentioned for conformance).</li>
-					<li>01-Feb-2021: Changed the recommendation that media overlays conform to the requirements of the
-						EPUB specification to a requirement. See <a href="https://github.com/w3c/epub-specs/issues/1486"
-							>issue 1486</a>.</li>
-					<li>17-Nov-2020: Added the <code>refines</code> attribute to the <code>certifierCredential</code>
-						and <code>certifierReport</code> properties and examples. See <a
-							href="https://github.com/w3c/epub-specs/issues/1410">issue 1410</a>.</li>
-					<li>16-Nov-2020: References to the optional accessibility control and API metadata have been removed
-						from the discoverability section. These metadata properties are more applicable to Reading
-						Systems. See <a href="https://github.com/w3c/epub-specs/issues/1327">issue 1327</a>.</li>
-					<li>26-Sept-2020: The revisions made to the Accessibility 1.0 specification as part of publishing it
-						as an ISO standard have been incorporated into the initial draft text.</li>
-				</ul>
-			</section>
+			<ul>
+				<li>09-June-2021: Clarified that a pagination source must not be specified when page break markers
+					and/or a page list are included in a digital-only publication. See <a
+						href="https://github.com/w3c/epub-specs/issues/1599">issue 1599</a>.</li>
+				<li>29-Apr-2021: Change conformance identifiers to use hyphens and dashes so they are not confused for
+					plain language strings. See <a href="https://github.com/w3c/epub-specs/issues/1455">issue
+					1455</a>.</li>
+				<li>26-Mar-2021: Added informative section detailing when to re-evaluate EPUB Publications. See <a
+						href="https://github.com/w3c/epub-specs/issues/1470">issue 1470</a>.</li>
+				<li>12-Mar-2021: Changed the distribution section to informative but added a note that the requirements
+					must be followed where required by law (e.g., in the EU). See <a
+						href="https://github.com/w3c/epub-specs/issues/1487">issue 1487</a>.</li>
+				<li>08-Mar-2021: Add objective for the sequence of <code>par</code> and <code>seq</code> elements in
+					media overlay documents to reflect a logical reading order. See <a
+						href="https://github.com/w3c/epub-specs/issues/1556">issue 1556</a>.</li>
+				<li>05-Mar-2021: Added recommendation that page markers be included for all pages of content reproduced
+					from source and best practice to include markers for all pages in the source. See <a
+						href="https://github.com/w3c/epub-specs/issues/1502">issue 1502</a>.</li>
+				<li>05-Mar-2021: Added recommendation that page list include links to all pages of content reproduced
+					from source and best practice to include links to all pages in the source. See <a
+						href="https://github.com/w3c/epub-specs/issues/1503">issue 1503</a>.</li>
+				<li>05-Mar-2021: Restructured the EPUB Requirements section to split out the individual objectives that
+					were grouped together under the Page Navigation and Media Overlays headings. See <a
+						href="https://github.com/w3c/epub-specs/issues/1458">issue 1458</a>.</li>
+				<li>25-Feb-2021: Replaced the IDPF URLs used to report conformance to the 1.0 specification with more
+					flexible text strings. See <a href="https://github.com/w3c/epub-specs/issues/1455">issue
+					1455</a>.</li>
+				<li>19-Feb-2021: References to WCAG 2.0 have been updated to undated references to WCAG 2 (except where
+					WCAG 2.0 is explicitly mentioned for conformance).</li>
+				<li>01-Feb-2021: Changed the recommendation that media overlays conform to the requirements of the EPUB
+					specification to a requirement. See <a href="https://github.com/w3c/epub-specs/issues/1486">issue
+						1486</a>.</li>
+				<li>17-Nov-2020: Added the <code>refines</code> attribute to the <code>certifierCredential</code> and
+						<code>certifierReport</code> properties and examples. See <a
+						href="https://github.com/w3c/epub-specs/issues/1410">issue 1410</a>.</li>
+				<li>16-Nov-2020: References to the optional accessibility control and API metadata have been removed
+					from the discoverability section. These metadata properties are more applicable to Reading Systems.
+					See <a href="https://github.com/w3c/epub-specs/issues/1327">issue 1327</a>.</li>
+				<li>26-Sept-2020: The revisions made to the Accessibility 1.0 specification as part of publishing it as
+					an ISO standard have been incorporated into the initial draft text.</li>
+			</ul>
 		</section>
 		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
 		></div>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -79,7 +79,7 @@
                      "wpt-tests-exist": true,
 		}
             };//]]>
-      </script> 
+      </script>
 	</head>
 	<body>
 		<section id="abstract">
@@ -9364,190 +9364,168 @@ EPUB/images/cover.png</pre>
 		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
 
-			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance
-				of <a>EPUB Publications</a> or are similarly noteworthy.</p>
+			<p>Note that this change log only identifies substantive changes since <a
+					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> &#8212; those that affect the
+				conformance of <a>EPUB Publications</a> or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+-label%3ASpec-RS+"
 					>Working Group's issue tracker</a>.</p>
 
-			<section id="changes-latest">
-				<h3>Substantive Changes since the <a href="https://www.w3.org/TR/2021/WD-epub-33-20210712/">Previous
-						Working Draft</a></h3>
-
-				<!--
-					After each working draft is published:
-						- change the link/text in the section heading to refer to the published draft (use the dated URL)
-						- move all changes down to the next section
-				-->
-
-				<ul>
-					<li>22-July-2021: Clarified TTS handling of images in media overlays. See <a
-							href="https://github.com/w3c/epub-specs/issues/1745">issue 1745</a>.</li>
-				</ul>
-			</section>
-
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
-					3.2</a></h3>
-
-				<ul>
-					<li>09-July-2021: Restored the custom attributes section due to known usage but without reference to
-						the attribute registry. See <a href="https://github.com/w3c/epub-specs/issues/1602">issue
-							1602</a>.</li>
-					<li>09-July-2021: Added the "Relationship to URL" section to explain the use of URL standard
-						terminology in this document relative to resource formats that do not reference it. See <a
-							href="https://github.com/w3c/epub-specs/issues/1726">issue 1726</a>.</li>
-					<li>05-July-2021: Removed the section on private use area characters from the XHTML restrictions.
-						The issues are more complex than what is covered and not in scope of EPUB to define. See <a
-							href="https://github.com/w3c/epub-specs/issues/1732">issue 1732</a>.</li>
-					<li>28-June-2021: Added a note discouraging EPUB Creators from referencing resources outside the
-						directory containing the Package Document to avoid interoperability issues. See <a
-							href="https://github.com/w3c/epub-specs/issues/1687">issue 1687</a></li>
-					<li>23-June-2021: Added the <code>base</code> element to the list of discouraged XHTML constructs.
-						See <a href="https://github.com/w3c/epub-specs/issues/1699">issue 1699</a>.</li>
-					<li>18-June-2021: Moved requirements for authoring SSML, PLS lexicons and CSS 3 Speech to the <a
-							href="https://www.w3.org/TR/epub-3-tts">EPUB 3 Text-to-Speech Enhancements</a> note. The
-						ability to use these technologies in EPUB 3 Publications remains unchanged. See <a
-							href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
-					<li>16-June-2021: Absolute URLs with <code>file</code> scheme should not be used on manifest items.
-						See <a href="https://github.com/w3c/epub-specs/issues/1688">issue 1688</a>.</li>
-					<li>31-May-2021: Require Unicode normalization and full case folding (in this order) for file name
-						uniqueness comparisons. See <a href="https://github.com/w3c/epub-specs/issues/1631">issue
-							1631</a> and <a href="https://github.com/w3c/epub-specs/pull/1648">pull request
-						1648</a>.</li>
-					<li>31-May-2021: Confirmed that SVG Content Documents do not have to be valid to the SVG
-						specification, only meet the well-formedness and ID requirements currently referenced and the
-						restrictions imposed by this specification. See <a
-							href="https://github.com/w3c/epub-specs/issues/1323">issue 1323</a>.</li>
-					<li>12-May-2021: Clarified that manifest items must not contain fragment identifiers. See <a
-							href="https://github.com/w3c/epub-specs/issues/1303">issue 1303</a>.</li>
-					<li>12-May-2021: Changed all references to URIs/IRIs to URLs and references to RFCs 3986 and 3987 to
-						the URL standard. See <a href="https://github.com/w3c/epub-specs/issues/808">issue 808</a>.</li>
-					<li>08-May-2021: Added clarifying text that <code>link</code> element can be used to link individual
-						metadata properties in an alternative format. See <a
-							href="https://github.com/w3c/epub-specs/issues/1666">issue 1666</a>.</li>
-					<li>06-May-2021: Noted that the working group will no longer maintain the publication type and
-						collection role registries and removed dependence on the latter for validating collection types
-						(use of NMToken values remains restricted to extension specifications). The registry of
-						authority codes is now integrated into the property definition. See <a
-							href="https://github.com/w3c/epub-specs/pull/1664">pull request 1664</a>.</li>
-					<li>06-May-2021: Added <code>application/ecmascript</code> as a core media type for scripts. See <a
-							href="https://github.com/w3c/epub-specs/issues/1353">issue 1353</a>.</li>
-					<li>06-May-2021: Added new section on fragment identifiers to Media Overlays and now recommend HTML
-						target element references and SVG fragment identifiers instead of requiring conformance to the
-						incompatible XPointer Shorthand syntax. See <a
-							href="https://github.com/w3c/epub-specs/issues/1586">issue 1586</a>.</li>
-					<li>28-Apr-2021: Drop requirement for resources referenced from HTML <code>link</code> elements to
-						have core media type fallbacks. See <a href="https://github.com/w3c/epub-specs/issues/1312"
-							>issue 1312</a>.</li>
-					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 is the recommended
-						encoding. See <a href="https://github.com/w3c/epub-specs/issues/1628">issue 1628</a>.</li>
-					<li>19-Apr-2021: The use of custom attributes in EPUB Content Documents is no longer supported. See
-							<a href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>
-					<li>13-Apr-2021: Require path names in OCF to also be UTF-8 encoded. See <a
-							href="https://github.com/w3c/epub-specs/issues/1630">issue 1630</a>.</li>
-					<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in <a
-							href="#sec-css-req"></a>. See <a href="https://github.com/w3c/epub-specs/issues/1613">issue
-							1614</a>.</li>
-					<li>09-Apr-2021: Added a new section dedicated to accessibility in EPUB Publications.</li>
-					<li>04-May-2021: Removed requirements around SVG <code>requiredExtensions</code> attribute. See <a
-							href="https://github.com/w3c/epub-specs/issues/1087">issue 1087</a>.</li>
-					<li>26-Mar-2021: Removed requirement for page list ordering to reflect the order of page breaks in
-						the content. See <a href="https://github.com/w3c/epub-specs/issues/1500">issue 1500</a>.</li>
-					<li>26-Mar-2021: Allowed <code>creator</code> and <code>contributor</code> elements to have multiple
-						roles and allowed roles for <code>publisher</code>. See <a
-							href="https://github.com/w3c/epub-specs/issues/1129">issue 1129</a> and <a
-							href="https://github.com/w3c/epub-specs/issues/1583">issue 1583</a></li>
-					<li>23-Mar-2021: Clarified the requirements for the use of data URLs in EPUB Publications. See <a
-							href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a>.</li>
-					<li>17-Mar-2021: Include non characters at the end of the supplementary planes in list of characters
-						not allowed in file names. See <a href="https://github.com/w3c/epub-specs/issues/1538">issue
-							1538</a>.</li>
-					<li>15-Mar-2021: Removed the normative dependencies on XML schemas and added element and attribute
-						definitions for the <code>container.xml</code>, <code>encryption.xml</code> and
-							<code>signatures.xml</code> files. All schemas are considered informative. See <a
-							href="https://github.com/w3c/epub-specs/issues/1566">issue 1566</a>.</li>
-					<li>10-Mar-2021: Require that resources referenced from an EPUB Publication not be located in the
-							<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205"
-							>issue 1205</a>.</li>
-					<li>08-Mar-2021: The fix for <a href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>
-						on 20-Jan-2021 incorrectly mentioned EPUB Content Documents having durations. Corrected to Media
-						Overlay Documents.</li>
-					<li>08-Mar-2021: Added recommendation that <code>refines</code> attribute use fragment identifiers
-						to reference Publication Resources. See <a href="https://github.com/w3c/epub-specs/issues/1361"
-							>issue 1361</a>.</li>
-					<li>08-Mar-2021: Change requirement that Media Overlay <code>par</code> and <code>seq</code>
-						ordering match the default reading order to guidance. See <a
-							href="https://github.com/w3c/epub-specs/issues/1458">issue 1458</a></li>
-					<li>05-Mar-2021: Clarified that whitespace within metadata element values is collapsed per the
-						[[Infra]] specification definition. See <a href="https://github.com/w3c/epub-specs/issues/1528"
-							>issue 1528</a>.</li>
-					<li>26-Feb-2021: Created a new section for describing general metadata value requirements,
-						specifically whitespace handling. See <a href="https://github.com/w3c/epub-specs/issues/1528"
-							>issue 1528</a>.</li>
-					<li>17-Feb-2020: File extension recommendations have been removed (affects the Package Document,
-						XHTML Content Documents, Media Overlay Documents). See <a
-							href="https://github.com/w3c/epub-specs/issues/1294">issue 1294</a>.</li>
-					<li>15-Feb-2021: Clarified that <code>nav</code> elements without an <code>epub:type</code>
-						attribute are not subject to the EPUB Navigation Document's content model restrictions. See <a
-							href="https://github.com/w3c/epub-specs/issues/976">issue 976</a>.</li>
-					<li>10-Feb-2021: A very first draft for <a href="#sec-security-privacy"></a> has been added.</li>
-					<li>04-Feb-2021: Clarify that the value of <code>dc:language</code> elements must be well-formed
-						language tags. See <a href="https://github.com/w3c/epub-specs/issues/1325">issue 1325</a>.</li>
-					<li>02-Feb-2021: Added <code>auto</code> value for <code>dir</code> attribute and clarified the
-						precedence of the attribute. See <a href="https://github.com/w3c/epub-specs/issues/1491">issue
-							1491</a> and <a href="https://github.com/w3c/epub-specs/issues/1494">issue 1494</a>.</li>
-					<li>02-Feb-2021: Added the <code>hreflang</code> attribute to <code>link</code> elements to identify
-						the language of linked resources. See <a href="https://github.com/w3c/epub-specs/issues/1488"
-							>issue 1488</a>.</li>
-					<li>20-Jan-2021: Clarified that user-defined media overlay style classes must be declared in the
-						Package Document metadata. See <a href="https://github.com/w3c/epub-specs/issues/1319">issue
-							1319</a>.</li>
-					<li>20-Jan-2021: Add recommendation that the sum of the media overlay durations for each Content
-						Document match the total duration specified for the EPUB Publication. See <a
-							href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>.</li>
-					<li>20-Jan-2021: Clarified that the <code>epub:type</code> attribute does not improve the
-						accessibility of publications. Added pointers to the <code>role</code> attribute and the
-						DPUB-ARIA vocabulary for accessibility.</li>
-					<li>13-Jan-2021: The requirement for progressive enhancement with spine-level scripting has been
-						changed to a recommendation that top-level content documents remain consumable when scripting is
-						not available. See <a href="https://github.com/w3c/epub-specs/issues/1444">issue 1444</a>.</li>
-					<li>24-Dec-2020: The specification no longer makes reference to a release identifier, but the
-						requirement to include a last modification date remains for backwards compatibility. See <a
-							href="https://github.com/w3c/epub-specs/issues/1440">issue 1440</a>.</li>
-					<li>16-Dec-2020: Terminology and requirements related to "renditions" of an EPUB Publication have
-						been simplified to improve the readability of the specifications (i.e., to align with the
-						generally understood concept that an EPUB Publication has only a single rendering described by a
-						single Package Document). These changes do not affect the ability to include multiple
-						renditions, which are now more fully covered in [[EPUB-MULTI-REND-11]]. See <a
-							href="https://github.com/w3c/epub-specs/issues/1436">issue 1436</a>.</li>
-					<li>14-Nov-2020: The term "semantic inflection" is no longer used to describe the process of adding
-						structural semantics to elements. The term is not widely understood outside of EPUB, and is
-						unnecessarily complex. The specification now simply refers to "expressing" or "adding" structual
-						semantics.</li>
-					<li>09-Nov-2020: The requirement that the ordering of the <code>toc nav</code> match the ordering of
-						EPUB Content Documents in the spine, and the elements within each file, has been reduced to a
-						recommendation. See <a href="https://github.com/w3c/epub-specs/issues/1283">issue 1283</a>.</li>
-					<li>06-Nov-2020: Clarified that HTML <code>script</code> elements that contain <a
-							href="#sec-scripted-context">data blocks are not instances of scripting</a>. See <a
-							href="https://github.com/w3c/epub-specs/issues/1352">issue 1352</a>.</li>
-					<li>06-Nov-2020: Added WebP to the <a href="#cmt-grp-image">image core media types</a>. See <a
-							href="https://github.com/w3c/epub-specs/issues/1344">issue 1344</a>.</li>
-					<li>06-Nov-2020: A <a href="#app-identifiers-allowed">restricted set of external identifiers</a> are
-						now allowed in publication resources. <a href="#sec-xml-constraints">References to external
-							entities</a> from the internal DTD subset remain restricted, however. See <a
-							href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
-					<li>12-Oct-2020: Added OPUS to the <a href="#cmt-grp-audio">audio core media types</a> with a
-						warning that it is still subject to review depending on support in Mac/iOS. See <a
-							href="https://github.com/w3c/epub-specs/issues/645">issue 645</a>.</li>
-					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
-						understanding and access to information. This specification now consolidates the authoring
-						requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF
-						and Media Overlays specifications. A separate document, EPUB Reading Systems 3.3, consolidates
-						the reading system requirements from those documents.</li>
-				</ul>
-			</section>
+			<ul>
+				<li>22-July-2021: Clarified TTS handling of images in media overlays. See <a
+						href="https://github.com/w3c/epub-specs/issues/1745">issue 1745</a>.</li>
+				<li>09-July-2021: Restored the custom attributes section due to known usage but without reference to the
+					attribute registry. See <a href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>
+				<li>09-July-2021: Added the "Relationship to URL" section to explain the use of URL standard terminology
+					in this document relative to resource formats that do not reference it. See <a
+						href="https://github.com/w3c/epub-specs/issues/1726">issue 1726</a>.</li>
+				<li>05-July-2021: Removed the section on private use area characters from the XHTML restrictions. The
+					issues are more complex than what is covered and not in scope of EPUB to define. See <a
+						href="https://github.com/w3c/epub-specs/issues/1732">issue 1732</a>.</li>
+				<li>28-June-2021: Added a note discouraging EPUB Creators from referencing resources outside the
+					directory containing the Package Document to avoid interoperability issues. See <a
+						href="https://github.com/w3c/epub-specs/issues/1687">issue 1687</a></li>
+				<li>23-June-2021: Added the <code>base</code> element to the list of discouraged XHTML constructs. See
+						<a href="https://github.com/w3c/epub-specs/issues/1699">issue 1699</a>.</li>
+				<li>18-June-2021: Moved requirements for authoring SSML, PLS lexicons and CSS 3 Speech to the <a
+						href="https://www.w3.org/TR/epub-3-tts">EPUB 3 Text-to-Speech Enhancements</a> note. The ability
+					to use these technologies in EPUB 3 Publications remains unchanged. See <a
+						href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
+				<li>16-June-2021: Absolute URLs with <code>file</code> scheme should not be used on manifest items. See
+						<a href="https://github.com/w3c/epub-specs/issues/1688">issue 1688</a>.</li>
+				<li>31-May-2021: Require Unicode normalization and full case folding (in this order) for file name
+					uniqueness comparisons. See <a href="https://github.com/w3c/epub-specs/issues/1631">issue 1631</a>
+					and <a href="https://github.com/w3c/epub-specs/pull/1648">pull request 1648</a>.</li>
+				<li>31-May-2021: Confirmed that SVG Content Documents do not have to be valid to the SVG specification,
+					only meet the well-formedness and ID requirements currently referenced and the restrictions imposed
+					by this specification. See <a href="https://github.com/w3c/epub-specs/issues/1323">issue
+					1323</a>.</li>
+				<li>12-May-2021: Clarified that manifest items must not contain fragment identifiers. See <a
+						href="https://github.com/w3c/epub-specs/issues/1303">issue 1303</a>.</li>
+				<li>12-May-2021: Changed all references to URIs/IRIs to URLs and references to RFCs 3986 and 3987 to the
+					URL standard. See <a href="https://github.com/w3c/epub-specs/issues/808">issue 808</a>.</li>
+				<li>08-May-2021: Added clarifying text that <code>link</code> element can be used to link individual
+					metadata properties in an alternative format. See <a
+						href="https://github.com/w3c/epub-specs/issues/1666">issue 1666</a>.</li>
+				<li>06-May-2021: Noted that the working group will no longer maintain the publication type and
+					collection role registries and removed dependence on the latter for validating collection types (use
+					of NMToken values remains restricted to extension specifications). The registry of authority codes
+					is now integrated into the property definition. See <a
+						href="https://github.com/w3c/epub-specs/pull/1664">pull request 1664</a>.</li>
+				<li>06-May-2021: Added <code>application/ecmascript</code> as a core media type for scripts. See <a
+						href="https://github.com/w3c/epub-specs/issues/1353">issue 1353</a>.</li>
+				<li>06-May-2021: Added new section on fragment identifiers to Media Overlays and now recommend HTML
+					target element references and SVG fragment identifiers instead of requiring conformance to the
+					incompatible XPointer Shorthand syntax. See <a href="https://github.com/w3c/epub-specs/issues/1586"
+						>issue 1586</a>.</li>
+				<li>28-Apr-2021: Drop requirement for resources referenced from HTML <code>link</code> elements to have
+					core media type fallbacks. See <a href="https://github.com/w3c/epub-specs/issues/1312">issue
+						1312</a>.</li>
+				<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 is the recommended
+					encoding. See <a href="https://github.com/w3c/epub-specs/issues/1628">issue 1628</a>.</li>
+				<li>19-Apr-2021: The use of custom attributes in EPUB Content Documents is no longer supported. See <a
+						href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>
+				<li>13-Apr-2021: Require path names in OCF to also be UTF-8 encoded. See <a
+						href="https://github.com/w3c/epub-specs/issues/1630">issue 1630</a>.</li>
+				<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in <a href="#sec-css-req"
+					></a>. See <a href="https://github.com/w3c/epub-specs/issues/1613">issue 1614</a>.</li>
+				<li>09-Apr-2021: Added a new section dedicated to accessibility in EPUB Publications.</li>
+				<li>04-May-2021: Removed requirements around SVG <code>requiredExtensions</code> attribute. See <a
+						href="https://github.com/w3c/epub-specs/issues/1087">issue 1087</a>.</li>
+				<li>26-Mar-2021: Removed requirement for page list ordering to reflect the order of page breaks in the
+					content. See <a href="https://github.com/w3c/epub-specs/issues/1500">issue 1500</a>.</li>
+				<li>26-Mar-2021: Allowed <code>creator</code> and <code>contributor</code> elements to have multiple
+					roles and allowed roles for <code>publisher</code>. See <a
+						href="https://github.com/w3c/epub-specs/issues/1129">issue 1129</a> and <a
+						href="https://github.com/w3c/epub-specs/issues/1583">issue 1583</a></li>
+				<li>23-Mar-2021: Clarified the requirements for the use of data URLs in EPUB Publications. See <a
+						href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a>.</li>
+				<li>17-Mar-2021: Include non characters at the end of the supplementary planes in list of characters not
+					allowed in file names. See <a href="https://github.com/w3c/epub-specs/issues/1538">issue
+					1538</a>.</li>
+				<li>15-Mar-2021: Removed the normative dependencies on XML schemas and added element and attribute
+					definitions for the <code>container.xml</code>, <code>encryption.xml</code> and
+						<code>signatures.xml</code> files. All schemas are considered informative. See <a
+						href="https://github.com/w3c/epub-specs/issues/1566">issue 1566</a>.</li>
+				<li>10-Mar-2021: Require that resources referenced from an EPUB Publication not be located in the
+						<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205"
+						>issue 1205</a>.</li>
+				<li>08-Mar-2021: The fix for <a href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a> on
+					20-Jan-2021 incorrectly mentioned EPUB Content Documents having durations. Corrected to Media
+					Overlay Documents.</li>
+				<li>08-Mar-2021: Added recommendation that <code>refines</code> attribute use fragment identifiers to
+					reference Publication Resources. See <a href="https://github.com/w3c/epub-specs/issues/1361">issue
+						1361</a>.</li>
+				<li>08-Mar-2021: Change requirement that Media Overlay <code>par</code> and <code>seq</code> ordering
+					match the default reading order to guidance. See <a
+						href="https://github.com/w3c/epub-specs/issues/1458">issue 1458</a></li>
+				<li>05-Mar-2021: Clarified that whitespace within metadata element values is collapsed per the [[Infra]]
+					specification definition. See <a href="https://github.com/w3c/epub-specs/issues/1528">issue
+					1528</a>.</li>
+				<li>26-Feb-2021: Created a new section for describing general metadata value requirements, specifically
+					whitespace handling. See <a href="https://github.com/w3c/epub-specs/issues/1528">issue
+					1528</a>.</li>
+				<li>17-Feb-2020: File extension recommendations have been removed (affects the Package Document, XHTML
+					Content Documents, Media Overlay Documents). See <a
+						href="https://github.com/w3c/epub-specs/issues/1294">issue 1294</a>.</li>
+				<li>15-Feb-2021: Clarified that <code>nav</code> elements without an <code>epub:type</code> attribute
+					are not subject to the EPUB Navigation Document's content model restrictions. See <a
+						href="https://github.com/w3c/epub-specs/issues/976">issue 976</a>.</li>
+				<li>10-Feb-2021: A very first draft for <a href="#sec-security-privacy"></a> has been added.</li>
+				<li>04-Feb-2021: Clarify that the value of <code>dc:language</code> elements must be well-formed
+					language tags. See <a href="https://github.com/w3c/epub-specs/issues/1325">issue 1325</a>.</li>
+				<li>02-Feb-2021: Added <code>auto</code> value for <code>dir</code> attribute and clarified the
+					precedence of the attribute. See <a href="https://github.com/w3c/epub-specs/issues/1491">issue
+						1491</a> and <a href="https://github.com/w3c/epub-specs/issues/1494">issue 1494</a>.</li>
+				<li>02-Feb-2021: Added the <code>hreflang</code> attribute to <code>link</code> elements to identify the
+					language of linked resources. See <a href="https://github.com/w3c/epub-specs/issues/1488">issue
+						1488</a>.</li>
+				<li>20-Jan-2021: Clarified that user-defined media overlay style classes must be declared in the Package
+					Document metadata. See <a href="https://github.com/w3c/epub-specs/issues/1319">issue 1319</a>.</li>
+				<li>20-Jan-2021: Add recommendation that the sum of the media overlay durations for each Content
+					Document match the total duration specified for the EPUB Publication. See <a
+						href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>.</li>
+				<li>20-Jan-2021: Clarified that the <code>epub:type</code> attribute does not improve the accessibility
+					of publications. Added pointers to the <code>role</code> attribute and the DPUB-ARIA vocabulary for
+					accessibility.</li>
+				<li>13-Jan-2021: The requirement for progressive enhancement with spine-level scripting has been changed
+					to a recommendation that top-level content documents remain consumable when scripting is not
+					available. See <a href="https://github.com/w3c/epub-specs/issues/1444">issue 1444</a>.</li>
+				<li>24-Dec-2020: The specification no longer makes reference to a release identifier, but the
+					requirement to include a last modification date remains for backwards compatibility. See <a
+						href="https://github.com/w3c/epub-specs/issues/1440">issue 1440</a>.</li>
+				<li>16-Dec-2020: Terminology and requirements related to "renditions" of an EPUB Publication have been
+					simplified to improve the readability of the specifications (i.e., to align with the generally
+					understood concept that an EPUB Publication has only a single rendering described by a single
+					Package Document). These changes do not affect the ability to include multiple renditions, which are
+					now more fully covered in [[EPUB-MULTI-REND-11]]. See <a
+						href="https://github.com/w3c/epub-specs/issues/1436">issue 1436</a>.</li>
+				<li>14-Nov-2020: The term "semantic inflection" is no longer used to describe the process of adding
+					structural semantics to elements. The term is not widely understood outside of EPUB, and is
+					unnecessarily complex. The specification now simply refers to "expressing" or "adding" structual
+					semantics.</li>
+				<li>09-Nov-2020: The requirement that the ordering of the <code>toc nav</code> match the ordering of
+					EPUB Content Documents in the spine, and the elements within each file, has been reduced to a
+					recommendation. See <a href="https://github.com/w3c/epub-specs/issues/1283">issue 1283</a>.</li>
+				<li>06-Nov-2020: Clarified that HTML <code>script</code> elements that contain <a
+						href="#sec-scripted-context">data blocks are not instances of scripting</a>. See <a
+						href="https://github.com/w3c/epub-specs/issues/1352">issue 1352</a>.</li>
+				<li>06-Nov-2020: Added WebP to the <a href="#cmt-grp-image">image core media types</a>. See <a
+						href="https://github.com/w3c/epub-specs/issues/1344">issue 1344</a>.</li>
+				<li>06-Nov-2020: A <a href="#app-identifiers-allowed">restricted set of external identifiers</a> are now
+					allowed in publication resources. <a href="#sec-xml-constraints">References to external entities</a>
+					from the internal DTD subset remain restricted, however. See <a
+						href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
+				<li>12-Oct-2020: Added OPUS to the <a href="#cmt-grp-audio">audio core media types</a> with a warning
+					that it is still subject to review depending on support in Mac/iOS. See <a
+						href="https://github.com/w3c/epub-specs/issues/645">issue 645</a>.</li>
+				<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
+					understanding and access to information. This specification now consolidates the authoring
+					requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF and
+					Media Overlays specifications. A separate document, EPUB Reading Systems 3.3, consolidates the
+					reading system requirements from those documents.</li>
+			</ul>
 		</section>
 		<div data-include="../common/acknowledgements-dedication.html" data-oninclude="fixIncludes"
 			data-include-replace="true"></div>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -1261,50 +1261,32 @@
 		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
 
-			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance
-				of <a>EPUB Publications</a> or are similarly noteworthy.</p>
+			<p>Note that this change log only identifies substantive changes since <a
+					href="http://idpf.org/epub/renditions/multiple/">EPUB Multiple-Rendition Publications 1.0</a>
+				&#8212; those that affect the conformance of <a>EPUB Publications</a> or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AMultipleRenditions11"
 					>working group's issue tracker</a>.</p>
 
-			<section id="changes-latest">
-				<h3>Substantive changes since the previous <a
-						href="https://www.w3.org/TR/2021/NOTE-epub-multi-rend-11-20210525/">Draft Note</a></h3>
-
-				<!--
-					After each working draft is published:
-						- change the link/text in the section heading to refer to the published draft (use the dated URL)
-						- move all changes down to the next section
-				-->
-
-				<ul> </ul>
-			</section>
-
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="http://idpf.org/epub/renditions/multiple/">EPUB
-						Multiple-Rendition Publications 1.0</a></h3>
-				<ul>
-					<li>19-Mar-2021: Require the use of the unique identifier in the <code>metadata.xml</code> file for
-						obfuscating resources and recommend it be the same as the identifier in the default rendition.
-						See <a href="https://github.com/w3c/publ-epub-revision/issues/1443">issue 1443</a>.</li>
-					<li>19-Mar-2021: Added note clarifying that Package Documents need to be in a common directory to
-						share resources. See <a href="https://github.com/w3c/publ-epub-revision/issues/619">issue
-							619</a>.</li>
-					<li>19-Mar-2021: Fixed incorrect reference to <code>link</code> element being a child of the
-							<code>container</code> element. See <a
-							href="https://github.com/w3c/publ-epub-revision/issues/584">issue 584</a>.</li>
-					<li>24-Dec-2020: The specification no longer makes reference to a release identifier, but the
-						requirement to include a unique identifier and last modification date in the
-							<code>metadata.xml</code> file remain for backwards compatibility. See <a
-							href="https://github.com/w3c/publ-epub-revision/issues/1440">issue 1440</a>.</li>
-					<li>16-Dec-2020: Terminology and requirements related to renditions of an EPUB Publication have been
-						moved to this specification to simplify readability of both this and the [[EPUB-33]]
-						specification. These changes do not affect the ability to include multiple renditions in an EPUB
-						Publication. See <a href="https://github.com/w3c/publ-epub-revision/issues/1436">issue
-						1436</a>.</li>
-				</ul>
-			</section>
+			<ul>
+				<li>19-Mar-2021: Require the use of the unique identifier in the <code>metadata.xml</code> file for
+					obfuscating resources and recommend it be the same as the identifier in the default rendition. See
+						<a href="https://github.com/w3c/publ-epub-revision/issues/1443">issue 1443</a>.</li>
+				<li>19-Mar-2021: Added note clarifying that Package Documents need to be in a common directory to share
+					resources. See <a href="https://github.com/w3c/publ-epub-revision/issues/619">issue 619</a>.</li>
+				<li>19-Mar-2021: Fixed incorrect reference to <code>link</code> element being a child of the
+						<code>container</code> element. See <a
+						href="https://github.com/w3c/publ-epub-revision/issues/584">issue 584</a>.</li>
+				<li>24-Dec-2020: The specification no longer makes reference to a release identifier, but the
+					requirement to include a unique identifier and last modification date in the
+						<code>metadata.xml</code> file remain for backwards compatibility. See <a
+						href="https://github.com/w3c/publ-epub-revision/issues/1440">issue 1440</a>.</li>
+				<li>16-Dec-2020: Terminology and requirements related to renditions of an EPUB Publication have been
+					moved to this specification to simplify readability of both this and the [[EPUB-33]] specification.
+					These changes do not affect the ability to include multiple renditions in an EPUB Publication. See
+						<a href="https://github.com/w3c/publ-epub-revision/issues/1436">issue 1436</a>.</li>
+			</ul>
 		</section>
 		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
 		></div>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -73,7 +73,7 @@
 				lint: {
 					"wpt-tests-exist": true,
 				}
-			};//]]></script> 
+			};//]]></script>
 	</head>
 	<body>
 		<section id="abstract">
@@ -2149,137 +2149,116 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
 
-			<p>Note that this change log only identifies substantive changes &#8212; those that affect the conformance
-				of Reading Systems or are similarly noteworthy.</p>
+			<p>Note that this change log only identifies substantive Changes since <a
+					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> &#8212; those that affect the
+				conformance of Reading Systems or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+label%3ASpec-RS+"
 					>Working Group's issue tracker</a>.</p>
 
-			<section id="changes-latest">
-				<h3>Substantive Changes since the <a href="https://www.w3.org/TR/2021/WD-epub-rs-33-20210712/">Previous
-						Working Draft</a></h3>
+			<ul>
+				<li>09-July-2021: Restored the custom attributes section due to known usage but without reference to the
+					attribute registry. See <a href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>
+				<li>09-July-2021: Removed recommendation to use the first language tag to determine an unspecified page
+					progression direction. See <a href="https://github.com/w3c/epub-specs/issues/1482">issue
+					1482</a>.</li>
+				<li>18-June-2021: Moved requirements for supporting SSML, PLS lexicons and CSS 3 Speech to the <a
+						href="https://www.w3.org/TR/epub-3-tts">EPUB 3 Text-to-Speech Support</a> note. See <a
+						href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
+				<li>20-May-2021: Providing a shared and unique origin for scripts is a requirements for Reading Systems
+					that support scripting. See <a href="https://github.com/w3c/epub-specs/issues/1659">issue
+					1659</a>.</li>
+				<li>20-May-2021: Removed requirement for reading systems to be conformant xml:base processors. See <a
+						href="https://github.com/w3c/epub-specs/pull/1678">pull request 1678</a>.</li>
+				<li>12-May-2021: Added additional requirement that Reading Systems ignore property values that expand to
+					invalid URL strings and property values with empty references. See <a
+						href="https://github.com/w3c/epub-specs/issues/1673">issue 1673</a>.</li>
+				<li>12-May-2021: Changed all references to URIs/IRIs to URLs and references to RFCs 3986 and 3987 to the
+					URL standard. See <a href="https://github.com/w3c/epub-specs/issues/808">issue 808</a>.</li>
 
-				<!--
-					After each working draft is published:
-						- change the link/text in the section heading to refer to the published draft (use the dated URL)
-						- move all changes down to the next section
-				-->
-
-				<ul>
-					<li>09-July-2021: Restored the custom attributes section due to known usage but without reference to
-						the attribute registry. See <a href="https://github.com/w3c/epub-specs/issues/1602">issue
-							1602</a>.</li>
-				</ul>
-			</section>
-
-			<section id="changes-older">
-				<h3>Substantive Changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB
-					3.2</a></h3>
-				<ul>
-					<li>09-July-2021: Removed recommendation to use the first language tag to determine an unspecified
-						page progression direction. See <a href="https://github.com/w3c/epub-specs/issues/1482">issue
-							1482</a>.</li>
-					<li>18-June-2021: Moved requirements for supporting SSML, PLS lexicons and CSS 3 Speech to the <a
-							href="https://www.w3.org/TR/epub-3-tts">EPUB 3 Text-to-Speech Support</a> note. See <a
-							href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
-					<li>20-May-2021: Providing a shared and unique origin for scripts is a requirements for Reading
-						Systems that support scripting. See <a href="https://github.com/w3c/epub-specs/issues/1659"
-							>issue 1659</a>.</li>
-					<li>20-May-2021: Removed requirement for reading systems to be conformant xml:base processors. See
-							<a href="https://github.com/w3c/epub-specs/pull/1678">pull request 1678</a>.</li>
-					<li>12-May-2021: Added additional requirement that Reading Systems ignore property values that
-						expand to invalid URL strings and property values with empty references. See <a
-							href="https://github.com/w3c/epub-specs/issues/1673">issue 1673</a>.</li>
-					<li>12-May-2021: Changed all references to URIs/IRIs to URLs and references to RFCs 3986 and 3987 to
-						the URL standard. See <a href="https://github.com/w3c/epub-specs/issues/808">issue 808</a>.</li>
-
-					<li>06-May-2021: Recommend that Reading Systems support references to HTML target elements and SVG
-						fragment identifiers in <code>textref</code> attributes and the <code>text</code> element's
-							<code>src</code> attribute. Support for other fragment identifier schemes is optional. See
-							<a href="https://github.com/w3c/epub-specs/issues/1586">issue 1586</a>.</li>
-					<li>23-Apr-2021: Clarified that Reading Systems should attempt to process invalid file and path
-						names. See <a href="https://github.com/w3c/epub-specs/issues/1629">issue 1629</a></li>
-					<li>16-Apr-2021: Removed the section on custom attributes. See <a
-							href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution2"
-							>Working Group Resolution</a>.</li>
-					<li>15-Apr-2021: Remove the reference to "presentation logic". See <a
-							href="https://github.com/w3c/epub-specs/issues/1516">issue 1516</a> and <a
-							href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution3"
-							>Working Group Resolution</a>.</li>
-					<li>12-Apr-2021: The section <a href="#app-epubReadingSystem"></a> has been marked as "at-risk". See
-							<a
-							href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-09-epub#resolution1"
-							>Working Group resolution</a>. </li>
-					<li>09-Apr-2021: Added a new section dedicated to accessibility and removed the outdated reference
-						to the defunct appendix in the Accessibility specification. See <a
-							href="https://github.com/w3c/epub-specs/issues/1608">issue 1608</a>.</li>
-					<li>09-Apr-2021: Added section clarifying all the conformance requirements on establishing the
-						primary language and base direction of Publication Resources. See <a
-							href="https://github.com/w3c/epub-specs/pull/1613">pull request 1613</a>. </li>
-					<li>01-Apr-2021: Added section clarifying how absolute URLs are created from relative in the Package
-						Document. See <a href="https://github.com/w3c/epub-specs/pull/1468">pull request 1468</a>.</li>
-					<li>30-Mar-2021: Restructured the document to remove the rendundant conformance sections and
-						requirements that were only used as locators when this specification was combined with the
-						authoring requirements. See <a href="https://github.com/w3c/epub-specs/pull/1597">pull request
-							1597</a> and <a href="https://github.com/w3c/epub-specs/pull/1609">pull request
-						1609</a>.</li>
-					<li>23-Mar-2021: Added requirement to prevent top-level navigation to data URLs. See <a
-							href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a>.</li>
-					<li>23-Mar-2021: Changed "suppressing" of non-linear content to "skipping" when traversing the spine
-						to clarify that the intention is not to remove all access to such content. See <a
-							href="https://github.com/w3c/epub-specs/issues/1480">issue 1480</a>.</li>
-					<li>10-Mar-2021: Changed restriction against using resources not listed in the Package Document to a
-						recommendation not to use. See <a href="https://github.com/w3c/epub-specs/issues/810">issue
-							810</a>.</li>
-					<li>09-March-2021: the statement on unique identifiers has been set to non-normative, following the
-						discussion and <a
-							href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-12-18-epub#resolution2"
-							>Working Group resolution</a>. See <a href="https://github.com/w3c/epub-specs/issues/1310"
-							>issue 1310</a>. </li>
-					<li>08-Mar-2021: Remove unnecessary requirement to assume default value for rendering metadata. See
-							<a href="https://github.com/w3c/epub-specs/issues/1313">issue 1313</a>.</li>
-					<li>05-Mar-2021: Added requirement for reading systems to collapse whitespace in DCMES and meta
-						elements per the [[Infra]] specification definition. See <a
-							href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
-					<li>26-Feb-2021: Clarified the trimming of leading and trailing whitespace is to be done in
-						accordance with the [[Infra]] specification definition, and removed the exception that
-							<code>meta</code> element properties may define their own whitespace handling rules. See <a
-							href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
-					<li>19-Feb-2021: Updated the <a href="#sec-scripted-content-security">scripting security
-							considerations</a> so that the text recommends assigning a unique origin to each EPUB
-						Publication for security rather than domain isolation at the Content Document level. See <a
-							href="https://github.com/w3c/epub-specs/issues/1156">issue 1156</a>.</li>
-					<li>15-Feb-2021: Clarified the requirements for presenting nav elements in the navigation document.
-						The toc nav is now the only required element, the page-list nav is recommended when present, and
-						all others are optional. See <a href="https://github.com/w3c/epub-specs/issues/975">issue
-							975</a>.</li>
-					<li>10-Feb-2021: A very first draft for <a href="#sec-security-privacy"></a> has been added.</li>
-					<li>04-Feb-2021: Added explicit requirement that reading systems not use the language in
-							<code>dc:language</code> elements as the language of resources.</li>
-					<li>02-Feb-2021: Added base direction determination rules for the <code>dir</code> attribute
-						accounting for the addition of the new <code>auto</code> value. See <a
-							href="https://github.com/w3c/epub-specs/issues/1491">issue 1491</a>.</li>
-					<li>02-Feb-2021: Noted that language information in the new <code>hreflang</code> attribute on
-							<code>link</code> elements is not authoritative. See <a
-							href="https://github.com/w3c/epub-specs/issues/1488">issue 1488</a>.</li>
-					<li>24-Dec-2020: The creation of a <a
-							href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
-							>release identifier</a> [[EPUBPackages-32]] is no longer defined. See <a
-							href="https://github.com/w3c/epub-specs/issues/1440">issue 1440</a>.</li>
-					<li>06-Nov-2020: Reading systems are now required to <a href="#confreq-rs-xml-extid">not resolve
-							external identifiers</a> in doctype declarations. See <a
-							href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
-					<li>05-Nov-2020: Generalized the restriction on custom attribute namespace URIs to exclude all of
-						idpf.org and w3.org. See <a href="https://github.com/w3c/epub-specs/issues/1388">issue
-						1388</a>.</li>
-					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
-						understanding and access to information. This specification now consolidates the reading system
-						requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF
-						and Media Overlays specifications. The EPUB 3.3 core specification now focuses only on authoring
-						requirements.</li>
-				</ul>
-			</section>
+				<li>06-May-2021: Recommend that Reading Systems support references to HTML target elements and SVG
+					fragment identifiers in <code>textref</code> attributes and the <code>text</code> element's
+						<code>src</code> attribute. Support for other fragment identifier schemes is optional. See <a
+						href="https://github.com/w3c/epub-specs/issues/1586">issue 1586</a>.</li>
+				<li>23-Apr-2021: Clarified that Reading Systems should attempt to process invalid file and path names.
+					See <a href="https://github.com/w3c/epub-specs/issues/1629">issue 1629</a></li>
+				<li>16-Apr-2021: Removed the section on custom attributes. See <a
+						href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution2"
+						>Working Group Resolution</a>.</li>
+				<li>15-Apr-2021: Remove the reference to "presentation logic". See <a
+						href="https://github.com/w3c/epub-specs/issues/1516">issue 1516</a> and <a
+						href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution3"
+						>Working Group Resolution</a>.</li>
+				<li>12-Apr-2021: The section <a href="#app-epubReadingSystem"></a> has been marked as "at-risk". See <a
+						href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-09-epub#resolution1"
+						>Working Group resolution</a>. </li>
+				<li>09-Apr-2021: Added a new section dedicated to accessibility and removed the outdated reference to
+					the defunct appendix in the Accessibility specification. See <a
+						href="https://github.com/w3c/epub-specs/issues/1608">issue 1608</a>.</li>
+				<li>09-Apr-2021: Added section clarifying all the conformance requirements on establishing the primary
+					language and base direction of Publication Resources. See <a
+						href="https://github.com/w3c/epub-specs/pull/1613">pull request 1613</a>. </li>
+				<li>01-Apr-2021: Added section clarifying how absolute URLs are created from relative in the Package
+					Document. See <a href="https://github.com/w3c/epub-specs/pull/1468">pull request 1468</a>.</li>
+				<li>30-Mar-2021: Restructured the document to remove the rendundant conformance sections and
+					requirements that were only used as locators when this specification was combined with the authoring
+					requirements. See <a href="https://github.com/w3c/epub-specs/pull/1597">pull request 1597</a> and <a
+						href="https://github.com/w3c/epub-specs/pull/1609">pull request 1609</a>.</li>
+				<li>23-Mar-2021: Added requirement to prevent top-level navigation to data URLs. See <a
+						href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a>.</li>
+				<li>23-Mar-2021: Changed "suppressing" of non-linear content to "skipping" when traversing the spine to
+					clarify that the intention is not to remove all access to such content. See <a
+						href="https://github.com/w3c/epub-specs/issues/1480">issue 1480</a>.</li>
+				<li>10-Mar-2021: Changed restriction against using resources not listed in the Package Document to a
+					recommendation not to use. See <a href="https://github.com/w3c/epub-specs/issues/810">issue
+					810</a>.</li>
+				<li>09-March-2021: the statement on unique identifiers has been set to non-normative, following the
+					discussion and <a
+						href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-12-18-epub#resolution2"
+						>Working Group resolution</a>. See <a href="https://github.com/w3c/epub-specs/issues/1310">issue
+						1310</a>. </li>
+				<li>08-Mar-2021: Remove unnecessary requirement to assume default value for rendering metadata. See <a
+						href="https://github.com/w3c/epub-specs/issues/1313">issue 1313</a>.</li>
+				<li>05-Mar-2021: Added requirement for reading systems to collapse whitespace in DCMES and meta elements
+					per the [[Infra]] specification definition. See <a
+						href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
+				<li>26-Feb-2021: Clarified the trimming of leading and trailing whitespace is to be done in accordance
+					with the [[Infra]] specification definition, and removed the exception that <code>meta</code>
+					element properties may define their own whitespace handling rules. See <a
+						href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
+				<li>19-Feb-2021: Updated the <a href="#sec-scripted-content-security">scripting security
+						considerations</a> so that the text recommends assigning a unique origin to each EPUB
+					Publication for security rather than domain isolation at the Content Document level. See <a
+						href="https://github.com/w3c/epub-specs/issues/1156">issue 1156</a>.</li>
+				<li>15-Feb-2021: Clarified the requirements for presenting nav elements in the navigation document. The
+					toc nav is now the only required element, the page-list nav is recommended when present, and all
+					others are optional. See <a href="https://github.com/w3c/epub-specs/issues/975">issue 975</a>.</li>
+				<li>10-Feb-2021: A very first draft for <a href="#sec-security-privacy"></a> has been added.</li>
+				<li>04-Feb-2021: Added explicit requirement that reading systems not use the language in
+						<code>dc:language</code> elements as the language of resources.</li>
+				<li>02-Feb-2021: Added base direction determination rules for the <code>dir</code> attribute accounting
+					for the addition of the new <code>auto</code> value. See <a
+						href="https://github.com/w3c/epub-specs/issues/1491">issue 1491</a>.</li>
+				<li>02-Feb-2021: Noted that language information in the new <code>hreflang</code> attribute on
+						<code>link</code> elements is not authoritative. See <a
+						href="https://github.com/w3c/epub-specs/issues/1488">issue 1488</a>.</li>
+				<li>24-Dec-2020: The creation of a <a
+						href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
+						>release identifier</a> [[EPUBPackages-32]] is no longer defined. See <a
+						href="https://github.com/w3c/epub-specs/issues/1440">issue 1440</a>.</li>
+				<li>06-Nov-2020: Reading systems are now required to <a href="#confreq-rs-xml-extid">not resolve
+						external identifiers</a> in doctype declarations. See <a
+						href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
+				<li>05-Nov-2020: Generalized the restriction on custom attribute namespace URIs to exclude all of
+					idpf.org and w3.org. See <a href="https://github.com/w3c/epub-specs/issues/1388">issue
+					1388</a>.</li>
+				<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
+					understanding and access to information. This specification now consolidates the reading system
+					requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF and
+					Media Overlays specifications. The EPUB 3.3 core specification now focuses only on authoring
+					requirements.</li>
+			</ul>
 		</section>
 		<div data-include="../common/acknowledgements-dedication.html" data-oninclude="fixIncludes"
 			data-include-replace="true"></div>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -553,43 +553,23 @@
 		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
 
-			<p>Note that this change log only identifies substantive changes &#8212; those that affect conformance or
-				are similarly noteworthy.</p>
+			<p>Note that this change log only identifies substantive changes since <a
+					href="https://www.w3.org/publishing/epub/epub-contentdocs.html">EPUB Content Documents 3.2</a>
+				&#8212; those that affect conformance or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+label%3ASpec-TTS"
 					>Working Group's issue tracker</a>.</p>
 
-			<section id="changes-latest">
-				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-contentdocs.html">EPUB
-						Content Documents 3.2</a></h3>
-
-				<!--
-					After each working draft is published:
-						- change the link/text in the section heading to refer to the published draft (use the dated URL)
-						- move all changes down to the next section
-				-->
-
-				<ul>
-					<li>25-June-2021: Clarified processing of <code>ssml:alphabet</code> attribute and added additional
-						requirements for the <code>ssml:ph</code> attribute to avoid its use for adding or removing text
-						vocalization. See <a href="https://github.com/w3c/epub-specs/issues/1706">issue 1706</a>.</li>
-					<li>25-June-2021: Clarified application of pronunciation lexicons. See <a
-							href="https://github.com/w3c/epub-specs/issues/1705">issue 1705</a>.</li>
-					<li>22-June-2021: Added that SSML and PLS can also be used with SVG Content Documents. See <a
-							href="https://github.com/w3c/epub-specs/issues/1710">issue 1710</a>.</li>
-				</ul>
-			</section>
-
-			<!-- 
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub/epub-contentdocs.html">EPUB
-					Content Documents 3.2</a></h3>
-				
-				<ul>
-				</ul>
-			</section>
-			-->
+			<ul>
+				<li>25-June-2021: Clarified processing of <code>ssml:alphabet</code> attribute and added additional
+					requirements for the <code>ssml:ph</code> attribute to avoid its use for adding or removing text
+					vocalization. See <a href="https://github.com/w3c/epub-specs/issues/1706">issue 1706</a>.</li>
+				<li>25-June-2021: Clarified application of pronunciation lexicons. See <a
+						href="https://github.com/w3c/epub-specs/issues/1705">issue 1705</a>.</li>
+				<li>22-June-2021: Added that SSML and PLS can also be used with SVG Content Documents. See <a
+						href="https://github.com/w3c/epub-specs/issues/1710">issue 1710</a>.</li>
+			</ul>
 		</section>
 		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
 		></div>


### PR DESCRIPTION
No point in having separate sections for changes since the last published WD/Note when we auto-publish new drafts with each commit now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1781.html" title="Last updated on Aug 25, 2021, 12:33 PM UTC (7a08d6b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1781/0c44222...7a08d6b.html" title="Last updated on Aug 25, 2021, 12:33 PM UTC (7a08d6b)">Diff</a>