### PR TITLE
Add a11y:disclaimer property

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -939,11 +939,32 @@
 						<pre>&lt;package …>
    &lt;metadata>
       …
-      &lt;meta property="dcterms:conformsTo">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
+      &lt;meta property="dcterms:conformsTo" id="conf">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
       …
    &lt;/metadata>
    …
 &lt;/package></pre>
+					</aside>
+
+					<p>As evaluating EPUB Publications for accessibility requires a complex mix of machine and human
+						validation, it is often not realistic to claim that not a single minor issue might have missed
+						detection, even though this is what [[WCAG2]] requires. To clarify that EPUB Publications have
+						been checked for conformance to the best of their abilities, EPUB Creators may prefer to include
+						a <a href="#disclaimer">disclaimer</a>.</p>
+
+					<p>Disclaimers should include contact information for reporting issues with the EPUB Publication to
+						the EPUB Creator.</p>
+
+					<aside class="example">
+						<p>The following example shows a disclaimer indicating how to report any issues.</p>
+						<pre>&lt;meta property="dcterms:conformsTo" id="conf">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
+&lt;meta property="a11y:disclaimer" refines="#conf">
+   This EPUB Publication has been checked for conformance to WCAG 2.1 Level AA
+   to the best of the publisher's abilities, but issues may be discovered in
+   different combinations of reading systems and assistive technologies. To
+   report a conformance issue, please send a detailed message of the problem
+   to accessibility@example.org
+&lt;/meta></pre>
 					</aside>
 
 					<div class="note">
@@ -1054,7 +1075,6 @@
 						<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
 &lt;link rel="a11y:certifierReport" refines="#certifier" href="reports/a11y.xhtml"/&gt;</pre>
 					</aside>
-
 
 					<div class="note">
 						<p>As each metadata format is unique in what it can express, this specification does not mandate
@@ -1398,6 +1418,50 @@
 							</tr>
 						</table>
 					</section>
+
+					<section id="disclaimer">
+						<h4>disclaimer</h4>
+
+						<table>
+							<tr>
+								<th>Name:</th>
+								<td>
+									<code>disclaimer</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Description:</th>
+								<td>Describes any potential limits on the claim made in the <a
+										href="#sec-conf-reporting-pub"><code>dcterms:conformsTo</code>
+									property</a>.</td>
+							</tr>
+							<tr>
+								<th>Allowed value(s):</th>
+								<td>
+									<code>xsd:string</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Cardinality:</th>
+								<td>Zero or one</td>
+							</tr>
+							<tr>
+								<th>Extends:</th>
+								<td>
+									<code>dcterms:conformsTo</code>
+								</td>
+							</tr>
+							<tr>
+								<th>Example:</th>
+								<td>
+									<pre>&lt;meta property="dcterms:conformsTo" id="conf">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
+&lt;meta property="a11y:disclaimer" refines="#conf">This publication has been
+   checked to conform to WCAG 2.1 AA to the best of the publisher's
+   abilities &#8230; &lt;/meta></pre>
+								</td>
+							</tr>
+						</table>
+					</section>
 				</section>
 			</section>
 		</section>
@@ -1413,6 +1477,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>07-Sep-2021: Added the a11y:disclaimer property for including disclaimers about the stated WCAG
+					conformance level. See <a href="https://github.com/w3c/epub-specs/issues/1767">issue 1767</a>.</li>
 				<li>09-June-2021: Clarified that a pagination source must not be specified when page break markers
 					and/or a page list are included in a digital-only publication. See <a
 						href="https://github.com/w3c/epub-specs/issues/1599">issue 1599</a>.</li>


### PR DESCRIPTION
Allows the publisher to include a disclaimer about the conformance claims. I've detailed the property in the conformance reporting section, as the disclaimer is about the claim itself, not a property of the certifier.

I've only informatively recommended including contact information. We could make this a normative recommendation, but it's not something we could machine check.

Let me know if you spot anything that could use improving, though.

Fixes #1767 


- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/disclaimer/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/disclaimer/epub33/a11y/index.html)
