### PR TITLE
Update references based on https://github.com/w3c/epub-tests/pull/60

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5140,7 +5140,7 @@ Spine:
 						block</a> [[CSS2]] in the manner applicable to their format:</p>
 
 				<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
-					<dt id="sec-fxl-icb-html">Expressing in XHTML</dt>
+					<dt id="sec-fxl-icb-html" data-tests="#confreq-fxl-rs-xhtml-icb">Expressing in XHTML</dt>
 					<dd>
 						<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
 								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1185,7 +1185,7 @@
 								<code>dir</code>
 							</dt>
 							<dd>
-								<p data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006">Specifies the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base
+								<p data-tests="#confreq-rs-pkg-dir_rtl-root-ltr,#confreq-rs-pkg-dir_rtl-root-unset,#confreq-rs-pkg-dir_unset-root-rtl,#confreq-rs-pkg-dir_unset-root-unset,#confreq-rs-pkg-dir-auto_root-rtl">Specifies the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base
 										direction</a> [[BIDI]] of the textual content and attribute values of the
 									carrying element and its descendants</p>
 								<p>Allowed values are:</p>
@@ -1195,7 +1195,7 @@
 									<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
 										Algorithm [[BIDI]].</li>
 								</ul>
-								<p data-tests="#confreq-rs-pkg-dir_rtl-003,#confreq-rs-pkg-dir_rtl-005">Reading Systems will assume the value <code>auto</code> when EPUB Creators omit the
+								<p data-tests="#confreq-rs-pkg-dir-auto_root-rtl,#confreq-rs-pkg-dir-auto_root-unset">Reading Systems will assume the value <code>auto</code> when EPUB Creators omit the
 									attribute or use an invalid value.</p>
 								<div class="note">
 									<p>The base direction specified in the <code>dir</code> attribute does not affect

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1185,9 +1185,10 @@
 								<code>dir</code>
 							</dt>
 							<dd>
-								<p data-tests="#confreq-rs-pkg-dir_rtl-root-ltr,#confreq-rs-pkg-dir_rtl-root-unset,#confreq-rs-pkg-dir_unset-root-rtl,#confreq-rs-pkg-dir_unset-root-unset,#confreq-rs-pkg-dir-auto_root-rtl">Specifies the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base
-										direction</a> [[BIDI]] of the textual content and attribute values of the
-									carrying element and its descendants</p>
+								<p data-tests="#confreq-rs-pkg-dir_creator-rtl,#confreq-rs-pkg-dir_rtl-root-ltr,#confreq-rs-pkg-dir_rtl-root-unset,#confreq-rs-pkg-dir_unset-root-rtl,#confreq-rs-pkg-dir_unset-root-unset,#confreq-rs-pkg-dir-auto_root-rtl">Specifies
+									the <a href="https://www.unicode.org/reports/tr9/tr9-42.html#BD5">base direction</a>
+									[[BIDI]] of the textual content and attribute values of the carrying element and its
+								descendants</p>
 								<p>Allowed values are:</p>
 								<ul>
 									<li><code>ltr</code> &#8212; left-to-right base direction;</li>
@@ -1195,8 +1196,9 @@
 									<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
 										Algorithm [[BIDI]].</li>
 								</ul>
-								<p data-tests="#confreq-rs-pkg-dir-auto_root-rtl,#confreq-rs-pkg-dir-auto_root-unset">Reading Systems will assume the value <code>auto</code> when EPUB Creators omit the
-									attribute or use an invalid value.</p>
+								<p data-tests="#confreq-rs-pkg-dir-auto_root-rtl,#confreq-rs-pkg-dir-auto_root-unset">Reading
+									Systems will assume the value <code>auto</code> when EPUB Creators omit the attribute or
+								use an invalid value.</p>
 								<div class="note">
 									<p>The base direction specified in the <code>dir</code> attribute does not affect
 										the ordering of characters within directional runs, only the relative ordering

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -342,7 +342,7 @@
 				<h4>Base Direction</h4>
 
 				<p id="confreq-rs-pkg-dir"
-				    data-tests="#confreq-rs-pkg-dir_rtl-001,#confreq-rs-pkg-dir_rtl-002,#confreq-rs-pkg-dir_rtl-004,#confreq-rs-pkg-dir_rtl-005,#confreq-rs-pkg-dir_rtl-006">
+				    data-tests="#confreq-rs-pkg-dir_rtl-root-ltr,#confreq-rs-pkg-dir_rtl-root-unset,#confreq-rs-pkg-dir_unset-root-rtl,#confreq-rs-pkg-dir_unset-root-unset,#confreq-rs-pkg-dir-auto_root-rtl">
 				    If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
 				    <code>rtl</code>, Reading Systems MUST override the bidi algorithm per
 				    <a data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]], setting
@@ -350,7 +350,7 @@
 				    is <code>rtl</code>.</p>
 
 				<p id="confreq-rs-pkg-dir-auto"
-				    data-tests="#confreq-rs-pkg-dir_rtl-003,#confreq-rs-pkg-dir_rtl-005">Otherwise
+				    data-tests="#confreq-rs-pkg-dir-auto_root-rtl,#confreq-rs-pkg-dir-auto_root-unset">Otherwise
 					the base direction is <code>auto</code>, in which case Reading Systems MUST determine the text's
 					direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of
 					[[BIDI]].</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -342,7 +342,7 @@
 				<h4>Base Direction</h4>
 
 				<p id="confreq-rs-pkg-dir"
-				    data-tests="#confreq-rs-pkg-dir_rtl-root-ltr,#confreq-rs-pkg-dir_rtl-root-unset,#confreq-rs-pkg-dir_unset-root-rtl,#confreq-rs-pkg-dir_unset-root-unset,#confreq-rs-pkg-dir-auto_root-rtl">
+				    data-tests="#confreq-rs-pkg-dir_creator-rtl,#confreq-rs-pkg-dir_rtl-root-ltr,#confreq-rs-pkg-dir_rtl-root-unset,#confreq-rs-pkg-dir_unset-root-rtl,#confreq-rs-pkg-dir_unset-root-unset,#confreq-rs-pkg-dir-auto_root-rtl">
 				    If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
 				    <code>rtl</code>, Reading Systems MUST override the bidi algorithm per
 				    <a data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]], setting
@@ -350,10 +350,9 @@
 				    is <code>rtl</code>.</p>
 
 				<p id="confreq-rs-pkg-dir-auto"
-				    data-tests="#confreq-rs-pkg-dir-auto_root-rtl,#confreq-rs-pkg-dir-auto_root-unset">Otherwise
-					the base direction is <code>auto</code>, in which case Reading Systems MUST determine the text's
-					direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of
-					[[BIDI]].</p>
+				    data-tests="#confreq-rs-pkg-dir-auto_root-rtl,#confreq-rs-pkg-dir-auto_root-unset">Otherwise the base
+				    direction is <code>auto</code>, in which case Reading Systems MUST determine the text's direction by
+				    applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of [[BIDI]].</p>
 			</section>
 
 			<section id="sec-pkg-doc-pub-identifiers">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1104,13 +1104,13 @@
 						<p>Reading Systems MUST use the width and height expressions as defined in <a
 								href="https://www.w3.org/TR/epub-33/#sec-fxl-icb-html">Expressing in HTML</a>
 							[[EPUB-33]] to render <a>XHTML Content Documents</a>.</p>
-						<p>Reading Systems MUST clip XHTML content to the initial containing block (ICB) dimensions
-							declared in the <code>viewport</code>
-							<code>meta</code> tag — content positioned outside of the initial containing block will not
-							be visible. When the ICB aspect ratio does not match the aspect ratio of the Reading System
-								<a>Content Display Area</a>, Reading Systems MAY position the ICB inside the area to
-							accommodate the user interface; in other words, added letter-boxing space MAY appear on
-							either side (or both) of the content.</p>
+						<p id="confreq-fxl-rs-xhtml-icb" data-tests="#confreq-fxl-rs-xhtml-icb">Reading Systems MUST clip
+							XHTML content to the initial containing block (ICB) dimensions declared in the
+							<code>viewport</code> <code>meta</code> tag — content positioned outside of the initial
+							containing block will not be visible. When the ICB aspect ratio does not match the aspect ratio
+							of the Reading System <a>Content Display Area</a>, Reading Systems MAY position the ICB inside
+							the area to accommodate the user interface; in other words, added letter-boxing space MAY appear
+							on either side (or both) of the content.</p>
 					</dd>
 
 					<dt>SVG</dt>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -470,12 +470,12 @@
 			<section id="sec-pkg-doc-manifest">
 				<h3>Manifest</h3>
 
-				<p>When an <code>href</code> attribute contains a <a
-						href="https://url.spec.whatwg.org/#relative-url-string">relative-URL string</a>, Reading Systems
-					MUST use the URL of the Package Document as the <a
-						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> when <a
-						href="https://url.spec.whatwg.org/#concept-url-parser">parsing</a> to a <a
-						href="https://url.spec.whatwg.org/#concept-url">URL record</a> [[URL]].</p>
+				<p id="confreq-rs-pkg-manifest-url" data-tests="#confreq-rs-pkg-manifest-url">When an <code>href</code>
+					attribute contains a <a href="https://url.spec.whatwg.org/#relative-url-string">relative-URL string</a>,
+					Reading Systems MUST use the URL of the Package Document as the
+					<a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> when
+					<a href="https://url.spec.whatwg.org/#concept-url-parser">parsing</a> to a
+					<a href="https://url.spec.whatwg.org/#concept-url">URL record</a> [[URL]].</p>
 
 				<p>Reading Systems MAY optimize the rendering depending on the properties set in the
 					<code>properties</code> attribute (e.g., disable a rendering process or use a fallback).

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -481,10 +481,10 @@
 					<span id="confreq-rs-pkg-manifest-unknown" data-tests="#confreq-rs-pkg-manifest-unknown">Reading
 						Systems MUST ignore values of the <code>properties</code> attribute they do not recognize.</span></p>
 
-				<p id="confreq-rendition-rs-manifest">It SHOULD NOT use non-<a>Publication Resources</a> in the
-					rendering of an EPUB Publication due to the inherent limitations and risks involved (e.g., lack of
-					information about the resource and how to process it, security risks from remotely-hosted sources,
-					lack of fallbacks, etc.).</p>
+				<p id="confreq-rendition-rs-manifest" data-tests="#confreq-rendition-rs-manifest">It SHOULD NOT use
+					non-<a>Publication Resources</a> in the rendering of an EPUB Publication due to the inherent limitations
+					and risks involved (e.g., lack of information about the resource and how to process it, security risks
+					from remotely-hosted sources, lack of fallbacks, etc.).</p>
 
 				<p>A Reading System that does not support the Media Type of a given Publication Resource MUST traverse
 					the fallback chain until it has identified at least one supported Publication Resource to use in


### PR DESCRIPTION
This corresponds to the changes in https://github.com/w3c/epub-tests/pull/60.

(Again, sorry for the large grab-bag PR; this was another plane flight. I'm home now, so no more like this.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1870.html" title="Last updated on Oct 26, 2021, 2:17 AM UTC (1c233c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1870/78e8050...1c233c9.html" title="Last updated on Oct 26, 2021, 2:17 AM UTC (1c233c9)">Diff</a>