### PR TITLE
Clarify toc link and label processing

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -884,7 +884,7 @@
 			<ul class="conformance-list">
 				<li>
 					<p id="confreq-nav-toc-access">MUST provide users access to the <a
-							href="https://www.w3.org/TR/epub-33/#confreq-nav-a">links and labels</a> in the <a
+							href="https://www.w3.org/TR/epub-33/#confreq-nav-a">links and headings</a> in the <a
 							href="https://www.w3.org/TR/epub-33/#sec-nav-toc"><code>toc nav</code> element</a>
 						[[EPUB-33]].</p>
 				</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -883,7 +883,8 @@
 
 			<ul class="conformance-list">
 				<li>
-					<p id="confreq-nav-toc-access">MUST provide users access to the links in the <a
+					<p id="confreq-nav-toc-access">MUST provide users access to the <a
+							href="https://www.w3.org/TR/epub-33/#confreq-nav-a">links and labels</a> in the <a
 							href="https://www.w3.org/TR/epub-33/#sec-nav-toc"><code>toc nav</code> element</a>
 						[[EPUB-33]].</p>
 				</li>
@@ -1788,8 +1789,10 @@
 					that users can fully interact with the content when using assistive technologies.</li>
 				<li>Document Object Model (DOM) &#8212; Provide access to the [[DOM]] of EPUB Content Documents so that
 					users can investigate the semantics and structure used in the source.</li>
-				<li>Table of Contents &#8212; Ensure that the rendering of the table of contents is accessible to
-					assistive technologies (e.g., that the link text can be read and the links activated).</li>
+				<li>Table of Contents &#8212; Ensure that users can access the link text, including <a
+						href="https://www.w3.org/TR/epub-33/#confreq-nav-a-title">text alternatives for visual
+						content</a>. Activating the table of contents links should be possible using different
+					inputs.</li>
 			</ul>
 
 			<p>The DAISY Consortium maintains an <a href="http://epubtest.org/test-books">accessibility test suite</a>


### PR DESCRIPTION
Looking at the text in the RS spec, I noticed we only require exposing the links, but technically you have to expose the links and headings (`span`). Looks like this distinction was dropped because it used to say "links and link labels," which sounds redundant.

At any rate, I've changed this to "links and headings" and put the link across to where the formatting rules are defined on this text. It doesn't formally change anything from what we expected before, so not noting this as a substantive change.

I've also updated the reading system bullet to further explain that the text alternatives should be exposed.

(I'll deal with the language issue in another pull request, as I think it'll be better to fit it into the general UI bullet.)

Fixes #1775 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1775/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1775/epub33/rs/index.html)
