### PR TITLE
add data-tests attribute for #confreq-rs-data-urls test

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1028,7 +1028,7 @@
 					</div>
 				</section>
 
-				<section id="sec-data-urls" data-tests="#confreq-rs-data-urls">
+				<section id="sec-data-urls">
 					<h4>Data URLs</h4>
 
 					<p>The <a href="https://datatracker.ietf.org/doc/html/rfc2397"><code>data:</code> URL scheme</a>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1028,7 +1028,7 @@
 					</div>
 				</section>
 
-				<section id="sec-data-urls">
+				<section id="sec-data-urls" data-tests="#confreq-rs-data-urls">
 					<h4>Data URLs</h4>
 
 					<p>The <a href="https://datatracker.ietf.org/doc/html/rfc2397"><code>data:</code> URL scheme</a>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -225,7 +225,7 @@
 			<section id="sec-epub-rs-conf-data-urls">
 				<h4>Data URLs</h4>
 
-				<p id="confreq-rs-data-urls">Reading Systems MUST prevent data URLs [[RFC2397]] from opening in <a
+				<p id="confreq-rs-data-urls" data-tests="#confreq-rs-data-urls">Reading Systems MUST prevent data URLs [[RFC2397]] from opening in <a
 						href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level
 						browsing contexts</a> [[HTML]], except when initiated through a Reading System affordance such
 					as a context menu. If a Reading System does not use a top-level browsing context for <a>Top-level


### PR DESCRIPTION
Adding data-tests attribute for the epub-33 rs related test that I created over on the testing repo.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/m22chan/epub-specs/pull/1862.html" title="Last updated on Oct 20, 2021, 7:47 PM UTC (404e4d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1862/b7b948c...m22chan:404e4d1.html" title="Last updated on Oct 20, 2021, 7:47 PM UTC (404e4d1)">Diff</a>