### PR TITLE
Add references to tests for page-progression-direction

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -528,15 +528,17 @@
 					specifically activates a hyperlink to such items). Reading Systems MAY also provide the option for
 					users to select whether to skip non-linear content by default or not.</p>
 
-				<p>If the EPUB Creator has not specified the <code>page-progression-direction</code>, the Reading System
-					MUST assume the value of <code>default</code>. When the EPUB Creator has set the value of the
-						<code>page-progression-direction</code> to <code>default</code>, either explicitly or
-					implicitly, the Reading System can choose rendering direction.</p>
+				<p id="confreq-rs-spine-progression-default" data-tests="#confreq-rs-spine-progression-default">If the EPUB
+					Creator has not specified the <code>page-progression-direction</code>, the Reading System MUST assume the
+					value of <code>default</code>. When the EPUB Creator has set the value of the
+					<code>page-progression-direction</code> to <code>default</code>, either explicitly or implicitly, the
+					Reading System can choose rendering direction.</p>
 
-				<p>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
-							><code>pre-paginated</code></a> XHTML Content Documents. The
-						<code>page-progression-direction</code> attribute defines the flow direction from one
-					fixed-layout page to the next.</p>
+				<p id="confreq-rs-spine-progression-prepaginated" data-tests="#confreq-rs-spine-progression-prepaginated">
+					Reading Systems MUST ignore the page progression direction defined in
+					<a href="#layout"><code>pre-paginated</code></a> XHTML Content Documents. The
+					<code>page-progression-direction</code> attribute defines the flow direction from one fixed-layout page
+					to the next.</p>
 
 				<p>If any of the <code>properties</code> attribute's values do not include a prefix, Reading Systems
 					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a


### PR DESCRIPTION
This corresponds to https://github.com/w3c/epub-tests/pull/65, except that the explicit ltr/rtl tests in that PR have no normative statement, which is noted in https://github.com/w3c/epub-specs/issues/1883.