### PR TITLE
Add refines attribute to certifier metadata examples

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -939,7 +939,7 @@
 						<pre>&lt;package …>
    &lt;metadata>
       …
-      &lt;meta property="dcterms:conformsTo">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
+      &lt;meta property="dcterms:conformsTo" id="conf">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
       …
    &lt;/metadata>
    …
@@ -975,49 +975,53 @@
 						<p>The following example shows an EPUB 3 Publication that has been self-evaluated by the
 							publisher (the values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code>
 							property are the same).</p>
-						<pre>&lt;metadata&gt;
+						<pre>&lt;metadata>
   …
-  &lt;dc:publisher&gt;Acme Publishing Inc.&lt;/dc:publisher&gt;
-  &lt;meta property="a11y:certifiedBy"&gt;Acme Publishing Inc.&lt;/meta&gt;
-  &lt;link rel="dcterms:conformsTo" href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"/&gt;
+  &lt;dc:publisher>Acme Publishing Inc.&lt;/dc:publisher>
   …
-&lt;/metadata&gt;</pre>
+  &lt;meta property="dcterms:conformsTo" id="conf">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
+  &lt;meta property="a11y:certifiedBy" refines="#conf">Acme Publishing Inc.&lt;/meta>
+  …
+&lt;/metadata></pre>
 					</aside>
 
 					<aside class="example">
 						<p>The following example shows an EPUB 3 Publication that has been evaluated by a third party
 							(the values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code> property
 							differ).</p>
-						<pre>&lt;metadata&gt;
+						<pre>&lt;metadata>
   …
-  &lt;dc:publisher&gt;Acme Publishing Inc.&lt;/dc:publisher&gt;
-  &lt;meta property="a11y:certifiedBy"&gt;Foo's Accessibility Testing&lt;/meta&gt;
-  &lt;link rel="dcterms:conformsTo" href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"/&gt;
+  &lt;dc:publisher>Acme Publishing Inc.&lt;/dc:publisher>
   …
-&lt;/metadata&gt;</pre>
+  &lt;meta property="dcterms:conformsTo" id="conf">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
+  &lt;meta property="a11y:certifiedBy" refines="#conf">Foo's Accessibility Testing&lt;/meta>
+  …
+&lt;/metadata></pre>
 					</aside>
 
 					<aside class="example">
 						<p>The following example shows an EPUB 3 Publication that has been self-evaluated by the EPUB
 							Creator.</p>
-						<pre>&lt;metadata&gt;
+						<pre>&lt;metadata>
   …
-  &lt;dc:creator&gt;Jane Doe&lt;/dc:creator&gt;
-  &lt;meta property="a11y:certifiedBy"&gt;Jane Doe&lt;/meta&gt;
-  &lt;link rel="dcterms:conformsTo" href="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"/&gt;
+  &lt;dc:creator>Jane Doe&lt;/dc:creator>
   …
-&lt;/metadata&gt;</pre>
+  &lt;meta property="dcterms:conformsTo" id="conf">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
+  &lt;meta property="a11y:certifiedBy" refines="#conf">Jane Doe&lt;/meta>
+  …
+&lt;/metadata></pre>
 					</aside>
 
 					<aside class="example">
 						<p>The following example shows a self-evaluated EPUB 2 Publication.</p>
-						<pre>&lt;metadata&gt;
+						<pre>&lt;metadata>
   …
-  &lt;dc:publisher&gt;Acme Publishing Inc.&lt;/dc:publisher&gt;
-  &lt;meta name="dcterms:conformsTo" content="http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-aa"/&gt;
-  &lt;meta name="a11y:certifiedBy" content="Acme Publishing Inc."/&gt;
+  &lt;dc:publisher>Acme Publishing Inc.&lt;/dc:publisher>
   …
-&lt;/metadata&gt;</pre>
+  &lt;meta name="dcterms:conformsTo" content="EPUB-A11Y-11_WCAG-21-AA"/>
+  &lt;meta name="a11y:certifiedBy" content="Acme Publishing Inc."/>
+  …
+&lt;/metadata></pre>
 					</aside>
 
 					<div class="note">
@@ -1034,8 +1038,9 @@
 					<aside class="example">
 						<p>The following example shows a credential. The <code>refines</code> attribute associates the
 							credential with the certifier.</p>
-						<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
-&lt;meta property="a11y:certifierCredential" refines="#certifier"&gt;A+ Accessibility Rating&lt;/meta&gt;</pre>
+						<pre>&lt;meta property="dcterms:conformsTo" id="conf">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
+&lt;meta property="a11y:certifiedBy" refines="#conf" id="certifier">EPUB Accessibility Evaluator&lt;/meta>
+&lt;meta property="a11y:certifierCredential" refines="#certifier">A+ Accessibility Rating&lt;/meta></pre>
 					</aside>
 
 					<p>If the party that evaluated the content provides a publicly-readable report of its assessment,
@@ -1044,15 +1049,17 @@
 
 					<aside class="example">
 						<p>The following example shows a link to a remotely hosted accessibility report.</p>
-						<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
+						<pre>&lt;meta property="dcterms:conformsTo" id="conf">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
+&lt;meta property="a11y:certifiedBy" refines="#conf" id="certifier">EPUB Accessibility Evaluator&lt;/meta>
 &lt;link rel="a11y:certifierReport" refines="#certifier"
-      href="http://www.example.com/a11y/report/9780000000001"/&gt;</pre>
+      href="http://www.example.com/a11y/report/9780000000001"/></pre>
 					</aside>
 
 					<aside class="example">
 						<p>The following example shows a link to a locally hosted accessibility report.</p>
-						<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
-&lt;link rel="a11y:certifierReport" refines="#certifier" href="reports/a11y.xhtml"/&gt;</pre>
+						<pre>&lt;meta property="dcterms:conformsTo" id="conf">EPUB-A11Y-11_WCAG-21-AA&lt;/meta>
+&lt;meta property="a11y:certifiedBy" refines="#conf" id="certifier">EPUB Accessibility Evaluator&lt;/meta>
+&lt;link rel="a11y:certifierReport" refines="#certifier" href="reports/a11y.xhtml"/></pre>
 					</aside>
 
 
@@ -1160,14 +1167,14 @@
 			<aside class="example">
 				<p>The following example shows a conformance statement for an EPUB 3 Publication that conforms to the
 					DAISY Navigable Audio-only EPUB 3 Guidelines [[DAISYAudio]].</p>
-				<pre>&lt;package …&gt;
-   &lt;metadata&gt;
+				<pre>&lt;package …>
+   &lt;metadata>
       …
-      &lt;link rel="dcterms:conformsTo" href="http://www.daisy.org/guidelines/epub/navigable-audio-only-epub3-guidelines"/&gt;
+      &lt;link rel="dcterms:conformsTo" href="http://www.daisy.org/guidelines/epub/navigable-audio-only-epub3-guidelines"/>
       …
-   &lt;/metadata&gt;
+   &lt;/metadata>
    …
-&lt;/package&gt;</pre>
+&lt;/package></pre>
 			</aside>
 
 			<p>If the URL is not sufficient for a user to understand conformance (e.g., the guidelines are not publicly
@@ -1177,26 +1184,26 @@
 			<aside class="example">
 				<p>The following example shows an accessibility summary for an EPUB Publication optimized for braille
 					rendering.</p>
-				<pre>&lt;meta property="schema:accessibilitySummary"&gt;
+				<pre>&lt;meta property="schema:accessibilitySummary">
     This publication is optimized for braille readers. It will not be 
     usable by persons who cannot read braille. The publication is designed
     for braille reading devices capable of displaying 6-character cells and
     40-character line lengths. The text is not contracted, and follows 
     Unified English Braille formatting conventions. All characters are
     encoded using the Unicode braille character set.
-&lt;/meta&gt;</pre>
+&lt;/meta></pre>
 			</aside>
 
 			<aside class="example">
 				<p>The following example shows an accessibility summary for an EPUB Publication optimized for audio
 					rendering.</p>
-				<pre>&lt;meta property="schema:accessibilitySummary"&gt;
+				<pre>&lt;meta property="schema:accessibilitySummary">
     This publication is an audio book. It will not be usable by persons who 
     cannot hear the audio. The publication is recorded by a professional
     narrator. There is navigation to the beginning of each chapter. The text
     of the publication is not included. Images are not included, but the
     photo captions are narrated at the end of the chapter where they occur.
-&lt;/meta&gt;</pre>
+&lt;/meta></pre>
 			</aside>
 
 			<div class="note">
@@ -1413,6 +1420,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>07-Sep-2021: Added <code>refines</code> attribute to certifier metadata examples to show the
+					expected linkage. See <a href="https://github.com/w3c/epub-specs/issues/1789">issue 1789</a>.</li>
 				<li>09-June-2021: Clarified that a pagination source must not be specified when page break markers
 					and/or a page list are included in a digital-only publication. See <a
 						href="https://github.com/w3c/epub-specs/issues/1599">issue 1599</a>.</li>


### PR DESCRIPTION
This pull request only adds the attribute to the examples. It does not add a requirement that the metadata be linked. (Doing so might be problematic for epub 2, for example, since there isn't a way to make explicit links between metadata.)

I also noticed that the old idpf conformance URLs were still used in some of the examples, so I went through and cleaned them out.

Fixes #1789 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/certifier-refines/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/certifier-refines/epub33/a11y/index.html)
