### PR TITLE
Clarify that reading systems must render non-linear content when hyperlinked to

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -118,8 +118,8 @@
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
 				Web content — including HTML, CSS, SVG and other resources — for distribution in a single-file
 				container.</p>
-			<p>This specification defines the conformance requirements for EPUB 3 Reading Systems — the user agents
-				that render EPUB Publications.</p>
+			<p>This specification defines the conformance requirements for EPUB 3 Reading Systems — the user agents that
+				render EPUB Publications.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="sec-introduction">
@@ -208,8 +208,10 @@
 			<section id="sec-epub-rs-conf-foreign-res">
 				<h4>Foreign Resources</h4>
 
-				<p id="confreq-rs-foreign" data-tests="#confreq-rs-foreign_image,#confreq-rs-foreign_xml-spine,#confreq-rs-foreign_xml-suffix-spine,confreq-rs-foreign_bad-fallback,#confreq-rs-foreign_json-spine">Reading Systems MAY support an arbitrary set of <a>Foreign Resource</a>
-					types, and MUST process fallbacks for unsupported Foreign Resources as defined in <a
+				<p id="confreq-rs-foreign"
+					data-tests="#confreq-rs-foreign_image,#confreq-rs-foreign_xml-spine,#confreq-rs-foreign_xml-suffix-spine,confreq-rs-foreign_bad-fallback,#confreq-rs-foreign_json-spine"
+					>Reading Systems MAY support an arbitrary set of <a>Foreign Resource</a> types, and MUST process
+					fallbacks for unsupported Foreign Resources as defined in <a
 						href="https://www.w3.org/TR/epub-33/#sec-foreign-restrictions">Foreign Resources</a> [[EPUB-33]]
 					if not.</p>
 			</section>
@@ -225,7 +227,8 @@
 			<section id="sec-epub-rs-conf-data-urls">
 				<h4>Data URLs</h4>
 
-				<p id="confreq-rs-data-urls" data-tests="#confreq-rs-data-urls">Reading Systems MUST prevent data URLs [[RFC2397]] from opening in <a
+				<p id="confreq-rs-data-urls" data-tests="#confreq-rs-data-urls">Reading Systems MUST prevent data URLs
+					[[RFC2397]] from opening in <a
 						href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level
 						browsing contexts</a> [[HTML]], except when initiated through a Reading System affordance such
 					as a context menu. If a Reading System does not use a top-level browsing context for <a>Top-level
@@ -236,14 +239,13 @@
 			<section id="sec-epub-rs-conf-cmt">
 				<h4>Core Media Types</h4>
 
-				<p id="confreq-rs-epub3-images"
-					data-tests="#cmt-gif,#cmt-jpg,#cmt-png,#cmt-svg,#cmt-webp">If a Reading System has a <a>Viewport</a>, it
-					MUST support the
-					<a href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type Resources</a>
-				    [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-images" data-tests="#cmt-gif,#cmt-jpg,#cmt-png,#cmt-svg,#cmt-webp">If a Reading
+					System has a <a>Viewport</a>, it MUST support the <a
+						href="https://www.w3.org/TR/epub-33/#cmt-grp-image">image Core Media Type Resources</a>
+					[[EPUB-33]].</p>
 
-				<p id="confreq-rs-epub3-mp3-aac" data-tests="#cmt-mp3,#cmt-mp4-aac,#cmt-ogg-opus">If it has the capability to
-					render pre-recorded audio, it MUST support the <a
+				<p id="confreq-rs-epub3-mp3-aac" data-tests="#cmt-mp3,#cmt-mp4-aac,#cmt-ogg-opus">If it has the
+					capability to render pre-recorded audio, it MUST support the <a
 						href="https://www.w3.org/TR/epub-33/#cmt-grp-audio">audio Core Media Type Resources</a>
 					[[EPUB-33]] and SHOULD support Media Overlays [[EPUB-33]].</p>
 
@@ -342,18 +344,17 @@
 				<h4>Base Direction</h4>
 
 				<p id="confreq-rs-pkg-dir"
-				    data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006">
-				    If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
-				    <code>rtl</code>, Reading Systems MUST override the bidi algorithm per
-				    <a data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]], setting
-				    the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the base direction
-				    is <code>rtl</code>.</p>
+					data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006"
+					> If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
+						<code>rtl</code>, Reading Systems MUST override the bidi algorithm per <a
+						data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]],
+					setting the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the
+					base direction is <code>rtl</code>.</p>
 
-				<p id="confreq-rs-pkg-dir-auto"
-				    data-tests="#confreq-rs-pkg-dir_rtl-003,#confreq-rs-pkg-dir_rtl-005">Otherwise
-					the base direction is <code>auto</code>, in which case Reading Systems MUST determine the text's
-					direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of
-					[[BIDI]].</p>
+				<p id="confreq-rs-pkg-dir-auto" data-tests="#confreq-rs-pkg-dir_rtl-003,#confreq-rs-pkg-dir_rtl-005"
+					>Otherwise the base direction is <code>auto</code>, in which case Reading Systems MUST determine the
+					text's direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule
+						P2</a> of [[BIDI]].</p>
 			</section>
 
 			<section id="sec-pkg-doc-pub-identifiers">
@@ -372,10 +373,11 @@
 					<dt id="conf-meta-ws">White Space</dt>
 					<dd>
 						<p id="confreq-rs-pkg-whitespace" data-tests="#confreq-rs-pkg-whitespace">Reading Systems MUST
-							<a href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">strip and collapse
-							ASCII whitespace</a> [[Infra]] from Dublin Core [[DC11]] and
-							<a href="https://www.w3.org/TR/epub-33/#sec-meta-elem"><code>meta</code></a> element
-							<a href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[EPUB-33]] before processing.</p>
+								<a href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">strip and
+								collapse ASCII whitespace</a> [[Infra]] from Dublin Core [[DC11]] and <a
+								href="https://www.w3.org/TR/epub-33/#sec-meta-elem"><code>meta</code></a> element <a
+								href="https://www.w3.org/TR/epub-33/#dfn-value">values</a> [[EPUB-33]] before
+							processing.</p>
 					</dd>
 
 					<dt id="dc-identifier">The <code>identifier</code> element</dt>
@@ -389,8 +391,8 @@
 					<dt id="dc-title">The <code>title</code> element</dt>
 					<dd>
 						<p id="title-order" data-tests="#title-order">Reading Systems MUST recognize the first
-							<code>title</code> element in document order as the main title of the EPUB Publication and
-						    present it to users before other title elements.</p>
+								<code>title</code> element in document order as the main title of the EPUB Publication
+							and present it to users before other title elements.</p>
 						<p>This specification does not define how to process additional <code>title</code> elements.</p>
 					</dd>
 
@@ -411,11 +413,11 @@
 					<dt id="dc-creator">The <code>creator</code> element</dt>
 					<dd>
 						<p id="confreq-rs-pkg-creator-order" data-tests="#confreq-rs-pkg-creator-order">When determining
-							display priority, Reading Systems MUST use the document order of <code>creator</code> elements in
-							the <code>metadata</code> section, where the first <code>creator</code> element encountered is
-							the primary creator. If a Reading System exposes creator metadata to the user, it SHOULD include
-							all the creators listed in the <code>metadata</code> section whenever possible (e.g., when not
-						    constrained by display considerations).</p>
+							display priority, Reading Systems MUST use the document order of <code>creator</code>
+							elements in the <code>metadata</code> section, where the first <code>creator</code> element
+							encountered is the primary creator. If a Reading System exposes creator metadata to the
+							user, it SHOULD include all the creators listed in the <code>metadata</code> section
+							whenever possible (e.g., when not constrained by display considerations).</p>
 					</dd>
 
 					<dt id="meta">The <code>meta</code> element</dt>
@@ -423,9 +425,9 @@
 						<p>If a Reading System does not recognize the <code>scheme</code> attribute value, it SHOULD
 							treat the value of the element as a string.</p>
 						<p>Reading Systems SHOULD ignore all <code>meta</code> elements whose <code>property</code>
-							attributes define expressions they do not recognize.
-							<span id="confreq-rs-pkg-meta-unknown" data-tests="#confreq-rs-pkg-meta-unknown">A Reading System
-							MUST NOT fail when encountering unknown expressions.</span></p>
+							attributes define expressions they do not recognize. <span id="confreq-rs-pkg-meta-unknown"
+								data-tests="#confreq-rs-pkg-meta-unknown">A Reading System MUST NOT fail when
+								encountering unknown expressions.</span></p>
 						<p>If the <code>property</code> attribute's value does not include a prefix, Reading Systems
 							MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to <a
 								href="#sec-property-datatype">expand the value</a>.</p>
@@ -478,9 +480,10 @@
 						href="https://url.spec.whatwg.org/#concept-url">URL record</a> [[URL]].</p>
 
 				<p>Reading Systems MAY optimize the rendering depending on the properties set in the
-					<code>properties</code> attribute (e.g., disable a rendering process or use a fallback).
-					<span id="confreq-rs-pkg-manifest-unknown" data-tests="#confreq-rs-pkg-manifest-unknown">Reading
-						Systems MUST ignore values of the <code>properties</code> attribute they do not recognize.</span></p>
+						<code>properties</code> attribute (e.g., disable a rendering process or use a fallback). <span
+						id="confreq-rs-pkg-manifest-unknown" data-tests="#confreq-rs-pkg-manifest-unknown">Reading
+						Systems MUST ignore values of the <code>properties</code> attribute they do not
+						recognize.</span></p>
 
 				<p id="confreq-rendition-rs-manifest">It SHOULD NOT use non-<a>Publication Resources</a> in the
 					rendering of an EPUB Publication due to the inherent limitations and risks involved (e.g., lack of
@@ -512,16 +515,17 @@
 			<section id="sec-pkg-doc-spine">
 				<h3>Spine</h3>
 
-				<p data-tests="#sec-pkg-doc-spine">Reading Systems MUST provide a means of rendering the EPUB Publication in the order defined in the
-						<code>spine</code>, which includes: 1) recognizing the first primary <code>itemref</code> as the
-					beginning of the default reading order; and, 2) rendering successive primary items in the order
-					given in the <code>spine</code>.</p>
+				<p data-tests="#sec-pkg-doc-spine">Reading Systems MUST provide a means of rendering the EPUB
+					Publication in the order defined in the <code>spine</code>, which includes: 1) recognizing the first
+					primary <code>itemref</code> as the beginning of the default reading order; and, 2) rendering
+					successive primary items in the order given in the <code>spine</code>.</p>
 
-				<p id="confreq-rendition-rs-spine-nonlinear">When a user traverses the default reading order defined in the
-					<a href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[EPUB-33]], a Reading System MAY
-					automatically skip <code>itemref</code> elements marked as non-linear (excluding when a user
-					specifically activates a hyperlink to such items). Reading Systems MAY also provide the option for
-					users to select whether to skip non-linear content by default or not.</p>
+				<p id="confreq-rendition-rs-spine-nonlinear">When a user traverses the default reading order defined in
+					the <a href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[EPUB-33]], a Reading System
+					MAY automatically skip <code>itemref</code> elements marked as non-linear. When a user activates a
+					hyperlink to a non-linear <code>itemref</code>, however, Reading Systems MUST render the referenced
+					resource or a designated fallback. Reading Systems MAY also provide the option for users to select
+					whether to skip non-linear content by default or not.</p>
 
 				<p>If the EPUB Creator has not specified the <code>page-progression-direction</code>, the Reading System
 					MUST assume the value of <code>default</code>. When the EPUB Creator has set the value of the
@@ -537,16 +541,16 @@
 					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 
-				<p id="confreq-rs-pkg-spine-unknown" data-tests="#confreq-rs-pkg-spine-unknown">Reading Systems MUST ignore
-					all values expressed in spine <code>itemref</code> <code>properties</code> attributes that they do not
-				  recognize.</p>
+				<p id="confreq-rs-pkg-spine-unknown" data-tests="#confreq-rs-pkg-spine-unknown">Reading Systems MUST
+					ignore all values expressed in spine <code>itemref</code>
+					<code>properties</code> attributes that they do not recognize.</p>
 			</section>
 
 			<section id="sec-pkg-doc-collections">
 				<h3>Collections</h3>
 
-				<p>In the context of this specification, support for collections in Reading Systems is OPTIONAL.
-					<span id="confreq-rs-pkg-collections-unknown" data-tests="#confreq-rs-pkg-collections-unknown">Reading
+				<p>In the context of this specification, support for collections in Reading Systems is OPTIONAL. <span
+						id="confreq-rs-pkg-collections-unknown" data-tests="#confreq-rs-pkg-collections-unknown">Reading
 						Systems MUST ignore <code>collection</code> elements that define unrecognized roles.</span></p>
 			</section>
 		</section>
@@ -563,7 +567,8 @@
 				<h3>XHTML Content Documents</h3>
 
 				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="#confreq-rs-epub3-xhtml">Reading Systems MUST
-					process <a href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a> [[EPUB-33]].</p>
+					process <a href="https://www.w3.org/TR/epub-33/#sec-xhtml">XHTML Content Documents</a>
+					[[EPUB-33]].</p>
 
 				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, Reading
 					Systems MUST process XHTML Content Documents using semantics defined by the [[HTML]] specification
@@ -667,14 +672,14 @@
 						<ul class="conformance-list">
 							<li>
 								<p id="confreq-mathml-rs-behavior" data-tests="#confreq-mathml-rs-behavior">MUST be an
-									<a href="https://www.w3.org/TR/MathML3/chapter2.html#fund.mathmlconf"
+										<a href="https://www.w3.org/TR/MathML3/chapter2.html#fund.mathmlconf"
 										>input-compliant processor</a> for <a
 										href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation MathML</a>, as
 									defined in the [[MATHML3]] specification.</p>
 							</li>
 							<li>
-								<p id="confreq-mathml-rs-render" data-tests="#confreq-mathml-rs-behavior">MUST, if it has a
-									<a>Viewport</a>, support visual rendering of Presentation MathML.</p>
+								<p id="confreq-mathml-rs-render" data-tests="#confreq-mathml-rs-behavior">MUST, if it
+									has a <a>Viewport</a>, support visual rendering of Presentation MathML.</p>
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
@@ -695,13 +700,15 @@
 						<section id="sec-xhtml-svg-css">
 							<h6>Embedded SVG and CSS</h6>
 
-							<p id="confreq-svg-rs-css-embed-ref" data-tests="#confreq-svg-rs-css-embed-ref">For the purposes
-								of styling SVG embedded in XHTML Content Documents <em>by reference</em>, Reading Systems
-								MUST NOT apply CSS style rules of the containing document to the referenced SVG document.</p>
+							<p id="confreq-svg-rs-css-embed-ref" data-tests="#confreq-svg-rs-css-embed-ref">For the
+								purposes of styling SVG embedded in XHTML Content Documents <em>by reference</em>,
+								Reading Systems MUST NOT apply CSS style rules of the containing document to the
+								referenced SVG document.</p>
 
-							<p id="confreq-svg-rs-css-embed-inc" data-tests="#confreq-svg-rs-css-embed-inc">For the purposes
-								of styling SVG embedded in XHTML Content Documents <em>by inclusion</em>, Reading Systems
-								MUST apply applicable CSS rules of the containing document to the included SVG elements.</p>
+							<p id="confreq-svg-rs-css-embed-inc" data-tests="#confreq-svg-rs-css-embed-inc">For the
+								purposes of styling SVG embedded in XHTML Content Documents <em>by inclusion</em>,
+								Reading Systems MUST apply applicable CSS rules of the containing document to the
+								included SVG elements.</p>
 
 							<div class="note">
 								<p>SVG included <em>by reference</em> is processed as a separate document, and can
@@ -726,8 +733,8 @@
 			<section id="sec-svg">
 				<h3>SVG Content Documents</h3>
 
-				<p id="confreq-rs-epub3-svg" class="support" data-tests="#confreq-rs-epub3-svg">Reading Systems MUST process
-					<a href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-svg" class="support" data-tests="#confreq-rs-epub3-svg">Reading Systems MUST
+					process <a href="https://www.w3.org/TR/epub-33/#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
 
 				<p>To process SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content
 						Documents</a>, a Reading System:</p>
@@ -945,9 +952,9 @@
 				</li>
 				<li>
 					<p id="confreq-nav-activation"
-					   data-tests="#confreq-nav-activation_in-spine,#confreq-nav-activation_not-in-spine">MUST relocate the
-					  current reading position to the destination identified by an activated link when the link is to a
-					  <a>Publication Resource</a>.</p>
+						data-tests="#confreq-nav-activation_in-spine,#confreq-nav-activation_not-in-spine">MUST relocate
+						the current reading position to the destination identified by an activated link when the link is
+						to a <a>Publication Resource</a>.</p>
 				</li>
 				<li>
 					<p id="confreq-nav-ol-style">MUST NOT show list item numbering on <code>nav</code> elements when
@@ -959,8 +966,8 @@
 			</ul>
 
 			<p id="confreq-nav-spine" data-tests="#confreq-nav-spine_in-spine,#confreq-nav-spine_not-in-spine">Reading
-				Systems MUST honor the above requirements irrespective of whether the EPUB Navigation Document is part of the
-				<a href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[EPUB-33]].</p>
+				Systems MUST honor the above requirements irrespective of whether the EPUB Navigation Document is part
+				of the <a href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[EPUB-33]].</p>
 
 		</section>
 		<section id="sec-fixed-layouts">
@@ -979,8 +986,9 @@
 							href="https://www.w3.org/TR/epub-33/#elemdef-opf-metadata"><code>metadata</code> section</a>
 						section [[EPUB-33]]. </p>
 
-					<p data-tests="fxl-properties-001.epub" id="layout-pre-paginated">When the <code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading
-						Systems MUST NOT include space between the adjacent content slots when rendering <a>Synthetic
+					<p data-tests="fxl-properties-001.epub" id="layout-pre-paginated">When the
+							<code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading Systems
+						MUST NOT include space between the adjacent content slots when rendering <a>Synthetic
 							Spreads</a>.</p>
 
 					<p>The <code>rendition:layout</code> property values have the following processing requirements:</p>
@@ -1048,19 +1056,23 @@
 				<section id="page-spread">
 					<h4>The <code>rendition:page-spread-*</code> Properties</h4>
 
-					<p data-tests="fxl-properties-007.epub">The <span id="page-spread-left"><code>rendition:page-spread-left</code></span> property indicates that the given spine item SHOULD
-						be rendered in the left-hand slot in the spread, and <span id="page-spread-right"><code>rendition:page-spread-right</code></span>
-						that it SHOULD be rendered in the right-hand slot. The <span id="page-spread-center"><code>rendition:page-spread-center</code></span>
-						property indicates that the synthetic spread mode SHOULD be overridden and a single viewport
-						rendered and positioned at the center of the screen.</p>
+					<p data-tests="fxl-properties-007.epub">The <span id="page-spread-left"
+								><code>rendition:page-spread-left</code></span> property indicates that the given spine
+						item SHOULD be rendered in the left-hand slot in the spread, and <span id="page-spread-right"
+								><code>rendition:page-spread-right</code></span> that it SHOULD be rendered in the
+						right-hand slot. The <span id="page-spread-center"
+							><code>rendition:page-spread-center</code></span> property indicates that the synthetic
+						spread mode SHOULD be overridden and a single viewport rendered and positioned at the center of
+						the screen.</p>
 
 					<p>The <code>rendition:page-spread-left</code>, <code>rendition:page-spread-right</code>, and
 							<code>rendition:page-spread-center</code> properties apply to both pre-paginated and
 						reflowable content, and they only apply when the Reading System is creating Synthetic
 						Spreads.</p>
 
-					<p data-tests="fxl-properties-008.epub">The <code id="page-break-precedence">rendition:page-spread-*</code> properties MUST take precedence over whatever value of
-						the <a href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
+					<p data-tests="fxl-properties-008.epub">The <code id="page-break-precedence"
+							>rendition:page-spread-*</code> properties MUST take precedence over whatever value of the
+							<a href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
 								><code>page-break-before</code> property</a> [[CSSSnapshot]] has been set for an
 							<a>XHTML Content Document</a>.</p>
 
@@ -1071,15 +1083,16 @@
 							regular and center-spread pages.</p>
 					</div>
 
-					<p id="page-layout-both" data-tests="fxl-properties-009.epub">When a <a href="#def-layout-reflowable">reflowable</a> spine item follows a <a
+					<p id="page-layout-both" data-tests="fxl-properties-009.epub">When a <a
+							href="#def-layout-reflowable">reflowable</a> spine item follows a <a
 							href="#def-layout-pre-paginated">pre-paginated</a> one, the reflowable one SHOULD start on
 						the next page &#8212; as defined by the <a
 							href="https://www.w3.org/TR/epub-33/#attrdef-spine-page-progression-direction"
 								><code>page-progression-direction</code></a> [[EPUB-33]] &#8212; when it lacks a
-							<code>rendition:page-spread-*</code> property value. 
-							
-							
-					<p id="page-spread-flow" data-tests="fxl-properties-010.epub">If the reflowable spine item has a <code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by inserting a
+							<code>rendition:page-spread-*</code> property value.</p>
+
+					<p id="page-spread-flow" data-tests="fxl-properties-010.epub">If the reflowable spine item has a
+							<code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by inserting a
 						blank page).</p>
 
 					<p>Similarly, when a pre-paginated spine item follows a reflowable one, the pre-paginated one SHOULD
@@ -1203,11 +1216,11 @@
 						<dt id="sec-container-metainf-container.xml">Container File (<code>container.xml</code>)</dt>
 						<dd>
 							<p id="container-default-rendition"
-							   data-tests="#container-default-rendition_arbitrary,#container-default-rendition_multiple">A
-							  Reading System MUST, by default, use the Package Document referenced from first
-							  <code>rootfile</code> element to render the EPUB Publication. If the Reading System recognizes
-							  a means of selecting from the other available options, it MAY choose a more appropriate
-							  Package Document.</p>
+								data-tests="#container-default-rendition_arbitrary,#container-default-rendition_multiple"
+								>A Reading System MUST, by default, use the Package Document referenced from first
+									<code>rootfile</code> element to render the EPUB Publication. If the Reading System
+								recognizes a means of selecting from the other available options, it MAY choose a more
+								appropriate Package Document.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-metadata.xml">Metadata File (<code>metadata.xml</code>)</dt>
@@ -1777,8 +1790,9 @@
 		<section id="sec-epub-rs-conf-backward">
 			<h3>Backward Compatibility</h3>
 
-			<p id="confreq-rs-backward-epub" data-tests="#confreq-rs-backward-epub">Reading Systems MUST attempt to process an EPUB Publication whose Package
-				Document <code>version</code> attribute is less than "<code>3.0</code>".</p>
+			<p id="confreq-rs-backward-epub" data-tests="#confreq-rs-backward-epub">Reading Systems MUST attempt to
+				process an EPUB Publication whose Package Document <code>version</code> attribute is less than
+					"<code>3.0</code>".</p>
 
 			<p id="confreq-rs-backward-conf">EPUB Publications with older version numbers will not always render exactly
 				as intended unless processed according to their respective specifications. Reading Systems SHOULD
@@ -2214,6 +2228,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>25-Oct-2021: Clarify that reading systems must render non-linear resources when they are hyperlinked
+					to by a user. See <a href="https://github.com/w3c/epub-specs/issues/1864">issue 1864</a>.</li>
 				<li>27-Aug-2021: Added accessibility bullet to cover the need for zooming, particularly for fixed-layout
 					documents. See <a href="https://github.com/w3c/epub-specs/issues/1776">issue 1776</a>.</li>
 				<li>27-Aug-2021: Remove the recommendation to support text search and selection in SVGs. Replacing with

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -523,9 +523,9 @@
 				<p id="confreq-rendition-rs-spine-nonlinear">When a user traverses the default reading order defined in
 					the <a href="https://www.w3.org/TR/epub-33/#sec-spine-elem">spine</a> [[EPUB-33]], a Reading System
 					MAY automatically skip <code>itemref</code> elements marked as non-linear. When a user activates a
-					hyperlink to a non-linear <code>itemref</code>, however, Reading Systems MUST render the referenced
-					resource or a designated fallback. Reading Systems MAY also provide the option for users to select
-					whether to skip non-linear content by default or not.</p>
+					hyperlink to a non-linear resource, however, Reading Systems MUST render the referenced resource or
+					a designated fallback. Reading Systems MAY also provide the option for users to select whether to
+					skip non-linear content by default or not.</p>
 
 				<p>If the EPUB Creator has not specified the <code>page-progression-direction</code>, the Reading System
 					MUST assume the value of <code>default</code>. When the EPUB Creator has set the value of the


### PR DESCRIPTION
Moves the parenthetical to a normative statement as requested in #1864. Feel free to modify this PR if you want to add the IDs at the same time, otherwise I won't auto-close that issue with this PR.

Fixes #1864

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1864/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1864/epub33/rs/index.html)
