### PR TITLE
Fix editors

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -47,12 +47,6 @@
 					w3cid: 92141
                 },
                 {
-                    name: "Dave Cramer",
-                    company: "Hachette Livre",
-                    companyURL: "https://www.hachettebookgroup.com",
-                    w3cid: 65283
-                },
-                {
                     name: "Marisa DeMeglio",
                     company: "DAISY Consortium",
                     companyURL: "https://daisy.org",

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -21,11 +21,6 @@
 				copyrightStart: "1999",
 				editors: [ 
 				{
-					name: "Dave Cramer",
-					company: "Invited Expert",
-					w3cid: 65283
-				},
-				{
 					name: "Matt Garrish",
 					company: "DAISY Consortium",
 					companyURL: "https://www.daisy.org",
@@ -38,6 +33,11 @@
 					w3cid: 7382,
 					orcid: "0000-0003-0782-2704",
 					companyURL: "https://www.w3.org",
+				},
+				{
+					name: "Dave Cramer",
+					company: "Invited Expert",
+					w3cid: 65283
 				}],
 				formerEditors: [
 				{


### PR DESCRIPTION
Remove Dave from former editors (he's in current editors too) and standardize order of editors — Matt, then Ivan, then Dave. I cleared this with Dave in today's testing call.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1863.html" title="Last updated on Oct 21, 2021, 6:19 PM UTC (4aeb012)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1863/ac1a93e...4aeb012.html" title="Last updated on Oct 21, 2021, 6:19 PM UTC (4aeb012)">Diff</a>