### PR TITLE
Reading system accessibility section improvements

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1787,7 +1787,7 @@
 					properties [[WAI-ARIA-11]], is exposed to the underlying operating system's accessibility API so
 					that users can fully interact with the content when using assistive technologies.</li>
 				<li>Document Object Model (DOM) &#8212; Provide access to the [[DOM]] of EPUB Content Documents so that
-					users can better understand the semantics and structure.</li>
+					users can investigate the semantics and structure used in the source.</li>
 				<li>Table of Contents &#8212; Ensure that the rendering of the table of contents is accessible to
 					assistive technologies (e.g., that the link text can be read and the links activated).</li>
 			</ul>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -73,7 +73,7 @@
 				lint: {
 					"wpt-tests-exist": true,
 				}
-			};//]]></script> 
+			};//]]></script>
 	</head>
 	<body>
 		<section id="abstract">
@@ -1769,8 +1769,10 @@
 				experience for users.</p>
 
 			<ul>
-				<li>Bookshelf &#8212; Ensure that the process for accessing and opening the user's content is accessible
-					(e.g., not relying on visual-only display like cover images).</li>
+				<li>Bookshelf &#8212; Ensure that the process for accessing and opening the user's content is
+					accessible. For example, do not rely on a visual-only display like cover images. Exposing text
+					representations of the title(s) and author(s), including the language they are expressed in, allows
+					assistive technologies to properly announce the options.</li>
 				<li>User Interface Controls &#8212; Ensure that all controls (e.g., search boxes, annotation controls,
 					and buttons to load features such as the table of contents) are exposed to assistive technologies
 					and their actions do not rely on specific modalities (e.g., they only operate through touch or a
@@ -1784,6 +1786,8 @@
 				<li>API Integration &#8212; Ensure that the accessibility tree, including support for roles, states and
 					properties [[WAI-ARIA-11]], is exposed to the underlying operating system's accessibility API so
 					that users can fully interact with the content when using assistive technologies.</li>
+				<li>Document Object Model (DOM) &#8212; Provide access to the [[DOM]] of EPUB Content Documents so that
+					users can better understand the semantics and structure.</li>
 				<li>Table of Contents &#8212; Ensure that the rendering of the table of contents is accessible to
 					assistive technologies (e.g., that the link text can be read and the links activated).</li>
 			</ul>


### PR DESCRIPTION
This PR expands the bullet on bookshelf accessibility to also mention exposing the language of the text and adds a new bullet about exposing the DOM. We already had a bullet about exposing the accessibility tree to the platform APIs, so I think the primary request was already covered in a different manner. But no harm is also suggesting to allow access to the DOM itself, since it provides different information.

Fixes #1770 
Fixes #1773 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/rs-a11y-improvements/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/rs-a11y-improvements/epub33/rs/index.html)
