### PR TITLE
Add references to tests for duplicate spine items

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -553,13 +553,16 @@
 					<code>properties</code> attributes that they do not recognize.</p>
 
 				<p>
-					<span id="confreq-rs-pkg-duplicate-item-rendering">Reading Systems MUST NOT skip spine references to
-						duplicate manifest items when rendering the linear reading order.</span>
-					<span id="confreq-rs-pkg-duplicate-item-ui"> The Reading System MUST treat these as distinct items
-						for UI purposes (for example, each occurrence could be independently bookmarked or annotated). </span>
-					<span id="confreq-rs-pkg-duplicate-item-hyperlink"> When a Reading System follows a hyperlink to a
-						resource referenced multiple times in the spine, the Reading System MUST move to the position of
-						the first occurrence of the document in the linear reading order. </span>
+					<span id="confreq-rs-pkg-duplicate-item-rendering" data-tests="#pkg-spine-duplicate-item-rendering">
+						Reading Systems MUST NOT skip spine references to duplicate manifest items when rendering the linear
+						reading order.</span>
+					<span id="confreq-rs-pkg-duplicate-item-ui" data-tests="#pkg-spine-duplicate-item-ui">The Reading System
+						MUST treat these as distinct items for UI purposes (for example, each occurrence could be
+						independently bookmarked or annotated).</span>
+					<span id="confreq-rs-pkg-duplicate-item-hyperlink" data-tests="#pkg-spine-duplicate-item-hyperlink">When
+						a Reading System follows a hyperlink to a resource referenced multiple times in the spine, the
+						Reading System MUST move to the position of the first occurrence of the document in the linear
+						reading order.</span>
 				</p>
 			</section>
 


### PR DESCRIPTION
This corresponds to https://github.com/w3c/epub-tests/pull/84.