### PR TITLE
Elaborate on use of par and seq elements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4251,9 +4251,9 @@ Spine:
 				<p>Note that Reading Systems may strip scripting, styling, and HTML formatting as they generate
 					navigational interfaces from information found in the EPUB Navigation Document, and this may make
 					the result difficult to read. If EPUB Creators require such formatting and functionality, then they
-					should also include the EPUB Navigation Document in the <a>spine</a>. The use of progressive enhancement
-					techniques for scripting and styling of the navigation document will help ensure the content will retain
-					its integrity when rendered in a non-browser context.</p>
+					should also include the EPUB Navigation Document in the <a>spine</a>. The use of progressive
+					enhancement techniques for scripting and styling of the navigation document will help ensure the
+					content will retain its integrity when rendered in a non-browser context.</p>
 			</section>
 
 			<section id="sec-nav-def">
@@ -7088,12 +7088,17 @@ store destination as source in ocf
 							represents how Reading Systems render the content in the corresponding EPUB Content
 							Documents during playback.</p>
 
-						<p>The <code>par</code> element represents phrases. Each element identifies a text and audio
-							component to synchronize during playback.</p>
+						<p>The <code>par</code> element represents a segment of content to render, such as a word,
+							phrase, sentence, table cell, list item, image or other identifiable piece of content in the
+							markup. Each element identifies both the content to display (in the <a
+								href="#elemdef-smil-text"><code>text</code> element</a>) and audio to synchronize (in
+							the <a href="#elemdef-smil-audio"><code>audio</code> element</a>) during playback.</p>
 
-						<p>The <code>seq</code> element represents sequences. EPUB Creators can use it to represent
-							nested containers such as sections, asides, headers, and footnotes. It allows EPUB Creators
-							to retain the structure inherent in these containers in the Media Overlay Document.</p>
+						<p>The <code>seq</code> element represents sequences &#8212; sets of <code>seq</code> and
+								<code>par</code> elements that combined represent a logical component. EPUB Creators can use it to
+							represent nested containers such as sections, asides, headers, and footnotes. It allows EPUB
+							Creators to retain the structure inherent in these containers in the Media Overlay
+							Document.</p>
 
 						<p>The <code>seq</code> element MUST contain an <a href="#attrdef-body-textref"
 									><code>epub:textref</code> attribute</a>. As <code>seq</code> elements do not

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7089,16 +7089,16 @@ store destination as source in ocf
 							Documents during playback.</p>
 
 						<p>The <code>par</code> element represents a segment of content to render, such as a word,
-							phrase, sentence, table cell, list item, image or other identifiable piece of content in the
-							markup. Each element identifies both the content to display (in the <a
+							phrase, sentence, table cell, list item, image, or other identifiable piece of content in
+							the markup. Each element identifies both the content to display (in the <a
 								href="#elemdef-smil-text"><code>text</code> element</a>) and audio to synchronize (in
 							the <a href="#elemdef-smil-audio"><code>audio</code> element</a>) during playback.</p>
 
-						<p>The <code>seq</code> element represents sequences &#8212; sets of <code>seq</code> and
-								<code>par</code> elements that combined represent a logical component. EPUB Creators can use it to
-							represent nested containers such as sections, asides, headers, and footnotes. It allows EPUB
-							Creators to retain the structure inherent in these containers in the Media Overlay
-							Document.</p>
+						<p>The <code>seq</code> element represents sequences &#8212; sets of <code>seq</code> and/or
+								<code>par</code> elements that together represent a logical component of the content.
+							EPUB Creators can use it to represent nested containers such as sections, asides, headers,
+							tables, lists, and footnotes. It allows EPUB Creators to retain the structure inherent in
+							these containers in the Media Overlay Document.</p>
 
 						<p>The <code>seq</code> element MUST contain an <a href="#attrdef-body-textref"
 									><code>epub:textref</code> attribute</a>. As <code>seq</code> elements do not


### PR DESCRIPTION
Added a bit of extra context about being able to use par for a variety of content components, not just phrases. Also clarified the seq explanation slightly and added tables and lists to what it can represent.

Fixes #1739


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1811.html" title="Last updated on Sep 17, 2021, 12:11 PM UTC (0e121d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1811/28d90ef...0e121d2.html" title="Last updated on Sep 17, 2021, 12:11 PM UTC (0e121d2)">Diff</a>