### PR TITLE
Standardize use of the registered trademark symbol

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -63,7 +63,7 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>EPUB Accessibility Techniques defines discovery and content accessibility requirements for EPUB
+			<p>EPUB Accessibility Techniques defines discovery and content accessibility requirements for EPUB®
 				Publications.</p>
 		</section>
 		<section id="sotd"></section>
@@ -74,7 +74,7 @@
 				<h3>Purpose and Scope</h3>
 
 				<p>This document, EPUB Accessibility Techniques, provides guidance on how to meet the
-					[[EPUB-A11Y-11]] discovery and accessibility requirements for EPUB® Publications.</p>
+					[[EPUB-A11Y-11]] discovery and accessibility requirements for EPUB Publications.</p>
 
 				<p>This document does not cover techniques and best practices already addressed in [[WCAG2]] and
 					[[WAI-ARIA-1.1]] for which no substantive differences in application exist.</p>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -72,7 +72,7 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This specification specifies content conformance requirements for verifying the accessibility of EPUB
+			<p>This specification specifies content conformance requirements for verifying the accessibility of EPUB®
 				Publications. It also specifies accessibility metadata requirements for the discoverability of EPUB
 				Publications.</p>
 		</section>
@@ -90,7 +90,7 @@
 			<section id="sec-overview" class="informative">
 				<h3>Overview</h3>
 
-				<p>This specification, EPUB Accessibility, addresses two key needs in the EPUB® ecosystem:</p>
+				<p>This specification, EPUB Accessibility, addresses two key needs in the EPUB ecosystem:</p>
 
 				<ul>
 					<li>discoverability of the accessible qualities of EPUB Publications; and</li>

--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -57,7 +57,7 @@
 		<section id="abstract">
 			<p>The <a href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">European Accessibility Act (EAA)</a>  is an EU directive that establishes binding accessibility targets that must be met by many different types of products and services to strengthen the rights of people with disabilities to access goods and services, including ebooks, dedicated reading software, ereading devices, and ecommerce.</p>
 			<p>The EAA has been approved on 27 June  2019, should be implemented by EU Member States within 28 June 2022 and will enter in force from 28 June 2025.</p>
-			<p>This note aims to demonstrate that the technical requirements of the European Accessibility Act related to ebooks are met by the EPUB standard.</p>
+			<p>This note aims to demonstrate that the technical requirements of the European Accessibility Act related to ebooks are met by the EPUB® standard.</p>
 			<p>The methodology used is mapping the requirements of the EU Accessibility Act related to ebooks to the <a href="https://www.w3.org/TR/epub-a11y-11/">EPUB Accessibility</a> specification.</p>
 		</section>
 		<section id="sotd"></section>

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -44,7 +44,7 @@
 	</head>
 <body>
 <section id="abstract">
-This document, EPUB Fixed Layout Accessibility, outlines techniques and best practices for producing more accessible fixed layout publications.
+This document, EPUB Fixed Layout Accessibility, outlines techniques and best practices for producing more accessible EPUB® fixed layout publications.
 </section>
 
 <section id="sotd"></section>

--- a/epub33/locators/index.html
+++ b/epub33/locators/index.html
@@ -60,7 +60,7 @@ TBW
 
 ## Use Cases
 
- * Susan, a teacher asks her students to go to a certain location in an EPUB file that contains no publisher-provided page list. The students are using different types of reading systems, nevertheless all are able to reach the same page.
+ * Susan, a teacher asks her students to go to a certain location in an EPUB® file that contains no publisher-provided page list. The students are using different types of reading systems, nevertheless all are able to reach the same page.
 
  * Ali is a student preparing a bibliography for an essay assignment. Several of his resources are EPUBs, and he wants to reference them accurately, including location of the citation.
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -81,7 +81,7 @@
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
 				Web content — including HTML, CSS, SVG and other resources — for distribution in a single-file
 				container.</p>
-			<p>This specification defines the conformance requirements for EPUB® 3 Reading Systems — the user agents
+			<p>This specification defines the conformance requirements for EPUB 3 Reading Systems — the user agents
 				that render EPUB Publications.</p>
 		</section>
 		<section id="sotd"></section>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -40,7 +40,7 @@
 	</head>
 	<body>
 		<section id="abstract">
-			<p>This document describes authoring features and reading system support for improving the voicing of EPUB 3
+			<p>This document describes authoring features and reading system support for improving the voicing of EPUB® 3
 				publications.</p>
 		</section>
 		<section id="sotd"></section>


### PR DESCRIPTION
This PR makes sure we have a ®symbol in all the specifications and notes. In some cases, I had to move the symbol up because there are now earlier uses in the abstracts. I also found a couple of specifications that had duplicates.