### PR TITLE
Add clarifications about the standard only applying to WCAG 2

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -350,7 +350,7 @@
 						<li>
 							<p id="confreq-wcag-20">MUST meet the requirements of WCAG 2.0 [[WCAG20]], but it is
 								strongly RECOMMENDED that it conform to the <a href="https://www.w3.org/TR/WCAG2/"
-									>latest recommended version</a>.</p>
+									>latest recommended version of WCAG 2</a>.</p>
 						</li>
 
 						<li>
@@ -370,9 +370,9 @@
 						practitioners do not recognize this level as providing a high degree of accessibility,
 						however.</p>
 
-					<p>Ideally, EPUB Creators should try to conform to the latest version of WCAG at Level AA, but local
-						and national laws, or procurer or distributor requirements, will define the formal thresholds
-						they must meet.</p>
+					<p>Ideally, EPUB Creators should try to conform to the latest version of WCAG 2 at Level AA, but
+						local and national laws, or procurer or distributor requirements, will define the formal
+						thresholds they must meet.</p>
 
 					<div class="note">
 						<p>Examples of legislative requirements for accessibility include the <a
@@ -395,6 +395,14 @@
 						they can, but fully conforming at AAA is typically not possible). When EPUB Creators meet only
 						Level A conformance, they compromise their content for various user groups, resulting in a less
 						optimal reading experience.</p>
+
+					<div class="note">
+						<p>Development of WCAG 3 is currently ongoing in W3C. As this version potentially represents a
+							significant departure from WCAG 2, a future version of this specification will address
+							conformance requirements related to it. EPUB Creators are encouraged to adopt WCAG 3 once it
+							is stable and widely recognized, but conformance to the new version is not a requirement of
+							this standard.</p>
+					</div>
 				</section>
 
 				<section id="sec-wcag-eval">


### PR DESCRIPTION
In addition to clarifying the latest version of WCAG means the latest version of WCAG 2, I've also added a note to the end of the section to explain that conformance to WCAG 3 will be handled in a future update so that there isn't any confusion about when it has to be met.

Fixes #1800 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1800/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1800/epub33/a11y/index.html)
