### PR TITLE
Typo fixes

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -356,14 +356,15 @@
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-wcag-20">MUST meet the requirements of WCAG 2.0 [[WCAG20]], but it is
-								strongly RECOMMENDED that it conform to the <a href="https://www.w3.org/TR/WCAG2/"
-									>latest recommended version of WCAG 2</a>.</p>
+								strongly RECOMMENDED that it meet the requirements of the <a
+									href="https://www.w3.org/TR/WCAG2/">latest recommended version of WCAG 2</a>.</p>
 						</li>
 
 						<li>
 							<p id="confreq-wcag-a">MUST meet the requirements of <a
 									href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a>, but it is strongly RECOMMENDED
-								that it meet <a href="https://www.w3.org/TR/WCAG2/#cc1">Level AA</a> [[WCAG2]].</p>
+								that it meet the requirements of <a href="https://www.w3.org/TR/WCAG2/#cc1">Level AA</a>
+								[[WCAG2]].</p>
 						</li>
 					</ul>
 
@@ -404,11 +405,11 @@
 						optimal reading experience.</p>
 
 					<div class="note">
-						<p>Development of WCAG 3 is currently ongoing in W3C. As this version potentially represents a
-							significant departure from WCAG 2, a future version of this specification will address
-							conformance requirements related to it. EPUB Creators are encouraged to adopt WCAG 3 once it
-							is stable and widely recognized, but conformance to the new version is not a requirement of
-							this standard.</p>
+						<p>The <a href="https://www.w3.org/WAI/GL/">W3C Accessibility Guidelines Working Group</a> is
+							currently developing WCAG 3. As this version potentially represents a significant departure
+							from WCAG 2, a future version of this specification will address conformance requirements
+							related to it. EPUB Creators are encouraged to adopt WCAG 3 once it is stable and widely
+							recognized, but conformance to the new version is not a requirement of this standard.</p>
 					</div>
 				</section>
 
@@ -426,8 +427,7 @@
 
 						<p>Consequently, when evaluating the accessibility of an EPUB Publication, EPUB Creators cannot
 							review individual pages — or Content Documents, as they are known in EPUB 3 — in isolation.
-							Rather, EPUB Creators MUST evaluate their overall accessibility as parts of a larger
-							work.</p>
+							Rather, EPUB Creators MUST evaluate their accessibility as part of the larger work.</p>
 
 						<p>For example, it is not sufficient for EPUB Creators to give individual EPUB Content Documents
 							a logical reading order if they list the documents in the wrong reading order. Likewise,
@@ -630,7 +630,7 @@
 										the user wants to cite something on the page.</p>
 									<p>The inclusion of page break markers can also allow users to move quickly forwards
 										and backwards by page without having to access the page list each time.</p>
-									<p>The inclusion of these markers also simplifies the creation a <a
+									<p>The inclusion of these markers also simplifies the creation of a <a
 											href="#sec-page-list">page list</a>, as they provide easily referenced
 										destinations for the links.</p>
 								</dd>
@@ -719,7 +719,7 @@
 										text-to-speech playback, the experience is considerably poorer than when
 										pre-recorded narration is provided. Text-to-speech engines have limited built-in
 										vocabularies, causing them to mangle and mispronounce most uncommon words they
-										encounter. As a reult users have to have words repeated and spelled out to make
+										encounter. As a result users have to have words repeated and spelled out to make
 										sense of the content, slowing down their reading and reducing comprehension.</p>
 									<p>For this reason, it is important to provide narration for the full text of a
 										publication in addition to the full text. Users can then decide which reading
@@ -1114,9 +1114,9 @@
 							It is not a requirement to conform to this specification.</p>
 					</div>
 
-					<p>How long a conformance evaluation of an EPUB Publication is good for is complex question. Unlike
-						web sites, which are continuously evolving, an EPUB Creators may never update an EPUB
-						Publication after its initial publication. As a result, an unmodified EPUB Publication will
+					<p>How long a conformance evaluation of an EPUB Publication is good for is a complex question.
+						Unlike web sites, which are continuously evolving, EPUB Creators may not update EPUB
+						Publications after their initial publication. As a result, an unmodified EPUB Publication will
 						always conform to its last evaluation.</p>
 
 					<p>It is common in publishing, however, to release updated versions of an EPUB Publication to fix
@@ -1280,7 +1280,7 @@
 				<p>A distributor may implement a digital rights management scheme that inherently impairs accessibility
 					through no fault of the EPUB Creator. Following the guidance in this section does not restrict EPUB
 					Creators from using such distributors. The intent is only that the EPUB Creator not impair
-					accessibility by activating a feature that that would normally not be active.</p>
+					accessibility by activating a feature that would normally not be active.</p>
 			</div>
 		</section>
 		<section id="privacy" class="informative">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -109,8 +109,8 @@
 					specific user needs so cannot meet broad accessibility requirements. Refer to the requirements for
 					optimized publications in <a href="#sec-optimized-pubs"></a> for more information.</p>
 
-				<p>This specification does not target a single version of EPUB. It applicable to EPUB Publications that
-					conform to any version or profile, including future versions of the standard.</p>
+				<p>This specification does not target a single version of EPUB. It is applicable to EPUB Publications
+					that conform to any version or profile, including future versions of the standard.</p>
 
 				<p>Ideally, these guidelines help evaluate any digital publication built on Open Web technologies,
 					although ensuring such application is outside the scope of this specification.</p>
@@ -146,7 +146,7 @@
 			<section id="sec-application" class="informative">
 				<h3>Application to Older Versions</h3>
 
-				<p>This specification applicable to any EPUB Publication, even if the content conforms to an older
+				<p>This specification is applicable to any EPUB Publication, even if the content conforms to an older
 					version of EPUB that does not refer to this specification (e.g., EPUB 2 [[OPF-201]]).</p>
 
 				<p>Creators of such EPUB Publications should create content in conformance with the accessibility and


### PR DESCRIPTION
Fixes the first two typos identified in #1823. Will leave this open until the issue is finalized.

Fixes #1823 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1823/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1823/epub33/a11y/index.html)
