### PR TITLE
Clarify use of landmarks nav

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4558,7 +4558,12 @@ Spine:
 
 						<p>The <code>landmarks</code>
 							<code>nav</code> element identifies fundamental structural components in the content to
-							enable Reading Systems to provide the user efficient access to them.</p>
+							enable Reading Systems to provide the user efficient access to them (e.g., through a
+							dedicated button in the user interface).</p>
+
+						<p>The <code>landmarks</code>
+							<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
+							nested sublists).</p>
 
 						<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is REQUIRED on
 								<code>a</code> element descendants of the <code>landmarks</code>
@@ -4583,6 +4588,29 @@ Spine:
 						<p>The <code>landmarks</code>
 							<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code>
 							value that reference the same resource, or fragment thereof.</p>
+
+						<p>EPUB Creators should limit the number of items they define in the <code>landmarks</code>
+							<code>nav</code> to only items that a Reading System is likely to use in its user interface.
+							The element is not meant to repeat the table of contents.</p>
+
+						<p>The following landmarks are recommended to include when available:</p>
+
+						<ul>
+							<li><a href="#bodymatter"><code>bodymatter</code></a> &#8212; Reading Systems often use this
+								landmark to automatically jump users past the front matter when they begin reading.</li>
+							<li><a href="#toc-1"><code>toc</code></a> &#8212; If the table of contents is available in
+								the spine, Reading Systems may use this landmark to take users to the document
+								containing it.</li>
+						</ul>
+
+						<p>Other possibilities for inclusion in the <code>landmarks</code>
+							<code>nav</code> are key reference sections such as indexes and glossaries.</p>
+
+						<p>Although the <code>landmarks</code>
+							<code>nav</code> is intended for Reading System use, EPUB Creators should still ensure that
+							the labels for the <code>landmarks</code>
+							<code>nav</code> are human readable. Reading Systems may expose the links directly to
+							users.</p>
 
 						<p>The <code>landmarks</code>
 							<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9401,6 +9401,10 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>27-Aug-2021: Add clarifications for including landmarks, such as limiting the number, recommending
+					known semantics, and ensuring the labels are human readable. Also added recommendation to not
+					include nested lists to match the page list. See <a
+						href="https://github.com/w3c/epub-specs/issues/1761">issue 1761</a>.</li>
 				<li>22-July-2021: Clarified TTS handling of images in media overlays. See <a
 						href="https://github.com/w3c/epub-specs/issues/1745">issue 1745</a>.</li>
 				<li>09-July-2021: Restored the custom attributes section due to known usage but without reference to the


### PR DESCRIPTION
This PR fixes #1761 as follows:

- adds parenthetical noting that these are intended for UI
- recommends not nesting lists (was going to make this a "must not", but instead this will match the page list)
- non-normatively recommends:
  - limiting the list to key structures, noting its not a mini toc
  - adding bodymatter and toc when present; adding key reference sections, otherwise
  - that link labels should be human readable


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1788.html" title="Last updated on Aug 27, 2021, 8:09 PM UTC (15ea01b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1788/72c2a70...15ea01b.html" title="Last updated on Aug 27, 2021, 8:09 PM UTC (15ea01b)">Diff</a>