### PR TITLE
Renaming tests' base URL

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -74,7 +74,7 @@
                 localBiblio: biblio,
                 preProcess:[inlineCustomCSS],
                 postProcess:[updatePermaLinks, addCautionHeaders],
-                testSuiteURI: "https://w3c.github.io/epub-tests/results/tests.html",
+                testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
                 lint: {
                      "wpt-tests-exist": true,
 		}

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -69,7 +69,7 @@
 				localBiblio: biblio,
 				preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
 				postProcess:[updatePermaLinks],
-				testSuiteURI: "https://w3c.github.io/epub-tests/docs/index.html",
+				testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
 				lint: {
 					"wpt-tests-exist": true,
 				}

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -69,7 +69,7 @@
 				localBiblio: biblio,
 				preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
 				postProcess:[updatePermaLinks],
-				testSuiteURI: "https://w3c.github.io/epub-tests/results/tests.html",
+				testSuiteURI: "https://w3c.github.io/epub-tests/docs/index.html",
 				lint: {
 					"wpt-tests-exist": true,
 				}


### PR DESCRIPTION
This PR must be merged if an only if https://github.com/w3c/epub-tests/pull/47 has been merged to adapt the test URL-s in the respec configuration object


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 12, 2021, 9:51 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fepub-specs%2Fb130db51d821444a9152b82898c3d93b12cf74dc%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 29343 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%231845.)._
</details>
