### PR TITLE
Restore reference to Unique Identifier

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -536,7 +536,7 @@
 					</dt>
 					<dd>
 						<p>The primary identifier for an <a>EPUB Publication</a>. The Unique Identifier is the
-								<dfn>value</dfn> of the <a href="#sec-opf-dcidentifier"><code>dc:identifier</code>
+								<a>value</a> of the <a href="#sec-opf-dcidentifier"><code>dc:identifier</code>
 								element</a> specified by the <a href="#attrdef-package-unique-identifier"
 									><code>unique-identifier</code> attribute</a> in the <a>Package Document</a>.</p>
 						<p>Significant revision, abridgement, etc. of the content requires a new Unique Identifier.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -535,9 +535,10 @@
 						<dfn id="dfn-unique-identifier">Unique Identifier</dfn>
 					</dt>
 					<dd>
-						<p>The primary identifier for an <a>EPUB Publication</a> in the <a>Package Document</a>, as
-							identified by the <a href="#attrdef-package-unique-identifier"
-									><code>unique-identifier</code> attribute</a>.</p>
+						<p>The primary identifier for an <a>EPUB Publication</a>. The Unique Identifier is the
+								<dfn>value</dfn> of the <a href="#sec-opf-dcidentifier"><code>dc:identifier</code>
+								element</a> specified by the <a href="#attrdef-package-unique-identifier"
+									><code>unique-identifier</code> attribute</a> in the <a>Package Document</a>.</p>
 						<p>Significant revision, abridgement, etc. of the content requires a new Unique Identifier.</p>
 					</dd>
 					<dt>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -264,21 +264,21 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-rs-xml-nval" data-tests="#confreq-rs-xml-nval_invalid,#confreq-rs-xml-nval_unclosed">a
-							<a href="https://www.w3.org/TR/2008/REC-xml-20081126/#proc-types"
-								>conformant non-validating processor</a> [[XML]].</p>
+						<p id="confreq-rs-xml-nval"
+							data-tests="#confreq-rs-xml-nval_invalid,#confreq-rs-xml-nval_unclosed">a <a
+								href="https://www.w3.org/TR/2008/REC-xml-20081126/#proc-types">conformant non-validating
+								processor</a> [[XML]].</p>
 					</li>
 					<li>
-						<p id="confreq-rs-xml-ns" data-tests="#confreq-rs-xml-ns">a
-							<a href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#ProcessorConformance"
+						<p id="confreq-rs-xml-ns" data-tests="#confreq-rs-xml-ns">a <a
+								href="https://www.w3.org/TR/2009/REC-XML-NAMES-20091208/#ProcessorConformance"
 								>conformant processor</a> as defined in [[XML-NAMES]].</p>
 					</li>
 				</ul>
 
-				<p id="confreq-rs-xml-extid" data-tests="#confreq-rs-xml-extid">In addition, when processing XML documents,
-					it MUST NOT resolve <a
-						href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID">external identifiers</a>
-					[[XML]].</p>
+				<p id="confreq-rs-xml-extid" data-tests="#confreq-rs-xml-extid">In addition, when processing XML
+					documents, it MUST NOT resolve <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ExternalID"
+						>external identifiers</a> [[XML]].</p>
 			</section>
 
 			<section id="sec-epub-rs-i18n">
@@ -346,27 +346,29 @@
 				<h4>Base Direction</h4>
 
 				<p id="confreq-rs-pkg-dir"
-				    data-tests="#confreq-rs-pkg-dir_creator-rtl,#confreq-rs-pkg-dir_rtl-root-ltr,#confreq-rs-pkg-dir_rtl-root-unset,#confreq-rs-pkg-dir_unset-root-rtl,#confreq-rs-pkg-dir_unset-root-unset,#confreq-rs-pkg-dir-auto_root-rtl">
-				    If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
-				    <code>rtl</code>, Reading Systems MUST override the bidi algorithm per
-				    <a data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]], setting
-				    the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the base direction
-				    is <code>rtl</code>.</p>
+					data-tests="#confreq-rs-pkg-dir_creator-rtl,#confreq-rs-pkg-dir_rtl-root-ltr,#confreq-rs-pkg-dir_rtl-root-unset,#confreq-rs-pkg-dir_unset-root-rtl,#confreq-rs-pkg-dir_unset-root-unset,#confreq-rs-pkg-dir-auto_root-rtl"
+					> If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
+						<code>rtl</code>, Reading Systems MUST override the bidi algorithm per <a
+						data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]],
+					setting the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the
+					base direction is <code>rtl</code>.</p>
 
 				<p id="confreq-rs-pkg-dir-auto"
-				    data-tests="#confreq-rs-pkg-dir-auto_root-rtl,#confreq-rs-pkg-dir-auto_root-unset">Otherwise the base
-				    direction is <code>auto</code>, in which case Reading Systems MUST determine the text's direction by
-				    applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a> of [[BIDI]].</p>
+					data-tests="#confreq-rs-pkg-dir-auto_root-rtl,#confreq-rs-pkg-dir-auto_root-unset">Otherwise the
+					base direction is <code>auto</code>, in which case Reading Systems MUST determine the text's
+					direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a>
+					of [[BIDI]].</p>
 			</section>
 
 			<section id="sec-pkg-doc-pub-identifiers">
 				<h3>Unique Identifier</h3>
 
-				<p id="confreq-rs-pkg-unique-id" data-tests="#confreq-rs-pkg-unique-id">Reading Systems SHOULD NOT depend on
-					the <code>unique-identifier</code> attribute being unique to one and only one EPUB Publication.
-					Determining whether two EPUB Publications with the same Unique Identifier represent different versions of
-					the same publication, or different publications, may require inspecting other metadata, such as the last
-					modification date, titles, and authors.</p>
+				<p id="confreq-rs-pkg-unique-id" data-tests="#confreq-rs-pkg-unique-id">Reading Systems SHOULD NOT
+					depend on the <a href="https://www.w3.org/TR/epub-33/#dfn-unique-identifier">Unique Identifier</a>
+					being unique to one and only one EPUB Publication. Determining whether two EPUB Publications with
+					the same Unique Identifier represent different versions of the same publication, or different
+					publications, may require inspecting other metadata, such as the last modification date, titles, and
+					authors.</p>
 			</section>
 
 			<section id="sec-pkg-doc-metadata">
@@ -476,11 +478,11 @@
 				<h3>Manifest</h3>
 
 				<p id="confreq-rs-pkg-manifest-url" data-tests="#confreq-rs-pkg-manifest-url">When an <code>href</code>
-					attribute contains a <a href="https://url.spec.whatwg.org/#relative-url-string">relative-URL string</a>,
-					Reading Systems MUST use the URL of the Package Document as the
-					<a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> when
-					<a href="https://url.spec.whatwg.org/#concept-url-parser">parsing</a> to a
-					<a href="https://url.spec.whatwg.org/#concept-url">URL record</a> [[URL]].</p>
+					attribute contains a <a href="https://url.spec.whatwg.org/#relative-url-string">relative-URL
+						string</a>, Reading Systems MUST use the URL of the Package Document as the <a
+						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> when <a
+						href="https://url.spec.whatwg.org/#concept-url-parser">parsing</a> to a <a
+						href="https://url.spec.whatwg.org/#concept-url">URL record</a> [[URL]].</p>
 
 				<p>Reading Systems MAY optimize the rendering depending on the properties set in the
 						<code>properties</code> attribute (e.g., disable a rendering process or use a fallback). <span
@@ -489,9 +491,9 @@
 						recognize.</span></p>
 
 				<p id="confreq-rendition-rs-manifest" data-tests="#confreq-rendition-rs-manifest">It SHOULD NOT use
-					non-<a>Publication Resources</a> in the rendering of an EPUB Publication due to the inherent limitations
-					and risks involved (e.g., lack of information about the resource and how to process it, security risks
-					from remotely-hosted sources, lack of fallbacks, etc.).</p>
+						non-<a>Publication Resources</a> in the rendering of an EPUB Publication due to the inherent
+					limitations and risks involved (e.g., lack of information about the resource and how to process it,
+					security risks from remotely-hosted sources, lack of fallbacks, etc.).</p>
 
 				<p>A Reading System that does not support the Media Type of a given Publication Resource MUST traverse
 					the fallback chain until it has identified at least one supported Publication Resource to use in
@@ -529,17 +531,17 @@
 					specifically activates a hyperlink to such items). Reading Systems MAY also provide the option for
 					users to select whether to skip non-linear content by default or not.</p>
 
-				<p id="confreq-rs-spine-progression-default" data-tests="#confreq-rs-spine-progression-default">If the EPUB
-					Creator has not specified the <code>page-progression-direction</code>, the Reading System MUST assume the
-					value of <code>default</code>. When the EPUB Creator has set the value of the
-					<code>page-progression-direction</code> to <code>default</code>, either explicitly or implicitly, the
-					Reading System can choose rendering direction.</p>
+				<p id="confreq-rs-spine-progression-default" data-tests="#confreq-rs-spine-progression-default">If the
+					EPUB Creator has not specified the <code>page-progression-direction</code>, the Reading System MUST
+					assume the value of <code>default</code>. When the EPUB Creator has set the value of the
+						<code>page-progression-direction</code> to <code>default</code>, either explicitly or
+					implicitly, the Reading System can choose rendering direction.</p>
 
-				<p id="confreq-rs-spine-progression-prepaginated" data-tests="#confreq-rs-spine-progression-prepaginated">
-					Reading Systems MUST ignore the page progression direction defined in
-					<a href="#layout"><code>pre-paginated</code></a> XHTML Content Documents. The
-					<code>page-progression-direction</code> attribute defines the flow direction from one fixed-layout page
-					to the next.</p>
+				<p id="confreq-rs-spine-progression-prepaginated"
+					data-tests="#confreq-rs-spine-progression-prepaginated"> Reading Systems MUST ignore the page
+					progression direction defined in <a href="#layout"><code>pre-paginated</code></a> XHTML Content
+					Documents. The <code>page-progression-direction</code> attribute defines the flow direction from one
+					fixed-layout page to the next.</p>
 
 				<p>If any of the <code>properties</code> attribute's values do not include a prefix, Reading Systems
 					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
@@ -902,7 +904,7 @@
 						a unique <a href="https://url.spec.whatwg.org/#origin">origin</a> in the absence of a reliable
 						Web origin (e.g., HTTP URL scheme + host + port). The necessary heuristics may include the
 						combination of the Publication's <a href="https://www.w3.org/TR/epub-33/#dfn-unique-identifier"
-							>unique identifier</a> (although, in practice, these identifiers may in fact not guarantee
+							>Unique Identifier</a> (although, in practice, these identifiers may in fact not guarantee
 						globally-unique identification, that is why it is recommended to combine multiple techniques),
 						filesystem path, <a href="https://www.w3.org/TR/epub-33/#dfn-zip-container">OCF Zip
 							Container</a> checksum, etc. </p>
@@ -1121,13 +1123,14 @@
 						<p>Reading Systems MUST use the width and height expressions as defined in <a
 								href="https://www.w3.org/TR/epub-33/#sec-fxl-icb-html">Expressing in HTML</a>
 							[[EPUB-33]] to render <a>XHTML Content Documents</a>.</p>
-						<p id="confreq-fxl-rs-xhtml-icb" data-tests="#confreq-fxl-rs-xhtml-icb">Reading Systems MUST clip
-							XHTML content to the initial containing block (ICB) dimensions declared in the
-							<code>viewport</code> <code>meta</code> tag — content positioned outside of the initial
-							containing block will not be visible. When the ICB aspect ratio does not match the aspect ratio
-							of the Reading System <a>Content Display Area</a>, Reading Systems MAY position the ICB inside
-							the area to accommodate the user interface; in other words, added letter-boxing space MAY appear
-							on either side (or both) of the content.</p>
+						<p id="confreq-fxl-rs-xhtml-icb" data-tests="#confreq-fxl-rs-xhtml-icb">Reading Systems MUST
+							clip XHTML content to the initial containing block (ICB) dimensions declared in the
+								<code>viewport</code>
+							<code>meta</code> tag — content positioned outside of the initial containing block will not
+							be visible. When the ICB aspect ratio does not match the aspect ratio of the Reading System
+								<a>Content Display Area</a>, Reading Systems MAY position the ICB inside the area to
+							accommodate the user interface; in other words, added letter-boxing space MAY appear on
+							either side (or both) of the content.</p>
 					</dd>
 
 					<dt>SVG</dt>


### PR DESCRIPTION
s/unique-identifier attribute/Unique Identifier/ in caution against reading systems depending on uniqueness.

Fixes #1894


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1895.html" title="Last updated on Nov 6, 2021, 4:36 PM UTC (d6a5d31)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1895/fb98744...d6a5d31.html" title="Last updated on Nov 6, 2021, 4:36 PM UTC (d6a5d31)">Diff</a>