### PR TITLE
Removing unnecessary global language support sections

### DIFF
--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -81,7 +81,7 @@
 	<body>
 		<section id="abstract">
 			<p>This document provides a starting point for content authors and software developers wishing to understand
-				the EPUB® 3 specifications. It consists entirely of informative overview material that describes the
+				the EPUB 3 specifications. It consists entirely of informative overview material that describes the
 				features available in EPUB 3.</p>
 
 			<p>The current version of EPUB 3 is defined in [[EPUB-33]], which represents the second minor revision of
@@ -322,8 +322,7 @@
 					rendering properties. EPUB 3 follows support for CSS as defined in the [[CSSSnapshot]].</p>
 
 				<p>EPUB 3 also supports CSS styles that enable both horizontal and vertical layout and both
-					left-to-right and right-to-left writing. Refer to <a href="#sec-gls-css"></a> in the Global Language
-					Support section for more information.</p>
+					left-to-right and right-to-left writing.</p>
 			</section>
 
 			<section id="sec-multimedia">
@@ -442,6 +441,15 @@
 		<section id="sec-gls">
 			<h1>Global Language Support</h1>
 
+
+			<p>
+				EPUB 3 leverages on the features in XHTML, SVG, CSS, or MathML for global language support, and it 
+				also relies on [[Unicode]] for encoding the content. 
+				This means that content documents in EPUB 3 have the possibility to use different character sets, express bidirectional text, 
+				ruby annotations, or typography for many different languages and cultures.
+				Features have also been added to the various components defined by EPUB 3 to ensure language support.
+			</p>
+
 			<section id="sec-gls-metadata">
 				<h2>Metadata</h2>
 
@@ -466,49 +474,7 @@
 						>page-progression-direction</a> [[EPUB-33]]).</p>
 			</section>
 
-			<section id="sec-gls-content-docs">
-				<h2>Content Documents</h2>
-
-				<p>XHTML Content Documents leverage the HTML directionality features to improve support for
-					bidirectional content rendering: the <a data-cite="html#the-bdi-element"><code>bdi</code></a> 
-					element allows an instance of directional text to be isolated from the surrounding content, 
-					the <a data-cite="html#the-bdo-element"><code>bdo</code></a> element allows directionality to
-					be overridden for its child content and the <a data-cite="html#the-dir-attribute"><code>dir</code></a> 
-					attribute allows the directionality of any element to be explicitly set.</p>
-
-				<p>XHTML Content Documents also support <a data-cite="html#the-ruby-element">ruby annotations</a> [[HTML]] for pronunciation support (which makes them
-					supported in Navigation Document links, as well).</p>
-
-				<p>SVG Content Documents support the rendering of bidirectional text, but do not include support for ruby.</p>
-
-			</section>
-
-			<section id="sec-gls-css">
-				<h2>CSS</h2>
-
-				<p>EPUB 3's support for CSS3 modules enables typography for many different languages and cultures. Some
-					specific enhancements include:</p>
-
-				<ul>
-					<li>
-						<p>support for vertical writing, which also provides Reading Systems the ability to allow users
-							to toggle direction;</p>
-					</li>
-					<li>
-						<p>better handling of emphasis, such as the inclusion of bōten;</p>
-					</li>
-					<li>
-						<p>better control over line breaking, so that breaks can occur at the character level for
-							languages that do not use spaces to delimit new words; and</p>
-					</li>
-					<li>
-						<p>better control over hyphenation, to further facilitate line breaking.</p>
-					</li>
-				</ul>
-
-			</section>
-
-			<section id="sec-gls-fonts">
+			<!-- <section id="sec-gls-fonts">
 				<h2>Fonts</h2>
 
 				<p>EPUB 3 does not require that Reading Systems come with a set of built-in system fonts. As occurs in
@@ -524,7 +490,7 @@
 				<p>Support for embedded fonts also ensures that characters and glyphs unique to an EPUB Publication can
 					be embedded for proper display.</p>
 
-			</section>
+			</section> -->
 
 			<section id="sec-gls-tts">
 				<h2>Text-to-speech</h2>


### PR DESCRIPTION
Fix #1809

See:

* For EPUB 3 Overview:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1809/epub33/overview/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/overview/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1809/epub33/overview/index.html)
