### PR TITLE
Proposal for base URLs to be used for URL parsing

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5345,8 +5345,7 @@ Spine:
 					<h4>URLs in the OCF Abstract Container</h4>
 
 					<p>The <a>container root URL</a> is the <a data-cite="url#concept-url">URL</a> [[URL]] of the
-						<a>Root Directory</a>. It is implementation specific, but the implementation MUST have the
-						following properties:</p>
+						<a>Root Directory</a>. It is implementation specific, but EPUB Creators MUST assume it has the following properties:</p>
 
 					<ul>
 						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -453,8 +453,10 @@
 						<dfn id="dfn-path-name" data-lt="Path Names">Path Name</dfn>
 					</dt>
 					<dd>
-						<p>The Path Name of a file or directory <var>file</var> is the <a data-cite="url#concept-url-path">path</a> of the <a>content URL</a> for <var>file</var>. 
-						It is derived from the <a>File Name</a> of <var>file</var> following the steps specified in <a href="#sec-file-names-to-path-names"></a>.</p>
+						<p>The Path Name of a file or directory is its full path relative to the root directory, as defined by the algorithm specified in <a href="#sec-file-names-to-path-names"></a>.</p>
+
+						<!-- <p>The Path Name of a file or directory <var>file</var> is the <a data-cite="url#concept-url-path">path</a> of the <a>content URL</a> for <var>file</var>. 
+						It is derived from the <a>File Name</a> of <var>file</var> following the steps specified in <a href="#sec-file-names-to-path-names"></a>.</p> -->
 					</dd>
 					<dt>
 						<dfn id="dfn-publication-resource" data-lt="Publication Resources">Publication Resource</dfn>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -287,7 +287,8 @@
 						<dfn id="dfn-container-root-url">Container Root URL</dfn>
 					</dt>
 					<dd>
-						<p>The (implementation specific) <a data-cite="url#concept-url">URL</a> representing the <a>Root Directory</a> of an <a>OCF Abstract Container</a>, defined in <a href="#sec-container-iri"></a>.</p>
+						<p>The <a data-cite="url#concept-url">URL</a> [[URL]] of the <a>Root Directory</a> representing the <a>OCF Abstract Container</a>. 
+							It is implementation specific, but EPUB Creators MUST assume it has properties defined in <a href="#sec-container-iri"></a>.</p>
 					</dd>
 
 					<dt>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -291,7 +291,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-container-url">Container URL</dfn>
+						<dfn id="dfn-content-url">Content URL</dfn>
 					</dt>
 					<dd>
 						<p>
@@ -453,8 +453,8 @@
 						<dfn id="dfn-path-name" data-lt="Path Names">Path Name</dfn>
 					</dt>
 					<dd>
-						<p>For a given <var>file</var> within the <a href="#sec-container-abstract">OCF Abstract
-							Container</a> the Path Name can be obtained by performing the following steps (expressed using the terminology of [[infra]]):</p>
+						<p>The Path Name of a file or directory <var>file</var> in the <a href="#sec-container-abstract">OCF Abstract
+							Container</a> is the result of following steps (expressed using the terminology of [[infra]]):</p>
 
 						<ol>
 							<li>Let <var>path</var> be an empty <a data-cite="infra#list">list</a>.</li>
@@ -1217,10 +1217,13 @@
 					<p>All [[XML]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
 						namespace [[XML-NAMES]] unless otherwise specified.</p>
 
-					<p>
-						To parse a URL string <var>url</var> used in the Package Document, the <a data-cite="url#concept-url-parser">URL Parser</a> [[URL]] MUST be used with the 
-						<a>container root URL</a> as <var>base</var>.
-					</p>	
+					<section>
+						<h4>Parsing URLs in the Package Document</h4>
+						<p>
+							To parse a URL string <var>url</var> used in the Package Document, the <a data-cite="url#concept-url-parser">URL Parser</a> [[URL]] MUST be applied to <var>url</var>, with the 
+							<a>container root URL</a> as <var>base</var>.
+						</p>		
+					</section>
 
 					<section id="sec-shared-attrs">
 						<h5>Shared Attributes</h5>
@@ -5338,11 +5341,11 @@ Spine:
 						<a>Root Directory</a>. It is implementation specific, but MUST abide to the following requirements:</p>
 
 					<ul>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing </a> "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a> MUST be the <a>container root URL</a>.</li>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing </a> "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a> MUST be the <a>container root URL</a>.</li>	
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> MUST be the <a>container root URL</a>.</li>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> MUST be the <a>container root URL</a>.</li>	
 					</ul>
 
-					<p>The <a>container URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result of parsing the file's <a>Path Name</a> with the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a>.</p>
+					<p>The <a>content URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result of <a data-cite="url#concept-url-parser">parsing</a> the file's <a>Path Name</a> with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 					<p>
 						In the <a>OCF Abstract Container</a>, when a file uses a URL string to reference another file in the container, the string MUST be a 
@@ -5357,7 +5360,7 @@ Spine:
 					</aside>
 
 					<p class="note">
-						The properties of the <a>container root URL</a> are such that whatever the amount of <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> in a URL string (for example, <code>../../../secret</code>), it will be parsed to a container URL (and not "leak" outside the container). However, for better interoperability with non-conforming or legacy Reading Systems, EPUB Creators should avoid to use more <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> than needed to reach the target container file.
+						The properties of the <a>container root URL</a> are such that whatever the amount of <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> in a URL string (for example, <code>../../../secret</code>), it will be parsed to a content URL (and not "leak" outside the container). However, for better interoperability with non-conforming or legacy Reading Systems, EPUB Creators should avoid to use more <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> than needed to reach the target container file.
 					</p>
 				</section>
 
@@ -5503,7 +5506,7 @@ Spine:
 						<h5>Parsing URLs in the <code>META-INF</code> Directory</h5>
 
 						<p>To parse a URL string <var>url</var> used in files located in the <code>META-INF</code> directory the 
-							<a data-cite="url#concept-url-parser">URL Parser</a> MUST use the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a> when applied to <var>url</var>.</p>
+							<a data-cite="url#concept-url-parser">URL Parser</a> MUST use the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> when applied to <var>url</var>.</p>
 
 						<aside class="example">
 						<p>For example, if <code>META-INF/container.xml</code> has the following content:</p>
@@ -9469,7 +9472,7 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>10-Nov-2021: Proper definition of the Container URL and handling of relative URLs. See <a
+				<li>10-Nov-2021: Proper definition of the content URL and handling of relative URLs. See <a
 						href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and 
 						<a href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
 				<li>29-Oct-2021: Recommended that EPUB Creators not use path-absolute-URL strings for referencing

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -282,6 +282,23 @@
 							media types designed for optimum compression or that provide optimized streaming
 							capabilities.</p>
 					</dd>
+
+					<dt>
+						<dfn id="dfn-container-root-url">Container Root URL</dfn>
+					</dt>
+					<dd>
+						<p>The (implementation specific) <a data-cite="url#concept-url">URL</a> representing the <a>Root Directory</a> of an <a>OCF Abstract Container</a>, defined in <a href="#sec-container-iri"></a>.</p>
+					</dd>
+
+					<dt>
+						<dfn id="dfn-container-url">Container URL</dfn>
+					</dt>
+					<dd>
+						<p>
+							The <a data-cite="url#concept-url">URL</a> of a file or directory in the <a>OCF Abstract Container</a>, defined in <a href="#sec-container-iri"></a>.
+						</p>
+					</dd>
+
 					<dt>
 						<dfn id="dfn-content-display-area">Content Display Area</dfn>
 					</dt>
@@ -436,14 +453,23 @@
 						<dfn id="dfn-path-name" data-lt="Path Names">Path Name</dfn>
 					</dt>
 					<dd>
-						<p>For a given directory within the <a href="#sec-container-abstract">OCF Abstract
-							Container</a>, the string holding all directory <a>File Name</a> in the full path
-							concatenated together with a <code>/</code> (<code>U+002F</code>) character separating the
-							directory File Names.</p>
-						<p>For a given file within the OCF Abstract Container, the Path Name is the string holding all
-							directory File Names concatenated together with a <code>/</code> character separating the
-							directory File Names, followed by a <code>/</code> character and then the File Name of the
-							file.</p>
+						<p>For a given <var>file</var> within the <a href="#sec-container-abstract">OCF Abstract
+							Container</a> the Path Name can be obtained by performing the following steps (expressed using the terminology of [[infra]]):</p>
+
+						<ol>
+							<li>Let <var>path</var> be an empty <a data-cite="infra#list">list</a>.</li>
+							<li><a data-cite="infra#list-prepend">Prepend</a> the <a>File Name</a> of <var>file</var> to <var>path</var>.</li>
+							<li>Let <var>parent</var> be the parent directory of <var>file</var>.</li>
+							<li>While <var>parent</var> is not the <a>Root Directory</a>:
+								<ol>
+									<li><a data-cite="infra#list-prepend">prepend</a> the <a>File Name</a> of <var>parent</var> to <var>path</var>;</li>
+									<li>set the parent directory of <var>parent</var> to <var>parent</var>.</li>
+								</ol>
+							</li>
+							<li>
+								Return the <a data-cite="infra#string-concatenate">concatenation</a> of <var>path</var> using the <code>/</code> (<code>U+002F SOLIDUS</code>) character.
+							</li>
+						</ol>	
 					</dd>
 					<dt>
 						<dfn id="dfn-publication-resource" data-lt="Publication Resources">Publication Resource</dfn>
@@ -1190,6 +1216,11 @@
 
 					<p>All [[XML]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
 						namespace [[XML-NAMES]] unless otherwise specified.</p>
+
+					<p>
+						To parse a URL string <var>url</var> used in the Package Document, the <a data-cite="url#concept-url-parser">URL Parser</a> [[URL]] MUST be used with the 
+						<a>container root URL</a> as <var>base</var>.
+					</p>	
 
 					<section id="sec-shared-attrs">
 						<h5>Shared Attributes</h5>
@@ -5301,11 +5332,22 @@ Spine:
 				</section>
 
 				<section id="sec-container-iri">
-					<h4>Relative URLs for Referencing Other Components</h4>
+					<h4>URLs in the OCF Abstract Container</h4>
 
-					<p>Files within the <a>OCF Abstract Container</a> MUST reference each other via <a
-							href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-							>relative-URL-with-fragment strings</a> [[URL]].</p>
+					<p>The <a>container root URL</a> is the <a data-cite="url#concept-url">URL</a> [[URL]] of the
+						<a>Root Directory</a>. It is implementation specific, but MUST abide to the following requirements:</p>
+
+					<ul>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing </a> "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a> MUST be the <a>container root URL</a>.</li>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing </a> "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a> MUST be the <a>container root URL</a>.</li>	
+					</ul>
+
+					<p>The <a>container URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result of parsing the file's <a>Path Name</a> with the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a>.</p>
+
+					<p>
+						In the <a>OCF Abstract Container</a>, when a file uses a URL string to reference another file in the container, the string MUST be a 
+						<a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a>.
+					</p>
 
 					<aside class="example">
 						<p>The following example shows how to reference, from an [[HTML]] <code>img</code> element, a
@@ -5314,47 +5356,9 @@ Spine:
 						<pre>&lt;img src="image1.jpg" alt="…" /&gt;</pre>
 					</aside>
 
-					<p>EPUB Creators SHOULD NOT use <a href="https://url.spec.whatwg.org/#path-absolute-url-string"
-							>path-absolute-URL strings</a> [[URI]] (i.e., where the path begins with a single slash) to
-						reference resources in the OCF Abstract Container.</p>
-
-					<div class="note">
-						<p>The base of an EPUB Publication can change from Reading System to Reading Systems depending
-							on how the content is served. Some Reading Systems may treat the location of the package
-							document as the base of the EPUB Publication, for example, while others may use the <a>Root
-								Directory</a>.</p>
-					</div>
-
-					<p>The relevant language specification for a given file format determines the <a
-							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] used to parse <a
-							href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-							>relative-URL-with-fragment strings</a> [[URL]]. For example, CSS defines how relative URL
-						references work in the context of CSS style sheets and property declarations
-						[[CSSSnapshot]].</p>
-
-					<p>Unlike most language specifications, the <a href="https://url.spec.whatwg.org/#concept-base-url"
-							>base URL</a> [[URL]] for all files within the <code>META-INF</code> directory is the
-							<a>Root Directory</a> of the OCF Abstract Container.</p>
-
-					<p>For example, if <code>META-INF/container.xml</code> has the following content:</p>
-
-					<pre class="example">
-&lt;?xml version="1.0"?&gt;
-&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
-    &lt;rootfiles&gt;
-        &lt;rootfile full-path="EPUB/Great_Expectations.opf"
-            media-type="application/oebps-package+xml" /&gt;	
-    &lt;/rootfiles&gt;
-&lt;/container&gt;
-            </pre>
-
-					<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the root directory for the
-						OCF Abstract Container and not relative to the <code>META-INF</code> directory.</p>
-
-					<p>All <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-							>relative-URL-with-fragment strings</a> [[URL]] MUST, after <a
-							href="https://url.spec.whatwg.org/#concept-url-parser">parsing to URL records</a> [[URL]],
-						identify resources within the OCF Abstract Container (i.e., at or below the Root Directory).</p>
+					<p class="note">
+						The properties of the <a>container root URL</a> are such that whatever the amount of <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> in a URL string (for example, <code>../../../secret</code>), it will be parsed to a container URL (and not "leak" outside the container). However, for better interoperability with non-conforming or legacy Reading Systems, EPUB Creators should avoid to use more <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> than needed to reach the target container file.
+					</p>
 				</section>
 
 				<section id="sec-container-filenames">
@@ -5494,6 +5498,32 @@ Spine:
 						<p>This directory is reserved for configuration files, specifically those defined in <a
 								href="#sec-container-metainf-files"></a>.</p>
 					</section>
+
+					<section id="sec-parsing-urls-metainf">
+						<h5>Parsing URLs in the <code>META-INF</code> Directory</h5>
+
+						<p>To parse a URL string <var>url</var> used in files located in the <code>META-INF</code> directory the 
+							<a data-cite="url#concept-url-parser">URL Parser</a> MUST use the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a> when applied to <var>url</var>.</p>
+
+						<aside class="example">
+						<p>For example, if <code>META-INF/container.xml</code> has the following content:</p>
+
+						<pre class="example">
+	&lt;?xml version="1.0"?&gt;
+	&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
+		&lt;rootfiles&gt;
+			&lt;rootfile full-path="EPUB/Great_Expectations.opf"
+				  media-type="application/oebps-package+xml" /&gt;	
+		&lt;/rootfiles&gt;
+	&lt;/container&gt;
+				</pre>
+	
+						<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the root directory for the
+							OCF Abstract Container and not relative to the <code>META-INF</code> directory.</p>
+						</aside>
+	
+					</section>
+
 
 					<section id="sec-container-metainf-files">
 						<h5>Reserved Files</h5>
@@ -9439,6 +9469,9 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>10-Nov-2021: Proper definition of the Container URL and handling of relative URLs. See <a
+						href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and 
+						<a href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
 				<li>29-Oct-2021: Recommended that EPUB Creators not use path-absolute-URL strings for referencing
 					resources due to the lack of a consistent root. See <a
 						href="https://github.com/w3c/epub-specs/issues/1681">issue 1681</a></li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1209,7 +1209,7 @@
 						<h4>Parsing URLs in the Package Document</h4>
 						<p>
 							To parse a URL string <var>url</var> used in the Package Document, the <a data-cite="url#concept-url-parser">URL Parser</a> [[URL]] MUST be applied to <var>url</var>, with the 
-							<a>container root URL</a> as <var>base</var>.
+							<a>content URL</a> of the Package Document as <var>base</var>.
 						</p>		
 					</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2796,8 +2796,7 @@
 
 								The value MUST be a an <a
 									href="https://url.spec.whatwg.org/#absolute-url-string">absolute-</a> or  <a href="https://url.spec.whatwg.org/#path-relative-scheme-less-URL">path-relative-scheme-less-URL</a> string. EPUB Creators MUST ensure each URL is unique within the <code>manifest</code> scope
-									after <a href="#parsing-urls-in-the-package-document">resolution
-									to an absolute URL</a>.</p>
+									after <a href="#parsing-urls-in-the-package-document">parsing</a>.</p>
 
 							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
 								element MUST conform to the applicable specification(s) as inferred from the MIME media
@@ -6759,8 +6758,7 @@ store destination as source in ocf
 									</dt>
 									<dd>
 										<p>Identifies an associated fragment of an EPUB Content Document.</p>
-										<p>The value MUST be a <a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a> with a <a
-												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
+										<p>The value MUST be a <a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a>.</p>
 									</dd>
 								</dl>
 							</dd>
@@ -6836,8 +6834,7 @@ store destination as source in ocf
 									</dt>
 									<dd>
 										<p>Identifies an associated fragment of an EPUB Content Document.</p>
-										<p>The value MUST be a <a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a> with a <a
-												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
+										<p>The value MUST be a <a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a>.</p>
 										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
 											information.</p>
 									</dd>
@@ -6968,10 +6965,7 @@ store destination as source in ocf
 									</dt>
 									<dd>
 										<p>Identifies the associated fragment of an EPUB Content Document.</p>
-										<p>The value MUST be a <a
-												href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-												>relative-URL-with-fragment string</a> [[URL]] with a <a
-												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
+										<p>The value MUST be a <a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a>.</p>
 									</dd>
 									<dt>
 										<code>id</code>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5320,66 +5320,8 @@ Spine:
 					</div>
 				</section>
 
-				<section id="sec-file-names-to-path-names">
-					<h4>Deriving the File Paths of Files</h4>
-
-					<p>To derive the <a>File Path</a> of a file or directory <var>file</var> in the <a href="#sec-container-abstract">OCF Abstract
-						Container</a> apply the following steps (expressed using the terminology of [[infra]]):</p>
-
-					<ol class="algorithm">
-						<li>Let <var>path</var> be an empty <a data-cite="infra#list">list</a>.</li>
-						<li>Let <var>current</var> be <var>file</var>.</li>
-						<li>While <var>current</var> is not the <a>Root Directory</a>:
-							<ol>
-								<li><a data-cite="infra#list-prepend">prepend</a> the <a>File Name</a> of <var>current</var> to <var>path</var>;</li>
-								<li>set <var>current</var> to the parent directory of <var>current</var>.</li>
-							</ol>	
-						</li>
-						<li>
-							Return the <a data-cite="infra#string-concatenate">concatenation</a> of <var>path</var> using the  <code>U+002F (/)</code> character.
-						</li>
-					</ol>
-				</section>
-
-				<section id="sec-container-iri">
-					<h4>URLs in the OCF Abstract Container</h4>
-
-					<p>The <a>container root URL</a> is the <a data-cite="url#concept-url">URL</a> [[URL]] of the
-						<a>Root Directory</a>. It is implementation specific, but EPUB Creators MUST assume it has the following properties:</p>
-
-					<ul>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>	
-					</ul>
-
-					<p>The <a>content URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result of <a data-cite="url#concept-url-parser">parsing</a> 
-						the file's <a>File Path</a> with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
-
-					<div class="note">
-						<p>
-							<a data-cite="url#concept-url-parser">Parsing</a> may replace some charaters in the File Path by their <a data-cite="url#percent-encode">percent encoded</a> alternative. For example, "<code>A/B/C/file&nbsp;name.xhtml</code>" becomes "<code>A/B/C/file%20name.xhtml</code>". 
-						</p>
-					</div>
-
-					<p>
-						In the <a>OCF Abstract Container</a>, when a file uses a URL string to reference another file in the container, the string MUST be a 
-						<a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a>.
-					</p>
-
-					<aside class="example">
-						<p>The following example shows how to reference, from an [[HTML]] <code>img</code> element, a
-							file named <code>image1.jpg</code> in the same directory as an <a>XHTML Content
-							Document</a>.</p>
-						<pre>&lt;img src="image1.jpg" alt="…" /&gt;</pre>
-					</aside>
-
-					<p class="note">
-						The properties of the <a>container root URL</a> are such that whatever the amount of <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> in a URL string (for example, <code>../../../secret</code>), it will be parsed to a content URL (and not "leak" outside the container). However, for better interoperability with non-conforming or legacy Reading Systems, EPUB Creators should avoid to use more <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> than needed to reach the target container file.
-					</p>
-				</section>
-
 				<section id="sec-container-filenames">
-					<h4>Path and File Names</h4>
+					<h4>File Paths and File Names</h4>
 
 					<p id="ocf-fn-cs">In the context of the Abstract Container, <a>File Paths</a> and <a>File Names</a>
 						are case sensitive.</p>
@@ -5395,7 +5337,7 @@ Spine:
 							<p id="ocf-fn-length">File Names MUST NOT exceed 255 bytes.</p>
 						</li>
 						<li>
-							<p id="ocf-pn-length">The File Path for any directory or file within the OCF Abstract
+							<p id="ocf-pn-length">The File Paths for any directory or file within the OCF Abstract
 								Container MUST NOT exceed 65535 bytes.</p>
 						</li>
 						<li>
@@ -5500,7 +5442,64 @@ Spine:
 								Creators</a> who want to use ZIP tools that have these restrictions may find it best to
 							restrict their File Names to the [[US-ASCII]] range.</p>
 					</div>
+				</section>
 
+				<section id="sec-file-names-to-path-names">
+					<h4>Deriving File Paths of Files</h4>
+
+					<p>To derive the <a>File Path</a> of a file or directory <var>file</var> in the <a href="#sec-container-abstract">OCF Abstract
+						Container</a> apply the following steps (expressed using the terminology of [[INFRA]]):</p>
+
+					<ol class="algorithm">
+						<li>Let <var>path</var> be an empty <a data-cite="infra#list">list</a>.</li>
+						<li>Let <var>current</var> be <var>file</var>.</li>
+						<li>While <var>current</var> is not the <a>Root Directory</a>:
+							<ol>
+								<li><a data-cite="infra#list-prepend">prepend</a> the <a>File Name</a> of <var>current</var> to <var>path</var>;</li>
+								<li>set <var>current</var> to the parent directory of <var>current</var>.</li>
+							</ol>	
+						</li>
+						<li>
+							Return the <a data-cite="infra#string-concatenate">concatenation</a> of <var>path</var> using the  <code>U+002F (/)</code> character.
+						</li>
+					</ol>
+				</section>
+
+				<section id="sec-container-iri">
+					<h4>URLs in the OCF Abstract Container</h4>
+
+					<p>The <a>container root URL</a> is the <a data-cite="url#concept-url">URL</a> [[URL]] of the
+						<a>Root Directory</a>. It is implementation specific, but EPUB Creators MUST assume it has the following properties:</p>
+
+					<ul>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>	
+					</ul>
+
+					<p>The <a>content URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result of <a data-cite="url#concept-url-parser">parsing</a> 
+						the file's <a>File Path</a> with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
+
+					<div class="note">
+						<p>
+							<a data-cite="url#concept-url-parser">Parsing</a> may replace some charaters in the File Path by their <a data-cite="url#percent-encode">percent encoded</a> alternative. For example, <code>A/B/C/file&nbsp;name.xhtml</code> becomes <code>A/B/C/file%20name.xhtml</code>. 
+						</p>
+					</div>
+
+					<p>
+						In the <a>OCF Abstract Container</a>, when a file uses a URL string to reference another file in the container, the string MUST be a 
+						<a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a>.
+					</p>
+
+					<aside class="example">
+						<p>The following example shows how to reference, from an [[HTML]] <code>img</code> element, a
+							file named <code>image1.jpg</code> in the same directory as an <a>XHTML Content
+							Document</a>.</p>
+						<pre>&lt;img src="image1.jpg" alt="…" /&gt;</pre>
+					</aside>
+
+					<p class="note">
+						The properties of the <a>container root URL</a> are such that whatever the amount of <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> in a URL string (for example, <code>../../../secret</code>), it will be parsed to a content URL (and not "leak" outside the container). However, for better interoperability with non-conforming or legacy Reading Systems, EPUB Creators should avoid to use more <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> than needed to reach the target container file.
+					</p>
 				</section>
 
 				<section id="sec-container-metainf">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -288,7 +288,7 @@
 					</dt>
 					<dd>
 						<p>The <a data-cite="url#concept-url">URL</a> [[URL]] of the <a>Root Directory</a> representing the <a>OCF Abstract Container</a>. 
-							It is implementation specific, but EPUB Creators MUST assume it has properties defined in <a href="#sec-container-iri"></a>.</p>
+							It is implementation specific, but EPUB Creators must assume it has properties defined in <a href="#sec-container-iri"></a>.</p>
 					</dd>
 
 					<dt>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -453,23 +453,8 @@
 						<dfn id="dfn-path-name" data-lt="Path Names">Path Name</dfn>
 					</dt>
 					<dd>
-						<p>The Path Name of a file or directory <var>file</var> in the <a href="#sec-container-abstract">OCF Abstract
-							Container</a> is the result of following steps (expressed using the terminology of [[infra]]):</p>
-
-						<ol>
-							<li>Let <var>path</var> be an empty <a data-cite="infra#list">list</a>.</li>
-							<li><a data-cite="infra#list-prepend">Prepend</a> the <a>File Name</a> of <var>file</var> to <var>path</var>.</li>
-							<li>Let <var>parent</var> be the parent directory of <var>file</var>.</li>
-							<li>While <var>parent</var> is not the <a>Root Directory</a>:
-								<ol>
-									<li><a data-cite="infra#list-prepend">prepend</a> the <a>File Name</a> of <var>parent</var> to <var>path</var>;</li>
-									<li>set the parent directory of <var>parent</var> to <var>parent</var>.</li>
-								</ol>
-							</li>
-							<li>
-								Return the <a data-cite="infra#string-concatenate">concatenation</a> of <var>path</var> using the <code>/</code> (<code>U+002F SOLIDUS</code>) character.
-							</li>
-						</ol>	
+						<p>The Path Name of a file or directory <var>file</var> is the <a data-cite="url#concept-url-path">path</a> of the <a>content URL</a> for <var>file</var>. 
+						It is derived from the <a>File Name</a> of <var>file</var> following the steps specified in <a href="#sec-file-names-to-path-names"></a>.</p>
 					</dd>
 					<dt>
 						<dfn id="dfn-publication-resource" data-lt="Publication Resources">Publication Resource</dfn>
@@ -5332,6 +5317,27 @@ Spine:
 								href="https://www.w3.org/TR/epub-multi-rend-11/#container">creating multiple
 								renditions</a> [[EPUB-MULTI-REND-11]] of the publication.</p>
 					</div>
+				</section>
+
+				<section id="sec-file-names-to-path-names">
+					<h4>Deriving Path Names from Files</h4>
+
+					<p>To derive the <a>Path Name</a> of a file or directory <var>file</var> in the <a href="#sec-container-abstract">OCF Abstract
+						Container</a> apply the following steps (expressed using the terminology of [[infra]]):</p>
+
+					<ol class="algorithm">
+						<li>Let <var>path</var> be an empty <a data-cite="infra#list">list</a>.</li>
+						<li>Let <var>current</var> be <var>file</var>.</li>
+						<li>While <var>current</var> is not the <a>Root Directory</a>:
+							<ol>
+								<li><a data-cite="infra#list-prepend">prepend</a> the <a>File Name</a> of <var>current</var> to <var>path</var>;</li>
+								<li>set <var>current</var> to the parent directory of <var>current</var>.</li>
+							</ol>	
+						</li>
+						<li>
+							Return the <a data-cite="infra#string-concatenate">concatenation</a> of <var>path</var> using the  <code>U+002F (/)</code> character.
+						</li>
+					</ol>
 				</section>
 
 				<section id="sec-container-iri">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5519,7 +5519,7 @@ Spine:
 						<h5>Parsing URLs in the <code>META-INF</code> Directory</h5>
 
 						<p>To parse a URL string <var>url</var> used in files located in the <code>META-INF</code> directory the 
-							<a data-cite="url#concept-url-parser">URL Parser</a> MUST be applied to <var>url</var>, with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var>.</p>
+							<a data-cite="url#concept-url-parser">URL Parser</a> MUST be applied to <var>url</var>, with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 						<aside class="example">
 						<p>For example, if <code>META-INF/container.xml</code> has the following content:</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5519,7 +5519,7 @@ Spine:
 						<h5>Parsing URLs in the <code>META-INF</code> Directory</h5>
 
 						<p>To parse a URL string <var>url</var> used in files located in the <code>META-INF</code> directory the 
-							<a data-cite="url#concept-url-parser">URL Parser</a> MUST use the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> when applied to <var>url</var>.</p>
+							<a data-cite="url#concept-url-parser">URL Parser</a> MUST be applied to <var>url</var>, with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var>.</p>
 
 						<aside class="example">
 						<p>For example, if <code>META-INF/container.xml</code> has the following content:</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5345,11 +5345,12 @@ Spine:
 					<h4>URLs in the OCF Abstract Container</h4>
 
 					<p>The <a>container root URL</a> is the <a data-cite="url#concept-url">URL</a> [[URL]] of the
-						<a>Root Directory</a>. It is implementation specific, but MUST abide to the following requirements:</p>
+						<a>Root Directory</a>. It is implementation specific, but the implementation MUST have the
+						following properties:</p>
 
 					<ul>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> MUST be the <a>container root URL</a>.</li>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> MUST be the <a>container root URL</a>.</li>	
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>	
 					</ul>
 
 					<p>The <a>content URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result of <a data-cite="url#concept-url-parser">parsing</a> the file's <a>Path Name</a> with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5496,7 +5496,7 @@ Spine:
 					</aside>
 
 					<p class="note">
-						The properties of the <a>container root URL</a> are such that whatever the amount of <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> in a URL string (for example, <code>../../../secret</code>), it will be parsed to a content URL (and not "leak" outside the container). However, for better interoperability with non-conforming or legacy Reading Systems, EPUB Creators should avoid to use more <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> than needed to reach the target container file.
+						The properties of the <a>container root URL</a> are such that whatever the amount of <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> in a URL string (for example, <code>../../../secret</code>), it will be parsed to a content URL (and not "leak" outside the container). However, for better interoperability with non-conforming or legacy Reading Systems, EPUB Creators should avoid using more <a data-cite="url/#double-dot-path-segment">double-dot path segments</a> than needed to reach the target container file.
 					</p>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1343,9 +1343,7 @@
 							</dt>
 							<dd>
 								<p>Establishes an association between the current expression and the element or resource
-									identified by its value. EPUB Creators MUST use as the value a <a
-										href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-										>relative-URL-with-fragment string</a> [[URL]] that references the resource or
+									identified by its value. EPUB Creators MUST use as the value a <a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a> that references the resource or
 									element they are describing.</p>
 								<aside class="example">
 									<p>The following example shows the <code>refines</code> element used to indicate a
@@ -2794,12 +2792,12 @@
 							</dl>
 
 							<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL
-								[[URL]] in its <code>href</code> attribute. EPUB Creators MAY use <a
-									href="https://url.spec.whatwg.org/#absolute-url-string">absolute-</a> or <a
-									href="https://url.spec.whatwg.org/#relative-url-string">relative-URL string</a>
-								[[URL]], but they MUST ensure each URL is unique within the <code>manifest</code> scope
-								after <a href="https://www.w3.org/TR/epub-rs-33/#sec-pkg-doc-relative-urls">resolution
-									to an absolute URL</a> [[EPUB-RS-33]].</p>
+								[[URL]] in its <code>href</code> attribute. 
+
+								The value MUST be a an <a
+									href="https://url.spec.whatwg.org/#absolute-url-string">absolute-</a> or  <a href="https://url.spec.whatwg.org/#path-relative-scheme-less-URL">path-relative-scheme-less-URL</a> string. EPUB Creators MUST ensure each URL is unique within the <code>manifest</code> scope
+									after <a href="#parsing-urls-in-the-package-document">resolution
+									to an absolute URL</a>.</p>
 
 							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
 								element MUST conform to the applicable specification(s) as inferred from the MIME media
@@ -6761,9 +6759,7 @@ store destination as source in ocf
 									</dt>
 									<dd>
 										<p>Identifies an associated fragment of an EPUB Content Document.</p>
-										<p>The value MUST be a <a
-												href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-												>relative-URL-with-fragment string</a> [[URL]] with a <a
+										<p>The value MUST be a <a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a> with a <a
 												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
 									</dd>
 								</dl>
@@ -6840,9 +6836,7 @@ store destination as source in ocf
 									</dt>
 									<dd>
 										<p>Identifies an associated fragment of an EPUB Content Document.</p>
-										<p>The value MUST be a <a
-												href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-												>relative-URL-with-fragment string</a> [[URL]] with a <a
+										<p>The value MUST be a <a data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string">URL-fragment string</a> with a <a
 												href="#sec-media-overlays-fragids">fragment identifier</a>.</p>
 										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
 											information.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -384,6 +384,15 @@
 							a file within a directory.</p>
 					</dd>
 					<dt>
+						<dfn id="dfn-file-path" data-lt="File Paths">File Path</dfn>
+					</dt>
+					<dd>
+						<p>The File Path of a file or directory is its full path relative to the root directory, as defined by the algorithm specified in <a href="#sec-file-names-to-path-names"></a>.</p>
+
+						<!-- <p>The File Path of a file or directory <var>file</var> is the <a data-cite="url#concept-url-path">path</a> of the <a>content URL</a> for <var>file</var>. 
+						It is derived from the <a>File Name</a> of <var>file</var> following the steps specified in <a href="#sec-file-names-to-path-names"></a>.</p> -->
+					</dd>
+					<dt>
 						<dfn id="dfn-fixed-layout-document" data-lt="Fixed-Layout Documents">Fixed-Layout Document</dfn>
 					</dt>
 					<dd>
@@ -448,15 +457,6 @@
 							defined in <a href="#sec-package-doc"></a>. The Package Document carries meta information
 							about the EPUB Publication, provides a manifest of resources and defines a default reading
 							order.</p>
-					</dd>
-					<dt>
-						<dfn id="dfn-path-name" data-lt="Path Names">Path Name</dfn>
-					</dt>
-					<dd>
-						<p>The Path Name of a file or directory is its full path relative to the root directory, as defined by the algorithm specified in <a href="#sec-file-names-to-path-names"></a>.</p>
-
-						<!-- <p>The Path Name of a file or directory <var>file</var> is the <a data-cite="url#concept-url-path">path</a> of the <a>content URL</a> for <var>file</var>. 
-						It is derived from the <a>File Name</a> of <var>file</var> following the steps specified in <a href="#sec-file-names-to-path-names"></a>.</p> -->
 					</dd>
 					<dt>
 						<dfn id="dfn-publication-resource" data-lt="Publication Resources">Publication Resource</dfn>
@@ -5321,9 +5321,9 @@ Spine:
 				</section>
 
 				<section id="sec-file-names-to-path-names">
-					<h4>Deriving the Path Names of Files</h4>
+					<h4>Deriving the File Paths of Files</h4>
 
-					<p>To derive the <a>Path Name</a> of a file or directory <var>file</var> in the <a href="#sec-container-abstract">OCF Abstract
+					<p>To derive the <a>File Path</a> of a file or directory <var>file</var> in the <a href="#sec-container-abstract">OCF Abstract
 						Container</a> apply the following steps (expressed using the terminology of [[infra]]):</p>
 
 					<ol class="algorithm">
@@ -5352,7 +5352,14 @@ Spine:
 						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>	
 					</ul>
 
-					<p>The <a>content URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result of <a data-cite="url#concept-url-parser">parsing</a> the file's <a>Path Name</a> with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
+					<p>The <a>content URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result of <a data-cite="url#concept-url-parser">parsing</a> 
+						the file's <a>File Path</a> with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
+
+					<div class="note">
+						<p>
+							<a data-cite="url#concept-url-parser">Parsing</a> may replace some charaters in the File Path by their <a data-cite="url#percent-encode">percent encoded</a> alternative. For example, "<code>A/B/C/file&nbsp;name.xhtml</code>" becomes "<code>A/B/C/file%20name.xhtml</code>". 
+						</p>
+					</div>
 
 					<p>
 						In the <a>OCF Abstract Container</a>, when a file uses a URL string to reference another file in the container, the string MUST be a 
@@ -5374,21 +5381,21 @@ Spine:
 				<section id="sec-container-filenames">
 					<h4>Path and File Names</h4>
 
-					<p id="ocf-fn-cs">In the context of the Abstract Container, <a>Path Names</a> and <a>File Names</a>
+					<p id="ocf-fn-cs">In the context of the Abstract Container, <a>File Paths</a> and <a>File Names</a>
 						are case sensitive.</p>
 
-					<p>In addition, the following restrictions are designed to allow Path Names and File Names to be
+					<p>In addition, the following restrictions are designed to allow File Paths and File Names to be
 						used without modification on most operating systems:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="ocf-fn-encoding">Path and File Names MUST be UTF-8 [[Unicode]] encoded.</p>
+							<p id="ocf-fn-encoding">File Names and Paths MUST be UTF-8 [[Unicode]] encoded.</p>
 						</li>
 						<li>
 							<p id="ocf-fn-length">File Names MUST NOT exceed 255 bytes.</p>
 						</li>
 						<li>
-							<p id="ocf-pn-length">The Path Name for any directory or file within the OCF Abstract
+							<p id="ocf-pn-length">The File Path for any directory or file within the OCF Abstract
 								Container MUST NOT exceed 65535 bytes.</p>
 						</li>
 						<li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5480,7 +5480,7 @@ Spine:
 
 					<div class="note">
 						<p>
-							<a data-cite="url#concept-url-parser">Parsing</a> may replace some charaters in the File Path by their <a data-cite="url#percent-encode">percent encoded</a> alternative. For example, <code>A/B/C/file&nbsp;name.xhtml</code> becomes <code>A/B/C/file%20name.xhtml</code>. 
+							<a data-cite="url#concept-url-parser">Parsing</a> may replace some characters in the File Path by their <a data-cite="url#percent-encode">percent encoded</a> alternative. For example, <code>A/B/C/file&nbsp;name.xhtml</code> becomes <code>A/B/C/file%20name.xhtml</code>. 
 						</p>
 					</div>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5320,7 +5320,7 @@ Spine:
 				</section>
 
 				<section id="sec-file-names-to-path-names">
-					<h4>Deriving Path Names from Files</h4>
+					<h4>Deriving the Path Names of Files</h4>
 
 					<p>To derive the <a>Path Name</a> of a file or directory <var>file</var> in the <a href="#sec-container-abstract">OCF Abstract
 						Container</a> apply the following steps (expressed using the terminology of [[infra]]):</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1170,6 +1170,7 @@
 					<ul>
 						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
 						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
+						<li>The <a date-cite="url#origin">origin</a> of the <a>container root URL</a> is unique for each EPUB Publication instance.</li>
 					</ul>
 
 					<p class="note">The unicity of the <a href="https://url.spec.whatwg.org/#origin">origin</a> per EPUB Publication

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -328,20 +328,6 @@
 			<p id="confreq-rs-epub-pub" class="support">Reading Systems MUST process the <a
 					href="https://www.w3.org/TR/epub-33/#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
 
-			<section id="sec-pkg-doc-relative-urls">
-				<h4>Parsing Relative URLs</h4>
-
-				<p>To parse <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-						>relative-URL-with-fragment strings</a> [[URL]] in the Package Document, Reading Systems MUST
-					use the URL of the Package Document as the <a href="https://url.spec.whatwg.org/#concept-base-url"
-						>base URL</a> [[URL]].</p>
-
-				<p>When an EPUB Publication is zipped, the base URL of the Package Document is obtained from the URL of
-					the <a>EPUB Container</a> together with a fragment identifier that specifies the path to Package
-					Document (relative to the <a>Root Directory</a>). This specification does not require a specific URL
-					scheme for referencing the path to the Package Document within the EPUB Container.</p>
-			</section>
-
 			<section id="sec-pkg-doc-base-dir">
 				<h4>Base Direction</h4>
 
@@ -866,13 +852,13 @@
 							interactive, scripted user agent according to [[HTML]].</p>
 					</li>
 
-					<li>
+					<!-- <li>
 						<p id="confreq-rs-scripted-origin"> It MUST assign a unique <a
 								href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]], shared by all <a
 								href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level scripts</a> of the
 							EPUB Publication. That <a href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] MUST
 							be <em>unique</em> for each EPUB Publication instance. </p>
-					</li>
+					</li> -->
 
 					<li>
 						<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to modify
@@ -896,20 +882,10 @@
 					</li>
 				</ul>
 
-				<div class="note">
-					<p> This specification does not mandate any particular implementation technique for the creation of
-						a unique <a href="https://url.spec.whatwg.org/#origin">origin</a> in the absence of a reliable
-						Web origin (e.g., HTTP URL scheme + host + port). The necessary heuristics may include the
-						combination of the Publication's <a href="https://www.w3.org/TR/epub-33/#dfn-unique-identifier"
-							>Unique Identifier</a> (although, in practice, these identifiers may in fact not guarantee
-						globally-unique identification, that is why it is recommended to combine multiple techniques),
-						filesystem path, <a href="https://www.w3.org/TR/epub-33/#dfn-zip-container">OCF Zip
-							Container</a> checksum, etc. </p>
-					<p> The unicity of the <a href="https://url.spec.whatwg.org/#origin">origin</a> per EPUB Publication
-						instance means that if two different users acquire a copy of the same EPUB Publication, the
-						origins will be different for the two users on those copies even if the same Reading System is
-						used. </p>
-				</div>
+				<p>Note also that, as defined in <a href="#sec-container-iri"></a>, Reading Systems 
+					must assign a unique <a href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]], shared by all <a
+					href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level scripts</a> of the EPUB Publication. </p>
+
 
 				<p class="ednote">Note that the definition of <code>epubReadingSystem</code> is currently marked as "at
 					risk". If, in the final version of this document, the object becomes non-normative, then each "MUST"
@@ -1170,14 +1146,88 @@
 				<h3>OCF Abstract Container</h3>
 
 				<section id="sec-container-iri">
-					<h4>Relative URLs for Referencing Other Components</h4>
+					<h4>URL of the Root Directory</h4>
 
-					<p>For <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
-							>relative-URL-with-fragment strings</a> [[URL]], Reading Systems MUST determine the <a
-							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] according to the
-						relevant language specifications for the given file formats. For example, CSS defines how
-						relative URL references work in the context of CSS style sheets and property declarations
-						[[CSSSnapshot]].</p>
+					<p>Reading Systems MUST assign a URL [[URL]] to the <a>Root Directory</a> of the <a>OCF Abstract Container</a>. This URL is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a>. The URL itself is implementation specific, but:</p>
+
+					<ul>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing </a> [[URL]] "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a> MUST be the <a>container root URL</a>.</li>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing </a> [[URL]] "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a> MUST be the <a>container root URL</a>.</li>
+						<li>The <a data-cite="url#origin">origin</a> of the <a>container root URL</a> MUST be unique for each EPUB Publication instance.</li>
+						<li>the <a data-cite="url#origin">origins</a> of the <a data-cite="epub-33#dfn-container-url">container URLs</a> of all the files in the <a>OCF Abstract Container</a> MUST be identical.</li>	
+					</ul>
+
+					<p class="note">The unicity of the <a href="https://url.spec.whatwg.org/#origin">origin</a> per EPUB Publication
+						instance means that if two different users acquire a copy of the same EPUB Publication, the
+						origins will be different for the two users on those copies even if the same Reading System is
+						used.</p>
+
+					<div class="note">
+						<p>The required properties of the container root URL are such that it behaves similarly to a URL defined as follows:</p>
+
+						<table class="zebra">
+							<thead>
+								<tr>
+									<td style="font-weight: bold; text-align: center;">
+										URL component
+									</td>
+									<td style="font-weight: bold; text-align: center;">
+										Values
+									</td>
+								</tr>	
+							</thead>
+							<tbody>
+								<tr>
+									<td>scheme</td>
+									<td><code>http</code> or <code>https</code></td>
+								</tr>
+								<tr>
+									<td>host</td>
+									<td><code>localhost</code></td>
+								</tr>
+								<tr>
+									<td>port</td>
+									<td>a dynamic port uniquely assigned to the EPUB instance</td>
+								</tr>	
+							</tbody>
+						</table>
+
+						<p>for example:</p>
+
+						<table class="zebra">
+							<thead>
+								<tr>
+									<td style="font-weight: bold; text-align: center;">Container File</td>
+									<td style="font-weight: bold; text-align: center;">File Path</td>
+									<td style="font-weight: bold; text-align: center;">URL</td>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										Root Directory
+									</td>
+									<td>
+										<var>empty string</var>
+									</td>
+									<td>
+										<code>https://localhost:49152/</code>
+									</td>
+								</tr>
+								<tr>
+									<td>
+										Package Document
+									</td>
+									<td>
+										<code>OPS/package.opf</code>
+									</td>
+									<td>
+										<code>https://localhost:49152/OPS/package.opf</code>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
 
 					<div class="note">
 						<p>Some language specifications reference <a href="https://www.ietf.org/standards/rfcs/"
@@ -1185,9 +1235,35 @@
 							for content in that particular language.</p>
 					</div>
 
-					<p>Unlike most language specifications, Reading Systems MUST use the <a>Root Directory</a> of the
-						OCF Abstract Container as the <a href="https://url.spec.whatwg.org/#concept-base-url">base
-							URL</a> [[URL]] for all files within the <code>META-INF</code> directory.</p>
+					<p class="note">Unlike most language specifications, Reading Systems MUST use the 
+						<a>container root URL</a> as the <a href="https://url.spec.whatwg.org/#concept-base-url">base
+							URL</a> [[URL]] for all files within the <code>META-INF</code> directory.
+							See also the section on <a href="https://www.w3.org/TR/epub-33/#sec-parsing-urls-metainf">Parsing URLs in the <code>META-INF</code> Directory</a> in [[!EPUB-33]].
+					</p>
+
+					<p class="ednote">
+						We may have to say a few words on what exactly an "EPUB Publication instance" mean.
+					</p>
+
+					<div class="ednote">
+						<p>The previous version contained this note:</p>
+
+						<p class="note">
+							This specification does not mandate any particular implementation technique for the creation of
+							a unique <a href="https://url.spec.whatwg.org/#origin">origin</a> in the absence of a reliable
+							Web origin (e.g., HTTP URL scheme + host + port). The necessary heuristics may include the
+							combination of the Publication's <a href="https://www.w3.org/TR/epub-33/#dfn-unique-identifier"
+								>Unique Identifier</a> (although, in practice, these identifiers may in fact not guarantee
+							globally-unique identification, that is why it is recommended to combine multiple techniques),
+							filesystem path, <a href="https://www.w3.org/TR/epub-33/#dfn-zip-container">OCF Zip
+								Container</a> checksum, etc. 
+						</p>
+	
+						<p>This note may not be relevant any more...</p>
+					</div>
+
+
+
 				</section>
 
 				<section id="sec-container-filenames">
@@ -2227,7 +2303,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>25-Oct-2021: Clarify that reading systems must render non-linear resources when they are hyperlinked
+				<li>10-Nov-2021: Proper definition of the Container URL and handling of relative URLs. See <a
+					href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and 
+					<a href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
+			    <li>25-Oct-2021: Clarify that reading systems must render non-linear resources when they are hyperlinked
 					to by a user. See <a href="https://github.com/w3c/epub-specs/issues/1864">issue 1864</a>.</li>
 				<li>27-Aug-2021: Added accessibility bullet to cover the need for zooming, particularly for fixed-layout
 					documents. See <a href="https://github.com/w3c/epub-specs/issues/1776">issue 1776</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1170,7 +1170,7 @@
 					<ul>
 						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
 						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
-						<li>The <a date-cite="url#concept-origin">origin</a> of the <a>container root URL</a> is unique for each EPUB Publication instance.</li>
+						<li>The <a href="https://url.spec.whatwg.org/#origin">origin</a> of the <a>container root URL</a> is unique for each EPUB Publication instance.</li>
 					</ul>
 
 					<p class="note">The unicity of the <a href="https://url.spec.whatwg.org/#origin">origin</a> per EPUB Publication

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1151,10 +1151,10 @@
 					<p>Reading Systems MUST assign a URL [[URL]] to the <a>Root Directory</a> of the <a>OCF Abstract Container</a>. This URL is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a>. The URL itself is implementation specific, but:</p>
 
 					<ul>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing </a> [[URL]] "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a> MUST be the <a>container root URL</a>.</li>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing </a> [[URL]] "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url">base</a> MUST be the <a>container root URL</a>.</li>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> MUST be the <a>container root URL</a>.</li>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> MUST be the <a>container root URL</a>.</li>
 						<li>The <a data-cite="url#origin">origin</a> of the <a>container root URL</a> MUST be unique for each EPUB Publication instance.</li>
-						<li>the <a data-cite="url#origin">origins</a> of the <a data-cite="epub-33#dfn-container-url">container URLs</a> of all the files in the <a>OCF Abstract Container</a> MUST be identical.</li>	
+						<li>The <a data-cite="url#origin">origins</a> of the <a data-cite="epub-33#dfn-content-url">content URLs</a> of all the files in the <a>OCF Abstract Container</a> MUST be identical.</li>	
 					</ul>
 
 					<p class="note">The unicity of the <a href="https://url.spec.whatwg.org/#origin">origin</a> per EPUB Publication
@@ -2303,7 +2303,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>10-Nov-2021: Proper definition of the Container URL and handling of relative URLs. See <a
+				<li>10-Nov-2021: Proper definition of the Content URL and handling of relative URLs. See <a
 					href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and 
 					<a href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
 			    <li>25-Oct-2021: Clarify that reading systems must render non-linear resources when they are hyperlinked

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1213,8 +1213,8 @@
 						<table class="zebra">
 							<thead>
 								<tr>
-									<td style="font-weight: bold; text-align: center;">Container File</td>
-									<td style="font-weight: bold; text-align: center;">File Path</td>
+									<td style="font-weight: bold; text-align: center;">Container File</td>
+									<td style="font-weight: bold; text-align: center;">File Path</td>
 									<td style="font-weight: bold; text-align: center;">URL</td>
 								</tr>
 							</thead>
@@ -1227,7 +1227,7 @@
 										<var>empty string</var>
 									</td>
 									<td>
-										<code>https://localhost:49152/</code>
+										<code>http://localhost:49152/</code>
 									</td>
 								</tr>
 								<tr>
@@ -1238,7 +1238,18 @@
 										<code>OPS/package.opf</code>
 									</td>
 									<td>
-										<code>https://localhost:49152/OPS/package.opf</code>
+										<code>http://localhost:49152/OPS/package.opf</code>
+									</td>
+								</tr>
+								<tr>
+									<td>
+										Content Document
+									</td>
+									<td>
+										<code>HTML/file name.xhtml</code>
+									</td>
+									<td>
+										<code>http://localhost:49152/HTML/file%20name.xhtml</code>
 									</td>
 								</tr>
 							</tbody>
@@ -1286,13 +1297,13 @@
 					<h4>File Names</h4>
 
 					<p>Although EPUB Creators are required to follow various <a
-							href="https://www.w3.org/TR/epub-33/#sec-container-filenames">File and Path Name
+							href="https://www.w3.org/TR/epub-33/#sec-container-filenames">File Name and File Path
 							restrictions</a> [[!EPUB-33]] for maximum interoperability, Reading Systems SHOULD attempt
-						to process File and Path Names that are not valid to these requirements. Invalid File and Path
-						Names may only be problematic on some operating systems.</p>
+						to process File Names and Paths that are not valid to these requirements. Invalid File Names and
+						Paths may only be problematic on some operating systems.</p>
 
-					<p>This specification does not specify how a Reading System that is unable to represent OCF File and
-						Path Names would compensate for this incompatibility.</p>
+					<p>This specification does not specify how a Reading System that is unable to represent OCF File Names and
+						Paths would compensate for this incompatibility.</p>
 
 					<p>If a Reading System cannot preserve the names of files during an unzipping process, it will have
 						to compensate for any name translation that took place in the content (i.e., in any URIs that

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -867,13 +867,13 @@
 							interactive, scripted user agent according to [[HTML]].</p>
 					</li>
 
-					<!-- <li>
+					<li>
 						<p id="confreq-rs-scripted-origin"> It MUST assign a unique <a
 								href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]], shared by all <a
 								href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level scripts</a> of the
 							EPUB Publication. That <a href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] MUST
 							be <em>unique</em> for each EPUB Publication instance. </p>
-					</li> -->
+					</li>
 
 					<li>
 						<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to modify
@@ -896,11 +896,6 @@
 							contexts.</p>
 					</li>
 				</ul>
-
-				<p>Note also that, as defined in <a href="#sec-container-iri"></a>, Reading Systems 
-					must assign a unique <a href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]], shared by all <a
-					href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level scripts</a> of the EPUB Publication. </p>
-
 
 				<p class="ednote">Note that the definition of <code>epubReadingSystem</code> is currently marked as "at
 					risk". If, in the final version of this document, the object becomes non-normative, then each "MUST"
@@ -1262,7 +1257,7 @@
 							for content in that particular language.</p>
 					</div>
 
-					<p class="note">Unlike most language specifications, Reading Systems MUST use the 
+					<p class="note">Unlike most language specifications, Reading Systems must use the 
 						<a>container root URL</a> as the <a href="https://url.spec.whatwg.org/#concept-base-url">base
 							URL</a> [[URL]] for all files within the <code>META-INF</code> directory.
 							See also the section on <a href="https://www.w3.org/TR/epub-33/#sec-parsing-urls-metainf">Parsing URLs in the <code>META-INF</code> Directory</a> in [[!EPUB-33]].

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1165,13 +1165,11 @@
 				<section id="sec-container-iri">
 					<h4>URL of the Root Directory</h4>
 
-					<p>Reading Systems MUST assign a URL [[URL]] to the <a>Root Directory</a> of the <a>OCF Abstract Container</a>. This URL is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a>. The URL itself is implementation specific, but:</p>
+					<p>Reading Systems MUST assign a URL [[URL]] to the <a>Root Directory</a> of the <a>OCF Abstract Container</a>. This URL is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a>. It is implementation specific, but the implementation MUST have the following properties:</p>
 
 					<ul>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> MUST be the <a>container root URL</a>.</li>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> MUST be the <a>container root URL</a>.</li>
-						<li>The <a data-cite="url#origin">origin</a> of the <a>container root URL</a> MUST be unique for each EPUB Publication instance.</li>
-						<li>The <a data-cite="url#origin">origins</a> of the <a data-cite="epub-33#dfn-content-url">content URLs</a> of all the files in the <a>OCF Abstract Container</a> MUST be identical.</li>	
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
 					</ul>
 
 					<p class="note">The unicity of the <a href="https://url.spec.whatwg.org/#origin">origin</a> per EPUB Publication

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2039,7 +2039,7 @@
 
 				<p>To limit the possible damage of untrusted scripts, this specification recommends that Reading Systems
 					establish a unique <a href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] allocated to
-					each <a>EPUB Publication</a> (see <a href="#sec-scripted-content"></a>). Adopting this approach
+					each <a>EPUB Publication</a> (see <a href="#sec-container-iri"></a>). Adopting this approach
 					isolates publications from each other, thereby limiting access to cookies, DOM storage, etc.
 					Examples of Web APIs that are tied to the concept of "origin" include Web Storage [[WEBSTORAGE]] and
 					IndexedDB [[INDEXEDDB]], which EPUB Content Documents can interact with via scripting. Reading

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1170,7 +1170,7 @@
 					<ul>
 						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
 						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
-						<li>The <a date-cite="url#origin">origin</a> of the <a>container root URL</a> is unique for each EPUB Publication instance.</li>
+						<li>The <a date-cite="url#concept-origin">origin</a> of the <a>container root URL</a> is unique for each EPUB Publication instance.</li>
 					</ul>
 
 					<p class="note">The unicity of the <a href="https://url.spec.whatwg.org/#origin">origin</a> per EPUB Publication


### PR DESCRIPTION
This is a PR version of @rdeltour's https://github.com/w3c/epub-specs/issues/1888#issuecomment-961502739 proposal.

Notes:

- I kept the term "Path Name" (for now). There is a symmetry with the usage of "File Name", and the term is referred to all over the place. It would require an extensive search-replace to get them all settled. We may do that later if we want to.
- I modified some statements to make them more spec-text, e.g., by using MUST if appropriate
- I agree with @rdeltour that the order of the sections 6.1.3 and 6.1.4. should be switched. I have not done that, though, because it would make the diff file much messier. We can do that once all the dust is settled...
- I have modified the scripting section on the RS spec (§4.4) by adding a reference to the new section on the root directory URL and removing the unique origin requirement from the bullet list. There were also two notes that appeared in that section; I moved one of the two to the new section and added the other as an editorial note; the latter does not sound to be relevant anymore, but better check.
- @mattgarrish, I have added an explicit reference to the two new terms in the RS text, because the magic script did not work well (I guess it would work once everything is published). I have done that so that ECHIDNA would not complain, we can improve that later.

Fix #1888
Fix #1374

See:

* For EPUB 3.3:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/spooky-base-urls/epub33/core/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/core/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/spooky-base-urls/epub33/core/index.html)
* For EPUB 3.3 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/spooky-base-urls/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/spooky-base-urls/epub33/rs/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1898.html" title="Last updated on Nov 19, 2021, 3:20 PM UTC (8e5f27e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1898/1182db6...8e5f27e.html" title="Last updated on Nov 19, 2021, 3:20 PM UTC (8e5f27e)">Diff</a>