### PR TITLE
Added test references in the content doc for the `dir` attribute tests

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1191,7 +1191,7 @@
 								<code>dir</code>
 							</dt>
 							<dd>
-								<p>Specifies the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base
+								<p data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006 >Specifies the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base
 										direction</a> [[BIDI]] of the textual content and attribute values of the
 									carrying element and its descendants</p>
 								<p>Allowed values are:</p>
@@ -1201,7 +1201,7 @@
 									<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
 										Algorithm [[BIDI]].</li>
 								</ul>
-								<p>Reading Systems will assume the value <code>auto</code> when EPUB Creators omit the
+								<p data-tests="#confreq-rs-pkg-dir_rtl-003,#confreq-rs-pkg-dir_rtl-005">Reading Systems will assume the value <code>auto</code> when EPUB Creators omit the
 									attribute or use an invalid value.</p>
 								<div class="note">
 									<p>The base direction specified in the <code>dir</code> attribute does not affect

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1191,7 +1191,7 @@
 								<code>dir</code>
 							</dt>
 							<dd>
-								<p data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006 >Specifies the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base
+								<p data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006">Specifies the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base
 										direction</a> [[BIDI]] of the textual content and attribute values of the
 									carrying element and its descendants</p>
 								<p>Allowed values are:</p>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1846.html" title="Last updated on Oct 9, 2021, 11:13 AM UTC (7d9705d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1846/fb4b8d1...7d9705d.html" title="Last updated on Oct 9, 2021, 11:13 AM UTC (7d9705d)">Diff</a>