### PR TITLE
Typo in conformsTo property name

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -964,7 +964,7 @@
 						<p>An EPUB Publication that only meets WCAG conformance requirements (i.e., does not fully
 							conform to this specification) can use a WCAG conformance URL (e.g.,
 								"<code>https://www.w3.org/TR/WCAG21/</code>" for [[WCAG21]]) with the
-								<code>confomsTo</code> property.</p>
+								<code>conformsTo</code> property.</p>
 					</div>
 				</section>
 


### PR DESCRIPTION
Fixes the typo reported in #1791 