### PR TITLE
Add references to test for linked records

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2585,9 +2585,9 @@
 </pre>
 							</aside>
 
-							<p id="sec-linked-records">EPUB Creators MAY provide one or more <a href="#record">linked
-									metadata records</a> to enhance the information available to Reading Systems, but
-								Reading Systems may ignore these records.</p>
+							<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB Creators MAY provide one or more
+								<a href="#record">linked metadata records</a> to enhance the information available to Reading
+								Systems, but Reading Systems may ignore these records.</p>
 
 							<p>When a Reading System <a href="https://www.w3.org/TR/epub-rs-33/#sec-linked-records"
 									>processes linked records</a> [[EPUB-RS-33]], the document order of

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -445,10 +445,11 @@
 						<p> The language identified in an <code>hreflang</code> is purely advisory. Upon fetching the
 							resource, a Reading System must only use the language information associated with the
 							resource to determine its language, not the metadata included in the link to the resource. </p>
-						<p id="sec-linked-records"> In the case of a <a href="https://www.w3.org/TR/epub-33/#record"
-								>linked metadata record</a> [[EPUB-33]], Reading Systems MUST NOT skip processing the
-							metadata expressed in the Package Document and only use the information expressed in the
-							record. Reading Systems MAY compile metadata from multiple linked records.</p>
+						<p id="sec-linked-records" data-tests="#pkg-linked-records"> In the case of a <a
+							href="https://www.w3.org/TR/epub-33/#record">linked metadata record</a> [[EPUB-33]], Reading
+							Systems MUST NOT skip processing the metadata expressed in the Package Document and only use the
+							information expressed in the record. Reading Systems MAY compile metadata from multiple linked
+							records.</p>
 						<p>When it comes to resolving discrepancies and conflicts between metadata expressed in the
 							Package Document and in linked metadata records, Reading Systems MUST use the document order
 							of <code>link</code> elements in the Package Document to establish precedence (i.e.,


### PR DESCRIPTION
Matthew added this test in https://github.com/w3c/epub-tests/pull/57. I meant to leave it to him to add references, but didn't remember that until after I'd created a new branch, so might as well just get it done :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1909.html" title="Last updated on Nov 12, 2021, 9:59 PM UTC (7283b3b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1909/7d1967e...7283b3b.html" title="Last updated on Nov 12, 2021, 9:59 PM UTC (7283b3b)">Diff</a>