### PR TITLE
Add explainer about applicability of SC 2.4.6

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1207,8 +1207,8 @@
 						currently states that all headings must describe their topic or purpose. The implication of this
 						wording is that all chapters in a novel, for example, have a topic or purpose and that that
 						topic or purpose is always clearly reflected by the title of the chapter. Not only is this not
-						the case, but this success criterion also complicates the use of chapter numbers as headings
-						since these do not establish a topic.</p>
+						always the case, but this success criterion also complicates the use of chapter numbers as
+						headings since these do not establish a topic.</p>
 
 					<p>After discussion in the <a href="https://github.com/w3c/wcag/issues/2039">Accessibility
 							Guidelines Working Group's issue tracker</a>, it is clear that the <a
@@ -1715,6 +1715,9 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>29-Sep-2021: Added <a href="#titles-003">TITLES-003</a> to explain that headings only have to be
+					unique, not define the topic or purpose of a section. See <a
+						href="https://github.com/w3c/epub-specs/issues/1810">issue 1810</a>.</li>
 				<li>10-June-2021: Clarified the technique on meaningful sequence that it applies to content that spans
 					pages in a spread and is not about ordering documents in the spine. See <a
 						href="https://github.com/w3c/epub-specs/issues/1695">issue 1695</a>.</li>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1199,6 +1199,31 @@
 &lt;/html></pre>
 					</aside>
 				</section>
+
+				<section class="suppress-numbering" id="titles-003">
+					<h4>TITLES-003: Heading topic or purpose</h4>
+
+					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#non-text-content">Success Criterion 2.4.6</a>
+						currently states that all headings must describe their topic or purpose. The implication of this
+						wording is that all chapters in a novel, for example, have a topic or purpose and that that
+						topic or purpose is always clearly reflected by the title of the chapter. Not only is this not
+						the case, but this success criterion also complicates the use of chapter numbers as headings
+						since these do not establish a topic.</p>
+
+					<p>After discussion in the <a href="https://github.com/w3c/wcag/issues/2039">Accessibility
+							Guidelines Working Group's issue tracker</a>, it is clear that the <a
+							href="https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels">understanding
+							document for 2.4.6</a> captures the intent of the success criterion better than the current
+						wording &#8212; namely, that the requirement for headings is only that they establish a unique
+						context for the content.</p>
+
+					<p>By this interpretation, the headings in publications should always pass provided they are
+						unique.</p>
+
+					<p>It is expected that the wording of the success criterion will be updated to better reflect the
+						uniqueness requirement, likely in the future WCAG 3 due the complexities of changing the wording
+						for WCAG 2.</p>
+				</section>
 			</section>
 
 			<section id="sec-wcag-descriptions">
@@ -1291,7 +1316,6 @@
 				<p>This section will be updated with techniques for using multiple renditions when there is enough
 					support in Reading Systems to broadly recommend their use.</p>
 			</section>
-
 		</section>
 		<section id="sec-epub">
 			<h2>EPUB Techniques</h2>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1205,10 +1205,10 @@
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#non-text-content">Success Criterion 2.4.6</a>
 						currently states that all headings must describe their topic or purpose. The implication of this
-						wording is that all chapters in a novel, for example, have a topic or purpose and that that
-						topic or purpose is always clearly reflected by the title of the chapter. Not only is this not
-						always the case, but this success criterion also complicates the use of chapter numbers as
-						headings since these do not establish a topic.</p>
+						wording is that all chapters in a novel, for example, have a topic or purpose and that the topic
+						or purpose is always clearly reflected by the title of the chapter. Not only is this not always
+						the case, but this success criterion also complicates the use of chapter numbers as headings
+						since these do not establish a topic.</p>
 
 					<p>After discussion in the <a href="https://github.com/w3c/wcag/issues/2039">Accessibility
 							Guidelines Working Group's issue tracker</a>, it is clear that the <a


### PR DESCRIPTION
This PR adds a new section to the titles and headings section of the techniques document to explain that the wording of SC 2.4.6 does not require the heading to describe a topic, only that it be unique to identify the section.

Fixes #1810 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1810/epub33/a11y-tech/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1810/epub33/a11y-tech/index.html)
