### PR TITLE
Update the overview and fix typos

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -115,8 +115,8 @@
 					improve the ability of users to determine if the content still meets their needs. Refer to <a
 						href="#sec-optimized-pubs"></a> for more information.</p>
 
-				<p>The specification also covers the impact of distribution on the accessibility and discoverability of
-					content in <a href="#sec-distribution"></a>.</p>
+				<p>The specification also addresses the impact of distribution on the accessibility and discoverability
+					of content in <a href="#sec-distribution"></a>.</p>
 
 				<p>This specification does not target a single version of EPUB. It is applicable to EPUB Publications
 					that conform to any version or profile, including future versions of the standard.</p>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -109,9 +109,14 @@
 					allows certification of quality. An accessible EPUB Publication is one that meets the accessibility
 					requirements described in <a href="#sec-accessible-pubs"></a>.</p>
 
-				<p>The specification also establishes how to identify content that EPUB Creators have optimized for
-					specific user needs so cannot meet broad accessibility requirements. Refer to the requirements for
-					optimized publications in <a href="#sec-optimized-pubs"></a> for more information.</p>
+				<p>The specification also discusses the practice of optimizing EPUB Publications for specific reading
+					modalities. In these cases, the content cannot meet the broad accessibility requirements of this
+					specification, but by following its discoverability and reporting requirements EPUB Creators can
+					improve the ability of users to determine if the content still meets their needs. Refer to <a
+						href="#sec-optimized-pubs"></a> for more information.</p>
+
+				<p>The specification also covers the impact of distribution on the accessibility and discoverability of
+					content in <a href="#sec-distribution"></a>.</p>
 
 				<p>This specification does not target a single version of EPUB. It is applicable to EPUB Publications
 					that conform to any version or profile, including future versions of the standard.</p>
@@ -161,7 +166,7 @@
 						Creators do not have to use images of text). Although this is an important feature, it is often
 						not enough on its own to ensure that the text is fully accessible in any given language (e.g.,
 						additional information about directionality, emphasis, pronunciation, etc. may also be
-						neeed).</p>
+						needed).</p>
 
 					<p>As a consequence, there may be language- or culture-specific practices for meeting accessibility
 						requirements. Whether these practices are defined within this specification and its techniques
@@ -655,8 +660,8 @@
 
 								<dt id="sec-page-breaks-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Inserting page breaks markers into an EPUB Publication provides users with
-										context about where they are in the text. Assistive technologies can use this
+									<p>Inserting page break markers into an EPUB Publication provides users with context
+										about where they are in the text. Assistive technologies can use this
 										information to announce the current page number the user is on, for example, if
 										the user wants to cite something on the page.</p>
 									<p>The inclusion of page break markers can also allow users to move quickly forwards


### PR DESCRIPTION
I've rewritten the paragraph about optimizations given our recent changes. It now reads:

"The specification also discusses the practice of optimizing EPUB Publications for specific reading modalities. In these cases, the content cannot meet the broad accessibility requirements of this specification, but by following its discoverability and reporting requirements EPUB Creators can improve the ability of users to determine if the content still meets their needs. Refer to § 4. Optimized Publications for more information."

I've also added a pointer to the distribution section in a new paragraph after the optimization one, as the overview should point to all the main sections. I don't think we need to say as much here, so I only have:

"The specification also addresses the impact of distribution on the accessibility and discoverability of content in § 5. Distribution."

The pull request also fixes a couple of typos reported in #1838 

Fixes #1838 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1838/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1838/epub33/a11y/index.html)
