### PR TITLE
Removed dependency on common biblio file

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../common/js/biblio.js" class="remove"></script>
+		<script src="biblio.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
@@ -52,7 +52,44 @@
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
-				localBiblio: biblio,
+				localBiblio: {
+					"EPUB-3": {
+						"title": "EPUB 3",
+						"href": "https://www.w3.org/TR/epub/",
+						"publisher": "W3C"
+					},
+					"EPUBMultipleRenditions-10": {
+						"authors":[
+						"Jim Lester",
+						"Takeshi Kania",
+						"Matt Garrish"],
+						"title": "EPUB Multiple-Rendition Publications 1.0",
+						"href": "http://www.idpf.org/epub/renditions/multiple/epub-multiple-renditions-20150826.html",
+						"date": "26 August 2015",
+						"publisher": "IDPF"
+					},
+					"ISO24751-3": {
+						"title": " ISO/IEC 24751-3:2008 Information technology -- Individualized adaptability and accessibility in e-learning, education and training -- Part 3: &quot;Access for all&quot; digital resource description",
+						"href": "http://www.iso.org/iso/catalogue_detail?csnumber=43604",
+						"date": "2008-10-01"
+					},
+					"OPF-201": {
+						"title": "Open Packaging Format 2.0.1",
+						"href": "http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
+						"date": "04 September 2010",
+						"publisher": "IDPF"
+					},
+					"SWF": {
+						"title": "SWF File Format Specification Version 19",
+						"href": "https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf",
+						"date": "2012"
+					},
+					"WCAG2": {
+						"title": "Web Content Accessibility Guidelines (WCAG) 2",
+						"href": "https://www.w3.org/TR/WCAG2/",
+						"publisher": "W3C"
+					}
+				},
 				postProcess:[updatePermaLinks]
 			};</script>
 		<style>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="biblio.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="biblio.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script class="remove">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../common/js/biblio.js" class="remove"></script>
+		<script src="biblio.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script class="remove">
@@ -53,7 +53,47 @@
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
-				localBiblio: biblio,
+				localBiblio: {
+					"DAISYAudio": {
+						"title": "Navigable audio-only EPUB 3 Guidelines",
+						"href": "http://www.daisy.org/guidelines/epub/navigable-audio-only-epub3-guidelines"
+					},
+					"EPUB-3": {
+						"title": "EPUB 3",
+						"href": "https://www.w3.org/TR/epub/",
+						"publisher": "W3C"
+					},
+					"EPUB-A11Y-10": {
+						"authors":[
+						"Matt Garrish",
+						"George Kerscher",
+						"Charles LaPierre",
+						"Avneesh Singh"],
+						"title": "EPUB Accessibility 1.0",
+						"href": "http://idpf.org/epub/a11y/accessibility-20170105.html",
+						"date": "05 January 2017",
+						"publisher": "IDPF"
+					},
+					"MARC21": {
+						"title": "MARC 21 XML",
+						"href": "https://www.loc.gov/standards/marcxml/"		
+					},
+					"ONIX": {
+						"title": "ONIX for Books 3.0",
+						"href": "https://www.editeur.org/8/ONIX/"
+					},
+					"OPF-201": {
+						"title": "Open Packaging Format 2.0.1",
+						"href": "http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
+						"date": "04 September 2010",
+						"publisher": "IDPF"
+					},
+					"WCAG2": {
+						"title": "Web Content Accessibility Guidelines (WCAG) 2",
+						"href": "https://www.w3.org/TR/WCAG2/",
+						"publisher": "W3C"
+					}
+				},
 				preProcess:[inlineCustomCSS],
 				postProcess:[updatePermaLinks]
 			};</script>

--- a/epub33/core/biblio.js
+++ b/epub33/core/biblio.js
@@ -1,0 +1,92 @@
+var biblio = {
+	"CSSSnapshot": {
+		"title": "CSS Snapshot",
+		"href": "https://www.w3.org/TR/CSS/"
+	},
+	"EPUBContentDocs-301": {
+		"authors":[
+		"Markus Gylling",
+		"William McCoy",
+		"Elika J. Etimad",
+		"Matt Garrish"],
+		"title": "EPUB Content Documents 3.0.1",
+		"href": "http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
+		"date": "26 June 2014",
+		"publisher": "IDPF"
+	},
+	"EPUBPackages-32": {
+		"authors":[
+		"Matt Garrish",
+		"Dave Cramer"],
+		"title": "EPUB Packages 3.2",
+		"href": "https://www.w3.org/publishing/epub32/epub-packages.html",
+		"date": "08 May 2019",
+		"publisher": "EPUB 3 Community Group"
+	},
+	"EPUBPublications-30": {
+		"authors":[
+		"Markus Gylling",
+		"William McCoy",
+		"Matt Garrish"],
+		"title": "EPUB Publications 3.0",
+		"href": "http://idpf.org/epub/30/spec/epub30-publications-20111011.html",
+		"date": "11 October 2011",
+		"publisher": "IDPF"
+	},
+	"EPUBPublications-301": {
+		"authors":[
+		"Markus Gylling",
+		"William McCoy",
+		"Matt Garrish"],
+		"title": "EPUB Publications 3.0.1",
+		"href": "http://idpf.org/epub/301/spec/epub-publications-20140626.html",
+		"date": "26 June 2014",
+		"publisher": "IDPF"
+	},
+	"H264": {
+		"title": "H.264 : Advanced video coding for generic audiovisual services",
+		"href": "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=13189",
+		"date": "2017-04-13"
+	},
+	"ISOSchematron": {
+		"title": "ISO/IEC 19757-3: Rule-based validation — Schematron",
+		"href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c040833_ISO_IEC_19757-3_2006(E).zip",
+		"date": "2006-06-01"
+	},
+	"NVDL": {
+		"title": "ISO/IEC 19757-4: NVDL (Namespace-based Validation Dispatching Language)",
+		"href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c038615_ISO_IEC_19757-4_2006(E).zip",
+		"date": "2006-06-01"
+	},
+	"ODF": {
+		"title": "Open Document Format for Office Applications (OpenDocument) v1.0",
+		"href": "https://www.oasis-open.org/committees/download.php/12572/OpenDocument-v1.0-os.pdf",
+		"date": "1 May 2005"
+	},
+	"ONIX": {
+		"title": "ONIX for Books 3.0",
+		"href": "https://www.editeur.org/8/ONIX/"
+	},
+	"OPF-201": {
+		"title": "Open Packaging Format 2.0.1",
+		"href": "http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
+		"date": "04 September 2010",
+		"publisher": "IDPF"
+	},
+	"US-ASCII": {
+		"title": "&quot;Coded Character Set - 7-bit American Standard Code for Information Interchange&quot;, ANSI X3.4, 1986."
+	},
+	"WCAG2": {
+		"title": "Web Content Accessibility Guidelines (WCAG) 2",
+		"href": "https://www.w3.org/TR/WCAG2/",
+		"publisher": "W3C"
+	},
+	"WebP-Container": {
+		"title": "WebP Container Specification",
+		"href": "https://developers.google.com/speed/webp/docs/riff_container"
+	},
+	"WebP-LB": {
+		"title": "WebP Lossless Bitstream Specification",
+		"href": "https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification"
+	},
+}

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB 3.3</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../common/js/biblio.js" class="remove"></script>
+		<script src="./biblio.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/add-caution-hd.js" class="remove"></script>

--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility - EU Accessibility Act Mapping</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../common/js/biblio.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script class="remove">

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8" />
 		<title>EPUB Canonical Fragment Identifiers 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../common/js/biblio.js" class="remove"></script>
 		<script src="../common/js/dfn-crossref.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
@@ -74,7 +73,6 @@
 				branch: "main"
 			  },
 			  pluralize: true,
-			  localBiblio: biblio,
 			  preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
 			  postProcess:[updatePermaLinks]
           };
@@ -196,7 +194,7 @@
 				<p>A fragment identifier is the part of an IRI [[RFC3987]] that defines a location within a resource.
 					Syntactically, it is the segment attached to the end of the resource IRI starting with a hash
 						(<code>#</code>). For HTML documents, IDs and named anchors are used as fragment identifiers,
-					while for XML documents the Shorthand XPointer [[XPTRSH]] notation is used to refer to a given
+					while for XML documents the Shorthand XPointer [[XPTR-FRAMEWORK]] notation is used to refer to a given
 					ID.</p>
 
 				<p>A Canonical Fragment Identifier (CFI) is a similar construct to these, but expresses a location

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8" />
 		<title>EPUB 3 Multiple-Rendition Publications 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../common/js/biblio.js" class="remove"></script>
 		<script src="../common/js/dfn-crossref.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
@@ -44,7 +43,29 @@
                     branch: "main"
                 },
                 pluralize: true,
-                localBiblio: biblio,
+				localBiblio: {
+					"ISO24751-3": {
+						"title": " ISO/IEC 24751-3:2008 Information technology -- Individualized adaptability and accessibility in e-learning, education and training -- Part 3: &quot;Access for all&quot; digital resource description",
+						"href": "http://www.iso.org/iso/catalogue_detail?csnumber=43604",
+						"date": "2008-10-01"
+					},
+					"EPUBCFI-11": {
+						"authors":[
+							"Peter Sorotokin",
+							"Garth Conboy",
+							"Brady Duga",
+							"John Rivlin",
+							"Don Beaver",
+							"Kevin Ballard",
+							"Alastair Fettes",
+							"Daniel Weck"
+						],
+						"title": "EPUB Canonical Fragment Identifiers 1.1",
+						"href": "http://idpf.org/epub/linking/cfi/epub-cfi-20170105.html",
+						"date": "5 October 2017",
+						"publisher": "IDPF"
+					},	
+				},
                 preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
                 postProcess:[updatePermaLinks]
             };//]]>

--- a/epub33/overview/biblio.js
+++ b/epub33/overview/biblio.js
@@ -1,0 +1,232 @@
+var biblio = {
+	"CSSSnapshot": {
+		"title": "CSS Snapshot",
+		"href": "https://www.w3.org/TR/CSS/"
+	},
+	"EPUB-31": {
+		"authors":[
+		"Markus Gylling",
+		"Tzviya Siegman",
+		"Matt Garrish"],
+		"title": "EPUB 3.1",
+		"href": "http://idpf.org/epub/31/spec/epub-spec-20170105.html",
+		"date": "05 January 2017",
+		"publisher": "IDPF"
+	},
+	"EPUB-32": {
+		"authors":[
+		"Matt Garrish",
+		"Dave Cramer"],
+		"title": "EPUB 3.2",
+		"href": "https://www.w3.org/publishing/epub32/epub-spec.html",
+		"date": "08 May 2019",
+		"publisher": "EPUB 3 Community Group"
+	},
+	"EPUBChanges-30": {
+		"authors":[
+		"William McCoy",
+		"Markus Gylling"],
+		"title": "EPUB 3 Changes from 2.0.1",
+		"href": "http://idpf.org/epub/30/spec/epub30-changes-20111011.html",
+		"date": "11 October 2011",
+		"publisher": "IDPF"
+	},
+	"EPUBChanges-301": {
+		"authors":[
+		"Markus Gylling",
+		"Matt Garrish"],
+		"title": "EPUB 3.0.1 Changes from 3.0",
+		"href": "http://idpf.org/epub/301/spec/epub-changes-20140626.html",
+		"date": "26 June 2014",
+		"publisher": "IDPF"
+	},
+	"EPUBChanges-31": {
+		"authors":[
+		"Markus Gylling",
+		"Matt Garrish"],
+		"title": "EPUB 3.1 Changes from 3.0.1",
+		"href": "http://idpf.org/epub/31/spec/epub-changes-20170105.html",
+		"date": "05 January 2017",
+		"publisher": "IDPF"
+	},
+	"EPUBChanges-32": {
+		"authors":[
+		"Matt Garrish",
+		"Dave Cramer"],
+		"title": "EPUB 3.2 Changes",
+		"href": "https://www.w3.org/publishing/epub32/epub-changes.html",
+		"date": "08 May 2019",
+		"publisher": "EPUB 3 Community Group"
+	},
+	"EPUBContentDocs-30": {
+		"authors":[
+		"Markus Gylling",
+		"William McCoy",
+		"Elika J. Etimad",
+		"Matt Garrish"],
+		"title": "EPUB Content Documents 3.0",
+		"href": "http://idpf.org/epub/30/spec/epub30-contentdocs-20111011.html",
+		"date": "11 October 2011",
+		"publisher": "IDPF"
+	},
+	"EPUBContentDocs-301": {
+		"authors":[
+		"Markus Gylling",
+		"William McCoy",
+		"Elika J. Etimad",
+		"Matt Garrish"],
+		"title": "EPUB Content Documents 3.0.1",
+		"href": "http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
+		"date": "26 June 2014",
+		"publisher": "IDPF"
+	},
+	"EPUBContentDocs-31": {
+		"authors":[
+		"Markus Gylling",
+		"William McCoy",
+		"Dave Cramer",
+		"Elika J. Etimad",
+		"Matt Garrish"],
+		"title": "EPUB Content Documents 3.1",
+		"href": "http://idpf.org/epub/31/spec/epub-contentdocs-20170105.html",
+		"date": "05 January 2017",
+		"publisher": "IDPF"
+	},
+	"EPUBContentDocs-32": {
+		"authors":[
+		"Dave Cramer",
+		"Matt Garrish"],
+		"title": "EPUB Content Documents 3.2",
+		"href": "https://www.w3.org/publishing/epub32/epub-contentdocs.html",
+		"date": "08 May 2019",
+		"publisher": "EPUB 3 Community Group"
+	},
+	"EPUBMediaOverlays-30": {
+		"authors":[
+		"Marisa DeMeglio",
+		"Daniel Weck"],
+		"title": "EPUB Media Overlays 3.0",
+		"href": "http://idpf.org/epub/30/spec/epub30-mediaoverlays-20111011.html",
+		"date": "11 October 2011",
+		"publisher": "IDPF"
+	},
+	"EPUBMediaOverlays-301": {
+		"authors":[
+		"Marisa DeMeglio",
+		"Daniel Weck"],
+		"title": "EPUB Media Overlays 3.0.1",
+		"href": "http://idpf.org/epub/301/spec/epub-mediaoverlays-20140626.html",
+		"date": "26 June 2014",
+		"publisher": "IDPF"
+	},
+	"EPUBMediaOverlays-31": {
+		"authors":[
+		"Marisa DeMeglio",
+		"Daniel Weck"],
+		"title": "EPUB Media Overlays 3.1",
+		"href": "http://idpf.org/epub/31/spec/epub-mediaoverlays-20170105.html",
+		"date": "05 January 2017",
+		"publisher": "IDPF"
+	},
+	"EPUBMediaOverlays-32": {
+		"authors":[
+		"Marisa DeMeglio",
+		"Daniel Weck"],
+		"title": "EPUB Media Overlays 3.2",
+		"href": "https://www.w3.org/publishing/epub32/epub-mediaoverlays.html",
+		"date": "08 May 2019",
+		"publisher": "EPUB 3 Community Group"
+	},
+	"EPUBPackages-31": {
+		"authors":[
+		"Markus Gylling",
+		"William McCoy",
+		"Matt Garrish"],
+		"title": "EPUB Packages 3.1",
+		"href": "http://idpf.org/epub/31/spec/epub-packages-20170105.html",
+		"date": "05 January 2017",
+		"publisher": "IDPF"
+	},
+	"EPUBPackages-32": {
+		"authors":[
+		"Matt Garrish",
+		"Dave Cramer"],
+		"title": "EPUB Packages 3.2",
+		"href": "https://www.w3.org/publishing/epub32/epub-packages.html",
+		"date": "08 May 2019",
+		"publisher": "EPUB 3 Community Group"
+	},
+	"EPUBPublications-30": {
+		"authors":[
+		"Markus Gylling",
+		"William McCoy",
+		"Matt Garrish"],
+		"title": "EPUB Publications 3.0",
+		"href": "http://idpf.org/epub/30/spec/epub30-publications-20111011.html",
+		"date": "11 October 2011",
+		"publisher": "IDPF"
+	},
+	"EPUBPublications-301": {
+		"authors":[
+		"Markus Gylling",
+		"William McCoy",
+		"Matt Garrish"],
+		"title": "EPUB Publications 3.0.1",
+		"href": "http://idpf.org/epub/301/spec/epub-publications-20140626.html",
+		"date": "26 June 2014",
+		"publisher": "IDPF"
+	},
+	"OCF-201": {
+		"title": "EPUB Open Container Format (OCF) 2.0.1",
+		"href": "http://www.idpf.org/epub/20/spec/OCF_2.0.1_draft.doc",
+		"date": "04 September 2010",
+		"publisher": "IDPF"
+	},
+	"OCF-30": {
+		"authors":[
+		"James Pritchett",
+		"Markus Gylling"],
+		"title": "EPUB Open Container Format (OCF) 3.0",
+		"href": "http://idpf.org/epub/30/spec/epub30-ocf-20111011.html",
+		"date": "11 October 2011",
+		"publisher": "IDPF"
+	},
+	"OCF-301": {
+		"authors":[
+		"James Pritchett",
+		"Markus Gylling"],
+		"title": "EPUB Open Container Format (OCF) 3.0.1",
+		"href": "http://idpf.org/epub/301/spec/epub-ocf-20140626.html",
+		"date": "26 June 2014",
+		"publisher": "IDPF"
+	},
+	"OCF-31": {
+		"authors":[
+		"James Pritchett",
+		"Markus Gylling"],
+		"title": "Open Container Format (OCF) 3.1",
+		"href": "http://idpf.org/epub/31/spec/epub-ocf-20170105.html",
+		"date": "05 January 2017",
+		"publisher": "IDPF"
+	},
+	"OCF-32": {
+		"authors":[
+		"Garth Conboy"],
+		"title": "Open Container Format (OCF) 3.2",
+		"href": "https://www.w3.org/publishing/epub32/epub-ocf.html",
+		"date": "08 May 2019",
+		"publisher": "EPUB 3 Community Group"
+	},
+	"OPF-201": {
+		"title": "Open Packaging Format 2.0.1",
+		"href": "http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
+		"date": "04 September 2010",
+		"publisher": "IDPF"
+	},
+	"OPS-201": {
+		"title": "Open Publication Structure 2.0.1",
+		"href": "http://www.idpf.org/epub/20/spec/OPS_2.0.1_draft.htm",
+		"date": "04 September 2010",
+		"publisher": "IDPF"
+	},
+}

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB 3 Overview</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../common/js/biblio.js" class="remove"></script>
+		<script src="./biblio.js" class="remove"></script>
 		<script src="../common/js/dfn-crossref.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB Reading Systems 3.3</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-		<script src="../common/js/biblio.js" class="remove"></script>
+		<!-- <script src="./biblio.js" class="remove"></script> -->
 		<script src="../common/js/dfn-crossref.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
@@ -66,7 +66,44 @@
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
-				localBiblio: biblio,
+				localBiblio: {
+					"CSSSnapshot": {
+						"title": "CSS Snapshot",
+						"href": "https://www.w3.org/TR/CSS/"
+					},
+					"EPUBContentDocs-301": {
+						"authors":[
+						"Markus Gylling",
+						"William McCoy",
+						"Elika J. Etimad",
+						"Matt Garrish"],
+						"title": "EPUB Content Documents 3.0.1",
+						"href": "http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
+						"date": "26 June 2014",
+						"publisher": "IDPF"
+					},
+					"EPUBPackages-32": {
+						"authors":[
+						"Matt Garrish",
+						"Dave Cramer"],
+						"title": "EPUB Packages 3.2",
+						"href": "https://www.w3.org/publishing/epub32/epub-packages.html",
+						"date": "08 May 2019",
+						"publisher": "EPUB 3 Community Group"
+					},
+					"H264": {
+						"title": "H.264 : Advanced video coding for generic audiovisual services",
+						"href": "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=13189",
+						"date": "2017-04-13"
+					},
+					"US-ASCII": {
+						"title": "&quot;Coded Character Set - 7-bit American Standard Code for Information Interchange&quot;, ANSI X3.4, 1986."
+					},
+					"W3CProcess": {
+						"title": "W3C Process Document",
+						"href": "https://www.w3.org/Consortium/Process/"
+					},
+				},
 				preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
 				postProcess:[updatePermaLinks],
 				testSuiteURI: "https://w3c.github.io/epub-tests/results/tests.html",

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8" />
 		<title>EPUB 3 Text-to-Speech Enhancements 1.0</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
-		<script src="../common/js/biblio.js" class="remove"></script>
 		<script src="../common/js/dfn-crossref.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
@@ -32,7 +31,19 @@
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
-				localBiblio: biblio,
+				localBiblio: {
+					"EPUBContentDocs-30": {
+						"authors":[
+						"Markus Gylling",
+						"William McCoy",
+						"Elika J. Etimad",
+						"Matt Garrish"],
+						"title": "EPUB Content Documents 3.0",
+						"href": "http://idpf.org/epub/30/spec/epub30-contentdocs-20111011.html",
+						"date": "11 October 2011",
+						"publisher": "IDPF"
+					},
+				},
 				preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
 				postProcess:[updatePermaLinks]
 			};//]]>


### PR DESCRIPTION
As discussed on https://github.com/w3c/epub-specs/pull/1847#issuecomment-940991574: removed the dependency on the common biblio file for overview, core, rs, epubcfi, multi-redn, tts. 

In most of the cases only 1-2 entries were necessary and I added them to the respec structure directly; only overview and core warrants, in my view, the extra drag of a separate biblio file locally.

(It seems that the only IDPF document that is in specref is the ssv one; no idea how this happened. Somebody needed it... We could add the historical references but I do not think it is worth it. These are all cast in concrete...)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1848.html" title="Last updated on Oct 13, 2021, 9:31 AM UTC (caed15f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1848/20faad5...caed15f.html" title="Last updated on Oct 13, 2021, 9:31 AM UTC (caed15f)">Diff</a>