### PR TITLE
Add note about lack of standardized sound hazards

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -396,21 +396,23 @@
 						<p>motion simulation — if a resource simulates motion, it can cause a user to become nauseated
 							(e.g., a video game drawn on the [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element"
-									><code>canvas</code> element</a>).</p>
+									><code>canvas</code> element</a> or parallax scrolling with CSS).</p>
 					</li>
 					<li>
-						<p>sound — certain sound patterns, such as ringing and buzzing, can cause seizures.</p>
+						<p>sound — certain sound patterns, such as ringing and buzzing, can cause seizures, while loud
+							or sudden changes in volume can also negatively affect users.</p>
 					</li>
 				</ul>
 
-				<div class="issue" data-number="1302">
-					<p>How to determine what constitutes a sound hazard, and whether more specific categories are
-						necessary to address different sound hazards, is currently under discussion. Guidance on how to
-						apply this value will be updated accordingly in a future draft.</p>
-				</div>
-
 				<p>EPUB Creators have to report whether their EPUB Publications contain resources that present any of
 					these hazards to users, as they can have real physical effects.</p>
+
+				<div class="note">
+					<p>What precisely constitutes a sound hazard, and how to test for these hazards, is not standardized
+						as of publication of this document. EPUB Creators will have to use their discretion on when to
+						specify a sound hazard until additional guidance is developed. This technique will be updated
+						whenever there is more clarity on this issue.</p>
+				</div>
 
 				<p>Hazards are identified in the [[schema-org]] <a href="https://schema.org/accessibilityHazard"
 							><code>accessibilityHazard</code> property</a>. Repeat this property for each hazard.</p>


### PR DESCRIPTION
Prior to transferring issue #1302, I've changed the link to the github issue to a note that there isn't a precise way of determining when content presents a sound hazard, so authors will have to use their discretion on whether to set.

On a minor note, I added parallax scrolling to the list of motion simulation causes and sudden volume changes to sound.

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1302/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1302/epub33/a11y/index.html)
