### PR TITLE
Remove registered trademark symbols

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -74,7 +74,7 @@
 				<h3>Purpose and Scope</h3>
 
 				<p>This document, EPUB Accessibility Techniques, provides guidance on how to meet the
-					[[EPUB-A11Y-11]] discovery and accessibility requirements for EPUB® Publications.</p>
+					[[EPUB-A11Y-11]] discovery and accessibility requirements for EPUB Publications.</p>
 
 				<p>This document does not cover techniques and best practices already addressed in [[WCAG2]] and
 					[[WAI-ARIA-1.1]] for which no substantive differences in application exist.</p>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -90,7 +90,7 @@
 			<section id="sec-overview" class="informative">
 				<h3>Overview</h3>
 
-				<p>This specification, EPUB Accessibility, addresses two key needs in the EPUB® ecosystem:</p>
+				<p>This specification, EPUB Accessibility, addresses two key needs in the EPUB ecosystem:</p>
 
 				<ul>
 					<li>discoverability of the accessible qualities of EPUB Publications; and</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -83,7 +83,7 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
+			<p>EPUB 3 defines a distribution and interchange format for digital publications and documents. The EPUB
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
 				Web content — including HTML, CSS, SVG, and other resources — for distribution in a single-file
 				container.</p>
@@ -2805,14 +2805,14 @@
 									significant. The <a class="codelink" href="#sec-spine-elem"><code>spine</code>
 										element</a> provides the presentation sequence of content documents.</p>
 							</div>
-							
+
 							<section id="sec-item-elem-examples">
 								<h6>Examples</h6>
-								
+
 								<aside class="example" id="example-manifest-cmt">
-									
-									<p>The following example shows a <code>manifest</code> that contains only <a>Core Media
-										Type Resources</a>.</p>
+
+									<p>The following example shows a <code>manifest</code> that contains only <a>Core
+											Media Type Resources</a>.</p>
 									<pre>&lt;manifest&gt;
     &lt;item id="nav" 
           href="nav.xhtml" 
@@ -2858,13 +2858,13 @@
 &lt;/manifest&gt;
 </pre>
 								</aside>
-								
+
 								<aside class="example" id="example-manifest-flbk">
-									<p>The following example shows a <code>manifest</code> that references two <a>Foreign
-										Resources</a> and therefore uses the <a
-											href="#sec-foreign-restrictions-manifest">fallback chain mechanism</a> to supply
-										content alternatives. The fallback chain terminates with a <a>Core Media Type
-											Resource</a>.</p>
+									<p>The following example shows a <code>manifest</code> that references two
+											<a>Foreign Resources</a> and therefore uses the <a
+											href="#sec-foreign-restrictions-manifest">fallback chain mechanism</a> to
+										supply content alternatives. The fallback chain terminates with a <a>Core Media
+											Type Resource</a>.</p>
 									<pre>&lt;manifest&gt;
     &lt;item id="item1" 
           href="chap1_docbook.xml" 
@@ -2881,11 +2881,11 @@
 &lt;/manifest&gt;
 </pre>
 								</aside>
-								
+
 								<aside class="example">
 									<p>The following example shows a reference to a remote audio file that EPUB Creators
-										must reference from the manifest (Reading Systems will render the audio inline in
-										the XHTML Content Document, so the file is a Publication Resource).</p>
+										must reference from the manifest (Reading Systems will render the audio inline
+										in the XHTML Content Document, so the file is a Publication Resource).</p>
 									<pre>XHTML:
 &lt;audio src="http://www.example.com/book/audio/ch01.mp4" controls="controls"/&gt;
 
@@ -2894,20 +2894,21 @@ Manifest:
       href="http://www.example.com/book/audio/ch01.mp4"
       media-type="audio/mp4"/&gt;</pre>
 								</aside>
-								
+
 								<aside class="example">
-									<p>The following example shows a link to the same audio file, but in this case the EPUB
-										Creator does not list the file in the manifest (hyperlinked Remote Resources are not
-										Publication Resources). The EPUB Creator would only list the audio file in the
-										manifest if it is also referenced it from an [[?HTML]] embedded content element, as
-										above (i.e., in a context where it is used as a Publication Resource).</p>
+									<p>The following example shows a link to the same audio file, but in this case the
+										EPUB Creator does not list the file in the manifest (hyperlinked Remote
+										Resources are not Publication Resources). The EPUB Creator would only list the
+										audio file in the manifest if it is also referenced it from an [[?HTML]]
+										embedded content element, as above (i.e., in a context where it is used as a
+										Publication Resource).</p>
 									<pre>XHTML:
 &lt;a href="http://www.example.com/book/audio/ch01.mp4"&gt;Go to audio file&lt;/a&gt;
 
 Manifest:
 No Entry</pre>
 								</aside>
-								
+
 								<aside class="example">
 									<p>The following example shows a link to a local version of the audio file. For this
 										link to be valid, EPUB Creators must list the audio file in the <a
@@ -3217,13 +3218,13 @@ Spine:
 
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
 									href="#sec-vocab-assoc"></a>.</p>
-							
+
 							<section id="sec-itemref-elem-examples">
 								<h6>Examples</h6>
-								
+
 								<aside class="example">
 									<p>The following example shows a <code>spine</code> element corresponding to <a
-										href="#example-manifest-cmt">the manifest example above</a>.</p>
+											href="#example-manifest-cmt">the manifest example above</a>.</p>
 									<pre>&lt;spine page-progression-direction="ltr"&gt;
     &lt;itemref idref="intro"/&gt;
     &lt;itemref idref="c1"/&gt;

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -84,7 +84,7 @@
 	<body>
 		<section id="abstract">
 			<p id="sibling-specs">This specification, EPUB Canonical Fragment Identifier (epubcfi), defines a
-				standardized method for referencing arbitrary content within an EPUB® Publication through the use of
+				standardized method for referencing arbitrary content within an EPUB Publication through the use of
 				fragment identifiers. </p>
 
 			<p>The Web has proven that the concept of hyperlinking is tremendously powerful, but EPUB Publications have

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -52,7 +52,7 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This specification, EPUB Multiple-Rendition Publications, defines the creation and rendering of EPUB®
+			<p>This specification, EPUB Multiple-Rendition Publications, defines the creation and rendering of EPUB
 				Publications consisting of more than one Rendition.</p>
 		</section>
 		<section id="sotd"></section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -77,12 +77,12 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
+			<p>EPUB 3 defines a distribution and interchange format for digital publications and documents. The EPUB
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
 				Web content — including HTML, CSS, SVG and other resources — for distribution in a single-file
 				container.</p>
-			<p>This specification defines the conformance requirements for EPUB® 3 Reading Systems — the user agents
-				that render EPUB Publications.</p>
+			<p>This specification defines the conformance requirements for EPUB 3 Reading Systems — the user agents that
+				render EPUB Publications.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="sec-introduction">
@@ -199,14 +199,13 @@
 			<section id="sec-epub-rs-conf-cmt">
 				<h4>Core Media Types</h4>
 
-				<p id="confreq-rs-epub3-images"
-					data-tests="#cmt-gif,#cmt-jpg,#cmt-png,#cmt-svg,#cmt-webp">If a Reading System has a <a>Viewport</a>, it
-					MUST support the
-					<a href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type Resources</a>
-				    [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-images" data-tests="#cmt-gif,#cmt-jpg,#cmt-png,#cmt-svg,#cmt-webp">If a Reading
+					System has a <a>Viewport</a>, it MUST support the <a
+						href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type Resources</a>
+					[[EPUB-33]].</p>
 
-				<p id="confreq-rs-epub3-mp3-aac" data-tests="#cmt-mp3,#cmt-mp4-aac,#cmt-ogg-opus">If it has the capability to
-					render pre-recorded audio, it MUST support the <a
+				<p id="confreq-rs-epub3-mp3-aac" data-tests="#cmt-mp3,#cmt-mp4-aac,#cmt-ogg-opus">If it has the
+					capability to render pre-recorded audio, it MUST support the <a
 						href="https://www.w3.org/TR/epub-33/#cmt-grp-audio">audio Core Media Type Resources</a>
 					[[EPUB-33]] and SHOULD support Media Overlays [[EPUB-33]].</p>
 
@@ -305,18 +304,17 @@
 				<h4>Base Direction</h4>
 
 				<p id="confreq-rs-pkg-dir"
-				    data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006">
-				    If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
-				    <code>rtl</code>, Reading Systems MUST override the bidi algorithm per
-				    <a data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]], setting
-				    the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the base direction
-				    is <code>rtl</code>.</p>
+					data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006"
+					> If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
+						<code>rtl</code>, Reading Systems MUST override the bidi algorithm per <a
+						data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]],
+					setting the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the
+					base direction is <code>rtl</code>.</p>
 
-				<p id="confreq-rs-pkg-dir-auto"
-				    data-tests="#confreq-rs-pkg-dir_rtl-003,#confreq-rs-pkg-dir_rtl-005">Otherwise
-					the base direction is <code>auto</code>, in which case Reading Systems MUST determine the text's
-					direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of
-					[[BIDI]].</p>
+				<p id="confreq-rs-pkg-dir-auto" data-tests="#confreq-rs-pkg-dir_rtl-003,#confreq-rs-pkg-dir_rtl-005"
+					>Otherwise the base direction is <code>auto</code>, in which case Reading Systems MUST determine the
+					text's direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule
+						P2</a> of [[BIDI]].</p>
 			</section>
 
 			<section id="sec-pkg-doc-pub-identifiers">
@@ -523,7 +521,8 @@
 				<h3>XHTML Content Documents</h3>
 
 				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="#confreq-rs-epub3-xhtml">Reading Systems MUST
-					process <a href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a> [[EPUB-33]].</p>
+					process <a href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a>
+					[[EPUB-33]].</p>
 
 				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, Reading
 					Systems MUST process XHTML Content Documents using semantics defined by the [[HTML]] specification
@@ -627,14 +626,14 @@
 						<ul class="conformance-list">
 							<li>
 								<p id="confreq-mathml-rs-behavior" data-tests="#confreq-mathml-rs-behavior">MUST be an
-									<a href="https://www.w3.org/TR/MathML3/chapter2.html#fund.mathmlconf"
+										<a href="https://www.w3.org/TR/MathML3/chapter2.html#fund.mathmlconf"
 										>input-compliant processor</a> for <a
 										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
 									defined in the [[MATHML3]] specification.</p>
 							</li>
 							<li>
-								<p id="confreq-mathml-rs-render" data-tests="#confreq-mathml-rs-behavior">MUST, if it has a
-									<a>Viewport</a>, support visual rendering of Presentation MathML.</p>
+								<p id="confreq-mathml-rs-render" data-tests="#confreq-mathml-rs-behavior">MUST, if it
+									has a <a>Viewport</a>, support visual rendering of Presentation MathML.</p>
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
@@ -655,13 +654,15 @@
 						<section id="sec-xhtml-svg-css">
 							<h6>Embedded SVG and CSS</h6>
 
-							<p id="confreq-svg-rs-css-embed-ref" data-tests="#confreq-svg-rs-css-embed-ref">For the purposes
-								of styling SVG embedded in XHTML Content Documents <em>by reference</em>, Reading Systems
-								MUST NOT apply CSS style rules of the containing document to the referenced SVG document.</p>
+							<p id="confreq-svg-rs-css-embed-ref" data-tests="#confreq-svg-rs-css-embed-ref">For the
+								purposes of styling SVG embedded in XHTML Content Documents <em>by reference</em>,
+								Reading Systems MUST NOT apply CSS style rules of the containing document to the
+								referenced SVG document.</p>
 
-							<p id="confreq-svg-rs-css-embed-inc" data-tests="#confreq-svg-rs-css-embed-inc">For the purposes
-								of styling SVG embedded in XHTML Content Documents <em>by inclusion</em>, Reading Systems
-								MUST apply applicable CSS rules of the containing document to the included SVG elements.</p>
+							<p id="confreq-svg-rs-css-embed-inc" data-tests="#confreq-svg-rs-css-embed-inc">For the
+								purposes of styling SVG embedded in XHTML Content Documents <em>by inclusion</em>,
+								Reading Systems MUST apply applicable CSS rules of the containing document to the
+								included SVG elements.</p>
 
 							<div class="note">
 								<p>SVG included <em>by reference</em> is processed as a separate document, and can
@@ -686,8 +687,8 @@
 			<section id="sec-svg">
 				<h3>SVG Content Documents</h3>
 
-				<p id="confreq-rs-epub3-svg" class="support" data-tests="#confreq-rs-epub3-svg">Reading Systems MUST process
-					<a href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-svg" class="support" data-tests="#confreq-rs-epub3-svg">Reading Systems MUST
+					process <a href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
 
 				<p>To process SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content
 						Documents</a>, a Reading System:</p>


### PR DESCRIPTION
Fixes #1835


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1836.html" title="Last updated on Oct 4, 2021, 11:04 AM UTC (d2ee249)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1836/f366b81...d2ee249.html" title="Last updated on Oct 4, 2021, 11:04 AM UTC (d2ee249)">Diff</a>