### PR TITLE
Allow characters in the emoji tag sequence in file names

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5445,7 +5445,7 @@ Spine:
 								</li>
 								<li>
 									<p>The Deprecated Characters in the Tags and Variation Selectors Supplement
-											(<code>U+E0001 and U+E007F</code>)</p>
+											(<code>U+E0001</code> and <code>U+E007F</code>)</p>
 								</li>
 								<li>
 									<p>Supplementary Private Use Area-A (<code>U+F0000 … U+FFFFF</code>)</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1214,9 +1214,9 @@
 									<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
 										Algorithm [[BIDI]].</li>
 								</ul>
-								<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will assume
-									the value <code>auto</code> when EPUB Creators omit the attribute or use an invalid
-									value.</p>
+								<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will
+									assume the value <code>auto</code> when EPUB Creators omit the attribute or use an
+									invalid value.</p>
 								<div class="note">
 									<p>The base direction specified in the <code>dir</code> attribute does not affect
 										the ordering of characters within directional runs, only the relative ordering
@@ -3223,9 +3223,9 @@ Spine:
 								the value "<code>yes</code>" for <code>itemref</code> elements without a
 									<code>linear</code> attribute.</p>
 
-							<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide a
-								means of accessing all non-linear content (e.g., hyperlinks in the content or from the
-								<a href="#sec-nav">EPUB Navigation Document</a>).</p>
+							<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide
+								a means of accessing all non-linear content (e.g., hyperlinks in the content or from the
+									<a href="#sec-nav">EPUB Navigation Document</a>).</p>
 
 							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
 									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>
@@ -5444,7 +5444,10 @@ Spine:
 									<p>Specials (<code>U+FFF0 … U+FFFF</code>)</p>
 								</li>
 								<li>
-									<p>Tags and Variation Selectors Supplement (<code>U+E0000 … U+E0FFF</code>)</p>
+									<p>Tags and Variation Selectors Supplement (<code>U+E0000 … U+E0FFF</code>),
+										excluding those allowed in the <a
+											href="https://unicode.org/reports/tr51/#def_emoji_tag_sequence">Emoji Tag
+											Sequence</a> [[UTS51]] (<code>U+E0020 … U+E007F</code>)</p>
 								</li>
 								<li>
 									<p>Supplementary Private Use Area-A (<code>U+F0000 … U+FFFFF</code>)</p>
@@ -9439,9 +9442,11 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>10-Nov-2021: Allow characters in the emoji tag sequence in file names. See <a
+						href="https://github.com/w3c/epub-specs/issues/1885">issue 1885</a></li>
 				<li>29-Oct-2021: Recommended that EPUB Creators not use path-absolute-URL strings for referencing
 					resources due to the lack of a consistent root. See <a
-						href="https://github.com/w3c/epub-specs/issues/1681">issue 1681</a></li>
+						href="https://github.com/w3c/epub-specs/issues/1681">issue 1681</a>.</li>
 				<li>18-Oct-2021: Clarified the contexts from which remote resources may be referenced. See <a
 						href="https://github.com/w3c/epub-specs/issues/1857">issue 1857</a>.</li>
 				<li>12-Oct-2021: The Structure Semantics Vocabulary has been moved into a separate Working Group Note.

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2585,9 +2585,9 @@
 </pre>
 							</aside>
 
-							<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB Creators MAY provide one or more
-								<a href="#record">linked metadata records</a> to enhance the information available to Reading
-								Systems, but Reading Systems may ignore these records.</p>
+							<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB Creators MAY provide one or
+								more <a href="#record">linked metadata records</a> to enhance the information available
+								to Reading Systems, but Reading Systems may ignore these records.</p>
 
 							<p>When a Reading System <a href="https://www.w3.org/TR/epub-rs-33/#sec-linked-records"
 									>processes linked records</a> [[EPUB-RS-33]], the document order of
@@ -5444,10 +5444,8 @@ Spine:
 									<p>Specials (<code>U+FFF0 … U+FFFF</code>)</p>
 								</li>
 								<li>
-									<p>Tags and Variation Selectors Supplement (<code>U+E0000 … U+E0FFF</code>),
-										excluding those allowed in the <a
-											href="https://unicode.org/reports/tr51/#def_emoji_tag_sequence">Emoji Tag
-											Sequence</a> [[UTS51]] (<code>U+E0020 … U+E007F</code>)</p>
+									<p>The Deprecated Characters in the Tags and Variation Selectors Supplement
+											(<code>U+E0001 and U+E007F</code>)</p>
 								</li>
 								<li>
 									<p>Supplementary Private Use Area-A (<code>U+F0000 … U+FFFFF</code>)</p>
@@ -9450,6 +9448,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>18-Nov-2021: Change to only disallow deprecated characters in the Tags and Variation Selectors
+					Supplement. See <a href="https://github.com/w3c/epub-specs/issues/1885">issue 1885</a></li>
 				<li>12-Nov-2021: Change the recommendation to use SHA-1 to encrypt the obfuscation key to a requirement.
 					See <a href="https://github.com/w3c/epub-specs/issues/1873">issue 1873</a>.</li>
 				<li>12-Nov-2021: Restrict the obfuscation algorithm to fonts and add caution to use better protection
@@ -9457,8 +9457,6 @@ EPUB/images/cover.png</pre>
 						1873</a>.</li>
 				<li>12-Nov-2021: Removed the statement about rights.xml being reserved for future standardization of DRM
 					information. See <a href="https://github.com/w3c/epub-specs/issues/181">issue 1874</a>.</li>
-				<li>10-Nov-2021: Allow characters in the emoji tag sequence in file names. See <a
-						href="https://github.com/w3c/epub-specs/issues/1885">issue 1885</a></li>
 				<li>29-Oct-2021: Recommended that EPUB Creators not use path-absolute-URL strings for referencing
 					resources due to the lack of a consistent root. See <a
 						href="https://github.com/w3c/epub-specs/issues/1681">issue 1681</a>.</li>


### PR DESCRIPTION
Fixes #1885


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1899.html" title="Last updated on Nov 18, 2021, 1:06 PM UTC (97f9b1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1899/1182db6...97f9b1b.html" title="Last updated on Nov 18, 2021, 1:06 PM UTC (97f9b1b)">Diff</a>