### PR TITLE
Add references to tests for relative URLs

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5467,8 +5467,9 @@ Spine:
 				<section id="sec-container-iri">
 					<h4>URLs in the OCF Abstract Container</h4>
 
-					<p>The <a>container root URL</a> is the <a data-cite="url#concept-url">URL</a> [[URL]] of the
-						<a>Root Directory</a>. It is implementation specific, but EPUB Creators MUST assume it has the following properties:</p>
+					<p id="confreq-root-url" data-tests="#pkg-manifest-url,#pkg-relative-url">The <a>container root URL</a>
+						is the <a data-cite="url#concept-url">URL</a> [[URL]] of the <a>Root Directory</a>. It is
+						implementation-specific, but EPUB Creators MUST assume it has the following properties:</p>
 
 					<ul>
 						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -331,7 +331,8 @@
 			<section id="sec-pkg-doc-relative-urls">
 				<h4>Parsing Relative URLs</h4>
 
-				<p>To parse <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
+				<p id="confreq-rs-pkg-relative-url" data-tests="#pkg-relative-url">To parse <a
+					href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
 						>relative-URL-with-fragment strings</a> [[URL]] in the Package Document, Reading Systems MUST
 					use the URL of the Package Document as the <a href="https://url.spec.whatwg.org/#concept-base-url"
 						>base URL</a> [[URL]].</p>
@@ -475,9 +476,9 @@
 			<section id="sec-pkg-doc-manifest">
 				<h3>Manifest</h3>
 
-				<p id="confreq-rs-pkg-manifest-url" data-tests="#pkg-manifest-url">When an <code>href</code> attribute
-					contains a <a href="https://url.spec.whatwg.org/#relative-url-string">relative-URL string</a>,
-					Reading Systems MUST use the URL of the Package Document as the <a
+				<p id="confreq-rs-pkg-manifest-url" data-tests="#pkg-manifest-url,#pkg-relative-url">When an
+					<code>href</code> attribute contains a <a href="https://url.spec.whatwg.org/#relative-url-string"
+						>relative-URL string</a>, Reading Systems MUST use the URL of the Package Document as the <a
 						href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> when <a
 						href="https://url.spec.whatwg.org/#concept-url-parser">parsing</a> to a <a
 						href="https://url.spec.whatwg.org/#concept-url">URL record</a> [[URL]].</p>


### PR DESCRIPTION
This corresponds to https://github.com/w3c/epub-tests/pull/79.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1908.html" title="Last updated on Nov 23, 2021, 2:34 PM UTC (d9cea62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1908/314625e...d9cea62.html" title="Last updated on Nov 23, 2021, 2:34 PM UTC (d9cea62)">Diff</a>