### PR TITLE
Remove generic technique identifiers

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -182,7 +182,7 @@
 			<h2>Discovery Metadata Techniques</h2>
 
 			<section class="suppress-numbering" id="meta-001">
-				<h3>META-001: Identify primary access modes</h3>
+				<h3>Identify primary access modes</h3>
 
 				<p>An access mode is defined as a "human sense perceptual system or cognitive faculty through which a
 					user may process or perceive the content of a digital resource." [[ISO24751-3]] For example, if an
@@ -238,7 +238,7 @@
 			</section>
 
 			<section class="suppress-numbering" id="meta-002">
-				<h3>META-002: Identify sufficient access modes</h3>
+				<h3>Identify sufficient access modes</h3>
 
 				<p>The access modes sufficient to consume an EPUB Publication express a broader picture of the potential
 					usability than do the <a href="#meta-001">basic access modes</a>. Where the basic access modes
@@ -344,7 +344,7 @@
 			</section>
 
 			<section class="suppress-numbering" id="meta-003">
-				<h3>META-003: Identify accessibility features</h3>
+				<h3>Identify accessibility features</h3>
 
 				<p>Identifying all the accessibility features and adaptations included in an EPUB Publication allows
 					users to determine whether the content is usable at a more fine-grained level than the access modes
@@ -382,7 +382,7 @@
 			</section>
 
 			<section class="suppress-numbering" id="meta-004">
-				<h3>META-004: Identify accessibility hazards</h3>
+				<h3>Identify accessibility hazards</h3>
 
 				<p>There are three widely recognized hazards that can affect readers of digital content:</p>
 
@@ -453,7 +453,7 @@
 			</section>
 
 			<section class="suppress-numbering" id="meta-005">
-				<h3>META-005: Include an accessibility summary</h3>
+				<h3>Include an accessibility summary</h3>
 
 				<p>An accessibility summary provides a brief, human-readable description of the accessibility
 					characteristics of an EPUB Publication, or lack thereof.</p>
@@ -496,7 +496,7 @@
 			</section>
 
 			<section class="suppress-numbering" id="meta-006">
-				<h3>META-006: Identify ARIA Conformance</h3>
+				<h3>Identify ARIA Conformance</h3>
 
 				<p>The use of the <code>schema:accesibilityAPI</code> property is no longer necessary for EPUB
 					Publications. EPUB Creators are not responsible for the interaction between Reading Systems and the
@@ -508,7 +508,7 @@
 			</section>
 
 			<section class="suppress-numbering" id="meta-007">
-				<h3>META-007: Identify Input Control Methods</h3>
+				<h3>Identify Input Control Methods</h3>
 
 				<p>The use of the <code>schema:accesibilityControl</code> property is no longer necessary for EPUB
 					Publications. This property does not differentiate issues arising from the Reading System interface
@@ -708,7 +708,7 @@
 				<h3>Content Access</h3>
 
 				<section class="suppress-numbering" id="access-001">
-					<h4>ACCESS-001: Ensure meaningful order of content across spreads</h4>
+					<h4>Ensure meaningful order of content across spreads</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#meaningful-sequence">Success Criterion 1.3.2</a>
 						specifies that each Web page have a meaningful order (i.e., that the visual presentation of the
@@ -730,7 +730,7 @@
 				</section>
 
 				<section class="suppress-numbering" id="access-002">
-					<h4>ACCESS-002: Provide multiple ways to access the content</h4>
+					<h4>Provide multiple ways to access the content</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#multiple-ways">Success Criterion
 						2.4.5</a> requires there be more than one way to locate a Web page within a set of Web pages. By
@@ -812,7 +812,7 @@
 				</section>
 
 				<section class="suppress-numbering" id="access-003">
-					<h4>ACCESS-003: Ensure the order of table of contents entries matches linear order</h4>
+					<h4>Ensure the order of table of contents entries matches linear order</h4>
 
 					<p>The table of contents provides users more than just links into the content. It is also a means to
 						understand the structure and ordering of an EPUB Publication. Consequently, users may have
@@ -848,7 +848,7 @@
 				<h3>Semantics</h3>
 
 				<section class="suppress-numbering" id="sem-001">
-					<h4>SEM-001: ARIA roles and <code>epub:type</code></h4>
+					<h4>ARIA roles and <code>epub:type</code></h4>
 
 					<div class="note">
 						<p>The following guidance is only for EPUB Content Documents. The <code>type</code> attribute is
@@ -884,7 +884,7 @@
 				</section>
 
 				<section class="suppress-numbering" id="sem-002">
-					<h4>SEM-002: Do not repeat semantics across chunked content</h4>
+					<h4>Do not repeat semantics across chunked content</h4>
 
 					<p>Although EPUB Publications appear as single contiguous documents to users when read, they are
 						typically composed of many individual EPUB Content Documents. This practice keeps the amount of
@@ -977,7 +977,7 @@
 				</section>
 
 				<section class="suppress-numbering" id="sem-003">
-					<h4>SEM-003: Include EPUB landmarks</h4>
+					<h4>Include EPUB landmarks</h4>
 
 					<p>[[WAI-ARIA-1.1]] <a href="https://www.w3.org/TR/wai-aria-1.1/#dfn-landmark">landmarks</a> are
 						similar in nature to <a href="https://www.w3.org/TR/epub/#sec-nav-landmarks">EPUB
@@ -1111,7 +1111,7 @@
 				<h3>Titles and Headings</h3>
 
 				<section class="suppress-numbering" id="titles-001">
-					<h4>TITLES-001: Include publication and document titles</h4>
+					<h4>Include publication and document titles</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#page-titled">Success Criterion 2.4.2</a> requires
 						that each Web page include a title. EPUB has a similar requirement for EPUB Publications:
@@ -1163,7 +1163,7 @@
 				</section>
 
 				<section class="suppress-numbering" id="titles-002">
-					<h4>TITLES-002: Ensure numbered headings reflect publication hierarchy</h4>
+					<h4>Ensure numbered headings reflect publication hierarchy</h4>
 
 					<p>To a user, an EPUB Publication appears as a single document that they read from beginning to end,
 						even though the content is often split across numerous EPUB Content Documents. As a result,
@@ -1237,7 +1237,7 @@
 				</section>
 
 				<section class="suppress-numbering" id="titles-003">
-					<h4>TITLES-003: Heading topic or purpose</h4>
+					<h4>Heading topic or purpose</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#non-text-content">Success Criterion 2.4.6</a>
 						currently states that all headings must describe their topic or purpose. The implication of this
@@ -1266,7 +1266,7 @@
 				<h3>Descriptions</h3>
 
 				<section class="suppress-numbering" id="desc-001">
-					<h4>DESC-001: Include alternative text descriptions</h4>
+					<h4>Include alternative text descriptions</h4>
 
 					<p>The first version of these techniques only required alternative text for images regardless of
 						their complexity. This exception is no longer valid.</p>
@@ -1294,7 +1294,7 @@
 				<h3>Text</h3>
 
 				<section id="text-001">
-					<h4>TEXT-001 - Use Unicode for text content</h4>
+					<h4>Use Unicode for text content</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#non-text-content">Success Criterion 1.1.1</a>
 						requires that text equivalents be provided for all non-text content to meet Level A. In some
@@ -1360,7 +1360,7 @@
 				<h3>Page Markers</h3>
 
 				<section class="suppress-numbering" id="page-001">
-					<h4>PAGE-001: Provide page break markers</h4>
+					<h4>Provide page break markers</h4>
 
 					<p>Both the EPUB Structural Semantics Vocabulary [[EPUB-SSV]] and Digital Publishing WAI-ARIA 1.0
 						Module [[DPUB-ARIA-1.0]] include a semantic for static page breaks: <a
@@ -1405,7 +1405,7 @@
 				</section>
 
 				<section class="suppress-numbering" id="page-002">
-					<h4>PAGE-002: Identify pages in audio playback</h4>
+					<h4>Identify pages in audio playback</h4>
 
 					<p>Readers rarely stop reading to review each new page number, so when page numbers are read aloud
 						in the audio playback of a publication it is not only distracting, but can be confusing, as well
@@ -1469,7 +1469,7 @@
 				</section>
 
 				<section class="suppress-numbering" id="page-003">
-					<h4>PAGE-003: Provide a page list</h4>
+					<h4>Provide a page list</h4>
 
 					<p>A page list — a list of hyperlinks to the static page break locations — is the most effective way
 						for users to find static page locations. Without a page list, the user would have to navigate
@@ -1549,7 +1549,7 @@
 				</section>
 
 				<section class="suppress-numbering" id="page-004">
-					<h4>PAGE-004: Identify the pagination source</h4>
+					<h4>Identify the pagination source</h4>
 
 					<p>Users typically want to know the source of the page break markers included in an EPUB Publication
 						when they are derived from a static media. Considerations like which printing, by which
@@ -1624,7 +1624,7 @@
 			<h2>Distribution Techniques</h2>
 
 			<section class="suppress-numbering" id="dist-001">
-				<h3>DIST-001: Do not restrict access through digital rights management</h3>
+				<h3>Do not restrict access through digital rights management</h3>
 
 				<p>EPUB Publications typically require preservation of the publisher's and author's intellectual
 					property when distributed (e.g., so that they can be made available for individual sale through
@@ -1646,7 +1646,7 @@
 			</section>
 
 			<section class="suppress-numbering" id="dist-002">
-				<h3>DIST-002: Include accessibility metadata in distribution records</h3>
+				<h3>Include accessibility metadata in distribution records</h3>
 
 				<p>When an EPUB Publication is ingested into a distribution system, such as a bookstore or library, a
 					metadata record is often provided separately to the distributor. In these scenarios, the metadata

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -181,7 +181,7 @@
 		<section id="sec-discovery">
 			<h2>Discovery Metadata Techniques</h2>
 
-			<section class="suppress-numbering" id="meta-001">
+			<section id="meta-001">
 				<h3>Identify primary access modes</h3>
 
 				<p>An access mode is defined as a "human sense perceptual system or cognitive faculty through which a
@@ -237,7 +237,7 @@
 					[[schema-org]] for more information about this property and its values.</p>
 			</section>
 
-			<section class="suppress-numbering" id="meta-002">
+			<section id="meta-002">
 				<h3>Identify sufficient access modes</h3>
 
 				<p>The access modes sufficient to consume an EPUB Publication express a broader picture of the potential
@@ -343,7 +343,7 @@
 				</div>
 			</section>
 
-			<section class="suppress-numbering" id="meta-003">
+			<section id="meta-003">
 				<h3>Identify accessibility features</h3>
 
 				<p>Identifying all the accessibility features and adaptations included in an EPUB Publication allows
@@ -381,7 +381,7 @@
 					property and its values.</p>
 			</section>
 
-			<section class="suppress-numbering" id="meta-004">
+			<section id="meta-004">
 				<h3>Identify accessibility hazards</h3>
 
 				<p>There are three widely recognized hazards that can affect readers of digital content:</p>
@@ -452,7 +452,7 @@
 					property and its values.</p>
 			</section>
 
-			<section class="suppress-numbering" id="meta-005">
+			<section id="meta-005">
 				<h3>Include an accessibility summary</h3>
 
 				<p>An accessibility summary provides a brief, human-readable description of the accessibility
@@ -495,7 +495,7 @@
 					property.</p>
 			</section>
 
-			<section class="suppress-numbering" id="meta-006">
+			<section id="meta-006">
 				<h3>Identify ARIA Conformance</h3>
 
 				<p>The use of the <code>schema:accesibilityAPI</code> property is no longer necessary for EPUB
@@ -507,7 +507,7 @@
 					controls.</p>
 			</section>
 
-			<section class="suppress-numbering" id="meta-007">
+			<section id="meta-007">
 				<h3>Identify Input Control Methods</h3>
 
 				<p>The use of the <code>schema:accesibilityControl</code> property is no longer necessary for EPUB
@@ -518,7 +518,7 @@
 					sufficient for authoring purposes.</p>
 			</section>
 
-			<section class="suppress-numbering" id="sec-meta-ex">
+			<section id="sec-meta-ex">
 				<h3>Examples</h3>
 
 				<p>The following examples show the metadata that would be added to an EPUB Publication that has textual
@@ -680,7 +680,7 @@
 				<p>Other techniques will apply depending on the technologies used (e.g., a [[SWF]] video in EPUB 2) or
 					any alternative formats embedded in the EPUB Publication (e.g., a PDF form).</p>
 
-				<section class="suppress-numbering" id="sec-wcag-general-res">
+				<section id="sec-wcag-general-res">
 					<h4>Helpful Resources</h4>
 
 					<p>EPUB Creators not familiar with the [[WCAG2]] may find the number of techniques daunting, as they
@@ -707,7 +707,7 @@
 			<section id="sec-wcag-content-access">
 				<h3>Content Access</h3>
 
-				<section class="suppress-numbering" id="access-001">
+				<section id="access-001">
 					<h4>Ensure meaningful order of content across spreads</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#meaningful-sequence">Success Criterion 1.3.2</a>
@@ -729,7 +729,7 @@
 						the continuation on the next).</p>
 				</section>
 
-				<section class="suppress-numbering" id="access-002">
+				<section id="access-002">
 					<h4>Provide multiple ways to access the content</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#multiple-ways">Success Criterion
@@ -773,7 +773,7 @@
 						</li>
 					</ul>
 
-					<section class="suppress-numbering" id="sec-access-002-toc">
+					<section id="sec-access-002-toc">
 						<h5>Note About the Table of Contents</h5>
 
 						<p>A common question about the EPUB table of contents is what completeness it needs to have with
@@ -811,7 +811,7 @@
 					</section>
 				</section>
 
-				<section class="suppress-numbering" id="access-003">
+				<section id="access-003">
 					<h4>Ensure the order of table of contents entries matches linear order</h4>
 
 					<p>The table of contents provides users more than just links into the content. It is also a means to
@@ -847,7 +847,7 @@
 			<section id="sec-wcag-semantics">
 				<h3>Semantics</h3>
 
-				<section class="suppress-numbering" id="sem-001">
+				<section id="sem-001">
 					<h4>ARIA roles and <code>epub:type</code></h4>
 
 					<div class="note">
@@ -883,7 +883,7 @@
 						equivalent ARIA roles in [[DPUB-ARIA-1.0]] and [[WAI-ARIA-1.1]].</p>
 				</section>
 
-				<section class="suppress-numbering" id="sem-002">
+				<section id="sem-002">
 					<h4>Do not repeat semantics across chunked content</h4>
 
 					<p>Although EPUB Publications appear as single contiguous documents to users when read, they are
@@ -976,7 +976,7 @@
 						Assistive Technology to inform the user that the landmark is available to navigate to.</p>
 				</section>
 
-				<section class="suppress-numbering" id="sem-003">
+				<section id="sem-003">
 					<h4>Include EPUB landmarks</h4>
 
 					<p>[[WAI-ARIA-1.1]] <a href="https://www.w3.org/TR/wai-aria-1.1/#dfn-landmark">landmarks</a> are
@@ -1085,7 +1085,7 @@
 &lt;/guide></pre>
 					</aside>
 
-					<section class="suppress-numbering" id="sec-sem-003-res">
+					<section id="sec-sem-003-res">
 						<h5>Helpful Resources</h5>
 
 						<p>The following resources explain EPUB and ARIA landmarks in more detail.</p>
@@ -1110,7 +1110,7 @@
 			<section id="sec-wcag-titles">
 				<h3>Titles and Headings</h3>
 
-				<section class="suppress-numbering" id="titles-001">
+				<section id="titles-001">
 					<h4>Include publication and document titles</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#page-titled">Success Criterion 2.4.2</a> requires
@@ -1162,7 +1162,7 @@
 							href="https://www.w3.org/WAI/WCAG21/Techniques/html/H25">Technique H25</a>.</p>
 				</section>
 
-				<section class="suppress-numbering" id="titles-002">
+				<section id="titles-002">
 					<h4>Ensure numbered headings reflect publication hierarchy</h4>
 
 					<p>To a user, an EPUB Publication appears as a single document that they read from beginning to end,
@@ -1236,7 +1236,7 @@
 					</aside>
 				</section>
 
-				<section class="suppress-numbering" id="titles-003">
+				<section id="titles-003">
 					<h4>Heading topic or purpose</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#non-text-content">Success Criterion 2.4.6</a>
@@ -1265,7 +1265,7 @@
 			<section id="sec-wcag-descriptions">
 				<h3>Descriptions</h3>
 
-				<section class="suppress-numbering" id="desc-001">
+				<section id="desc-001">
 					<h4>Include alternative text descriptions</h4>
 
 					<p>The first version of these techniques only required alternative text for images regardless of
@@ -1274,7 +1274,7 @@
 					<p>EPUB Creators must now ensure that their image-based content meets [[WCAG2]] requirements for
 						alternative text and extended descriptions to conform with [[EPUB-A11Y-11]].</p>
 
-					<section class="suppress-numbering" id="sec-desc-001-res">
+					<section id="sec-desc-001-res">
 						<h5>Helpful Resources</h5>
 
 						<p>The following documents provide guidance on including extended descriptions:</p>
@@ -1359,7 +1359,7 @@
 			<section id="sec-epub-page-markers">
 				<h3>Page Markers</h3>
 
-				<section class="suppress-numbering" id="page-001">
+				<section id="page-001">
 					<h4>Provide page break markers</h4>
 
 					<p>Both the EPUB Structural Semantics Vocabulary [[EPUB-SSV]] and Digital Publishing WAI-ARIA 1.0
@@ -1404,7 +1404,7 @@
 						purpose has been changed in [[HTML]] for use solely as a link.</p>
 				</section>
 
-				<section class="suppress-numbering" id="page-002">
+				<section id="page-002">
 					<h4>Identify pages in audio playback</h4>
 
 					<p>Readers rarely stop reading to review each new page number, so when page numbers are read aloud
@@ -1468,7 +1468,7 @@
 						apply.</p>
 				</section>
 
-				<section class="suppress-numbering" id="page-003">
+				<section id="page-003">
 					<h4>Provide a page list</h4>
 
 					<p>A page list — a list of hyperlinks to the static page break locations — is the most effective way
@@ -1548,7 +1548,7 @@
 					</aside>
 				</section>
 
-				<section class="suppress-numbering" id="page-004">
+				<section id="page-004">
 					<h4>Identify the pagination source</h4>
 
 					<p>Users typically want to know the source of the page break markers included in an EPUB Publication
@@ -1623,7 +1623,7 @@
 		<section id="sec-distribution">
 			<h2>Distribution Techniques</h2>
 
-			<section class="suppress-numbering" id="dist-001">
+			<section id="dist-001">
 				<h3>Do not restrict access through digital rights management</h3>
 
 				<p>EPUB Publications typically require preservation of the publisher's and author's intellectual
@@ -1645,7 +1645,7 @@
 					Assistive Technologies on EPUB Publications users have the right to access.</p>
 			</section>
 
-			<section class="suppress-numbering" id="dist-002">
+			<section id="dist-002">
 				<h3>Include accessibility metadata in distribution records</h3>
 
 				<p>When an EPUB Publication is ingested into a distribution system, such as a bookstore or library, a
@@ -1717,7 +1717,7 @@
 &lt;/ONIXMessage></pre>
 				</aside>
 
-				<section class="suppress-numbering" id="sec-dist-002-res">
+				<section id="sec-dist-002-res">
 					<h4>Helpful Resources</h4>
 
 					<p>See the following resources for more information about including accessibility metadata in

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1751,6 +1751,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>25-Oct-2021: Removed the generic technique labels for each section. See <a
+						href="https://github.com/w3c/epub-specs/issues/1866">issue 1866</a>.</li>
 				<li>29-Sep-2021: Added <a href="#titles-003">TITLES-003</a> to explain that headings only have to be
 					unique, not define the topic or purpose of a section. See <a
 						href="https://github.com/w3c/epub-specs/issues/1810">issue 1810</a>.</li>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -349,8 +349,8 @@
 					<p>See <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-discovery">Discovery Metadata
 							Techniques</a> [[EPUB-A11Y-TECH-11]] for more information on these properties and how to
 						include them in different versions of EPUB. See also <a
-							href="https://www.w3.org/TR/epub-a11y-tech-11/#dist-002">DIST-002: Include accessibility
-							metadata in distribution records</a> [[EPUB-A11Y-TECH-11]] for more information on including
+							href="https://www.w3.org/TR/epub-a11y-tech-11/#dist-002">Include accessibility metadata in
+							distribution records</a> [[EPUB-A11Y-TECH-11]] for more information on including
 						accessibility metadata in other formats.</p>
 				</div>
 			</section>


### PR DESCRIPTION
Also worth noting is that we have permalinks for each section, so having these labels that match the IDs isn't helpful anymore in terms of linking to sections.

Fixes #1866 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1866/epub33/a11y-tech/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1866/epub33/a11y-tech/index.html)
