### PR TITLE
Add/update references to new CG vocabulary and crosswalk documents

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -51,6 +51,15 @@
 					branch: "main"
 				},
 				localBiblio: {
+					"A11Y-DISCOV-VOCAB": {
+						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
+						"href": "https://www.w3.org/2021/a11y-discov-vocab/latest/",
+						"editors": [
+							"Charles LaPierre",
+							"Madeleine Rothberg",
+							"Matt Garrish"
+						]
+					},
 					"EPUB-3": {
 						"title": "EPUB 3",
 						"href": "https://www.w3.org/TR/epub/",
@@ -232,8 +241,9 @@
 					access mode. See the following section on <a href="#meta-002">sufficient access modes</a> for how to
 					indicate that the available adaptations allow the content to be consumed in another mode.</p>
 
-				<p>Refer to the <a href="https://schema.org/accessMode"><code>accessMode</code></a> definition in
-					[[schema-org]] for more information about this property and its values.</p>
+				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessMode">The
+							<code>accessMode</code> Property</a> [[A11Y-DISCOV-VOCAB]] for more information about this
+					property and its values.</p>
 			</section>
 
 			<section id="meta-002">
@@ -329,9 +339,9 @@
 					visual or auditory losses as inconsequential if a transcript provides all the necessary information
 					to understand the concepts being conveyed.</p>
 
-				<p>Refer to the <a href="https://schema.org/accessModeSufficient"
-					><code>accessModeSufficient</code></a> definition in [[schema-org]] for more information about this
-					property and its values.</p>
+				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessModeSufficient">The
+							<code>accessModeSufficient</code> Property</a> [[A11Y-DISCOV-VOCAB]] for more information
+					about this property and its values.</p>
 
 				<div class="note">
 					<p>The <code>accessModeSufficient</code> property, as defined in [[schema-org]], allows more
@@ -375,9 +385,9 @@
 					aware what features are built into a format. Failing to include entries will reduce the
 					discoverability of the publication when users search for specific features.</p>
 
-				<p>Refer to the <a href="https://schema.org/accessibilityFeature"
-					><code>accessibilityFeature</code></a> definition in [[schema-org]] for more information about this
-					property and its values.</p>
+				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature">The
+							<code>accessibilityFeature</code> Property</a> [[A11Y-DISCOV-VOCAB]] for more information
+					about this property and its values.</p>
 			</section>
 
 			<section id="meta-004">
@@ -446,9 +456,9 @@
 
 				<p>If hazards cannot be definitively determined, report the value "<code>unknown</code>".</p>
 
-				<p>Refer to the <a href="https://schema.org/accessibilityHazard"
-					><code>accessibilityHazard</code></a> definition in [[schema-org]] for more information about this
-					property and its values.</p>
+				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityHazard">The
+							<code>accessibilityHazard</code> Property</a> [[A11Y-DISCOV-VOCAB]] for more information
+					about this property and its values.</p>
 			</section>
 
 			<section id="meta-005">
@@ -489,9 +499,9 @@
 				<p>Do not repeat this property unless it contains the summary in another language. In the case of
 					multiple summaries, use the <code>xml:lang</code> attribute to differentiate the language.</p>
 
-				<p>Refer to the <a href="https://schema.org/accessibilitySummary"
-					><code>accessibilitySummary</code></a> definition in [[schema-org]] for more information about this
-					property.</p>
+				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilitySummary">The
+							<code>accessibilitySummary</code> Property</a> [[A11Y-DISCOV-VOCAB]] for more information
+					about this property.</p>
 			</section>
 
 			<section id="meta-006">
@@ -1725,8 +1735,8 @@
 					<ul>
 						<li>
 							<p>
-								<a href="http://www.a11ymetadata.org/the-specification/metadata-crosswalk/"
-									>Accessibility Metadata Crosswalk</a>
+								<a href="https://w3c.github.io/a11y-discov-vocab/crosswalk/">Schema.org Accessibility
+									Properties Crosswalk</a>
 							</p>
 						</li>
 						<li>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -52,6 +52,15 @@
 					branch: "main"
 				},
 				localBiblio: {
+					"A11Y-DISCOV-VOCAB": {
+						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
+						"href": "https://www.w3.org/2021/a11y-discov-vocab/latest/",
+						"editors": [
+							"Charles LaPierre",
+							"Madeleine Rothberg",
+							"Matt Garrish"
+						]
+					},
 					"DAISYAudio": {
 						"title": "Navigable audio-only EPUB 3 Guidelines",
 						"href": "http://www.daisy.org/guidelines/epub/navigable-audio-only-epub3-guidelines"
@@ -343,6 +352,12 @@
 
 				<p>EPUB Creators MAY include additional [[schema-org]] accessibility metadata not specified in this
 					section.</p>
+
+				<div class="note">
+					<p>For the complete list of approved terms to use with these properties, refer to the <a
+							href="https://www.w3.org/2021/a11y-discov-vocab/latest/">Schema.org Accessibility Properties
+							for Discoverability Vocabulary</a> [[A11Y-DISCOV-VOCAB]].</p>
+				</div>
 
 				<div class="note">
 					<p>See <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-discovery">Discovery Metadata


### PR DESCRIPTION
As requested in #1799, I've added a note to the end of the discoverability section in the accessibility spec with a link to the vocabulary.

I also updated all the references in the techniques document that went back to schema.org to find out more about the values to go to the vocabulary and updated the link to the crosswalk in the distribution technique.

All we should need now is a final green light on using the properties.

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1799/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1799/epub33/a11y/index.html)
- Accessibility Techniques [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1799/epub33/a11y-tech/index.html)
- Accessibility Techniques [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-1799/epub33/a11y-tech/index.html)
