### PR TITLE
Clarify note about wcag-only conformance reporting

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -963,7 +963,7 @@
 					<div class="note">
 						<p>EPUB Creators may use a conformance URL, as defined in the <a
 								href="https://www.w3.org/TR/WCAG/#conformance-required">Required Components of a
-								Conformance Claim</a> [[WCAG2]], with the <code>confomsTo</code> property for EPUB
+								Conformance Claim</a> [[WCAG2]], with the <code>conformsTo</code> property for EPUB
 							Publications that only meet WCAG conformance requirements (i.e., that do not fully conform
 							to this specification).</p>
 

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -961,10 +961,15 @@
 					</div>
 
 					<div class="note">
-						<p>An EPUB Publication that only meets WCAG conformance requirements (i.e., does not fully
-							conform to this specification) can use a WCAG conformance URL (e.g.,
-								"<code>https://www.w3.org/TR/WCAG21/</code>" for [[WCAG21]]) with the
-								<code>conformsTo</code> property.</p>
+						<p>EPUB Creators may use a conformance URL, as defined in the <a
+								href="https://www.w3.org/TR/WCAG/#conformance-required">Required Components of a
+								Conformance Claim</a> [[WCAG2]], with the <code>confomsTo</code> property for EPUB
+							Publications that only meet WCAG conformance requirements (i.e., that do not fully conform
+							to this specification).</p>
+
+						<p>As [[WCAG2]] does not define how to specify the conformance level in the URL, however, EPUB
+							Creators will have to find an alternative means of relating this information when necessary
+							(e.g., through the accessibility summary).</p>
 					</div>
 				</section>
 


### PR DESCRIPTION
This pull request changes the note so it links to the section in WCAG that explains the URL to use for conformance reporting. It also notes that the level cannot be specified in the URL so has to be provided by another means such as the summary.

Fixes #1791

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1791/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1791/epub33/a11y/index.html)


