### PR TITLE
Remove the paragraph about reserving rights.xml

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1214,9 +1214,9 @@
 									<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
 										Algorithm [[BIDI]].</li>
 								</ul>
-								<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will assume
-									the value <code>auto</code> when EPUB Creators omit the attribute or use an invalid
-									value.</p>
+								<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will
+									assume the value <code>auto</code> when EPUB Creators omit the attribute or use an
+									invalid value.</p>
 								<div class="note">
 									<p>The base direction specified in the <code>dir</code> attribute does not affect
 										the ordering of characters within directional runs, only the relative ordering
@@ -3179,9 +3179,10 @@ Spine:
 								</dd>
 							</dl>
 
-							<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an <a href="#elemdef-package-item"><code>item</code></a> in the <a>manifest</a> via the IDREF [[XML]]
-								in its <code>idref</code> attribute, and item IDs MUST NOT be referenced more than once.
-							</p>
+							<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an <a
+									href="#elemdef-package-item"><code>item</code></a> in the <a>manifest</a> via the
+								IDREF [[XML]] in its <code>idref</code> attribute, and item IDs MUST NOT be referenced
+								more than once. </p>
 
 							<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a)
 								an <a>EPUB Content Document</a> or b) another type of <a>Publication Resource</a> which,
@@ -3222,9 +3223,9 @@ Spine:
 								the value "<code>yes</code>" for <code>itemref</code> elements without a
 									<code>linear</code> attribute.</p>
 
-							<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide a
-								means of accessing all non-linear content (e.g., hyperlinks in the content or from the
-								<a href="#sec-nav">EPUB Navigation Document</a>).</p>
+							<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide
+								a means of accessing all non-linear content (e.g., hyperlinks in the content or from the
+									<a href="#sec-nav">EPUB Navigation Document</a>).</p>
 
 							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
 									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>
@@ -6037,11 +6038,6 @@ Spine:
 									<code>META-INF</code> directory for digital rights management (DRM) information for
 								trusted exchange of EPUB Publications among rights holders, intermediaries, and
 								users.</p>
-
-							<p>This version of the specification does not require a specific format for DRM information,
-								but a future version might. EPUB Creators SHOULD only use namespace-qualified elements
-								[[XML-NAMES]] in the <code>rights.xml</code> file to avoid collision with a future
-								format.</p>
 
 							<p>When EPUB Creators do not include a <code>rights.xml</code> file, no part of the
 								container is rights governed at the container level. Rights expressions might exist
@@ -9438,9 +9434,11 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>12-Nov-2021: Removed the statement about rights.xml being reserved for future standardization of DRM
+					information. See <a href="https://github.com/w3c/epub-specs/issues/181">issue 1874</a>.</li>
 				<li>29-Oct-2021: Recommended that EPUB Creators not use path-absolute-URL strings for referencing
 					resources due to the lack of a consistent root. See <a
-						href="https://github.com/w3c/epub-specs/issues/1681">issue 1681</a></li>
+						href="https://github.com/w3c/epub-specs/issues/1681">issue 1681</a>.</li>
 				<li>18-Oct-2021: Clarified the contexts from which remote resources may be referenced. See <a
 						href="https://github.com/w3c/epub-specs/issues/1857">issue 1857</a>.</li>
 				<li>12-Oct-2021: The Structure Semantics Vocabulary has been moved into a separate Working Group Note.


### PR DESCRIPTION
As resolved on the 2021-11-11 call, removes the old statement that rights.xml is reserved for possible future standardization of DRM information as we don't plan to ever do this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1905.html" title="Last updated on Nov 12, 2021, 2:05 PM UTC (a739547)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1905/7d1967e...a739547.html" title="Last updated on Nov 12, 2021, 2:05 PM UTC (a739547)">Diff</a>