### PR TITLE
Updates to structure vocab

### DIFF
--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -98,6 +98,7 @@
 			<p>This vocabulary, a part of EPUB® 3, defines a set of properties relating to the description 
 				of structural semantics of written works.</p>
 		</section>
+		
 		<section id="sotd"></section>
 
 		<section id="sec-introduction">
@@ -150,8 +151,36 @@
 		</section>
 			
 		<section id="sec-partitions">
-			<h4>Document Partitions</h4>
+			<h2>Document Partitions</h2>
+			
 			<dl>
+				<dt id="backmatter">backmatter</dt>
+				<dd>
+					<p>Ancillary material occurring after the main content of a publication, such as indices,
+						appendices, etc.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				
+				<dt id="bodymatter">bodymatter</dt>
+				<dd>
+					<p>The main content of a publication.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				
 				<dt id="cover">cover</dt>
 				<dd>
 					<p>A section that introduces the work, often consisting of a marketing image, the title, author,
@@ -171,6 +200,7 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-cover">doc-cover</a> (only allowed on
 						cover image tag)</p>
 				</dd>
+				
 				<dt id="frontmatter">frontmatter</dt>
 				<dd>
 					<p>Preliminary material to the main content of a publication, such as tables of contents,
@@ -184,67 +214,13 @@
 							href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
 					</p>
 				</dd>
-				<dt id="bodymatter">bodymatter</dt>
-				<dd>
-					<p>The main content of a publication.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
-					</p>
-				</dd>
-				<dt id="backmatter">backmatter</dt>
-				<dd>
-					<p>Ancillary material occurring after the main content of a publication, such as indices,
-						appendices, etc.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
-					</p>
-				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-divisions">
-			<h4>Document Divisions</h4>
+			<h2>Document Divisions</h2>
+			
 			<dl>
-				<dt id="volume">volume</dt>
-				<dd>
-					<p>A component of a collection.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
-					</p>
-				</dd>
-				<dt id="part">part</dt>
-				<dd>
-					<p>A major structural division in a work that contains a set of related sections dealing with a
-						particular subject, narrative arc, or similar encapsulated theme.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-part">doc-part</a>
-					</p>
-				</dd>
 				<dt id="chapter">chapter</dt>
 				<dd>
 					<p>A major thematic section of content in a work.</p>
@@ -263,8 +239,22 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-chapter">doc-chapter</a>
 					</p>
 				</dd>
-				<dt id="subchapter">subchapter<span class="status deprecated"> [deprecated]</span>
-				</dt>
+				
+				<dt id="division">division</dt>
+				<dd>
+					<p>A major structural division that may also appear as a substructure of a part (esp. in
+						legislation).</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				
+				<dt id="subchapter">subchapter<span class="status deprecated"> [deprecated]</span></dt>
 				<dd>
 					<p>A major sub-division of a chapter.</p>
 				</dd>
@@ -276,24 +266,47 @@
 							href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
 					</p>
 				</dd>
-				<dt id="division">division</dt>
+				
+				<dt id="part">part</dt>
 				<dd>
-					<p>A major structural division that may also appear as a substructure of a part (esp. in
-						legislation).</p>
+					<p>A major structural division in a work that contains a set of related sections dealing with a
+						particular subject, narrative arc, or similar encapsulated theme.</p>
 				</dd>
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
 						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
 							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-part">doc-part</a>
+					</p>
+				</dd>
+				
+				<dt id="volume">volume</dt>
+				<dd>
+					<p>A component of a collection.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a>
 					</p>
 				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-sections">
-			<h4>Document Sections and Components</h4>
+			<h2>Document Sections and Components</h2>
+			
 			<p>Sections and components that typically occur in the publication bodymatter.</p>
+			
 			<dl>
 				<dt id="abstract-1">abstract<span class="status draft"> [draft]</span>
 				</dt>
@@ -316,6 +329,91 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-abstract">doc-abstract</a>
 					</p>
 				</dd>
+				
+				<dt id="afterword">afterword</dt>
+				<dd>
+					<p>A closing statement from the author or a person of importance, typically providing insight
+						into how the content came to be written, its significance, or related events that have
+						transpired since its timeline.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-afterword">doc-afterword</a>
+					</p>
+				</dd>
+				
+				<dt id="conclusion">conclusion</dt>
+				<dd>
+					<p>A concluding section or statement that summarizes the work or wraps up the narrative.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-conclusion">doc-conclusion</a>
+					</p>
+				</dd>
+				
+				<dt id="epigraph">epigraph</dt>
+				<dd>
+					<p>A quotation set at the start of the work or a section that establishes the theme or sets the
+						mood.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-epigraph">doc-epigraph</a>
+					</p>
+				</dd>
+				
+				<dt id="epilogue">epilogue</dt>
+				<dd>
+					<p>A concluding section of narrative that wraps up or comments on the actions and events of the
+						work, typically from a future perspective.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-epilogue">doc-epilogue</a>
+					</p>
+				</dd>
+				
 				<dt id="foreword">foreword</dt>
 				<dd>
 					<p>An introductory section that precedes the work, typically not written by the author of the
@@ -336,6 +434,42 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-foreword">doc-foreword</a>
 					</p>
 				</dd>
+				
+				<dt id="introduction">introduction</dt>
+				<dd>
+					<p>A preliminary section that typically introduces the scope or nature of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-introduction">doc-introduction</a>
+					</p>
+				</dd>
+				
+				<dt id="preamble">preamble</dt>
+				<dd>
+					<p>A section in the beginning of the work, typically containing introductory and/or explanatory
+						prose regarding the scope or nature of the work's content</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				
 				<dt id="preface">preface</dt>
 				<dd>
 					<p>An introductory section that precedes the work, typically written by the author of the
@@ -356,6 +490,7 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-preface">doc-preface</a>
 					</p>
 				</dd>
+				
 				<dt id="prologue">prologue</dt>
 				<dd>
 					<p>An introductory section that sets the background to a work, typically part of the
@@ -376,124 +511,79 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-prologue">doc-prologue</a>
 					</p>
 				</dd>
-				<dt id="introduction">introduction</dt>
-				<dd>
-					<p>A preliminary section that typically introduces the scope or nature of the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-introduction">doc-introduction</a>
-					</p>
-				</dd>
-				<dt id="preamble">preamble</dt>
-				<dd>
-					<p>A section in the beginning of the work, typically containing introductory and/or explanatory
-						prose regarding the scope or nature of the work's content</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dt id="conclusion">conclusion</dt>
-				<dd>
-					<p>A concluding section or statement that summarizes the work or wraps up the narrative.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-conclusion">doc-conclusion</a>
-					</p>
-				</dd>
-				<dt id="epilogue">epilogue</dt>
-				<dd>
-					<p>A concluding section of narrative that wraps up or comments on the actions and events of the
-						work, typically from a future perspective.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-epilogue">doc-epilogue</a>
-					</p>
-				</dd>
-				<dt id="afterword">afterword</dt>
-				<dd>
-					<p>A closing statement from the author or a person of importance, typically providing insight
-						into how the content came to be written, its significance, or related events that have
-						transpired since its timeline.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-afterword">doc-afterword</a>
-					</p>
-				</dd>
-				<dt id="epigraph">epigraph</dt>
-				<dd>
-					<p>A quotation set at the start of the work or a section that establishes the theme or sets the
-						mood.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-epigraph">doc-epigraph</a>
-					</p>
-				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-navigation">
-			<h4>Document Navigation</h4>
+			<h2>Document Navigation</h2>
+			
 			<dl>
+				<dt id="landmarks">landmarks</dt>
+				<dd>
+					<p>A collection of references to well-known/recurring components within the publication</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="https://www.w3.org/TR/epub-33/#sec-nav-landmarks">The <code>landmarks nav</code> Element</a> [[EPUB-33]]
+					</p>
+				</dd>
+				
+				<dt id="loa">loa</dt>
+				<dd>
+					<p>A listing of audio clips included in the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				
+				<dt id="loi">loi</dt>
+				<dd>
+					<p>A listing of illustrations included in the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				
+				<dt id="lot">lot</dt>
+				<dd>
+					<p>A listing of tables included in the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				
+				<dt id="lov">lov</dt>
+				<dd>
+					<p>A listing of video clips included in the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				
 				<dt id="toc-1">toc</dt>
 				<dd>
 					<p>A navigational aid that provides an ordered list of links to the major sectional headings in
@@ -519,8 +609,8 @@
 						<a href="https://www.w3.org/TR/epub-33/#sec-nav-toc">The <code>toc nav</code> Element</a> [[EPUB-33]]
 					</p>
 				</dd>
-				<dt id="toc-brief">toc-brief<span class="status draft"> [draft]</span>
-				</dt>
+				
+				<dt id="toc-brief">toc-brief<span class="status draft"> [draft]</span></dt>
 				<dd>
 					<p>An abridged version of the table of contents.</p>
 				</dd>
@@ -531,71 +621,12 @@
 							content</a>
 					</p>
 				</dd>
-				<dt id="landmarks">landmarks</dt>
-				<dd>
-					<p>A collection of references to well-known/recurring components within the publication</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-							content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Usage details: </span>
-						<a href="https://www.w3.org/TR/epub-33/#sec-nav-landmarks">The <code>landmarks nav</code> Element</a> [[EPUB-33]]
-					</p>
-				</dd>
-				<dt id="loa">loa</dt>
-				<dd>
-					<p>A listing of audio clips included in the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-							content</a>
-					</p>
-				</dd>
-				<dt id="loi">loi</dt>
-				<dd>
-					<p>A listing of illustrations included in the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-							content</a>
-					</p>
-				</dd>
-				<dt id="lot">lot</dt>
-				<dd>
-					<p>A listing of tables included in the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-							content</a>
-					</p>
-				</dd>
-				<dt id="lov">lov</dt>
-				<dd>
-					<p>A listing of video clips included in the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-							content</a>
-					</p>
-				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-document-references">
-			<h4>Document Reference Sections</h4>
+			<h2>Document Reference Sections</h2>
+			
 			<dl>
 				<dt id="appendix">appendix</dt>
 				<dd>
@@ -615,6 +646,7 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-appendix">doc-appendix</a>
 					</p>
 				</dd>
+				
 				<dt id="colophon">colophon</dt>
 				<dd>
 					<p>A short section of production notes particular to the edition (e.g., describing the typeface
@@ -635,8 +667,8 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-colophon">doc-colophon</a>
 					</p>
 				</dd>
-				<dt id="credits">credits<span class="status draft"> [draft]</span>
-				</dt>
+				
+				<dt id="credits">credits<span class="status draft"> [draft]</span></dt>
 				<dd>
 					<p>A collection of <a href="#credit">credits</a>.</p>
 				</dd>
@@ -655,8 +687,8 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-credits">doc-credits</a>
 					</p>
 				</dd>
-				<dt id="keywords">keywords<span class="status draft"> [draft]</span>
-				</dt>
+				
+				<dt id="keywords">keywords<span class="status draft"> [draft]</span></dt>
 				<dd>
 					<p>A collection of <a href="#keyword">keywords</a>.</p>
 				</dd>
@@ -670,519 +702,11 @@
 					</p>
 				</dd>
 			</dl>
-			<section id="indexes">
-				<h3 id="h_indexes">Indexes</h3>
-				<dl>
-					<dt id="index">index</dt>
-					<dd>
-						<p>A navigational aid that provides a detailed list of links to key subjects, names and
-							other important topics covered in the work.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-								content</a>, <a
-								href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element"
-								>body</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-index">index
-								property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">DPUB-ARIA role: </span>
-							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-index">doc-index</a>
-						</p>
-					</dd>
-					<dt id="index-headnotes">index-headnotes</dt>
-					<dd>
-						<p>Narrative or other content to assist users in using the index.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index">index</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-								content</a>, <a
-								href="https://html.spec.whatwg.org/multipage/sections.html#the-header-element"
-								>header</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-headnotes">index-headnotes property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-legend">index-legend</dt>
-					<dd>
-						<p>List of symbols, abbreviations or special formatting used in the index, and their
-							meanings.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-headnotes">index-headnotes</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-								content</a>, <a
-								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"
-								>dl</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-legend">index-legend property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-group">index-group</dt>
-					<dd>
-						<p>Collection of consecutive main entries that share a common characteristic, for example
-							the starting letter of the main entries.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index">index</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-								content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-group">index-group property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-entry-list">index-entry-list</dt>
-					<dd>
-						<p>Collection of consecutive main entries or subentries.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-entry">index-entry</a>
-							</span>, <span class="subpropref">
-								<a href="#index-group">index-group</a>, </span> and <span class="subpropref">
-								<a href="#index">index</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element"
-								>ul</a>; this property is implied when the ul has an ancestor of index except within
-							index-headnotes</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-entry-list">index-entry-list property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-entry">index-entry</dt>
-					<dd>
-						<p>One term with any attendant subentries, locators, cross references, and/or editorial
-							note.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-entry-list">index-entry-list</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element"
-								>li</a>; this property is implied when parent ul is of type index-entry-list
-							(implicit or explicit)</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-entry">index-entry property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-term">index-term</dt>
-					<dd>
-						<p>Word, phrase, string, glyph, or image representing the indexable content.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-xref-related">index-xref-related</a>
-							</span>, <span class="subpropref">
-								<a href="#index-entry">index-entry</a>
-							</span> and <span class="subpropref">
-								<a href="#index-xref-preferred">index-xref-preferred</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content">phrasing
-								content</a>; typically <a
-								href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element"
-								>span</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term">index-term property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-editor-note">index-editor-note</dt>
-					<dd>
-						<p>Editorial note pertaining to a single entry.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-entry">index-entry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-editor-note">index-editor-note property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-locator">index-locator</dt>
-					<dd>
-						<p>A reference to an occurrence of the indexed content in the publication.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-entry">index-entry</a>
-							</span>, <span class="subpropref">
-								<a href="#index-locator-list">index-locator-list</a>
-							</span>, and <span class="subpropref">
-								<a href="#index-locator-range">index-locator-range</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
-								>a</a>; this property is implied when parent context is index-locator-list or
-							index-locator-range</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator">index-locator property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-locator-list">index-locator-list</dt>
-					<dd>
-						<p>Collection of sequential locators or locator ranges.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-entry">index-entry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element"
-								>ul</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator-list">index-locator-list property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-locator-range">index-locator-range</dt>
-					<dd>
-						<p>A pair of locators that connects a term to a range of content rather than a single
-							point.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-locator-list">index-locator-list</a>
-							</span> and <span class="subpropref">
-								<a href="#index-entry">index-entry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator-range">index-locator-range property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-xref-preferred">index-xref-preferred</dt>
-					<dd>
-						<p>Reference from one term to one or more preferred terms or term categories in an index
-							(analogous to "See xxx").</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-entry">index-entry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-xref">index-xref-preferred property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-xref-related">index-xref-related</dt>
-					<dd>
-						<p>Reference from one term to one or more related terms or term categories in an index
-							(analogous to "See also xxx").</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-entry">index-entry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-xref">index-xref-related property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-term-category">index-term-category</dt>
-					<dd>
-						<p>Word, phrase, string, glyph, or image representing a category of terms in the index.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-xref-related">index-xref-related</a>
-							</span> and <span class="subpropref">
-								<a href="#index-xref-preferred">index-xref-preferred</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
-								>a</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term-category">index-term-category property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-					<dt id="index-term-categories">index-term-categories</dt>
-					<dd>
-						<p>Wrapper for a list of the term categories belonging to an index.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#index-xref-related">index-xref-related</a>
-							</span> and <span class="subpropref">
-								<a href="#index-xref-preferred">index-xref-preferred</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
-								>a</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term-categories">index-term-categories property</a> [[EPUB-INDEXES-10]]
-						</p>
-					</dd>
-				</dl>
-			</section>
-			<section id="glossaries">
-				<h3 id="h_glossaries">Glossaries</h3>
-				<dl>
-					<dt id="glossary">glossary</dt>
-					<dd>
-						<p>A brief dictionary of new, uncommon, or specialized terms used in the content.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"
-								>dl</a>, <a
-								href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-								content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">DPUB-ARIA role: </span>
-							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossary">doc-glossary</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.1">The Glossary
-								Container</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-					<dt id="glossterm">glossterm</dt>
-					<dd>
-						<p>A glossary term.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#glossary">glossary</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>The glossterm property is implied
-							on <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element"
-								>dt</a> elements within a <a
-								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"
-								>dl</a> element marked with the <a href="#glossary">glossary</a> property.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.2">Glossary Terms
-								and Definitions</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-					<dt id="glossdef">glossdef</dt>
-					<dd>
-						<p>The definition of a <a href="#glossterm">term in a glossary</a>.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#glossary">glossary</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>The glossdef property is implied
-							on <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element"
-								>dd</a> elements within a <a
-								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"
-								>dl</a> element marked with the <a href="#glossary">glossary</a> property.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.2">Glossary Terms
-								and Definitions</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-				</dl>
-			</section>
+			
 			<section id="bibliographies">
 				<h3 id="h_bibliographies">Bibliographies</h3>
+				
 				<dl>
-					<dt id="bibliography">bibliography</dt>
-					<dd>
-						<p>A list of external references cited in the work, which may be to print or digital
-							sources.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-								content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">DPUB-ARIA role: </span>
-							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-bibliography">doc-bibliography</a>
-						</p>
-					</dd>
 					<dt id="biblioentry">biblioentry</dt>
 					<dd>
 						<p>A single reference to an external source in a <a href="#bibliography">bibliography</a>. A
@@ -1210,31 +734,111 @@
 							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-biblioentry">doc-biblioentry</a>
 							(Deprecated)</p>
 					</dd>
-				</dl>
-			</section>
-			<section id="dictionaries">
-				<h3>Dictionaries</h3>
-				
-				<dl>
-					<dt id="dictionary">dictionary</dt>
+					<dt id="bibliography">bibliography</dt>
 					<dd>
-						<p>A collection of dictionary entries.</p>
+						<p>A list of external references cited in the work, which may be to print or digital
+							sources.</p>
 					</dd>
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-								<a
-									href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element"
-									>body</a> or <a 
-									href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-										>section</a>
+							<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+								content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">DPUB-ARIA role: </span>
+							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-bibliography">doc-bibliography</a>
+						</p>
+					</dd>
+				</dl>
+			</section>
+			
+			<section id="dictionaries">
+				<h3>Dictionaries</h3>
+				
+				<dl>
+					<dt id="antonym-group">antonym-group</dt>
+					<dd>
+						<p>A group of terms, each having an opposite or nearly opposite meaning from a headword or idiom.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
 						</p>
 					</dd>
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.1">The Dictionary
-								Container</a> [[EPUB-DICT-10]]
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.9.2">Antonym
+								Groups</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="condensed-entry">condensed-entry</dt>
+					<dd>
+						<p>A condensed dictionary entry designed for constrained lookup viewports.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-aside-element"
+								>aside</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.2.2.2">The Condensed
+								Entry</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="def">def</dt>
+					<dd>
+						<p>The definition of a particular meaning of a headword or idiom.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.6">Definitions</a> [[EPUB-DICT-10]]
 						</p>
 					</dd>
 					
@@ -1265,81 +869,19 @@
 								Entry</a> [[EPUB-DICT-10]]
 						</p>
 					</dd>
-
-					<dt id="condensed-entry">condensed-entry</dt>
+					
+					<dt id="dictionary">dictionary</dt>
 					<dd>
-						<p>A condensed dictionary entry designed for constrained lookup viewports.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required parent context:</span>
-							<span class="subpropref">
-								<a href="#dictentry">dictentry</a>
-							</span>
-						</p>
+						<p>A collection of dictionary entries.</p>
 					</dd>
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a 
-								href="https://html.spec.whatwg.org/multipage/sections.html#the-aside-element"
-								>aside</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.2.2.2">The Condensed
-								Entry</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-
-					<dt id="phonetic-transcription">phonetic-transcription</dt>
-					<dd>
-						<p>A phonetic transcription of the pronunciation of a headword or other component of a dictionary entry.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required ancestor context:</span>
-							<span class="subpropref">
-								<a href="#dictentry">dictentry</a> or <a href="#glossary">glossary</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a 
-								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
-								>flow content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.4">Phonetic
-								Transcriptions</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-
-					<dt id="part-of-speech">part-of-speech</dt>
-					<dd>
-						<p>The grammatical function of a headword.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required ancestor context:</span>
-							<span class="subpropref">
-								<a href="#dictentry">dictentry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a 
-								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
-								>flow content</a>
+								<a
+									href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element"
+									>body</a> or <a 
+									href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+										>section</a>
 						</p>
 					</dd>
 					<dd>
@@ -1349,35 +891,7 @@
 								Container</a> [[EPUB-DICT-10]]
 						</p>
 					</dd>
-
-					<dt id="gram-info">gram-info</dt>
-					<dd>
-						<p>Supplemental grammatical information related to the headword and modifying a part of speech or a particular meaning.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required ancestor context:</span>
-							<span class="subpropref">
-								<a href="#dictentry">dictentry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a 
-								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
-								>flow content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.5.2">Related Grammatical
-								Information</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-
+					
 					<dt id="etymology">etymology</dt>
 					<dd>
 						<p>An explanation of the historical origin of a headword.</p>
@@ -1405,38 +919,10 @@
 							[[EPUB-DICT-10]]
 						</p>
 					</dd>
-
-					<dt id="part-of-speech-list">part-of-speech-list</dt>
+					
+					<dt id="example">example</dt>
 					<dd>
-						<p>A list of part of speech groups in a dictionary entry.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required ancestor context:</span>
-							<span class="subpropref">
-								<a href="#dictentry">dictentry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a 
-								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
-								>ol</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.2">Part of
-								Speech Lists</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-
-					<dt id="part-of-speech-group">part-of-speech-group</dt>
-					<dd>
-						<p>A unit that associates a part of speech with its related sense and phrase groups.</p>
+						<p>An illustration of the usage of a defined term or phrase.</p>
 					</dd>
 					<dd>
 						<p>
@@ -1457,130 +943,19 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.3">Part of Speech
-								Groups</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-
-					<dt id="sense-list">sense-list</dt>
-					<dd>
-						<p>A list of sense groups in a dictionary entry.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required ancestor context:</span>
-							<span class="subpropref">
-								<a href="#dictentry">dictentry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a 
-								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
-								>ol</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.4">Sense
-								Lists</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-
-					<dt id="sense-group">sense-group</dt>
-					<dd>
-						<p>A unit for organizing information pertaining to a particular meaning of a headword or idiom.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required ancestor context:</span>
-							<span class="subpropref">
-								<a href="#dictentry">dictentry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a 
-								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
-								>flow content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.5">Sense
-								Groups</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-
-					<dt id="def">def</dt>
-					<dd>
-						<p>The definition of a particular meaning of a headword or idiom.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required ancestor context:</span>
-							<span class="subpropref">
-								<a href="#dictentry">dictentry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a 
-								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
-								>flow content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.6">Definitions</a> [[EPUB-DICT-10]]
-						</p>
-					</dd>
-
-					<dt id="tran">tran</dt>
-					<dd>
-						<p>The translation of a particular meaning of a source language headword, idiom, or example into a target language.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Required ancestor context:</span>
-							<span class="subpropref">
-								<a href="#dictentry">dictentry</a>
-							</span>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a 
-								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
-								>flow content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.7">Translations</a> [[EPUB-DICT-10]]
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.3">Examples</a> [[EPUB-DICT-10]]
 						</p>
 					</dd>
 					
-					<dt id="tran-info">tran-info</dt>
+					<dt id="gram-info">gram-info</dt>
 					<dd>
-						<p>Grammatical or usage information related to a translation.</p>
+						<p>Supplemental grammatical information related to the headword and modifying a part of speech or a particular meaning.</p>
 					</dd>
 					<dd>
 						<p>
 							<span class="subproplabel">Required ancestor context:</span>
 							<span class="subpropref">
-								<a href="#tran">tran</a>
+								<a href="#dictentry">dictentry</a>
 							</span>
 						</p>
 					</dd>
@@ -1595,7 +970,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.8">Translation-Related
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.5.2">Related Grammatical
 								Information</a> [[EPUB-DICT-10]]
 						</p>
 					</dd>
@@ -1627,9 +1002,9 @@
 						</p>
 					</dd>
 					
-					<dt id="example">example</dt>
+					<dt id="part-of-speech">part-of-speech</dt>
 					<dd>
-						<p>An illustration of the usage of a defined term or phrase.</p>
+						<p>The grammatical function of a headword.</p>
 					</dd>
 					<dd>
 						<p>
@@ -1650,10 +1025,95 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.3">Examples</a> [[EPUB-DICT-10]]
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.1">The Dictionary
+								Container</a> [[EPUB-DICT-10]]
 						</p>
 					</dd>
 					
+					<dt id="part-of-speech-list">part-of-speech-list</dt>
+					<dd>
+						<p>A list of part of speech groups in a dictionary entry.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
+								>ol</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.2">Part of
+								Speech Lists</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="part-of-speech-group">part-of-speech-group</dt>
+					<dd>
+						<p>A unit that associates a part of speech with its related sense and phrase groups.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.3">Part of Speech
+								Groups</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="phonetic-transcription">phonetic-transcription</dt>
+					<dd>
+						<p>A phonetic transcription of the pronunciation of a headword or other component of a dictionary entry.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a> or <a href="#glossary">glossary</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.4">Phonetic
+								Transcriptions</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
 					<dt id="phrase-list">phrase-list</dt>
 					<dd>
 						<p>A list of phrase groups in a dictionary entry.</p>
@@ -1712,6 +1172,62 @@
 						</p>
 					</dd>
 					
+					<dt id="sense-list">sense-list</dt>
+					<dd>
+						<p>A list of sense groups in a dictionary entry.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
+								>ol</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.4">Sense
+								Lists</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="sense-group">sense-group</dt>
+					<dd>
+						<p>A unit for organizing information pertaining to a particular meaning of a headword or idiom.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.5">Sense
+								Groups</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
 					<dt id="synonym-group">synonym-group</dt>
 					<dd>
 						<p>A group of terms, each having identical or similar meaning to a headword or idiom.</p>
@@ -1740,9 +1256,9 @@
 						</p>
 					</dd>
 					
-					<dt id="antonym-group">antonym-group</dt>
+					<dt id="tran">tran</dt>
 					<dd>
-						<p>A group of terms, each having an opposite or nearly opposite meaning from a headword or idiom.</p>
+						<p>The translation of a particular meaning of a source language headword, idiom, or example into a target language.</p>
 					</dd>
 					<dd>
 						<p>
@@ -1763,17 +1279,736 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.9.2">Antonym
-								Groups</a> [[EPUB-DICT-10]]
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.7">Translations</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="tran-info">tran-info</dt>
+					<dd>
+						<p>Grammatical or usage information related to a translation.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#tran">tran</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.8">Translation-Related
+								Information</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+				</dl>
+			</section>
+			
+			<section id="glossaries">
+				<h3 id="h_glossaries">Glossaries</h3>
+				
+				<dl>
+					<dt id="glossary">glossary</dt>
+					<dd>
+						<p>A brief dictionary of new, uncommon, or specialized terms used in the content.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"
+								>dl</a>, <a
+									href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+									content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">DPUB-ARIA role: </span>
+							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossary">doc-glossary</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.1">The Glossary
+								Container</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="glossdef">glossdef</dt>
+					<dd>
+						<p>The definition of a <a href="#glossterm">term in a glossary</a>.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#glossary">glossary</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>The glossdef property is implied
+							on <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element"
+								>dd</a> elements within a <a
+									href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"
+									>dl</a> element marked with the <a href="#glossary">glossary</a> property.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.2">Glossary Terms
+								and Definitions</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="glossterm">glossterm</dt>
+					<dd>
+						<p>A glossary term.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#glossary">glossary</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>The glossterm property is implied
+							on <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element"
+								>dt</a> elements within a <a
+									href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"
+									>dl</a> element marked with the <a href="#glossary">glossary</a> property.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.2">Glossary Terms
+								and Definitions</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+				</dl>
+			</section>
+			
+			<section id="indexes">
+				<h3 id="h_indexes">Indexes</h3>
+				
+				<dl>
+					<dt id="index">index</dt>
+					<dd>
+						<p>A navigational aid that provides a detailed list of links to key subjects, names and
+							other important topics covered in the work.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+								content</a>, <a
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element"
+								>body</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-index">index
+								property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">DPUB-ARIA role: </span>
+							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-index">doc-index</a>
+						</p>
+					</dd>
+					
+					<dt id="index-editor-note">index-editor-note</dt>
+					<dd>
+						<p>Editorial note pertaining to a single entry.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-entry">index-entry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-editor-note">index-editor-note property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-entry">index-entry</dt>
+					<dd>
+						<p>One term with any attendant subentries, locators, cross references, and/or editorial
+							note.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-entry-list">index-entry-list</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element"
+								>li</a>; this property is implied when parent ul is of type index-entry-list
+							(implicit or explicit)</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-entry">index-entry property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-entry-list">index-entry-list</dt>
+					<dd>
+						<p>Collection of consecutive main entries or subentries.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-entry">index-entry</a>
+							</span>, <span class="subpropref">
+								<a href="#index-group">index-group</a>, </span> and <span class="subpropref">
+									<a href="#index">index</a>
+								</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element"
+								>ul</a>; this property is implied when the ul has an ancestor of index except within
+							index-headnotes</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-entry-list">index-entry-list property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-group">index-group</dt>
+					<dd>
+						<p>Collection of consecutive main entries that share a common characteristic, for example
+							the starting letter of the main entries.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index">index</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+								content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-group">index-group property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-headnotes">index-headnotes</dt>
+					<dd>
+						<p>Narrative or other content to assist users in using the index.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index">index</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+								content</a>, <a
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-header-element"
+								>header</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-headnotes">index-headnotes property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-legend">index-legend</dt>
+					<dd>
+						<p>List of symbols, abbreviations or special formatting used in the index, and their
+							meanings.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-headnotes">index-headnotes</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+								content</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"
+								>dl</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-legend">index-legend property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-locator">index-locator</dt>
+					<dd>
+						<p>A reference to an occurrence of the indexed content in the publication.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-entry">index-entry</a>
+							</span>, <span class="subpropref">
+								<a href="#index-locator-list">index-locator-list</a>
+							</span>, and <span class="subpropref">
+								<a href="#index-locator-range">index-locator-range</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
+								>a</a>; this property is implied when parent context is index-locator-list or
+							index-locator-range</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator">index-locator property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-locator-list">index-locator-list</dt>
+					<dd>
+						<p>Collection of sequential locators or locator ranges.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-entry">index-entry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element"
+								>ul</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator-list">index-locator-list property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-locator-range">index-locator-range</dt>
+					<dd>
+						<p>A pair of locators that connects a term to a range of content rather than a single
+							point.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-locator-list">index-locator-list</a>
+							</span> and <span class="subpropref">
+								<a href="#index-entry">index-entry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator-range">index-locator-range property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-term">index-term</dt>
+					<dd>
+						<p>Word, phrase, string, glyph, or image representing the indexable content.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-xref-related">index-xref-related</a>
+							</span>, <span class="subpropref">
+								<a href="#index-entry">index-entry</a>
+							</span> and <span class="subpropref">
+								<a href="#index-xref-preferred">index-xref-preferred</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content">phrasing
+								content</a>; typically <a
+								href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element"
+								>span</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term">index-term property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-term-categories">index-term-categories</dt>
+					<dd>
+						<p>Wrapper for a list of the term categories belonging to an index.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-xref-related">index-xref-related</a>
+							</span> and <span class="subpropref">
+								<a href="#index-xref-preferred">index-xref-preferred</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
+								>a</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term-categories">index-term-categories property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-term-category">index-term-category</dt>
+					<dd>
+						<p>Word, phrase, string, glyph, or image representing a category of terms in the index.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-xref-related">index-xref-related</a>
+							</span> and <span class="subpropref">
+								<a href="#index-xref-preferred">index-xref-preferred</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
+								>a</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term-category">index-term-category property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-xref-preferred">index-xref-preferred</dt>
+					<dd>
+						<p>Reference from one term to one or more preferred terms or term categories in an index
+							(analogous to "See xxx").</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-entry">index-entry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-xref">index-xref-preferred property</a> [[EPUB-INDEXES-10]]
+						</p>
+					</dd>
+					
+					<dt id="index-xref-related">index-xref-related</dt>
+					<dd>
+						<p>Reference from one term to one or more related terms or term categories in an index
+							(analogous to "See also xxx").</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#index-entry">index-entry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-xref">index-xref-related property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 				</dl>
 			</section>
 		</section>
+		
 		<section id="sec-preliminary">
-			<h4>Preliminary Sections and Components</h4>
+			<h2>Preliminary Sections and Components</h2>
+			
 			<p>Preliminary sections and components, typically occurring in the publication frontmatter.</p>
+			
 			<dl>
+				<dt id="acknowledgments">acknowledgments</dt>
+				<dd>
+					<p>A section or statement that acknowledges significant contributions by persons, organizations,
+						governments, and other entities to the realization of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-acknowledgments">doc-acknowledgments</a>
+					</p>
+				</dd>
+				
+				<dt id="contributors">contributors</dt>
+				<dd>
+					<p>A list of contributors to the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				
+				<dt id="copyright-page">copyright-page</dt>
+				<dd>
+					<p>The copyright page of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				
+				<dt id="dedication">dedication</dt>
+				<dd>
+					<p>An inscription at the front of the work, typically addressed in tribute to one or more
+						persons close to the author.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-dedication">doc-dedication</a>
+					</p>
+				</dd>
+				
+				<dt id="errata">errata</dt>
+				<dd>
+					<p>A set of corrections discovered after initial publication of the work, sometimes referred to
+						as corrigenda.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-aside-element">aside</a>,
+						<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+							>grouping content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-errata">doc-errata</a>
+					</p>
+				</dd>
+				
+				<dt id="halftitlepage">halftitlepage</dt>
+				<dd>
+					<p>The half title page of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				
+				<dt id="imprimatur">imprimatur</dt>
+				<dd>
+					<p>A formal statement authorizing the publication of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				
+				<dt id="imprint">imprint</dt>
+				<dd>
+					<p>Information relating to the publication or distribution of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				
+				<dt id="other-credits">other-credits</dt>
+				<dd>
+					<p>Acknowledgments of previously published parts of the work, illustration credits, and
+						permission to quote from copyrighted material.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				
+				<dt id="revision-history">revision-history</dt>
+				<dd>
+					<p>A record of changes made to a work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				
+				<dt id="seriespage">seriespage <span class="status draft"> [draft]</span></dt>
+				<dd>
+					<p>Marketing section used to list related publications.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+							>section</a>, <a
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+					</p>
+				</dd>
+				
 				<dt id="titlepage">titlepage</dt>
 				<dd>
 					<p>The title page of the work.</p>
@@ -1787,180 +2022,14 @@
 							>grouping content</a>
 					</p>
 				</dd>
-				<dt id="halftitlepage">halftitlepage</dt>
-				<dd>
-					<p>The half title page of the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dt id="copyright-page">copyright-page</dt>
-				<dd>
-					<p>The copyright page of the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dt id="seriespage">seriespage <span class="status draft"> [draft]</span>
-				</dt>
-				<dd>
-					<p>Marketing section used to list related publications.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dt id="acknowledgments">acknowledgments</dt>
-				<dd>
-					<p>A section or statement that acknowledges significant contributions by persons, organizations,
-						governments, and other entities to the realization of the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-acknowledgments">doc-acknowledgments</a>
-					</p>
-				</dd>
-				<dt id="imprint">imprint</dt>
-				<dd>
-					<p>Information relating to the publication or distribution of the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dt id="imprimatur">imprimatur</dt>
-				<dd>
-					<p>A formal statement authorizing the publication of the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dt id="contributors">contributors</dt>
-				<dd>
-					<p>A list of contributors to the work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dt id="other-credits">other-credits</dt>
-				<dd>
-					<p>Acknowledgments of previously published parts of the work, illustration credits, and
-						permission to quote from copyrighted material.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dt id="errata">errata</dt>
-				<dd>
-					<p>A set of corrections discovered after initial publication of the work, sometimes referred to
-						as corrigenda.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/sections.html#the-aside-element">aside</a>,
-							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-errata">doc-errata</a>
-					</p>
-				</dd>
-				<dt id="dedication">dedication</dt>
-				<dd>
-					<p>An inscription at the front of the work, typically addressed in tribute to one or more
-						persons close to the author.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-dedication">doc-dedication</a>
-					</p>
-				</dd>
-				<dt id="revision-history">revision-history</dt>
-				<dd>
-					<p>A record of changes made to a work.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
-							>section</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-							>grouping content</a>
-					</p>
-				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-complementary">
-			<h4>Complementary Content</h4>
+			<h2>Complementary Content</h2>
+			
 			<dl>
-				<dt id="case-study">case-study<span class="status draft"> [draft]</span>
-				</dt>
+				<dt id="case-study">case-study<span class="status draft"> [draft]</span></dt>
 				<dd>
 					<p>A detailed analysis of a specific topic.</p>
 				</dd>
@@ -1979,8 +2048,8 @@
 							content</a>
 					</p>
 				</dd>
-				<dt id="help">help<span class="status deprecated"> [deprecated]</span>
-				</dt>
+				
+				<dt id="help">help<span class="status deprecated"> [deprecated]</span></dt>
 				<dd>
 					<p>Helpful information that clarifies some aspect of the content or assists in its
 						comprehension.</p>
@@ -2009,8 +2078,8 @@
 						</span>
 					</p>
 				</dd>
-				<dt id="marginalia">marginalia<span class="status deprecated"> [deprecated]</span>
-				</dt>
+				
+				<dt id="marginalia">marginalia<span class="status deprecated"> [deprecated]</span></dt>
 				<dd>
 					<p>Content, both textual and graphical, that is offset in the margin.</p>
 				</dd>
@@ -2039,6 +2108,7 @@
 						</span>
 					</p>
 				</dd>
+				
 				<dt id="notice">notice</dt>
 				<dd>
 					<p>Notifies the user of consequences that might arise from an action or event. Examples include
@@ -2059,8 +2129,8 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-notice">doc-notice</a>
 					</p>
 				</dd>
-				<dt id="pullquote">pullquote<span class="status draft"> [draft]</span>
-				</dt>
+				
+				<dt id="pullquote">pullquote<span class="status draft"> [draft]</span></dt>
 				<dd>
 					<p>A distinctively placed or highlighted quotation from the current content designed to draw
 						attention to a topic or highlight a key point.</p>
@@ -2085,8 +2155,8 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pullquote">doc-pullquote</a>
 					</p>
 				</dd>
-				<dt id="sidebar">sidebar<span class="status deprecated"> [deprecated]</span>
-				</dt>
+				
+				<dt id="sidebar">sidebar<span class="status deprecated"> [deprecated]</span></dt>
 				<dd>
 					<p>Secondary or supplementary content, typically formatted as an inset or box.</p>
 				</dd>
@@ -2113,6 +2183,7 @@
 						</span>
 					</p>
 				</dd>
+				
 				<dt id="tip">tip</dt>
 				<dd>
 					<p>Helpful information that clarifies some aspect of the content or assists in its
@@ -2140,8 +2211,8 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-tip">doc-tip</a>
 					</p>
 				</dd>
-				<dt id="warning">warning<span class="status deprecated"> [deprecated]</span>
-				</dt>
+				
+				<dt id="warning">warning<span class="status deprecated"> [deprecated]</span></dt>
 				<dd>
 					<p>A warning.</p>
 				</dd>
@@ -2164,12 +2235,32 @@
 				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-titles">
-			<h4>Titles and Headings</h4>
+			<h2>Titles and Headings</h2>
+			
 			<dl>
-				<dt id="halftitle">halftitle</dt>
+				<dt id="bridgehead">bridgehead</dt>
 				<dd>
-					<p>The title appearing on the first page of a work or immediately before the text.</p>
+					<p>A structurally insignificant heading that does not contribute to the hierarchical structure
+						of the work.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>,
+						typically <a
+							href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">p</a>,
+						<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element"
+							>div</a> or <a
+								href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element"
+								>span</a>
+					</p>
+				</dd>
+				
+				<dt id="covertitle">covertitle</dt>
+				<dd>
+					<p>The title of the work as displayed on the work's cover.</p>
 				</dd>
 				<dd>
 					<p>
@@ -2185,10 +2276,11 @@
 						<a href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
 							content</a>. This property should only appear once within the document scope.</p>
 				</dd>
+				
 				<dt id="fulltitle">fulltitle</dt>
 				<dd>
 					<p>The full title of the work, either simple, in which case it is identical to <a
-							href="#doc-title">title</a>, or compound, in which case it consists of a <a
+						href="#doc-title">title</a>, or compound, in which case it consists of a <a
 							href="#doc-title">title</a> and a <a href="#subtitle">subtitle</a>.</p>
 				</dd>
 				<dd>
@@ -2213,9 +2305,10 @@
 						<a href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
 							content</a>. This property should only appear once within the document scope.</p>
 				</dd>
-				<dt id="covertitle">covertitle</dt>
+				
+				<dt id="halftitle">halftitle</dt>
 				<dd>
-					<p>The title of the work as displayed on the work's cover.</p>
+					<p>The title appearing on the first page of a work or immediately before the text.</p>
 				</dd>
 				<dd>
 					<p>
@@ -2231,53 +2324,8 @@
 						<a href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
 							content</a>. This property should only appear once within the document scope.</p>
 				</dd>
-				<dt id="doc-title">title</dt>
-				<dd>
-					<p>The primary name of a document component, such as a list, table, or figure.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
-							content</a>, <a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content"
-							>phrasing content</a> descendants of <a
-							href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
-							content</a>.</p>
-				</dd>
-				<dt id="subtitle">subtitle</dt>
-				<dd>
-					<p>An explanatory or alternate title for the work, or a section or component within it.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Inherits from:</span>
-						<span class="subpropref">
-							<a href="#doc-title">title</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
-							content</a>, <a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content"
-							>phrasing content</a> descendants of <a
-							href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
-							content</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element"
-							>paragraphs</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element"
-							>divs</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-subtitle">doc-subtitle</a>
-					</p>
-				</dd>
-				<dt id="label">label<span class="status draft"> [draft]</span>
-				</dt>
+				
+				<dt id="label">label<span class="status draft"> [draft]</span></dt>
 				<dd>
 					<p>The text label that precedes an <a href="#ordinal">ordinal</a> in a component title (e.g.,
 						'Chapter', 'Part', 'Figure', 'Table').</p>
@@ -2295,16 +2343,16 @@
 						<span class="subproplabel">HTML usage context: </span>
 						<a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content">Phrasing
 							content</a> descendants of <a
-							href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
-							content</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element"
-							>li</a> and <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element"
-							>figcaption</a>
+								href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
+								content</a>, <a
+									href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element"
+									>li</a> and <a
+										href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element"
+										>figcaption</a>
 					</p>
 				</dd>
-				<dt id="ordinal">ordinal<span class="status draft"> [draft]</span>
-				</dt>
+				
+				<dt id="ordinal">ordinal<span class="status draft"> [draft]</span></dt>
 				<dd>
 					<p>An ordinal specifier for a component in a sequence of components (e.g., '1', 'IV',
 						'B-1').</p>
@@ -2322,37 +2370,70 @@
 						<span class="subproplabel">HTML usage context: </span>
 						<a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content">Phrasing
 							content</a> descendants of <a
-							href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
-							content</a>, <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element"
-							>li</a> and <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element"
-							>figcaption</a>
+								href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
+								content</a>, <a
+									href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element"
+									>li</a> and <a
+										href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element"
+										>figcaption</a>
 					</p>
 				</dd>
-				<dt id="bridgehead">bridgehead</dt>
+				
+				<dt id="subtitle">subtitle</dt>
 				<dd>
-					<p>A structurally insignificant heading that does not contribute to the hierarchical structure
-						of the work.</p>
+					<p>An explanatory or alternate title for the work, or a section or component within it.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref">
+							<a href="#doc-title">title</a>
+						</span>
+					</p>
 				</dd>
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>,
-						typically <a
-							href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">p</a>,
-							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element"
-							>div</a> or <a
-							href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element"
-							>span</a>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
+							content</a>, <a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content"
+								>phrasing content</a> descendants of <a
+									href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
+									content</a>, <a
+										href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element"
+										>paragraphs</a>, <a
+											href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element"
+											>divs</a>
 					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-subtitle">doc-subtitle</a>
+					</p>
+				</dd>
+				
+				<dt id="doc-title">title</dt>
+				<dd>
+					<p>The primary name of a document component, such as a list, table, or figure.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
+							content</a>, <a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content"
+							>phrasing content</a> descendants of <a
+							href="https://html.spec.whatwg.org/multipage/dom.html#heading-content">heading
+							content</a>.</p>
 				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-educational">
-			<h4>Educational Content</h4>
+			<h2>Educational Content</h2>
+			
 			<section id="learning-obj">
-				<h5 id="h_learning-obj">Learning objectives</h5>
+				<h3 id="h_learning-obj">Learning objectives</h3>
+				
 				<dl>
 					<dt id="learning-objective">learning-objective</dt>
 					<dd>
@@ -2367,8 +2448,8 @@
 								content</a>
 						</p>
 					</dd>
-					<dt id="learning-objectives">learning-objectives<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="learning-objectives">learning-objectives<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A collection of <a href="#learning-objective">learning-objectives</a>.</p>
 					</dd>
@@ -2381,8 +2462,8 @@
 								>grouping content</a>
 						</p>
 					</dd>
-					<dt id="learning-outcome">learning-outcome<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="learning-outcome">learning-outcome<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>The understanding or ability a student is expected to achieve as a result of a lesson or
 							activity.</p>
@@ -2393,8 +2474,8 @@
 							<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
 						</p>
 					</dd>
-					<dt id="learning-outcomes">learning-outcomes<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="learning-outcomes">learning-outcomes<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A collection of <a href="#learning-outcome">learning-outcomes</a>.</p>
 					</dd>
@@ -2407,6 +2488,7 @@
 								>grouping content</a>
 						</p>
 					</dd>
+					
 					<dt id="learning-resource">learning-resource</dt>
 					<dd>
 						<p>A resource provided to enhance learning, or a reference to such a resource.</p>
@@ -2417,8 +2499,8 @@
 							<a href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
 						</p>
 					</dd>
-					<dt id="learning-resources">learning-resources<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="learning-resources">learning-resources<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A collection of <a href="#learning-resource">learning-resources</a>.</p>
 					</dd>
@@ -2431,8 +2513,8 @@
 								>grouping content</a>
 						</p>
 					</dd>
-					<dt id="learning-standard">learning-standard<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="learning-standard">learning-standard<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A formal set of expectations or requirements typically issued by a government or a
 							standards body.</p>
@@ -2446,8 +2528,8 @@
 								content</a>
 						</p>
 					</dd>
-					<dt id="learning-standards">learning-standards<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="learning-standards">learning-standards<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A collection of <a href="#learning-standard">learning-standards</a>.</p>
 					</dd>
@@ -2462,11 +2544,12 @@
 					</dd>
 				</dl>
 			</section>
+			
 			<section id="testing">
-				<h5 id="h_testing">Testing</h5>
+				<h3 id="h_testing">Testing</h3>
+				
 				<dl>
-					<dt id="answer">answer<span class="status draft"> [draft]</span>
-					</dt>
+					<dt id="answer">answer<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>The component of a self-assessment problem that provides the answer to the question.</p>
 					</dd>
@@ -2479,8 +2562,8 @@
 								>grouping content</a>
 						</p>
 					</dd>
-					<dt id="answers">answers<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="answers">answers<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A collection of <a href="#answer">answers</a>.</p>
 					</dd>
@@ -2493,6 +2576,7 @@
 								>grouping content</a>
 						</p>
 					</dd>
+					
 					<dt id="assessment">assessment</dt>
 					<dd>
 						<p>A test, quiz, or other activity that helps measure a student's understanding of what is
@@ -2505,8 +2589,8 @@
 								content</a>
 						</p>
 					</dd>
-					<dt id="assessments">assessments<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="assessments">assessments<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A collection of <a href="#assessment">assessments</a>.</p>
 					</dd>
@@ -2517,8 +2601,8 @@
 								content</a>
 						</p>
 					</dd>
-					<dt id="feedback">feedback<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="feedback">feedback<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>Instruction to the reader based on the result of an assessment.</p>
 					</dd>
@@ -2531,9 +2615,8 @@
 								content</a>
 						</p>
 					</dd>
-					<dt id="fill-in-the-blank-problem">fill-in-the-blank-problem<span class="status draft">
-							[draft]</span>
-					</dt>
+					
+					<dt id="fill-in-the-blank-problem">fill-in-the-blank-problem<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A problem that requires the reader to input a text answer to complete a sentence,
 							statement or similar.</p>
@@ -2547,8 +2630,8 @@
 								>grouping content</a>
 						</p>
 					</dd>
-					<dt id="general-problem">general-problem<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="general-problem">general-problem<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A problem with a free-form solution.</p>
 					</dd>
@@ -2561,26 +2644,8 @@
 								>grouping content</a>
 						</p>
 					</dd>
-					<dt id="qna">qna</dt>
-					<dd>
-						<p>A section of content structured as a series of questions and answers, such as an
-							interview or list of frequently asked questions.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>lists or <a
-								href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-								content</a>
-						</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">DPUB-ARIA role: </span>
-							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-qna">doc-qna</a>
-						</p>
-					</dd>
-					<dt id="match-problem">match-problem<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="match-problem">match-problem<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A problem that requires the reader to match the contents of one list with the
 							corresponding items in another list.</p>
@@ -2594,9 +2659,8 @@
 								>grouping content</a>
 						</p>
 					</dd>
-					<dt id="multiple-choice-problem">multiple-choice-problem<span class="status draft">
-							[draft]</span>
-					</dt>
+					
+					<dt id="multiple-choice-problem">multiple-choice-problem<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A problem with a set of potential answers to choose from ‒ some, all, or none of which
 							may be correct.</p>
@@ -2610,8 +2674,8 @@
 								>grouping content</a>
 						</p>
 					</dd>
-					<dt id="practice">practice<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="practice">practice<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A review exercise or sample.</p>
 					</dd>
@@ -2632,20 +2696,8 @@
 								>grouping content</a>
 						</p>
 					</dd>
-					<dt id="question">question<span class="status draft"> [draft]</span>
-					</dt>
-					<dd>
-						<p>The component of a self-assessment problem that identifies the question to be solved.</p>
-					</dd>
-					<dd>
-						<p>
-							<span class="subproplabel">HTML usage context: </span>
-							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
-								>grouping content</a>
-						</p>
-					</dd>
-					<dt id="practices">practices<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="practices">practices<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A collection of <a href="#practice">practices</a>.</p>
 					</dd>
@@ -2656,8 +2708,39 @@
 								content</a>
 						</p>
 					</dd>
-					<dt id="true-false-problem">true-false-problem<span class="status draft"> [draft]</span>
-					</dt>
+					
+					<dt id="qna">qna</dt>
+					<dd>
+						<p>A section of content structured as a series of questions and answers, such as an
+							interview or list of frequently asked questions.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>lists or <a
+								href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+								content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">DPUB-ARIA role: </span>
+							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-qna">doc-qna</a>
+						</p>
+					</dd>
+					
+					<dt id="question">question<span class="status draft"> [draft]</span></dt>
+					<dd>
+						<p>The component of a self-assessment problem that identifies the question to be solved.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#grouping-content"
+								>grouping content</a>
+						</p>
+					</dd>
+					
+					<dt id="true-false-problem">true-false-problem<span class="status draft"> [draft]</span></dt>
 					<dd>
 						<p>A problem with either a true or false answer.</p>
 					</dd>
@@ -2673,41 +2756,11 @@
 				</dl>
 			</section>
 		</section>
+		
 		<section id="sec-comics">
-			<h4>Comics</h4>
+			<h2>Comics</h2>
+			
 			<dl>
-				<dt id="panel">panel</dt>
-				<dd>
-					<p>An individual frame, or drawing.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">li</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Usage details: </span>
-						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
-					</p>
-				</dd>
-				<dt id="panel-group">panel-group</dt>
-				<dd>
-					<p>A group of <a href="#panel">panels</a> (e.g., a strip).</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">li</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Usage details: </span>
-						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
-					</p>
-				</dd>
 				<dt id="balloon">balloon</dt>
 				<dd>
 					<p>An area in a comic <a href="#panel">panel</a> that contains the words, spoken or thought, of
@@ -2725,6 +2778,58 @@
 						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
 					</p>
 				</dd>
+				
+				<dt id="panel">panel</dt>
+				<dd>
+					<p>An individual frame, or drawing.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">li</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
+					</p>
+				</dd>
+				
+				<dt id="panel-group">panel-group</dt>
+				<dd>
+					<p>A group of <a href="#panel">panels</a> (e.g., a strip).</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">li</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
+					</p>
+				</dd>
+				
+				<dt id="sound-area">sound-area</dt>
+				<dd>
+					<p>An area of text in a comic <a href="#panel">panel</a> that represents a sound.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">li</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
+					</p>
+				</dd>
+				
 				<dt id="text-area">text-area</dt>
 				<dd>
 					<p>An area of text in a comic <a href="#panel">panel</a>. Used to represent titles, narrative
@@ -2742,29 +2847,14 @@
 						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
 					</p>
 				</dd>
-				<dt id="sound-area">sound-area</dt>
-				<dd>
-					<p>An area of text in a comic <a href="#panel">panel</a> that represents a sound.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">li</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Usage details: </span>
-						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
-					</p>
-				</dd>
 			</dl>
 		</section>
+		
 		<section id="notes">
-			<h4>Notes and Annotations</h4>
+			<h2>Notes and Annotations</h2>
+			
 			<dl>
-				<dt id="annotation">annotation<span class="status deprecated"> [deprecated]</span>
-				</dt>
+				<dt id="annotation">annotation<span class="status deprecated"> [deprecated]</span></dt>
 				<dd>
 					<p>Explanatory information about passages in the work.</p>
 				</dd>
@@ -2792,30 +2882,60 @@
 						</span>
 					</p>
 				</dd>
-				<dt id="note">note<span class="status deprecated"> [deprecated]</span>
-				</dt>
+				
+				<dt id="endnote">endnote</dt>
 				<dd>
-					<p>A note. This property does not carry spatial positioning semantics, as do the <a
-							href="#footnote">footnote</a> and <a href="#endnote">endnote</a> properties. It can be
-						used to identify footnotes, endnotes, marginal notes, inline notes, and similar when legacy
-						naming conventions are not desired.</p>
+					<p>One of a collection of notes that occur at the end of a work, or a section within it, that
+						provides additional context to a referenced passage of text.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
+						<span class="subpropref">
+							<a href="#endnotes">endnotes</a>
+						</span>
+					</p>
 				</dd>
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>On the <a
 							href="https://html.spec.whatwg.org/multipage/sections.html#the-aside-element">aside</a>
-						element when identifying a single note, or on descendants of sectioning content when
-						identifying individual notes in a group (refer to <a href="#footnotes">footnotes</a> and <a
-							href="#endnotes">endnotes</a>).</p>
+						element when identifying a single endnote, or on descendants of sectioning content when
+						identifying individual endnotes in a group (refer to <a href="#footnotes">footnotes</a> and
+						<a href="#endnotes">endnotes</a>).</p>
 				</dd>
 				<dd>
 					<p>
-						<span class="subproplabel">Replaced by:</span>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-endnote">doc-endnote</a> (Deprecated)</p>
+				</dd>
+				
+				<dt id="endnotes">endnotes</dt>
+				<dd>
+					<p>A collection of notes at the end of a work or a section within it.</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">See also:</span>
 						<span class="subpropref">
-							<a href="#footnote">footnote</a>, <a href="#endnote">endnote</a>
+							<a href="#endnote">endnote</a>
 						</span>
 					</p>
 				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-endnotes">doc-endnotes</a>
+					</p>
+				</dd>
+				
 				<dt id="footnote">footnote</dt>
 				<dd>
 					<p>Ancillary information, such as a citation or commentary, that provides additional context to
@@ -2843,34 +2963,52 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-footnote">doc-footnote</a>
 					</p>
 				</dd>
-				<dt id="endnote">endnote</dt>
+				
+				<dt id="footnotes">footnotes</dt>
 				<dd>
-					<p>One of a collection of notes that occur at the end of a work, or a section within it, that
-						provides additional context to a referenced passage of text.</p>
+					<p>A collection of <a href="#footnote">footnotes</a>.</p>
 				</dd>
 				<dd>
 					<p>
 						<span class="subproplabel">See also:</span>
 						<span class="subpropref">
-							<a href="#endnotes">endnotes</a>
+							<a href="#footnote">footnote</a>
 						</span>
 					</p>
 				</dd>
 				<dd>
 					<p>
-						<span class="subproplabel">HTML usage context: </span>On the <a
-							href="https://html.spec.whatwg.org/multipage/sections.html#the-aside-element">aside</a>
-						element when identifying a single endnote, or on descendants of sectioning content when
-						identifying individual endnotes in a group (refer to <a href="#footnotes">footnotes</a> and
-							<a href="#endnotes">endnotes</a>).</p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
+							content</a>
+					</p>
+				</dd>
+				
+				<dt id="note">note<span class="status deprecated"> [deprecated]</span></dt>
+				<dd>
+					<p>A note. This property does not carry spatial positioning semantics, as do the <a
+						href="#footnote">footnote</a> and <a href="#endnote">endnote</a> properties. It can be
+						used to identify footnotes, endnotes, marginal notes, inline notes, and similar when legacy
+						naming conventions are not desired.</p>
 				</dd>
 				<dd>
 					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-endnote">doc-endnote</a> (Deprecated)</p>
+						<span class="subproplabel">HTML usage context: </span>On the <a
+							href="https://html.spec.whatwg.org/multipage/sections.html#the-aside-element">aside</a>
+						element when identifying a single note, or on descendants of sectioning content when
+						identifying individual notes in a group (refer to <a href="#footnotes">footnotes</a> and <a
+							href="#endnotes">endnotes</a>).</p>
 				</dd>
-				<dt id="rearnote">rearnote<span class="status deprecated"> [deprecated]</span>
-				</dt>
+				<dd>
+					<p>
+						<span class="subproplabel">Replaced by:</span>
+						<span class="subpropref">
+							<a href="#footnote">footnote</a>, <a href="#endnote">endnote</a>
+						</span>
+					</p>
+				</dd>
+				
+				<dt id="rearnote">rearnote<span class="status deprecated"> [deprecated]</span></dt>
 				<dd>
 					<p>A note appearing in the rear (backmatter) of the work, or at the end of a section.</p>
 				</dd>
@@ -2898,52 +3036,8 @@
 						</span>
 					</p>
 				</dd>
-				<dt id="footnotes">footnotes</dt>
-				<dd>
-					<p>A collection of <a href="#footnote">footnotes</a>.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">See also:</span>
-						<span class="subpropref">
-							<a href="#footnote">footnote</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-							content</a>
-					</p>
-				</dd>
-				<dt id="endnotes">endnotes</dt>
-				<dd>
-					<p>A collection of notes at the end of a work or a section within it.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">See also:</span>
-						<span class="subpropref">
-							<a href="#endnote">endnote</a>
-						</span>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-							content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-endnotes">doc-endnotes</a>
-					</p>
-				</dd>
-				<dt id="rearnotes">rearnotes<span class="status deprecated"> [deprecated]</span>
-				</dt>
+				
+				<dt id="rearnotes">rearnotes<span class="status deprecated"> [deprecated]</span></dt>
 				<dd>
 					<p>A collection of notes appearing at the rear (backmatter) of the work, or at the end of a
 						section.</p>
@@ -2973,11 +3067,12 @@
 				</dd>
 			</dl>
 		</section>
+		
 		<section id="links">
-			<h4>References</h4>
+			<h2>References</h2>
+			
 			<dl>
-				<dt id="annoref">annoref<span class="status deprecated"> [deprecated]</span>
-				</dt>
+				<dt id="annoref">annoref<span class="status deprecated"> [deprecated]</span></dt>
 				<dd>
 					<p>A reference to an annotation.</p>
 				</dd>
@@ -3012,8 +3107,36 @@
 						</span>
 					</p>
 				</dd>
-				<dt id="biblioref">biblioref<span class="status draft"> [draft]</span>
-				</dt>
+				
+				<dt id="backlink">backlink<span class="status draft"> [draft]</span></dt>
+				<dd>
+					<p>A link that allows the user to return to a related location in the content (e.g., from a <a
+						href="#footnote">footnote</a> to its reference or from a <a href="#glossdef">glossary
+							definition</a> to where a <a href="#glossterm">term</a> is used).</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Inherits from:</span>
+						<span class="subpropref">
+							<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
+						</span>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">HTML usage context: </span>
+						<a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
+							>a</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-backlink">doc-backlink</a>
+					</p>
+				</dd>
+				
+				<dt id="biblioref">biblioref<span class="status draft"> [draft]</span></dt>
 				<dd>
 					<p>A reference to a <a href="#biblioentry">bibliography entry</a>.</p>
 				</dd>
@@ -3038,8 +3161,8 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-biblioref">doc-biblioref</a>
 					</p>
 				</dd>
-				<dt id="glossref">glossref<span class="status draft"> [draft]</span>
-				</dt>
+				
+				<dt id="glossref">glossref<span class="status draft"> [draft]</span></dt>
 				<dd>
 					<p>A reference to a <a href="#glossdef">glossary definition</a>.</p>
 				</dd>
@@ -3064,6 +3187,7 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossref">doc-glossref</a>
 					</p>
 				</dd>
+				
 				<dt id="noteref">noteref</dt>
 				<dd>
 					<p>A reference to a note, typically appearing as a superscripted number or symbol in the main
@@ -3098,42 +3222,28 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-noteref">doc-noteref</a>
 					</p>
 				</dd>
-				<dt id="backlink">backlink<span class="status draft"> [draft]</span>
-				</dt>
+			</dl>
+		</section>
+		
+		<section id="document-text">
+			<h2>Document Text</h2>
+			
+			<p>Terms for describing components at the phrasing level.</p>
+			
+			<dl>
+				<dt id="concluding-sentence">concluding-sentence</dt>
 				<dd>
-					<p>A link that allows the user to return to a related location in the content (e.g., from a <a
-							href="#footnote">footnote</a> to its reference or from a <a href="#glossdef">glossary
-							definition</a> to where a <a href="#glossterm">term</a> is used).</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Inherits from:</span>
-						<span class="subpropref">
-							<a href="http://www.w3.org/1999/xhtml/vocab/#link">xhv:link</a>
-						</span>
-					</p>
+					<p>A phrase or sentence serving as a concluding summary of the containing paragraph.</p>
 				</dd>
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element"
-							>a</a>
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content">phrasing
+							content</a>
 					</p>
 				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-backlink">doc-backlink</a>
-					</p>
-				</dd>
-			</dl>
-		</section>
-		<section id="document-text">
-			<h4>Document Text</h4>
-			<p>Terms for describing components at the phrasing level.</p>
-			<dl>
-				<dt id="credit">credit<span class="status draft"> [draft]</span>
-				</dt>
+				
+				<dt id="credit">credit<span class="status draft"> [draft]</span></dt>
 				<dd>
 					<p>An acknowledgment of the source of integrated content from third-party sources, such as
 						photos. Typically identifies the creator, copyright, and any restrictions on reuse.</p>
@@ -3151,6 +3261,7 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-credit">doc-credit</a>
 					</p>
 				</dd>
+				
 				<dt id="keyword">keyword</dt>
 				<dd>
 					<p>A key word or phrase.</p>
@@ -3162,6 +3273,7 @@
 							content</a>
 					</p>
 				</dd>
+				
 				<dt id="topic-sentence">topic-sentence</dt>
 				<dd>
 					<p>A phrase or sentence serving as an introductory summary of the containing paragraph.</p>
@@ -3173,22 +3285,38 @@
 							content</a>
 					</p>
 				</dd>
-				<dt id="concluding-sentence">concluding-sentence</dt>
+			</dl>
+		</section>
+		
+		<section id="sec-pagination">
+			<h2>Pagination</h2>
+			
+			<dl>
+				<dt id="page-list">page-list</dt>
 				<dd>
-					<p>A phrase or sentence serving as a concluding summary of the containing paragraph.</p>
+					<p>A navigational aid that provides a list of links to the <a href="#pagebreak">pagebreaks</a>
+						in the content.</p>
 				</dd>
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content">phrasing
+						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
 							content</a>
 					</p>
 				</dd>
-			</dl>
-		</section>
-		<section id="sec-pagination">
-			<h4>Pagination</h4>
-			<dl>
+				<dd>
+					<p>
+						<span class="subproplabel">DPUB-ARIA role: </span>
+						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagelist">doc-pagelist</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="https://www.w3.org/TR/epub-33/#sec-nav-pagelist">The <code>page-list nav</code> Element</a> [[EPUB-33]]
+					</p>
+				</dd>
+				
 				<dt id="pagebreak">pagebreak</dt>
 				<dd>
 					<p>A separator denoting the position before which a break occurs between two contiguous pages in
@@ -3214,34 +3342,12 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagebreak">doc-pagebreak</a>
 					</p>
 				</dd>
-				<dt id="page-list">page-list</dt>
-				<dd>
-					<p>A navigational aid that provides a list of links to the <a href="#pagebreak">pagebreaks</a>
-						in the content.</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">HTML usage context: </span>
-						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
-							content</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">DPUB-ARIA role: </span>
-						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagelist">doc-pagelist</a>
-					</p>
-				</dd>
-				<dd>
-					<p>
-						<span class="subproplabel">Usage details: </span>
-						<a href="https://www.w3.org/TR/epub-33/#sec-nav-pagelist">The <code>page-list nav</code> Element</a> [[EPUB-33]]
-					</p>
-				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-tables">
-			<h4>Tables</h4>
+			<h2>Tables</h2>
+			
 			<dl>
 				<dt id="table">table</dt>
 				<dd>
@@ -3257,6 +3363,7 @@
 							data-cite="epub-33#sec-smil-seq-elem">seq</a> or <a data-cite="epub-33#sec-smil-par-elem">par</a> as an
 						escapable or skippable table structure.</p>
 				</dd>
+				
 				<dt id="table-row">table-row</dt>
 				<dd>
 					<p>A row of data or content in a tabular structure.</p>
@@ -3271,6 +3378,7 @@
 							data-cite="epub-33#sec-smil-seq-elem">seq</a> or <a data-cite="epub-33#sec-smil-par-elem">par</a> as an
 						escapable or skippable table row.</p>
 				</dd>
+				
 				<dt id="table-cell">table-cell</dt>
 				<dd>
 					<p>A single cell of tabular data or content.</p>
@@ -3287,8 +3395,10 @@
 				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-lists">
-			<h4>Lists</h4>
+			<h2>Lists</h2>
+			
 			<dl>
 				<dt id="list">list</dt>
 				<dd>
@@ -3304,6 +3414,7 @@
 							data-cite="epub-33#sec-smil-seq-elem">seq</a> or <a data-cite="epub-33#sec-smil-par-elem">par</a> as an
 						escapable or skippable list structure.</p>
 				</dd>
+				
 				<dt id="list-item">list-item</dt>
 				<dd>
 					<p>A single item in an enumeration.</p>
@@ -3320,8 +3431,10 @@
 				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-figures">
-			<h4>Figures</h4>
+			<h2>Figures</h2>
+			
 			<dl>
 				<dt id="figure">figure</dt>
 				<dd>
@@ -3340,8 +3453,10 @@
 				</dd>
 			</dl>
 		</section>
+		
 		<section id="sec-asides">
-			<h4>Asides</h4>
+			<h2>Asides</h2>
+			
 			<dl>
 				<dt id="aside">aside</dt>
 				<dd>

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -46,6 +46,40 @@
 						w3cid: 106061
 					}
 				],
+				localBiblio: {
+					"EPUB-DICT-10": {
+						"title": "EPUB Dictionaries and Glossaries 1.0",
+						"href": "http://www.idpf.org/epub/dict",
+						"editors": [
+							"Jeffrey Alexander",
+							"Romain Deltour"
+						],
+						"date": "26 August 2015",
+						"publisher": "IDPF"
+					},
+					"EPUB-INDEXES-10": {
+						"title": "EPUB Indexes 1.0",
+						"href": "http://www.idpf.org/epub/idx",
+						"editors": [
+							"Michele Combs",
+							"Tzviya Siegman"
+						],
+						"date": "26 August 2015",
+						"publisher": "IDPF"
+					},
+					"EPUB-REGION-NAV-10": {
+						"title": "EPUB Region-Based Navigation 1.0",
+						"href": "http://www.idpf.org/epub/renditions/region-nav",
+						"editors": [
+							"Matthieu Kopp",
+							"Brady Kroupa",
+							"Jim Lester",
+							"Matt Garrish"
+						],
+						"date": "26 August 2015",
+						"publisher": "IDPF"
+					},
+    			},
 				includePermalinks: true,
 				permalinkEdge: true,
 				permalinkHide: false,
@@ -108,8 +142,8 @@
 				<p>When processing HTML documents, Reading Systems may ignore such non-compliant properties, unless
 					their usage context is explicitly overridden or extended by the host specification.</p>
 				
-				<p>The <i>Usage Details</i> sections identify IDPF specifications that define or utilize the specified
-					properties.</p>
+				<p>The <i>Usage details</i> fields, when present, identify specifications that define or utilize
+					the specified properties.</p>
 			</section>
 		</section>
 			
@@ -477,6 +511,12 @@
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-toc">doc-toc</a>
 					</p>
 				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="https://www.w3.org/TR/epub-33/#sec-nav-toc">The <code>toc nav</code> Element</a> [[EPUB-33]]
+					</p>
+				</dd>
 				<dt id="toc-brief">toc-brief<span class="status draft"> [draft]</span>
 				</dt>
 				<dd>
@@ -498,6 +538,12 @@
 						<span class="subproplabel">HTML usage context: </span>
 						<a href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content">sectioning
 							content</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="https://www.w3.org/TR/epub-33/#sec-nav-landmarks">The <code>landmarks nav</code> Element</a> [[EPUB-33]]
 					</p>
 				</dd>
 				<dt id="loa">loa</dt>
@@ -642,8 +688,8 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-index">EPUB Indexes – index
-								property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-index">index
+								property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dd>
@@ -676,8 +722,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-headnotes">EPUB Indexes –
-								index-headnotes property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-headnotes">index-headnotes property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-legend">index-legend</dt>
@@ -705,8 +750,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-legend">EPUB Indexes –
-								index-legend property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-legend">index-legend property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-group">index-group</dt>
@@ -732,8 +776,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-group">EPUB Indexes – index-group
-								property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-group">index-group property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-entry-list">index-entry-list</dt>
@@ -761,8 +804,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-entry-list">EPUB Indexes –
-								index-entry-list property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-entry-list">index-entry-list property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-entry">index-entry</dt>
@@ -788,8 +830,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-entry">EPUB Indexes – index-entry
-								property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-entry">index-entry property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-term">index-term</dt>
@@ -820,8 +861,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term">EPUB Indexes – index-term
-								property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term">index-term property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-editor-note">index-editor-note</dt>
@@ -845,8 +885,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-editor-note">EPUB Indexes –
-								index-editor-note property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-editor-note">index-editor-note property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-locator">index-locator</dt>
@@ -875,8 +914,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator">EPUB Indexes –
-								index-locator property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator">index-locator property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-locator-list">index-locator-list</dt>
@@ -901,8 +939,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator-list">EPUB Indexes –
-								index-locator-list property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator-list">index-locator-list property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-locator-range">index-locator-range</dt>
@@ -929,8 +966,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator-range">EPUB Indexes –
-								index-locator-range property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator-range">index-locator-range property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-xref-preferred">index-xref-preferred</dt>
@@ -955,8 +991,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-xref">EPUB Indexes –
-								index-xref-preferred property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-xref">index-xref-preferred property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-xref-related">index-xref-related</dt>
@@ -981,8 +1016,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-xref">EPUB Indexes –
-								index-xref-related property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-xref">index-xref-related property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-term-category">index-term-category</dt>
@@ -1009,8 +1043,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term-category">EPUB Indexes –
-								index-term-category property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term-category">index-term-category property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 					<dt id="index-term-categories">index-term-categories</dt>
@@ -1037,8 +1070,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term-categories">EPUB Indexes –
-								index-term-categories property</a>
+							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term-categories">index-term-categories property</a> [[EPUB-INDEXES-10]]
 						</p>
 					</dd>
 				</dl>
@@ -1065,6 +1097,13 @@
 							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossary">doc-glossary</a>
 						</p>
 					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.1">The Glossary
+								Container</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
 					<dt id="glossterm">glossterm</dt>
 					<dd>
 						<p>A glossary term.</p>
@@ -1085,6 +1124,13 @@
 								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"
 								>dl</a> element marked with the <a href="#glossary">glossary</a> property.</p>
 					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.2">Glossary Terms
+								and Definitions</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
 					<dt id="glossdef">glossdef</dt>
 					<dd>
 						<p>The definition of a <a href="#glossterm">term in a glossary</a>.</p>
@@ -1104,6 +1150,13 @@
 								>dd</a> elements within a <a
 								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element"
 								>dl</a> element marked with the <a href="#glossary">glossary</a> property.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.2">Glossary Terms
+								and Definitions</a> [[EPUB-DICT-10]]
+						</p>
 					</dd>
 				</dl>
 			</section>
@@ -1154,6 +1207,563 @@
 							<span class="subproplabel">DPUB-ARIA role: </span>
 							<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-biblioentry">doc-biblioentry</a>
 							(Deprecated)</p>
+					</dd>
+				</dl>
+			</section>
+			<section id="dictionaries">
+				<h3>Dictionaries</h3>
+				
+				<dl>
+					<dt id="dictionary">dictionary</dt>
+					<dd>
+						<p>A collection of dictionary entries.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+								<a
+									href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element"
+									>body</a> or <a 
+									href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
+										>section</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.1">The Dictionary
+								Container</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="dictentry">dictentry</dt>
+					<dd>
+						<p>A dictionary entry.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#dictionary">dictionary</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-article-element"
+								>article</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.2.1">The Dictionary
+								Entry</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="condensed-entry">condensed-entry</dt>
+					<dd>
+						<p>A condensed dictionary entry designed for constrained lookup viewports.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/sections.html#the-aside-element"
+								>aside</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.2.2.2">The Condensed
+								Entry</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="phonetic-transcription">phonetic-transcription</dt>
+					<dd>
+						<p>A phonetic transcription of the pronunciation of a headword or other component of a dictionary entry.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a> or <a href="#glossary">glossary</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.4">Phonetic
+								Transcriptions</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="part-of-speech">part-of-speech</dt>
+					<dd>
+						<p>The grammatical function of a headword.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.1">The Dictionary
+								Container</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="gram-info">gram-info</dt>
+					<dd>
+						<p>Supplemental grammatical information related to the headword and modifying a part of speech or a particular meaning.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.5.2">Related Grammatical
+								Information</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="etymology">etymology</dt>
+					<dd>
+						<p>An explanation of the historical origin of a headword.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.6">Etymologies</a>
+							[[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="part-of-speech-list">part-of-speech-list</dt>
+					<dd>
+						<p>A list of part of speech groups in a dictionary entry.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
+								>ol</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.2">Part of
+								Speech Lists</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="part-of-speech-group">part-of-speech-group</dt>
+					<dd>
+						<p>A unit that associates a part of speech with its related sense and phrase groups.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.3">Part of Speech
+								Groups</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="sense-list">sense-list</dt>
+					<dd>
+						<p>A list of sense groups in a dictionary entry.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
+								>ol</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.4">Sense
+								Lists</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="sense-group">sense-group</dt>
+					<dd>
+						<p>A unit for organizing information pertaining to a particular meaning of a headword or idiom.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.5">Sense
+								Groups</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="def">def</dt>
+					<dd>
+						<p>The definition of a particular meaning of a headword or idiom.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.6">Definitions</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+
+					<dt id="tran">tran</dt>
+					<dd>
+						<p>The translation of a particular meaning of a source language headword, idiom, or example into a target language.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.7">Translations</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="tran-info">tran-info</dt>
+					<dd>
+						<p>Grammatical or usage information related to a translation.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#tran">tran</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.8">Translation-Related
+								Information</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="idiom">idiom</dt>
+					<dd>
+						<p>A defining instance of a phrase.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required parent context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a> or <a href="#phrase-group">phrase-group</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element"
+								>dfn</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.2">Idioms</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="example">example</dt>
+					<dd>
+						<p>An illustration of the usage of a defined term or phrase.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.3">Examples</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="phrase-list">phrase-list</dt>
+					<dd>
+						<p>A list of phrase groups in a dictionary entry.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
+								>ol</a> or <a 
+									href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element"
+									>ul</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.4">Phrase
+								Lists</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="phrase-group">phrase-group</dt>
+					<dd>
+						<p>A unit for organizing information pertaining to an idiom or example.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.5">Phrase
+								Groups</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="synonym-group">synonym-group</dt>
+					<dd>
+						<p>A group of terms, each having identical or similar meaning to a headword or idiom.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.9.1">Synonym
+								Groups</a> [[EPUB-DICT-10]]
+						</p>
+					</dd>
+					
+					<dt id="antonym-group">antonym-group</dt>
+					<dd>
+						<p>A group of terms, each having an opposite or nearly opposite meaning from a headword or idiom.</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Required ancestor context:</span>
+							<span class="subpropref">
+								<a href="#dictentry">dictentry</a>
+							</span>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">HTML usage context: </span>
+							<a 
+								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content"
+								>flow content</a>
+						</p>
+					</dd>
+					<dd>
+						<p>
+							<span class="subproplabel">Usage details: </span>
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.9.2">Antonym
+								Groups</a> [[EPUB-DICT-10]]
+						</p>
 					</dd>
 				</dl>
 			</section>
@@ -2077,7 +2687,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">Usage details: </span>
-						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
 					</p>
 				</dd>
 				<dt id="panel-group">panel-group</dt>
@@ -2093,7 +2703,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">Usage details: </span>
-						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
 					</p>
 				</dd>
 				<dt id="balloon">balloon</dt>
@@ -2110,7 +2720,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">Usage details: </span>
-						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
 					</p>
 				</dd>
 				<dt id="text-area">text-area</dt>
@@ -2127,7 +2737,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">Usage details: </span>
-						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
 					</p>
 				</dd>
 				<dt id="sound-area">sound-area</dt>
@@ -2143,7 +2753,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">Usage details: </span>
-						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
+						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a> [[EPUB-REGION-NAV-10]]
 					</p>
 				</dd>
 			</dl>
@@ -2618,6 +3228,12 @@
 					<p>
 						<span class="subproplabel">DPUB-ARIA role: </span>
 						<a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagelist">doc-pagelist</a>
+					</p>
+				</dd>
+				<dd>
+					<p>
+						<span class="subproplabel">Usage details: </span>
+						<a href="https://www.w3.org/TR/epub-33/#sec-nav-pagelist">The <code>page-list nav</code> Element</a> [[EPUB-33]]
 					</p>
 				</dd>
 			</dl>

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -142,8 +142,10 @@
 				<p>When processing HTML documents, Reading Systems may ignore such non-compliant properties, unless
 					their usage context is explicitly overridden or extended by the host specification.</p>
 				
-				<p>The <i>Usage details</i> fields, when present, identify specifications that define or utilize
-					the specified properties.</p>
+				<p>The <i>Usage details</i> field, when present, identifies a specification that defines or utilizes
+					the designated property. Authors are only required to follow these usage details if they are
+					creating content that conforms to the specified specification, or if the rules apply to all
+					EPUB Publications. In all other cases, the properties may be used however needed.</p>
 			</section>
 		</section>
 			


### PR DESCRIPTION
Prompted by the email question about the reference to IDPF specs, I took a deeper look at the vocabulary and fixed a few other things:

- I think we should keep the explanation of the "usage details" sections, but we don't need to mention IDPF in it. In this PR, I've tried to better explain, too, that those fields only apply when following the respective specification. You can use any term in any way if you don't intend to conform (e.g., using `index` doesn't require following the indexes spec).
- I've added proper bracketed references for all the IDPF specs and added them to `localBiblio`
- I've added usage details and links to EPUB 3.3 for toc, page-list, and landmarks
- Surprisingly, none of the dictionary terms were added after that specification became a recommendation. Do you know if there was a reason for that @rdeltour or if no one got around to it? I've added a section to cover them.