### PR TITLE
Added the ® sign to the first appearance of 'EPUB'

### DIFF
--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -82,7 +82,7 @@
 	<body>
 		<section id="abstract">
 			<p>This document provides a starting point for content authors and software developers wishing to understand
-				the EPUB 3 specifications. It consists entirely of informative overview material that describes the
+				the EPUB® 3 specifications. It consists entirely of informative overview material that describes the
 				features available in EPUB 3.</p>
 
 			<p>The current version of EPUB 3 is defined in [[EPUB-33]], which represents the second minor revision of


### PR DESCRIPTION
This is an alternative to #1836 to fix #1835: re-adding the ® sign to the Overview document's abstract.