### PR TITLE
Fill in privacy/security section for accessibility specification

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1250,9 +1250,24 @@
 		<section id="privacy">
 			<h2>Privacy and Security</h2>
 
-			<div class="ednote">
-				<p>The working group will address issues related to privacy and security, if any, in a future draft.</p>
-			</div>
+			<p>The authoring of accessible content does not introduce any new privacy or security considerations for
+				users. Meeting accessibility requirements is about optimally using the available technologies, and no
+				new features are introduced by this specification.</p>
+
+			<p>The inclusion of accessibility metadata by EPUB Creators similarly does not introduce security or privacy
+				issues for the EPUB Creator, as describing an EPUB Publication only provides a general idea of its
+				suitability for different user groups.</p>
+
+			<p>The use of accessibility metadata in reading systems, bookstores and any other interface that can build a
+				profile of the user, on the other hand, has the potential to violate individual privacy laws. While it
+				might seem helpful to store and anticipate the type of content a user is most likely to consume, for
+				example, or how best to initiate its playback, developers should not engage in such profiling unless
+				explicit permission is obtained from the user and a means of easily removing the profile is
+				available.</p>
+
+			<p>Developers should also be mindful about storing or mining information about the types of searches a user
+				performs when searching for content based on its accessibility characteristics. This information can be
+				used to indirectly profile the abilities of users.</p>
 		</section>
 		<section id="app-a11y-vocab" class="appendix vocab">
 			<h2>EPUB Accessibility Vocabulary</h2>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1265,6 +1265,10 @@
 				explicit permission is obtained from the user and a means of easily removing the profile is
 				available.</p>
 
+			<p>Even in the case where a user assents to the application maintaining information about their
+				accessibility needs, developers must ensure that this information is kept private (e.g., it must not be
+				shared with third party advertisers or even with the original publisher).</p>
+
 			<p>Developers should also be mindful about storing or mining information about the types of searches a user
 				performs when searching for content based on its accessibility characteristics. This information can be
 				used to indirectly profile the abilities of users.</p>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1247,7 +1247,7 @@
 					accessibility by activating a feature that that would normally not be active.</p>
 			</div>
 		</section>
-		<section id="privacy">
+		<section id="privacy" class="informative">
 			<h2>Privacy and Security</h2>
 
 			<p>The authoring of accessible content does not introduce any new privacy or security considerations for


### PR DESCRIPTION
This pull request replaces the placeholder text. It notes that there aren't issues on the authoring side as we're not introducing new features to the content and the metadata itself only describes the publication generally.

Where we have potential privacy issues is in how the metadata may be used. I've covered some possible scenarios where problems may arise, in conjunction with #1803, but if anyone has other areas of concern they feel should be addressed please reply to this PR.

Fixes #1803 
