### PR TITLE
Clarify where remote resources can be referenced

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -993,7 +993,7 @@
 									href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
 										><code>audio</code> element</a> (either from its <code>src</code> attribute or a
 								child <a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element"
-										><code>track</code> element</a>) or from a Media Overlays <a
+										><code>track</code> element</a>) and from the Media Overlays <a
 									href="#sec-smil-audio-elem"><code>audio</code> element</a>.</p>
 						</li>
 						<li>
@@ -1011,7 +1011,10 @@
 						<li>
 							<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a> referenced
 								from <a href="https://www.w3.org/TR/css-fonts-5/#font-face-rule"><code>@font-face</code>
-									rules</a> [[CSS-Fonts-5]].</p>
+									rules</a> [[CSS-FONTS-5]], <a href="https://www.w3.org/TR/css-cascade-4/#at-import"
+										><code>@import</code> rules</a> [[CSS-CASCADE-4]], and the [[HTML]] <a
+									href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"
+										><code>link</code> element</a>.</p>
 						</li>
 					</ul>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -988,16 +988,29 @@
 
 					<ul class="conformance-list">
 						<li>
-							<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a></p>
+							<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a> when
+								referenced from the {{HTML]] <a
+									href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
+										><code>audio</code> element</a> (either from its <code>src</code> attribute or a
+								child <a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element"
+										><code>track</code> element</a>).</p>
 						</li>
 						<li>
-							<p id="sec-resource-locations-video"><a href="#cmt-grp-video">Video resources</a></p>
+							<p id="sec-resource-locations-video"><a href="#cmt-grp-video">Video resources</a> when
+								referenced from the [[HTML]] <a
+									href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
+										><code>video</code> element</a> (either from its <code>src</code> attribute or a
+								child <a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element"
+										><code>track</code> element</a>).</p>
 						</li>
 						<li>
-							<p id="sec-resource-locations-script">Resources that scripts retrieve</p>
+							<p id="sec-resource-locations-script">Resources retrieved via scripting APIs (e.g.,
+								XmlHttpRequest [[?XHR]] and Fetch [[?FETCH]]).</p>
 						</li>
 						<li>
-							<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a></p>
+							<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a> referenced
+								from <a href="https://www.w3.org/TR/css-fonts-5/#font-face-rule"><code>@font-face</code>
+									rules</a> [[CSS-Fonts-5]].</p>
 						</li>
 					</ul>
 
@@ -1191,7 +1204,9 @@
 								<code>dir</code>
 							</dt>
 							<dd>
-								<p data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006">Specifies the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base
+								<p
+									data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006"
+									>Specifies the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base
 										direction</a> [[BIDI]] of the textual content and attribute values of the
 									carrying element and its descendants</p>
 								<p>Allowed values are:</p>
@@ -1201,8 +1216,9 @@
 									<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
 										Algorithm [[BIDI]].</li>
 								</ul>
-								<p data-tests="#confreq-rs-pkg-dir_rtl-003,#confreq-rs-pkg-dir_rtl-005">Reading Systems will assume the value <code>auto</code> when EPUB Creators omit the
-									attribute or use an invalid value.</p>
+								<p data-tests="#confreq-rs-pkg-dir_rtl-003,#confreq-rs-pkg-dir_rtl-005">Reading Systems
+									will assume the value <code>auto</code> when EPUB Creators omit the attribute or use
+									an invalid value.</p>
 								<div class="note">
 									<p>The base direction specified in the <code>dir</code> attribute does not affect
 										the ordering of characters within directional runs, only the relative ordering
@@ -2805,14 +2821,14 @@
 									significant. The <a class="codelink" href="#sec-spine-elem"><code>spine</code>
 										element</a> provides the presentation sequence of content documents.</p>
 							</div>
-							
+
 							<section id="sec-item-elem-examples">
 								<h6>Examples</h6>
-								
+
 								<aside class="example" id="example-manifest-cmt">
-									
-									<p>The following example shows a <code>manifest</code> that contains only <a>Core Media
-										Type Resources</a>.</p>
+
+									<p>The following example shows a <code>manifest</code> that contains only <a>Core
+											Media Type Resources</a>.</p>
 									<pre>&lt;manifest&gt;
     &lt;item id="nav" 
           href="nav.xhtml" 
@@ -2858,13 +2874,13 @@
 &lt;/manifest&gt;
 </pre>
 								</aside>
-								
+
 								<aside class="example" id="example-manifest-flbk">
-									<p>The following example shows a <code>manifest</code> that references two <a>Foreign
-										Resources</a> and therefore uses the <a
-											href="#sec-foreign-restrictions-manifest">fallback chain mechanism</a> to supply
-										content alternatives. The fallback chain terminates with a <a>Core Media Type
-											Resource</a>.</p>
+									<p>The following example shows a <code>manifest</code> that references two
+											<a>Foreign Resources</a> and therefore uses the <a
+											href="#sec-foreign-restrictions-manifest">fallback chain mechanism</a> to
+										supply content alternatives. The fallback chain terminates with a <a>Core Media
+											Type Resource</a>.</p>
 									<pre>&lt;manifest&gt;
     &lt;item id="item1" 
           href="chap1_docbook.xml" 
@@ -2881,11 +2897,11 @@
 &lt;/manifest&gt;
 </pre>
 								</aside>
-								
+
 								<aside class="example">
 									<p>The following example shows a reference to a remote audio file that EPUB Creators
-										must reference from the manifest (Reading Systems will render the audio inline in
-										the XHTML Content Document, so the file is a Publication Resource).</p>
+										must reference from the manifest (Reading Systems will render the audio inline
+										in the XHTML Content Document, so the file is a Publication Resource).</p>
 									<pre>XHTML:
 &lt;audio src="http://www.example.com/book/audio/ch01.mp4" controls="controls"/&gt;
 
@@ -2894,20 +2910,21 @@ Manifest:
       href="http://www.example.com/book/audio/ch01.mp4"
       media-type="audio/mp4"/&gt;</pre>
 								</aside>
-								
+
 								<aside class="example">
-									<p>The following example shows a link to the same audio file, but in this case the EPUB
-										Creator does not list the file in the manifest (hyperlinked Remote Resources are not
-										Publication Resources). The EPUB Creator would only list the audio file in the
-										manifest if it is also referenced it from an [[?HTML]] embedded content element, as
-										above (i.e., in a context where it is used as a Publication Resource).</p>
+									<p>The following example shows a link to the same audio file, but in this case the
+										EPUB Creator does not list the file in the manifest (hyperlinked Remote
+										Resources are not Publication Resources). The EPUB Creator would only list the
+										audio file in the manifest if it is also referenced it from an [[?HTML]]
+										embedded content element, as above (i.e., in a context where it is used as a
+										Publication Resource).</p>
 									<pre>XHTML:
 &lt;a href="http://www.example.com/book/audio/ch01.mp4"&gt;Go to audio file&lt;/a&gt;
 
 Manifest:
 No Entry</pre>
 								</aside>
-								
+
 								<aside class="example">
 									<p>The following example shows a link to a local version of the audio file. For this
 										link to be valid, EPUB Creators must list the audio file in the <a
@@ -3208,9 +3225,9 @@ Spine:
 								the value "<code>yes</code>" for <code>itemref</code> elements without a
 									<code>linear</code> attribute.</p>
 
-							<p id="confreq-spine-nonlinear" data-tests="#confreq-spine-nonlinear">EPUB Creators MUST provide
-								a means of accessing all non-linear content (e.g., hyperlinks in the content or from the
-								<a href="#sec-nav">EPUB Navigation Document</a>).</p>
+							<p id="confreq-spine-nonlinear" data-tests="#confreq-spine-nonlinear">EPUB Creators MUST
+								provide a means of accessing all non-linear content (e.g., hyperlinks in the content or
+								from the <a href="#sec-nav">EPUB Navigation Document</a>).</p>
 
 							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
 									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>
@@ -3218,13 +3235,13 @@ Spine:
 
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
 									href="#sec-vocab-assoc"></a>.</p>
-							
+
 							<section id="sec-itemref-elem-examples">
 								<h6>Examples</h6>
-								
+
 								<aside class="example">
 									<p>The following example shows a <code>spine</code> element corresponding to <a
-										href="#example-manifest-cmt">the manifest example above</a>.</p>
+											href="#example-manifest-cmt">the manifest example above</a>.</p>
 									<pre>&lt;spine page-progression-direction="ltr"&gt;
     &lt;itemref idref="intro"/&gt;
     &lt;itemref idref="c1"/&gt;
@@ -4554,7 +4571,8 @@ Spine:
 							nested sublists).</p>
 
 						<p>EPUB Creators MAY identify the destinations of the <code>page-list</code> references in their
-							respective EPUB Content Documents using the <a href="https://w3c.github.io/epub-specs/epub33/ssv/#pagebreak"><code>pagebreak</code>
+							respective EPUB Content Documents using the <a
+								href="https://w3c.github.io/epub-specs/epub33/ssv/#pagebreak"><code>pagebreak</code>
 								term</a>.</p>
 					</section>
 
@@ -4600,9 +4618,12 @@ Spine:
 						<p>The following landmarks are recommended to include when available:</p>
 
 						<ul>
-							<li><a href="https://w3c.github.io/epub-specs/epub33/ssv/#bodymatter"><code>bodymatter</code></a> [[?EPUB-SSV-11]] &#8212; Reading Systems often use this
-								landmark to automatically jump users past the front matter when they begin reading.</li>
-							<li><a href="https://w3c.github.io/epub-specs/epub33/ssv/#toc-1"><code>toc</code></a> [[?EPUB-SSV-11]] &#8212; If the table of contents is available in
+							<li><a href="https://w3c.github.io/epub-specs/epub33/ssv/#bodymatter"
+										><code>bodymatter</code></a> [[?EPUB-SSV-11]] &#8212; Reading Systems often use
+								this landmark to automatically jump users past the front matter when they begin
+								reading.</li>
+							<li><a href="https://w3c.github.io/epub-specs/epub33/ssv/#toc-1"
+								><code>toc</code></a> [[?EPUB-SSV-11]] &#8212; If the table of contents is available in
 								the spine, Reading Systems may use this landmark to take users to the document
 								containing it.</li>
 						</ul>
@@ -7307,9 +7328,9 @@ store destination as source in ocf
 							EPUB Content Document element or has a text fallback).</p>
 
 						<div class="note">
-							<p>See <a href="https://www.w3.org/TR/epub-tts-10/">EPUB 3 Text-to-Speech
-									Support</a> [[EPUB-TTS-10]] for more information about using TTS technologies in
-								EPUB Publications.</p>
+							<p>See <a href="https://www.w3.org/TR/epub-tts-10/">EPUB 3 Text-to-Speech Support</a>
+								[[EPUB-TTS-10]] for more information about using TTS technologies in EPUB
+								Publications.</p>
 						</div>
 					</section>
 				</section>
@@ -7575,8 +7596,8 @@ html.my-document-playing * {
 &lt;/html&gt;</pre>
 					</aside>
 
-					<p>The following non-exhaustive list represents terms from the Structural Semantics Vocabulary [[?EPUB-SSV-11]]
-						for which Reading Systems may offer the option of skippability:</p>
+					<p>The following non-exhaustive list represents terms from the Structural Semantics
+						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems may offer the option of skippability:</p>
 
 					<ul>
 						<li>
@@ -7677,8 +7698,8 @@ html.my-document-playing * {
 &lt;/smil&gt;</pre>
 					</aside>
 
-					<p>The following non-exhaustive list represents terms from the Structural
-							Semantics Vocabulary [[?EPUB-SSV-11]] for which Reading Systems may offer the option of escapability:</p>
+					<p>The following non-exhaustive list represents terms from the Structural Semantics
+						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems may offer the option of escapability:</p>
 
 					<ul>
 						<li>
@@ -8007,10 +8028,10 @@ html.my-document-playing * {
 					section).</p>
 
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
-					the EPUB 3 Structural Semantics Vocabulary [[?EPUB-SSV-11]]. EPUB Creators MAY include
-					unprefixed terms that are not part of this vocabulary, but the preferred method for adding custom
-					semantics is to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a
-						href="#sec-vocab-assoc"></a> for more information.</p>
+					the EPUB 3 Structural Semantics Vocabulary [[?EPUB-SSV-11]]. EPUB Creators MAY include unprefixed
+					terms that are not part of this vocabulary, but the preferred method for adding custom semantics is
+					to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a href="#sec-vocab-assoc"></a>
+					for more information.</p>
 
 				<aside class="example" id="ex.epubtype.note">
 					<p>The following example shows how a preamble could be marked up with the <code>epub:type</code>
@@ -9409,9 +9430,10 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>12-Oct-2021: The Structure Semantics Vocabulary has been moved into a separate Working Group Note. 
-					See <a href="https://github.com/w3c/epub-specs/issues/1761">issue 1763</a>
-				</li>
+				<li>18-Oct-2021: Clarified the contexts from which remote resources may be referenced. See <a
+						href="https://github.com/w3c/epub-specs/issues/1857">issue 1857</a>.</li>
+				<li>12-Oct-2021: The Structure Semantics Vocabulary has been moved into a separate Working Group Note.
+					See <a href="https://github.com/w3c/epub-specs/issues/1763">issue 1763</a>.</li>
 				<li>27-Aug-2021: Add clarifications for including landmarks, such as limiting the number, recommending
 					known semantics, and ensuring the labels are human readable. Also added recommendation to not
 					include nested lists to match the page list. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -988,16 +988,16 @@
 
 					<ul class="conformance-list">
 						<li>
-							<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a> when
-								referenced from the {{HTML]] <a
+							<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a> referenced
+								from the {{HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
 										><code>audio</code> element</a> (either from its <code>src</code> attribute or a
 								child <a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element"
 										><code>track</code> element</a>).</p>
 						</li>
 						<li>
-							<p id="sec-resource-locations-video"><a href="#cmt-grp-video">Video resources</a> when
-								referenced from the [[HTML]] <a
+							<p id="sec-resource-locations-video"><a href="#cmt-grp-video">Video resources</a> referenced
+								from the [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/media.html#the-video-element"
 										><code>video</code> element</a> (either from its <code>src</code> attribute or a
 								child <a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element"

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -989,11 +989,12 @@
 					<ul class="conformance-list">
 						<li>
 							<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a> referenced
-								from the {{HTML]] <a
+								from the [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
 										><code>audio</code> element</a> (either from its <code>src</code> attribute or a
 								child <a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element"
-										><code>track</code> element</a>).</p>
+										><code>track</code> element</a>) or from a Media Overlays <a
+									href="#sec-smil-audio-elem"><code>audio</code> element</a>.</p>
 						</li>
 						<li>
 							<p id="sec-resource-locations-video"><a href="#cmt-grp-video">Video resources</a> referenced


### PR DESCRIPTION
Implements the proposal in https://github.com/w3c/epub-specs/issues/1857#issue-1027275195

Fixes #1857


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1859.html" title="Last updated on Oct 19, 2021, 11:58 AM UTC (2532c2f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1859/38bd812...2532c2f.html" title="Last updated on Oct 19, 2021, 11:58 AM UTC (2532c2f)">Diff</a>