### PR TITLE
Change respec test references to use generated report

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -74,7 +74,7 @@
                 localBiblio: biblio,
                 preProcess:[inlineCustomCSS],
                 postProcess:[addConformanceLinks, addCautionHeaders],
-                testSuiteURI: "https://github.com/w3c/epub-tests/tree/HEAD/tests/EPUBs/",
+                testSuiteURI: "https://w3c.github.io/epub-tests/results/tests.html#",
                 lint: {
                      "wpt-tests-exist": true,
 		}
@@ -722,28 +722,28 @@
 									<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
 								</tr>
 								<tr>
-									<td id="cmt-gif" data-tests="cmt-gif.epub">
+									<td id="cmt-gif" data-tests="cmt-gif">
 										<code>image/gif</code>
 									</td>
 									<td> [[GIF]] </td>
 									<td>GIF Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-jpeg" data-tests="cmt-jpeg.epub">
+									<td id="cmt-jpeg" data-tests="cmt-jpeg">
 										<code>image/jpeg</code>
 									</td>
 									<td> [[JPEG]] </td>
 									<td>JPEG Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-png" data-tests="cmt-png.epub">
+									<td id="cmt-png" data-tests="cmt-png">
 										<code>image/png</code>
 									</td>
 									<td> [[PNG]] </td>
 									<td>PNG Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-svg" data-tests="cmt-svg,confreq-rs-epub3-svg.epub">
+									<td id="cmt-svg" data-tests="cmt-svg,confreq-rs-epub3-svg">
 										<code>image/svg+xml</code>
 									</td>
 									<td>
@@ -752,7 +752,7 @@
 									<td>SVG documents</td>
 								</tr>
 								<tr>
-									<td id="cmt-webp" data-tests="cmt-webp.epub">
+									<td id="cmt-webp" data-tests="cmt-webp">
 										<code>image/webp</code>
 									</td>
 									<td> [[WebP-Container]], [[WebP-LB]] </td>
@@ -763,21 +763,21 @@
 									<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>
 								</tr>
 								<tr>
-									<td id="cmt-mp3" data-tests="cmt-mp3.epub">
+									<td id="cmt-mp3" data-tests="cmt-mp3">
 										<code>audio/mpeg</code>
 									</td>
 									<td> [[MP3]] </td>
 									<td>MP3 audio</td>
 								</tr>
 								<tr>
-									<td id="cmt-mp4-aac" data-tests="cmt-mp4-aac.epub">
+									<td id="cmt-mp4-aac" data-tests="cmt-mp4-aac">
 										<code>audio/mp4</code>
 									</td>
 									<td> [[MPEG4-Audio]], [[MP4]] </td>
 									<td>AAC LC audio using MP4 container</td>
 								</tr>
 								<tr>
-									<td id="cmt-ogg-opus" data-tests="cmt-ogg-opus.epub">
+									<td id="cmt-ogg-opus" data-tests="cmt-ogg-opus">
 										<code>audio/opus</code>
 									</td>
 									<td>[[RFC7845]]</td>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -74,7 +74,7 @@
                 localBiblio: biblio,
                 preProcess:[inlineCustomCSS],
                 postProcess:[addConformanceLinks, addCautionHeaders],
-                testSuiteURI: "https://w3c.github.io/epub-tests/results/tests.html#",
+                testSuiteURI: "https://w3c.github.io/epub-tests/results/tests.html",
                 lint: {
                      "wpt-tests-exist": true,
 		}
@@ -722,28 +722,28 @@
 									<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
 								</tr>
 								<tr>
-									<td id="cmt-gif" data-tests="cmt-gif">
+									<td id="cmt-gif" data-tests="#cmt-gif">
 										<code>image/gif</code>
 									</td>
 									<td> [[GIF]] </td>
 									<td>GIF Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-jpeg" data-tests="cmt-jpeg">
+									<td id="cmt-jpeg" data-tests="#cmt-jpeg">
 										<code>image/jpeg</code>
 									</td>
 									<td> [[JPEG]] </td>
 									<td>JPEG Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-png" data-tests="cmt-png">
+									<td id="cmt-png" data-tests="#cmt-png">
 										<code>image/png</code>
 									</td>
 									<td> [[PNG]] </td>
 									<td>PNG Images</td>
 								</tr>
 								<tr>
-									<td id="cmt-svg" data-tests="cmt-svg,confreq-rs-epub3-svg">
+									<td id="cmt-svg" data-tests="#cmt-svg,#confreq-rs-epub3-svg">
 										<code>image/svg+xml</code>
 									</td>
 									<td>
@@ -752,7 +752,7 @@
 									<td>SVG documents</td>
 								</tr>
 								<tr>
-									<td id="cmt-webp" data-tests="cmt-webp">
+									<td id="cmt-webp" data-tests="#cmt-webp">
 										<code>image/webp</code>
 									</td>
 									<td> [[WebP-Container]], [[WebP-LB]] </td>
@@ -763,21 +763,21 @@
 									<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>
 								</tr>
 								<tr>
-									<td id="cmt-mp3" data-tests="cmt-mp3">
+									<td id="cmt-mp3" data-tests="#cmt-mp3">
 										<code>audio/mpeg</code>
 									</td>
 									<td> [[MP3]] </td>
 									<td>MP3 audio</td>
 								</tr>
 								<tr>
-									<td id="cmt-mp4-aac" data-tests="cmt-mp4-aac">
+									<td id="cmt-mp4-aac" data-tests="#cmt-mp4-aac">
 										<code>audio/mp4</code>
 									</td>
 									<td> [[MPEG4-Audio]], [[MP4]] </td>
 									<td>AAC LC audio using MP4 container</td>
 								</tr>
 								<tr>
-									<td id="cmt-ogg-opus" data-tests="cmt-ogg-opus">
+									<td id="cmt-ogg-opus" data-tests="#cmt-ogg-opus">
 										<code>audio/opus</code>
 									</td>
 									<td>[[RFC7845]]</td>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -69,7 +69,7 @@
 				localBiblio: biblio,
 				preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
 				postProcess:[addConformanceLinks],
-				testSuiteURI: "https://w3c.github.io/epub-tests/results/tests.html#",
+				testSuiteURI: "https://w3c.github.io/epub-tests/results/tests.html",
 				lint: {
 					"wpt-tests-exist": true,
 				}
@@ -200,11 +200,12 @@
 				<h4>Core Media Types</h4>
 
 				<p id="confreq-rs-epub3-images"
-					data-tests="cmt-gif,cmt-jpg,cmt-png,cmt-svg,cmt-webp">If a Reading System has a <a>Viewport</a>, it MUST
-					support the <a href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type Resources</a>
+					data-tests="#cmt-gif,#cmt-jpg,#cmt-png,#cmt-svg,#cmt-webp">If a Reading System has a <a>Viewport</a>, it
+					MUST support the
+					<a href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type Resources</a>
 				    [[EPUB-33]].</p>
 
-				<p id="confreq-rs-epub3-mp3-aac" data-tests="cmt-mp3,cmt-mp4-aac,cmt-ogg-opus">If it has the capability to
+				<p id="confreq-rs-epub3-mp3-aac" data-tests="#cmt-mp3,#cmt-mp4-aac,#cmt-ogg-opus">If it has the capability to
 					render pre-recorded audio, it MUST support the <a
 						href="https://www.w3.org/TR/epub-33/#cmt-grp-audio">audio Core Media Type Resources</a>
 					[[EPUB-33]] and SHOULD support Media Overlays [[EPUB-33]].</p>
@@ -304,14 +305,15 @@
 				<h4>Base Direction</h4>
 
 				<p id="confreq-rs-pkg-dir"
-				    data-tests="confreq-rs-pkg-dir_rtl-001,confreq-rs-pkg-dir_rtl-004,confreq-rs-pkg-dir_rtl-005,confreq-rs-pkg-dir_rtl-006">
+				    data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006">
 				    If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
 				    <code>rtl</code>, Reading Systems MUST override the bidi algorithm per
 				    <a data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]], setting
 				    the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the base direction
 				    is <code>rtl</code>.</p>
 
-				<p id="confreq-rs-pkg-dir-auto" data-tests="confreq-rs-pkg-dir_rtl-002,confreq-rs-pkg-dir_rtl-003">Otherwise
+				<p id="confreq-rs-pkg-dir-auto"
+				    data-tests="#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-003">Otherwise
 					the base direction is <code>auto</code>, in which case Reading Systems MUST determine the text's
 					direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of
 					[[BIDI]].</p>
@@ -520,7 +522,7 @@
 			<section id="sec-xhtml">
 				<h3>XHTML Content Documents</h3>
 
-				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="confreq-rs-epub3-xhtml">Reading Systems MUST
+				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="#confreq-rs-epub3-xhtml">Reading Systems MUST
 					process <a href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a> [[EPUB-33]].</p>
 
 				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, Reading
@@ -624,15 +626,15 @@
 
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-mathml-rs-behavior" data-tests="confreq-mathml-rs-behavior">MUST be an
+								<p id="confreq-mathml-rs-behavior" data-tests="#confreq-mathml-rs-behavior">MUST be an
 									<a href="https://www.w3.org/TR/MathML3/chapter2.html#fund.mathmlconf"
 										>input-compliant processor</a> for <a
 										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
 									defined in the [[MATHML3]] specification.</p>
 							</li>
 							<li>
-								<p id="confreq-mathml-rs-render" data-tests="confreq-mathml-rs-behavior">MUST, if
-									it has a <a>Viewport</a>, support visual rendering of Presentation MathML.</p>
+								<p id="confreq-mathml-rs-render" data-tests="#confreq-mathml-rs-behavior">MUST, if it has a
+									<a>Viewport</a>, support visual rendering of Presentation MathML.</p>
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
@@ -653,11 +655,11 @@
 						<section id="sec-xhtml-svg-css">
 							<h6>Embedded SVG and CSS</h6>
 
-							<p id="confreq-svg-rs-css-embed-ref" data-tests="confreq-svg-rs-css-embed-ref">For the purposes
+							<p id="confreq-svg-rs-css-embed-ref" data-tests="#confreq-svg-rs-css-embed-ref">For the purposes
 								of styling SVG embedded in XHTML Content Documents <em>by reference</em>, Reading Systems
 								MUST NOT apply CSS style rules of the containing document to the referenced SVG document.</p>
 
-							<p id="confreq-svg-rs-css-embed-inc" data-tests="confreq-svg-rs-css-embed-inc">For the purposes
+							<p id="confreq-svg-rs-css-embed-inc" data-tests="#confreq-svg-rs-css-embed-inc">For the purposes
 								of styling SVG embedded in XHTML Content Documents <em>by inclusion</em>, Reading Systems
 								MUST apply applicable CSS rules of the containing document to the included SVG elements.</p>
 
@@ -684,7 +686,7 @@
 			<section id="sec-svg">
 				<h3>SVG Content Documents</h3>
 
-				<p id="confreq-rs-epub3-svg" class="support" data-tests="confreq-rs-epub3-svg">Reading Systems MUST process
+				<p id="confreq-rs-epub3-svg" class="support" data-tests="#confreq-rs-epub3-svg">Reading Systems MUST process
 					<a href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
 
 				<p>To process SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -69,7 +69,7 @@
 				localBiblio: biblio,
 				preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
 				postProcess:[addConformanceLinks],
-				testSuiteURI: "https://github.com/w3c/epub-tests/tree/HEAD/tests/EPUBs/",
+				testSuiteURI: "https://w3c.github.io/epub-tests/results/tests.html#",
 				lint: {
 					"wpt-tests-exist": true,
 				}
@@ -200,12 +200,12 @@
 				<h4>Core Media Types</h4>
 
 				<p id="confreq-rs-epub3-images"
-					data-tests="cmt-gif.epub,cmt-jpg.epub,cmt-png.epub,cmt-svg.epub,cmt-webp.epub">If a Reading System
-					has a <a>Viewport</a>, it MUST support the <a href="https://www.w3.org/TR/epub-33/#cmt-grp-image"
-						>image Core Media Type Resources</a> [[EPUB-33]].</p>
+					data-tests="cmt-gif,cmt-jpg,cmt-png,cmt-svg,cmt-webp">If a Reading System has a <a>Viewport</a>, it MUST
+					support the <a href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type Resources</a>
+				    [[EPUB-33]].</p>
 
-				<p id="confreq-rs-epub3-mp3-aac" data-tests="cmt-mp3.epub,cmt-mp4-aac.epub,cmt-ogg-opus.epub">If it has
-					the capability to render pre-recorded audio, it MUST support the <a
+				<p id="confreq-rs-epub3-mp3-aac" data-tests="cmt-mp3,cmt-mp4-aac,cmt-ogg-opus">If it has the capability to
+					render pre-recorded audio, it MUST support the <a
 						href="https://www.w3.org/TR/epub-33/#cmt-grp-audio">audio Core Media Type Resources</a>
 					[[EPUB-33]] and SHOULD support Media Overlays [[EPUB-33]].</p>
 
@@ -303,15 +303,18 @@
 			<section id="sec-pkg-doc-base-dir">
 				<h4>Base Direction</h4>
 
-				<p id="confreq-rs-pkg-dir" data-tests="confreq-rs-pkg-dir.epub">If the <code>dir</code> attribute is set
-					and indicates a base direction of <code>ltr</code> or <code>rtl</code>, Reading Systems MUST
-					override the bidi algorithm per <a data-cite="bidi#Higher-Level_Protocols">the higher-level
-						protocols</a> defined in [[BIDI]], setting the paragraph embedding level to 0 if the base
-					direction is <code>ltr</code>, or 1 if the base direction is <code>rtl</code>.</p>
+				<p id="confreq-rs-pkg-dir"
+				    data-tests="confreq-rs-pkg-dir_rtl-001,confreq-rs-pkg-dir_rtl-004,confreq-rs-pkg-dir_rtl-005,confreq-rs-pkg-dir_rtl-006">
+				    If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
+				    <code>rtl</code>, Reading Systems MUST override the bidi algorithm per
+				    <a data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]], setting
+				    the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the base direction
+				    is <code>rtl</code>.</p>
 
-				<p id="confreq-rs-pkg-dir-auto" data-tests="confreq-rs-pkg-dir-auto.epub">Otherwise the base direction
-					is <code>auto</code>, in which case Reading Systems MUST determine the text's direction by applying
-					the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of [[BIDI]].</p>
+				<p id="confreq-rs-pkg-dir-auto" data-tests="confreq-rs-pkg-dir_rtl-002,confreq-rs-pkg-dir_rtl-003">Otherwise
+					the base direction is <code>auto</code>, in which case Reading Systems MUST determine the text's
+					direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of
+					[[BIDI]].</p>
 			</section>
 
 			<section id="sec-pkg-doc-pub-identifiers">
@@ -517,9 +520,8 @@
 			<section id="sec-xhtml">
 				<h3>XHTML Content Documents</h3>
 
-				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="confreq-rs-epub3-xhtml.epub">Reading Systems
-					MUST process <a href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a>
-					[[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="confreq-rs-epub3-xhtml">Reading Systems MUST
+					process <a href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a> [[EPUB-33]].</p>
 
 				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, Reading
 					Systems MUST process XHTML Content Documents using semantics defined by the [[HTML]] specification
@@ -622,14 +624,14 @@
 
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-mathml-rs-behavior" data-tests="confreq-mathml-rs-behavior.epub">MUST be
-									an <a href="https://www.w3.org/TR/MathML3/chapter2.html#fund.mathmlconf"
+								<p id="confreq-mathml-rs-behavior" data-tests="confreq-mathml-rs-behavior">MUST be an
+									<a href="https://www.w3.org/TR/MathML3/chapter2.html#fund.mathmlconf"
 										>input-compliant processor</a> for <a
 										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
 									defined in the [[MATHML3]] specification.</p>
 							</li>
 							<li>
-								<p id="confreq-mathml-rs-render" data-tests="confreq-mathml-rs-behavior.epub">MUST, if
+								<p id="confreq-mathml-rs-render" data-tests="confreq-mathml-rs-behavior">MUST, if
 									it has a <a>Viewport</a>, support visual rendering of Presentation MathML.</p>
 							</li>
 							<li>
@@ -651,15 +653,13 @@
 						<section id="sec-xhtml-svg-css">
 							<h6>Embedded SVG and CSS</h6>
 
-							<p id="confreq-svg-rs-css-embed-ref" data-tests="confreq-svg-rs-css-embed-ref.epub">For the
-								purposes of styling SVG embedded in XHTML Content Documents <em>by reference</em>,
-								Reading Systems MUST NOT apply CSS style rules of the containing document to the
-								referenced SVG document.</p>
+							<p id="confreq-svg-rs-css-embed-ref" data-tests="confreq-svg-rs-css-embed-ref">For the purposes
+								of styling SVG embedded in XHTML Content Documents <em>by reference</em>, Reading Systems
+								MUST NOT apply CSS style rules of the containing document to the referenced SVG document.</p>
 
-							<p id="confreq-svg-rs-css-embed-inc" data-tests="confreq-svg-rs-css-embed-inc.epub">For the
-								purposes of styling SVG embedded in XHTML Content Documents <em>by inclusion</em>,
-								Reading Systems MUST apply applicable CSS rules of the containing document to the
-								included SVG elements.</p>
+							<p id="confreq-svg-rs-css-embed-inc" data-tests="confreq-svg-rs-css-embed-inc">For the purposes
+								of styling SVG embedded in XHTML Content Documents <em>by inclusion</em>, Reading Systems
+								MUST apply applicable CSS rules of the containing document to the included SVG elements.</p>
 
 							<div class="note">
 								<p>SVG included <em>by reference</em> is processed as a separate document, and can
@@ -684,8 +684,8 @@
 			<section id="sec-svg">
 				<h3>SVG Content Documents</h3>
 
-				<p id="confreq-rs-epub3-svg" class="support" data-tests="confreq-rs-epub3-svg.epub">Reading Systems MUST
-					process <a href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-svg" class="support" data-tests="confreq-rs-epub3-svg">Reading Systems MUST process
+					<a href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
 
 				<p>To process SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content
 						Documents</a>, a Reading System:</p>


### PR DESCRIPTION
Will this actually work in Respec? I don't know! (Because I don't know how to check.) But let's find out.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1826.html" title="Last updated on Sep 28, 2021, 5:58 PM UTC (1959c5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1826/9c8c5db...1959c5d.html" title="Last updated on Sep 28, 2021, 5:58 PM UTC (1959c5d)">Diff</a>