### PR TITLE
Added alt text on the svg images

### DIFF
--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -350,3 +350,12 @@ div.caution-title > span {
 	color: rgb(140,40,0);
 	text-transform: uppercase;
 }
+
+details.desc {
+	margin-top: -2.5rem !important;
+	margin-left: 3rem !important;
+}
+
+details.desc > summary {
+	text-align: left;
+}

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -80,21 +80,6 @@
 		}
             };//]]>
       </script>
-	  <style>
-		details.figure {
-			margin-bottom: 0;
-		}
-		details.figure > p {
-			text-align: left;
-			font-size: 80%;
-		}
-		details.figure > summary {
-			list-style: none;
-		}
-		details.figure > summary::-webkit-details-marker {
-			display: none;
-		}
-	  </style>
 	</head>
 	<body>
 		<section id="abstract">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -80,6 +80,21 @@
 		}
             };//]]>
       </script>
+	  <style>
+		details.figure {
+			margin-bottom: 0;
+		}
+		details.figure > p {
+			text-align: left;
+			font-size: 80%;
+		}
+		details.figure > summary {
+			list-style: none;
+		}
+		details.figure > summary::-webkit-details-marker {
+			display: none;
+		}
+	  </style>
 	</head>
 	<body>
 		<section id="abstract">

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -76,10 +76,8 @@
 			<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
 
 			<figure id="fig-flow-paginated-single">
-				<figcaption>
-					<p>Rendering of an EPUB publication with a single spine item, and with the
-						<code>rendition:flow</code> set to <code>paginated</code>.</p>
-				</figcaption>
+				<figcaption>Rendering of an EPUB publication with a single spine item, and with the
+					<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
 				<img src="images/Rendering_Paginated_Single_Spine.svg" width="600" aria-details="flow-paginated-single-diagram"
 					alt="The continuous progression of paginated content produced for a single document."/>
 			</figure>
@@ -93,10 +91,8 @@
 			</details>
 			
 			<figure id="fig-flow-paginated-multiple">
-				<figcaption>
-					<p>Rendering of an EPUB publication with a single spine item, and with the
-						<code>rendition:flow</code> set to <code>paginated</code>.</p>
-				</figcaption>
+				<figcaption>Rendering of an EPUB publication with a single spine item, and with the
+					<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
 				<img src="images/Rendering_Paginated_Multiple_Spine.svg" width="600" aria-details="flow-paginated-multiple-diagram"
 					alt="The continuous progression of paginated content produced for each document with transitions to
 							new pages between documents."/>
@@ -112,10 +108,8 @@
 			</details>
 			
 			<figure id="fig-flow-scrolled-continuous">
-				<figcaption>
-					<p>Rendering of an EPUB publication with a single spine item, and with the
-						<code>rendition:flow</code> set to <code>scrolled-continuous</code>.</p>
-				</figcaption>
+				<figcaption>Rendering of an EPUB publication with a single spine item, and with the
+						<code>rendition:flow</code> set to <code>scrolled-continuous</code>.</figcaption>
 				<img src="images/Rendering_Scrolled_Continuous.svg" width="220" aria-details="flow-scrolled-continuous"
 						alt="The progression of a continuous scroll of content extends vertically off the user's screen,
 							with new documents added to the bottom as encountered."/>
@@ -129,10 +123,8 @@
 			</details>
 			
 			<figure id="fig-flow-scrolled-doc">
-				<figcaption>
-					<p>Rendering of an EPUB publication with a single spine item, and with the
-						<code>rendition:flow</code> set to <code>scrolled-doc</code>.</p>
-				</figcaption>
+				<figcaption>Rendering of an EPUB publication with a single spine item, and with the
+						<code>rendition:flow</code> set to <code>scrolled-doc</code>.</figcaption>
 				<img src="images/Rendering_Scrolled_Doc.svg" width="600" aria-details="flow-scrolled-doc-diagram"
 					alt="The progression of scrollable documents depicting how only the content within each document
 						is scrollable."/>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -75,75 +75,78 @@
 				
 			<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
 
-			<figure>
-				<details class="figure">
-					<summary>				
-						<img src="images/Rendering_Paginated_Single_Spine.svg" width="600" alt="Rendering of an EPUB publication with a single spine item, and with the rendition:flow set to paginated." aria-describedby="paginated_single"/>
-					</summary>
-					<p id="paginated_single">
-						Three column-like rectangles linked left-to-middle and middle-to-right with respective arrows,
-						with a text flowing from one rectangle to the next one. The text is sectioned with headers
-						figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a schematic view of
-						a tablet.
-					</p>
-				</details>
+			<figure id="fig-flow-paginated-single">
 				<figcaption>
-					Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>paginated</code>.
+					<p>Rendering of an EPUB publication with a single spine item, and with the
+						<code>rendition:flow</code> set to <code>paginated</code>.</p>
 				</figcaption>
+				<img src="images/Rendering_Paginated_Single_Spine.svg" width="600" aria-details="flow-paginated-single-diagram"
+					alt="The continuous progression of paginated content produced for a single document."/>
 			</figure>
-
-			<figure>
-				<details class="figure">
-					<summary>				
-						<img src="images/Rendering_Paginated_Multiple_Spine.svg" width="600" alt="Rendering of an EPUB publication with a spine item per chapter, and with the rendition:flow set to paginated." aria-describedby="paginated_multiple"/>
-					</summary>
-					<p id="paginated_multiple">
-						Three column-like rectangles linked left-to-middle and middle-to-right with respective arrows,
-						with a text flowing from one rectangle to the next one. The text is sectioned with headers
-						figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top of the rightmost
-						rectangle, leaving an empty space at the bottom of the middle rectangle. The leftmost rectangle
-						is enclosed in a schematic view of a tablet.
-					</p>
-				</details>
+			
+			<details id="flow-paginated-single-diagram" class="desc">
+				<summary>Description</summary>
+				<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective arrows,
+					with a text flowing from one rectangle to the next one. The text is sectioned with headers
+					figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a schematic view of
+					a tablet.</p>
+			</details>
+			
+			<figure id="fig-flow-paginated-multiple">
 				<figcaption>
-					Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>paginated</code>.
+					<p>Rendering of an EPUB publication with a single spine item, and with the
+						<code>rendition:flow</code> set to <code>paginated</code>.</p>
 				</figcaption>
+				<img src="images/Rendering_Paginated_Multiple_Spine.svg" width="600" aria-details="flow-paginated-multiple-diagram"
+					alt="The continuous progression of paginated content produced for each document with transitions to
+							new pages between documents."/>
 			</figure>
-
-			<figure>
-				<details class="figure">
-					<summary>				
-						<img src="images/Rendering_Scrolled_Continuous.svg" width="220" alt="Rendering of an EPUB publication with the rendition:flow set to scrolled-continuous." aria-describedby="scrolled_continuous"/>
-					</summary>
-					<p id="scrolled_continuous">
-						A single, column-like strip (i.e., a rectangle without a bottom edge) with a text flowing down the strip.
-						The text is sectioned with headers figuring 'Chapter 1', '2'. The top part of the strip
-						is enclosed in a schematic view of a tablet.
-					</p>
-				</details>
+			
+			<details id="flow-paginated-multiple-diagram" class="desc">
+				<summary>Description</summary>
+				<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective arrows,
+					with a text flowing from one rectangle to the next one. The text is sectioned with headers
+					figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top of the rightmost
+					rectangle, leaving an empty space at the bottom of the middle rectangle. The leftmost rectangle
+					is enclosed in a schematic view of a tablet.</p>
+			</details>
+			
+			<figure id="fig-flow-scrolled-continuous">
 				<figcaption>
-					Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>scrolled-continuous</code>.
+					<p>Rendering of an EPUB publication with a single spine item, and with the
+						<code>rendition:flow</code> set to <code>scrolled-continuous</code>.</p>
 				</figcaption>
+				<img src="images/Rendering_Scrolled_Continuous.svg" width="220" aria-details="flow-scrolled-continuous"
+						alt="The progression of a continuous scroll of content extends vertically off the user's screen,
+							with new documents added to the bottom as encountered."/>
 			</figure>
-
-			<figure>
-				<details class="figure">
-					<summary>				
-						<img src="images/Rendering_Scrolled_Doc.svg" width="600" alt="Rendering of an EPUB publication with a spine item per chapter, and with the rendition:flow set to scrolled-doc" aria-describedby="scrolled_doc"/>
-					</summary>
-					<p id="scrolled_doc">
-						Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle
-						and middle-to-right with respective arrows, each containing a text flowing down the strip.
-						The text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip starts with
-						a chapter header and flows down the strip. The top part of the leftmost strip is enclosed
-						in a schematic view of a tablet.
-					</p>
-				</details>
+			
+			<details id="flow-scrolled-continuous-diagram" class="desc">
+				<summary>Description</summary>
+				<p>A single, column-like strip (i.e., a rectangle without a bottom edge) with a text flowing down the strip.
+					The text is sectioned with headers figuring 'Chapter 1', '2'. The top part of the strip
+					is enclosed in a schematic view of a tablet.</p>
+			</details>
+			
+			<figure id="fig-flow-scrolled-doc">
 				<figcaption>
-					Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>scrolled-doc</code>.
+					<p>Rendering of an EPUB publication with a single spine item, and with the
+						<code>rendition:flow</code> set to <code>scrolled-doc</code>.</p>
 				</figcaption>
+				<img src="images/Rendering_Scrolled_Doc.svg" width="600" aria-details="flow-scrolled-doc-diagram"
+					alt="The progression of scrollable documents depicting how only the content within each document
+						is scrollable."/>
 			</figure>
-
+			
+			<details id="flow-scrolled-doc-diagram" class="desc">
+				<summary>Description</summary>
+				<p>Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle
+					and middle-to-right with respective arrows, each containing a text flowing down the strip.
+					The text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip starts with
+					a chapter header and flows down the strip. The top part of the leftmost strip is enclosed
+					in a schematic view of a tablet.</p>
+			</details>
+			
 			<section id="layout-property-flow-overrides">
 				<h5>Spine Overrides</h5>
 				

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -76,23 +76,23 @@
 			<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
 
 			<figure>
-				<figcaption> Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>paginated</code>. </figcaption>
-				<img src="images/Rendering_Paginated_Single_Spine.svg" width="600" alt="" />
+				<figcaption>Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
+				<img src="images/Rendering_Paginated_Single_Spine.svg" width="600" alt="Three column-like rectangles linked left-to-middle and middle-to-right with respective arrows, with a text flowing from one rectangle to the next one. The text is sectioned with headers figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a schematic view of a tablet." />
 			</figure>
 
 			<figure>
-				<figcaption> Rendering of an EPUB publication with a spine item per chapter, and with the <code>rendition:flow</code> set to <code>paginated</code>. </figcaption>
-				<img src="images/Rendering_Paginated_Multiple_Spine.svg" width="600" alt="" />
+				<figcaption>Rendering of an EPUB publication with a spine item per chapter, and with the <code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
+				<img src="images/Rendering_Paginated_Multiple_Spine.svg" width="600" alt="Three column-like rectangles linked left-to-middle and middle-to-right with respective arrows, with a text flowing from one rectangle to the next one. The text is sectioned with headers figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top of the rightmost rectangle, leaving an empty space at the bottom of the middle rectangle. The leftmost rectangle is enclosed in a schematic view of a tablet." />
 			</figure>
 
 			<figure>
-				<figcaption> Rendering of an EPUB publication with the <code>rendition:flow</code> set to <code>scrolled-continuous</code>. </figcaption>
-				<img src="images/Rendering_Scrolled_Continuous.svg" width="220" alt="" />
+				<figcaption>Rendering of an EPUB publication with the <code>rendition:flow</code> set to <code>scrolled-continuous</code>.</figcaption>
+				<img src="images/Rendering_Scrolled_Continuous.svg" width="220" alt="A column-like strip (i.e., a rectangle without a bottom edge) with a text flowing down the strip. The text is sectioned with headers figuring 'Chapter 1', '2'. The top part of the strip is enclosed in a schematic view of a tablet." />
 			</figure>
 
 			<figure>
-				<figcaption> Rendering of an EPUB publication with a spine item per chapter, and with the <code>rendition:flow</code> set to <code>scrolled-doc</code>. </figcaption>
-				<img src="images/Rendering_Scrolled_Doc.svg" width="600" alt="" />
+				<figcaption>Rendering of an EPUB publication with a spine item per chapter, and with the <code>rendition:flow</code> set to <code>scrolled-doc</code>.</figcaption>
+				<img src="images/Rendering_Scrolled_Doc.svg" width="600" alt="Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle and middle-to-right with respective arrows, each containing a text flowing down the strip. The text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip starts with a chapter header and flows down the strip. The top part of the leftmost strip is enclosed in a schematic view of a tablet." />
 			</figure>
 
 			<section id="layout-property-flow-overrides">

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -75,24 +75,73 @@
 				
 			<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
 
-			<figure>
-				<figcaption>Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
-				<img src="images/Rendering_Paginated_Single_Spine.svg" width="600" alt="Three column-like rectangles linked left-to-middle and middle-to-right with respective arrows, with a text flowing from one rectangle to the next one. The text is sectioned with headers figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a schematic view of a tablet." />
+			<figure role="group">
+				<details class="figure">
+					<summary>				
+						<img src="images/Rendering_Paginated_Single_Spine.svg" width="600" alt="Rendering of an EPUB publication with a single spine item, and with the rendition:flow set to paginated." aria-describedby="paginated_single"/>
+					</summary>
+					<p id="paginated_single">
+						Three column-like rectangles linked left-to-middle and middle-to-right with respective arrows,
+						with a text flowing from one rectangle to the next one. The text is sectioned with headers
+						figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a schematic view of
+						a tablet.
+					</p>
+				</details>
+				<figcaption>
+					Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>paginated</code>.
+				</figcaption>
 			</figure>
 
-			<figure>
-				<figcaption>Rendering of an EPUB publication with a spine item per chapter, and with the <code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
-				<img src="images/Rendering_Paginated_Multiple_Spine.svg" width="600" alt="Three column-like rectangles linked left-to-middle and middle-to-right with respective arrows, with a text flowing from one rectangle to the next one. The text is sectioned with headers figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top of the rightmost rectangle, leaving an empty space at the bottom of the middle rectangle. The leftmost rectangle is enclosed in a schematic view of a tablet." />
+			<figure role="group">
+				<details class="figure">
+					<summary>				
+						<img src="images/Rendering_Paginated_Multiple_Spine.svg" width="600" alt="Rendering of an EPUB publication with a spine item per chapter, and with the rendition:flow set to paginated." aria-describedby="paginated_multiple"/>
+					</summary>
+					<p id="paginated_multiple">
+						Three column-like rectangles linked left-to-middle and middle-to-right with respective arrows,
+						with a text flowing from one rectangle to the next one. The text is sectioned with headers
+						figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top of the rightmost
+						rectangle, leaving an empty space at the bottom of the middle rectangle. The leftmost rectangle
+						is enclosed in a schematic view of a tablet.
+					</p>
+				</details>
+				<figcaption>
+					Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>paginated</code>.
+				</figcaption>
 			</figure>
 
-			<figure>
-				<figcaption>Rendering of an EPUB publication with the <code>rendition:flow</code> set to <code>scrolled-continuous</code>.</figcaption>
-				<img src="images/Rendering_Scrolled_Continuous.svg" width="220" alt="A column-like strip (i.e., a rectangle without a bottom edge) with a text flowing down the strip. The text is sectioned with headers figuring 'Chapter 1', '2'. The top part of the strip is enclosed in a schematic view of a tablet." />
+			<figure role="group">
+				<details class="figure">
+					<summary>				
+						<img src="images/Rendering_Scrolled_Continuous.svg" width="220" alt="Rendering of an EPUB publication with the rendition:flow set to scrolled-continuous." aria-describedby="scrolled_continuous"/>
+					</summary>
+					<p id="scrolled_continuous">
+						A single, column-like strip (i.e., a rectangle without a bottom edge) with a text flowing down the strip.
+						The text is sectioned with headers figuring 'Chapter 1', '2'. The top part of the strip
+						is enclosed in a schematic view of a tablet.
+					</p>
+				</details>
+				<figcaption>
+					Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>scrolled-continuous</code>.
+				</figcaption>
 			</figure>
 
-			<figure>
-				<figcaption>Rendering of an EPUB publication with a spine item per chapter, and with the <code>rendition:flow</code> set to <code>scrolled-doc</code>.</figcaption>
-				<img src="images/Rendering_Scrolled_Doc.svg" width="600" alt="Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle and middle-to-right with respective arrows, each containing a text flowing down the strip. The text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip starts with a chapter header and flows down the strip. The top part of the leftmost strip is enclosed in a schematic view of a tablet." />
+			<figure role="group">
+				<details class="figure">
+					<summary>				
+						<img src="images/Rendering_Scrolled_Doc.svg" width="600" alt="Rendering of an EPUB publication with a spine item per chapter, and with the rendition:flow set to scrolled-doc" aria-describedby="scrolled_doc"/>
+					</summary>
+					<p id="scrolled_doc">
+						Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle
+						and middle-to-right with respective arrows, each containing a text flowing down the strip.
+						The text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip starts with
+						a chapter header and flows down the strip. The top part of the leftmost strip is enclosed
+						in a schematic view of a tablet.
+					</p>
+				</details>
+				<figcaption>
+					Rendering of an EPUB publication with a single spine item, and with the <code>rendition:flow</code> set to <code>scrolled-doc</code>.
+				</figcaption>
 			</figure>
 
 			<section id="layout-property-flow-overrides">

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -75,7 +75,7 @@
 				
 			<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
 
-			<figure role="group">
+			<figure>
 				<details class="figure">
 					<summary>				
 						<img src="images/Rendering_Paginated_Single_Spine.svg" width="600" alt="Rendering of an EPUB publication with a single spine item, and with the rendition:flow set to paginated." aria-describedby="paginated_single"/>
@@ -92,7 +92,7 @@
 				</figcaption>
 			</figure>
 
-			<figure role="group">
+			<figure>
 				<details class="figure">
 					<summary>				
 						<img src="images/Rendering_Paginated_Multiple_Spine.svg" width="600" alt="Rendering of an EPUB publication with a spine item per chapter, and with the rendition:flow set to paginated." aria-describedby="paginated_multiple"/>
@@ -110,7 +110,7 @@
 				</figcaption>
 			</figure>
 
-			<figure role="group">
+			<figure>
 				<details class="figure">
 					<summary>				
 						<img src="images/Rendering_Scrolled_Continuous.svg" width="220" alt="Rendering of an EPUB publication with the rendition:flow set to scrolled-continuous." aria-describedby="scrolled_continuous"/>
@@ -126,7 +126,7 @@
 				</figcaption>
 			</figure>
 
-			<figure role="group">
+			<figure>
 				<details class="figure">
 					<summary>				
 						<img src="images/Rendering_Scrolled_Doc.svg" width="600" alt="Rendering of an EPUB publication with a spine item per chapter, and with the rendition:flow set to scrolled-doc" aria-describedby="scrolled_doc"/>


### PR DESCRIPTION
@clapierre, I would appreciate if you looked at these. You have much more experience than I have. 

The figures themselves are in section D.4.1.1.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1783.html" title="Last updated on Sep 2, 2021, 1:00 PM UTC (27179e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1783/3cfe077...27179e4.html" title="Last updated on Sep 2, 2021, 1:00 PM UTC (27179e4)">Diff</a>