### PR TITLE
Replace svg search recommendation with accessibility bullet

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2161,6 +2161,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>27-Aug-2021: Remove the recommendation to support text search and selection in SVGs. Replacing with
+					a more general bullet on search accessibility to avoid defining requirements on reading system UI.
+					See <a href="https://github.com/w3c/epub-specs/issues/1774">issue 1774</a>.</li>
 				<li>09-July-2021: Restored the custom attributes section due to known usage but without reference to the
 					attribute registry. See <a href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>
 				<li>09-July-2021: Removed recommendation to use the first language tag to determine an unspecified page

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -708,10 +708,6 @@
 							embedded SVG, a Reading System MUST also conform to the constraints defined in <a
 								href="#sec-xhtml-svg-css"></a>.</p>
 					</li>
-					<li>
-						<p id="confreq-svg-rs-text">SHOULD support user selection and searching of text within SVG
-							elements.</p>
-					</li>
 				</ul>
 			</section>
 
@@ -1777,6 +1773,9 @@
 					and buttons to load features such as the table of contents) are exposed to assistive technologies
 					and their actions do not rely on specific modalities (e.g., they only operate through touch or a
 					mouse).</li>
+				<li>Search &#8212; Search access to the full text content of all EPUB Content Documents (including
+					alternative text attributes, text in SVG images, etc.) is necessary to ensure users can locate
+					information easily.</li>
 				<li>Display Control &#8212; Provide methods for users to tailor the styling of the content to their
 					preferences (e.g., to change and increase fonts, increase line and word spacing, and apply alternate
 					contrasts).</li>


### PR DESCRIPTION
Search accessibility is more than svg text (e.g., including alt text), so I added another bullet to the accessibility section to replace the recommendation we're removing.

Fixes #1774 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1774/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1774/epub33/rs/index.html)
