### PR TITLE
Some editorial changes following PR 1898

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5837,9 +5837,7 @@ No Entry</pre>
 								<var>url</var>, with the <a>container root URL</a> as <a
 								data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
-						<aside class="example" title="Relative URL in a container.xml file">
-							<p>If <code>META-INF/container.xml</code> has the following content:</p>
-
+						<aside class="example" title="URLs in a container.xml file are relative to the OCF Abstract Container">
 							<pre>
 	&lt;?xml version="1.0"?&gt;
 	&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
@@ -5849,7 +5847,7 @@ No Entry</pre>
 		&lt;/rootfiles&gt;
 	&lt;/container&gt;
 				</pre>
-							<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the root directory
+							<p>The path <code>EPUB/Great_Expectations.opf</code> is relative to the root directory
 								for the OCF Abstract Container and not relative to the <code>META-INF</code>
 								directory.</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5744,7 +5744,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-file-names-to-path-names">
-					<h4>Deriving File Paths of Files</h4>
+					<h4>Deriving File Paths</h4>
 
 					<p>To derive the <a>File Path</a>, given a file or directory <var>file</var> in the <a
 							href="#sec-container-abstract">OCF Abstract Container</a>, apply the following steps

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5837,7 +5837,7 @@ No Entry</pre>
 								<var>url</var>, with the <a>container root URL</a> as <a
 								data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
-						<aside class="example">
+						<aside class="example" title="Relative URL in a container.xml file">
 							<p>If <code>META-INF/container.xml</code> has the following content:</p>
 
 							<pre>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6035,7 +6035,7 @@ No Entry</pre>
 				<section id="sec-file-names-to-path-names">
 					<h4>Deriving File Paths</h4>
 
-					<p>To derive the <a>File Path</a>, given a file or directory <var>file</var> in the <a
+					<p>To <dfn id="dfn-derive-the-file-path">derive the File Path</dfn>, given a file or directory <var>file</var> in the <a
 							href="#sec-container-abstract">OCF Abstract Container</a>, apply the following steps
 						(expressed using the terminology of [[INFRA]]):</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2886,7 +2886,7 @@
 									href="https://url.spec.whatwg.org/#path-relative-scheme-less-URL"
 									>path-relative-scheme-less-URL</a> string. EPUB Creators MUST ensure each URL is
 								unique within the <code>manifest</code> scope after <a
-									href="#parsing-urls-in-the-package-document">parsing</a>.</p>
+									href="#sec-parse-package-urls">parsing</a>.</p>
 
 							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
 								element MUST conform to the applicable specification(s) as inferred from the MIME media
@@ -5746,13 +5746,14 @@ No Entry</pre>
 				<section id="sec-file-names-to-path-names">
 					<h4>Deriving File Paths of Files</h4>
 
-					<p>To derive the <a>File Path</a> of a file or directory <var>file</var> in the <a
+					<p>To derive the <a>File Path</a> of the directory or file in the <a
 							href="#sec-container-abstract">OCF Abstract Container</a> apply the following steps
 						(expressed using the terminology of [[INFRA]]):</p>
 
 					<ol class="algorithm">
+						<!-- <li>Let <var>file</var> be the directory or file to parse</li> -->
 						<li>Let <var>path</var> be an empty <a data-cite="infra#list">list</a>.</li>
-						<li>Let <var>current</var> be <var>file</var>.</li>
+						<li>Let <var>current</var> be the directory or file to parse.</li>
 						<li>While <var>current</var> is not the <a>Root Directory</a>: <ol>
 								<li><a data-cite="infra#list-prepend">prepend</a> the <a>File Name</a> of
 										<var>current</var> to <var>path</var>;</li>
@@ -5837,9 +5838,9 @@ No Entry</pre>
 								data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 						<aside class="example">
-							<p>For example, if <code>META-INF/container.xml</code> has the following content:</p>
+							<p>If <code>META-INF/container.xml</code> has the following content:</p>
 
-							<pre class="example">
+							<pre>
 	&lt;?xml version="1.0"?&gt;
 	&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
 		&lt;rootfiles&gt;
@@ -5848,7 +5849,6 @@ No Entry</pre>
 		&lt;/rootfiles&gt;
 	&lt;/container&gt;
 				</pre>
-
 							<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the root directory
 								for the OCF Abstract Container and not relative to the <code>META-INF</code>
 								directory.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5746,14 +5746,14 @@ No Entry</pre>
 				<section id="sec-file-names-to-path-names">
 					<h4>Deriving File Paths of Files</h4>
 
-					<p>To derive the <a>File Path</a> of the directory or file in the <a
-							href="#sec-container-abstract">OCF Abstract Container</a> apply the following steps
+					<p>To derive the <a>File Path</a>, given a file or directory <var>file</var> in the <a
+							href="#sec-container-abstract">OCF Abstract Container</a>, apply the following steps
 						(expressed using the terminology of [[INFRA]]):</p>
 
 					<ol class="algorithm">
 						<!-- <li>Let <var>file</var> be the directory or file to parse</li> -->
 						<li>Let <var>path</var> be an empty <a data-cite="infra#list">list</a>.</li>
-						<li>Let <var>current</var> be the directory or file to parse.</li>
+						<li>Let <var>current</var> be <var>file</var>.</li>
 						<li>While <var>current</var> is not the <a>Root Directory</a>: <ol>
 								<li><a data-cite="infra#list-prepend">prepend</a> the <a>File Name</a> of
 										<var>current</var> to <var>path</var>;</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -475,7 +475,7 @@
 						id="confreq-rs-pkg-manifest-unknown" data-tests="#pkg-manifest-unknown">Reading Systems MUST
 						ignore values of the <code>properties</code> attribute they do not recognize.</span></p>
 
-				<p id="confreq-rendition-rs-manifest" data-tests="#pkg-manifest-unlisted-resource">It SHOULD NOT use
+				<p id="confreq-rendition-rs-manifest" data-tests="#pkg-manifest-unlisted-resource">Reading Systems SHOULD NOT use
 						non-<a>Publication Resources</a> in the rendering of an EPUB Publication due to the inherent
 					limitations and risks involved (e.g., lack of information about the resource and how to process it,
 					security risks from remotely-hosted sources, lack of fallbacks, etc.).</p>


### PR DESCRIPTION
These are issues found by @mattgarrish.

It fixes #1923 and #1924.

It also fixes the editorial comment of https://github.com/w3c/epub-specs/issues/1919#issuecomment-974495911, but the closure of #1919 shouldn't be done automatically by merging this PR.

Finally, there was an invalid cross-reference to a parsing section.


See:

* For EPUB 3.3:
    * [Preview](https://raw.githack.com/w3c/epub-specs/post-1898-minor-editorials/epub33/core/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/core/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/post-1898-minor-editorials/epub33/core/index.html)
* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/post-1898-minor-editorials/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/post-1898-minor-editorials/epub33/rs/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1927.html" title="Last updated on Nov 24, 2021, 6:18 AM UTC (a9fd23b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1927/a3a2d65...a9fd23b.html" title="Last updated on Nov 24, 2021, 6:18 AM UTC (a9fd23b)">Diff</a>