### PR TITLE
Add example of using dcterms:date to date an evaluation

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -103,11 +103,11 @@
 					accessibility, this specification sets formal requirements for certifying content accessible. These
 					requirements provide EPUB Creators a clear set of guidelines to evaluate their content against and
 					allows certification of quality. An accessible EPUB Publication is one that meets the accessibility
-					requirements described in <a href="#sec-access-pub"></a>.</p>
+					requirements described in <a href="#sec-accessible-pubs"></a>.</p>
 
 				<p>The specification also establishes how to identify content that EPUB Creators have optimized for
 					specific user needs so cannot meet broad accessibility requirements. Refer to the requirements for
-					optimized publications in <a href="#sec-opt-pubs"></a> for more information.</p>
+					optimized publications in <a href="#sec-optimized-pubs"></a> for more information.</p>
 
 				<p>This specification does not target a single version of EPUB. It applicable to EPUB Publications that
 					conform to any version or profile, including future versions of the standard.</p>
@@ -217,7 +217,7 @@
 
 				<p>All EPUB Publications MUST include accessibility metadata in the Package Document that exposes their
 					accessible properties, regardless of whether the publications also meet the <a
-						href="#sec-access-pub">accessibility</a> or <a href="#sec-opt-pubs">optimization</a>
+						href="#sec-accessible-pubs">accessibility</a> or <a href="#sec-optimized-pubs">optimization</a>
 					requirements.</p>
 
 				<p>EPUB Publications MUST include the following accessibility metadata:</p>
@@ -282,10 +282,10 @@
 					discoverability requirements of this specification.</p>
 			</section>
 		</section>
-		<section id="sec-access-pub">
+		<section id="sec-accessible-pubs">
 			<h2>Accessible Publications</h2>
 
-			<section id="sec-access-pub-intro" class="informative">
+			<section id="sec-accessible-pubs-intro" class="informative">
 				<h3>Introduction</h3>
 
 				<p>EPUB builds on the Open Web Platform, with HTML, CSS, JavaScript and SVG, the core technologies used
@@ -1027,6 +1027,16 @@
 							diminish the trust users have in the claim.</p>
 					</div>
 
+					<p>The date the evaluation was performed on MAY be specified by linking a <a
+							href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/date"
+								><code>dcterms:date</code> property</a> [[DCTERMS]] to the certifier.</p>
+
+					<aside class="example">
+						<p>The following example shows the date an evaluation was carried out on.</p>
+						<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
+&lt;meta property="dcterms:date" refines="#certifier">2021-09-07&lt;/meta></pre>
+					</aside>
+
 					<p>If the party that evaluates the content has a credential or badge that establishes their
 						authority to evaluate content, include that information in an <a href="#certifierCredential"
 								><code>a11y:certifierCredential</code> property</a>.</p>
@@ -1054,7 +1064,6 @@
 						<pre>&lt;meta property="a11y:certifiedBy" id="certifier"&gt;EPUB Accessibility Evaluator&lt;/meta&gt;
 &lt;link rel="a11y:certifierReport" refines="#certifier" href="reports/a11y.xhtml"/&gt;</pre>
 					</aside>
-
 
 					<div class="note">
 						<p>As each metadata format is unique in what it can express, this specification does not mandate
@@ -1135,7 +1144,7 @@
 				</section>
 			</section>
 		</section>
-		<section id="sec-opt-pubs">
+		<section id="sec-optimized-pubs">
 			<h2>Optimized Publications</h2>
 
 			<p>Although WCAG [[WCAG2]] provides a general set of guidelines for making content broadly accessible,
@@ -1413,6 +1422,9 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>07-Sep-2021: Added explanation that the <code>dcterms:date</code> property can be used to indicate
+					when an evaluation was performed. See <a href="https://github.com/w3c/epub-specs/issues/1590">issue
+						1590</a>.</li>
 				<li>09-June-2021: Clarified that a pagination source must not be specified when page break markers
 					and/or a page list are included in a digital-only publication. See <a
 						href="https://github.com/w3c/epub-specs/issues/1599">issue 1599</a>.</li>


### PR DESCRIPTION
This is a revisit of #1590 as the question has been asked again by @murata2makoto.

Expressing a date can be done using `dcterms:date`, so it doesn't require us to add or mandate anything. The pull request only notes this is possible to do and provides an example.

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/certified-date/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/certified-date/epub33/a11y/index.html)
