### PR TITLE
Change SSV Short name from `epub-ssv-11` to `epub-ssv`

### DIFF
--- a/epub33/core/biblio.js
+++ b/epub33/core/biblio.js
@@ -1,5 +1,5 @@
 var biblio = {
-	"EPUB-SSV-11": {
+	"EPUB-SSV": {
 		"title": "EPUB 3 Structural Semantics Vocabulary",
 		"href": "https://w3c.github.io/epub-specs/epub33/ssv/",
 		"authors" : [

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4578,7 +4578,7 @@ Spine:
 
 						<aside class="example">
 							<p>The following example shows a <code>landmarks</code>
-								<code>nav</code> element with structural semantics drawn from [[?EPUB-SSV-11]].</p>
+								<code>nav</code> element with structural semantics drawn from [[?EPUB-SSV]].</p>
 							<pre>&lt;nav epub:type="landmarks"&gt;
     &lt;h2&gt;Guide&lt;/h2&gt;
     &lt;ol&gt;
@@ -4600,9 +4600,9 @@ Spine:
 						<p>The following landmarks are recommended to include when available:</p>
 
 						<ul>
-							<li><a href="https://w3c.github.io/epub-specs/epub33/ssv/#bodymatter"><code>bodymatter</code></a> [[?EPUB-SSV-11]] &#8212; Reading Systems often use this
+							<li><a href="https://w3c.github.io/epub-specs/epub33/ssv/#bodymatter"><code>bodymatter</code></a> [[?EPUB-SSV]] &#8212; Reading Systems often use this
 								landmark to automatically jump users past the front matter when they begin reading.</li>
-							<li><a href="https://w3c.github.io/epub-specs/epub33/ssv/#toc-1"><code>toc</code></a> [[?EPUB-SSV-11]] &#8212; If the table of contents is available in
+							<li><a href="https://w3c.github.io/epub-specs/epub33/ssv/#toc-1"><code>toc</code></a> [[?EPUB-SSV]] &#8212; If the table of contents is available in
 								the spine, Reading Systems may use this landmark to take users to the document
 								containing it.</li>
 						</ul>
@@ -7575,7 +7575,7 @@ html.my-document-playing * {
 &lt;/html&gt;</pre>
 					</aside>
 
-					<p>The following non-exhaustive list represents terms from the Structural Semantics Vocabulary [[?EPUB-SSV-11]]
+					<p>The following non-exhaustive list represents terms from the Structural Semantics Vocabulary [[?EPUB-SSV]]
 						for which Reading Systems may offer the option of skippability:</p>
 
 					<ul>
@@ -7678,7 +7678,7 @@ html.my-document-playing * {
 					</aside>
 
 					<p>The following non-exhaustive list represents terms from the Structural
-							Semantics Vocabulary [[?EPUB-SSV-11]] for which Reading Systems may offer the option of escapability:</p>
+							Semantics Vocabulary [[?EPUB-SSV]] for which Reading Systems may offer the option of escapability:</p>
 
 					<ul>
 						<li>
@@ -8007,7 +8007,7 @@ html.my-document-playing * {
 					section).</p>
 
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
-					the EPUB 3 Structural Semantics Vocabulary [[?EPUB-SSV-11]]. EPUB Creators MAY include
+					the EPUB 3 Structural Semantics Vocabulary [[?EPUB-SSV]]. EPUB Creators MAY include
 					unprefixed terms that are not part of this vocabulary, but the preferred method for adding custom
 					semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a
 						href="#sec-vocab-assoc"></a> for more information.</p>

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -66,7 +66,7 @@
 		</section>
 		<section id="sotd"></section>
 
-		<section id="introduction">
+		<section id="sec-introduction">
 			<h2>Introduction</h2>
 
 			<p>Structural semantics add additional meaning about the specific structural purpose an HTML (or SVG) element plays.
@@ -113,7 +113,7 @@
 			</section>
 		</section>
 			
-		<section id="partitions">
+		<section id="sec-partitions">
 			<h4>Document Partitions</h4>
 			<dl>
 				<dt id="cover">cover</dt>
@@ -175,7 +175,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="divisions">
+		<section id="sec-divisions">
 			<h4>Document Divisions</h4>
 			<dl>
 				<dt id="volume">volume</dt>
@@ -255,7 +255,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="sections">
+		<section id="sec-sections">
 			<h4>Document Sections and Components</h4>
 			<p>Sections and components that typically occur in the publication bodymatter.</p>
 			<dl>
@@ -455,7 +455,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="navigation">
+		<section id="sec-navigation">
 			<h4>Document Navigation</h4>
 			<dl>
 				<dt id="toc-1">toc</dt>
@@ -546,7 +546,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="document-references">
+		<section id="sec-document-references">
 			<h4>Document Reference Sections</h4>
 			<dl>
 				<dt id="appendix">appendix</dt>
@@ -1158,7 +1158,7 @@
 				</dl>
 			</section>
 		</section>
-		<section id="preliminary">
+		<section id="sec-preliminary">
 			<h4>Preliminary Sections and Components</h4>
 			<p>Preliminary sections and components, typically occurring in the publication frontmatter.</p>
 			<dl>
@@ -1344,7 +1344,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="complementary">
+		<section id="sec-complementary">
 			<h4>Complementary Content</h4>
 			<dl>
 				<dt id="case-study">case-study<span class="status draft"> [draft]</span>
@@ -1552,7 +1552,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="titles">
+		<section id="sec-titles">
 			<h4>Titles and Headings</h4>
 			<dl>
 				<dt id="halftitle">halftitle</dt>
@@ -1737,7 +1737,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="educational">
+		<section id="sec-educational">
 			<h4>Educational Content</h4>
 			<section id="learning-obj">
 				<h5 id="h_learning-obj">Learning objectives</h5>
@@ -2061,7 +2061,7 @@
 				</dl>
 			</section>
 		</section>
-		<section id="comics">
+		<section id="sec-comics">
 			<h4>Comics</h4>
 			<dl>
 				<dt id="panel">panel</dt>
@@ -2574,7 +2574,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="pagination">
+		<section id="sec-pagination">
 			<h4>Pagination</h4>
 			<dl>
 				<dt id="pagebreak">pagebreak</dt>
@@ -2622,7 +2622,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="tables">
+		<section id="sec-tables">
 			<h4>Tables</h4>
 			<dl>
 				<dt id="table">table</dt>
@@ -2669,7 +2669,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="lists">
+		<section id="sec-lists">
 			<h4>Lists</h4>
 			<dl>
 				<dt id="list">list</dt>
@@ -2702,7 +2702,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="figures">
+		<section id="sec-figures">
 			<h4>Figures</h4>
 			<dl>
 				<dt id="figure">figure</dt>
@@ -2722,7 +2722,7 @@
 				</dd>
 			</dl>
 		</section>
-		<section id="asides">
+		<section id="sec-asides">
 			<h4>Asides</h4>
 			<dl>
 				<dt id="aside">aside</dt>

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
 	<head>
 		<meta charset="utf-8" />
-		<title>EPUB 3 Structural Semantics Vocabulary 1.1</title>
+		<title>EPUB 3 Structural Semantics Vocabulary</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
 		<script src="../common/js/dfn-crossref.js" class="remove"></script>
 		<script src="../common/js/permalink-a11y.js" class="remove"></script>

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -13,7 +13,7 @@
 				group: "epub",
 				wgPublicList: "public-epub3",
 				specStatus: "ED",
-				shortName: "epub-ssv-1.1",
+				shortName: "epub-ssv",
 				edDraftURI: "https://w3c.github.io/epub-specs/epub33/ssv/",
 				noRecTrack: true,
 				editors: [


### PR DESCRIPTION
The WG [resolution on publication](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-10-14-epub#resolution1) specified the shortname as `epub-ssv` and not as `epub-ssv-11`. This PR makes the necessary changes.

B.t.w.: if we do this (potentially yielding a small clash with the `epub-ssv` already used for the IDPF version in specref) then we may want to remove the 1.1 from the title, too. This PR preempted this and does that, too, but I can roll that back.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1856.html" title="Last updated on Oct 15, 2021, 9:58 AM UTC (a52c59a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1856/7339274...a52c59a.html" title="Last updated on Oct 15, 2021, 9:58 AM UTC (a52c59a)">Diff</a>