### PR TITLE
Minor addition to the navigation document warning

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4249,11 +4249,11 @@ Spine:
 					attribute.</p>
 
 				<p>Note that Reading Systems may strip scripting, styling, and HTML formatting as they generate
-					navigational interfaces from information found in the EPUB Navigation Document. If EPUB Creators
-					require such formatting and functionality, then they should also include the EPUB Navigation
-					Document in the <a>spine</a>. The use of progressive enhancement techniques for scripting and
-					styling of the navigation document will help ensure the content will retain its integrity when
-					rendered in a non-browser context.</p>
+					navigational interfaces from information found in the EPUB Navigation Document, and this may make
+					the result difficult to read. If EPUB Creators require such formatting and functionality, then they
+					should also include the EPUB Navigation Document in the <a>spine</a>. The use of progressive enhancement
+					techniques for scripting and styling of the navigation document will help ensure the content will retain
+					its integrity when rendered in a non-browser context.</p>
 			</section>
 
 			<section id="sec-nav-def">


### PR DESCRIPTION
partial fix for 1793

Cc: @murata2makoto


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1805.html" title="Last updated on Sep 9, 2021, 1:36 PM UTC (8d46325)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1805/83414ff...8d46325.html" title="Last updated on Sep 9, 2021, 1:36 PM UTC (8d46325)">Diff</a>