### PR TITLE
Restrict obfuscation to fonts and caution against use

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5839,8 +5839,8 @@ Spine:
 									of embedded fonts referenced by an <a>EPUB Publication</a> to make them more
 									difficult to extract for unrestricted use. Although obfuscation is not encryption,
 									Reading Systems use the <code>encryption.xml</code> file in conjunction with the <a
-										href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify
-									resources to de-obfuscated.</p>
+										href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify fonts to
+									de-obfuscated.</p>
 
 								<p id="encryption-restrictions">EPUB Creators MUST NOT encrypt or obfuscate the
 									following files:</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6354,6 +6354,9 @@ Spine:
 						will meet the requirements of most vendors who require some assurance that their fonts cannot
 						simply be extracted by unzipping the Container.</p>
 
+					<p>Also note that the algorithm is restricted to obfuscating fonts. It is not intended as a general
+						purpose mechanism for obfuscating any resource in the EPUB Container.</p>
+
 					<p>In the case of fonts, this mechanism simply provides a stumbling block for those who are unaware
 						of the license details. It will not prevent a determined user from gaining full access to the
 						font. Given an OCF Container, it is possible to apply the algorithms defined to extract the raw
@@ -6443,10 +6446,9 @@ store destination as source in ocf
 						use of the algorithm described in this specification.</p>
 
 					<p>EPUB Creators MUST list the path to the obfuscated font in the <code>CipherReference</code> child
-						of the <code>CipherData</code> element. Note that EPUB Creators MAY only use the obfuscation
-						algorithm with <a href="#cmt-grp-font">Font Core Media Types</a>. Consequently, the
-							<code>URI</code> attribute of the <code>CipherReference</code> element MUST NOT reference
-						non-font resources.</p>
+						of the <code>CipherData</code> element. As the obfuscation algorithm is restricted to fonts, the
+							<code>URI</code> attribute of the <code>CipherReference</code> element MUST reference a <a
+							href="#cmt-grp-font">Font Core Media Type</a>.</p>
 
 					<aside class="example">
 						<p>The following example shows an entry for an obfuscated font in the

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1214,9 +1214,9 @@
 									<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
 										Algorithm [[BIDI]].</li>
 								</ul>
-								<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will assume
-									the value <code>auto</code> when EPUB Creators omit the attribute or use an invalid
-									value.</p>
+								<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will
+									assume the value <code>auto</code> when EPUB Creators omit the attribute or use an
+									invalid value.</p>
 								<div class="note">
 									<p>The base direction specified in the <code>dir</code> attribute does not affect
 										the ordering of characters within directional runs, only the relative ordering
@@ -3179,9 +3179,10 @@ Spine:
 								</dd>
 							</dl>
 
-							<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an <a href="#elemdef-package-item"><code>item</code></a> in the <a>manifest</a> via the IDREF [[XML]]
-								in its <code>idref</code> attribute, and item IDs MUST NOT be referenced more than once.
-							</p>
+							<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an <a
+									href="#elemdef-package-item"><code>item</code></a> in the <a>manifest</a> via the
+								IDREF [[XML]] in its <code>idref</code> attribute, and item IDs MUST NOT be referenced
+								more than once. </p>
 
 							<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a)
 								an <a>EPUB Content Document</a> or b) another type of <a>Publication Resource</a> which,
@@ -3222,9 +3223,9 @@ Spine:
 								the value "<code>yes</code>" for <code>itemref</code> elements without a
 									<code>linear</code> attribute.</p>
 
-							<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide a
-								means of accessing all non-linear content (e.g., hyperlinks in the content or from the
-								<a href="#sec-nav">EPUB Navigation Document</a>).</p>
+							<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide
+								a means of accessing all non-linear content (e.g., hyperlinks in the content or from the
+									<a href="#sec-nav">EPUB Navigation Document</a>).</p>
 
 							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
 									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>
@@ -6307,8 +6308,16 @@ Spine:
 				</section>
 			</section>
 
-			<section id="sec-resource-obfuscation">
-				<h3>Resource Obfuscation</h3>
+			<section id="sec-font-obfuscation">
+				<h3>Font Obfuscation</h3>
+
+				<div class="caution">
+					<p>Better methods of protecting fonts exist. Both [[WOFF]] and [[WOFF2]] fonts, for example, allow
+						the embedding of licensing information and also provide some protection through font table
+						compression. The use of remotely hosted fonts also allows for font subsetting. EPUB Creators are
+						advised to use font obfuscation as defined in this section only when no other options are
+						available to them.</p>
+				</div>
 
 				<section id="fobfus-intro" class="informative">
 					<h4>Introduction</h4>
@@ -6319,11 +6328,11 @@ Spine:
 						(e.g., a folder).</p>
 
 					<p>While this simplicity of ZIP files is quite useful, it also poses a problem when ease of
-						extraction of resources is not a desired side-effect of not encrypting them. An <a>EPUB
-							Creator</a> who wishes to include a third-party font, for example, typically does not want
-						that font extracted and re-used by others. More critically, many commercial fonts allow
-						embedding, but embedding a font implies making it an integral part of the EPUB Publication, not
-						just providing the original font file along with the content.</p>
+						extraction of fonts is not a desired side-effect of not encrypting them. An <a>EPUB Creator</a>
+						who wishes to include a third-party font, for example, typically does not want that font
+						extracted and re-used by others. More critically, many commercial fonts allow embedding, but
+						embedding a font implies making it an integral part of the EPUB Publication, not just providing
+						the original font file along with the content.</p>
 
 					<p>Since integrated ZIP support is so ubiquitous in modern operating systems, simply placing a font
 						in the ZIP archive is insufficient to signify that the font cannot be reused in other contexts.
@@ -6336,21 +6345,20 @@ Spine:
 						computing device, and it cannot be directly used by other EPUB Publications.</p>
 
 					<p>It is beyond the scope of this specification to provide a digital rights management or
-						enforcement system for such resources. This section instead defines a method of obfuscation that
-						will require additional work on the part of the final OCF recipient to gain general access to
-						any obfuscated resources.</p>
+						enforcement system for fonts. This section instead defines a method of obfuscation that will
+						require additional work on the part of the final OCF recipient to gain general access to any
+						obfuscated fonts.</p>
 
 					<p>Note this specification does not claim that this constitutes encryption, nor does it guarantee
 						that the resource will be secure from copyright infringement. The hope is that this algorithm
-						will meet the requirements of most vendors who require some assurance that their resources
-						cannot simply be extracted by unzipping the Container.</p>
+						will meet the requirements of most vendors who require some assurance that their fonts cannot
+						simply be extracted by unzipping the Container.</p>
 
-					<p>In the case of fonts, the primary use case for obfuscation, the defined mechanism will simply
-						provide a stumbling block for those who are unaware of the license details. It will not prevent
-						a determined user from gaining full access to the font. Given an OCF Container, it is possible
-						to apply the algorithms defined to extract the raw font file. Whether this method of obfuscation
-						satisfies the requirements of individual font licenses remains a question for the licensor and
-						licensee.</p>
+					<p>In the case of fonts, this mechanism simply provides a stumbling block for those who are unaware
+						of the license details. It will not prevent a determined user from gaining full access to the
+						font. Given an OCF Container, it is possible to apply the algorithms defined to extract the raw
+						font file. Whether this method of obfuscation satisfies the requirements of individual font
+						licenses remains a question for the licensor and licensee.</p>
 				</section>
 
 				<section id="obfus-keygen">
@@ -6365,38 +6373,38 @@ Spine:
 						Unicode code points <code>U+0020</code>, <code>U+0009</code>, <code>U+000D</code> and
 							<code>U+000A</code>.</p>
 
-					<p>EPUB Creators SHOULD generate a SHA-1 digest of the UTF-8 representation of the resulting string
-						as specified by the Secure Hash Standard [[FIPS-180-4]]. They can then use this digest as the
-						key for the algorithm.</p>
+					<p>EPUB Creators MUST generate a SHA-1 digest of the UTF-8 representation of the resulting string as
+						specified by the Secure Hash Standard [[FIPS-180-4]]. They can then use this digest as the key
+						for the algorithm.</p>
 				</section>
 
 				<section id="obfus-algorithm">
 					<h4>Obfuscation Algorithm</h4>
 
-					<p>The algorithm employed to obfuscate resource consists of modifying the first 1040 bytes (~1KB) of
-						the file. (In the unlikely event that the file is less than 1040 bytes, this process will modify
-						the entire file.)</p>
+					<p>The algorithm employed to obfuscate fonts consists of modifying the first 1040 bytes (~1KB) of
+						the font file. (In the unlikely event that the font file is less than 1040 bytes, this process
+						will modify the entire file.)</p>
 
-					<p>To obfuscate the original data, store, as the first byte of the embedded resource, the result of
-						performing a logical exclusive or (XOR) on the first byte of the raw file and the first byte of
-						the <a href="#obfus-keygen">obfuscation key</a>.</p>
+					<p>To obfuscate the original data, store, as the first byte of the embedded font, the result of
+						performing a logical exclusive or (XOR) on the first byte of the raw font file and the first
+						byte of the <a href="#obfus-keygen">obfuscation key</a>.</p>
 
 					<p>Repeat this process with the next byte of source and key and continue for all bytes in the key.
 						At this point, the process continues starting with the first byte of the key and 21st byte of
 						the source. Once 1040 bytes are encoded in this way (or the end of the source is reached),
 						directly copy any remaining data in the source to the destination.</p>
 
-					<p>EPUB Creators MUST obfuscate resources before compressing and adding them to the OCF Container.
-						Note that as obfuscation is not encryption, this requirement is not a violation of the one in <a
-							href="#sec-container-metainf-encryption.xml"></a> to compress resources before encrypting
+					<p>EPUB Creators MUST obfuscate fonts before compressing and adding them to the OCF Container. Note
+						that as obfuscation is not encryption, this requirement is not a violation of the one in <a
+							href="#sec-container-metainf-encryption.xml"></a> to compress fonts before encrypting
 						them.</p>
 
 					<aside class="example">
 						<p>The following pseudo-code exemplifies the obfuscation algorithm.</p>
 						<pre class="programlisting">
 set ocf to OCF container file
-set source to file
-set destination to obfuscated file
+set source to font file
+set destination to obfuscated font file
 set keyData to key for file
 set outer to 0
 while outer &lt; 52 and not (source at EOF)
@@ -6422,19 +6430,23 @@ store destination as source in ocf
 				</section>
 
 				<section id="obfus-specifying">
-					<h4>Specifying Obfuscated Resources</h4>
+					<h4>Specifying Obfuscated Fonts</h4>
 
-					<p>Although not technically encrypted data, all obfuscated resources MUST have an entry in the <code
+					<p>Although not technically encrypted data, all obfuscated fonts MUST have an entry in the <code
 							class="filename">encryption.xml</code> file accompanying the EPUB Publication (see <a
 							href="#sec-container-metainf-encryption.xml"></a>).</p>
 
-					<p>EPUB Creators MUST specify an <code>EncryptedData</code> element for each obfuscated resource.
-						Each <code>EncryptedData</code> element MUST contain a child <code>EncryptionMethod</code>
+					<p>EPUB Creators MUST specify an <code>EncryptedData</code> element for each obfuscated font. Each
+							<code>EncryptedData</code> element MUST contain a child <code>EncryptionMethod</code>
 						element whose <code>Algorithm</code> attribute has the value
 							<code>http://www.idpf.org/2008/embedding</code>. The presence of this attribute signals the
-						use of the algorithm described in this specification. EPUB Creators MUST list the path to the
-						obfuscated resource in the <code>CipherReference</code> child of the <code>CipherData</code>
-						element.</p>
+						use of the algorithm described in this specification.</p>
+
+					<p>EPUB Creators MUST list the path to the obfuscated font in the <code>CipherReference</code> child
+						of the <code>CipherData</code> element. Note that EPUB Creators MAY only use the obfuscation
+						algorithm with <a href="#cmt-grp-font">Font Core Media Types</a>. Consequently, the
+							<code>URI</code> attribute of the <code>CipherReference</code> element MUST NOT reference
+						non-font resources.</p>
 
 					<aside class="example">
 						<p>The following example shows an entry for an obfuscated font in the
@@ -6454,9 +6466,9 @@ store destination as source in ocf
                 </pre>
 					</aside>
 
-					<p>To prevent trivial copying of the embedded resource to other EPUB Publications, EPUB Creators
-						MUST NOT provide the <a href="#obfus-keygen">obfuscation key</a> in the
-							<code>encryption.xml</code> file.</p>
+					<p>To prevent trivial copying of the embedded font to other EPUB Publications, EPUB Creators MUST
+						NOT provide the <a href="#obfus-keygen">obfuscation key</a> in the <code>encryption.xml</code>
+						file.</p>
 				</section>
 			</section>
 		</section>
@@ -9438,6 +9450,9 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>12-Nov-2021: Restrict the obfuscation algorithm to fonts and add caution to use better protection
+					methods whenever possible. See <a href="https://github.com/w3c/epub-specs/issues/1873">issue
+						1873</a>.</li>
 				<li>29-Oct-2021: Recommended that EPUB Creators not use path-absolute-URL strings for referencing
 					resources due to the lack of a consistent root. See <a
 						href="https://github.com/w3c/epub-specs/issues/1681">issue 1681</a></li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9450,6 +9450,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>12-Nov-2021: Change the recommendation to use SHA-1 to encrypt the obfuscation key to a requirement.
+					See <a href="https://github.com/w3c/epub-specs/issues/1873">issue 1873</a>.</li>
 				<li>12-Nov-2021: Restrict the obfuscation algorithm to fonts and add caution to use better protection
 					methods whenever possible. See <a href="https://github.com/w3c/epub-specs/issues/1873">issue
 						1873</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5240,8 +5240,8 @@ Spine:
 						</dt>
 						<dd>
 							<p>Contains information about the encryption of <a>Publication Resources</a>. This file is
-								mandatory when EPUB Creators use <a href="#sec-resource-obfuscation"
-								>obfuscation</a>.</p>
+								mandatory when EPUB Creators use <a href="#sec-font-obfuscation">font
+								obfuscation</a>.</p>
 						</dd>
 						<dt>
 							<code>metadata.xml</code>
@@ -5836,11 +5836,11 @@ Spine:
 									rather than Deflate-compress them.</p>
 
 								<p id="encryption-obfuscation">Note that some situations require obfuscating the storage
-									of embedded resources referenced by an <a>EPUB Publication</a> to make them more
-									difficult to extract for unrestricted use (e.g., fonts). Although obfuscation is not
-									encryption, Reading Systems use the <code>encryption.xml</code> file in conjunction
-									with the <a href="#sec-resource-obfuscation">resource obfuscation algorithm</a> to
-									identify resources to de-obfuscated.</p>
+									of embedded fonts referenced by an <a>EPUB Publication</a> to make them more
+									difficult to extract for unrestricted use. Although obfuscation is not encryption,
+									Reading Systems use the <code>encryption.xml</code> file in conjunction with the <a
+										href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify
+									resources to de-obfuscated.</p>
 
 								<p id="encryption-restrictions">EPUB Creators MUST NOT encrypt or obfuscate the
 									following files:</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -551,16 +551,13 @@
 					<code>properties</code> attributes that they do not recognize.</p>
 
 				<p>
-					<span id="confreq-rs-pkg-duplicate-item-rendering">Reading Systems MUST NOT skip spine references to duplicate manifest items when rendering the linear reading order.</span> 
-					<span id="confreq-rs-pkg-duplicate-item-ui">
-						The Reading System MUST treat these as distinct items for UI purposes (for example, each occurrence
-						could be independently bookmarked or annotated).
-					</span>
-					<span id="confreq-rs-pkg-duplicate-item-hyperlink">
-						When a Reading System follows a hyperlink to a resource referenced multiple times in the
-						spine, the Reading System MUST move to the position of the first occurrence of the
-						document in the linear reading order.
-					</span>
+					<span id="confreq-rs-pkg-duplicate-item-rendering">Reading Systems MUST NOT skip spine references to
+						duplicate manifest items when rendering the linear reading order.</span>
+					<span id="confreq-rs-pkg-duplicate-item-ui"> The Reading System MUST treat these as distinct items
+						for UI purposes (for example, each occurrence could be independently bookmarked or annotated). </span>
+					<span id="confreq-rs-pkg-duplicate-item-hyperlink"> When a Reading System follows a hyperlink to a
+						resource referenced multiple times in the spine, the Reading System MUST move to the position of
+						the first occurrence of the document in the linear reading order. </span>
 				</p>
 			</section>
 
@@ -1319,10 +1316,10 @@
 					</li>
 				</ul>
 			</section>
-			<section id="sec-container-res-obfus">
-				<h3>Resource Obfuscation</h3>
+			<section id="sec-container-fobfus">
+				<h3>Font Obfuscation</h3>
 
-				<p id="confreq-ocf-fobfus">Reading Systems MUST support deobfuscation of resources as defined in <a
+				<p id="confreq-ocf-fobfus">Reading Systems MUST support deobfuscation of fonts as defined in <a
 						href="https://www.w3.org/TR/epub-33/#sec-resource-obfuscation"><em>Resource Obfuscation</em></a>
 					[[EPUB-33]].</p>
 
@@ -2245,10 +2242,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>
-					01-Nov-2021: Added a statement on the Reading System behavior when item references are repeated in the 
-					spine. See <a href="https://github.com/w3c/epub-specs/issues/1686">issue 1686</a>.
-				</li>
+				<li> 01-Nov-2021: Added a statement on the Reading System behavior when item references are repeated in
+					the spine. See <a href="https://github.com/w3c/epub-specs/issues/1686">issue 1686</a>. </li>
 				<li>25-Oct-2021: Clarify that reading systems must render non-linear resources when they are hyperlinked
 					to by a user. See <a href="https://github.com/w3c/epub-specs/issues/1864">issue 1864</a>.</li>
 				<li>27-Aug-2021: Added accessibility bullet to cover the need for zooming, particularly for fixed-layout

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1320,7 +1320,7 @@
 				<h3>Font Obfuscation</h3>
 
 				<p id="confreq-ocf-fobfus">Reading Systems MUST support deobfuscation of fonts as defined in <a
-						href="https://www.w3.org/TR/epub-33/#sec-resource-obfuscation"><em>Resource Obfuscation</em></a>
+						href="https://www.w3.org/TR/epub-33/#sec-font-obfuscation"><em>Font Obfuscation</em></a>
 					[[EPUB-33]].</p>
 
 				<p>For Reading Systems to get the original obfuscated data back, simply reverse the process: the source


### PR DESCRIPTION
As discussed on the 2021-11-11 call regarding #1873 , this PR:

- renames "resource obfuscation" back to "font obfuscation"
- adds a restriction that only font CMTs can be obfuscated to s. 6.3.4
- adds a caution note to the beginning of the section explaining that better protection methods exist

The first two bullets are pretty straightforward, but let me know if the caution note is complete/accurate about the alternatives.

Update: This also s/SHOULD/MUST/ for using SHA-1 to encrypt the key.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1906.html" title="Last updated on Nov 17, 2021, 3:04 PM UTC (46de524)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1906/7d1967e...46de524.html" title="Last updated on Nov 17, 2021, 3:04 PM UTC (46de524)">Diff</a>