### PR TITLE
Add references for various @dauwhe tests

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3208,8 +3208,9 @@ Spine:
 								the value "<code>yes</code>" for <code>itemref</code> elements without a
 									<code>linear</code> attribute.</p>
 
-							<p>EPUB Creators MUST provide a means of accessing all non-linear content (e.g., hyperlinks
-								in the content or from the <a href="#sec-nav">EPUB Navigation Document</a>).</p>
+							<p id="confreq-spine-nonlinear" data-tests="#confreq-spine-nonlinear">EPUB Creators MUST provide
+								a means of accessing all non-linear content (e.g., hyperlinks in the content or from the
+								<a href="#sec-nav">EPUB Navigation Document</a>).</p>
 
 							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
 									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -334,12 +334,11 @@
 				<dl class="conformance-list">
 					<dt id="conf-meta-ws">White Space</dt>
 					<dd>
-						<p>Reading Systems MUST <a
-								href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">strip and
-								collapse ASCII whitespace</a> [[Infra]] from Dublin Core [[DC11]] and <a
-								href="https://www.w3.org/TR/epub-33/#sec-meta-elem"><code>meta</code></a> element <a
-								href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[EPUB-33]] before
-							processing.</p>
+						<p id="confreq-rs-pkg-whitespace" data-tests="#confreq-rs-pkg-whitespace">Reading Systems MUST
+							<a href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">strip and collapse
+							ASCII whitespace</a> [[Infra]] from Dublin Core [[DC11]] and
+							<a href="https://www.w3.org/TR/epub-33/#sec-meta-elem"><code>meta</code></a> element
+							<a href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[EPUB-33]] before processing.</p>
 					</dd>
 
 					<dt id="dc-identifier">The <code>identifier</code> element</dt>
@@ -352,9 +351,9 @@
 
 					<dt id="dc-title">The <code>title</code> element</dt>
 					<dd>
-						<p id="title-order">Reading Systems MUST recognize the first <code>title</code> element in
-							document order as the main title of the EPUB Publication and present it to users before
-							other title elements.</p>
+						<p id="title-order" data-test="#title-order">Reading Systems MUST recognize the first
+							<code>title</code> element in document order as the main title of the EPUB Publication and
+						    present it to users before other title elements.</p>
 						<p>This specification does not define how to process additional <code>title</code> elements.</p>
 					</dd>
 
@@ -374,12 +373,12 @@
 
 					<dt id="dc-creator">The <code>creator</code> element</dt>
 					<dd>
-						<p>When determining display priority, Reading Systems MUST use the document order of
-								<code>creator</code> elements in the <code>metadata</code> section, where the first
-								<code>creator</code> element encountered is the primary creator. If a Reading System
-							exposes creator metadata to the user, it SHOULD include all the creators listed in the
-								<code>metadata</code> section whenever possible (e.g., when not constrained by display
-							considerations).</p>
+						<p id="confreq-rs-pkg-creator-order" data-tests="#confreq-rs-pkg-creator-order">When determining
+							display priority, Reading Systems MUST use the document order of <code>creator</code> elements in
+							the <code>metadata</code> section, where the first <code>creator</code> element encountered is
+							the primary creator. If a Reading System exposes creator metadata to the user, it SHOULD include
+							all the creators listed in the <code>metadata</code> section whenever possible (e.g., when not
+						    constrained by display considerations).</p>
 					</dd>
 
 					<dt id="meta">The <code>meta</code> element</dt>
@@ -387,8 +386,9 @@
 						<p>If a Reading System does not recognize the <code>scheme</code> attribute value, it SHOULD
 							treat the value of the element as a string.</p>
 						<p>Reading Systems SHOULD ignore all <code>meta</code> elements whose <code>property</code>
-							attributes define expressions they do not recognize. A Reading System MUST NOT fail when
-							encountering unknown expressions.</p>
+							attributes define expressions they do not recognize.
+							<span id="confreq-rs-pkg-meta-unknown" data-tests="#confreq-rs-pkg-meta-unknown">A Reading System
+							MUST NOT fail when encountering unknown expressions.</span></p>
 						<p>If the <code>property</code> attribute's value does not include a prefix, Reading Systems
 							MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to <a
 								href="#sec-property-datatype">expand the value</a>.</p>
@@ -441,8 +441,9 @@
 						href="https://url.spec.whatwg.org/#concept-url">URL record</a> [[URL]].</p>
 
 				<p>Reading Systems MAY optimize the rendering depending on the properties set in the
-						<code>properties</code> attribute (e.g., disable a rendering process or use a fallback). Reading
-					Systems MUST ignore values of the <code>properties</code> attribute they do not recognize.</p>
+					<code>properties</code> attribute (e.g., disable a rendering process or use a fallback).
+					<span id="confreq-rs-pkg-manifest-unknown" data-tests="#confreq-rs-pkg-manifest-unknown">Reading
+						Systems MUST ignore values of the <code>properties</code> attribute they do not recognize.</span></p>
 
 				<p id="confreq-rendition-rs-manifest">It SHOULD NOT use non-<a>Publication Resources</a> in the
 					rendering of an EPUB Publication due to the inherent limitations and risks involved (e.g., lack of
@@ -479,8 +480,8 @@
 					beginning of the default reading order; and, 2) rendering successive primary items in the order
 					given in the <code>spine</code>.</p>
 
-				<p>When a user traverses the default reading order defined in the <a
-						href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[EPUB-33]], a Reading System MAY
+				<p id="confreq-rendition-rs-spine-nonlinear">When a user traverses the default reading order defined in the
+					<a href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[EPUB-33]], a Reading System MAY
 					automatically skip <code>itemref</code> elements marked as non-linear (excluding when a user
 					specifically activates a hyperlink to such items). Reading Systems MAY also provide the option for
 					users to select whether to skip non-linear content by default or not.</p>
@@ -499,15 +500,17 @@
 					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 
-				<p>Reading Systems MUST ignore all metadata properties expressed in spine <code>itemref</code>
-					<code>properties</code> attribute that they do not recognize.</p>
+				<p id="confreq-rs-pkg-spine-unknown" data-tests="#confreq-rs-pkg-spine-unknown">Reading Systems MUST ignore
+					all metadata properties expressed in spine <code>itemref</code> <code>properties</code> attribute that
+				    they do not recognize.</p>
 			</section>
 
 			<section id="sec-pkg-doc-collections">
 				<h3>Collections</h3>
 
-				<p>In the context of this specification, support for collections in Reading Systems is OPTIONAL. Reading
-					Systems MUST ignore <code>collection</code> elements that define unrecognized roles.</p>
+				<p>In the context of this specification, support for collections in Reading Systems is OPTIONAL.
+					<span id="confreq-rs-pkg-collections-unknown" data-tests="#confreq-rs-pkg-collections-unknown">Reading
+						Systems MUST ignore <code>collection</code> elements that define unrecognized roles.</span></p>
 			</section>
 		</section>
 		<section id="sec-contentdocs">
@@ -904,8 +907,10 @@
 						[[EPUB-33]].</p>
 				</li>
 				<li>
-					<p id="confreq-nav-activation">MUST relocate the current reading position to the destination
-						identified by an activated link when the link is to a <a>Publication Resource</a>.</p>
+					<p id="confreq-nav-activation"
+					   data-tests="#confreq-nav-activation_in-spine,#confreq-nav-activation_not-in-spine">MUST relocate the
+					  current reading position to the destination identified by an activated link when the link is to a
+					  <a>Publication Resource</a>.</p>
 				</li>
 				<li>
 					<p id="confreq-nav-ol-style">MUST NOT show list item numbering on <code>nav</code> elements when
@@ -916,9 +921,9 @@
 				</li>
 			</ul>
 
-			<p id="confreq-nav-spine">Reading Systems MUST honor the above requirements irrespective of whether the EPUB
-				Navigation Document is part of the <a href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a>
-				[[EPUB-33]].</p>
+			<p id="confreq-nav-spine" data-tests="#confreq-nav-spine_in-spine,#confreq-nav-spine_not-in-spine">Reading
+				Systems MUST honor the above requirements irrespective of whether the EPUB Navigation Document is part of the
+				<a href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[EPUB-33]].</p>
 
 		</section>
 		<section id="sec-fixed-layouts">
@@ -1158,10 +1163,12 @@
 					<dl class="conformance-list">
 						<dt id="sec-container-metainf-container.xml">Container File (<code>container.xml</code>)</dt>
 						<dd>
-							<p id="container-default-rendition">A Reading System MUST, by default, use the Package
-								Document referenced from first <code>rootfile</code> element to render the EPUB
-								Publication. If the Reading System recognizes a means of selecting from the other
-								available options, it MAY choose a more appropriate Package Document.</p>
+							<p id="container-default-rendition"
+							   data-tests="#container-default-rendition_arbitrary,#container-default-rendition_multiple">A
+							  Reading System MUST, by default, use the Package Document referenced from first
+							  <code>rootfile</code> element to render the EPUB Publication. If the Reading System recognizes
+							  a means of selecting from the other available options, it MAY choose a more appropriate
+							  Package Document.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-metadata.xml">Metadata File (<code>metadata.xml</code>)</dt>


### PR DESCRIPTION
This uses the new test names from https://github.com/w3c/epub-tests/pull/48.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1850.html" title="Last updated on Oct 13, 2021, 6:11 PM UTC (a23f364)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1850/f63ba0f...a23f364.html" title="Last updated on Oct 13, 2021, 6:11 PM UTC (a23f364)">Diff</a>