### PR TITLE
Change the section on optimized publications to informative

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1283,7 +1283,7 @@
 				</section>
 			</section>
 		</section>
-		<section id="sec-optimized-pubs">
+		<section id="sec-optimized-pubs" class="informative">
 			<h2>Optimized Publications</h2>
 
 			<p>Although WCAG [[WCAG2]] provides a general set of guidelines for making content broadly accessible,
@@ -1300,10 +1300,36 @@
 				failure to achieve a WCAG conformance level does not make it any less accessible to the intended
 				audience.</p>
 
-			<p>EPUB Creators MUST identify the standard or guidelines that an optimized EPUB Publication adheres to in a
-					<code>conformsTo</code> property in accordance with [[DCTERMS]]. For the value, EPUB Creators MUST
-				specify a URL, in accordance with [[URL]], that references the standard or guidelines the content
-				follows.</p>
+			<p>Defining requirements for optimized publications is outside the scope of this specification, as is
+				formally recognizing other standards and guidelines that address these specific needs. The general model
+				of this specification can be used as a basis for identifying how an EPUB Creator has optimized their
+				content, however.</p>
+
+			<p>In particular, if an EPUB Publication meets the requirements of an optimization standard, the following
+				best practices are recommended:</p>
+
+			<ul>
+				<li>The EPUB Publication should meet the <a href="#sec-discovery">discovery metadata requirements</a> of
+					this specification so its accessible properties are machine-readable.</li>
+				<li>The EPUB Publication should identify the standard or guidelines it follows in a
+						<code>conformsTo</code> property in accordance with [[DCTERMS]] so this information can be made
+					available to users.</li>
+				<li>If the standard does not define conformance values for the <code>conformsTo</code> property, EPUB
+					Creators should use a URL [[URL]] to where the standard is publicly available so users can look up
+					the specific details of the standard.</li>
+				<li>If the identifier is not sufficient for a user to understand conformance (e.g., the guidelines are
+					not publicly available), EPUB Creators should provide additional information about they have
+					optimized the content in the <a href="#confreq-schema-accessibilitySummary">accessibility
+						summary</a>.</li>
+			</ul>
+
+			<p>When creating guidelines for optimized EPUB Publications, it is recommended that these practices be
+				integrated as a formal requirement for conformance.</p>
+
+			<div class="note">
+				<p>Refer to the <a href="https://w3c.github.io/epub-specs/docs/optimized-pubs/">Guide to Optimized
+						Publication Standards</a> for an informative list of standards.</p>
+			</div>
 
 			<aside class="example">
 				<p>The following example shows a conformance statement for an EPUB 3 Publication that conforms to the
@@ -1319,10 +1345,6 @@
    …
 &lt;/package></pre>
 			</aside>
-
-			<p>If the URL is not sufficient for a user to understand conformance (e.g., the guidelines are not publicly
-				available), more information about how the content has been optimized SHOULD be provided in the <a
-					href="#confreq-schema-accessibilitySummary">accessibility summary</a>.</p>
 
 			<aside class="example">
 				<p>The following example shows an accessibility summary for an EPUB Publication optimized for braille
@@ -1348,13 +1370,6 @@
     photo captions are narrated at the end of the chapter where they occur.
 &lt;/meta></pre>
 			</aside>
-
-			<div class="note">
-				<p>This specification does not define or recommend standards or guidelines for producing optimized
-					content. For an informative list of such standards, refer to the <a
-						href="https://w3c.github.io/epub-specs/docs/optimized-pubs/">Guide to Optimized Publication
-						Standards</a>.</p>
-			</div>
 		</section>
 		<section id="sec-distribution" class="informative">
 			<h2>Distribution</h2>
@@ -1603,6 +1618,9 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>28-Sep-2021: The section on optimized publication has been made informative and rewritten to
+					highlight best practices for identifying conformance to such standards. See <a
+						href="https://github.com/w3c/epub-specs/pulls/1833">pull request 1833</a>.</li>
 				<li>23-Sep-2021: Added section explaining effects of internationalization on techniques used. See <a
 						href="https://github.com/w3c/epub-specs/issues/1790">issue 1790</a>.</li>
 				<li>07-Sep-2021: Added <code>refines</code> attribute to certifier metadata examples to show the


### PR DESCRIPTION
As originally mentioned in https://github.com/w3c/epub-specs/pull/1824#issuecomment-926744548, this pull request changes the section on optimized publications to informative.

I've rewritten the latter part of the section to focus on explaining how this specification can be a model for identifying optimizations so that we avoid making requirements on guidelines we don't control. More specifically, I've grouped all the recommendations together into a single list and updated the prose so that we're not requiring specific practices (i.e., that URLs must be used when we no longer require them ourselves).

The recommendations remain largely the same, so other than making the section informative the guidance is largely unchanged. We're effectively just leaving some room for specific guidelines to make these recommendations requirements themselves.

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/informative-opt-pubs/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/informative-opt-pubs/epub33/a11y/index.html)
