### PR TITLE
Adding directionality test references to RS

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -303,13 +303,13 @@
 			<section id="sec-pkg-doc-base-dir">
 				<h4>Base Direction</h4>
 
-				<p id="confreq-rs-pkg-dir" data-tests="confreq-rs-pkg-dir.epub">If the <code>dir</code> attribute is set
+				<p id="confreq-rs-pkg-dir" data-tests="confreq-rs-pkg-dir.epub,confreq-rs-pkg-dir_rtl-001.epub,confreq-rs-pkg-dir_rtl-002.epub,confreq-rs-pkg-dir_rtl-004.epub,confreq-rs-pkg-dir_rtl-005.epub,confreq-rs-pkg-dir_rtl-006.epub">If the <code>dir</code> attribute is set
 					and indicates a base direction of <code>ltr</code> or <code>rtl</code>, Reading Systems MUST
 					override the bidi algorithm per <a data-cite="bidi#Higher-Level_Protocols">the higher-level
 						protocols</a> defined in [[BIDI]], setting the paragraph embedding level to 0 if the base
 					direction is <code>ltr</code>, or 1 if the base direction is <code>rtl</code>.</p>
 
-				<p id="confreq-rs-pkg-dir-auto" data-tests="confreq-rs-pkg-dir-auto.epub">Otherwise the base direction
+				<p id="confreq-rs-pkg-dir-auto" data-tests="confreq-rs-pkg-dir-auto.epub,confreq-rs-pkg-dir_rtl-003.epub,confreq-rs-pkg-dir_rtl-005.epub">Otherwise the base direction
 					is <code>auto</code>, in which case Reading Systems MUST determine the text's direction by applying
 					the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of [[BIDI]].</p>
 			</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -303,13 +303,13 @@
 			<section id="sec-pkg-doc-base-dir">
 				<h4>Base Direction</h4>
 
-				<p id="confreq-rs-pkg-dir" data-tests="confreq-rs-pkg-dir.epub,confreq-rs-pkg-dir_rtl-001.epub,confreq-rs-pkg-dir_rtl-002.epub,confreq-rs-pkg-dir_rtl-004.epub,confreq-rs-pkg-dir_rtl-005.epub,confreq-rs-pkg-dir_rtl-006.epub">If the <code>dir</code> attribute is set
+				<p id="confreq-rs-pkg-dir" data-tests="confreq-rs-pkg-dir_rtl-001.epub,confreq-rs-pkg-dir_rtl-002.epub,confreq-rs-pkg-dir_rtl-004.epub,confreq-rs-pkg-dir_rtl-005.epub,confreq-rs-pkg-dir_rtl-006.epub">If the <code>dir</code> attribute is set
 					and indicates a base direction of <code>ltr</code> or <code>rtl</code>, Reading Systems MUST
 					override the bidi algorithm per <a data-cite="bidi#Higher-Level_Protocols">the higher-level
 						protocols</a> defined in [[BIDI]], setting the paragraph embedding level to 0 if the base
 					direction is <code>ltr</code>, or 1 if the base direction is <code>rtl</code>.</p>
 
-				<p id="confreq-rs-pkg-dir-auto" data-tests="confreq-rs-pkg-dir-auto.epub,confreq-rs-pkg-dir_rtl-003.epub,confreq-rs-pkg-dir_rtl-005.epub">Otherwise the base direction
+				<p id="confreq-rs-pkg-dir-auto" data-tests="confreq-rs-pkg-dir_rtl-003.epub,confreq-rs-pkg-dir_rtl-005.epub">Otherwise the base direction
 					is <code>auto</code>, in which case Reading Systems MUST determine the text's direction by applying
 					the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of [[BIDI]].</p>
 			</section>


### PR DESCRIPTION
This is to be checked in case https://github.com/w3c/epub-tests/pull/31 is approved (and merged): it adds the references to the tests in that PR to the RS spec.