### PR TITLE
Restore schema.org properties to accessibility specification

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -215,7 +215,7 @@
 			<section id="sec-disc-package">
 				<h3>Package Metadata</h3>
 
-				<p>All EPUB Publications MUST include [[schema.org]] accessibility metadata in the Package Document that
+				<p>All EPUB Publications MUST include [[schema-org]] accessibility metadata in the Package Document that
 					exposes their accessible properties, regardless of whether the publications also meets the <a
 						href="#sec-accessible-pubs">accessibility</a> or <a href="#sec-optimized-pubs">optimization</a>
 					requirements.</p>
@@ -249,7 +249,7 @@
 					</li>
 				</ul>
 
-				<p>EPUB Publications SHOULD include the following [[schema.org]] accessibility metadata:</p>
+				<p>EPUB Publications SHOULD include the following [[schema-org]] accessibility metadata:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -263,7 +263,7 @@
 					</li>
 				</ul>
 
-				<p>EPUB Creators MAY include additional [[schema.org]] accessibility metadata not specified in this
+				<p>EPUB Creators MAY include additional [[schema-org]] accessibility metadata not specified in this
 					section.</p>
 
 				<div class="note">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -215,8 +215,8 @@
 			<section id="sec-disc-package">
 				<h3>Package Metadata</h3>
 
-				<p>All EPUB Publications MUST include accessibility metadata in the Package Document that exposes their
-					accessible properties, regardless of whether the publications also meet the <a
+				<p>All EPUB Publications MUST include [[schema.org]] accessibility metadata in the Package Document that
+					exposes their accessible properties, regardless of whether the publications also meets the <a
 						href="#sec-accessible-pubs">accessibility</a> or <a href="#sec-optimized-pubs">optimization</a>
 					requirements.</p>
 
@@ -224,44 +224,47 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-schema-accessMode">Access modes — a human sensory perceptual system or cognitive
-							faculty necessary to process or perceive the content (e.g., textual, visual, auditory,
-							tactile).</p>
+						<p id="confreq-schema-accessMode"><a href="https://schema.org/accessMode">accessMode</a> — a
+							human sensory perceptual system or cognitive faculty necessary to process or perceive the
+							content (e.g., textual, visual, auditory, tactile).</p>
 					</li>
 
 					<li>
-						<p id="confreq-schema-accessibilityFeature">Accessibility features — features and adaptations
-							that contribute to the overall accessibility of the content (e.g., alternative text,
-							extended descriptions, captions).</p>
+						<p id="confreq-schema-accessibilityFeature"><a href="https://schema.org/accessibilityFeature"
+								>accessibilityFeature</a> — features and adaptations that contribute to the overall
+							accessibility of the content (e.g., alternative text, extended descriptions, captions).</p>
 					</li>
 
 					<li>
-						<p id="confreq-schema-accessibilityHazard">Accessibility hazards — any potential hazards that
-							the content presents (e.g., flashing, motion simulation, sound).</p>
+						<p id="confreq-schema-accessibilityHazard"><a href="https://schema.org/accessibilityHazard"
+								>accessibilityHazard</a> — any potential hazards that the content presents (e.g.,
+							flashing, motion simulation, sound).</p>
 					</li>
 
 					<li>
-						<p id="confreq-schema-accessibilitySummary">Accessibility summary — a human-readable summary of
-							the overall accessibility, which includes a description of any known deficiencies (e.g.,
-							lack of extended descriptions, specific hazards).</p>
+						<p id="confreq-schema-accessibilitySummary"><a href="https://schema.org/accessibilitySummary"
+								>accessibilitySummary</a> — a human-readable summary of the overall accessibility, which
+							includes a description of any known deficiencies (e.g., lack of extended descriptions,
+							specific hazards).</p>
 					</li>
 				</ul>
 
-				<p>EPUB Publications SHOULD include the following accessibility metadata:</p>
+				<p>EPUB Publications SHOULD include the following [[schema.org]] accessibility metadata:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-schema-accessModeSufficient">Sufficient access modes — a set of one or more
-							access modes sufficient to consume the content without significant loss of information. An
-							EPUB Publication can have more than one set of sufficient access modes for its consumption
-							depending on the types of content it includes (i.e., unlike <a
-								href="#confreq-schema-accessMode">access modes</a>, this property takes into account any
-							affordances for content that is not broadly accessible, such as the inclusion of transcripts
-							for audio content).</p>
+						<p id="confreq-schema-accessModeSufficient"><a href="https://schema.org/accessibilityHazard"
+								>accessModeSufficient</a> — a set of one or more access modes sufficient to consume the
+							content without significant loss of information. An EPUB Publication can have more than one
+							set of sufficient access modes for its consumption depending on the types of content it
+							includes (i.e., unlike <a href="#confreq-schema-accessMode">access modes</a>, this property
+							takes into account any affordances for content that is not broadly accessible, such as the
+							inclusion of transcripts for audio content).</p>
 					</li>
 				</ul>
 
-				<p>EPUB Creators MAY include additional accessibility metadata not specified in this section.</p>
+				<p>EPUB Creators MAY include additional [[schema.org]] accessibility metadata not specified in this
+					section.</p>
 
 				<div class="note">
 					<p>See <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-discovery">Discovery Metadata

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -216,7 +216,7 @@
 				<h3>Package Metadata</h3>
 
 				<p>All EPUB Publications MUST include [[schema-org]] accessibility metadata in the Package Document that
-					exposes their accessible properties, regardless of whether the publications also meets the <a
+					exposes their accessible properties, regardless of whether the publications also meet the <a
 						href="#sec-accessible-pubs">accessibility</a> or <a href="#sec-optimized-pubs">optimization</a>
 					requirements.</p>
 


### PR DESCRIPTION
This pull request restores the discovery metadata section to the way it was in the IDPF 1.0 version -- directly referencing the schema.org properties instead of using prose labels.

@iherman should we merge this while we work to ensure the normative references are respected, or wait until we get a green light? Seems to make the most sense to make our preference clear and undo later if rejected.

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1799/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1799/epub33/a11y/index.html)
