### PR TITLE
Add language techniques for package document

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1305,7 +1305,9 @@
 
 					<p>Consequently, it is necessary to provide the language of all text content in the Package Document
 						to conform with these WCAG success criteria. The easiest way to meet this requirement is to add
-						an <code>xml:lang</code> attribute on the root <code>package</code> element.</p>
+						an <code>xml:lang</code> attribute on the root <a
+							href="https://www.w3.org/TR/epub/#sec-package-elem"><code>package</code> element</a>
+						[[EPUB-3]].</p>
 
 					<aside class="example" title="All text declared to be in Japanese by default">
 						<pre><code>&lt;package &#8230; xml:lang="jp">
@@ -1340,8 +1342,9 @@
 					<h4>Language of the EPUB Publication</h4>
 
 					<p>In addition to being able to express the language of text content, the Package Document also
-						allows EPUB Creators to identify the languages of the EPUB Publication in
-							<code>dc:language</code> elements.</p>
+						allows EPUB Creators to identify the languages of the EPUB Publication in <a
+							href="https://www.w3.org/TR/epub/#sec-opf-dclanguage"><code>dc:language</code> elements</a>
+						[[EPUB-3]].</p>
 
 					<aside class="example" title="Setting the language of an EPUB Publication to Italian">
 						<pre><code>&lt;package &#8230;>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1289,6 +1289,88 @@
 				</section>
 			</section>
 
+			<section id="sec-wcag-language">
+				<h3>Language</h3>
+
+				<section id="lang-001">
+					<h4>Language of Package Document</h4>
+
+					<p>[[WCAG2]] Success Criterions <a href="https://www.w3.org/TR/WCAG2/#language-of-page">3.1.1</a>
+						and <a href="https://www.w3.org/TR/WCAG2/#language-of-parts">3.1.2</a> deal with the language of
+						a page and changes of language with in, respectively.</p>
+
+					<p>For EPUB Publications, the Package Document is also an important source of metadata information
+						about the publication. For example, Reading Systems expose details of the publications to users
+						in their bookshelves using this information.</p>
+
+					<p>Consequently, it is necessary to provide the language of all text content in the Package Document
+						to conform with these WCAG success criteria. The easiest way to meet this requirement is to add
+						an <code>xml:lang</code> attribute on the root <code>package</code> element.</p>
+
+					<aside class="example" title="All text declared to be in Japanese by default">
+						<pre><code>&lt;package &#8230; xml:lang="jp">
+   &#8230;
+&lt;/package></code></pre>
+					</aside>
+
+					<p>If individual metadata fields within the Package Document are expressed in a different language,
+						it is similarly required that the language change be identified by an <code>xml:lang</code>
+						attribute on the element for the field.</p>
+
+					<aside class="example" title="Overriding the default language for a title">
+						<pre><code>&lt;package &#8230; xml:lang="en">
+   &lt;metadata
+       xmlns:dc="http://purl.org/dc/elements/1.1/">
+      &lt;dc:title xml:lang="fr">Mon premier guide de cuisson, un Mémoire&lt;/dc:title>
+      &#8230;
+   &lt;/metadata>
+   &#8230;
+&lt;/package></code></pre>
+					</aside>
+
+					<p>Providing this information enables Reading Systems to correctly render the text content in the
+						proper language for users.</p>
+
+					<p class="note">The languages specified in the Package Document have no effect on individual EPUB
+						Content Documents (i.e., the language of each document must be specified using the language
+						expression mechanisms it provides).</p>
+				</section>
+
+				<section id="lang-002">
+					<h4>Language of the EPUB Publication</h4>
+
+					<p>In addition to being able to express the language of text content, the Package Document also
+						allows EPUB Creators to identify the languages of the EPUB Publication in
+							<code>dc:language</code> elements.</p>
+
+					<aside class="example" title="Setting the language of an EPUB Publication to Italian">
+						<pre><code>&lt;package &#8230;>
+   &lt;metadata
+       xmlns:dc="http://purl.org/dc/elements/1.1/">
+      &#8230;
+      &lt;dc:language>it&lt;/dc:language>
+      &#8230;
+   &lt;/metadata>
+   &#8230;
+&lt;/package></code></pre>
+					</aside>
+
+					<p>Although it is not strictly required to set this information to meet [[WCAG2]] <a
+							href="https://www.w3.org/TR/WCAG2/#language-of-page">Success Criterion 3.1.1</a>, as it is
+						only informative, it should be considered a best practice to always set this field with the
+						proper language information. (Note that EPUB3 requires the language always be specified, so
+						omitting will fail validation requirements.)</p>
+
+					<p>Although Reading Systems do not use this language information to render the text content of the
+						EPUB Publication, they do use it to optimize the reading experience for users (e.g., to preload
+						text-to-speech engines so users do not have a delay when synthesizing the text).</p>
+
+					<p class="note">The languages specified in the Package Document have no effect on individual EPUB
+						Content Documents (i.e., the language of each document must be specified using the language
+						expression mechanisms it provides).</p>
+				</section>
+			</section>
+
 			<section id="sec-wcag-text">
 				<h3>Text</h3>
 
@@ -1750,6 +1832,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>10-Nov-2021: Added techniques for setting language in the Package Document. See <a
+						href="https://github.com/w3c/epub-specs/issues/1842">issue 1842</a>.</li>
 				<li>25-Oct-2021: Removed the generic technique labels for each section. See <a
 						href="https://github.com/w3c/epub-specs/issues/1866">issue 1866</a>.</li>
 				<li>29-Sep-2021: Added <a href="#titles-003">TITLES-003</a> to explain that headings only have to be


### PR DESCRIPTION
I've added two techniques to cover language in the package document:

- the first covers the requirement to set xml:lang globally and for language overrides
- the second mentions setting dc:language as best practice. Since it doesn't directly affect text rendering, I can't place this as a WCAG requirement (epub validation will still ensure it is set in most cases).

Fixes #1842

- Accessibility Techniques [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1842/epub33/a11y-tech/index.html)
- Accessibility Techniques [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1842/epub33/a11y-tech/index.html)
