### PR TITLE
Add section on internationalization and techniques

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -64,7 +64,8 @@
 			}
 			.varlist {
 				margin-left: 3rem;
-			}</style>
+			}
+		</style>
 	</head>
 	<body>
 		<section id="abstract">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -141,6 +141,25 @@
 							layout publications</a>. When that document is formally published, it should be mentioned in
 						this section.</p>
 				</div>
+
+				<section id="sec-sc-i18n">
+					<h4>Internationalization</h4>
+
+					<p>This specification is also designed to address the accessibility needs of users independent of
+						what languages they read. The same is true for the principles and success criteria defined in
+						[[WCAG2]]. The goal is to ensure that users can fully consume the information of a publication
+						regardless of their preferred reading modality.</p>
+
+					<p>At the same time, the language and writing conventions of the authored text will influence the
+						techniques necessary to meet the accessibility requirements. The fact that EPUB 3 requires
+						support for Unicode text, for example, is not enough on its own to ensure that the text in any
+						given language is fully accessible even though it ensures the correct character data can be
+						used.</p>
+
+					<p>That there will be language-specific best practices for meeting accessibility requirements is
+						consequently an expected outcome, even if these best practices are generally outside the scope
+						of this specification and its techniques (except where specific to EPUB).</p>
+				</section>
 			</section>
 
 			<section id="sec-application" class="informative">
@@ -190,6 +209,7 @@
 						playback.</p>
 				</div>
 			</section>
+
 			<section id="conformance"></section>
 		</section>
 		<section id="sec-discovery">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -64,8 +64,7 @@
 			}
 			.varlist {
 				margin-left: 3rem;
-			}
-		</style>
+			}</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -157,9 +156,10 @@
 						[[EPUB-3]], for example, is not enough on its own to ensure that the text in any given language
 						is fully accessible even though it ensures the correct character data can be used.</p>
 
-					<p>That there will be language-specific best practices for meeting accessibility requirements is
-						consequently an expected outcome, even if these best practices are generally outside the scope
-						of this specification and its techniques (except where specific to EPUB).</p>
+					<p>As a consequence, there may be language- or culture-specific practices for meeting accessibility
+						requirements. Whether these practices are defined within this specification and its techniques
+						or elsewhere (e.g., in WCAG techniques or language-specific best practice recommendations) will
+						depend on whether the issues are specific to EPUB or broadly affect all Web content.</p>
 				</section>
 			</section>
 

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -151,10 +151,10 @@
 						regardless of their preferred reading modality.</p>
 
 					<p>At the same time, the language and writing conventions of the authored text will influence the
-						techniques necessary to meet the accessibility requirements. The fact that EPUB 3 requires
-						support for Unicode text, for example, is not enough on its own to ensure that the text in any
-						given language is fully accessible even though it ensures the correct character data can be
-						used.</p>
+						techniques necessary to meet the accessibility requirements. The fact that EPUB <a
+							href="https://www.w3.org/TR/epub-33/#confreq-xml-enc">requires support for Unicode text</a>
+						[[EPUB-3]], for example, is not enough on its own to ensure that the text in any given language
+						is fully accessible even though it ensures the correct character data can be used.</p>
 
 					<p>That there will be language-specific best practices for meeting accessibility requirements is
 						consequently an expected outcome, even if these best practices are generally outside the scope
@@ -1488,6 +1488,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>23-Sep-2021: Added section explaining effects of internationalization on techniques used. See <a
+						href="https://github.com/w3c/epub-specs/issues/1790">issue 1790</a>.</li>
 				<li>07-Sep-2021: Added <code>refines</code> attribute to certifier metadata examples to show the
 					expected linkage. See <a href="https://github.com/w3c/epub-specs/issues/1789">issue 1789</a>.</li>
 				<li>07-Sep-2021: Added explanation that the <code>dcterms:date</code> property can be used to indicate

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -151,10 +151,13 @@
 						regardless of their preferred reading modality.</p>
 
 					<p>At the same time, the language and writing conventions of the authored text will influence the
-						techniques necessary to meet the accessibility requirements. The fact that EPUB <a
+						techniques necessary to meet the accessibility requirements. EPUB <a
 							href="https://www.w3.org/TR/epub-33/#confreq-xml-enc">requires support for Unicode text</a>
-						[[EPUB-3]], for example, is not enough on its own to ensure that the text in any given language
-						is fully accessible even though it ensures the correct character data can be used.</p>
+						[[EPUB-3]], for example, which ensures the correct character data can be used (i.e., EPUB
+						Creators do not have to use images of text). Although this is an important feature, it is often
+						not enough on its own to ensure that the text is fully accessible in any given language (e.g.,
+						additional information about directionality, emphasis, pronunciation, etc. may also be
+						neeed).</p>
 
 					<p>As a consequence, there may be language- or culture-specific practices for meeting accessibility
 						requirements. Whether these practices are defined within this specification and its techniques


### PR DESCRIPTION
As discussed on the call today, here's what I'm thinking in terms of addressing internationalization.

The PR adds a basic subsection to the existing success techniques section that explains that there will be differences in the best practices necessary to make content accessible in any given language, but that it's an expected part of how the guidelines are crafted.

I don't think we need to go deeper than this for the accessibility specification, but it opens the door to adding more specific details to the techniques.

I've worked in mention that Unicode is a requirement of EPUB, @avneeshsingh, but not exactly in the way you may have imagined. I can always look at rewriting it if you think the point you're trying to get across might not be fully captured.

Fixes #1790 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1790/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1790/epub33/a11y/index.html)
