### PR TITLE
Clarifications to manifest fallbacks and examples

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -87,20 +87,16 @@
 		<section id="sotd"></section>
 		<section id="sec-introduction">
 			<h2>Introduction</h2>
-
 			<section id="sec-intro-overview" class="informative">
 				<h3>Overview</h3>
-
 				<p>EPUB 3 has been widely adopted as the format for digital books (ebooks), and this revision continues
 					to increase the format's capabilities to better support a wider range of publication requirements,
 					including complex layouts, rich media and interactivity, and global typography features. The
 					expectation is that publishers will utilize the EPUB 3 format for a broad range of content,
 					including books, magazines, and educational, professional, and scientific publications.</p>
-
 				<p>This specification represents the core of EPUB 3 and includes the conformance requirements for
 						<a>EPUB Publications</a> — the product of the standard. The other specifications that comprise
 					EPUB 3 are as follows:</p>
-
 				<ul>
 					<li>
 						<p><a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3 Reading Systems</a> [[EPUB-RS-33]] —
@@ -112,25 +108,20 @@
 							accessibility conformance and discovery requirements for EPUB Publications.</p>
 					</li>
 				</ul>
-
 				<p>These specifications represent the formal list recognized as belonging to EPUB 3 and that contain
 					functionality normatively referenced as part of the standard. The development of extension
 					specifications periodically adds new functionality to EPUB Publications. Features and functionality
 					defined outside of core revisions to the standard, while not formally recognized in this
 					specification, are nonetheless available for <a>EPUB Creators</a> and Reading System developers to
 					use.</p>
-
 				<p>The informative <a href="https://www.w3.org/TR/epub-overview-33/">EPUB 3 Overview</a>
 					[[EPUB-OVERVIEW-33]] provides a general introduction to EPUB 3. A list of technical changes from the
 					previous version is also available in the <a href="#change-log">change log</a>.</p>
 			</section>
-
 			<section id="sec-intro-spec-org" class="informative">
 				<h3>Organization</h3>
-
 				<p>This section reviews the organization of the EPUB specifications through the central product they
 					define: the <a>EPUB Publication</a>.</p>
-
 				<p>An EPUB Publication is typically represented by a single <a>Package Document</a>. This document
 					includes metadata used by <a>Reading Systems</a> to present the content to the user, such as the
 					title and author for display in a bookshelf as well as rendering metadata (e.g., whether the content
@@ -138,12 +129,10 @@
 						<a>spine</a> that lists the default sequence in which to render documents as a user progresses
 					through the content. Refer to <a href="#sec-package-doc"></a> for the requirements for the Package
 					Document.</p>
-
 				<p>An EPUB Publication also includes another key file called the <a>EPUB Navigation Document</a>. This
 					document provides critical navigation capabilities, such as the table of contents, that allow users
 					to navigate the content quickly and easily. Refer to <a href="#sec-nav"></a> for more information
 					about this document.</p>
-
 				<!--
 				<figure>
 					<figcaption> The following example visually represents the structure of the EPUB format. </figcaption>
@@ -152,84 +141,66 @@
 					</object>
 				</figure>
 				-->
-
 				<p>The actual content of an EPUB Publication &#8212; what users are presented with when they begin
 					reading &#8212; is built on the Open Web Platform and comes in two flavors: <a
 						data-lt="XHTML Content Document">XHTML</a> and <a data-lt="SVG Content Document">SVG</a>. Called
 						<a>EPUB Content Documents</a>, these documents typically reference many additional resources
 					required for their proper rendering, such as images, audio and video clips, scripts, and style
 					sheets.</p>
-
 				<p>Refer to <a href="#sec-contentdocs"></a> for detailed information about the rules and requirements to
 					produce EPUB Content Documents, and [[EPUB-A11Y-11]] for accessibility requirements.</p>
-
 				<p><a>Media Overlay Documents</a> complement EPUB Content Documents. They provide declarative markup for
 					synchronizing the text in EPUB Content Documents with prerecorded audio. The result is the ability
 					to create a read-aloud experience where <a>Reading Systems</a> highlight the text as it is narrated.
 					Refer to <a href="#sec-media-overlays"></a> for the definition of Media Overlay Documents.</p>
-
 				<p>A ZIP-based archive with the file extension <code>.epub</code> bundles the EPUB Publication's
 					resources for distribution. As conformant ZIP archives, EPUB Publications can be unzipped by many
 					software programs, simplifying both their production and consumption.</p>
-
 				<p>The container format not only provides a means of determining that the zipped content represents an
 					EPUB Publication (the <code>mimetype</code> file), but also provides a universally-named directory
 					of informative resources (<code>/META-INF</code>). Key among these resources is the
 						<code>container.xml</code> file, which directs Reading Systems to the available Package
 					Documents. Refer to <a href="#sec-ocf"></a> for more information about the Container format.</p>
-
 				<p>While conceptually simple, an EPUB Publication is more than just a collection of HTML pages and
 					dependent assets in a ZIP package as presented here. Additional information about the primary
 					features and functionality that EPUB Publications provide to enhance the reading experience is
 					available from the referenced specifications, and a more general introduction to the features of
 					EPUB 3 is provided in the informative [[EPUB-OVERVIEW-33]].</p>
-
 				<p>Refer to [[EPUB-RS-33]] for the processing requirements for Reading Systems. Although it is not
 					necessary that <a>EPUB Creators</a> read that document to create EPUB Publications, an understanding
 					of how Reading Systems present the content can help craft publications for optimal presentation to
 					users.</p>
 			</section>
-
 			<section id="sec-intro-relations" class="informative">
 				<h3>Relationship to Other Specifications</h3>
-
 				<section id="sec-overview-relations-html">
 					<h4>Relationship to HTML</h4>
-
 					<p>The [[HTML]] standard is continuously evolving &#8212; there are no longer versioned releases of
 						it. That standard, in turn, references various technologies that continue to evolve, such as
 						MathML, SVG, CSS, and JavaScript.</p>
-
 					<p>The benefit of this approach for EPUB is that <a>EPUB Publications</a> always keep pace with
 						changes to the Web without the need for new revisions. <a>EPUB Creators</a>, however, must keep
 						track of the various changes to HTML and the technologies it references to ensure they keep
 						their processes up to date.</p>
-
 					<div class="caution">
 						<p>As HTML evolves, it is possible that previously-valid features may become obsolete or be
 							removed. In general, however, the removal of features typically only occurs when serious
 							issues arise with them (e.g., lack of support in browsers, security issues).</p>
 					</div>
-
 					<p>The <a href="#sec-xhtml">XHTML profile defined by this specification</a> inherits all definitions
 						of semantics, structure and processing behaviors from HTML unless otherwise specified.</p>
-
 					<p>In addition, this specification <a href="#sec-xhtml-extensions">defines a set of extensions</a>
 						to the [[HTML]] document model that EPUB Creators may include in <a>XHTML Content
 						Documents</a>.</p>
 				</section>
-
 				<section id="sec-overview-relations-svg">
 					<h4>Relationship to SVG</h4>
-
 					<p>This specification does not reference a specific version of [[SVG]], but instead uses an undated
 						reference. Whenever there is any ambiguity in this reference, the latest recommended
 						specification is the authoritative reference.</p>
-
 					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. <a>EPUB
 							Creators</a>, however, must keep track of changes to the SVG standard to ensure they keep
 						their processes up to date.</p>
-
 					<div class="caution">
 						<p>As SVG evolves, features previously-valid features may become obsolete or be removed. The
 							Working Group anticipates the W3C will make any such changes carefully to ensure minimal
@@ -237,24 +208,18 @@
 							revisit the use of an undated reference.</p>
 					</div>
 				</section>
-
 				<section id="sec-overview-relations-css">
 					<h4>Relationship to CSS</h4>
-
 					<p>EPUB 3 supports CSS as defined by the CSS Working Group Snapshot [[CSSSnapshot]]. EPUB 3 also
 						maintains some prefixed CSS properties, to ensure consistent support for global languages.</p>
 				</section>
-
 				<section id="sec-overview-relations-smil">
 					<h4>Relationship to SMIL</h4>
-
 					<p>This specification relies on a subset of [[SMIL3]], from which the Media Overlays elements and
 						attributes defined in <a href="#sec-overlays-def"></a> are derived.</p>
 				</section>
-
 				<section id="sec-overview-relations-url">
 					<h4>Relationship to URL</h4>
-
 					<p>This specification refers to the [[URL]] standard for terminology and processing related to URLs
 						expressed in EPUB Publications. It is anticipated that new and revised Web formats will adopt
 						this standard, but until then this may put this specification in conflict with the internal
@@ -264,15 +229,11 @@
 						resources.</p>
 				</section>
 			</section>
-
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
-
 				<p>This specification defines the following terms specific to EPUB 3. They appear capitalized wherever
 					used.</p>
-
 				<p>Only the first instance of a term in a section links to its definition.</p>
-
 				<dl class="termlist">
 					<dt>
 						<dfn id="dfn-codec" data-lt="Codecs">Codec</dfn>
@@ -561,26 +522,19 @@
 					</dd>
 				</dl>
 			</section>
-
 			<section id="conformance"></section>
-
 			<section id="sec-intro-shorthands">
 				<h3>Authoring Shorthands</h3>
-
 				<section id="sec-shorthands-prefixes">
 					<h4>Prefixes</h4>
-
 					<p>In <a>Package Document</a> metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
 							prefixes</a> are used without declaration.</p>
 				</section>
-
 				<section id="sec-shorthands-ns">
 					<h4>Namespaces</h4>
-
 					<p>For convenience, the following namespace prefixes [[XML-NAMES]] are used in this specification
 						without explicitly being declared. EPUB Creators MUST declare these prefixes to use them in an
 							<a>EPUB Content Document</a>.</p>
-
 					<table class="mapping">
 						<tr>
 							<th>prefix</th>
@@ -600,12 +554,9 @@
 		</section>
 		<section id="sec-publications">
 			<h2>EPUB Publications</h2>
-
 			<section id="sec-epub-conf">
 				<h3>Conformance Criteria</h3>
-
 				<p>An EPUB Publication:</p>
-
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-package">MUST define at least one rendering of its content as follows:</p>
@@ -630,31 +581,23 @@
 								href="#sec-ocf"></a>.</p>
 					</li>
 				</ul>
-
 				<p id="confreq-res-location">In addition, all Publication Resources MUST adhere to the requirements in
 						<a href="#sec-publication-resources"></a>.</p>
-
 				<p>The rest of this specification covers specific conformance details.</p>
 			</section>
-
 			<section id="sec-publication-resources">
 				<h3>Publication Resources</h3>
-
 				<section id="sec-core-media-types">
 					<h4>Core Media Types</h4>
-
 					<section id="sec-cmt-intro" class="informative">
 						<h5>Introduction</h5>
-
 						<p>An <a>EPUB Publication</a> typically consists of many <a>Publication Resources</a>. These
 							resources are divided into two categories: those that do not require fallbacks (<a>Core
 								Media Type Resources</a>) and those that do (<a>Foreign Resources</a>).</p>
-
 						<p>The Working Group typically only includes formats as Core Media Type Resources when they have
 							broad support in web browser cores &#8212; the rendering engines that EPUB 3 Reading Systems
 							build upon. They are an agreement between Reading System developers and EPUB Creators to
 							ensure the predictability of rendering of EPUB Publications.</p>
-
 						<p>Inclusion as a Core Media Type Resource does not mean that all Reading Systems will support
 							the rendering of a resource, however. Reading Systems support also depends on the
 							capabilities of the application (e.g., a Reading System with a <a>Viewport</a> must support
@@ -662,16 +605,13 @@
 								<a href="https://www.w3.org/TR/epub-rs-33/#sec-epub-rs-conf-cmt">Core Media Types</a>
 							[[EPUB-RS-33]] for more information about which Reading Systems rendering capabilities
 							require support for which Core Media Type Resources.</p>
-
 						<p>Foreign Resources come with no guarantee of rendering support, which is why they require a
 							fallback to a Core Media Type Resource. EPUB Publications should be fully consumable on any
 							conforming Reading System, so providing a fallback is necessary to ensure that the use of
 							Foreign Resources does not impact on the ability of the user to consume the content.</p>
-
 						<p>This section lists the <a href="#sec-cmt-supported">set of Core Media Type Resources</a> and
 							identifies <a href="#sec-foreign-restrictions">fallback mechanisms</a> used to satisfy the
 							consumability requirement.</p>
-
 						<div class="note">
 							<p>EPUB also exempts some [[HTML]] elements from support requirements (see <a
 									href="#sec-xhtml-fallbacks"></a>). Resources referenced from these elements are
@@ -679,16 +619,12 @@
 								fallbacks, but they also have no support requirements.</p>
 						</div>
 					</section>
-
 					<section id="sec-cmt-supported">
 						<h5>Supported Media Types</h5>
-
 						<p><a>EPUB Creators</a> may include <a>Publication Resources</a> that conform to the following
 							MIME media type [[RFC2046]] specifications in <a>EPUB Publications</a> without
 							fallbacks.</p>
-
 						<p>The columns in the following table represent the following information:</p>
-
 						<ul>
 							<li>
 								<p><strong>Media Type</strong>—The MIME media type [[RFC2046]] used to represent the
@@ -702,7 +638,6 @@
 							<li><strong>Applies to</strong>—The Publication Resource type(s) that the Media Type and
 								Content Type Definition applies to.</li>
 						</ul>
-
 						<table id="tbl-core-media-types">
 							<thead>
 								<tr>
@@ -752,7 +687,6 @@
 									<td> [[WebP-Container]], [[WebP-LB]] </td>
 									<td>WebP Images</td>
 								</tr>
-
 								<tr>
 									<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>
 								</tr>
@@ -841,7 +775,6 @@
 									</td>
 									<td>[[OpenType]]</td>
 									<td>OpenType fonts</td>
-
 								</tr>
 								<tr>
 									<td id="cmt-woff">
@@ -863,7 +796,6 @@
 								<tr>
 									<th colspan="3" id="cmt-grp-other" class="tbl-group">Other</th>
 								</tr>
-
 								<tr>
 									<td id="cmt-xhtml">
 										<code>application/xhtml+xml</code>
@@ -893,7 +825,6 @@
 									<td> [[OPF-201]] </td>
 									<td>The <a href="#legacy">legacy</a> NCX.</td>
 								</tr>
-
 								<tr>
 									<td id="cmt-smil">
 										<code>application/smil+xml</code>
@@ -917,13 +848,10 @@
 								continue to monitor these issues.</p>
 						</div>
 					</section>
-
 					<section id="sec-foreign-restrictions">
 						<h5>Foreign Resources</h5>
-
 						<p id="confreq-foreign-no-fallback">EPUB Creators MAY include Foreign Resources without
 							fallbacks provided they:</p>
-
 						<ul>
 							<li>
 								<p>do not reference the resources from <a href="#sec-itemref-elem">spine
@@ -939,18 +867,15 @@
 											><code>foreignObject</code></a> elements).</p>
 							</li>
 						</ul>
-
 						<p class="note">This exception allows EPUB Creators to include resources in the <a>EPUB
 								Container</a> that are not for use by EPUB Reading Systems. The primary case for this
 							exception is to allow data files to travel with an EPUB Publication, whether for scripts to
 							use in their constituent EPUB Content Documents or for external applications to use (e.g., a
 							scientific journal might include a data set with instructions on how to extract it from the
 							EPUB Container).</p>
-
 						<p id="confreq-cmt">When a <a>Foreign Resource</a> is included in the spine or directly rendered
 							in its native format in an EPUB Content Document, a fallback <a>Core Media Type Resource</a>
 							MUST be included. Fallbacks take one of the following forms:</p>
-
 						<ul>
 							<li>
 								<p>intrinsic fallback mechanisms provided by the host format (e.g., [[?HTML]] elements
@@ -963,20 +888,16 @@
 										Document</a>.</p>
 							</li>
 						</ul>
-
 						<div class="note">
 							<p>Refer to the [[HTML]] and [[SVG]] specifications for the intrinsic fallback capabilities
 								their elements provide.</p>
 						</div>
 					</section>
 				</section>
-
 				<section id="sec-resource-locations">
 					<h4>Resource Locations</h4>
-
 					<p>EPUB Creators MUST <a href="#sec-container-iri">locate all Publication Resources in the EPUB
 							Container</a>, with the following exceptions:</p>
-
 					<ul class="conformance-list">
 						<li>
 							<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a> referenced
@@ -1008,48 +929,39 @@
 										><code>link</code> element</a>.</p>
 						</li>
 					</ul>
-
 					<p>EPUB Creators should locate these resources inside the EPUB Container whenever feasible to allow
 						users access to the entire presentation regardless of connectivity status.</p>
-
 					<aside class="example">
 						<p>The following example shows a reference to an audio file in an <a>XHTML Content Document</a>
 							that is located inside the EPUB Container.</p>
 						<pre>&lt;audio src="audio/ch01.mp4" controls="controls"/&gt;</pre>
 					</aside>
-
 					<aside class="example">
 						<p>The following example shows a reference to an audio file in an XHTML Content Document that is
 							located outside the EPUB Container.</p>
 						<pre>&lt;audio src="http://www.example.com/book/audio/ch01.mp4" controls="controls"/&gt;</pre>
 					</aside>
-
 					<div class="note">
 						<p>The rules in this section for Publication Resource locations apply regardless of whether the
 							given resource is a <a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
 					</div>
-
 					<div class="note">
 						<p>The inclusion of Remote Resources is indicated via the <a href="#remote-resources"
 									><code>remote-resources</code> property</a> on the <a>manifest</a>
 							<a href="#sec-item-elem"><code>item</code> element</a>.</p>
 					</div>
 				</section>
-
 				<section id="sec-data-urls">
 					<h4>Data URLs</h4>
-
 					<p>The <a href="https://datatracker.ietf.org/doc/html/rfc2397"><code>data:</code> URL scheme</a>
 						[[RFC2397]] is used to encode resources directly into a URL string. The advantage of this scheme
 						is that it allows EPUB Creators to embed a resource within another, avoiding the need for an
 						external file.</p>
-
 					<p><a>EPUB Creators</a> MAY use data URLs in EPUB Publications provided their use does not result in
 						a <a>Top-level Content Document</a> or <a
 							href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context"
 							>top-level browsing context</a> [[HTML]]. This restriction applies to data URLs used in the
 						following scenarios:</p>
-
 					<ul>
 						<li>
 							<p>in manifest <a href="#sec-item-elem"><code>item</code> elements</a> referenced from the
@@ -1069,29 +981,22 @@
 							<p>in calls to [[ECMASCRIPT]] <code>window.open</code> or <code>document.open</code>.</p>
 						</li>
 					</ul>
-
 					<div class="note">
 						<p>The list of prohibited uses for data URLs is subject to change as the respective standards
 							that allow their use evolve.</p>
 					</div>
-
 					<p>This restriction on their use is to prevent security issues and also to ensure that <a>Reading
 							Systems</a> can determine where to take a user next (i.e., because these resources are not
 						be listed in the spine).</p>
-
 					<p>Resources represented as data URLs are not Publication Resources so are exempt from the
 						requirement for EPUB Creators to list them in the <a>manifest</a>.</p>
-
 					<p>EPUB Creators MUST encode Data URLs as Core Media Types or use them where they can provide a
 						fallback (i.e., Data URLs are subject to the <a href="#sec-foreign-restrictions">foreign
 							resource restrictions</a>).</p>
 				</section>
-
 				<section id="sec-xml-constraints">
 					<h4>XML Conformance</h4>
-
 					<p>Any <a>Publication Resource</a> that is an XML-Based Media Type:</p>
-
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-xml-wellformed">MUST be a conformant XML 1.0 Document as defined in <a
@@ -1120,30 +1025,23 @@
 								RECOMMENDED encoding.</p>
 						</li>
 					</ul>
-
 					<p>The above constraints apply regardless of whether the given Publication Resource is a <a>Core
 							Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
-
 					<div class="note">
 						<p>[[HTML]] and [[SVG]] are removing support for the XML `base` attribute [[XMLBase]]. EPUB
 							Creators should avoid using this feature.</p>
 					</div>
 				</section>
 			</section>
-
 			<section id="sec-package-doc">
 				<h3>Package Document</h3>
-
 				<section id="sec-package-intro" class="informative">
 					<h4>Introduction</h4>
-
 					<p>The <a>Package Document</a> is an XML document that consists of a set of elements that each
 						encapsulate information about a particular aspect of an <a>EPUB Publication</a>. These elements
 						serve to centralize metadata, detail the individual resources, and provide the reading order and
 						other information necessary for its rendering.</p>
-
 					<p>The following list summarizes the information found in the Package Document:</p>
-
 					<ul>
 						<li>
 							<p><a href="#sec-pkg-metadata">Metadata</a> — mechanisms to include and/or reference
@@ -1169,31 +1067,24 @@
 								rendering.</p>
 						</li>
 					</ul>
-
 					<div class="note">
 						<p>An EPUB Publication can reference more than one Package Document, allowing for alternative
 							representations of the content. For more information, refer to <a
 								href="#sec-container-metainf-container.xml"></a></p>
 					</div>
-
 					<div class="note">
 						<p>Refer to <a href="#app-media-type-app-oebps-package"></a> for information about the file
 							properties of Package Documents.</p>
 					</div>
 				</section>
-
 				<section id="sec-package-def">
 					<h4>Package Document Definition</h4>
-
 					<p>All [[XML]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
 						namespace [[XML-NAMES]] unless otherwise specified.</p>
-
 					<section id="sec-shared-attrs">
 						<h5>Shared Attributes</h5>
-
 						<p>This section provides definitions for shared attributes (i.e., attributes allowed on two or
 							more elements).</p>
-
 						<dl class="variablelist">
 							<dt id="attrdef-dir">
 								<code>dir</code>
@@ -1388,12 +1279,9 @@
 							</dd>
 						</dl>
 					</section>
-
 					<section id="sec-package-elem">
 						<h5>The <code>package</code> Element</h5>
-
 						<p>The <code>package</code> element is the root element of the <a>Package Document</a>.</p>
-
 						<dl id="elemdef-opf-package" class="elemdef">
 							<dt>Element Name</dt>
 							<dd>
@@ -1515,37 +1403,28 @@
 								</ul>
 							</dd>
 						</dl>
-
 						<p id="attrdef-package-version">The <code>version</code> attribute specifies the EPUB
 							specification version to which the given EPUB Publication conforms. The attribute MUST have
 							the value "<code>3.0</code>" to indicate conformance with EPUB 3.</p>
-
 						<div class="note">
 							<p>Updates to this specification do not represent new versions of EPUB 3 (i.e., each new 3.X
 								specification is a continuation of the EPUB 3 format). The Working Group is committed to
 								minimizing any changes that would invalidate existing content, allowing the
 									<code>version</code> attribute value to remain unchanged.</p>
 						</div>
-
 						<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an
 							IDREF [[XML]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"
 									><code>dc:identifier</code></a> element that provides the preferred, or primary,
 							identifier.</p>
-
 						<p id="attrdef-package-prefix">The <code>prefix</code> attribute provides a declaration
 							mechanism for prefixes not <a href="#sec-metadata-reserved-prefixes">reserved by this
 								specification</a>. Refer to <a href="#sec-prefix-attr"></a> for more information.</p>
-
 					</section>
-
 					<section id="sec-pkg-metadata">
 						<h5>Metadata Section</h5>
-
 						<section id="sec-metadata-elem">
 							<h6>The <code>metadata</code> Element</h6>
-
 							<p>The <code>metadata</code> element encapsulates meta information.</p>
-
 							<dl id="elemdef-opf-metadata" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
@@ -1624,9 +1503,7 @@
 									</ul>
 								</dd>
 							</dl>
-
 							<p>The Package Document <code>metadata</code> element has two primary functions:</p>
-
 							<ol type="1">
 								<li>
 									<p>to provide a minimal set of meta information for Reading Systems to use to
@@ -1639,7 +1516,6 @@
 											properties</a>).</p>
 								</li>
 							</ol>
-
 							<p>The Package Document does not provide complex metadata encoding capabilities. If EPUB
 								Creators need to provide more detailed information, they can associate metadata records
 								(e.g., that conform to an international standard such as [[ONIX]] or are created for
@@ -1647,7 +1523,6 @@
 								approach allows Reading Systems to process the metadata in its native form, avoiding the
 								potential problems and information loss caused by translating to use the minimal Package
 								Document structure.</p>
-
 							<p id="core-metadata-reqs">In keeping with this philosophy, the Package Document only has
 								the following minimal metadata requirements: it MUST contain the [[DCTERMS]] <a
 									href="#sec-opf-dcidentifier"><code>title</code></a>, <a
@@ -1655,7 +1530,6 @@
 									href="#elemdef-opf-dclanguage"><code>language</code></a> elements together with the
 								[[DCTERMS]] <a href="#last-modified-date"><code>modified</code> property</a>. All other
 								metadata is OPTIONAL.</p>
-
 							<aside class="example">
 								<p>The following example shows the minimal set of metadata that EPUB Creators must
 									include in the Package Document.</p>
@@ -1671,49 +1545,38 @@
 &lt;/package&gt;
 </pre>
 							</aside>
-
 							<p>The <a href="#sec-meta-elem"><code>meta</code> element</a> provides a generic mechanism
 								for including <a href="#sec-vocab-assoc">metadata properties from any vocabulary</a>.
 								Although EPUB Creators MAY use this mechanism for any metadata purposes, they will
 								typically use it to include rendering metadata defined in EPUB specifications.</p>
-
 							<div class="note">
 								<p>See [[EPUB-A11Y-11]] for accessibility metadata recommendations.</p>
 							</div>
-
 						</section>
-
 						<section id="sec-metadata-values">
 							<h5>Metadata Values</h5>
-
 							<p>The Dublin Core elements [[DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code>
 									element</a> have mandatory <a
 									href="https://dom.spec.whatwg.org/#concept-child-text-content">child text
 									content</a> [[DOM]]. This specification refers to this content as the
 									<dfn>value</dfn> of the element in their descriptions.</p>
-
 							<p>These elements MUST have non-empty values after <a
 									href="https://infra.spec.whatwg.org/#strip-leading-and-trailing-ascii-whitespace"
 									>leading and trailing ASCII whitespace</a> [[Infra]] is stripped (i.e., they must
 								consist of at least one non-whitespace character).</p>
-
 							<p>Whitespace within these element values are not significant. Sequences of one or more
 								whitespace characters are <a
 									href="https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace">collapsed
 									to a single space</a> [[Infra]] during processing .</p>
 						</section>
-
 						<section id="sec-opf-dcmes-required">
 							<h6>DCMES Required Elements</h6>
-
 							<section id="sec-opf-dcidentifier">
 								<h6>The <code>identifier</code> Element</h6>
-
 								<p>The [[DCTERMS]] <code>identifier</code> element contains an identifier such as a
 										<abbr title="Universally Unique Identifier">UUID</abbr>, <abbr
 										title="Digital Object Identfier">DOI</abbr> or <abbr
 										title="International Standard Book Number">ISBN</abbr>.</p>
-
 								<dl id="elemdef-opf-dcidentifier" class="elemdef">
 									<dt>Element Name</dt>
 									<dd>
@@ -1750,7 +1613,6 @@
 										<p>Text</p>
 									</dd>
 								</dl>
-
 								<p>The <a>EPUB Creator</a> MUST provide an identifier that is unique to one and only one
 										<a>EPUB Publication</a> &#8212; its <a>Unique Identifier</a> &#8212; in an
 										<code>identifier</code> element. This <code>identifier</code> element MUST
@@ -1758,7 +1620,6 @@
 										href="#elemdef-opf-package"><code>package</code> element's</a>
 									<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
 										attribute</a>.</p>
-
 								<aside class="example">
 									<p>The following example shows the unique <code>identifier</code> element.</p>
 									<pre>&lt;package … unique-identifier="pub-id"&gt;
@@ -1770,20 +1631,16 @@
     &lt;/metadata&gt;
 &lt;/package&gt;</pre>
 								</aside>
-
 								<p>Although not static, EPUB Creators should make changes to the Unique Identifier for
 									an EPUB Publication as infrequently as possible. Unique Identifiers should have
 									maximal persistence both for referencing and distribution purposes. EPUB Creators
 									should not issue new identifiers when making minor revisions such as updating
 									metadata, fixing errata, or making similar minor changes.</p>
-
 								<p>EPUB Creators MAY specify additional identifiers. The identifiers should be fully
 									qualified URIs.</p>
-
 								<p>EPUB Creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
 										property</a> to indicate that an <code>identifier</code> conforms to an
 									established system or an issuing authority granted it.</p>
-
 								<aside class="example">
 									<p>The following example shows an identifier additionally marked as a <a
 											href="https://doi.org">DOI</a> using the identifier-type property. Here, <a
@@ -1796,13 +1653,10 @@
 &lt;/metadata></pre>
 								</aside>
 							</section>
-
 							<section id="sec-opf-dctitle">
 								<h6>The <code>title</code> Element</h6>
-
 								<p>The [[DCTERMS]] <code>title</code> element represents an instance of a name for the
 										<a>EPUB Publication</a>.</p>
-
 								<dl id="elemdef-opf-dctitle" class="elemdef">
 									<dt>Element Name</dt>
 									<dd>
@@ -1855,10 +1709,8 @@
 										<p>Text</p>
 									</dd>
 								</dl>
-
 								<p>The <code>metadata</code> section MUST contain at least one <code>title</code>
 									element containing the title for the EPUB Publication.</p>
-
 								<aside class="example">
 									<p>The following example shows a basic title element.</p>
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
@@ -1867,22 +1719,17 @@
 &lt;/metadata&gt;
 </pre>
 								</aside>
-
 								<p id="title-order">The first <code>title</code> element in document order is the main
 									title of the EPUB Publication (i.e., the primary one Reading Systems present to
 									users).</p>
-
 								<p>EPUB Creators should use only a single <code>title</code> element to ensure
 									consistent rendering of the title in Reading Systems.</p>
-
 								<div class="note">
 									<p>Although it is possible to include more than one <code>title</code> element for
 										multipart titles, Reading System support for additional <code>title</code>
 										elements is inconsistent. Reading Systems may ignore the additional segments or
 										combine them in unexpected ways.</p>
-
 									<p>For example, the following example shows a basic multipart title:</p>
-
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:title&gt;THE LORD OF THE RINGS&lt;/dc:title&gt;
     &lt;dc:title&gt;Part One: The Fellowship of the Ring&lt;/dc:title&gt;
@@ -1891,7 +1738,6 @@
 </pre>
 									<p>The same title could instead be expressed using a single <code>dc:title</code>
 										element as follows:</p>
-
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     &lt;dc:title&gt;
         THE LORD OF THE RINGS, Part One: The Fellowship of the Ring
@@ -1899,7 +1745,6 @@
     …
 &lt;/metadata&gt;
 </pre>
-
 									<p>Previous versions of this specification recommended using the <a
 											href="#sec-property-title-type"><code>title-type</code></a> and <a
 											href="#sec-property-display-seq"><code>display-seq</code></a> properties to
@@ -1908,13 +1753,10 @@
 										add these semantics but they are also not well supported.</p>
 								</div>
 							</section>
-
 							<section id="sec-opf-dclanguage">
 								<h6>The <code>language</code> Element</h6>
-
 								<p>The [[DCTERMS]] <code>language</code> element specifies the language of the content
 									of the <a>EPUB Publication</a>.</p>
-
 								<dl id="elemdef-opf-dclanguage" class="elemdef">
 									<dt>Element Name</dt>
 									<dd>
@@ -1947,12 +1789,10 @@
 										<p>Text</p>
 									</dd>
 								</dl>
-
 								<p>The <code>metadata</code> section MUST contain at least one <code>language</code>
 									element. The <a>value</a> of each <code>language</code> element MUST be a <a
 										href="https://www.rfc-editor.org/rfc/rfc5646.html#section-2.2.9">well-formed
 										language tag</a> [[BCP47]].</p>
-
 								<aside class="example">
 									<p>The following example shows an <a>EPUB Publication</a> is in U.S. English.</p>
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
@@ -1962,12 +1802,10 @@
 &lt;/metadata&gt;
 </pre>
 								</aside>
-
 								<p>Although EPUB Creators MAY specify additional <code>language</code> elements for
 									multilingual Publications, Reading Systems will treat the first
 										<code>language</code> element in document order as the primary language of the
 									EPUB Publication.</p>
-
 								<div class="note">
 									<p><a>Publication Resources</a> do not inherit their language from the
 											<code>dc:language</code> element(s). EPUB Creators must set the language of
@@ -1975,19 +1813,15 @@
 								</div>
 							</section>
 						</section>
-
 						<section id="sec-opf-dcmes-optional">
 							<h6>DCMES Optional Elements</h6>
-
 							<section id="sec-opf-dcmes-optional-def">
 								<h6>General Definition</h6>
-
 								<p>All [[DCTERMS]] elements except for <a href="#sec-opf-dcidentifier"
 											><code>identifier</code></a>, <a href="#sec-opf-dclanguage"
 											><code>language</code></a>, and <a href="#sec-opf-dctitle"
 											><code>title</code></a> are designated as OPTIONAL. These elements conform
 									to the following generalized definition:</p>
-
 								<dl class="elemdef">
 									<dt>Element Name</dt>
 									<dd>
@@ -2038,31 +1872,24 @@
 										<p>Text</p>
 									</dd>
 								</dl>
-
 								<p>This specification does not modify the [[DCTERMS]] element definitions except as
 									noted in the following sections.</p>
 							</section>
-
 							<section id="sec-opf-dccontributor">
 								<h6>The <code>contributor</code> Element</h6>
-
 								<p>The [[DCTERMS]] <code>contributor</code> element is used to represent the name of a
 									person, organization, etc. that played a secondary role in the creation of the
 									content.</p>
-
 								<p>The requirements for the <code>contributor</code> element are identical to those for
 									the <a href="#sec-opf-dccreator"><code>creator</code> element</a> in all other
 									respects.</p>
 							</section>
-
 							<section id="sec-opf-dccreator">
 								<h6>The <code>creator</code> Element</h6>
-
 								<p>The [[DCTERMS]] <code>creator</code> element represents the name of a person,
 									organization, etc. responsible for the creation of the content. EPUB Creators can <a
 										href="#subexpression">associate</a> a <a href="#role"><code>role</code>
 										property</a> with the element to indicate the function the creator played.</p>
-
 								<aside class="example">
 									<p>The following example shows how to represent a creator as an author using a <a
 											href="http://id.loc.gov/vocabulary/relators.html">MARC relators</a>
@@ -2074,15 +1901,12 @@
     …
 &lt;/metadata></pre>
 								</aside>
-
 								<p>The <code>creator</code> element SHOULD contain the name of the creator as EPUB
 									Creators intend Reading Systems to display it to users.</p>
-
 								<p>EPUB Creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
 									<a href="#subexpression">to associate</a> a normalized form of the creator's name,
 									and the <a href="#alternate-script"><code>alternate-script</code> property</a> to
 									represent the creator's name in another language or script.</p>
-
 								<aside class="example">
 									<p>The following example shows creator metadata that facilitates sorting and
 										rendering.</p>
@@ -2095,14 +1919,11 @@
     …
 &lt;/metadata></pre>
 								</aside>
-
 								<p>If an EPUB Publication has more than one creator, EPUB Creators SHOULD specify each
 									in a separate <code>creator</code> element.</p>
-
 								<p>The document order of <code>creator</code> elements in the <code>metadata</code>
 									section determines the display priority, where the first <code>creator</code>
 									element encountered is the primary creator.</p>
-
 								<aside class="example">
 									<p>In the following example, Lewis Carroll, listed first, is the primary
 										creator.</p>
@@ -2114,23 +1935,18 @@
 &lt;/metadata&gt;
 </pre>
 								</aside>
-
 								<p>EPUB Creators SHOULD represent secondary contributors using the <a
 										href="#sec-opf-dccontributor"><code>contributor</code> element</a>.</p>
 							</section>
-
 							<section id="sec-opf-dcdate">
 								<h6>The <code>date</code> Element</h6>
-
 								<p>The [[DCTERMS]] <code>date</code> element MUST only be used to define the publication
 									date of the <a>EPUB Publication</a>. The publication date is not the same as the <a
 										href="#last-modified-date">last modified date</a> (the last time the EPUB
 									Creator changed the EPUB Publication).</p>
-
 								<p>It is RECOMMENDED that the date string conform to [[ISO8601]], particularly the
 									subset expressed in W3C Date and Time Formats [[DateTime]], as such strings are both
 									human and machine readable.</p>
-
 								<aside class="example">
 									<p>The following example shows a publication date.</p>
 									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
@@ -2140,58 +1956,44 @@
 &lt;/metadata&gt;
 </pre>
 								</aside>
-
 								<p>EPUB Creators SHOULD express additional dates using the specialized date properties
 									available in the [[DCTERMS]] vocabulary, or similar.</p>
-
 								<p>EPUB Publications MUST NOT contain more than one <code>date</code> element.</p>
 							</section>
-
 							<section id="sec-opf-dcsubject">
 								<h6>The <code>subject</code> Element</h6>
-
 								<p>The [[DCTERMS]] <code>subject</code> element identifies the subject of the EPUB
 									Publication. EPUB Creators SHOULD set the <a>value</a> of the element to the
 									human-readable heading or label, but MAY use a code value if the subject taxonomy
 									does not provide a separate descriptive label.</p>
-
 								<p>EPUB Creators MAY identify the system or scheme they drew the element's <a>value</a>
 									from using the <a href="#authority"><code>authority</code> property</a>.</p>
-
 								<p>When a scheme is identified, EPUB Creators MUST <a href="#subexpression"
 										>associate</a> a subject code using the <a href="#term"><code>term</code>
 										property</a>.</p>
-
 								<aside class="example">
 									<p>The following example shows a BISAC code and heading.</p>
 									<pre>&lt;dc:subject id="subject01"&gt;FICTION / Occult &amp;amp; Supernatural&lt;/dc:subject&gt;
 &lt;meta refines="#subject01" property="authority">BISAC&lt;/meta>
 &lt;meta refines="#subject01" property="term">FIC024000&lt;/meta></pre>
 								</aside>
-
 								<aside class="example">
 									<p>The following example shows the use of a URL for the scheme.</p>
 									<pre>&lt;dc:subject id="sbj01"&gt;Number Theory&lt;/dc:subject&gt;
 &lt;meta refines="#sbj01" property="authority">http://www.ams.org/msc/msc2010.html&lt;/meta>
 &lt;meta refines="#sbj01" property="term">11&lt;/meta></pre>
 								</aside>
-
 								<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
 											<code>subject</code> element</a> that does not specify a scheme.</p>
-
 								<p>The <a>values</a> of the <code>subject</code> element and <code>term</code> property
 									are case sensitive only when the designated scheme requires.</p>
 							</section>
-
 							<section id="sec-opf-dctype">
 								<h6>The <code>type</code> Element</h6>
-
 								<p>The [[DCTERMS]] <code>type</code> element is used to indicate that the EPUB
 									Publication is of a specialized type (e.g., annotations or a dictionary packaged in
 									EPUB format).</p>
-
 								<p>EPUB Creators MAY use any text string as a <a>value</a>.</p>
-
 								<div class="note">
 									<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB
 										3 Working Group maintained an <a
@@ -2202,12 +2004,9 @@
 								</div>
 							</section>
 						</section>
-
 						<section id="sec-meta-elem">
 							<h6>The <code>meta</code> Element</h6>
-
 							<p>The <code>meta</code> element provides a generic means of including package metadata.</p>
-
 							<dl id="elemdef-meta" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
@@ -2278,46 +2077,36 @@
 									<p>Text</p>
 								</dd>
 							</dl>
-
 							<p id="attrdef-meta-property">Each <code>meta</code> element defines a metadata expression.
 								The <code>property</code> attribute takes a <a href="#sec-property-datatype"
 										><var>property</var> data type value</a> that defines the statement made in the
 								expression, and the text content of the element represents the assertion. (Refer to <a
 									href="#sec-vocab-assoc"></a> for more information.)</p>
-
 							<p>This specification defines two types of metadata expressions that EPUB Creators can
 								define using the <code>meta</code> element:</p>
-
 							<ul>
 								<li id="primary-expression">A <em>primary expression</em> is one in which the expression
 									defined in the <code>meta</code> element establishes some aspect of the <a>EPUB
 										Publication</a>. A <code>meta</code> element that omits a refines attribute
 									defines a primary expression.</li>
-
 								<li id="subexpression">A <em>subexpression</em> is one in which the expression defined
 									in the <code>meta</code> element is associated with another expression or resource
 									using the <code>refines</code> attribute to enhance its meaning. A subexpression
 									might refine a media clip, for example, by expressing its duration, or refine a
 									creator or contributor expression by defining the role of the person.</li>
 							</ul>
-
 							<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions,
 								thereby creating chains of information.</p>
-
 							<p class="note">All the DCMES [[DCTERMS]] elements represent primary expressions, and permit
 								refinement by meta element subexpressions.</p>
-
 							<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a
 									href="#sec-default-vocab">default vocabulary</a> for use with the
 									<code>property</code> attribute.</p>
-
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
 									href="#sec-vocab-assoc"></a>.</p>
-
 							<aside class="example">
 								<p>The following example shows various property declarations using <a
 										href="#sec-reserved-prefixes">reserved prefixes</a>.</p>
-
 								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
     …
     &lt;meta property="dcterms:modified"&gt;2016-02-29T12:34:56Z&lt;/meta&gt;
@@ -2327,30 +2116,24 @@
 &lt;/metadata&gt;
 </pre>
 							</aside>
-
 							<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme the
 								EPUB Creator obtained the element's <a>value</a> from. The value of the attribute MUST
 								be a <a href="#sec-property-datatype"><var>property</var> data type value</a> that
 								resolves to the resource that defines the scheme.</p>
-
 							<aside class="example">
 								<p>The following example shows a <code>scheme</code> attribute that indicates [[ONIX]]
 									code list 5 is the source of the <a>value</a> of the <code>meta</code> tag.</p>
 								<pre>&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta></pre>
 							</aside>
 						</section>
-
 						<section id="sec-metadata-last-modified">
 							<h5>Last Modified Date</h5>
-
 							<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one
 								[[DCTERMS]] <code>modified</code> property containing the last modification date. The
 									<a>value</a> of this property MUST be an [[XMLSCHEMA-2]] dateTime conformant date of
 								the form: <code>CCYY-MM-DDThh:mm:ssZ</code></p>
-
 							<p>EPUB Creators MUST express the last modification date in Coordinated Universal Time (UTC)
 								and MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>
-
 							<aside class="example">
 								<p>The following example shows a last modification date.</p>
 								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
@@ -2359,14 +2142,11 @@
     …
 &lt;/metadata&gt;</pre>
 							</aside>
-
 							<p>EPUB Creators should update the last modified date whenever they make changes to the EPUB
 								Publication.</p>
-
 							<p>EPUB Creators MAY specify additional modified properties in the Package Document
 								metadata, but they MUST have a different subject (i.e., they require a
 									<code>refines</code> attribute that references an element or resource).</p>
-
 							<div class="note">
 								<p>The requirements for the last modification date are to ensure compatibility with
 									earlier versions of EPUB 3 that defined a <a
@@ -2374,13 +2154,10 @@
 										>release identifier</a> [[EPUBPackages-32]] for EPUB Publications.</p>
 							</div>
 						</section>
-
 						<section id="sec-link-elem">
 							<h6>The <code>link</code> Element</h6>
-
 							<p>The <code>link</code> element associates resources with an <a>EPUB Publication</a>, such
 								as metadata records.</p>
-
 							<dl id="elemdef-opf-link" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
@@ -2459,14 +2236,11 @@
 									<p>Empty</p>
 								</dd>
 							</dl>
-
 							<p>The <a href="#sec-metadata-elem"><code>metadata</code> element</a> MAY contain zero or
 								more <code>link</code> elements, each of which identifies the location of a linked
 								resource in its REQUIRED <code>href</code> attribute</p>
-
 							<p id="linked-res-manifest">Linked Resources are <a>Publication Resources</a> only when they
 								are:</p>
-
 							<ul>
 								<li>
 									<p>referenced from the <a href="#sec-spine-elem">spine</a>; or</p>
@@ -2479,12 +2253,10 @@
 												><code>script</code> element</a>).</p>
 								</li>
 							</ul>
-
 							<p>In all other cases (e.g., when linking to standalone [[?ONIX]] or [[?XMP]] records), the
 								linked resources are not Publication Resources (i.e., are not subject to <a
 									href="#sec-core-media-types">Core Media Type requirements</a>) and EPUB Creators
 								MUST NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
-
 							<aside class="example">
 								<p>The following example shows a reference to a metadata record embedded in a
 										<code>script</code> element inside an <a>XHTML Content Document</a>. Note that
@@ -2515,26 +2287,21 @@
     &lt;/body&gt;
 &lt;/html&gt;</pre>
 							</aside>
-
 							<p id="linked-res-location">EPUB Creators MAY locate linked resources <a
 									data-lt="Local Resource">locally</a> or <a data-lt="Remote Resource">remotely</a>,
 								but should consider that <a>Reading Systems</a> are not required to retrieve to Remote
 								Resources (i.e., Reading Systems might not make Remote Resources available).</p>
-
 							<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
 									attribute</a> is OPTIONAL when a linked resource is located outside the EPUB
 								Container, as more than one media type could be served from the same URL [[URL]]. EPUB
 								Creators MUST specify the attribute for all <a>Local Resources</a>.</p>
-
 							<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the
 								language of the linked resource. The value MUST be a <a
 									href="https://www.rfc-editor.org/rfc/rfc5646.html#section-2.2.9">well-formed
 									language tag</a> [[BCP47]].</p>
-
 							<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated
 								list of <a href="#sec-property-datatype">property</a> values that establish the
 								relationship the resource has with the EPUB Publication.</p>
-
 							<aside class="example">
 								<p>The following example shows the <code>link</code> element used to associate a local
 									MARC XML record.</p>
@@ -2542,13 +2309,11 @@
       href="meta/9780000000001.xml" 
       media-type="application/marc"/&gt;</pre>
 							</aside>
-
 							<p>The value of the <code>media-type</code> attribute is not always sufficient to identify
 								the type of linked resource (e.g., many XML-based record formats use the media type
 									"<code>application/xml</code>"). To aid Reading Systems in the identification of
 								such generic resources, the <code>properties</code> attribute can specify a semantic
 								identifier.</p>
-
 							<aside class="example">
 								<p>The following example shows the <code>properties</code> attribute used to identify a
 									remote XMP record.</p>
@@ -2557,14 +2322,11 @@
       media-type="application/xml"
       properties="xmp"/&gt;</pre>
 							</aside>
-
 							<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a
 									href="#sec-default-vocab">default vocabulary</a> for the <code>rel</code> and
 									<code>properties</code> attributes.</p>
-
 							<p><a>EPUB Creators</a> MAY add relationships and properties from other vocabularies as
 								defined in <a href="#sec-vocab-assoc"></a>.</p>
-
 							<aside class="example">
 								<p>The following example shows the <code>link</code> element used to associate an
 									informational web page. Note that as <code>foaf</code> is not a <a
@@ -2581,16 +2343,13 @@
 &lt;/package&gt;
 </pre>
 							</aside>
-
 							<p id="sec-linked-records">EPUB Creators MAY provide one or more <a href="#record">linked
 									metadata records</a> to enhance the information available to Reading Systems, but
 								Reading Systems may ignore these records.</p>
-
 							<p>When a Reading System <a href="https://www.w3.org/TR/epub-rs-33/#sec-linked-records"
 									>processes linked records</a> [[EPUB-RS-33]], the document order of
 									<code>link</code> elements is used to determine which has the highest priority in
 								the case of conflicts (i.e., first in document order has the highest priority).</p>
-
 							<aside class="example">
 								<p>The following example shows a remote record that has higher precedence than a local
 									record, which in turn has higher precedence than the metadata found in the
@@ -2608,17 +2367,14 @@
     …
 &lt;/metadata&gt;</pre>
 							</aside>
-
 							<div class="note">
 								<p>Due to the variety of metadata record formats and serializations that an EPUB Creator
 									can link to an EPUB Publication, and the complexity of comparing metadata properties
 									between them, this specification does not require Reading Systems to process linked
 									records.</p>
 							</div>
-
 							<p>In addition to full records, EPUB Creators MAY also use the <code>link</code> element to
 								identify individual metadata properties available in an alternative format.</p>
-
 							<aside class="example">
 								<p>The following example shows a link to an embedded [[HTML]] description of the EPUB
 									Publication.</p>
@@ -2628,16 +2384,12 @@
 							</aside>
 						</section>
 					</section>
-
 					<section id="sec-pkg-manifest">
 						<h5>Manifest Section</h5>
-
 						<section id="sec-manifest-elem">
 							<h6>The <code>manifest</code> Element</h6>
-
 							<p>The <code>manifest</code> element provides an exhaustive list of <a>Publication
 									Resources</a> used in the rendering of the content.</p>
-
 							<dl id="elemdef-opf-manifest" class="elemdef">
 								<dt>Element name</dt>
 								<dd>
@@ -2670,21 +2422,17 @@
 									</p>
 								</dd>
 							</dl>
-
 							<p id="confreq-rendition-manifest">EPUB Creators MUST list all <a>Publication Resources</a>
 								in the <code>manifest</code>, regardless of whether they are <a data-lt="Local Resource"
 									>Local</a> or <a>Remote Resources</a>, using <a class="codelink"
 									href="#sec-item-elem"><code>item</code> elements</a>.</p>
-
 							<p>Note that the <code>manifest</code> is not self-referencing: EPUB Creators MUST NOT
 								specify an <code>item</code> element that refers to the Package Document itself.</p>
-
 							<div class="note">
 								<p>Failure to provide a complete manifest of resources may lead to rendering issues.
 									Reading Systems might not unzip such resources or could prevent access to them for
 									security reasons.</p>
 							</div>
-
 							<div class="note">
 								<p>This specification supports internationalized resource naming, so elements and
 									attributes that reference Publication Resources accept URLs [[URL]] as their value.
@@ -2692,12 +2440,9 @@
 									should restrict resource names to the ASCII character set.</p>
 							</div>
 						</section>
-
 						<section id="sec-item-elem">
 							<h6>The <code>item</code> Element</h6>
-
 							<p>The <code>item</code> element represents a <a>Publication Resource</a>.</p>
-
 							<dl id="elemdef-package-item" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
@@ -2768,7 +2513,6 @@
 									<p>Empty</p>
 								</dd>
 							</dl>
-
 							<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL
 								[[URL]] in its <code>href</code> attribute. EPUB Creators MAY use <a
 									href="https://url.spec.whatwg.org/#absolute-url-string">absolute-</a> or <a
@@ -2776,65 +2520,52 @@
 								[[URL]], but they MUST ensure each URL is unique within the <code>manifest</code> scope
 								after <a href="https://www.w3.org/TR/epub-rs-33/#sec-pkg-doc-relative-urls">resolution
 									to an absolute URL</a> [[EPUB-RS-33]].</p>
-
 							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
 								element MUST conform to the applicable specification(s) as inferred from the MIME media
 								type provided in the <a href="#attrdef-media-type"><code>media-type</code>
 								attribute</a>. For <a>Core Media Type Resources</a>, EPUB Creators MUST use the media
 								type designated in <a href="#sec-cmt-supported"></a>.</p>
-
 							<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[XML]]
 								that identifies a fallback for the Publication Resource referenced from the
 									<code>item</code> element, as defined in <a
 									href="#sec-foreign-restrictions-manifest"></a>.</p>
-
 							<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
 									Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
 									<code>properties</code> attribute.</p>
-
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
 									href="#sec-vocab-assoc"></a>.</p>
-
 							<p>EPUB Creators MUST declare all applicable descriptive metadata properties for each
 								Publication Resource in this attribute (e.g., if the resource is the <a
 									href="#sec-cover-image">cover image</a>, contains <a href="#sec-scripted"
 									>scripting</a>, or references <a href="#sec-remote-resources">remote
 								resources</a>).</p>
-
 							<p>EPUB Creators MUST declare exactly one <code>item</code> as the <a>EPUB Navigation
 									Document</a> using the <code>nav</code> property.</p>
-
 							<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF
 								[[XML]] that identifies the <a>Media Overlay Document</a> for the resource described by
 								this <code>item</code>. Refer to <a href="#sec-docs-package"></a> for more
 								information.</p>
-
 							<div class="note">
 								<p>The order of <code>item</code> elements in the <code>manifest</code> is not
 									significant. The <a class="codelink" href="#sec-spine-elem"><code>spine</code>
 										element</a> provides the presentation sequence of content documents.</p>
 							</div>
-
 							<section id="sec-foreign-restrictions-manifest">
 								<h6>Manifest Fallbacks</h6>
-
 								<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback
 									chains to Core Media Type Resources. They are used to create fallbacks for Foreign
 									Resources in the <a href="#sec-spine-elem">spine</a> and when intrinsic fallback
 									capabilities are not available (e.g., for the [[HTML]] <a
 										href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"
 											><code>img</code></a> element).</p>
-
 								<p>EPUB Creators MAY reference Foreign Resources in contexts in which an intrinsic
 									fallback cannot be provided (e.g., directly from <a>spine</a>
 									<a href="#elemdef-spine-itemref"><code>itemref</code> elements</a>; from [[HTML]]
 										<code>img</code>, <code>iframe</code> and <code>link</code> elements in <a>XHTML
 										Content Documents</a>; and from <code>@import</code> rules in CSS Style Sheets).
 									EPUB Creators MUST provide manifest fallbacks in such cases.</p>
-
 								<p>EPUB Creators MAY also provide fallbacks for <a>Core Media Type Resources</a> (e.g.,
 									to provide a static alternative to a <a>Scripted Content Document</a>).</p>
-
 								<p>The <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> on the
 										<a>manifest</a>
 									<a href="#elemdef-package-item"><code>item</code></a> element specifies the fallback
@@ -2842,15 +2573,12 @@
 									[[XML]] value MUST resolve to another <code>item</code> in the
 									<code>manifest</code>. This fallback <code>item</code> MAY itself specify another
 									fallback <code>item</code>, and so on.</p>
-
 								<p>The ordered list of all the ID references that a Reading System can reach, starting
 									from a given item's <code>fallback</code> attribute, represents the <em>fallback
 										chain</em> for that item. The order of the resources in the fallback chain
 									represents the EPUB Creator's preferred fallback order.</p>
-
 								<p>Fallback chains MUST conform to one of the following requirements, as
 									appropriate:</p>
-
 								<ul>
 									<li>
 										<p>For Foreign Resources referenced directly from spine <a
@@ -2863,14 +2591,11 @@
 												Resource</a>.</p>
 									</li>
 								</ul>
-
 								<p>Fallback chains MUST NOT contain circular or self-references to <code>item</code>
 									elements in the chain.</p>
-
 								<p>EPUB Creators MAY provide fallbacks for <a>Top-Level Content Documents</a> that are
 									EPUB Content Documents (e.g., to provide <a href="#confreq-cd-scripted-flbk"
 										>fallbacks for scripted content</a>).</p>
-
 								<div class="note">
 									<p>As it is not possible to use manifest fallbacks for resources represented in <a
 											href="#sec-data-urls">data URLs</a>, EPUB Creators can only represent
@@ -2878,161 +2603,199 @@
 										available.</p>
 								</div>
 							</section>
-
 							<section id="sec-item-elem-examples">
 								<h6>Examples</h6>
-
 								<aside class="example" id="example-manifest-cmt">
-
 									<p>The following example shows a <code>manifest</code> that contains only <a>Core
 											Media Type Resources</a>.</p>
-									<pre>&lt;manifest&gt;
-    &lt;item id="nav" 
+									<pre>&lt;package &#8230;>
+   &#8230;
+   &lt;manifest&gt;
+      &lt;item id="nav" 
           href="nav.xhtml" 
           properties="nav"
           media-type="application/xhtml+xml"/&gt;
-    &lt;item id="intro" 
+      &lt;item id="intro" 
           href="intro.xhtml" 
           media-type="application/xhtml+xml"/&gt;
-    &lt;item id="c1" 
+      &lt;item id="c1" 
           href="chap1.xhtml" 
           media-type="application/xhtml+xml"/&gt;
-    &lt;item id="c1-answerkey" 
+      &lt;item id="c1-answerkey" 
           href="chap1-answerkey.xhtml" 
           media-type="application/xhtml+xml"/&gt;
-    &lt;item id="c2" 
+      &lt;item id="c2" 
           href="chap2.xhtml" 
           media-type="application/xhtml+xml"/&gt;
-    &lt;item id="c2-answerkey" 
+      &lt;item id="c2-answerkey" 
           href="chap2-answerkey.xhtml" 
           media-type="application/xhtml+xml"/&gt;
-    &lt;item id="c3" 
+      &lt;item id="c3" 
           href="chap3.xhtml" 
           media-type="application/xhtml+xml"/&gt;
-    &lt;item id="c3-answerkey" 
+      &lt;item id="c3-answerkey" 
           href="chap3-answerkey.xhtml" 
           media-type="application/xhtml+xml"/&gt;    
-    &lt;item id="notes" 
+      &lt;item id="notes" 
           href="notes.xhtml" 
           media-type="application/xhtml+xml"/&gt;
-    &lt;item id="cover" 
+      &lt;item id="cover" 
           href="./images/cover.svg" 
           properties="cover-image"
           media-type="image/svg+xml"/&gt;
-    &lt;item id="f1" 
+      &lt;item id="f1" 
           href="./images/fig1.jpg" 
           media-type="image/jpeg"/&gt;
-    &lt;item id="f2" 
+      &lt;item id="f2" 
           href="./images/fig2.jpg" 
           media-type="image/jpeg"/&gt;
-    &lt;item id="css" 
+      &lt;item id="css" 
           href="./style/book.css" 
           media-type="text/css"/&gt;   
-&lt;/manifest&gt;
-</pre>
+   &lt;/manifest&gt;
+   &#8230;
+&lt;/package></pre>
 								</aside>
-
 								<aside class="example" id="example-manifest-flbk"
 									title="Foreign Resource with Fallback in Spine">
 									<p>The following example shows the <a href="#sec-foreign-restrictions-manifest"
 											>fallback chain mechanism</a> allowing a <a>Foreign Resource</a> (JPEG) to
 										be listed in the spine with fallback to an SVG Content Document.</p>
-									<pre>Spine:
-&lt;itemref idref="page-001"/&gt;
+									<pre>&lt;package &#8230;>
+   &#8230;
+   &lt;manifest>
+      &#8230;
+      &lt;item id="page-001"
+          href="images/page-001.jpg"
+          media-type="image/jpeg"
+          fallback="#page-001-svg"/&gt;
 
-Manifest:
-&lt;manifest&gt;
-   &lt;item id="page-001"
-      href="images/page-001.jpg"
-      media-type="image/jpeg"
-      fallback="#page-001-svg"/&gt;
-
-   &lt;item id="page-001-svg"
-      href="images/page-001.svg"
-      media-type="image/svg+xml"/&gt;
+      &lt;item id="page-001-svg"
+          href="images/page-001.svg"
+          media-type="image/svg+xml"/&gt;
       … 
-&lt;/manifest&gt;
-</pre>
+      &#8230;
+   &lt;/manifest>
+   &lt;spine>
+      &#8230;
+      &lt;itemref idref="page-001"/&gt;
+      &#8230;
+   &lt;/spine>
+&lt;/package></pre>
 								</aside>
-
 								<aside class="example" title="Foreign Resource with Fallback">
 									<p>The following example shows a hyperlink to a JPEG that will render as a
 											<a>Top-Level Content Document</a>. As a result, EPUB Creators must list the
 										JPEG as a non-linear item in the <a href="#sec-spine-elem">spine</a>
 										<em>and</em> specify a fallback to an EPUB Content Document in its manifest
-										declaration (in this case, an SVG).</p>
+										declaration (in this case, an SVG). If the image were only used in the
+											<code>img</code> tag, a spine entry would not be needed.</p>
 									<pre>XHTML:
-&lt;img src="images/infographic.jpg" alt="&#8230;" />
-&lt;a href="images/infographic.jpg"&gt;Expand Image&lt;/a&gt;
+&lt;html &#8230;>
+   &#8230;
+   &lt;body>
+      &#8230;
+      &lt;img src="images/infographic.jpg" alt="&#8230;" 
+      &lt;a href="images/infographic.jpg"&gt;Expand Image&lt;/a&gt;
+      &#8230;
+   &lt;/body>
+&lt;/html>
 
-Spine:
-&lt;itemref idref="img01" linear="no"/&gt;
+Package Document:
+&lt;package &#8230;>
+   &#8230;
+   &lt;manifest>
+      &#8230;
+      &lt;item id="img01"
+          href="images/infographic.jpg"
+          media-type="image/jpeg"
+          fallback="#infographic-svg"/&gt;
 
-Manifest:
-&lt;item id="img01"
-      href="images/infographic.jpg"
-      media-type="image/jpeg"
-      fallback="#infographic-svg"/&gt;
-
-&lt;item id="infographic-svg"
-      href="images/infographic.svg"
-      media-type="image/svg+xml"/&gt;</pre>
+      &lt;item id="infographic-svg"
+          href="images/infographic.svg"
+          media-type="image/svg+xml"/&gt;
+      &#8230;
+   &lt;/manifest>
+   &lt;spine>
+      &#8230;
+      &lt;itemref idref="img01" linear="no"/&gt;
+      &#8230;
+   &lt;/spine>
+&lt;/package></pre>
 								</aside>
-
 								<aside class="example" title="Remote Resources that are Publication Resources">
 									<p>The following example shows a reference to a remote audio file. Because the
 											<code>audio</code> element embeds the audio in its EPUB Content Document,
 										the file is considered a Publication Resource. EPUB Creators therefore must list
-										the audio file in the manifest and indicate that its parent EPUB Content Document
-										contains a remote resource.</p>
+										the audio file in the manifest and indicate that its parent EPUB Content
+										Document contains a remote resource.</p>
 									<pre>XHTML:
-&lt;audio src="http://www.example.com/book/audio/ch01.mp4" controls="controls"/&gt;
+&lt;html &#8230;>
+   &#8230;
+   &lt;body>
+      &#8230;
+      &lt;audio
+          src="http://www.example.com/book/audio/ch01.mp4"
+          controls="controls"/&gt;
+      &#8230;
+   &lt;/body>
+&lt;/html>
 
 Manifest:
-&lt;item id="audio01"
-      href="http://www.example.com/book/audio/ch01.mp4"
-      media-type="audio/mp4"/&gt;
-
-&lt;item id="c01"
-      href="XHTML/chapter001.xhtml"
-      media-type="application/xhtml+xml"
-      properties="remote-resources"/&gt;</pre>
+&lt;package &#8230;>
+   &#8230;
+   &lt;manifest>
+      &#8230;
+      &lt;item id="audio01"
+          href="http://www.example.com/book/audio/ch01.mp4"
+          media-type="audio/mp4"/&gt;
+   
+      &lt;item id="c01"
+          href="XHTML/chapter001.xhtml"
+          media-type="application/xhtml+xml"
+          properties="remote-resources"/&gt;
+      &#8230;
+   &lt;/manifest>
+   &#8230;
+&lt;/package></pre>
 								</aside>
-
 								<aside class="example" title="External Resources that are not Publication Resources">
 									<p>The following example shows a hyperlink to an audio file hosted on the web.
 										Reading Systems will open such external content in a new browser window; it is
 										not rendered within the publication. In this case, EPUB Creators do not list the
 										file in the manifest because it is not a Publication Resource.</p>
 									<pre>XHTML:
-&lt;a href="http://www.example.com/book/audio/ch01.mp4"&gt;Go to audio file&lt;/a&gt;
+&lt;html &#8230;>
+   &#8230;
+   &lt;body>
+      &#8230;
+      &lt;a
+          href="http://www.example.com/book/audio/ch01.mp4"&gt;
+         Listen to audio
+      &lt;/a&gt;
+      &#8230;
+   &lt;/body>
+&lt;/html>
 
 Manifest:
 No Entry</pre>
 								</aside>
 							</section>
 						</section>
-
 						<section id="sec-opf-bindings">
 							<h6>The <code>bindings</code> Element (Deprecated)</h6>
-
 							<p>The <code>bindings</code> element defines a set of custom handlers for media types not
 								supported by this specification. Its use is <a href="#deprecated">deprecated</a>.</p>
-
 							<p>Refer to [[EPUBPublications-301]] for more information about this element.</p>
 						</section>
 					</section>
-
 					<section id="sec-pkg-spine">
 						<h5>Spine Section</h5>
-
 						<section id="sec-spine-elem">
 							<h6>The <code>spine</code> Element</h6>
-
 							<p>The <code>spine</code> element defines an ordered list of <a href="#sec-itemref-elem"
 									>manifest <code>item</code> references</a> that represent the default reading
 								order.</p>
-
 							<dl id="elemdef-opf-spine" class="elemdef">
 								<dt>Element name</dt>
 								<dd>
@@ -3086,10 +2849,8 @@ No Entry</pre>
 									</p>
 								</dd>
 							</dl>
-
 							<p id="confreq-pub-resource">The <code>spine</code> MUST specify at least one <a>Publication
 									Resource</a>.</p>
-
 							<p id="spine-inclusion-req">EPUB Creators MUST list in the <code>spine</code> all
 								Publication Resources that are hyperlinked to from Publication Resources in the
 									<code>spine</code>, where hyperlinking encompasses any linking mechanism that
@@ -3102,46 +2863,37 @@ No Entry</pre>
 								and/or form elements). The requirement to list hyperlinked resources applies recursively
 								(i.e., EPUB Creators must list all Publication Resources hyperlinked from hyperlinked
 								Publication Resources, and so on.).</p>
-
 							<p>EPUB Creators also MUST list in the <code>spine</code> all Publication Resources
 								hyperlinked to from the <a>EPUB Navigation Document</a>, regardless of whether EPUB
 								Creators include the Navigation Document in the <code>spine</code>.</p>
-
 							<div class="note">
 								<p>As <a>Remote Resources</a> referenced from hyperlinks are not Publication Resources,
 									they are not subject to the requirement to include in the spine (e.g., Web pages and
 									resources).</p>
 							</div>
-
 							<p>Embedded Publication Resources (e.g., via the [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element"
 										><code>iframe</code></a> element) must not be listed in the
 								<code>spine</code>.</p>
-
 							<p id="attrdef-spine-page-progression-direction">The <code>page-progression-direction</code>
 								attribute sets the global direction in which the content flows. Allowed values are
 									<code>ltr</code> (left-to-right), <code>rtl</code> (right-to-left) and
 									<code>default</code>. When EPUB Creators specify the <code>default</code> value,
 								they are expressing no preference and the Reading System can choose the rendering
 								direction.</p>
-
 							<p>Although the <code>page-progression-direction</code> attribute sets the global flow
 								direction, individual Content Documents and parts of Content Documents MAY override this
 								setting (e.g., via the <code>writing-mode</code> CSS property). Reading Systems can also
 								provide mechanisms to override the default direction (e.g., buttons or settings that
 								allow the application of alternate style sheets).</p>
-
 							<p>The <a href="#legacy">legacy</a>
 								<code>toc</code> attribute takes an IDREF [[XML]] that identifies the manifest item that
 								represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
 						</section>
-
 						<section id="sec-itemref-elem">
 							<h6>The <code>itemref</code> Element</h6>
-
 							<p>The <code>itemref</code> element identifies a <a>Publication Resource</a> in the default
 								reading order.</p>
-
 							<dl id="elemdef-spine-itemref" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
@@ -3196,65 +2948,52 @@ No Entry</pre>
 									<p>Empty</p>
 								</dd>
 							</dl>
-
 							<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an <a
 									href="#elemdef-package-item"><code>item</code></a> in the <a>manifest</a> via the
 								IDREF [[XML]] in its <code>idref</code> attribute, and item IDs MUST NOT be referenced
 								more than once. </p>
-
 							<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a)
 								an <a>EPUB Content Document</a> or b) another type of <a>Publication Resource</a> which,
 									<em>regardless of whether it is a <a>Core Media Type Resource</a> or a <a>Foreign
 										Resource</a></em>, MUST include an EPUB Content Document in its <a
 									href="#sec-foreign-restrictions-manifest">fallback chain</a>.</p>
-
 							<div class="note">
 								<p>Although EPUB Publications <a href="#confreq-nav">require an EPUB Navigation
 										Document</a>, it is not mandatory to include it in the <code>spine</code>.</p>
 							</div>
-
 							<p id="attrdef-itemref-linear">The <code>linear</code> attribute indicates whether the
 								referenced <code>item</code> contains content that contributes to the primary reading
 								order and that Reading Systems must read sequentially ("<code>yes</code>"), or auxiliary
 								content that enhances or augments the primary content that Reading Systems can access
 								out of sequence ("<code>no</code>"). Examples of auxiliary content include notes,
 								descriptions, and answer keys.</p>
-
 							<p>The <code>linear</code> attribute allows Reading Systems to distinguish content that a
 								user should access as part of the default reading order from supplementary content which
 								a Reading System might, for example, present in a popup window or omit from an aural
 								rendering.</p>
-
 							<p>Specifying that content is non-linear does not require Reading Systems to present it in a
 								specific way, however; it is only a hint to the purpose. Reading Systems may present
 								non-linear content where it occurs in the spine, for example, or may skip it until users
 								reach the end of the spine.</p>
-
 							<div class="note">
 								<p>EPUB Creators should list non-linear content at the end of the spine except when it
 									makes sense for users to encounter it between linear spine items.</p>
 							</div>
-
 							<p id="linear-itemrefs">The <a>spine</a> MUST contain at least one linear
 									<code>itemref</code> element &#8212; whose <code>linear</code> attribute value is
 								either explicitly or implicitly set to "<code>yes</code>". Reading Systems will assume
 								the value "<code>yes</code>" for <code>itemref</code> elements without a
 									<code>linear</code> attribute.</p>
-
 							<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide
 								a means of accessing all non-linear content (e.g., hyperlinks in the content or from the
 									<a href="#sec-nav">EPUB Navigation Document</a>).</p>
-
 							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
 									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>
 								for the <code>properties</code> attribute.</p>
-
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
 									href="#sec-vocab-assoc"></a>.</p>
-
 							<section id="sec-itemref-elem-examples">
 								<h6>Examples</h6>
-
 								<aside class="example">
 									<p>The following example shows a <code>spine</code> element corresponding to <a
 											href="#example-manifest-cmt">the manifest example above</a>.</p>
@@ -3273,15 +3012,11 @@ No Entry</pre>
 							</section>
 						</section>
 					</section>
-
 					<section id="sec-pkg-collections">
 						<h5>Collections</h5>
-
 						<section id="sec-collection-elem">
 							<h6>The <code>collection</code> Element</h6>
-
 							<p>The <code>collection</code> element defines a related group of resources.</p>
-
 							<dl id="elemdef-collection" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
@@ -3342,32 +3077,27 @@ No Entry</pre>
 										<code>[1 or more]</code> ))</p>
 								</dd>
 							</dl>
-
 							<p>The <code>collection</code> element allows EPUB Creators to assemble resources into
 								logical groups for a variety of potential uses: enabling reassembly into a meaningful
 								unit of content split across multiple <a>EPUB Content Documents</a> (e.g., an index
 								split across multiple documents), identifying resources for specialized purposes (e.g.,
 								preview content), or collecting together resources that present additional information
 								about the <a>EPUB Publication</a>.</p>
-
 							<p>The <code>collection</code> element, as defined in this section, represents a generic
 								framework from which specializations are intended to be derived (e.g., through EPUB
 								sub-specifications). Such specializations MUST define the purpose of the
 									<code>collection</code> element, as well as all requirements for its valid
 								production and use (specifically any requirements that differ from the general framework
 								presented below).</p>
-
 							<p id="attrdef-collection-role">Each specialization MUST define a role value that uniquely
 								identifies all conformant <code>collection</code> elements. EPUB Creators MUST identify
 								the role of each <code>collection</code> element in its <code>role</code> attribute,
 								whose value MUST be one or more NMTOKENs [[XMLSCHEMA-2]] and/or <a
 									href="https://url.spec.whatwg.org/#absolute-url-with-fragment-string"
 									>absolute-URL-with-fragment strings</a> [[URL]].</p>
-
 							<p>This specification reserves the use of NMTOKEN values for roles defined in EPUB
 								specifications. NMTOKEN values not defined by a recognized specification are not valid.
 								This section does not define any roles.</p>
-
 							<p>Third parties MAY define custom roles for the <code>collection</code> element, but they
 								MUST identify such roles using <a
 									href="https://url.spec.whatwg.org/#absolute-url-with-fragment-string"
@@ -3375,8 +3105,6 @@ No Entry</pre>
 								the string "<code>idpf.org</code>" in the <a
 									href="https://url.spec.whatwg.org/#concept-host">host component</a> [[URL]] of their
 								identifying URL.</p>
-
-
 							<div class="note">
 								<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
 									Working Group maintained both a <a href="http://www.idpf.org/epub/registries/roles"
@@ -3385,12 +3113,10 @@ No Entry</pre>
 									This Working Group no longer maintains these registries and does not anticipate
 									defining new types of collections.</p>
 							</div>
-
 							<p id="elemdef-collection-metadata">The OPTIONAL <code>metadata</code> element child of
 									<code>collection</code> is an adaptation of the package <a
 									href="#elemdef-opf-metadata"><code>metadata</code> element</a>, with the following
 								differences in syntax and semantics:</p>
-
 							<ul>
 								<li>
 									<p>No metadata is mandatory by default.</p>
@@ -3408,18 +3134,14 @@ No Entry</pre>
 												<code>meta</code> elements</a>.</p>
 								</li>
 							</ul>
-
 							<p>EPUB specifications that implement collections MAY override package-level restrictions on
 								the use of metadata elements.</p>
-
 							<p>A <code>collection</code> MAY define sub-collections through the inclusion of one or more
 								child <code>collection</code> elements.</p>
-
 							<p id="elemdef-collection-link">The <code>link</code> element child of
 									<code>collection</code> is an adaptation of the metadata <a href="#elemdef-opf-link"
 										><code>link</code> element</a>, with the following differences in syntax and
 								semantics:</p>
-
 							<ul>
 								<li>
 									<p>The <code>rel</code> attribute is OPTIONAL.</p>
@@ -3434,10 +3156,8 @@ No Entry</pre>
 									<p>EPUB Creators MUST NOT specify the <code>refines</code> attribute.</p>
 								</li>
 							</ul>
-
 							<p>Each <code>link</code> element MUST reference a resource that is a member of the group.
 								The order of <code>link</code> elements is not significant.</p>
-
 							<p>Specializations of the <code>collection</code> element MAY tailor the requirements
 								defined above to better reflect their needs (e.g., requiring metadata, imposing further
 								restrictions on the use of elements and attributes, or making the order of
@@ -3447,11 +3167,9 @@ No Entry</pre>
 								above). Specializations MUST NOT define collections in a way that overrides the
 								requirements of the <a href="#elemdef-opf-manifest"><code>manifest</code></a> and <a
 									href="#elemdef-opf-spine"><code>spine</code></a>.</p>
-
 							<p>The rendering of an EPUB Publication MUST NOT be dependent on the recognition of
 									<code>collection</code> elements. The content MUST remain consumable by a user
 								without any information loss or other significant deterioration.</p>
-
 							<aside class="example" id="example-collection">
 								<p>The following example shows the assembly of two <a>XHTML Content Documents</a> that
 									represent a single unit.</p>
@@ -3467,26 +3185,19 @@ No Entry</pre>
     …
 &lt;/package&gt;</pre>
 							</aside>
-
 						</section>
-
 					</section>
-
 					<section id="sec-pkg-legacy">
 						<h5>Legacy Content</h5>
-
 						<section id="sec-opf2-meta">
 							<h6>The <code>meta</code> Element</h6>
-
 							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
 										><code>meta</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a>
 								feature that previously provided a means of including generic metadata. The EPUB 3 <a
 									href="#sec-meta-elem"><code>meta</code> element</a>, which uses different attributes
 								and requires text content, replaces this attribute.</p>
-
 							<p>For more information about the <code>meta</code> element, refer to its definition in
 								[[OPF-201]].</p>
-
 							<div class="note">
 								<p>The [[OPF-201]] <code>meta</code> element is retained in EPUB 3 primarily so that
 									EPUB Creators can identify the cover image for compatibility with EPUB 2 Reading
@@ -3495,28 +3206,22 @@ No Entry</pre>
 										href="#sec-item-elem">manifest <code>item</code></a> for the image.</p>
 							</div>
 						</section>
-
 						<section id="sec-opf2-guide">
 							<h6>The <code>guide</code> Element</h6>
-
 							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
 										><code>guide</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a>
 								feature that previously provided machine-processable navigation to key structures. The
 									<a href="#sec-nav-landmarks">landmarks nav</a> in the <a>EPUB Navigation
 									Document</a> replaces this element.</p>
-
 							<p>For more information about the <code>guide</code> element, refer to its definition in
 								[[OPF-201]].</p>
 						</section>
-
 						<section id="sec-opf2-ncx">
 							<h6>NCX</h6>
-
 							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a>
 								[[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table
 								of contents. The <a href="#sec-nav">EPUB Navigation Document</a> replaces this
 								document.</p>
-
 							<p>For more information about the NCX, refer to its definition in [[OPF-201]].</p>
 						</section>
 					</section>
@@ -3525,23 +3230,17 @@ No Entry</pre>
 		</section>
 		<section id="sec-contentdocs">
 			<h2>EPUB Content Documents</h2>
-
 			<section id="sec-xhtml">
 				<h3>XHTML Content Documents</h3>
-
 				<section id="sec-xhtml-intro" class="informative">
 					<h4>Introduction</h4>
-
 					<p>This section defines a profile of [[HTML]] for creating XHTML Content Documents. An instance of
 						an XML document that conforms to this profile is a <a>Core Media Type Resource</a> and is
 						referred to in this specification as an <a>XHTML Content Document</a>.</p>
 				</section>
-
 				<section id="sec-xhtml-req">
 					<h4>XHTML Requirements</h4>
-
 					<p>An XHTML Content Document:</p>
-
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-cd-html-docprops-syntax">MUST be an [[HTML]] document that conforms to the <a
@@ -3558,53 +3257,41 @@ No Entry</pre>
 								conformance constraints defined therein.</p>
 						</li>
 					</ul>
-
 					<p>Unless specified otherwise, XHTML Content Documents inherit all definitions of semantics,
 						structure, and processing behaviors from the [[HTML]] specification.</p>
-
 					<div class="note">
 						<p>The recommendation that EPUB Publications follow the accessibility requirements in
 							[[EPUB-A11Y-11]] applies to XHTML Content Documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
-
 				<section id="sec-xhtml-extensions">
 					<h4>HTML Extensions</h4>
-
 					<p>This section defines EPUB 3 <a>XHTML Content Document</a> extensions to the underlying [[HTML]]
 						document model.</p>
-
 					<div class="note">
 						<p>Although [[HTML]] allows user agents to support <a
 								href="https://html.spec.whatwg.org/multipage/infrastructure.html#extensibility-2"
 								>vendor-neutral extensions</a>, unless such extensions are listed in this section, they
 							are not supported features of EPUB 3.</p>
 					</div>
-
 					<section id="sec-xhtml-structural-semantics">
 						<h5>Structural Semantics</h5>
-
 						<p>EPUB Creators MAY use the <a href="#sec-epub-type-attribute"><code>epub:type</code>
 								attribute</a> in <a>XHTML Content Documents</a> to express <a
 								href="#sec-structural-semantics-intro">structural semantics</a>.</p>
-
 						<p>As the [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element"
 									><code>head</code> element</a> contains metadata for the document, structural
 							semantics expressed on this element or any descendant of it have no meaning.</p>
 					</section>
-
 					<section id="sec-xhtml-rdfa">
 						<h5>RDFa</h5>
-
 						<p>The [[HTML-RDFA]] specification defines a set of attributes that EPUB Creators MAY use in
 								<a>XHTML Content Documents</a> to semantically enrich the content. The use of these
 							attributes MUST conform to the requirements defined in [[HTML-RDFA]].</p>
-
 						<p>The [[HTML-RDFA]] specification defines changes to the [[HTML]] content model when authors
 							use RDFa attributes. This modified content model is valid in XHTML Content Documents.</p>
-
 						<div class="note">
 							<p>The listing of RDFa does not express a preference on the part of the Working Group, only
 								that these attributes represent an extension of the HTML grammar. EPUB Creators can also
@@ -3614,58 +3301,43 @@ No Entry</pre>
 								supported.</p>
 						</div>
 					</section>
-
 					<section id="sec-xhtml-content-switch">
 						<h5>Content Switching (Deprecated)</h5>
-
 						<p>The <code>switch</code> element provides a simple mechanism through which <a>EPUB
 								Creators</a> can tailor the content displayed to users, one that is not dependent on the
 							scripting capabilities of the <a>EPUB Reading System</a>.</p>
-
 						<p>Use of the <code>switch</code> element is <a href="#deprecated">deprecated</a>. Refer to its
 							definition in [[EPUBContentDocs-301]] for usage information.</p>
 					</section>
-
 					<section id="sec-xhtml-epub-trigger">
 						<h5>The <code>epub:trigger</code> Element (Deprecated)</h5>
-
 						<p>The <code>trigger</code> element enables the creation of markup-defined user interfaces for
 							controlling multimedia objects, such as audio and video playback, in both scripted and
 							non-scripted contexts.</p>
-
 						<p>Use of the <code>trigger</code> element is <a href="#deprecated">deprecated</a>. Refer to its
 							definition in [[EPUBContentDocs-301]] for usage information.</p>
 					</section>
-
 					<section id="sec-xhtml-custom-attributes">
 						<h5>Custom Attributes</h5>
-
 						<p><a>EPUB Creators</a> MAY specify <a
 								href="https://www.w3.org/TR/epub-rs-33/#sec-xhtml-custom-attributes">custom
 								attributes</a> [[EPUB-RS-33]] in <a>XHTML Content Documents</a> to take advantage of
 								<a>Reading System</a>-specific functionality not defined in this specification.</p>
-
 						<p>Custom attributes MAY be specified on any element in an XHTML Content Document.</p>
-
 						<p>When using custom attributes, the content MUST remain consumable by a user without any
 							information loss or other significant deterioration, regardless of the Reading System it is
 							rendered on.</p>
 					</section>
 				</section>
-
 				<section id="sec-xhtml-deviations">
 					<h4>HTML Deviations and Constraints</h4>
-
 					<p>This section defines deviations from, and constraints on, the underlying [[HTML]] document model
 						applicable to EPUB 3 <a>XHTML Content Documents</a>.</p>
-
 					<section id="sec-xhtml-mathml">
 						<h5>Embedded MathML</h5>
-
 						<p>XHTML Content Documents support embedded [[MATHML3]]. Occurrences of MathML markup MUST
 							conform to the constraints expressed in the MathML specification [[MATHML3]], with the
 							following additional restrictions:</p>
-
 						<dl class="conformance-list">
 							<dt id="math-pres">Presentation MathML</dt>
 							<dd>
@@ -3693,42 +3365,33 @@ No Entry</pre>
 									Documents.</p>
 							</dd>
 						</dl>
-
 						<p>This subset eases the implementation burden on Reading Systems and promotes accessibility,
 							while retaining compatibility with [[HTML]] user agents.</p>
-
 						<div class="note">
 							<p>The <a href="#mathml"><code>mathml</code> property</a> of the <a>manifest</a>
 								<code>item</code> element indicates that an XHTML Content Document contains embedded
 								MathML.</p>
 						</div>
 					</section>
-
 					<section id="sec-xhtml-svg">
 						<h5>Embedded SVG</h5>
-
 						<p><a>XHTML Content Documents</a> support the embedding of <a
 								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
 								fragments</a> [[SVG]] <em>by reference</em> (embedding via reference, for example, from
 							an <code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
 							direct inclusion of the <code>svg</code> element in the XHTML Content Document).</p>
-
 						<p>The content conformance constraints for SVG embedded in XHTML Content Documents are the same
 							as defined for <a>SVG Content Documents</a> in <a href="#sec-svg-restrictions"></a>.</p>
-
 						<div class="note">
 							<p>The <a href="#svg"><code>svg</code> property</a> of the <a>manifest</a>
 								<a href="#sec-item-elem"><code>item</code> element</a> indicates that an XHTML Content
 								Document contains embedded SVG.</p>
 						</div>
 					</section>
-
 					<section id="sec-xhtml-deviations-discouraged" class="informative">
 						<h5>Discouraged Constructs</h5>
-
 						<section id="sec-xhtml-deviations-base">
 							<h6>The <code>base</code> Element</h6>
-
 							<p id="confreq-html-vocab-base"> The [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element"
 										><code>base</code></a> element can be used to specify the <a
@@ -3742,12 +3405,9 @@ No Entry</pre>
 								Web site if the <code>base</code> element specifies an absolute URL). To avoid
 								significant interoperability issues, EPUB Creators should not use the <code>base</code>
 								element. </p>
-
 						</section>
-
 						<section id="sec-xhtml-deviations-rp">
 							<h6>The <code>rp</code> Element</h6>
-
 							<p id="confreq-html-vocab-rp">The [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element"
 										><code>rp</code></a> element is intended to provide a fallback for older
@@ -3755,10 +3415,8 @@ No Entry</pre>
 								display around <code>ruby</code> markup). As EPUB 3 Reading Systems are ruby-aware, and
 								can provide fallbacks, EPUB Creators should not use <code>rp</code> elements.</p>
 						</section>
-
 						<section id="sec-xhtml-deviations-embed">
 							<h6>The <code>embed</code> Element</h6>
-
 							<p id="confreq-html-vocab-embed">Since the [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element"
 										><code>embed</code></a> element does not include intrinsic facilities to provide
@@ -3770,10 +3428,8 @@ No Entry</pre>
 								intrinsic fallback capabilities.</p>
 						</section>
 					</section>
-
 					<section id="sec-xhtml-fallbacks">
 						<h5>Foreign Resource Restrictions</h5>
-
 						<p id="confreq-resources-cd-fallback">EPUB Creators MAY reference Foreign Resources from
 							elements that have intrinsic fallback mechanisms, where an intrinsic fallback method is the
 							capability to offer an alternative presentation if Reading Systems do not support the
@@ -3784,7 +3440,6 @@ No Entry</pre>
 							agents cannot render a resource. When referencing a Foreign Resource, EPUB Creators MUST
 							provide a <a>Core Media Type Resource</a> or embedded HTML content via the given element's
 							intrinsic fallback mechanism.</p>
-
 						<p id="confreq-resources-cd-fallback-media">EPUB Creators MAY embed [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/dom.html#flow-content">flow content</a>
 							within the <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
@@ -3793,13 +3448,11 @@ No Entry</pre>
 									><code>video</code></a> elements for rendering in older Reading Systems that do not
 							recognize these elements (e.g., EPUB 2 Reading Systems), but it does not represent a
 							fallback Core Media Type Resource.</p>
-
 						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that EPUB Creators can
 							specify in the [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"
 									><code>img</code> element</a>, the following fallback conditions apply to its
 							use:</p>
-
 						<ul>
 							<li>
 								<p>If it is the child of a <a
@@ -3821,10 +3474,8 @@ No Entry</pre>
 									<code>srcset</code> attributes provided EPUB Creators define a <a
 									href="#sec-foreign-restrictions-manifest">manifest fallback</a>.</li>
 						</ul>
-
 						<p>EPUB Creators MAY reference <a href="#sec-core-media-types">Foreign Resources</a> from the
 							following [[HTML]] elements without providing a fallback Core Media Type Resource:</p>
-
 						<ul>
 							<li>
 								<p id="confreq-resources-cd-fallback-link"><a
@@ -3846,7 +3497,6 @@ No Entry</pre>
 											><code>source</code></a> elements</p>
 							</li>
 						</ul>
-
 						<div class="note">
 							<p>Refer to <a href="#sec-foreign-restrictions-manifest">manifest fallbacks</a> for the
 								provision of fallbacks for elements without intrinsic mechanisms, such as the [[HTML]]
@@ -3857,44 +3507,34 @@ No Entry</pre>
 					</section>
 				</section>
 			</section>
-
 			<section id="sec-svg">
 				<h3>SVG Content Documents</h3>
-
 				<div class="caution">
 					<p><a>Reading Systems</a> may not support all the features of [[SVG]] or supported them across all
 						platforms that Reading Systems run on. When utilizing such features, <a>EPUB Creators</a> should
 						consider the inherent risks on interoperability and document longevity.</p>
 				</div>
-
 				<section id="sec-svg-intro" class="informative">
 					<h4>Introduction</h4>
-
 					<p>The Scalable Vector Graphics (SVG) specification [[SVG]] defines a format for representing
 						final-form vector graphics and text.</p>
-
 					<p>Although <a>EPUB Creators</a> typically use <a href="#sec-xhtml">XHTML Content Documents</a> as
 						the <a data-lt="Top-level Content Document">top-level</a> document type, the use of <a>SVG
 							Content Documents</a> is also permitted. EPUB Creators will typically only need SVGs for
 						certain special cases, such as when final-form page images are the only suitable representation
 						of the content (e.g., for cover art or in the context of manga or comic books).</p>
-
 					<p>This section defines a profile for [[SVG]] documents. An instance of an XML document that
 						conforms to this profile is a <a>Core Media Type Resource</a> and is referred to in this
 						specification as an <a>SVG Content Document</a>.</p>
-
 					<div class="note">
 						<p>This section defines conformance requirements for <a>SVG Content Documents</a>. Refer to <a
 								href="#sec-xhtml-svg"></a> for the conformance requirements for SVG embedded in XHTML
 							Content Documents.</p>
 					</div>
 				</section>
-
 				<section id="sec-svg-req">
 					<h4>SVG Requirements</h4>
-
 					<p>An SVG Content Document:</p>
-
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-cd-svg-docprops-schema">MUST be a <a
@@ -3909,20 +3549,16 @@ No Entry</pre>
 									href="#sec-vocab-assoc">vocabulary association mechanisms</a>.</p>
 						</li>
 					</ul>
-
 					<div class="note">
 						<p>The recommendation that EPUB Publications follow the accessibility requirements in
 							[[EPUB-A11Y-11]] applies to SVG Content Documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
-
 				<section id="sec-svg-restrictions">
 					<h4>Restrictions on SVG</h4>
-
 					<p>This specification restricts the content model of <a>SVG Content Documents</a> and <a
 							href="#sec-xhtml-svg">SVG embedded in XHTML Content Documents</a> as follows:</p>
-
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-svg-foreignObject">The [[SVG]] <a
@@ -3956,28 +3592,21 @@ No Entry</pre>
 					</ul>
 				</section>
 			</section>
-
 			<section>
 				<h3>Common Resource Requirements</h3>
-
 				<p>This section defines requirements for technologies usable in both XHTML and SVG Content
 					Documents.</p>
-
 				<section id="sec-css">
 					<h3>Cascading Style Sheets (CSS)</h3>
-
 					<section id="sec-css-intro" class="informative">
 						<h4>Introduction</h4>
-
 						<p>CSS is an integral part of the Open Web Platform. Readers, publishers, and document authors
 							expect CSS to "just work," as they expect HTML to just work.</p>
-
 						<p>In the past, EPUB defined a profile of CSS that mandated support for certain properties and
 							provided prefixed versions of numerous other properties. Although the CSS Working Group no
 							longer recommends the use of prefixed properties, this specification maintains some prefixed
 							properties to avoid breaking existing content. But with the minor exceptions defined in this
 							section, EPUB defers to the W3C to define CSS.</p>
-
 						<div class="note">
 							<p>Keep in mind that some <a>Reading Systems</a> will not support all desired features of
 								CSS. The following are known to be particularly problematic:</p>
@@ -3995,12 +3624,9 @@ No Entry</pre>
 							</ul>
 						</div>
 					</section>
-
 					<section id="sec-css-req">
 						<h4>CSS Requirements</h4>
-
 						<p>A CSS style sheet:</p>
-
 						<ul class="conformance-list">
 							<li>
 								<p id="confreq-css-props">MAY include any CSS properties, with the following
@@ -4027,13 +3653,11 @@ No Entry</pre>
 									as the RECOMMENDED encoding.</p>
 							</li>
 						</ul>
-
 						<div class="note">
 							<p>This specification restricts the use of the <code>direction</code> and
 									<code>unicode-bidi</code> properties because Reading Systems may not implement, or
 								may switch off, CSS processing. EPUB Creators must use the following format-specific
 								methods when they need control over these aspects of the rendering:</p>
-
 							<ul>
 								<li>
 									<p>the <a href="https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute"
@@ -4055,17 +3679,14 @@ No Entry</pre>
 							</ul>
 						</div>
 					</section>
-
 					<section id="sec-css-prefixed">
 						<h4>Prefixed Properties</h4>
-
 						<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to
 							world languages were not yet mature. To ensure backwards compatibility for content authored
 							using these prefixes, they have been retained in this specification. Unless otherwise noted,
 							prefixed properties and values behave exactly as their unprefixed equivalents as described
 							in the appropriate CSS specification. The prefixed properties are documented in an <a
 								href="#css-prefixes">Appendix</a>. </p>
-
 						<div class="caution">
 							<p><a>EPUB Creators</a> should use unprefixed properties and <a>Reading Systems</a> should
 								support current CSS specifications. This specification retains the widely-used prefixed
@@ -4076,86 +3697,67 @@ No Entry</pre>
 								move to unprefixed versions as soon as support allows, as the Working Group does not
 								anticipate supporting them in the next major version of EPUB.</p>
 						</div>
-
 						<p class="note">In some cases, the unprefixed versions of these properties now support
 							additional values. Reading Systems MAY support these values even with the prefixed
 							property.</p>
 					</section>
 				</section>
-
 				<section id="sec-scripted-content">
 					<h3>Scripting</h3>
-
 					<section id="sec-scripted-support">
 						<h4>Script Inclusion</h4>
-
 						<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in
 							the respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB Content
 							Document contains scripting, this specification refers to it as a <a>Scripted Content
 								Document</a>. This label also applies to <a>XHTML Content Documents</a> when they
 							contain instances of [[HTML]] <a
 								href="https://html.spec.whatwg.org/multipage/forms.html#forms">forms</a>.</p>
-
 						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
 							<code>item</code> element is used to indicate that an EPUB Content Document is a <a>Scripted
 								Content Document</a>.</p>
-
 						<p>When an [[HTML]] <code>script</code> element contains a <a
 								href="https://html.spec.whatwg.org/multipage/scripting.html#data-block">data block</a>
 							[[HTML]], it does not represent scripted content.</p>
-
 						<div class="note">
 							<p>[[SVG]] does not define data blocks as of publication, but the same exclusion would apply
 								if a future update adds the concept.</p>
 						</div>
-
 						<p>EPUB Creators should note that Reading Systems are required to behave as though a unique <a
 								href="https://url.spec.whatwg.org/#origin">origin</a> [[URL]] has been assigned to each
 							EPUB Publication. In practice, this means that it is not possible for scripts to share data
 							between EPUB Publications.</p>
-
 						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
 							rights and restrictions that a Reading System places on it (refer to <a
 								href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content">Scripting Conformance</a>
 							[[?EPUB-RS-33]] for more information).</p>
-
 						<div class="note">
 							<p>Reading Systems may render Scripted Content Documents in a manner that disables other
 								EPUB capabilities and/or provides a different rendering and user experience (e.g., by
 								disabling pagination).</p>
 						</div>
 					</section>
-
 					<section id="sec-scripted-context">
 						<h4>Scripting Contexts</h4>
-
 						<p>EPUB 3 defines two contexts for script execution:</p>
-
 						<ul>
 							<li><a href="#sec-scripted-container-constrained">container-constrained</a> &#8212; when the
 								execution of a script occurs within an <code>iframe</code>; and</li>
 							<li><a href="#sec-scripted-spine">spine-level</a> &#8212; when the execution of a script
 								occurs directly within a <a>Top-level Content Document</a>.</li>
 						</ul>
-
 						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference
 							it via the element's <code>src</code> attribute makes no difference to its executing
 							context.</p>
-
 						<p>Which context EPUB Creators use for their scripts affects both what actions the scripts can
 							perform and the likelihood of support in Reading Systems, as described in the following
 							subsections.</p>
-
 						<div class="note">
 							<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference
 								between the two contexts.</p>
 						</div>
-
 						<section id="sec-scripted-container-constrained">
 							<h5>Container-Constrained Scripts</h5>
-
 							<p>A <dfn>container-constrained script</dfn> is either of the following:</p>
-
 							<ul>
 								<li>
 									<p>An instance of the [[HTML]] <a
@@ -4176,37 +3778,30 @@ No Entry</pre>
 												><code>iframe</code></a> element.</p>
 								</li>
 							</ul>
-
 							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
 								instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e.,
 								the one that contains the <code>iframe</code> element). It also MUST NOT contain
 								instructions for manipulating the size of its containing rectangle.</p>
-
 							<p>EPUB Creators should note that <a
 									href="https://www.w3.org/TR/epub-rs-33/#sec-scripted-content">support for
 									container-constrained scripting in Reading Systems</a> is only recommended in
 								reflowable documents [[EPUB-RS-33]]. Furthermore, Reading System support in
 								fixed-layouts EPUBs is optional.</p>
-
 							<p>EPUB Creators should ensure container-constrained scripts degrade gracefully in Reading
 								Systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
-
 							<div class="note">
 								<p>EPUB Creators choosing to restrict the usage of scripting to the
 									container-constrained model will ensure a more consistent user experience between
 									scripted and non-scripted content (e.g., consistent pagination behavior).</p>
 							</div>
 						</section>
-
 						<section id="sec-scripted-spine">
 							<h5>Spine-Level Scripts</h5>
-
 							<p>A <dfn>spine-level script</dfn> is an instance of the [[HTML]] <a
 									href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"
 										><code>script</code></a> or [[SVG]] <a
 									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 								element contained in a <a>Top-level Content Document</a>.</p>
-
 							<p>EPUB Creators should note that support for spine-level scripting in Reading Systems is
 								only recommended in <a
 									href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-fxl-support"
@@ -4214,7 +3809,6 @@ No Entry</pre>
 									href="https://www.w3.org/TR/epub-rs-33/#confreq-rs-scripted-scrolled">reflowable
 									documents set to scroll</a> [[EPUB-RS-33]]. Furthermore, Reading System support in
 								all other contexts is optional.</p>
-
 							<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include
 								spine-level scripting SHOULD remain consumable by the user without any information loss
 								or other significant deterioration when scripting is disabled or not available (e.g., by
@@ -4223,28 +3817,22 @@ No Entry</pre>
 								Content Documents can result in EPUB Publications being unreadable.</p>
 						</section>
 					</section>
-
 					<section id="sec-scripted-content-events" class="informative">
 						<h4>Event Model</h4>
-
 						<p><a>EPUB Creators</a> should consider the wide variety of possible Reading System
 							implementations when adding scripting functionality to their EPUB Publications (e.g., not
 							all devices have physical keyboards, and in many cases a soft keyboard is activated only for
 							text input elements). Consequently, EPUB Creators should not rely on keyboard events alone;
 							they should always provide alternative ways to trigger a desired action.</p>
 					</section>
-
 					<section id="sec-scripted-a11y">
 						<h4>Scripting Accessibility</h4>
-
 						<p id="confreq-cd-scripted-a11y">EPUB Content Documents that contain scripting SHOULD employ
 							relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable
 							by all users.</p>
 					</section>
-
 					<section id="sec-scripted-fallbacks">
 						<h4 id="confreq-cd-scripted-flbk">Scripting Fallbacks</h4>
-
 						<p id="confreq-cd-scripted-fallback">EPUB Content Documents that contain scripting MAY provide
 							fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
 							available for the [[HTML]] <a
@@ -4258,26 +3846,21 @@ No Entry</pre>
 							thereof.</p>
 					</section>
 				</section>
-
 			</section>
 		</section>
 		<section id="sec-nav">
 			<h2>EPUB Navigation Document</h2>
-
 			<section id="sec-nav-intro" class="informative">
 				<h3>Introduction</h3>
-
 				<p>The EPUB Navigation Document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
 						Publication</a>. It allows <a>EPUB Creators</a> to include a human- and machine-readable global
 					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
-
 				<p>The EPUB Navigation Document is a special type of <a>XHTML Content Document</a> that defines the <a
 						href="#sec-nav-toc">table of contents</a> for <a>Reading Systems</a>. It may also include other
 					specialized navigation elements, such as a <a href="#sec-nav-pagelist">page list</a> and a list of
 					key <a href="#sec-nav-landmarks">landmarks</a>. These navigation elements have <a
 						href="#sec-nav-def-model">additional restrictions</a> on their content to facilitate their
 					processing.</p>
-
 				<p>The EPUB Navigation Document is not exclusively for machine processing, however. There are no
 					restrictions on the structure or content of the EPUB Navigation Document outside of the specialized
 					navigation elements (i.e., EPUB Creators can mark the rest of the document up like any other XHTML
@@ -4285,7 +3868,6 @@ No Entry</pre>
 					for duplicate tables of contents. EPUB Creators can hide navigation elements that are only for
 					machine processing (e.g., the page list) with the <a href="#sec-nav-def-hidden">hidden</a>
 					attribute.</p>
-
 				<p>Note that Reading Systems may strip scripting, styling, and HTML formatting as they generate
 					navigational interfaces from information found in the EPUB Navigation Document, and this may make
 					the result difficult to read. If EPUB Creators require such formatting and functionality, then they
@@ -4293,17 +3875,13 @@ No Entry</pre>
 					enhancement techniques for scripting and styling of the navigation document will help ensure the
 					content will retain its integrity when rendered in a non-browser context.</p>
 			</section>
-
 			<section id="sec-nav-def">
 				<h3>EPUB Navigation Document Definition</h3>
-
 				<section id="sec-nav-def-model">
 					<h4>The <code>nav</code> Element: Restrictions</h4>
-
 					<p>When a <code>nav</code> element carries the <a href="#sec-epub-type-attribute"
 								><code>epub:type</code> attribute</a> in an <a>EPUB Navigation Document</a>, this
 						specification restricts the content model of the element and its descendants as follows:</p>
-
 					<dl class="elemdef">
 						<dt>Content Model</dt>
 						<dd>
@@ -4394,10 +3972,8 @@ No Entry</pre>
 							<p>Refer the definition below for additional requirements.</p>
 						</dd>
 					</dl>
-
 					<p>The following elaboration of the content model of the <code>nav</code> element explains the
 						purpose and restrictions of the various elements:</p>
-
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-nav-ol">The <code>ol</code> child of the <code>nav</code> element represents
@@ -4458,7 +4034,6 @@ No Entry</pre>
 								this section for constructing the primary navigation list.</p>
 						</li>
 					</ul>
-
 					<aside class="example">
 						<p>The following example shows the basic patterns of a navigation element.</p>
 						<pre>&lt;nav epub:type="…"&gt;
@@ -4482,10 +4057,8 @@ No Entry</pre>
 &lt;/nav&gt;
 </pre>
 					</aside>
-
 					<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, EPUB Creators MAY
 						include the EPUB Navigation Document in the <a href="#sec-spine-elem">spine</a>.</p>
-
 					<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
 						items within <code>nav</code> elements is equivalent to the <a
 							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
@@ -4493,19 +4066,14 @@ No Entry</pre>
 						list styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
 								><code>spine</code></a>.</p>
 				</section>
-
 				<section id="sec-nav-def-types">
 					<h4>The <code>nav</code> Element: Types</h4>
-
 					<section id="sec-nav-def-types-intro" class="informative">
 						<h5>Introduction</h5>
-
 						<p>The <code>nav</code> elements defined in an EPUB Navigation Document are distinguished
 							semantically by the value of their <a href="#sec-epub-type-attribute"><code>epub:type</code>
 								attribute</a>.</p>
-
 						<p>This specification defines three types of navigation aid:</p>
-
 						<dl class="variablelist">
 							<dt>
 								<a href="#sec-nav-toc">
@@ -4537,25 +4105,19 @@ No Entry</pre>
 									interest.</p>
 							</dd>
 						</dl>
-
 						<p>An EPUB Navigation Document may contain at most one navigation aid for each of these
 							types.</p>
-
 						<p>The EPUB Navigation Document may include additional navigation types. See <a
 								href="#sec-nav-def-types-other"></a> for more information.</p>
 					</section>
-
 					<section id="sec-nav-toc">
 						<h5>The <code>toc nav</code> Element </h5>
-
 						<p>The <code>toc</code>
 							<code>nav</code> element defines the primary navigational hierarchy. It conceptually
 							corresponds to a table of contents in a printed work (i.e., it provides navigation to the
 							major structural sections of the publication).</p>
-
 						<p>EPUB Creators SHOULD order the references in the <code>toc</code>
 							<code>nav</code> element such that they reflect both:</p>
-
 						<ul>
 							<li>
 								<p>the order of the <a href="#confreq-nav-a-href">referenced EPUB Content Documents</a>
@@ -4566,50 +4128,39 @@ No Entry</pre>
 									Documents.</p>
 							</li>
 						</ul>
-
 						<p>The <code>toc</code>
 							<code>nav</code> element MUST occur exactly once in an EPUB Navigation Document.</p>
 					</section>
-
 					<section id="sec-nav-pagelist">
 						<h5>The <code>page-list nav</code> Element </h5>
-
 						<p>The <code>page-list</code>
 							<code>nav</code> element provides navigation to positions in the content that correspond to
 							the locations of page boundaries present in a print source.</p>
-
 						<p>The <code>page-list</code>
 							<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more
 							than once.</p>
-
 						<p>The <code>page-list</code>
 							<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
 							nested sublists).</p>
-
 						<p>EPUB Creators MAY identify the destinations of the <code>page-list</code> references in their
 							respective EPUB Content Documents using the <a
 								href="https://w3c.github.io/epub-specs/epub33/ssv/#pagebreak"><code>pagebreak</code>
 								term</a>.</p>
 					</section>
-
 					<section id="sec-nav-landmarks">
 						<h5>The <code>landmarks nav</code> Element </h5>
-
 						<p>The <code>landmarks</code>
 							<code>nav</code> element identifies fundamental structural components in the content to
 							enable Reading Systems to provide the user efficient access to them (e.g., through a
 							dedicated button in the user interface).</p>
-
 						<p>The <code>landmarks</code>
 							<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
 							nested sublists).</p>
-
 						<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is REQUIRED on
 								<code>a</code> element descendants of the <code>landmarks</code>
 							<code>nav</code> element. The structural semantics of each link target within the
 								<code>landmarks</code>
 							<code>nav</code> element is determined by the value of this attribute.</p>
-
 						<aside class="example">
 							<p>The following example shows a <code>landmarks</code>
 								<code>nav</code> element with structural semantics drawn from [[?EPUB-SSV-11]].</p>
@@ -4622,17 +4173,13 @@ No Entry</pre>
     &lt;/ol&gt;
 &lt;/nav&gt;</pre>
 						</aside>
-
 						<p>The <code>landmarks</code>
 							<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code>
 							value that reference the same resource, or fragment thereof.</p>
-
 						<p>EPUB Creators should limit the number of items they define in the <code>landmarks</code>
 							<code>nav</code> to only items that a Reading System is likely to use in its user interface.
 							The element is not meant to repeat the table of contents.</p>
-
 						<p>The following landmarks are recommended to include when available:</p>
-
 						<ul>
 							<li><a href="https://w3c.github.io/epub-specs/epub33/ssv/#bodymatter"
 										><code>bodymatter</code></a> [[?EPUB-SSV-11]] &#8212; Reading Systems often use
@@ -4643,35 +4190,28 @@ No Entry</pre>
 								the spine, Reading Systems may use this landmark to take users to the document
 								containing it.</li>
 						</ul>
-
 						<p>Other possibilities for inclusion in the <code>landmarks</code>
 							<code>nav</code> are key reference sections such as indexes and glossaries.</p>
-
 						<p>Although the <code>landmarks</code>
 							<code>nav</code> is intended for Reading System use, EPUB Creators should still ensure that
 							the labels for the <code>landmarks</code>
 							<code>nav</code> are human readable. Reading Systems may expose the links directly to
 							users.</p>
-
 						<p>The <code>landmarks</code>
 							<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more
 							than once.</p>
 					</section>
-
 					<section id="sec-nav-def-types-other">
 						<h5>Other <code>nav</code> Elements</h5>
-
 						<p>EPUB Navigation Documents MAY contain one or more <code>nav</code> elements in addition to
 							the <code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
 							<code>nav</code> elements defined in the preceding sections. If these <code>nav</code>
 							elements are intended for Reading System processing, they MUST have an <a
 								href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> and are subject to
 							the content model restrictions defined in <a href="#sec-nav-def-model"></a>.</p>
-
 						<p>This specification imposes no restrictions on the semantics of any additional
 								<code>nav</code> elements: they MAY represent navigational semantics for any information
 							domain, and they MAY contain link targets with homogeneous or heterogeneous semantics.</p>
-
 						<aside class="example">
 							<p>The following example shows a custom list of tables navigation element.</p>
 							<pre>&lt;nav aria-labelledby="lot"&gt;
@@ -4690,15 +4230,12 @@ No Entry</pre>
 						</aside>
 					</section>
 				</section>
-
 				<section id="sec-nav-def-hidden">
 					<h4>The <code>hidden</code> attribute</h4>
-
 					<p>In some cases, <a>EPUB Creators</a> might wish to hide parts of the navigation data within the
 						content flow (i.e., the Reading System's principal rendering of the <a>spine</a> contents). A
 						typical example is the <a href="#sec-nav-pagelist">list of page breaks</a>, which EPUB Creators
 						do not want Reading Systems to render as part of the content flow.</p>
-
 					<p> While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
 							property</a> [[CSSSnapshot]] controls the visual rendering of EPUB Navigation Documents in
 						Reading Systems with <a>Viewports</a>, not all Reading Systems provide such an interface. To
@@ -4708,7 +4245,6 @@ No Entry</pre>
 						data are excluded from rendering in the content flow. The <code>hidden</code> attribute has no
 						effect on how Reading Systems render the navigation data outside of the content flow (such as in
 						dedicated navigation user interfaces provided by Reading Systems).</p>
-
 					<aside class="example">
 						<p>The following example shows a partial <code>page-list</code>
 							<code>nav</code> element. The presence of the <code>hidden</code> attribute on the root
@@ -4724,7 +4260,6 @@ No Entry</pre>
 &lt;/nav&gt;
 </pre>
 					</aside>
-
 					<aside class="example">
 						<p>The following example shows a partial <code>toc</code>
 							<code>nav</code> element where the <code>hidden</code> attribute limits content flow
@@ -4763,26 +4298,21 @@ No Entry</pre>
 		</section>
 		<section id="sec-fixed-layouts">
 			<h2>Fixed Layouts</h2>
-
 			<section id="fxl-intro" class="informative">
 				<h3>Introduction</h3>
-
 				<p>EPUB documents, unlike print books or PDF files, are designed to change. The content flows, or
 					reflows, to fit the screen and to fit the needs of the user. As noted in <a
 						href="https://www.w3.org/TR/epub-overview-33/#sec-rendering">Rendering and CSS</a> "content
 					presentation adapts to the user, rather than the user having to adapt to a particular presentation
 					of content." [[EPUB-OVERVIEW-33]]</p>
-
 				<p>But this principle does not work for all types of documents. Sometimes content and design are so
 					intertwined it is not possible to separate them. Any change in appearance risks changing the meaning
 					or losing all meaning. <a>Fixed-Layout Documents</a> give <a>EPUB Creators</a> greater control over
 					presentation when a reflowable EPUB is not suitable for the content.</p>
-
 				<p>EPUB Creators define fixed layouts using a <a href="#sec-fxl-package">set of Package Document
 						properties</a> to control the rendering in <a>Reading Systems</a>. In addition, they set <a
 						href="#sec-fxl-package">the dimensions of each Fixed-Layout Document</a> in its respective EPUB
 					Content Document.</p>
-
 				<div class="note" id="note-mechanisms">
 					<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
 						content is necessary, the EPUB Creator's choice of mechanism will depend on many factors
@@ -4790,22 +4320,16 @@ No Entry</pre>
 						attempt to dictate the EPUB Creator's choice of mechanism.</p>
 				</div>
 			</section>
-
 			<section id="sec-fxl-package">
 				<h3>Fixed-Layout Package Settings</h3>
-
 				<section id="layout">
 					<h4>Layout</h4>
-
 					<p>The <code>rendition:layout</code> property specifies whether the content is reflowable or
 						pre-paginated.</p>
-
 					<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code> property</a>
 						is specified on a <code>meta</code> element, it indicates that the paginated or reflowable
 						layout style applies globally (i.e., for all spine items).</p>
-
 					<p>EPUB Creators MAY use the following values with the <code>rendition:layout</code> property:</p>
-
 					<dl class="variablelist">
 						<dt id="def-layout-reflowable">reflowable</dt>
 						<dd>
@@ -4818,7 +4342,6 @@ No Entry</pre>
 									href="#elemdef-spine-itemref"><code>itemref</code></a> when rendering).</p>
 						</dd>
 					</dl>
-
 					<div class="note" id="uaag">
 						<p>Reading Systems typically restrict or deny the application of user or user agent style sheets
 							to pre-paginated documents because dynamic style changes are likely to have unintended
@@ -4828,25 +4351,18 @@ No Entry</pre>
 								href="https://www.w3.org/TR/2015/NOTE-UAAG20-20151215/#gl-text-config">Guideline 1.4 -
 								Provide text configuration</a> [[UAAG20]] for related information.</p>
 					</div>
-
 					<p>When the property is set to <code>pre-paginated</code> for a spine item, its content dimensions
 						MUST be set as defined in <a href="#sec-fixed-layouts"></a>.</p>
-
 					<p>The <code>rendition:layout</code> property MUST NOT be declared more than once.</p>
-
 					<aside class="example" id="fxl-ex1">
 						<p>The following example demonstrates fully fixed-layout content, using [[CSS3-MediaQueries]] to
 							apply different style sheets for three different device categories. Note that the Media
 							Queries only affect the style sheet applied to the document; the size of the content area
 							set in the <code>viewport</code>
 							<code>meta</code> tag is static.</p>
-
 						<p><strong>Package Document</strong></p>
-
 						<pre>&lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;</pre>
-
 						<p><strong>XHTML</strong></p>
-
 						<pre>&lt;head&gt;
     &lt;meta name="viewport" content="width=1200, height=900"/&gt;
 	
@@ -4860,41 +4376,30 @@ No Entry</pre>
 &lt;/head&gt;
 </pre>
 					</aside>
-
 					<section id="layout-overrides">
 						<h5>Layout Overrides</h5>
-
 						<p id="property-layout-local">EPUB Creators MAY specify the following properties locally on
 							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
 								href="#property-layout-global">global value</a> for the given spine item:</p>
-
 						<dl>
 							<dt id="layout-pre-paginated">layout-pre-paginated</dt>
 							<dd>Specifies that the given spine item is pre-paginated.</dd>
-
 							<dt id="layout-reflowable">layout-reflowable</dt>
 							<dd>Specifies that the given spine item is reflowable.</dd>
 						</dl>
-
 						<p>EPUB Creators MAY use only one of these overrides on any given spine item.</p>
-
 					</section>
 				</section>
-
 				<section id="orientation">
 					<h4>Orientation</h4>
-
 					<p>The <code>rendition:orientation</code> property specifies which orientation the EPUB Creator
 						intends the content to be rendered in. </p>
-
 					<p id="property-orientation-global">When the <a href="#orientation"
 								><code>rendition:orientation</code> property</a> is specified on a <code>meta</code>
 						element, it indicates that the intended orientation applies globally (i.e., for all spine
 						items).</p>
-
 					<p>EPUB Creators MAY use the following values with the <code>rendition:orientation</code>
 						property:</p>
-
 					<dl class="variablelist">
 						<dt>landscape</dt>
 						<dd>
@@ -4909,10 +4414,8 @@ No Entry</pre>
 							<p>The content is not orientation constrained. Default value.</p>
 						</dd>
 					</dl>
-
 					<p>EPUB Creators MUST NOT declare the <code>rendition:orientation</code> property more than
 						once.</p>
-
 					<aside class="example" id="fxl-ex2">
 						<p>The following example demonstrates fully fixed-layout content Reading Systems should render
 							without synthetic spreads and locked to landscape orientation.</p>
@@ -4923,45 +4426,33 @@ No Entry</pre>
     &lt;meta property="rendition:orientation"&gt;landscape&lt;/meta&gt;
 &lt;/metadata&gt;</pre>
 					</aside>
-
 					<section id="orientation-overrides">
 						<h5>Orientation Overrides</h5>
-
 						<p id="property-orientation-local">EPUB Creators MAY specify the following properties locally on
 							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
 								href="#property-orientation-global">global value</a> for the given spine item:</p>
-
 						<dl>
 							<dt id="orientation-auto">orientation-auto</dt>
 							<dd>Specifies that the Reading System determines the orientation to render the spine item
 								in.</dd>
-
 							<dt id="orientation-landscape">orientation-landscape</dt>
 							<dd>Specifies that Reading Systems should render the given spine item in landscape
 								orientation.</dd>
-
 							<dt id="orientation-portrait">orientation-portrait</dt>
 							<dd>Specifies that Reading Systems should render the given spine item in portrait
 								orientation.</dd>
 						</dl>
-
 						<p>EPUB Creators MAY use only one of these overrides on any given spine item.</p>
-
 					</section>
 				</section>
-
 				<section id="spread">
 					<h4>Synthetic Spreads</h4>
-
 					<p>The <code>rendition:spread</code> property specifies the intended Reading System synthetic spread
 						behavior.</p>
-
 					<p id="property-spread-global">When the <code>rendition:spread</code> property is specified on a
 							<code>meta</code> element, it indicates that the intended <a>Synthetic Spread</a> behavior
 						applies globally (i.e., for all spine items).</p>
-
 					<p>EPUB Creators MAY use the following values with the <code>rendition:spread</code> property:</p>
-
 					<dl class="variablelist">
 						<dt>none</dt>
 						<dd>
@@ -4989,22 +4480,18 @@ No Entry</pre>
 								value.</p>
 						</dd>
 					</dl>
-
 					<p>The <code>rendition:spread</code> property MUST NOT be declared more than once.</p>
-
 					<div class="note">
 						<p>When Synthetic Spreads are used in the context of HTML and SVG Content Documents, the
 							dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
 								<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"><code>viewBox</code>
 								attribute</a> represents the size of one page in the spread, respectively.</p>
 					</div>
-
 					<div class="note">
 						<p>Refer to <a href="#sec-spine-elem">spine</a> for information about declaration of global flow
 							directionality using the <code>page-progression-direction</code> attribute and that of local
 							page-progression-direction within content documents.</p>
 					</div>
-
 					<aside class="example" id="fxl-ex3">
 						<p>The following example demonstrates fully fixed-layout content intended for Reading Systems to
 							render using synthetic spreads in landscape orientation, and with no spreads in portrait
@@ -5014,7 +4501,6 @@ No Entry</pre>
     &lt;meta property="rendition:spread"&gt;landscape&lt;/meta&gt;
 &lt;/metadata&gt;</pre>
 					</aside>
-
 					<aside class="example" id="fxl-ex4">
 						<p>The following example demonstrates reflowable content with a single fixed-layout title page,
 							where the EPUB Creator intends the fixed-layout page for a right-hand spread slot.</p>
@@ -5030,43 +4516,33 @@ No Entry</pre>
 									><code>rendition:page-spread-right</code></a> in place of
 								<code>page-spread-right</code>.</p>
 					</aside>
-
 					<section id="spread-overrides">
 						<h5>Synthetic Spread Overrides</h5>
-
 						<p id="property-spread-local">EPUB Creators MAY specify the following properties locally on
 							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
 								href="#property-spread-global">global value</a> for the given spine item:</p>
-
 						<dl>
 							<dt id="spread-auto">spread-auto</dt>
 							<dd>Specifies the Reading System determines when to render a synthetic spread for the spine
 								item. </dd>
-
 							<dt id="spread-both">spread-both</dt>
 							<dd>Specifies the Reading System should render a synthetic spread for the spine item in both
 								portrait and landscape orientations. </dd>
-
 							<dt id="spread-landscape">spread-landscape</dt>
 							<dd>Specifies the Reading System should render a synthetic spread for the spine item only
 								when in landscape orientation.</dd>
-
 							<dt id="spread-none">spread-none</dt>
 							<dd>Specifies the Reading System should not render a synthetic spread for the spine
 								item.</dd>
-
 							<dt id="spread-portrait">spread-portrait</dt>
 							<dd>The <code>spread-portrait</code> property is <a href="#deprecated">deprecated</a>. Refer
 								to its definition in [[EPUBPublications-301]] for more information.</dd>
 						</dl>
-
 						<p>EPUB Creators MAY use only one of these overrides on any given spine item.</p>
 					</section>
 				</section>
-
 				<section id="page-spread">
 					<h4>Spread Placement</h4>
-
 					<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to populate the
 						spread by rendering the next <a>EPUB Content Document</a> in the next available unpopulated
 						viewport, where the next available viewport is determined by the given <a href="#sec-spine-elem"
@@ -5074,38 +4550,32 @@ No Entry</pre>
 						Creator MAY override this automatic population behavior and force Reading Systems to place a
 						document in a particular viewport by specifying one of the following properties on its spine
 							<code>itemref</code> element:</p>
-
 					<dl>
 						<dt id="page-spread-center">
 							<code>rendition:page-spread-center</code>
 						</dt>
 						<dd>The <code>rendition:page-spread-center</code> property specifies the forced placement of a
 							Content Document in a <a>Synthetic Spread</a>. </dd>
-
 						<dt id="fxl-page-spread-left">
 							<code>rendition:page-spread-left</code>
 						</dt>
 						<dd>The <code>rendition:page-spread-left</code> property is an alias for the <code><a
 									href="#page-spread-left">page-spread-left</a></code> property.</dd>
-
 						<dt id="fxl-page-spread-right">
 							<code>rendition:page-spread-right</code>
 						</dt>
 						<dd>The <code>rendition:page-spread-right</code> property is an alias for the <code><a
 									href="#page-spread-right">page-spread-right</a></code> property.</dd>
 					</dl>
-
 					<p>The <code>rendition:page-spread-left</code> property indicates that the given spine item is to be
 						rendered in the left-hand slot in the spread, and <code>rendition:page-spread-right</code> that
 						it be rendered in the right-hand slot. The <code>rendition:page-spread-center</code> property
 						indicates to override the synthetic spread mode and render a single viewport positioned at the
 						center of the screen.</p>
-
 					<p>The <code>rendition:page-spread-left</code>, <code>rendition:page-spread-right</code> and
 							<code>rendition:page-spread-center</code> properties apply to both pre-paginated and
 						reflowable content, and they only apply when the Reading System is creating Synthetic
 						Spreads.</p>
-
 					<p>Although EPUB Creators often indicate to use a spread in certain device orientations, the content
 						itself does not represent true spreads (i.e., two consecutive pages that Reading Systems must
 						rendered side-by-side for readability, such as a two-page map). To indicate that two consecutive
@@ -5113,10 +4583,8 @@ No Entry</pre>
 							<code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 						properties on the spine items for the two adjacent EPUB Content Documents, and omit the
 						properties on spine items where one-up or two-up presentation is equally acceptable.</p>
-
 					<p>EPUB Creators MAY only declare one <code>page-spread-*</code> property on any given spine
 						item.</p>
-
 					<div class="note" id="note-page-spread-aliases">
 						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 							properties are aliases for the <a href="#page-spread-left"><code>page-spread-left</code></a>
@@ -5127,7 +4595,6 @@ No Entry</pre>
 								Properties Vocabulary</a> to add an unprefixed <code>page-spread-center</code>
 							property.</p>
 					</div>
-
 					<aside class="example" id="fxl-ex5">
 						<p>The following example demonstrates reflowable content with a two-page fixed-layout center
 							plate that the EPUB Creator intends Reading Systems to render using synthetic spreads in any
@@ -5143,7 +4610,6 @@ No Entry</pre>
     …
 &lt;/spine&gt;</pre>
 					</aside>
-
 					<aside class="example" id="fxl-ex6">
 						<p>The following example demonstrates fixed-layout content where Reading Systems must disable
 							synthetic spreads for a center plate. Note that the <code>rendition:spread</code>
@@ -5159,29 +4625,22 @@ No Entry</pre>
 &lt;/spine&gt;</pre>
 					</aside>
 				</section>
-
 				<section id="viewport">
 					<h4>Viewport Dimensions (Deprecated)</h4>
-
 					<p>The <code>rendition:viewport</code> property allows <a>EPUB Creators</a> to express the CSS
 						initial containing block (ICB) [[CSS2]] for XHTML and SVG Content Documents whose
 							<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
-
 					<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its definition in
 						[[EPUBPublications-301]] for more information.</p>
 				</section>
 			</section>
-
 			<section id="sec-fxl-content-dimensions">
 				<h3>Content Document Dimensions</h3>
-
 				<p>This section defines rules for the expression and interpretation of dimensional properties of
 						<a>Fixed-Layout Documents</a>.</p>
-
 				<p id="confreg-fxl-icb">Fixed-Layout Documents specify their <a
 						href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial containing
 						block</a> [[CSS2]] in the manner applicable to their format:</p>
-
 				<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
 					<dt id="sec-fxl-icb-html" data-tests="#fxl-xhtml-icb">Expressing in XHTML</dt>
 					<dd>
@@ -5200,7 +4659,6 @@ No Entry</pre>
 &lt;/head&gt;</pre>
 						</aside>
 					</dd>
-
 					<dt id="sec-fxl-icb-svg">Expressing in SVG</dt>
 					<dd>
 						<p>For SVG <a>Fixed-Layout Documents</a>, the initial containing block [[CSS2]] dimensions MUST
@@ -5222,21 +4680,16 @@ No Entry</pre>
 		</section>
 		<section id="sec-ocf">
 			<h2>Open Container Format</h2>
-
 			<section id="sec-container-abstract">
 				<h3>OCF Abstract Container</h3>
-
 				<section id="sec-container-abstract-intro" class="informative">
 					<h4>Introduction</h4>
-
 					<p>The <a>OCF Abstract Container</a> file system model uses a single common <a>Root Directory</a>
 						for all the contents. All <a>Local Resources</a> for the <a>EPUB Publication</a> are located
 						within the directory tree headed by the Root Directory, but no specific file system structure
 						for them is mandated by this specification.</p>
-
 					<p>The file system model also includes a mandatory directory named <code>META-INF</code> that is a
 						direct child of the Root Directory and stores the following special files:</p>
-
 					<dl class="variablelist">
 						<dt>
 							<code>container.xml</code>
@@ -5283,31 +4736,23 @@ No Entry</pre>
 							<p>A manifest of container contents as allowed by Open Document Format [[ODF]].</p>
 						</dd>
 					</dl>
-
 					<p>Refer to <a href="#sec-container-metainf"></a> for conformance requirements for the various files
 						in the <code>META-INF</code> directory.</p>
-
 				</section>
-
 				<section id="sec-container-file-and-dir-structure">
 					<h4>File and Directory Structure</h4>
-
 					<p>The virtual file system for the <a>OCF Abstract Container</a> MUST have a single common <a>Root
 							Directory</a> for all the contents of the container.</p>
-
 					<p>The OCF Abstract Container MUST include a directory for configuration files named
 							<code>META-INF</code> that is a direct child of the container's Root Directory. Refer to <a
 							href="#sec-container-metainf"></a> for the requirements for the contents of this
 						directory.</p>
-
 					<p>The file name <code>mimetype</code> in the Root Directory is reserved for use by <a>OCF ZIP
 							Containers</a>, as explained in <a href="#sec-container-zip"></a>.</p>
-
 					<p>EPUB Creators MAY locate all other files within the OCF Abstract Container in any location
 						descendant from the Root Directory, provided they are not within the <code>META-INF</code>
 						directory. EPUB Creators MUST NOT reference files in the <code>META-INF</code> directory from an
 						EPUB Publication.</p>
-
 					<div class="note">
 						<p>Some Reading Systems do not provide access to resources outside the directory where the
 							Package Document is stored. EPUB Creators should therefore place all resources at or below
@@ -5317,45 +4762,36 @@ No Entry</pre>
 								renditions</a> [[EPUB-MULTI-REND-11]] of the publication.</p>
 					</div>
 				</section>
-
 				<section id="sec-container-iri">
 					<h4>Relative URLs for Referencing Other Components</h4>
-
 					<p>Files within the <a>OCF Abstract Container</a> MUST reference each other via <a
 							href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
 							>relative-URL-with-fragment strings</a> [[URL]].</p>
-
 					<aside class="example">
 						<p>The following example shows how to reference, from an [[HTML]] <code>img</code> element, a
 							file named <code>image1.jpg</code> in the same directory as an <a>XHTML Content
 							Document</a>.</p>
 						<pre>&lt;img src="image1.jpg" alt="…" /&gt;</pre>
 					</aside>
-
 					<p>EPUB Creators SHOULD NOT use <a href="https://url.spec.whatwg.org/#path-absolute-url-string"
 							>path-absolute-URL strings</a> [[URI]] (i.e., where the path begins with a single slash) to
 						reference resources in the OCF Abstract Container.</p>
-
 					<div class="note">
 						<p>The base of an EPUB Publication can change from Reading System to Reading Systems depending
 							on how the content is served. Some Reading Systems may treat the location of the package
 							document as the base of the EPUB Publication, for example, while others may use the <a>Root
 								Directory</a>.</p>
 					</div>
-
 					<p>The relevant language specification for a given file format determines the <a
 							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]] used to parse <a
 							href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
 							>relative-URL-with-fragment strings</a> [[URL]]. For example, CSS defines how relative URL
 						references work in the context of CSS style sheets and property declarations
 						[[CSSSnapshot]].</p>
-
 					<p>Unlike most language specifications, the <a href="https://url.spec.whatwg.org/#concept-base-url"
 							>base URL</a> [[URL]] for all files within the <code>META-INF</code> directory is the
 							<a>Root Directory</a> of the OCF Abstract Container.</p>
-
 					<p>For example, if <code>META-INF/container.xml</code> has the following content:</p>
-
 					<pre class="example">
 &lt;?xml version="1.0"?&gt;
 &lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
@@ -5365,25 +4801,19 @@ No Entry</pre>
     &lt;/rootfiles&gt;
 &lt;/container&gt;
             </pre>
-
 					<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the root directory for the
 						OCF Abstract Container and not relative to the <code>META-INF</code> directory.</p>
-
 					<p>All <a href="https://url.spec.whatwg.org/#relative-url-with-fragment-string"
 							>relative-URL-with-fragment strings</a> [[URL]] MUST, after <a
 							href="https://url.spec.whatwg.org/#concept-url-parser">parsing to URL records</a> [[URL]],
 						identify resources within the OCF Abstract Container (i.e., at or below the Root Directory).</p>
 				</section>
-
 				<section id="sec-container-filenames">
 					<h4>Path and File Names</h4>
-
 					<p id="ocf-fn-cs">In the context of the Abstract Container, <a>Path Names</a> and <a>File Names</a>
 						are case sensitive.</p>
-
 					<p>In addition, the following restrictions are designed to allow Path Names and File Names to be
 						used without modification on most operating systems:</p>
-
 					<ul class="conformance-list">
 						<li>
 							<p id="ocf-fn-encoding">Path and File Names MUST be UTF-8 [[Unicode]] encoded.</p>
@@ -5480,7 +4910,6 @@ No Entry</pre>
 								information.)</p>
 						</li>
 					</ul>
-
 					<div class="note">
 						<p> If EPUB Creators dynamically integrate resources (i.e., where the naming is beyond their
 							control), they should be aware that automatic truncation of File Names to keep them within
@@ -5490,56 +4919,40 @@ No Entry</pre>
 								data-cite="international-specs/#char_truncation">"Truncating or limiting the length of
 								strings"</a> in [[international-specs]] for more information. </p>
 					</div>
-
-
 					<div class="note">
 						<p>Some commercial ZIP tools do not support the full Unicode range for File Names. <a>EPUB
 								Creators</a> who want to use ZIP tools that have these restrictions may find it best to
 							restrict their File Names to the [[US-ASCII]] range.</p>
 					</div>
-
 				</section>
-
 				<section id="sec-container-metainf">
 					<h4><code>META-INF</code> Directory</h4>
-
 					<section id="sec-container-metainf-inc">
 						<h5>Inclusion</h5>
-
 						<p>All <a>OCF Abstract Containers</a> MUST include a directory called <code>META-INF</code> in
 							their <a>Root Directory</a>.</p>
-
 						<p>This directory is reserved for configuration files, specifically those defined in <a
 								href="#sec-container-metainf-files"></a>.</p>
 					</section>
-
 					<section id="sec-container-metainf-files">
 						<h5>Reserved Files</h5>
-
 						<section id="sec-container-metainf-container.xml">
 							<h6>Container File (<code>container.xml</code>)</h6>
-
 							<p>The REQUIRED <code>container.xml</code> file in the <code>META-INF</code> directory
 								identifies the <a>Package Documents</a> available in the <a>OCF Abstract
 								Container</a>.</p>
-
 							<p>All [[XML]] elements defined in this section are in the
 									<code>urn:oasis:names:tc:opendocument:xmlns:container</code> namespace [[XML-NAMES]]
 								unless specified otherwise.</p>
-
 							<p>The contents of this file MUST be valid to the definition in this section after removing
 								all elements and attributes from other namespaces (including all attributes and contents
 								of such elements).</p>
-
 							<p class="note">An <a href="#app-schema-container">XML Schema</a> also informally defines
 								the content of this file.</p>
-
 							<section id="sec-container.xml-container-elem">
 								<h6>The <code>container</code> Element</h6>
-
 								<p>The <code>container</code> element is the root element of the
 										<code>container.xml</code> file.</p>
-
 								<dl id="elemdef-container" class="elemdef">
 									<dt>Element Name</dt>
 									<dd>
@@ -5573,13 +4986,10 @@ No Entry</pre>
 									</dd>
 								</dl>
 							</section>
-
 							<section id="sec-container.xml-rootfiles-elem">
 								<h6>The <code>rootfiles</code> Element</h6>
-
 								<p>The <code>rootfiles</code> element contains a list of <a>Package Documents</a>
 									available in the <a>EPUB Container</a>.</p>
-
 								<dl id="elemdef-rootfiles" class="elemdef">
 									<dt>Element Name</dt>
 									<dd>
@@ -5604,13 +5014,10 @@ No Entry</pre>
 									</dd>
 								</dl>
 							</section>
-
 							<section id="sec-container.xml-rootfile-elem">
 								<h6>The <code>rootfile</code> Element</h6>
-
 								<p>Each <code>rootfile</code> element identifies the location of one <a>Package
 										Document</a> in the <a>EPUB Container</a>.</p>
-
 								<dl id="elemdef-rootfile" class="elemdef">
 									<dt>Element Name</dt>
 									<dd>
@@ -5637,7 +5044,6 @@ No Entry</pre>
 														>path-relative-scheme-less-URL string</a> [[URL]]. The path is
 													relative to the <a>Root Directory</a>.</p>
 											</dd>
-
 											<dt>
 												<code>media-type</code>
 												<code>[required]</code>
@@ -5654,11 +5060,9 @@ No Entry</pre>
 										<p>Empty</p>
 									</dd>
 								</dl>
-
 								<p>If an EPUB Creator defines more than one <code>rootfile</code> element, each MUST
 									reference a Package Document that conforms to the same version of EPUB. Each Package
 									Document represents one rendering of the EPUB Publication.</p>
-
 								<div class="note">
 									<p>Although the EPUB Container provides the ability to reference more than one
 										Package Document, this specification does not define how to interpret, or select
@@ -5666,13 +5070,10 @@ No Entry</pre>
 										information on how to bundle more than one rendering of the content.</p>
 								</div>
 							</section>
-
 							<section id="sec-container.xml-links-elem">
 								<h6>The <code>links</code> Element</h6>
-
 								<p>The <code id="elemdef-container-links">links</code> element identifies resources
 									necessary for the processing of the <a>OCF ZIP Container</a>.</p>
-
 								<dl id="elemdef-links" class="elemdef">
 									<dt>Element Name</dt>
 									<dd>
@@ -5696,16 +5097,13 @@ No Entry</pre>
 										</ul>
 									</dd>
 								</dl>
-
 								<div class="note">
 									<p>This specification currently does not define uses for the <code>links</code>
 										element. Refer to [[EPUB-Multi-Rend-11]] for an example of its use.</p>
 								</div>
 							</section>
-
 							<section id="sec-container.xml-link-elem">
 								<h6>The <code>link</code> Element</h6>
-
 								<dl id="elemdef-link" class="elemdef">
 									<dt>Element Name</dt>
 									<dd>
@@ -5733,7 +5131,6 @@ No Entry</pre>
 														>path-relative-scheme-less-URL string</a> [[URL]]. The path is
 													relative to the <a>Root Directory</a>.</p>
 											</dd>
-
 											<dt>
 												<code>media-type</code>
 												<code>[optional]</code>
@@ -5742,7 +5139,6 @@ No Entry</pre>
 												<p>Identifies the type and format of the referenced resource.</p>
 												<p>The value of the attribute MUST be a media type [[RFC2046]].</p>
 											</dd>
-
 											<dt>
 												<code>rel</code>
 												<code>[required]</code>
@@ -5760,14 +5156,11 @@ No Entry</pre>
 									</dd>
 								</dl>
 							</section>
-
 							<section id="sec-container-container.xml-example" class="informative">
 								<h6>Container Example</h6>
-
 								<p>The following example shows a sample <code>container.xml</code> file for an EPUB
 									Publication with the root file <code>EPUB/My Crazy Life.opf</code> (the Package
 									Document):</p>
-
 								<pre class="example">
 &lt;?xml version="1.0"?&gt;
 &lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
@@ -5779,19 +5172,15 @@ No Entry</pre>
                     </pre>
 							</section>
 						</section>
-
 						<section id="sec-container-metainf-encryption.xml">
 							<h6>Encryption File (<code>encryption.xml</code>)</h6>
-
 							<p>The OPTIONAL <code>encryption.xml</code> file in the <code>META-INF</code> directory
 								holds all encryption information on the contents of the container. If an EPUB Creator
 								encrypts any resources within the container, they MUST include an
 									<code>encryption.xml</code> file to provide information about the encryption
 								used.</p>
-
 							<section id="sec-encryption.xml-encryption">
 								<h6>The <code>encryption</code> element</h6>
-
 								<dl class="elemdef" id="elemdef-encryption">
 									<dt>Element Name</dt>
 									<dd>
@@ -5820,25 +5209,20 @@ No Entry</pre>
 										</ul>
 									</dd>
 								</dl>
-
 								<p>The <code>encryption</code> element contains child elements of type
 										<code>EncryptedKey</code> and <code>EncryptedData</code> as defined by
 									[[XMLENC-CORE1]].</p>
-
 								<p>An <code id="elemdef-encryption-EncryptedKey">EncryptedKey</code> element describes
 									each encryption key used in the container, while an <code
 										id="elemdef-encryption-EncryptedData">EncryptedData</code> element describes
 									each encrypted file. Each <code>EncryptedData</code> element refers to an
 										<code>EncryptedKey</code> element, as described in XML Encryption.</p>
-
 								<p class="note">An <a href="#app-schema-encryption">XML Schema</a> also informally
 									defines the content of the <code>encryption.xml</code> file.</p>
-
 								<p>OCF encrypts individual files independently, trading off some security for improved
 									performance, allowing the container contents to be incrementally decrypted.
 									Encryption in this way exposes the directory structure and file naming of the whole
 									package.</p>
-
 								<p>OCF uses XML Encryption [[XMLENC-CORE1]] to provide a framework for encryption,
 									allowing a variety of algorithms to be used. XML Encryption specifies a process for
 									encrypting arbitrary data and representing the result in XML. Even though an <a>OCF
@@ -5846,23 +5230,19 @@ No Entry</pre>
 									Encryption to encrypt all data in an OCF Abstract Container. OCF encryption supports
 									only the encryption of entire files within the container, not parts of files. EPUB
 									Creators MUST NOT encrypt the <code>encryption.xml</code> file when present.</p>
-
 								<p>Encrypted data replaces unencrypted data in an OCF Abstract Container. For example,
 									if an EPUB Creator encrypts an image named <code>photo.jpeg</code>, they should
 									replace the contents of the <code>photo.jpeg</code> resource with its encrypted
 									contents. Within the ZIP directory, EPUB Creators SHOULD store encrypted files
 									rather than Deflate-compress them.</p>
-
 								<p id="encryption-obfuscation">Note that some situations require obfuscating the storage
 									of embedded resources referenced by an <a>EPUB Publication</a> to make them more
 									difficult to extract for unrestricted use (e.g., fonts). Although obfuscation is not
 									encryption, Reading Systems use the <code>encryption.xml</code> file in conjunction
 									with the <a href="#sec-resource-obfuscation">resource obfuscation algorithm</a> to
 									identify resources to de-obfuscated.</p>
-
 								<p id="encryption-restrictions">EPUB Creators MUST NOT encrypt or obfuscate the
 									following files:</p>
-
 								<ul class="nomark">
 									<li>
 										<code>mimetype</code>
@@ -5891,12 +5271,10 @@ No Entry</pre>
 										</a>
 									</li>
 								</ul>
-
 								<p>EPUB Creators MAY subsequently encrypt signed resources using the Decryption
 									Transform for XML Signature [[XMLENC-DECRYPT]]. This feature enables a Reading
 									System to distinguish data encrypted before signing from data encrypted after
 									signing.</p>
-
 								<aside class="example">
 									<p>In the following example, adapted from <a
 											href="https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/#sec-eg-Symmetric-Key"
@@ -5932,15 +5310,12 @@ No Entry</pre>
                     </pre>
 								</aside>
 							</section>
-
 							<section id="sec-enc-compression">
 								<h6>Order of Compression and Encryption</h6>
-
 								<p>When stored in a ZIP container, EPUB Creators SHOULD compress streams of data with
 										<a>Non-Codec</a> content types before encrypting them. EPUB Creators MUST use
 									Deflate compression. This practice ensures that file entries stored in the ZIP
 									container have a smaller size.</p>
-
 								<p>EPUB Creators SHOULD NOT compress streams of data with <a>Codec</a> content types
 									before encrypting them. In such cases, additional compression introduces unnecessary
 									processing overhead at production time (especially with large resource files) and
@@ -5949,7 +5324,6 @@ No Entry</pre>
 									ability of Reading Systems to handle partial content requests (e.g. HTTP byte
 									ranges), due to the technical impossibility to determine the length of the full
 									resource ahead of media playback (e.g. HTTP Content-Length header).</p>
-
 								<p>When EPUB Creators compress streams of data before encrypting, they SHOULD provide
 									additional <code>EncryptionProperties</code> metadata to specify the size of the
 									initial resource (i.e., before compression and encryption), as per the
@@ -5957,7 +5331,6 @@ No Entry</pre>
 									compress streams of data before encrypting, they MAY provide the additional
 										<code>EncryptionProperties</code> metadata to specify the size of the initial
 									resource (i.e., before encryption).</p>
-
 								<dl class="elemdef" id="elemdef-enc-Compression">
 									<dt>Element Name</dt>
 									<dd>
@@ -5996,7 +5369,6 @@ No Entry</pre>
 										<p>Empty</p>
 									</dd>
 								</dl>
-
 								<aside class="example">
 									<p>The following example shows an MP4 file that that has been Deflate compressed and
 										whose original size was 3500000 bytes.</p>
@@ -6017,68 +5389,50 @@ No Entry</pre>
 								</aside>
 							</section>
 						</section>
-
 						<section id="sec-container-metainf-manifest.xml">
 							<h6>Manifest File (<code>manifest.xml</code>)</h6>
-
 							<p>The OPTIONAL <code>manifest.xml</code> file in the <code>META-INF</code> directory
 								provides a manifest of files in the Container.</p>
-
 							<p>The OCF specification does not mandate a format for the manifest.</p>
-
 							<p>Note that <a>Package Documents</a> specify the only manifests used for processing <a>EPUB
 									Publications</a>. Reading Systems do not use this file.</p>
-
 							<div class="note">This feature exists only for compatibility with [[ODF]].</div>
 						</section>
-
 						<section id="sec-container-metainf-metadata.xml">
 							<h6>Metadata File (<code>metadata.xml</code>)</h6>
-
 							<p>EPUB Creators MUST use the OPTIONAL <code>metadata.xml</code> file in the
 									<code>META-INF</code> directory only for container-level metadata.</p>
-
 							<p>If EPUB Creators include a <code>metadata.xml</code> file, they SHOULD use only
 								namespace-qualified elements [[XML-NAMES]] in it. The file SHOULD contain the root
 								element <code>metadata</code> in the namespace
 									<code>http://www.idpf.org/2013/metadata</code>, but this specification allows other
 								root elements for backwards compatibility.</p>
-
 							<p>This version of the specification does not define metadata for use in the
 									<code>metadata.xml</code> file. Future versions of this specification MAY define
 								container-level metadata.</p>
 						</section>
-
 						<section id="sec-container-metainf-rights.xml">
 							<h6>Rights Management File (<code>rights.xml</code>)</h6>
-
 							<p>This specification resrves the OPTIONAL <code>rights.xml</code> file in the
 									<code>META-INF</code> directory for digital rights management (DRM) information for
 								trusted exchange of EPUB Publications among rights holders, intermediaries, and
 								users.</p>
-
 							<p>When EPUB Creators do not include a <code>rights.xml</code> file, no part of the
 								container is rights governed at the container level. Rights expressions might exist
 								within the EPUB Publications.</p>
-
 							<p>If EPUB Creators do not include a <code>rights.xml</code> file, no part of the OCF
 								Abstract Container is rights governed.</p>
 						</section>
-
 						<section id="sec-container-metainf-signatures.xml">
 							<h6>Digital Signatures File (<code>signatures.xml</code>)</h6>
-
 							<div class="note">
 								<p>Adding a digital signature is not a guarantee that a malicious actor cannot tamper
 									with an EPUB Publication as Reading Systems do not have to check signatures.</p>
 							</div>
-
 							<p>The OPTIONAL <code>signatures.xml</code> file in the <code>META-INF</code> directory
 								holds digital signatures for the container and its contents.</p>
-
 							<section id="sec-signatures.xml-signatures">
 								<h6>The <code>signatures</code> element</h6>
-
 								<dl class="elemdef" id="elemdef-signatures">
 									<dt>Element Name</dt>
 									<dd>
@@ -6105,23 +5459,18 @@ No Entry</pre>
 										</ul>
 									</dd>
 								</dl>
-
 								<p>The <code>signature</code> element contains child elements of type
 										<code>Signature</code>, as defined by [[XMLDSIG-CORE1]]. EPUB Creators can apply
 									signatures to an EPUB Publication as a whole or to its parts, and can specify the
 									signing of any kind of data (i.e., not just XML).</p>
-
 								<p class="note">An <a href="#app-schema-signatures">XML Schema</a> also informally
 									defines the content of the <code>signatures.xml</code> file.</p>
-
 								<p>When an EPUB Creator does not include a <code>signatures.xml</code> file, they are
 									not signing any part of the container at the container level. Digital signing might
 									exist within the <a>EPUB Publication</a>.</p>
-
 								<p id="sig-container">When an EPUB Creator creates a data signature for the container,
 									they SHOULD add the signature as the last child <code>Signature</code> element of
 									the <code>signatures</code> element.</p>
-
 								<div class="note">
 									<p>Each <code>Signature</code> in the <code>signatures.xml</code> file identifies by
 										URL [[URL]] the data to which the signature applies, using the [[XMLDSIG-CORE1]]
@@ -6133,16 +5482,13 @@ No Entry</pre>
 										signed files in a single XML Signature <code>Manifest</code> element and
 										reference them by one or more <code>Signature</code> elements.</p>
 								</div>
-
 								<p id="sig-restrictions">EPUB Creators can sign any or all files in the container in
 									their entirety, except for the <code>signatures.xml</code> file since that file will
 									contain the computed signature information. Whether and how EPUB Creators sign the
 										<code>signatures.xml</code> file depends on their objective.</p>
-
 								<p>If the EPUB Creator wants to allow signatures to be added or removed from the
 									container without invalidating their signature, they SHOULD NOT sign the
 										<code>signatures.xml</code> file.</p>
-
 								<p>If the EPUB Creator wants any addition or removal of a signature to invalidate their
 									signature, they can use the Enveloped Signature transform defined in <a
 										href="https://www.w3.org/TR/2008/REC-xmldsig-core-20080610/#sec-EnvelopedSignature"
@@ -6150,20 +5496,17 @@ No Entry</pre>
 									file excluding the <code>Signature</code> being created. This transform would sign
 									all previous signatures, and it would become invalid if a subsequent signature were
 									added to the package.</p>
-
 								<div class="note">
 									<p>If the EPUB Creator wants the removal of an existing signature to invalidate the
 										their signature, but also wants to allow the addition of signatures, they could
 										use an XPath transform to sign just the existing signatures. The details of such
 										a transform are outside the scope of this specification, however.</p>
 								</div>
-
 								<p>The [[XMLDSIG-CORE1]] specification does not associate any semantics with a
 									signature; an agent might include semantic information, for example, by adding
 									information to the Signature element that describes the signature. The
 									[[XMLDSIG-CORE1]] specification describes how additional information can be added to
 									a signature, such as by use the <code>SignatureProperties</code> element.</p>
-
 								<aside class="example">
 									<p>The following XML expression shows the content of an example
 											<code>signatures.xml</code> file. It is based on the examples found in <a
@@ -6221,16 +5564,12 @@ No Entry</pre>
 					</section>
 				</section>
 			</section>
-
 			<section id="sec-container-zip">
 				<h3>OCF ZIP Container</h3>
-
 				<section id="sec-container-zip-intro" class="informative">
 					<h4>Introduction</h4>
-
 					<p>An <a>OCF ZIP Container</a> is a physical single-file manifestation of an <a>OCF Abstract
 							Container</a>. The Container allows:</p>
-
 					<ul>
 						<li>
 							<p>the exchange of in-progress <a>EPUB Publication</a> between different individuals and/or
@@ -6245,13 +5584,10 @@ No Entry</pre>
 						</li>
 					</ul>
 				</section>
-
 				<section id="sec-zip-container-zipreqs">
 					<h4>ZIP File Requirements</h4>
-
 					<p>An <a>OCF ZIP Container</a> uses the ZIP format as specified by [[ZIP]], but with the following
 						constraints and clarifications:</p>
-
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-zip-abstr">The contents of the OCF ZIP Container MUST be a conforming <a
@@ -6281,9 +5617,7 @@ No Entry</pre>
 								[[Unicode]].</p>
 						</li>
 					</ul>
-
 					<p>The following constraints apply to specific fields in the OCF ZIP Container archive:</p>
-
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-zip-fld-version">In the local file header table, EPUB Creators MUST set the
@@ -6298,10 +5632,8 @@ No Entry</pre>
 						</li>
 					</ul>
 				</section>
-
 				<section id="sec-zip-container-mime">
 					<h4>OCF ZIP Container Media Type Identification</h4>
-
 					<p>EPUB Creators MUST include the <code>mimetype</code> file as the first file in the <a>OCF ZIP
 							Container</a>. In addition:</p>
 					<ul>
@@ -6313,52 +5645,42 @@ No Entry</pre>
 						<li>EPUB Creators MUST NOT compress or encrypt the <code>mimetype</code> file, and MUST NOT
 							include an extra field in its ZIP header.</li>
 					</ul>
-
 					<div class="note">
 						<p>Refer to <a href="#app-media-type"></a> for further information about the
 								<code>application/epub+zip</code> media type.</p>
 					</div>
 				</section>
 			</section>
-
 			<section id="sec-resource-obfuscation">
 				<h3>Resource Obfuscation</h3>
-
 				<section id="fobfus-intro" class="informative">
 					<h4>Introduction</h4>
-
 					<p>Since an <a>OCF ZIP Container</a> is fundamentally a ZIP file, commonly available ZIP tools can
 						be used to extract any unencrypted content stream from the package. Moreover, the nature of ZIP
 						files means that their contents might appear like any other native container on some systems
 						(e.g., a folder).</p>
-
 					<p>While this simplicity of ZIP files is quite useful, it also poses a problem when ease of
 						extraction of resources is not a desired side-effect of not encrypting them. An <a>EPUB
 							Creator</a> who wishes to include a third-party font, for example, typically does not want
 						that font extracted and re-used by others. More critically, many commercial fonts allow
 						embedding, but embedding a font implies making it an integral part of the EPUB Publication, not
 						just providing the original font file along with the content.</p>
-
 					<p>Since integrated ZIP support is so ubiquitous in modern operating systems, simply placing a font
 						in the ZIP archive is insufficient to signify that the font cannot be reused in other contexts.
 						This uncertainty can undermine the otherwise useful font embedding capability of EPUB
 						Publications.</p>
-
 					<p>To discourage reuse of the font, some font vendors might only allow use of their fonts in EPUB
 						Publications if those fonts are bound in some way to the EPUB Publication. That is, if the font
 						file cannot be installed directly for use on an operating system with the built-in tools of that
 						computing device, and it cannot be directly used by other EPUB Publications.</p>
-
 					<p>It is beyond the scope of this specification to provide a digital rights management or
 						enforcement system for such resources. This section instead defines a method of obfuscation that
 						will require additional work on the part of the final OCF recipient to gain general access to
 						any obfuscated resources.</p>
-
 					<p>Note this specification does not claim that this constitutes encryption, nor does it guarantee
 						that the resource will be secure from copyright infringement. The hope is that this algorithm
 						will meet the requirements of most vendors who require some assurance that their resources
 						cannot simply be extracted by unzipping the Container.</p>
-
 					<p>In the case of fonts, the primary use case for obfuscation, the defined mechanism will simply
 						provide a stumbling block for those who are unaware of the license details. It will not prevent
 						a determined user from gaining full access to the font. Given an OCF Container, it is possible
@@ -6366,45 +5688,35 @@ No Entry</pre>
 						satisfies the requirements of individual font licenses remains a question for the licensor and
 						licensee.</p>
 				</section>
-
 				<section id="obfus-keygen">
 					<h4>Obfuscation Key</h4>
-
 					<p>EPUB Creators MUST derive the key used in the obfuscation algorithm from the <a>Unique
 							Identifier</a>.</p>
-
 					<p>All white space characters, as defined in <a
 							href="https://www.w3.org/TR/2008/REC-xml-20081126/#sec-common-syn">section 2.3 of the XML
 							1.0 specification</a> [[XML]], MUST be removed from this identifier — specifically, the
 						Unicode code points <code>U+0020</code>, <code>U+0009</code>, <code>U+000D</code> and
 							<code>U+000A</code>.</p>
-
 					<p>EPUB Creators SHOULD generate a SHA-1 digest of the UTF-8 representation of the resulting string
 						as specified by the Secure Hash Standard [[FIPS-180-4]]. They can then use this digest as the
 						key for the algorithm.</p>
 				</section>
-
 				<section id="obfus-algorithm">
 					<h4>Obfuscation Algorithm</h4>
-
 					<p>The algorithm employed to obfuscate resource consists of modifying the first 1040 bytes (~1KB) of
 						the file. (In the unlikely event that the file is less than 1040 bytes, this process will modify
 						the entire file.)</p>
-
 					<p>To obfuscate the original data, store, as the first byte of the embedded resource, the result of
 						performing a logical exclusive or (XOR) on the first byte of the raw file and the first byte of
 						the <a href="#obfus-keygen">obfuscation key</a>.</p>
-
 					<p>Repeat this process with the next byte of source and key and continue for all bytes in the key.
 						At this point, the process continues starting with the first byte of the key and 21st byte of
 						the source. Once 1040 bytes are encoded in this way (or the end of the source is reached),
 						directly copy any remaining data in the source to the destination.</p>
-
 					<p>EPUB Creators MUST obfuscate resources before compressing and adding them to the OCF Container.
 						Note that as obfuscation is not encryption, this requirement is not a violation of the one in <a
 							href="#sec-container-metainf-encryption.xml"></a> to compress resources before encrypting
 						them.</p>
-
 					<aside class="example">
 						<p>The following pseudo-code exemplifies the obfuscation algorithm.</p>
 						<pre class="programlisting">
@@ -6434,14 +5746,11 @@ store destination as source in ocf
             </pre>
 					</aside>
 				</section>
-
 				<section id="obfus-specifying">
 					<h4>Specifying Obfuscated Resources</h4>
-
 					<p>Although not technically encrypted data, all obfuscated resources MUST have an entry in the <code
 							class="filename">encryption.xml</code> file accompanying the EPUB Publication (see <a
 							href="#sec-container-metainf-encryption.xml"></a>).</p>
-
 					<p>EPUB Creators MUST specify an <code>EncryptedData</code> element for each obfuscated resource.
 						Each <code>EncryptedData</code> element MUST contain a child <code>EncryptionMethod</code>
 						element whose <code>Algorithm</code> attribute has the value
@@ -6449,7 +5758,6 @@ store destination as source in ocf
 						use of the algorithm described in this specification. EPUB Creators MUST list the path to the
 						obfuscated resource in the <code>CipherReference</code> child of the <code>CipherData</code>
 						element.</p>
-
 					<aside class="example">
 						<p>The following example shows an entry for an obfuscated font in the
 								<code>encryption.xml</code> file.</p>
@@ -6467,7 +5775,6 @@ store destination as source in ocf
 
                 </pre>
 					</aside>
-
 					<p>To prevent trivial copying of the embedded resource to other EPUB Publications, EPUB Creators
 						MUST NOT provide the <a href="#obfus-keygen">obfuscation key</a> in the
 							<code>encryption.xml</code> file.</p>
@@ -6476,45 +5783,35 @@ store destination as source in ocf
 		</section>
 		<section id="sec-media-overlays">
 			<h2>Media Overlays</h2>
-
 			<section id="sec-overlays-introduction" class="informative">
 				<h4>Introduction</h4>
-
 				<p>Mainstream ebooks, educational tools and ebooks formatted for persons with print disabilities are
 					some examples of works that contain synchronized audio narration. In EPUB 3, EPUB Creators can
 					create these types of books using Media Overlay Documents to describe the timing for the
 					pre-recorded audio narration and how it relates to the EPUB Content Document markup. The
 					specification defines the file format for Media Overlays as a subset of [[SMIL3]], a W3C
 					recommendation for representing synchronized multimedia information in XML.</p>
-
 				<p>The text and audio synchronization enabled by Media Overlays provides enhanced accessibility for any
 					user who has difficulty following the text of a traditional book. Media Overlays also provide a
 					continuous listening experience for readers who are unable to read the text for any reason,
 					something that traditional audio embedding techniques cannot offer. They are even useful for
 					purposes not traditionally considered accessibility concerns (e.g., for language learning).</p>
-
 				<p>The Media Overlays feature is transparent to <a>EPUB Reading Systems</a> that do not support the
 					feature. The inclusion of Media Overlays in an EPUB Publication has no impact on the ability of
 					Media Overlay-unaware Reading Systems to render the EPUB Publication as though the Media Overlays
 					are not present.</p>
-
 				<p>Media Overlays in EPUB are not an equivalent to audiobooks, as audiobooks are primarily audio-based
 					with text occasionally provided as an alternate format. The W3C [[Audiobooks]] recommendation is for
 					building audio publications.</p>
-
 				<p>Although future versions of this specification might incorporate support for video media (e.g.,
 					synchronized text/sign-language books), this version supports only synchronizing audio media with
 					the EPUB Content Document.</p>
 			</section>
-
 			<section id="sec-overlay-docs">
 				<h3>Media Overlay Documents</h3>
-
 				<section id="sec-overlay-req">
 					<h4>Media Overlay Document Requirements</h4>
-
 					<p>A <a>Media Overlay Document</a>:</p>
-
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-mo-docprops-schema">MUST be valid to the Media Overlays schema as defined in
@@ -6532,18 +5829,13 @@ store destination as source in ocf
 						</li>
 					</ul>
 				</section>
-
 				<section id="sec-overlays-def">
 					<h3>Media Overlay Document Definition</h3>
-
 					<p>All elements [[XML]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
 						namespace [[XML-NAMES]] unless otherwise specified.</p>
-
 					<section id="sec-smil-smil-elem">
 						<h5>The <code>smil</code> Element</h5>
-
 						<p>The <code>smil</code> element is the root element of all Media Overlay Documents.</p>
-
 						<dl class="elemdef" id="elemdef-smil">
 							<dt>Element Name</dt>
 							<dd>
@@ -6610,13 +5902,10 @@ store destination as source in ocf
 							</dd>
 						</dl>
 					</section>
-
 					<section id="sec-smil-head-elem">
 						<h5>The <code>head</code> Element</h5>
-
 						<p>The <code>head</code> element is the container for metadata in the Media Overlay
 							Document.</p>
-
 						<dl class="elemdef" id="elemdef-smil-head">
 							<dt>Element Name</dt>
 							<dd>
@@ -6643,18 +5932,14 @@ store destination as source in ocf
 								</p>
 							</dd>
 						</dl>
-
 						<p>As this specification does not define any metadata properties that must occur in the Media
 							Overlay Document, the <code>head</code> element is OPTIONAL.</p>
 					</section>
-
 					<section id="sec-smil-metadata-elem">
 						<h5>The <code>metadata</code> Element</h5>
-
 						<p>The <code>metadata</code> element represents metadata for the Media Overlay Document. The
 								<code>metadata</code> element is an extension point that allows the inclusion of
 							metadata from any metainformation structuring language.</p>
-
 						<dl class="elemdef" id="elemdef-smil-metadata">
 							<dt>Element Name</dt>
 							<dd>
@@ -6675,19 +5960,15 @@ store destination as source in ocf
 								<p><code>[0 or more]</code> elements from any namespace</p>
 							</dd>
 						</dl>
-
 						<p>This specification defines no metadata properties that MUST occur in the Media Overlay
 							Document; the <code>metadata</code> element is provided for custom metadata
 							requirements.</p>
 					</section>
-
 					<section id="sec-smil-body-elem">
 						<h5>The <code>body</code> Element</h5>
-
 						<p>The <code>body</code> element is the starting point for the presentation contained in the
 							Media Overlay Document. It contains the main sequence of <code>par</code> and
 								<code>seq</code> elements.</p>
-
 						<dl class="elemdef" id="elemdef-smil-body">
 							<dt>Element Name</dt>
 							<dd>
@@ -6760,12 +6041,9 @@ store destination as source in ocf
 							</dd>
 						</dl>
 					</section>
-
 					<section id="sec-smil-seq-elem">
 						<h5>The <code>seq</code> Element</h5>
-
 						<p>The <code>seq</code> element contains a sequential rendering of media objects.</p>
-
 						<dl class="elemdef" id="elemdef-smil-seq">
 							<dt>Element Name</dt>
 							<dd>
@@ -6841,12 +6119,9 @@ store destination as source in ocf
 							</dd>
 						</dl>
 					</section>
-
 					<section id="sec-smil-par-elem">
 						<h5>The <code>par</code> Element</h5>
-
 						<p>The <code>par</code> element defines the parallel rendering of media objects.</p>
-
 						<dl class="elemdef" id="elemdef-smil-par">
 							<dt>Element Name</dt>
 							<dd>
@@ -6912,14 +6187,11 @@ store destination as source in ocf
 							</dd>
 						</dl>
 					</section>
-
 					<section id="sec-smil-text-elem">
 						<h5>The <code>text</code> Element</h5>
-
 						<p>The <code>text</code> element references an element in the <a>EPUB Content Document</a>. A
 								<code>text</code> element typically refers to a textual element but can also refer to
 							other EPUB Content Document media elements (see <a href="#sec-embedded-media"></a>).</p>
-
 						<dl class="elemdef" id="elemdef-smil-text">
 							<dt>Element Name</dt>
 							<dd>
@@ -6962,12 +6234,9 @@ store destination as source in ocf
 							</dd>
 						</dl>
 					</section>
-
 					<section id="sec-smil-audio-elem">
 						<h5>The <code>audio</code> Element</h5>
-
 						<p>The <code>audio</code> element represents a clip of audio media.</p>
-
 						<dl class="elemdef" id="elemdef-smil-audio">
 							<dt>Element Name</dt>
 							<dd>
@@ -7039,13 +6308,10 @@ store destination as source in ocf
 					</section>
 				</section>
 			</section>
-
 			<section id="sec-overlay-doc-create">
 				<h3>Creating Media Overlays</h3>
-
 				<section id="sec-docs-intro" class="informative">
 					<h4>Introduction</h4>
-
 					<p>EPUB Creators can represent a pre-recorded narration of a publication as a series of audio clips,
 						each corresponding to part of an <a>EPUB Content Document</a>. A single audio clip, for example,
 						typically represents a single phrase or paragraph, but infers no order relative to the other
@@ -7053,13 +6319,11 @@ store destination as source in ocf
 						tying the structured audio narration to its corresponding text (or other media) in the EPUB
 						Content Document using [[SMIL3]] markup. Media Overlays are, in fact, a simplified subset of
 						SMIL 3.0 that define the playback sequence of these clips.</p>
-
 					<p>The SMIL elements primarily used for structuring Media Overlays are <a href="#elemdef-smil-body"
 								><code>body</code></a> (used for the main sequence), <a href="#elemdef-smil-seq"
 								><code>seq</code></a> (sequence) and <a href="#elemdef-smil-par"><code>par</code></a>
 						(parallel). (Refer to <a href="#sec-overlays-def"></a> for more information on these and other
 						SMIL elements.)</p>
-
 					<p>The <code>par</code> element is the basic building block of an Overlay and corresponds to a
 						phrase in the EPUB Content Document. The element provides two key pieces of information for
 						synchronizing content: 1) the audio clip containing the narration for the phrase; and 2) a
@@ -7069,14 +6333,12 @@ store destination as source in ocf
 						element. Since <code>par</code> elements render their children in parallel, Reading Systems play
 						the audio clip and EPUB Content Document fragment at the same time, resulting in a synchronized
 						presentation.</p>
-
 					<p>The <code>text</code> element <code>src</code> attribute references the associated phrase,
 						sentence, or other segment of the EPUB Content Document by its URL [[URL]] reference. The
 							<code>audio</code> element <code>src</code> attribute similarly references the location of
 						the corresponding audio clip and adds the OPTIONAL <a href="#attrdef-smil-clipBegin"
 								><code>clipBegin</code></a> and <a href="#attrdef-smil-clipEnd"><code>clipEnd</code></a>
 						attributes to indicate a specific offset within the clip.</p>
-
 					<aside class="example">
 						<p>The following example shows the Media Overlays markup for a single phrase or sentence.</p>
 						<pre>&lt;par&gt;                        
@@ -7084,12 +6346,10 @@ store destination as source in ocf
     &lt;audio src="chapter1_audio.mp3" clipBegin="23s" clipEnd="30s"/&gt;
 &lt;/par&gt;</pre>
 					</aside>
-
 					<p>EPUB Creators place <code>par</code> elements together sequentially to form a series of phrases
 						or sentences. Not every element of the EPUB Content Document will have a corresponding
 							<code>par</code> element in the Media Overlay, only those relevant to the audio
 						narration.</p>
-
 					<aside class="example">
 						<p>The following example shows a basic Media Overlay Document containing a sequence of phrases.
 							The <code>body</code> element acts as the main sequence for the whole document.</p>
@@ -7111,15 +6371,12 @@ store destination as source in ocf
     &lt;/body&gt;
 &lt;/smil&gt;</pre>
 					</aside>
-
 					<p>EPUB Creators can also add <code>par</code> elements to <code>seq</code> elements to define more
 						complex structures such as parts and chapters (see <a href="#sec-media-overlays-structure"
 						></a>).</p>
 				</section>
-
 				<section id="sec-docs-relations">
 					<h4>Relationship to the EPUB Content Document</h4>
-
 					<div class="note">
 						<p>In this section, the <a>EPUB Content Document</a> is assumed to be an <a>XHTML Content
 								Document</a>. While EPUB Creators may use Media Overlays with <a>SVG Content
@@ -7128,30 +6385,25 @@ store destination as source in ocf
 					</div>
 					<section id="sec-media-overlays-structure">
 						<h5>Overlay Structure</h5>
-
 						<p>The <a href="#elemdef-smil-body"><code>body</code></a> of a Media Overlay Document consists
 							of two elements: the <a href="#elemdef-smil-par"><code>par</code> element</a> and the <a
 								href="#elemdef-smil-seq"><code>seq</code> element</a>. The ordering of these elements
 							represents how Reading Systems render the content in the corresponding EPUB Content
 							Documents during playback.</p>
-
 						<p>The <code>par</code> element represents a segment of content to render, such as a word,
 							phrase, sentence, table cell, list item, image, or other identifiable piece of content in
 							the markup. Each element identifies both the content to display (in the <a
 								href="#elemdef-smil-text"><code>text</code> element</a>) and audio to synchronize (in
 							the <a href="#elemdef-smil-audio"><code>audio</code> element</a>) during playback.</p>
-
 						<p>The <code>seq</code> element represents sequences &#8212; sets of <code>seq</code> and/or
 								<code>par</code> elements that together represent a logical component of the content.
 							EPUB Creators can use it to represent nested containers such as sections, asides, headers,
 							tables, lists, and footnotes. It allows EPUB Creators to retain the structure inherent in
 							these containers in the Media Overlay Document.</p>
-
 						<p>The <code>seq</code> element MUST contain an <a href="#attrdef-body-textref"
 									><code>epub:textref</code> attribute</a>. As <code>seq</code> elements do not
 							provide synchronization instructions, this attribute allows a Reading System to match the
 							fragment to a location in the text.</p>
-
 						<div class="example" id="example-mo-nesting">
 							<p>The following example shows a Media Overlay Document with nested <code>seq</code>
 								elements, representing a chapter with both a section header and a figure.</p>
@@ -7218,7 +6470,6 @@ store destination as source in ocf
 &lt;/smil&gt;
 </pre>
 						</div>
-
 						<div class="note">
 							<p>The reason for grouping structures like sections, figures, tables, and footnotes in a
 									<code>seq</code> element is so that Reading Systems can identify their start and end
@@ -7227,7 +6478,6 @@ store destination as source in ocf
 								page break announcements (see <a href="#sec-behaviors-skip-escape"></a>), or customizing
 								the reading mode to suit structures such as tables.</p>
 						</div>
-
 						<aside class="example">
 							<p>The following example shows the EPUB Content Document that corresponds to the <a
 									href="#example-mo-nesting">previous Media Overlay example</a>.</p>
@@ -7256,29 +6506,23 @@ store destination as source in ocf
 &lt;/html&gt;</pre>
 						</aside>
 					</section>
-
 					<section id="sec-media-overlays-fragids">
 						<h5>Referencing Document Fragments</h5>
-
 						<p>The <code>epub:textref</code> attribute and the <a href="#elemdef-smil-text"
 									><code>text</code> element's</a>
 							<code>src</code> attribute both require a fragment identifier that references a specific
 							fragment (e.g., an element or text string) of the associated <a>EPUB Content
 							Document</a>.</p>
-
 						<p>For XHTML and SVG Content Documents, the fragment SHOULD be a reference to a <a
 								href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#target-element"
 								>target element</a> [[HTML]] or an <a
 								href="https://www.w3.org/TR/SVG2/linking.html#SVGFragmentIdentifiers">SVG Fragment
 								Identifier</a> [[SVG]], respectively.</p>
-
 						<p>EPUB Creators MAY use other fragment identifier schemes, but Reading Systems may not support
 							such identifiers.</p>
 					</section>
-
 					<section id="sec-media-overlays-granularity" class="informative">
 						<h5>Overlay Granularity</h5>
-
 						<p>The granularity level of the Media Overlay depends on how EPUB Creators mark up the EPUB
 							Content Document and the type of fragment identifier they use in the <a
 								href="#elemdef-smil-text"><code>text</code> elements'</a>
@@ -7295,60 +6539,47 @@ store destination as source in ocf
 							that do not rely on the presence of elements could provide even finer granularity, where
 							supported.</p>
 					</section>
-
 					<section id="sec-embedded-media">
 						<h5>Embedded Media</h5>
-
 						<p>Any <a>EPUB Content Document</a> associated with a Media Overlay MAY contain embedded media
 							such as video, audio, and images. EPUB Creators MAY use the Media Overlay <a
 								href="#elemdef-smil-text"><code>text</code> element</a> in such instances to reference
 							the embedded media by its element's <code>id</code> attribute value.</p>
-
 						<section id="sec-emb-audio-video">
 							<h6>Embedded Audio and Video</h6>
-
 							<p>When a <code>text</code> element references embedded audio or video, the <a
 									href="#elemdef-smil-audio"><code>audio</code></a> sibling element is OPTIONAL.
 								Reading Systems will intiate playback of the media in the absence of an
 									<code>audio</code> element.</p>
-
 							<p><a>EPUB Creators</a> SHOULD avoid using scripts to control playback of referenced
 								embedded EPUB Content Document media, as this might conflict with Media Overlays
 								playback behavior.</p>
-
 							<p>EPUB Creators should carefully examine any overlapping audio situations and deal with
 								them at the production stage, as Reading Systems handling of simultaneous volume levels
 								is optional.</p>
 						</section>
-
 						<section id="sec-emb-img">
 							<h6>Embedded Images</h6>
-
 							<p>When a <code>text</code> element references an embedded image, the <a
 									href="#elemdef-smil-audio"><code>audio</code></a> sibling element is OPTIONAL. In
 								the absence of an <code>audio</code> element, Reading Systems will voice the image using
 									<a href="#sec-tts">Text-to-Speech rendering</a>.</p>
-
 							<p>EPUB Creators MUST ensure they provide fallback text for an image when an omitting an
 									<code>audio</code> element (e.g., using the [[HTML]] <code>alt</code>
 								attribute).</p>
 						</section>
 					</section>
-
 					<section id="sec-tts">
 						<h5>Text-to-Speech Rendering</h5>
-
 						<p>This specification allows the use of text-to-speech (TTS) &#8212; the rendering of the
 							textual content of an <a>EPUB Publication</a> as artificial human speech using a synthesized
 							voice &#8212; in addition to pre-recorded audio clips.</p>
-
 						<p>A Media Overlay <a href="#elemdef-smil-par"><code>par</code> element</a> MAY omit an <a
 								href="#elemdef-smil-audio"><code>audio</code> element</a> when its <a
 								href="#elemdef-smil-text"><code>text</code> element</a> references text or an image. In
 							these cases, Reading Systems are expected to render the referenced fragment via TTS, so EPUB
 							Creators MUST ensure the fragment is appropriate for TTS rendering (e.g., contains a textual
 							EPUB Content Document element or has a text fallback).</p>
-
 						<div class="note">
 							<p>See <a href="https://www.w3.org/TR/epub-tts-10/">EPUB 3 Text-to-Speech Support</a>
 								[[EPUB-TTS-10]] for more information about using TTS technologies in EPUB
@@ -7356,22 +6587,18 @@ store destination as source in ocf
 						</div>
 					</section>
 				</section>
-
 				<section id="sec-docs-structural-semantic">
 					<h4>Structural Semantics in Overlays</h4>
-
 					<p>To express <a href="#app-structural-semantics">structural semantics</a> in <a>Media Overlay
 							Documents</a>, EPUB Creators MAY specify the <a href="#attrdef-epub-type"
 								><code>epub:type</code> attribute</a> on <a href="#elemdef-smil-par"
 							><code>par</code></a>, <a href="#elemdef-smil-seq"><code>seq</code></a>, and <a
 							href="#elemdef-smil-body"><code>body</code></a> elements.</p>
-
 					<p>The <code>epub:type</code> attribute facilitates Reading System behavior appropriate for the
 						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
 							>skippability and escapability</a> and <a
 							href="https://www.w3.org/TR/epub-rs-33/#note-table-reading-mode">table reading mode</a>
 						[[?EPUB-RS-33]].</p>
-
 					<aside class="example">
 						<p>The following example shows the semantic markup for a Media Overlay containing a figure.</p>
 						<pre>&lt;smil xmlns="http://www.w3.org/ns/SMIL" 
@@ -7395,49 +6622,37 @@ store destination as source in ocf
     &lt;/body&gt;
 &lt;/smil&gt;</pre>
 					</aside>
-
 					<p>Media Overlays MAY use the applicable <a href="#sec-vocab-assoc">vocabulary association
 							mechanisms</a> for the <code>epub:type</code> attribute to define additional semantics.</p>
 				</section>
-
 				<section id="sec-docs-assoc-style">
 					<h4>Associating Style Information</h4>
-
 					<p>EPUB Creators MAY express visual rendering information for the currently playing <a>EPUB Content
 							Document</a> element in a CSS Style Sheet using author-defined classes.</p>
-
 					<p>When used, EPUB Creators MUST declare the class names in the Package Document using the <a
 							href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 								><code>playback-active-class</code></a> properties.</p>
-
 					<p>EPUB Creators MUST define exactly one CSS class name in each property they define. Each property
 						MUST define a <a href="https://www.w3.org/TR/CSS2/syndata.html#characters">valid CSS class
 							name</a> not including any <a href="https://www.w3.org/TR/CSS2/selector.html">selectors</a>
 						[[CSS2]]. This specification <strong>does not</strong> reserve names for use with these
 						properties.</p>
-
 					<p>EPUB Creators MAY define any CSS properties for the specified CSS classes, but must ensure that
 						each EPUB Content Document with an associated Media Overlay Document includes a link to the CSS
 						style sheet with the class definitions. Reading Systems might provide their own styling, or no
 						styling at all, in the absence of a linked definition.</p>
-
 					<p>EPUB Creators MUST NOT use the <code>active-class</code> and <code>playback-active-class</code>
 						properties in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a>
 						as they always apply to the entire <a>EPUB Publication</a>.</p>
-
 					<aside class="example">
 						<p>This example demonstrates how EPUB Creators can associate style information with the
 							currently playing EPUB Content Document.</p>
-
 						<p>The author-defined CSS class names, declared using the metadata properties <a
 								href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 									><code>playback-active-class</code></a> in the Package Document:</p>
-
 						<pre>&lt;meta property="media:active-class"&gt;my-active-item&lt;/meta&gt;
 &lt;meta property="media:playback-active-class"&gt;my-document-playing&lt;/meta&gt;</pre>
-
 						<p>The CSS Style Sheet containing the author-defined class names:</p>
-
 						<pre>/* emphasize the active element */
 .my-active-item {
     background-color: yellow;
@@ -7449,9 +6664,7 @@ html.my-document-playing * {
     color: gray;
 }
 </pre>
-
 						<p>The relevant EPUB Content Document excerpt:</p>
-
 						<pre>&lt;html&gt;
     …
     &lt;span id="txt1"&gt;This is the first phrase.&lt;/span&gt;
@@ -7459,13 +6672,11 @@ html.my-document-playing * {
     &lt;span id="txt3"&gt;This is the third phrase.&lt;/span&gt;
     …
 &lt;/html&gt;</pre>
-
 						<p>In this example, the Reading System would apply the author-defined
 								<code>my-active-item</code> class to each text element in the EPUB Content Document as
 							it became active during playback. Conversely, Reading Systems would remove the class name
 							when the element is no longer active. The user would see each EPUB Content Document element
 							styled with a yellow background for the duration of that element's playback.</p>
-
 						<p>The Reading System would also apply the author-defined <code>my-document-playing</code> class
 							to the document element of the EPUB Content Document when Media Overlays playback begins.
 							The Reading System would remove the class name when playback stops. In the case of an XHTML
@@ -7476,25 +6687,19 @@ html.my-document-playing * {
 							return to their defaults.</p>
 					</aside>
 				</section>
-
 				<section id="sec-docs-package">
 					<h4>Media Overlays Packaging</h4>
-
 					<section id="sec-package-including">
 						<h5>Including Media Overlays</h5>
-
 						<p>If an <a>EPUB Content Document</a> is wholly or partially referenced by a Media Overlay, then
 							its <a>manifest</a>
 							<a href="#elemdef-package-item"><code>item</code> element</a> MUST specify a
 								<code>media-overlay</code> attribute. The attribute MUST reference the ID [[XML]] of the
 							manifest <code>item</code> for the corresponding Media Overlay Document.</p>
-
 						<p>EPUB Creators MUST only specify the <code>media-overlay</code> attribute on manifest
 								<code>item</code> elements that reference <a>EPUB Content Documents</a>.</p>
-
 						<p>Manifest items for Media Overlay Documents MUST have the media type
 								<code>application/smil+xml</code>.</p>
-
 						<aside class="example">
 							<p>The following example shows the entries for an EPUB Content Document and its associated
 								Media Overlay in the manifest of a Package Document.</p>
@@ -7511,28 +6716,22 @@ html.my-document-playing * {
 &lt;/manifest&gt;</pre>
 						</aside>
 					</section>
-
 					<section id="sec-mo-package-metadata">
 						<h5>Overlays Package Metadata</h5>
-
 						<p id="total-duration">EPUB Creators MUST specify the duration of the entire <a>EPUB
 								Publication</a> in the <a>Package Document</a> using a <a href="#elemdef-meta"
 									><code>meta</code> element</a> with the <a href="#duration"><code>duration</code>
 								property</a>.</p>
-
 						<p>In addition, EPUB Creators MUST provide the duration of each Media Overlay Document. EPUB
 							Creators may use the <a href="#attrdef-refines"><code>refines</code> attribute</a> to
 							associate each duration declaration to the corresponding <a>manifest</a>
 							<a href="#elemdef-package-item"><code>item</code></a>.</p>
-
 						<p>The sum of the durations for each Media Overlay Document SHOULD equal the <a
 								href="#total-duration">total duration</a>.</p>
-
 						<p><a>EPUB Creators</a> MAY also specify <a href="#narrator"><code>narrator</code></a>
 							information in the Package Document, as well as <a href="#sec-docs-assoc-style"
 								>author-defined CSS class names</a> to apply to the currently playing EPUB Content
 							Document element.</p>
-
 						<aside class="example">
 							<p>The following example shows a Package Document with metadata about Media Overlays.</p>
 							<pre>&lt;metadata&gt;
@@ -7547,7 +6746,6 @@ html.my-document-playing * {
    …
 &lt;/metadata&gt;</pre>
 						</aside>
-
 						<div class="note">
 							<p>The <code>media:</code> prefix is <a href="#sec-metadata-reserved-prefixes">reserved</a>
 								for inclusion of these properties in package metadata.</p>
@@ -7555,19 +6753,15 @@ html.my-document-playing * {
 					</section>
 				</section>
 			</section>
-
 			<section id="sec-behaviors-skip-escape">
 				<h3>Skippability and Escapability</h3>
-
 				<section id="sec-skippability">
 					<h4>Skippability</h4>
-
 					<p>While reading, users may want to turn on or off certain features of the content, such as
 						footnotes, page numbers, or other types of secondary content. This feature is called
 						skippability. Reading Systems use the semantic information provided by Media Overlay elements'
 							<a href="#sec-docs-structural-semantic"><code>epub:type</code></a> attribute to determine
 						when to offer users the option of skippable features.</p>
-
 					<aside class="example">
 						<p>The following example shows a Media Overlay Document with a page break. A Reading System
 							could offer the user the option of turning on and off the page break/page number
@@ -7603,7 +6797,6 @@ html.my-document-playing * {
 &lt;/smil&gt;
 </pre>
 					</aside>
-
 					<aside class="example">
 						<p>The following example shows an EPUB Content Document with a page break.</p>
 						<pre>&lt;html … &gt;
@@ -7617,10 +6810,8 @@ html.my-document-playing * {
     &lt;/body&gt;
 &lt;/html&gt;</pre>
 					</aside>
-
 					<p>The following non-exhaustive list represents terms from the Structural Semantics
 						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems may offer the option of skippability:</p>
-
 					<ul>
 						<li>
 							<p>footnote</p>
@@ -7632,22 +6823,18 @@ html.my-document-playing * {
 							<p>pagebreak</p>
 						</li>
 					</ul>
-
 					<div class="note">
 						<p>Reading System are not required to support for skippability based on <code>epub:type</code>
 							values.</p>
 					</div>
 				</section>
-
 				<section id="sec-escapability">
 					<h4>Escapability</h4>
-
 					<p>Escapable items are nested structures, such as tables and lists, that users might wish to skip
 						over, continuing to read from the point immediately after the nested structure. The escapability
 						feature differs from the skippability feature in that it does not enable or disable entire types
 						of items, but provides an exit from them (e.g., a user can listen to some of the content before
 						choosing to escape).</p>
-
 					<aside class="example">
 						<p>The following example shows the Media Overlay Document for an EPUB Content Document
 							containing a paragraph, a table, and another paragraph. A Reading System that supported
@@ -7719,10 +6906,8 @@ html.my-document-playing * {
     &lt;/body&gt;
 &lt;/smil&gt;</pre>
 					</aside>
-
 					<p>The following non-exhaustive list represents terms from the Structural Semantics
 						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems may offer the option of escapability:</p>
-
 					<ul>
 						<li>
 							<p>table</p>
@@ -7745,17 +6930,14 @@ html.my-document-playing * {
 					</ul>
 				</section>
 			</section>
-
 			<section id="sec-nav-doc">
 				<h3>Navigation Document Overlays</h3>
-
 				<p>As the <a>EPUB Navigation Document</a> is an <a>XHTML Content Document</a>, <a>EPUB Creators</a> MAY
 					associate an audio Media Overlay with it. Unlike traditional XHTML Content Documents, however,
 						<a>Reading Systems</a> must present the EPUB Navigation Document to users even when it is not
 					included in the <a>spine</a> (see <a href="https://www.w3.org/TR/epub-rs-33/#sec-nav">Navigation
 						Document Processing</a> [[?EPUB-RS-33]]). As a result, the method in which an associated Media
 					Overlay behaves can change depending on the context:</p>
-
 				<ul>
 					<li>
 						<p>When included in the spine, playback of the EPUB Navigation Document's Media Overlay obeys
@@ -7767,7 +6949,6 @@ html.my-document-playing * {
 							when user access navigation links.</p>
 					</li>
 				</ul>
-
 				<div class="note">
 					<p>Specific implementation details are beyond the scope of this specification. The <a
 							href="https://www.daisy.org/guidelines/epub/media-overlays-playback-requirements">DAISY
@@ -7778,28 +6959,22 @@ html.my-document-playing * {
 		</section>
 		<section id="sec-accessibility" class="informative">
 			<h2>Accessibility</h2>
-
 			<p>EPUB 3 builds upon the Open Web Platform expressly so that it can leverage the structure, semantics and,
 				by extension, accessibility built into its underlying technologies.</p>
-
 			<p>The requirements and practices for creating accessible web content have already been documented in the
 				W3C's <a href="https://www.w3.org/TR/wcag/">Web Content Accessibility Guidelines (WCAG)</a> [[WCAG2]].
 				These guidelines also form the basis for defining accessibility in EPUB Publications.</p>
-
 			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, <a
 					href="https://www.w3.org/TR/epub-a11y-11/">EPUB Accessibility</a> [[EPUB-A11Y-11]], defines how to
 				apply the standard to <a>EPUB Publications</a>. It also adds EPUB-specific requirements and
 				recommendations for metadata, pagination, and media overlays.</p>
-
 			<p>This specification recommends that EPUB Publications <a href="#confreq-a11y">conform to the EPUB
 					Accessibility standard</a>. A benefit of following this recommendation is that it helps ensure that
 				EPUB Publications meet the accessibility requirements legislated in jurisdictions around the world,
 				ensuring EPUB Creators are not locked out of potential markets.</p>
-
 			<p><a>EPUB Creators</a>, however, should look beyond legal imperatives and treat accessibility as a
 				requirement for all their content. The more accessible that EPUB Publications are, the greater the
 				potential audience for them.</p>
-
 			<div class="note">
 				<p>This specification does not integrate the accessibility requirements to allow them to adapt and
 					evolve independent of the EPUB specification &#8212; accessibility practices often need more
@@ -7811,20 +6986,16 @@ html.my-document-playing * {
 		</section>
 		<section id="sec-security-privacy" class="informative">
 			<h2>Security and Privacy</h2>
-
 			<div class="ednote">
 				<p>This is a very initial draft intended only as a starting point. It is inspired by the <a
 						href="https://www.w3.org/TR/pub-manifest/#security-privacy">relevant section of the Publication
 						Manifest</a> specification. It will require more work.</p>
 			</div>
-
 			<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
 				representing, packaging, and encoding structured and semantically enhanced Web content — including HTML,
 				CSS, SVG, JavaScript, and other resources — for distribution in a single-file container.</p>
-
 			<p>This means that, essentially, the security and privacy issues are reliant on the features of those
 				formats. In particular:</p>
-
 			<ul>
 				<li>EPUB 3 allows references to remotely hosted resources from within <a>EPUB Content Documents</a>, but
 					also from the <a>Package Document</a> (e.g., in a <a href="#sec-item-elem"><code>item</code></a>
@@ -7835,11 +7006,9 @@ html.my-document-playing * {
 					an EPUB Publication's creator(s) (e.g., names, identifying URLs) to be included, so authoring tools
 					could expose unexpected information if explicit author approval of metadata is not required.</li>
 			</ul>
-
 			<p>In general, EPUB 3 tries to avoid extending the underlying technologies it builds on, but it has
 				introduced some new features. These additions are not known to present any new privacy or security
 				issues:</p>
-
 			<ul>
 				<li>
 					<p><a href="#sec-xhtml-content-switch">Content switching</a> and <a href="#sec-xhtml-epub-trigger"
@@ -7859,19 +7028,15 @@ html.my-document-playing * {
 		</section>
 		<section id="app-overview-unsupported" class="appendix">
 			<h2>Unsupported Features</h2>
-
 			<p>This specification contains certain features the Working Group no longer recommends for use or that are
 				only retained for legacy support reasons. This section defines the meanings of the designations attached
 				to these features and their support expectations.</p>
-
 			<section id="deprecated">
 				<h3>Deprecated Features</h3>
-
 				<p>A <strong>deprecated</strong> feature is one the Working Group no longer recommends for use in this
 					version of the specification. Deprecated features typically have limited or no support in Reading
 					Systems and/or usage in EPUB Publications. If this specification designates a feature as deprecated,
 					the following hold true:</p>
-
 				<ul>
 					<li>
 						<p><a>EPUB Creators</a> SHOULD NOT not to use the feature in their <a>EPUB Publications</a>.</p>
@@ -7882,18 +7047,14 @@ html.my-document-playing * {
 							deprecated features before adding new support for them.</p>
 					</li>
 				</ul>
-
 				<p>Validation tools SHOULD alert EPUB Creators to the presence of deprecated features when encountered
 					in EPUB Publications.</p>
 			</section>
-
 			<section id="legacy">
 				<h3>Legacy Features</h3>
-
 				<p>A <strong>legacy</strong> feature is one that the Working Group has retained only for authoring
 					content that is compatible with versions of EPUB prior to 3.0. If this specification designates a
 					feature as legacy, the following hold true:</p>
-
 				<ul>
 					<li>
 						<p><a>EPUB Creators</a> MAY include the legacy feature for compatibility purposes.</p>
@@ -7903,7 +7064,6 @@ html.my-document-playing * {
 							version of EPUB.</p>
 					</li>
 				</ul>
-
 				<p>Validation tools SHOULD NOT alert EPUB Creators about the presence of legacy features in an <a>EPUB
 						Publication</a>, as their inclusion is valid for backwards compatibility. Validation tools MUST
 					alert EPUB Creators if a legacy feature does not conform to its definition or otherwise breaks a
@@ -7912,17 +7072,14 @@ html.my-document-playing * {
 		</section>
 		<section id="app-identifiers-allowed" class="appendix">
 			<h2>Allowed External Identifiers</h2>
-
 			<p>The following table lists the <a aria-label="public identifiers"
 					href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-pubid">public </a> and <a
 					href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-sysid">system identifiers</a> [[XML]] allowed
 				in <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#dt-doctype">document type declarations</a>.
 				[[XML]]</p>
-
 			<p>EPUB Creators MAY use these external identifiers only in <a>Publication Resources</a> with the listed
 				media types specified in their <a href="#sec-manifest-elem">manifest</a> declarations. (Refer to <a
 					href="#sec-xml-constraints"></a> for more information.)</p>
-
 			<table>
 				<thead>
 					<tr>
@@ -7969,34 +7126,27 @@ html.my-document-playing * {
 		</section>
 		<section id="app-structural-semantics" class="appendix">
 			<h2>Expressing Structural Semantics</h2>
-
 			<section id="sec-structural-semantics-intro">
 				<h3>Introduction</h3>
-
 				<p>Structural semantics add additional meaning about the specific structural purpose an element plays.
 					The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is used to express
 					domain-specific semantics in <a>EPUB Content Documents</a> and <a>Media Overlay Documents</a>, with
 					the structural information it carries complementing the underlying vocabulary.</p>
-
 				<p>The applied semantics refine the meaning of their containing elements without changing their nature
 					for assistive technologies, as happens when using the similar <a
 						href="https://html.spec.whatwg.org/multipage/infrastructure.html#attr-aria-role"
 							><code>role</code> attribute</a> [[HTML]]. The attribute does not enhance the accessibility
 					of the content, in other words, only provides hints about the purpose.</p>
-
 				<p>Semantic metadata enriches content for use in publishing workflows and for author-defined purposes.
 					It also allows Reading Systems to learn more about the structure and content of a document (e.g., to
 					enable <a href="#sec-behaviors-skip-escape">skippability and escapability</a> in Media
 					Overlays).</p>
-
 				<p>This specification defines a method for adding structural semantics using <em>the attribute
 					axis</em>: instead of adding new elements, EPUB Creators can append the <code>epub:type</code>
 					attribute to existing elements to add the desired semantics.</p>
 			</section>
-
 			<section id="sec-epub-type-attribute">
 				<h3>The <code>epub:type</code> Attribute</h3>
-
 				<dl class="elemdef" id="attrdef-epub-type">
 					<dt>Attribute Name</dt>
 					<dd>
@@ -8022,7 +7172,6 @@ html.my-document-playing * {
 						<p>White space is the set of characters as defined in [[XML]].</p>
 					</dd>
 				</dl>
-
 				<div class="note">
 					<p>Although the <code>epub:type</code> attribute is similar in nature to the <a
 							href="https://html.spec.whatwg.org/multipage/infrastructure.html#attr-aria-role"
@@ -8035,11 +7184,9 @@ html.my-document-playing * {
 							WAI-ARIA Module 1.0</a> [[DPUB-ARIA-1.0]] for more information about accessible publishing
 						roles.</p>
 				</div>
-
 				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
 					is one or more white space-separated terms stemming from external vocabularies associated with the
 					document instance.</p>
-
 				<p>The inflected semantic MUST express a subclass of the semantic of the carrying element. In the case
 					of semantically neutral elements, such as the [[HTML]] <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element"
@@ -8048,13 +7195,11 @@ html.my-document-playing * {
 							><code>span</code></a> elements, the inflected semantic MUST NOT attach a meaning that is
 					already conveyed by an existing element (e.g., that a <code>div</code> represents a paragraph or
 					section).</p>
-
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
 					the EPUB 3 Structural Semantics Vocabulary [[?EPUB-SSV-11]]. EPUB Creators MAY include unprefixed
 					terms that are not part of this vocabulary, but the preferred method for adding custom semantics is
 					to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a href="#sec-vocab-assoc"></a>
 					for more information.</p>
-
 				<aside class="example" id="ex.epubtype.note">
 					<p>The following example shows how a preamble could be marked up with the <code>epub:type</code>
 						attribute on its containing [[HTML]] <code>section</code> element.</p>
@@ -8067,7 +7212,6 @@ html.my-document-playing * {
     …
 &lt;/html&gt;</pre>
 				</aside>
-
 				<aside class="example" id="ex.epubtype.gloss">
 					<p>The following example shows the <code>epub:type</code> attribute used to add glossary semantics
 						on an [[HTML]] definition list.</p>
@@ -8080,7 +7224,6 @@ html.my-document-playing * {
     …
 &lt;/html&gt;</pre>
 				</aside>
-
 				<aside class="example" id="ex.epubtype.pg">
 					<p>The following example shows the <code>epub:type</code> attribute used to add page break
 						semantics.</p>
@@ -8097,51 +7240,40 @@ html.my-document-playing * {
 		</section>
 		<section id="app-vocabs" class="appendix">
 			<h2>Vocabularies</h2>
-
 			<p>This appendix defines a general set of mechanisms by which attributes in this specification can reference
 				terms from vocabularies. It also defines EPUB-specific vocabularies for use with the attributes.</p>
-
 			<section id="sec-vocab-assoc">
 				<h3>Vocabulary Association Mechanisms</h3>
-
 				<section id="sec-vocab-assoc-intro" class="informative">
 					<h4>Introduction</h4>
-
 					<p>EPUB defines a formal method of referencing terms and properties defined in metadata and semantic
 						vocabularies using the <a href="#sec-property-datatype"><var>property</var> data type</a>. The
 							<code>epub:type</code> attribute uses this data type in <a>EPUB Content Documents</a> and
 							<a>Media Overlay Documents</a> to add <a href="#app-structural-semantics">structural
 							semantics</a>, for example, while the <code>property</code> and <code>rel</code> attributes
 						use the data type to define properties and relationships in the <a>Package Document</a>.</p>
-
 					<p>A <var>property</var> value is like a CURIE [[RDFA-CORE]] &#8212; it represents a URL [[URL]] in
 						compact form. The expression consists of a prefix and a reference, where the prefix — whether
 						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
 						vocabulary. When a Reading System converts the prefix to its URL representation and combines
 						with the reference, the resulting URL normally resolves to a fragment within that vocabulary
 						that contains human- and/or machine-readable information about the term.</p>
-
 					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> data type
 						also defines a <a href="#sec-default-vocab">default vocabulary</a>. Terms and properties
 						referenced from the default vocabularies do not include a prefix as the mapping <a>Reading
 							Systems</a> use to map to a URL is predefined.</p>
-
 					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
 						terms and properties, EPUB Creators only need to declare a <a href="#sec-prefix-attr"
 						>prefix</a>. In another authoring convenience, this specification also <a
 							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
 						publishing vocabularies (i.e., their declaration is optional).</p>
-
 					<p>The following sections provide additional details on the <var>property</var> data type and
 						vocabulary association mechanism.</p>
 				</section>
-
 				<section id="sec-property-datatype">
 					<h4>The <var>property</var> Data Type</h4>
-
 					<p>The <var>property</var> data type is a compact means of expressing a URL [[URL]] and consists of
 						an OPTIONAL prefix separated from a reference by a colon.</p>
-
 					<table class="productionset">
 						<caption>(EBNF productions <a
 								href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
@@ -8180,72 +7312,52 @@ html.my-document-playing * {
 							<td>/* as defined in [[URL]] */<br /></td>
 						</tr>
 					</table>
-
 					<p>This specification derives the <var>property</var> data type from the CURIE data type defined in
 						[[RDFA-CORE]]. A <var>property</var> represents a subset of CURIEs.</p>
-
 					<aside class="example">
 						<p>The following example shows a <var>property</var> value composed of the prefix
 								<code>dcterms</code> and the reference <code>modified</code>.</p>
 						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
 					</aside>
-
 					<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-datatype">processing</a>
 						[[EPUB-RS-33]], this property would expand to the following URL:</p>
-
 					<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
-
 					<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
 							prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
-
 					<p>When an EPUB Creator omits a prefix from a <var>property</var> value, the expressed reference
 						represents a term from the <a href="#sec-default-vocab">default vocabulary</a> for that
 						attribute.</p>
-
 					<aside class="example">
 						<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
 							manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
-
 						<pre>&lt;item … properties="mathml"/&gt;</pre>
-
 						<p>This property expands to:</p>
-
 						<pre>http://idpf.org/epub/vocab/package/item/#mathml</pre>
-
 						<p>when the prefix URL for the vocabulary is concatenated with the reference.</p>
 					</aside>
-
 					<p>An empty string does not represent a valid <var>property</var> value, even though it is valid to
 						the definition above.</p>
 				</section>
-
 				<section id="sec-default-vocab">
 					<h5>Default Vocabularies</h5>
-
 					<p>A default vocabulary is one that EPUB Creators do not have to declare a <a
 							href="#sec-prefix-attr">prefix</a> for in order to use its terms and properties where a <a
 							href="#sec-property-datatype"><var>property</var> value</a> is expected. EPUB Creators MUST
 						NOT add a prefix to terms and properties from a default vocabulary.</p>
-
 					<p>EPUB Creators MUST NOT assign a prefix to the URLs associated with these vocabularies using the
 							<a href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
-
 					<div class="note">
 						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"
 									><var>property</var> data type</a> for more information about its default
 							vocabulary.</p>
 					</div>
 				</section>
-
 				<section id="sec-prefix-attr">
 					<h4>The <code>prefix</code> Attribute</h4>
-
 					<p>The <code>prefix</code> attribute defines prefix mappings for use in <a
 							href="#sec-property-datatype"><var>property</var> values</a>.</p>
-
 					<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
 						prefix-to-URL mappings of the form:</p>
-
 					<table class="productionset">
 						<caption>(EBNF productions <a
 								href="http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=26153"
@@ -8305,12 +7417,9 @@ html.my-document-playing * {
 							<td> </td>
 						</tr>
 					</table>
-
 					<p>EPUB Creators MUST only specify the <code>prefix</code> attribute on the root element of the
 						respective format.</p>
-
 					<p>The attribute is not namespaced when used in the <a>Package Document</a>.</p>
-
 					<aside class="example">
 						<p>The following example shows prefix declarations for the Friend of a Friend
 							(<code>foaf</code>) and DBPedia (<code>dbp</code>) vocabularies in the Package Document.</p>
@@ -8320,11 +7429,9 @@ html.my-document-playing * {
    …
 &lt;/package></pre>
 					</aside>
-
 					<p>EPUB Creators MUST declare the attribute in the namespace
 							<code>http://www.idpf.org/2007/ops</code> in <a>EPUB Content Documents</a> and <a>Media
 							Overlay Documents</a>.</p>
-
 					<aside class="example">
 						<p>The following example shows the <code>prefix</code> attribute declared in an <a>XHTML Content
 								Document</a>.</p>
@@ -8334,57 +7441,44 @@ html.my-document-playing * {
    …
 &lt;/html></pre>
 					</aside>
-
 					<div class="note">
 						<p>Although the <code>prefix</code> attribute is modeled on the identically named
 								<code>prefix</code> attribute in [[RDFA-CORE]], EPUB Creators cannot use the attributes
 							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB Content
 							Documents is the RDFa attribute.</p>
-
 						<p>It is common for both attributes to appear in EPUB Content Documents that also specify RDFa
 							expressions.</p>
-
 						<pre>&lt;html … prefix="…"
         xmlns:epub="http://www.idpf.org/2007/ops"
         epub:prefix="…">   …
 &lt;/html></pre>
 					</div>
-
 					<p>Note that for <a href="#sec-xhtml-svg">embedded SVG</a>, prefixes MUST be declared on the
 						[[HTML]] root <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element"
 								><code>html</code> element</a>.</p>
-
 					<p>To avoid conflicts, EPUB Creators MUST NOT use the <code>prefix</code> attribute to declare a
 						prefix that maps to the <a href="#sec-default-vocab">default vocabulary</a>.</p>
-
 					<p>EPUB Creators MUST NOT declare the prefix '_' as this specification reserves this prefix for
 						future compatibility with RDFa [[RDFA-CORE]] processing.</p>
-
 					<p>For future compatibility with alternative serializations of the Package Document, EPUB Creators
 						MUST NOT declare a prefix for the Dublin Core <em>/elements/1.1/</em> namespace [[DCTERMS]].
 							<a>EPUB Creators</a> MUST use only the [[DCTERMS]] elements <a href="#sec-pkg-metadata"
 							>allowed in the Package Document metadata</a>.</p>
 				</section>
-
 				<section id="sec-reserved-prefixes">
 					<h4>Reserved Prefixes</h4>
-
 					<div class="caution">
 						<p>Although reserved prefixes are an authoring convenience, EPUB Creators should avoid relying
 							on them as they may cause interoperability issues. Validation tools will often reject new
 							prefixes until their developers update the tools to the latest version of the specification,
 							for example. EPUB Creators should declare all prefixes they use to avoid such issues.</p>
 					</div>
-
 					<p><a>EPUB Creators</a> MAY use reserved prefixes in attributes that expect a <a
 							href="#sec-property-datatype"><var>property</var> value</a> without declaring them in a <a
 							href="#sec-prefix-attr"><code>prefix</code> attribute</a>.</p>
-
 					<p>EPUB Creators SHOULD NOT override reserved prefixes in the <a href="#sec-prefix-attr"
 								><code>prefix</code> attribute</a>.</p>
-
 					<p>The reserved prefixes an EPUB Creators can use depends on the context:</p>
-
 					<dl class="conformance-list">
 						<dt>Package Document</dt>
 						<dd id="sec-metadata-reserved-prefixes">
@@ -8433,7 +7527,6 @@ html.my-document-playing * {
 								</tbody>
 							</table>
 						</dd>
-
 						<dt id="sec-content-reserved-prefixes">Structural Semantics</dt>
 						<dd>
 							<p>EPUB Creators MAY use the following reserved prefixes in the <a
@@ -8461,28 +7554,19 @@ html.my-document-playing * {
 					</dl>
 				</section>
 			</section>
-
 			<div data-include="vocab/meta-property.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-
 			<div data-include="vocab/link.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-
 			<div data-include="vocab/rendering.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-
 			<div data-include="vocab/item-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-
 			<div data-include="vocab/itemref-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-
 			<div data-include="vocab/overlays.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-
 		</section>
 		<section id="css-prefixes" class="appendix">
 			<h2>Prefixed CSS Properties</h2>
 			<p>This appendix describes the prefixed CSS properties supported by EPUB. </p>
 			<section id="sec-css-prefixed-writing-modes">
 				<h5>CSS Writing Modes</h5>
-
 				<p>This section describes the <code>-epub-</code> prefixed properties for [[CSS-Writing-Modes-3]].</p>
-
 				<section id="sec-css-prefixed-writing-modes-text-orientation">
 					<h6>The <code>-epub-text-orientation</code> Property</h6>
 					<p>This is a prefixed version of the CSS <code>text-orientation</code> property.</p>
@@ -8500,10 +7584,8 @@ html.my-document-playing * {
 							</tr>
 						</tbody>
 					</table>
-
 					<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>. User
 						agents MUST interpret these values according to the following table: </p>
-
 					<table class="data">
 						<thead>
 							<tr>
@@ -8525,10 +7607,8 @@ html.my-document-playing * {
 								<td><code>sideways</code></td>
 							</tr>
 						</tbody>
-
 					</table>
 				</section>
-
 				<section id="sec-css-prefixed-writing-modes-writing-mode">
 					<h6>The <code>-epub-writing-mode</code> Property</h6>
 					<p>This is a prefixed version of the CSS <code>writing-mode</code> property, with the same syntax
@@ -8548,11 +7628,9 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 				</section>
-
 				<section id="sec-css-prefixed-writing-modes-text-combine">
 					<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>
 						Properties</h6>
-
 					<p>These are prefixed versions of <code>text-combine-upright</code>, although
 							<code>-epub-text-combine</code> is deprecated. See the table below for how values of both
 						properties translate to unprefixed CSS.</p>
@@ -8570,7 +7648,6 @@ html.my-document-playing * {
 							</tr>
 						</tbody>
 					</table>
-
 					<table class="def propdef">
 						<tbody>
 							<tr>
@@ -8614,11 +7691,9 @@ html.my-document-playing * {
 								<td>Error</td>
 							</tr>
 						</tbody>
-
 					</table>
 				</section>
 			</section>
-
 			<section id="sec-css-prefixed-text">
 				<h5>CSS Text Level 3</h5>
 				<p>This section describes the <code>-epub-</code> prefixed properties (and one prefixed value) for
@@ -8727,15 +7802,12 @@ html.my-document-playing * {
 								<td><code>text-transform: full-width</code></td>
 							</tr>
 						</tbody>
-
 					</table>
 				</section>
 			</section>
-
 			<section id="sec-css-prefixed-text-decoration">
 				<h5>CSS Text Decoration Level 3</h5>
 				<p>This section describes the <code>-epub-</code> prefixed properties for [[CSS-Text-Decor-3]].</p>
-
 				<section id="sec-css-prefixed-text-epub-text-emphasis-color">
 					<h6>The <code>-epub-text-emphasis-color</code> Property</h6>
 					<p>This is a prefixed version of the <code>text-emphasis-color</code> property.</p>
@@ -8823,74 +7895,56 @@ html.my-document-playing * {
 								<td><code>text-underline-position: auto</code></td>
 							</tr>
 						</tbody>
-
 					</table>
 				</section>
 			</section>
 		</section>
 		<section id="app-schemas" class="appendix informative">
 			<h2>Schemas</h2>
-
 			<section id="app-package-schema">
 				<h3>Package Document Schema</h3>
-
 				<p>A non-normative schema for Package Documents is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
 						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.</p>
-
 				<p>Validation using this schema requires a processor that supports [[NVDL]], [[RelaxNG-Schema]],
 					[[ISOSchematron]] and [[XMLSCHEMA-2]].</p>
-
 				<div class="note">
 					<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG
 						and ISO Schematron schemas alone.</p>
 				</div>
-
 				<div class="note">
 					<p>These schemas may be updated and corrected outside of formal revisions of this specification. As
 						a result, they are subject to change at any time. </p>
 				</div>
 			</section>
-
 			<section id="app-ocf-schema">
 				<h3>OCF Schemas</h3>
-
 				<section id="app-schema-container">
 					<h4>Schema for <code>container.xml</code></h4>
-
 					<p>A non-normative schema for <code>container.xml</code> files is available at <a
 							href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl">
 							<code>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl</code></a>.</p>
-
 					<p>Validation using this schema requires a processor that supports [[RelaxNG-Schema]] and
 						[[XMLSCHEMA-2]].</p>
 				</section>
-
 				<section id="app-schema-encryption">
 					<h4>Schema for <code>encryption.xml</code></h4>
-
 					<p>The schema for <code>encryption.xml</code> files is included in
 						[[XMLSEC-RNGSCHEMA-20130411]].</p>
 				</section>
-
 				<section id="app-schema-signatures">
 					<h4>Schema for <code>signatures.xml</code></h4>
-
 					<p>The schema for <code>signatures.xml</code> files is included in
 						[[XMLSEC-RNGSCHEMA-20130411]].</p>
 				</section>
 			</section>
-
 			<section id="app-schema-overlays">
 				<h3>Media Overlays Schema</h3>
-
 				<p>A non-normative schema for Media Overlays is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl"
 						>https://github.com/w3c/epubcheck/tree/main/src/master/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl</a>.</p>
-
 				<p>Validation using this schema requires a processor that supports [[NVDL]], [[RelaxNG-Schema]],
 					[[ISOSchematron]] and [[XMLSCHEMA-2]].</p>
-
 				<div class="note">
 					<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG
 						and ISO Schematron schemas alone.</p>
@@ -8899,12 +7953,9 @@ html.my-document-playing * {
 		</section>
 		<section id="app-examples" class="appendix informative">
 			<h2>Detailed Examples</h2>
-
 			<section id="scripted-contexts-example">
 				<h3>Scripting Contexts</h3>
-
 				<p>Consider the following example Package Document:</p>
-
 				<pre>&lt;package …&gt;
     …
     &lt;manifest&gt;
@@ -8928,9 +7979,7 @@ html.my-document-playing * {
     &lt;/spine&gt;
     …
 &lt;/package&gt;</pre>
-
 				<p>and the following file <code>scripted01.xhtml</code>:</p>
-
 				<pre>&lt;html …&gt;
     &lt;head&gt;
         …
@@ -8944,10 +7993,7 @@ html.my-document-playing * {
         …
     &lt;/body&gt;
 &lt;/html&gt;</pre>
-
-
 				<p>and the following file <code>scripted02.xhtml</code>:</p>
-
 				<pre>&lt;html …&gt;
     &lt;head&gt;
         …
@@ -8957,9 +8003,7 @@ html.my-document-playing * {
         …
     &lt;/body&gt;
 &lt;/html&gt;</pre>
-
 				<p>From these examples, it is true that:</p>
-
 				<ul>
 					<li>
 						<p>the code in the <code>script</code> element in the <code>head</code> in
@@ -8973,13 +8017,10 @@ html.my-document-playing * {
 					</li>
 				</ul>
 			</section>
-
 			<section id="ocf-example">
 				<h3>Packaged EPUB</h3>
-
 				<p>The following example demonstrates the use of the OCF format to contain a signed and encrypted EPUB
 					Publication within an <a>OCF ZIP Container</a>.</p>
-
 				<aside class="example">
 					<p>Ordered list of files in the OCF ZIP Container</p>
 					<pre>mimetype
@@ -8991,12 +8032,10 @@ EPUB/book.html
 EPUB/nav.html
 EPUB/images/cover.png</pre>
 				</aside>
-
 				<aside class="example">
 					<p>The contents of the <code>mimetype</code> file</p>
 					<pre>application/epub+zip</pre>
 				</aside>
-
 				<aside class="example">
 					<p>The contents of the <code>META-INF/container.xml</code> file</p>
 					<pre>&lt;?xml version="1.0"?&gt;
@@ -9007,7 +8046,6 @@ EPUB/images/cover.png</pre>
     &lt;/rootfiles&gt;
 &lt;/container&gt;</pre>
 				</aside>
-
 				<aside class="example">
 					<p>The contents of the <code>META-INF/signatures.xml</code> file</p>
 					<pre>&lt;signatures xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
@@ -9078,7 +8116,6 @@ EPUB/images/cover.png</pre>
     &lt;/Signature&gt;
 &lt;/signatures&gt;</pre>
 				</aside>
-
 				<aside class="example">
 					<p>The contents of the <code>META-INF/encryption.xml</code> file</p>
 					<pre>&lt;?xml version="1.0"?&gt;
@@ -9126,7 +8163,6 @@ EPUB/images/cover.png</pre>
     &lt;/enc:EncryptedData&gt;
 &lt;/encryption&gt;</pre>
 				</aside>
-
 				<aside class="example">
 					<p>The contents of the <code>EPUB/As_You_Like_It.opf</code> file</p>
 					<pre>&lt;?xml version="1.0"?&gt;
@@ -9179,12 +8215,9 @@ EPUB/images/cover.png</pre>
 &lt;/package&gt;</pre>
 				</aside>
 			</section>
-
 			<section id="clock-examples">
 				<h3>Clock Values</h3>
-
 				<p>The following are examples of allowed clock values:</p>
-
 				<ul>
 					<li>
 						<p><code>5:34:31.396</code> = 5 hours, 34 minutes, 31 seconds, and 396 milliseconds</p>
@@ -9224,18 +8257,14 @@ EPUB/images/cover.png</pre>
 		</section>
 		<section id="app-media-types" class="appendix informative">
 			<h2>Media Type Registrations</h2>
-
 			<section id="app-media-type-app-oebps-package">
 				<h3>The <code>application/oebps-package+xml</code> Media Type</h3>
-
 				<p>This appendix registers the media type <code>application/oebps-package+xml</code> for the EPUB
 					Package Document. This registration supersedes [[RFC4839]].</p>
-
 				<p>The Package Document is an XML file that describes an EPUB Publication. It identifies the resources
 					in the EPUB Publication and provides metadata information. The Package Document and its related
 					specifications are maintained and defined by the <a href="https://www.w3.org">World Wide Web
 						Consortium</a> (W3C).</p>
-
 				<dl class="variablelist">
 					<dt>MIME media type name:</dt>
 					<dd>
@@ -9328,18 +8357,14 @@ EPUB/images/cover.png</pre>
 					</dd>
 				</dl>
 			</section>
-
 			<section class="informative" id="app-media-type">
 				<h3>The <code>application/epub+zip</code> Media Type</h3>
-
 				<p>This appendix registers the media type <code>application/epub+zip</code> for the EPUB Open Container
 					Format (OCF).</p>
-
 				<p>An <a>OCF ZIP Container</a>, or <a>EPUB Container</a>, file is a container technology based on the
 					[[ZIP]] archive format. It is used to encapsulate the EPUB Publication. OCF and its related
 					standards are maintained and defined by the <a href="https://www.w3.org">World Wide Web
 						Consortium</a> (W3C).</p>
-
 				<dl class="variablelist">
 					<dt>MIME media type name:</dt>
 					<dd>
@@ -9442,15 +8467,12 @@ EPUB/images/cover.png</pre>
 		</section>
 		<section id="change-log" class="appendix informative">
 			<h2>Change Log</h2>
-
 			<p>Note that this change log only identifies substantive changes since <a
 					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> &#8212; those that affect the
 				conformance of <a>EPUB Publications</a> or are similarly noteworthy.</p>
-
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+-label%3ASpec-RS+"
 					>Working Group's issue tracker</a>.</p>
-
 			<ul>
 				<li>12-Nov-2021: Removed the statement about rights.xml being reserved for future standardization of DRM
 					information. See <a href="https://github.com/w3c/epub-specs/issues/181">issue 1874</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2744,7 +2744,7 @@ Package Document:
       &#8230;
       &lt;itemref
           idref="img01"
-          properties="layout-pre-paginated page-spread-center"
+          properties="layout-pre-paginated"
           linear="no"/>
       &#8230;
    &lt;/spine>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2669,6 +2669,7 @@
    &#8230;
 &lt;/package></pre>
 								</aside>
+
 								<aside class="example" id="example-manifest-flbk"
 									title="Foreign Resource with Fallback in Spine">
 									<p>The following example shows the <a href="#sec-foreign-restrictions-manifest"
@@ -2698,7 +2699,9 @@
    &lt;/spine>
 &lt;/package></pre>
 								</aside>
-								<aside class="example" title="Top-Level Content Document with Fallback">
+
+								<aside class="example"
+									title="Embedded Core Media Type with Link to View as Top-Level Content Document">
 									<p>The following example shows a JPEG embedded in an EPUB Content Document (via the
 											<code>img</code> tag) with a hyperlink that allows it to open as a separate
 										page (e.g., for easier zooming). Although embedding the image using the
@@ -2750,6 +2753,61 @@ Package Document:
    &lt;/spine>
 &lt;/package></pre>
 								</aside>
+
+								<aside class="example"
+									title="Link to View Foreign Resource as Top-Level Content Document">
+									<p>The following example shows a link to the raw CSV data file. The data will open
+										in the Reading System as a <a>Top-Level Content Document</a> so EPUB Creators
+										must list it in the spine and provide a fallback to an <a>EPUB Content
+											Document</a>. Because there is no guarantee users will be able to access the
+										data in its raw form, instructions on how to extract the file from the
+										<a>EPUB Container</a> are also provided.</p>
+									<pre>XHTML:
+&lt;html &#8230;>
+   &#8230;
+   &lt;body>
+      &#8230;
+      &lt;p>
+         &lt;a href="../data/raw.csv">
+            [Open the raw CSV data for this project.]
+         &lt;/a>
+      &lt;/p>
+      &lt;p class="small">To extract the data file
+         from this publication, unzip the EPUB file.
+         The data is located in the
+      	&lt;code>/EPUB/data/raw.csv&lt;/code> file.
+      &lt;/p>
+      &#8230;
+   &lt;/body>
+&lt;/html>
+
+Package Document:
+&lt;package &#8230;>
+   &#8230;
+   &lt;manifest>
+      &#8230;
+      &lt;item
+          id="data01"
+          href="data/raw.csv"
+          media-type="text/csv"
+          fallback="#data-html"/>
+
+      &lt;item
+          id="data-html"
+          href="xhtml/data-table.html"
+          media-type="application/xhtml+xml"/>
+      &#8230;
+   &lt;/manifest>
+   &lt;spine>
+      &#8230;
+      &lt;itemref
+          idref="data01"
+          linear="no"/>
+      &#8230;
+   &lt;/spine>
+&lt;/package></pre>
+								</aside>
+
 								<aside class="example" title="Remote Resources that are Publication Resources">
 									<p>The following example shows a reference to a remote audio file. Because the
 											<code>audio</code> element embeds the audio in its EPUB Content Document,
@@ -2788,6 +2846,7 @@ Package Document:
    &#8230;
 &lt;/package></pre>
 								</aside>
+
 								<aside class="example" title="External Resources that are not Publication Resources">
 									<p>The following example shows a hyperlink to an audio file hosted on the web.
 										Reading Systems will open such external content in a new browser window; it is

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2610,49 +2610,49 @@
 											Media Type Resources</a>.</p>
 									<pre>&lt;package &#8230;>
    &#8230;
-   &lt;manifest&gt;
+   &lt;manifest>
       &lt;item id="nav" 
           href="nav.xhtml" 
           properties="nav"
-          media-type="application/xhtml+xml"/&gt;
+          media-type="application/xhtml+xml"/>
       &lt;item id="intro" 
           href="intro.xhtml" 
-          media-type="application/xhtml+xml"/&gt;
+          media-type="application/xhtml+xml"/>
       &lt;item id="c1" 
           href="chap1.xhtml" 
-          media-type="application/xhtml+xml"/&gt;
+          media-type="application/xhtml+xml"/>
       &lt;item id="c1-answerkey" 
           href="chap1-answerkey.xhtml" 
-          media-type="application/xhtml+xml"/&gt;
+          media-type="application/xhtml+xml"/>
       &lt;item id="c2" 
           href="chap2.xhtml" 
-          media-type="application/xhtml+xml"/&gt;
+          media-type="application/xhtml+xml"/>
       &lt;item id="c2-answerkey" 
           href="chap2-answerkey.xhtml" 
-          media-type="application/xhtml+xml"/&gt;
+          media-type="application/xhtml+xml"/>
       &lt;item id="c3" 
           href="chap3.xhtml" 
-          media-type="application/xhtml+xml"/&gt;
+          media-type="application/xhtml+xml"/>
       &lt;item id="c3-answerkey" 
           href="chap3-answerkey.xhtml" 
-          media-type="application/xhtml+xml"/&gt;    
+          media-type="application/xhtml+xml"/>    
       &lt;item id="notes" 
           href="notes.xhtml" 
-          media-type="application/xhtml+xml"/&gt;
+          media-type="application/xhtml+xml"/>
       &lt;item id="cover" 
           href="./images/cover.svg" 
           properties="cover-image"
-          media-type="image/svg+xml"/&gt;
+          media-type="image/svg+xml"/>
       &lt;item id="f1" 
           href="./images/fig1.jpg" 
-          media-type="image/jpeg"/&gt;
+          media-type="image/jpeg"/>
       &lt;item id="f2" 
           href="./images/fig2.jpg" 
-          media-type="image/jpeg"/&gt;
+          media-type="image/jpeg"/>
       &lt;item id="css" 
           href="./style/book.css" 
-          media-type="text/css"/&gt;   
-   &lt;/manifest&gt;
+          media-type="text/css"/>   
+   &lt;/manifest>
    &#8230;
 &lt;/package></pre>
 								</aside>
@@ -2668,17 +2668,17 @@
       &lt;item id="page-001"
           href="images/page-001.jpg"
           media-type="image/jpeg"
-          fallback="#page-001-svg"/&gt;
+          fallback="#page-001-svg"/>
 
       &lt;item id="page-001-svg"
           href="images/page-001.svg"
-          media-type="image/svg+xml"/&gt;
+          media-type="image/svg+xml"/>
       … 
       &#8230;
    &lt;/manifest>
    &lt;spine>
       &#8230;
-      &lt;itemref idref="page-001"/&gt;
+      &lt;itemref idref="page-001"/>
       &#8230;
    &lt;/spine>
 &lt;/package></pre>
@@ -2695,8 +2695,13 @@
    &#8230;
    &lt;body>
       &#8230;
-      &lt;img src="images/infographic.jpg" alt="&#8230;" 
-      &lt;a href="images/infographic.jpg"&gt;Expand Image&lt;/a&gt;
+      &lt;img
+          src="images/infographic.jpg"
+          alt="&#8230;"/>
+      &lt;a
+          href="images/infographic.jpg">
+         Expand Image
+      &lt;/a>
       &#8230;
    &lt;/body>
 &lt;/html>
@@ -2709,16 +2714,16 @@ Package Document:
       &lt;item id="img01"
           href="images/infographic.jpg"
           media-type="image/jpeg"
-          fallback="#infographic-svg"/&gt;
+          fallback="#infographic-svg"/>
 
       &lt;item id="infographic-svg"
           href="images/infographic.svg"
-          media-type="image/svg+xml"/&gt;
+          media-type="image/svg+xml"/>
       &#8230;
    &lt;/manifest>
    &lt;spine>
       &#8230;
-      &lt;itemref idref="img01" linear="no"/&gt;
+      &lt;itemref idref="img01" linear="no"/>
       &#8230;
    &lt;/spine>
 &lt;/package></pre>
@@ -2736,7 +2741,7 @@ Package Document:
       &#8230;
       &lt;audio
           src="http://www.example.com/book/audio/ch01.mp4"
-          controls="controls"/&gt;
+          controls="controls"/>
       &#8230;
    &lt;/body>
 &lt;/html>
@@ -2748,12 +2753,12 @@ Manifest:
       &#8230;
       &lt;item id="audio01"
           href="http://www.example.com/book/audio/ch01.mp4"
-          media-type="audio/mp4"/&gt;
+          media-type="audio/mp4"/>
    
       &lt;item id="c01"
           href="XHTML/chapter001.xhtml"
           media-type="application/xhtml+xml"
-          properties="remote-resources"/&gt;
+          properties="remote-resources"/>
       &#8230;
    &lt;/manifest>
    &#8230;
@@ -2770,9 +2775,9 @@ Manifest:
    &lt;body>
       &#8230;
       &lt;a
-          href="http://www.example.com/book/audio/ch01.mp4"&gt;
+          href="http://www.example.com/book/audio/ch01.mp4">
          Listen to audio
-      &lt;/a&gt;
+      &lt;/a>
       &#8230;
    &lt;/body>
 &lt;/html>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2611,45 +2611,58 @@
 									<pre>&lt;package &#8230;>
    &#8230;
    &lt;manifest>
-      &lt;item id="nav" 
+      &lt;item
+          id="nav" 
           href="nav.xhtml" 
           properties="nav"
           media-type="application/xhtml+xml"/>
-      &lt;item id="intro" 
+      &lt;item
+          id="intro" 
           href="intro.xhtml" 
           media-type="application/xhtml+xml"/>
-      &lt;item id="c1" 
+      &lt;item
+          id="c1" 
           href="chap1.xhtml" 
           media-type="application/xhtml+xml"/>
-      &lt;item id="c1-answerkey" 
+      &lt;item
+          id="c1-answerkey" 
           href="chap1-answerkey.xhtml" 
           media-type="application/xhtml+xml"/>
-      &lt;item id="c2" 
+      &lt;item
+          id="c2" 
           href="chap2.xhtml" 
           media-type="application/xhtml+xml"/>
-      &lt;item id="c2-answerkey" 
+      &lt;item
+          id="c2-answerkey" 
           href="chap2-answerkey.xhtml" 
           media-type="application/xhtml+xml"/>
-      &lt;item id="c3" 
+      &lt;item
+          id="c3" 
           href="chap3.xhtml" 
           media-type="application/xhtml+xml"/>
-      &lt;item id="c3-answerkey" 
+      &lt;item
+          id="c3-answerkey" 
           href="chap3-answerkey.xhtml" 
           media-type="application/xhtml+xml"/>    
-      &lt;item id="notes" 
+      &lt;item
+          id="notes" 
           href="notes.xhtml" 
           media-type="application/xhtml+xml"/>
-      &lt;item id="cover" 
+      &lt;item
+          id="cover" 
           href="./images/cover.svg" 
           properties="cover-image"
           media-type="image/svg+xml"/>
-      &lt;item id="f1" 
+      &lt;item
+          id="f1" 
           href="./images/fig1.jpg" 
           media-type="image/jpeg"/>
-      &lt;item id="f2" 
+      &lt;item
+          id="f2" 
           href="./images/fig2.jpg" 
           media-type="image/jpeg"/>
-      &lt;item id="css" 
+      &lt;item
+          id="css" 
           href="./style/book.css" 
           media-type="text/css"/>   
    &lt;/manifest>
@@ -2665,12 +2678,14 @@
    &#8230;
    &lt;manifest>
       &#8230;
-      &lt;item id="page-001"
+      &lt;item
+          id="page-001"
           href="images/page-001.jpg"
           media-type="image/jpeg"
           fallback="#page-001-svg"/>
 
-      &lt;item id="page-001-svg"
+      &lt;item
+          id="page-001-svg"
           href="images/page-001.svg"
           media-type="image/svg+xml"/>
       … 
@@ -2685,12 +2700,13 @@
 								</aside>
 								<aside class="example" title="Top-Level Content Document with Fallback">
 									<p>The following example shows a JPEG embedded in an EPUB Content Document (via the
-											<code>img</code> tag) and also hyperlinked to allow it to open as a
-										full-screen document (i.e., as a <a>Top-Level Content Document</a>). Although
-										embedding the image in a <code>img</code> tag does not require it to be listed
-										in the spine or have a fallback, by hyperlinking to the image the EPUB Creator
-										must list it as an item in the <a href="#sec-spine-elem">spine</a> and include a
-										fallback to an EPUB Content Document.</p>
+											<code>img</code> tag) with a hyperlink that allows it to open as a separate
+										page (e.g., for easier zooming). Although embedding the image using the
+											<code>img</code> tag does not require it to be listed in the <a
+											href="#sec-spine-elem">spine</a> or have a fallback, adding the hyperlink
+										causes the document to open as a <a>Top-Level Content Document</a>. As a result,
+										the EPUB Creator must list the image in the spine and include a fallback to an
+										EPUB Content Document.</p>
 									<pre>XHTML:
 &lt;html &#8230;>
    &#8230;
@@ -2712,19 +2728,24 @@ Package Document:
    &#8230;
    &lt;manifest>
       &#8230;
-      &lt;item id="img01"
+      &lt;item
+          id="img01"
           href="images/infographic.jpg"
           media-type="image/jpeg"
           fallback="#infographic-svg"/>
 
-      &lt;item id="infographic-svg"
+      &lt;item
+          id="infographic-svg"
           href="images/infographic.svg"
           media-type="image/svg+xml"/>
       &#8230;
    &lt;/manifest>
    &lt;spine>
       &#8230;
-      &lt;itemref idref="img01" linear="no"/>
+      &lt;itemref
+          idref="img01"
+          properties="layout-pre-paginated page-spread-center"
+          linear="no"/>
       &#8230;
    &lt;/spine>
 &lt;/package></pre>
@@ -2752,11 +2773,13 @@ Package Document:
    &#8230;
    &lt;manifest>
       &#8230;
-      &lt;item id="audio01"
+      &lt;item
+          id="audio01"
           href="http://www.example.com/book/audio/ch01.mp4"
           media-type="audio/mp4"/>
    
-      &lt;item id="c01"
+      &lt;item
+          id="c01"
           href="XHTML/chapter001.xhtml"
           media-type="application/xhtml+xml"
           properties="remote-resources"/>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2683,13 +2683,14 @@
    &lt;/spine>
 &lt;/package></pre>
 								</aside>
-								<aside class="example" title="Foreign Resource with Fallback">
-									<p>The following example shows a hyperlink to a JPEG that will render as a
-											<a>Top-Level Content Document</a>. As a result, EPUB Creators must list the
-										JPEG as a non-linear item in the <a href="#sec-spine-elem">spine</a>
-										<em>and</em> specify a fallback to an EPUB Content Document in its manifest
-										declaration (in this case, an SVG). If the image were only used in the
-											<code>img</code> tag, a spine entry would not be needed.</p>
+								<aside class="example" title="Top-Level Content Document with Fallback">
+									<p>The following example shows a JPEG embedded in an EPUB Content Document (via the
+											<code>img</code> tag) and also hyperlinked to allow it to open as a
+										full-screen document (i.e., as a <a>Top-Level Content Document</a>). Although
+										embedding the image in a <code>img</code> tag does not require it to be listed
+										in the spine or have a fallback, by hyperlinking to the image the EPUB Creator
+										must list it as an item in the <a href="#sec-spine-elem">spine</a> and include a
+										fallback to an EPUB Content Document.</p>
 									<pre>XHTML:
 &lt;html &#8230;>
    &#8230;

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -958,19 +958,16 @@
 									alternate embedded message when a media type cannot be rendered); or</p>
 							</li>
 							<li>
-								<p><a href="#sec-foreign-restrictions-manifest">manifest fallbacks</a>.</p>
+								<p><a href="#sec-foreign-restrictions-manifest">manifest fallback</a> chains defined on
+										<a href="sec-item-elem"><code>item</code> elements</a> in the <a>Package
+										Document</a>.</p>
 							</li>
 						</ul>
 
-						<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback chains
-							to Core Media Type Resources. They are used to create fallbacks for Foreign Resources in the
-								<a href="#sec-spine-elem">spine</a> and when intrinsic fallback capabilities are not
-							available (e.g., for the [[HTML]] <a
-								href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"
-									><code>img</code></a> element).</p>
-
-						<p>Refer to the [[HTML]] and [[SVG]] specifications for the intrinsic fallback capabilities
-							their elements provide.</p>
+						<div class="note">
+							<p>Refer to the [[HTML]] and [[SVG]] specifications for the intrinsic fallback capabilities
+								their elements provide.</p>
+						</div>
 					</section>
 				</section>
 
@@ -2788,10 +2785,8 @@
 
 							<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[XML]]
 								that identifies a fallback for the Publication Resource referenced from the
-									<code>item</code> element. EPUB Creators MAY provide fallbacks for <a>Core Media
-									Type Resources</a> (e.g., to provide a static alternative to a <a>Scripted Content
-									Document</a>). Refer to <a href="#sec-foreign-restrictions-manifest"></a> for
-								fallback requirements for Foreign Resources.</p>
+									<code>item</code> element, as defined in <a
+									href="#sec-foreign-restrictions-manifest"></a>.</p>
 
 							<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
 									Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
@@ -2819,6 +2814,70 @@
 									significant. The <a class="codelink" href="#sec-spine-elem"><code>spine</code>
 										element</a> provides the presentation sequence of content documents.</p>
 							</div>
+
+							<section id="sec-foreign-restrictions-manifest">
+								<h6>Manifest Fallbacks</h6>
+
+								<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback
+									chains to Core Media Type Resources. They are used to create fallbacks for Foreign
+									Resources in the <a href="#sec-spine-elem">spine</a> and when intrinsic fallback
+									capabilities are not available (e.g., for the [[HTML]] <a
+										href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element"
+											><code>img</code></a> element).</p>
+
+								<p>EPUB Creators MAY reference Foreign Resources in contexts in which an intrinsic
+									fallback cannot be provided (e.g., directly from <a>spine</a>
+									<a href="#elemdef-spine-itemref"><code>itemref</code> elements</a>; from [[HTML]]
+										<code>img</code>, <code>iframe</code> and <code>link</code> elements in <a>XHTML
+										Content Documents</a>; and from <code>@import</code> rules in CSS Style Sheets).
+									EPUB Creators MUST provide manifest fallbacks in such cases.</p>
+
+								<p>EPUB Creators MAY also provide fallbacks for <a>Core Media Type Resources</a> (e.g.,
+									to provide a static alternative to a <a>Scripted Content Document</a>).</p>
+
+								<p>The <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> on the
+										<a>manifest</a>
+									<a href="#elemdef-package-item"><code>item</code></a> element specifies the fallback
+									for the referenced Publication Resource. The <code>fallback</code> attribute's IDREF
+									[[XML]] value MUST resolve to another <code>item</code> in the
+									<code>manifest</code>. This fallback <code>item</code> MAY itself specify another
+									fallback <code>item</code>, and so on.</p>
+
+								<p>The ordered list of all the ID references that a Reading System can reach, starting
+									from a given item's <code>fallback</code> attribute, represents the <em>fallback
+										chain</em> for that item. The order of the resources in the fallback chain
+									represents the EPUB Creator's preferred fallback order.</p>
+
+								<p>Fallback chains MUST conform to one of the following requirements, as
+									appropriate:</p>
+
+								<ul>
+									<li>
+										<p>For Foreign Resources referenced directly from spine <a
+												href="#elemdef-spine-itemref"><code>itemref</code> elements</a>, the
+											chain MUST contain at least one <a>EPUB Content Document</a>.</p>
+									</li>
+									<li>
+										<p>For Foreign Resources for which an EPUB Creator cannot provide an intrinsic
+											fallback, the chain MUST contain at least one <a>Core Media Type
+												Resource</a>.</p>
+									</li>
+								</ul>
+
+								<p>Fallback chains MUST NOT contain circular or self-references to <code>item</code>
+									elements in the chain.</p>
+
+								<p>EPUB Creators MAY provide fallbacks for <a>Top-Level Content Documents</a> that are
+									EPUB Content Documents (e.g., to provide <a href="#confreq-cd-scripted-flbk"
+										>fallbacks for scripted content</a>).</p>
+
+								<div class="note">
+									<p>As it is not possible to use manifest fallbacks for resources represented in <a
+											href="#sec-data-urls">data URLs</a>, EPUB Creators can only represent
+										Foreign Resources as data URLs where an intrinsic fallback mechanism is
+										available.</p>
+								</div>
+							</section>
 
 							<section id="sec-item-elem-examples">
 								<h6>Examples</h6>
@@ -2873,126 +2932,85 @@
 </pre>
 								</aside>
 
-								<aside class="example" id="example-manifest-flbk">
-									<p>The following example shows a <code>manifest</code> that references two
-											<a>Foreign Resources</a> and therefore uses the <a
-											href="#sec-foreign-restrictions-manifest">fallback chain mechanism</a> to
-										supply content alternatives. The fallback chain terminates with a <a>Core Media
-											Type Resource</a>.</p>
-									<pre>&lt;manifest&gt;
-    &lt;item id="item1" 
-          href="chap1_docbook.xml" 
-          media-type="application/docbook+xml" 
-          fallback="fall1"/&gt;
-    &lt;item id="fall1" 
-          href="chap1.xml" 
-          media-type="application/z3998-auth+xml" 
-          fallback="fall2" /&gt;
-    &lt;item id="fall2" 
-          href="chap1.xhtml" 
-          media-type="application/xhtml+xml"/&gt; 
-    … 
+								<aside class="example" id="example-manifest-flbk"
+									title="Foreign Resource with Fallback in Spine">
+									<p>The following example shows the <a href="#sec-foreign-restrictions-manifest"
+											>fallback chain mechanism</a> allowing a <a>Foreign Resource</a> (JPEG) to
+										be listed in the spine with fallback to an SVG Content Document.</p>
+									<pre>Spine:
+&lt;itemref idref="page-001"/&gt;
+
+Manifest:
+&lt;manifest&gt;
+   &lt;item id="page-001"
+      href="images/page-001.jpg"
+      media-type="image/jpeg"
+      fallback="#page-001-svg"/&gt;
+
+   &lt;item id="page-001-svg"
+      href="images/page-001.svg"
+      media-type="image/svg+xml"/&gt;
+      … 
 &lt;/manifest&gt;
 </pre>
 								</aside>
 
-								<aside class="example">
-									<p>The following example shows a reference to a remote audio file that EPUB Creators
-										must reference from the manifest (Reading Systems will render the audio inline
-										in the XHTML Content Document, so the file is a Publication Resource).</p>
+								<aside class="example" title="Foreign Resource with Fallback">
+									<p>The following example shows a hyperlink to a JPEG that will render as a
+											<a>Top-Level Content Document</a>. As a result, EPUB Creators must list the
+										JPEG as a non-linear item in the <a href="#sec-spine-elem">spine</a>
+										<em>and</em> specify a fallback to an EPUB Content Document in its manifest
+										declaration (in this case, an SVG).</p>
+									<pre>XHTML:
+&lt;img src="images/infographic.jpg" alt="&#8230;" />
+&lt;a href="images/infographic.jpg"&gt;Expand Image&lt;/a&gt;
+
+Spine:
+&lt;itemref idref="img01" linear="no"/&gt;
+
+Manifest:
+&lt;item id="img01"
+      href="images/infographic.jpg"
+      media-type="image/jpeg"
+      fallback="#infographic-svg"/&gt;
+
+&lt;item id="infographic-svg"
+      href="images/infographic.svg"
+      media-type="image/svg+xml"/&gt;</pre>
+								</aside>
+
+								<aside class="example" title="Remote Resources that are Publication Resources">
+									<p>The following example shows a reference to a remote audio file. Because the
+											<code>audio</code> element embeds the audio in its EPUB Content Document,
+										the file is considered a Publication Resource. EPUB Creators therefore must list
+										the audio file in the manifest and indicate that its parent EPUB Content Document
+										contains a remote resource.</p>
 									<pre>XHTML:
 &lt;audio src="http://www.example.com/book/audio/ch01.mp4" controls="controls"/&gt;
 
 Manifest:
 &lt;item id="audio01"
       href="http://www.example.com/book/audio/ch01.mp4"
-      media-type="audio/mp4"/&gt;</pre>
+      media-type="audio/mp4"/&gt;
+
+&lt;item id="c01"
+      href="XHTML/chapter001.xhtml"
+      media-type="application/xhtml+xml"
+      properties="remote-resources"/&gt;</pre>
 								</aside>
 
-								<aside class="example">
-									<p>The following example shows a link to the same audio file, but in this case the
-										EPUB Creator does not list the file in the manifest (hyperlinked Remote
-										Resources are not Publication Resources). The EPUB Creator would only list the
-										audio file in the manifest if it is also referenced it from an [[?HTML]]
-										embedded content element, as above (i.e., in a context where it is used as a
-										Publication Resource).</p>
+								<aside class="example" title="External Resources that are not Publication Resources">
+									<p>The following example shows a hyperlink to an audio file hosted on the web.
+										Reading Systems will open such external content in a new browser window; it is
+										not rendered within the publication. In this case, EPUB Creators do not list the
+										file in the manifest because it is not a Publication Resource.</p>
 									<pre>XHTML:
 &lt;a href="http://www.example.com/book/audio/ch01.mp4"&gt;Go to audio file&lt;/a&gt;
 
 Manifest:
 No Entry</pre>
 								</aside>
-
-								<aside class="example">
-									<p>The following example shows a link to a local version of the audio file. For this
-										link to be valid, EPUB Creators must list the audio file in the <a
-											href="#sec-spine-elem">spine</a> and requires a fallback to an EPUB Content
-										Document in its manifest declaration.</p>
-									<pre>XHTML:
-&lt;a href="audio/ch01.mp4"&gt;Open Audio File&lt;/a&gt;
-
-Manifest:
-&lt;item id="audio01"
-      href="audio/ch01.mp4"
-      media-type="audio/mp4"
-      fallback="#audio01-xhtml"/&gt;
-
-Spine:
-&lt;itemref idref="audio01" linear="no"/&gt;</pre>
-								</aside>
 							</section>
-						</section>
-
-						<section id="sec-foreign-restrictions-manifest">
-							<h6>Manifest Fallbacks</h6>
-
-							<p>EPUB Creators MAY reference Foreign Resources in contexts in which an intrinsic fallback
-								cannot be provided (e.g., directly from <a>spine</a>
-								<a href="#elemdef-spine-itemref"><code>itemref</code> elements</a>; from [[HTML]]
-									<code>img</code>, <code>iframe</code> and <code>link</code> elements in <a>XHTML
-									Content Documents</a>; and from <code>@import</code> rules in CSS Style Sheets).
-								EPUB Creators MUST provide manifest fallbacks in such cases.</p>
-
-							<p>The <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> on the
-									<a>manifest</a>
-								<a href="#elemdef-package-item"><code>item</code></a> element specifies the fallback for
-								the referenced Publication Resource. The <code>fallback</code> attribute's IDREF [[XML]]
-								value MUST resolve to another <code>item</code> in the <code>manifest</code>. This
-								fallback <code>item</code> MAY itself specify another fallback <code>item</code>, and so
-								on.</p>
-
-							<p>The ordered list of all the ID references that a Reading System can reach, starting from
-								a given item's <code>fallback</code> attribute, represents the <em>fallback chain</em>
-								for that item. The order of the resources in the fallback chain represents the EPUB
-								Creator's preferred fallback order.</p>
-
-							<p>Fallback chains MUST conform to one of the following requirements, as appropriate:</p>
-
-							<ul>
-								<li>
-									<p>For Foreign Resources referenced directly from spine <a
-											href="#elemdef-spine-itemref"><code>itemref</code> elements</a>, the chain
-										MUST contain at least one <a>EPUB Content Document</a>.</p>
-								</li>
-								<li>
-									<p>For Foreign Resources for which an EPUB Creator cannot provide an intrinsic
-										fallback, the chain MUST contain at least one <a>Core Media Type
-										Resource</a>.</p>
-								</li>
-							</ul>
-
-							<p>Fallback chains MUST NOT contain circular or self-references to <code>item</code>
-								elements in the chain.</p>
-
-							<p>EPUB Creators MAY provide fallbacks for <a>Top-Level Content Documents</a> that are EPUB
-								Content Documents (e.g., to provide <a href="#confreq-cd-scripted-flbk">fallbacks for
-									scripted content</a>).</p>
-
-							<div class="note">
-								<p>As it is not possible to use manifest fallbacks for resources represented in <a
-										href="#sec-data-urls">data URLs</a>, EPUB Creators can only represent Foreign
-									Resources as data URLs where an intrinsic fallback mechanism is available.</p>
-							</div>
 						</section>
 
 						<section id="sec-opf-bindings">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2746,7 +2746,7 @@ Package Document:
    &lt;/body>
 &lt;/html>
 
-Manifest:
+Package Document:
 &lt;package &#8230;>
    &#8230;
    &lt;manifest>


### PR DESCRIPTION
This PR covers what was mentioned in #1877 plus some other improvements I thought would help. Specifically, it:

- moves the manifest fallbacks section under the item element definition
- takes the explanation of fallbacks from 2.2.1.3 Foreign Resources to better introduce the section - leaving a more basic explanation of how they're expressed in that section
- moves the sentence about fallbacks for core media types from the item element definition and reworded per the issue
- reorders the examples so the two about manifest fallbacks are together and the two about listing resources are together
- adds titles to the examples to help explain their relationships
- replaces the example with a docbook/z3986/xhtml fallback chain with a JPEG/SVG
- tries to simplify the example descriptions to make the point of each example more understandable
- adds additional markup to clarify the examples, like including the xhtml manifest entry for a remote audio reference to show it needs the remote-resources properties attribute

Fixes #1877


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1911.html" title="Last updated on Nov 20, 2021, 1:51 PM UTC (a6ee952)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1911/1182db6...a6ee952.html" title="Last updated on Nov 20, 2021, 1:51 PM UTC (a6ee952)">Diff</a>