### PR TITLE
Add reference to test for unique identifier

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -275,7 +275,8 @@
 					</li>
 				</ul>
 
-				<p id="confreq-rs-xml-extid">In addition, when processing XML documents, it MUST NOT resolve <a
+				<p id="confreq-rs-xml-extid" data-tests="#confreq-rs-xml-extid">In addition, when processing XML documents,
+					it MUST NOT resolve <a
 						href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">external identifiers</a>
 					[[XML]].</p>
 			</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -362,10 +362,11 @@
 			<section id="sec-pkg-doc-pub-identifiers">
 				<h3>Unique Identifier</h3>
 
-				<p>Reading Systems SHOULD NOT depend on the <code>unique-identifier</code> attribute being unique to one
-					and only one EPUB Publication. Determining whether two EPUB Publications with the same Unique
-					Identifier represent different versions of the same publication, or different publications, may
-					require inspecting other metadata, such as the last modification date, titles, and authors.</p>
+				<p id="confreq-rs-pkg-unique-id" data-tests="#confreq-rs-pkg-unique-id">Reading Systems SHOULD NOT depend on
+					the <code>unique-identifier</code> attribute being unique to one and only one EPUB Publication.
+					Determining whether two EPUB Publications with the same Unique Identifier represent different versions of
+					the same publication, or different publications, may require inspecting other metadata, such as the last
+					modification date, titles, and authors.</p>
 			</section>
 
 			<section id="sec-pkg-doc-metadata">


### PR DESCRIPTION
This corresponds to part of https://github.com/w3c/epub-tests/pull/64. I forgot to include this in https://github.com/w3c/epub-specs/pull/1880.