### PR TITLE
Add titles to examples

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -99,6 +99,11 @@
 				},
 				postProcess:[updatePermaLinks]
 			};</script>
+		<style>
+			pre,
+			code {
+				white-space: break-spaces !important;
+			}</style>
 	</head>
 	<body>
 		<section id="abstract">

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -99,11 +99,6 @@
 				},
 				postProcess:[updatePermaLinks]
 			};</script>
-		<style>
-			pre,
-			code {
-				white-space: break-spaces !important;
-			}</style>
 	</head>
 	<body>
 		<section id="abstract">

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -223,9 +223,7 @@
 					the [[schema-org]] <a href="https://schema.org/accessMode"><code>accessMode</code> property</a>,
 					repeating the property for each applicable mode.</p>
 
-				<aside class="example">
-					<p>The following example shows the metadata entries for an EPUB 3 Publication that has textual and
-						visual access modes.</p>
+				<aside class="example" title="Metadata entries for textual and visual access modes">
 					<pre>&lt;meta
     property="schema:accessMode">
    textual
@@ -264,8 +262,7 @@
 					for all these images. The publication has both textual and visual content, so the EPUB Creator will
 					include the following metadata entries to indicate this:</p>
 
-				<div class="example">
-					<pre>&lt;meta
+				<pre>&lt;meta
     property="schema:accessMode">
    textual
 &lt;/meta>
@@ -273,7 +270,6 @@
     property="schema:accessMode">
    visual
 &lt;/meta></pre>
-				</div>
 
 				<p>This metadata does not make clear whether a textual access mode is sufficient to read the entire
 					publication, or whether a visual one is, only that two modes are required by default. This
@@ -282,12 +278,10 @@
 				<p>The first set of sufficiency metadata the EPUB Creator inputs will establish the textual and visual
 					requirement:</p>
 
-				<div class="example">
-					<pre>&lt;meta
+				<pre>&lt;meta
     property="schema:accessModeSufficient">
    textual,visual
 &lt;/meta></pre>
-				</div>
 
 				<p>The order in which the access modes are listed is not important. The only requirement is that they be
 					separated by commas.</p>
@@ -295,12 +289,10 @@
 				<p>Since the EPUB Creator has also included descriptions for all the images, the EPUB Creator can also
 					indicate that a purely textual access mode is sufficient to read the content:</p>
 
-				<div class="example">
-					<pre>&lt;meta
+				<pre>&lt;meta
     property="schema:accessModeSufficient">
    textual
 &lt;/meta></pre>
-				</div>
 
 				<p>Without this metadata, users would not have known that they could read the publication only via its
 					text content.</p>
@@ -314,8 +306,7 @@
 
 				<p>The full set of entries in this example is as follows:</p>
 
-				<div class="example">
-					<pre>&lt;meta
+				<pre>&lt;meta
     property="schema:accessMode">
    textual
 &lt;/meta>
@@ -331,7 +322,6 @@
     property="schema:accessModeSufficient">
    textual
 &lt;/meta></pre>
-				</div>
 
 				<p>Note that sufficiency of access is often a subjective determination of the EPUB Creator based on
 					their understanding of what information is essential to comprehending the text. Some information
@@ -367,9 +357,7 @@
 						href="https://schema.org/accessibilityFeature"><code>accessibilityFeature</code> property</a>.
 					Repeat this property for each feature.</p>
 
-				<aside class="example">
-					<p>The following example shows the metadata entries for an EPUB 3 Publication that has both MathML
-						and alternative text.</p>
+				<aside class="example" title="Metadata entries for MathML and alternative text">
 					<pre>&lt;meta
     property="schema:accessibilityFeature">
    MathML
@@ -432,9 +420,8 @@
 					from hazards that affect them, but also want to know what dangers are present in any publications
 					they discover.</p>
 
-				<aside class="example">
-					<p>The following example shows the metadata entries for an EPUB 3 Publication that has a flashing
-						hazard but no motion simulation or sound hazards.</p>
+				<aside class="example"
+					title="Metadata entries for a flashing hazard but no motion simulation or sound hazards">
 					<pre>&lt;meta
     property="schema:accessibilityHazard">
    flashing
@@ -476,9 +463,8 @@
 						href="https://schema.org/accessibilitySummary"
 					><code>accessibilitySummary</code> property</a>.</p>
 
-				<aside class="example">
-					<p>The following example shows an accessibility summary for an EPUB 3 Publication that failed to
-						meet the content accessibility requirements.</p>
+				<aside class="example"
+					title="Accessibility summary for a publication that fails the content accessibility requirements">
 					<pre>&lt;meta
     property="schema:accessibilitySummary">
    The publication is missing alternative text for complex diagrams.
@@ -486,10 +472,8 @@
 &lt;/meta></pre>
 				</aside>
 
-				<aside class="example">
-					<p>The following example shows an accessibility summary for an EPUB 3 Publication with a motion
-						simulation hazard.</p>
-					<pre>&lt;meta
+				<aside class="example" title="Accessibility summary for a publication with a motion simulation hazard">
+					<pre>&lt;meta3
     property="schema:accessibilitySummary">
    Chapter four contains a first-person interactive game that could cause
    motion sickness in certain individuals. The game is only provided for
@@ -536,8 +520,7 @@
 					and visual access modes, is sufficient for reading by text, contains alternative text and MathML
 					markup, and has a flashing hazard.</p>
 
-				<aside class="example">
-					<p>EPUB 3</p>
+				<aside class="example" title="EPUB 3">
 					<pre>&lt;package … >
    &lt;metadata>
       …
@@ -545,42 +528,52 @@
           property="schema:accessMode">
          textual
       &lt;/meta>
+      
       &lt;meta
           property="schema:accessMode">
          visual
       &lt;/meta>
+      
       &lt;meta
           property="schema:accessModeSufficient">
          textual,visual
       &lt;/meta>
+      
       &lt;meta
           property="schema:accessModeSufficient">
          textual
       &lt;/meta>
+      
       &lt;meta
           property="schema:accessibilityFeature">
          transcript
       &lt;/meta>
+      
       &lt;meta
           property="schema:accessibilityFeature">
          MathML
       &lt;/meta>
+      
       &lt;meta
           property="schema:accessibilityFeature">
          alternativeText
       &lt;/meta>
+      
       &lt;meta
           property="schema:accessibilityHazard">
          flashing
       &lt;/meta>
+      
       &lt;meta
           property="schema:accessibilityHazard">
          noMotionSimulationHazard
       &lt;/meta>
-      &lt;meta
+      
+      &lt;meta
           property="schema:accessibilityHazard">
          noSoundHazard
       &lt;/meta>
+      
       &lt;meta
           property="schema:accessibilitySummary">
          The video in chapter 2 presents a flashing hazard. A transcript is
@@ -592,9 +585,7 @@
 &lt;/package></pre>
 				</aside>
 
-
-				<aside>
-					<p>EPUB 2</p>
+				<aside class="example" title="EPUB 2">
 					<pre>&lt;package … >
     &lt;metadata>
        …
@@ -927,8 +918,7 @@
 						Structurally, each chapter belongs to its part (i.e., is grouped with it), as in the following
 						markup:</p>
 
-					<div class="example">
-						<pre>&lt;section
+					<pre>&lt;section
     role="doc-part">
    &lt;h1>Part 1&lt;/h1>
    
@@ -939,25 +929,21 @@
    &lt;/section>
    …
 &lt;/section></pre>
-					</div>
 
 					<p>Since this would lead to a large content file, the part heading is typically split out into its
 						own Content Document so that it will appear on its own page:</p>
 
-					<div class="example">
-						<pre>&lt;html … >
+					<pre>&lt;html … >
    …
    &lt;body
        role="doc-part">
       &lt;h1>Part 1&lt;/h1>
    &lt;/body>
 &lt;/html></pre>
-					</div>
 
 					<p>Each chapter is then separated into a separate Content Document:</p>
 
-					<div class="example">
-						<pre>&lt;html … >
+					<pre>&lt;html … >
    …
    &lt;body
        role="doc-chapter">
@@ -965,12 +951,10 @@
       …
    &lt;/body>
 &lt;/html></pre>
-					</div>
 
 					<p>It is not necessary to add a part wrapper to each chapter, as in the following example:</p>
 
-					<div class="example">
-						<pre>&lt;html … >
+					<pre>&lt;html … >
    …
    &lt;body
        role="doc-part">
@@ -981,7 +965,6 @@
       &lt;/section>
    &lt;/body>
 &lt;/html></pre>
-					</div>
 
 					<p>Doing so introduces a new <code>part</code> landmark into each document, which will cause an
 						Assistive Technology to inform the user that the landmark is available to navigate to.</p>
@@ -1020,9 +1003,7 @@
 						but it is recommended to include a link to the start of the body matter as well as to any major
 						reference sections (e.g., table of contents, endnotes, bibliography, glossary, index).</p>
 
-					<aside class="example">
-						<p>The following example shows the EPUB 3 landmarks as expressed in the EPUB Navigation
-							Document.</p>
+					<aside class="example" title="Landmarks expressed in the EPUB 3 Navigation Document">
 						<pre>&lt;nav epub:type="landmarks">
    &lt;ol>
       &lt;li>
@@ -1071,9 +1052,7 @@
 &lt;/nav></pre>
 					</aside>
 
-					<aside class="example">
-						<p>The following example shows the EPUB 2 landmarks as expressed in the Package Document
-								<code>guide</code> element.</p>
+					<aside class="example" title="Landmarks expressed in the EPUB 2 guide element">
 						<pre>&lt;guide>
    &lt;reference
        type="toc"
@@ -1133,8 +1112,7 @@
 						that describes its content. If not provided, Assistive Technologies often will announce the name
 						of the file to users.</p>
 
-					<aside class="example">
-						<p>The following example shows a title for an EPUB Content Document.</p>
+					<aside class="example" title="Title for an EPUB Content Document">
 						<pre>&lt;html …>
    &lt;head>
       &lt;title>Chapter 1&lt;/title>
@@ -1151,8 +1129,7 @@
 						name of the publication), order the title such that the most precise description of the current
 						document comes first.</p>
 
-					<aside class="example">
-						<p>The following example shows a structured title.</p>
+					<aside class="example" title="A structured title">
 						<pre>&lt;html …>
    &lt;head>
       &lt;title>
@@ -1198,10 +1175,10 @@
 						be subsequent headings at the same level as the first (e.g., multiple subsections in one
 						document could all have <code>h3</code> headings).</p>
 
-					<aside class="example">
-						<p>The following example shows two consecutive EPUB Content Documents in a textbook. The first
-							contains a section heading (<code>h2</code>) and the first two subsections
-							(<code>h3</code>). The second contains the final two subsections (<code>h3</code>).</p>
+					<aside class="example" title="Heading order across documents">
+						<p>In this example, there are two consecutive EPUB Content Documents in a textbook. The first
+							contains the section heading (<code>h2</code>) and the first two subsections
+								(<code>h3</code>). The second contains the final two subsections (<code>h3</code>).</p>
 						<pre>&lt;html …>
    …
    &lt;body>
@@ -1322,8 +1299,8 @@
 						[[EPUB-3]].</p>
 
 					<aside class="example" title="All text declared to be in Japanese by default">
-						<pre><code>&lt;package &#8230; xml:lang="jp">
-   &#8230;
+						<pre><code>&lt;package … xml:lang="jp">
+   …
 &lt;/package></code></pre>
 					</aside>
 
@@ -1332,13 +1309,12 @@
 						attribute on the element for the field.</p>
 
 					<aside class="example" title="Overriding the default language for a title">
-						<pre><code>&lt;package &#8230; xml:lang="en">
-   &lt;metadata
-       xmlns:dc="http://purl.org/dc/elements/1.1/">
+						<pre><code>&lt;package … xml:lang="en">
+   &lt;metadata …>
       &lt;dc:title xml:lang="fr">Mon premier guide de cuisson, un Mémoire&lt;/dc:title>
-      &#8230;
+      …
    &lt;/metadata>
-   &#8230;
+   …
 &lt;/package></code></pre>
 					</aside>
 
@@ -1359,14 +1335,13 @@
 						[[EPUB-3]].</p>
 
 					<aside class="example" title="Setting the language of an EPUB Publication to Italian">
-						<pre><code>&lt;package &#8230;>
-   &lt;metadata
-       xmlns:dc="http://purl.org/dc/elements/1.1/">
-      &#8230;
+						<pre><code>&lt;package …>
+   &lt;metadata …>
+      …
       &lt;dc:language>it&lt;/dc:language>
-      &#8230;
+      …
    &lt;/metadata>
-   &#8230;
+   …
 &lt;/package></code></pre>
 					</aside>
 
@@ -1467,8 +1442,8 @@
 					<p>It is recommended that both semantics be applied to EPUB 3 content to ensure maximum
 						compatibility with Reading Systems and Assistive Technologies.</p>
 
-					<aside class="example">
-						<p>The following example shows an HTML5 <code>span</code> element identified as a page
+					<aside class="example" title="Expressing a page break">
+						<p>In this example, the EPUB Creator identifies an HTML <code>span</code> element as a page
 							break.</p>
 						<pre>&lt;span
     id="page001"
@@ -1486,11 +1461,17 @@
 						destinations can be included to enable hyperlinking, but the <a href="#page-003">page
 						list</a> is the only way a user can jump to the locations.</p>
 
-					<aside class="example">
-						<p>The following example shows an XHTML 1.1 <code>span</code> element used as a hyperlink
-							destination.</p>
-						<pre>&lt;span
-    id="page001"/></pre>
+					<aside class="example" title="Adding a hyperlink destination">
+						<p>In this example, the EPUB Creator adds an XHTML 1.1 <code>span</code> element to use as a
+							hyperlink destination.</p>
+						<pre>&lt;html …>
+   …
+   &lt;body>
+      …
+      &lt;span id="page001"/>
+      …
+   &lt;/body>
+&lt;/html></pre>
 					</aside>
 
 					<p>Do not use the [[HTML]] <a
@@ -1517,8 +1498,7 @@
 						[[EPUB-SSV]] to each <a href="https://www.w3.org/TR/epub/#sec-smil-par-elem"><code>par</code>
 							element</a> [[EPUB-3]] that identifies a page number in the media overlay documents.</p>
 
-					<aside class="example">
-						<p>The following example shows a page number identified in a media overlays document.</p>
+					<aside class="example" title="A page number identified in a Media Overlays Document">
 						<pre>&lt;smil
     xmlns="http://www.w3.org/ns/SMIL" 
     xmlns:epub="http://www.idpf.org/2007/ops"
@@ -1581,9 +1561,7 @@
 							<a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1.2"
 								><code>pageList</code> element</a> [[OPF-201]].</p>
 
-					<aside class="example">
-						<p>The following example shows an EPUB 3 <code>page-list nav</code> element that contains a list
-							of links to the static page breaks.</p>
+					<aside class="example" title="A page-list nav element">
 						<pre>&lt;nav
     epub:type="page-list">
    &lt;ol>
@@ -1610,9 +1588,9 @@
 &lt;/nav></pre>
 					</aside>
 
-					<aside class="example">
-						<p>The following example shows an EPUB 2 NCX that contains a list of page break locations in its
-								<code>pageList</code>.</p>
+					<aside class="example" title="A page list in the NCX">
+						<p>In this example, the <code>pageList</code> element contains the list of page break
+							locations.</p>
 						<pre>&lt;ncx
     xmlns="http://www.daisy.org/z3986/2005/ncx/"
     version="2005-1"
@@ -1656,11 +1634,10 @@
 					<p>To allow users to determine the suitability of the pagination, identify the ISBN of the source
 						work in the Package Document metadata.</p>
 
-					<aside class="example">
-						<p>The following example shows a <code>dc:source</code> element containing the ISBN of the print
-							source of pagination. This example is valid for both EPUB 2 and 3.</p>
-						<pre>&lt;metadata
-    xmlns:dc="http://purl.org/dc/elements/1.1/">
+					<aside class="example" title="Expressing the source of pagination">
+						<p>In this example, the <code>dc:source</code> element contains the ISBN of the print source of
+							pagination. This example is valid for both EPUB 2 and 3.</p>
+						<pre>&lt;metadata …>
    …
    &lt;dc:source>
       urn:isbn:9780375704024
@@ -1673,12 +1650,11 @@
 							href="https://www.w3.org/TR/epub/#source-of"><code>source-of</code> property</a> with the
 						value "<code>pagination</code>" [[EPUB-33]].</p>
 
-					<aside class="example">
-						<p>The following example shows a <code>dc:source</code> element explicitly identified as the
-							source of pagination. The <code>refines</code> attribute identifies the ID of the element
-							the <code>source-of</code> property is modifying.</p>
-						<pre>&lt;metadata
-    xmlns:dc="http://purl.org/dc/elements/1.1/">
+					<aside class="example" title="Adding a source-of declaration">
+						<p>In this example, a <code>dc:source</code> element is explicitly identified as the source of
+							pagination. The <code>refines</code> attribute identifies the ID of the element the
+								<code>source-of</code> property is modifying.</p>
+						<pre>&lt;metadata …>
    …
    &lt;dc:source
        id="pg-src">
@@ -1699,11 +1675,8 @@
 					<p>If an ISBN is not available, include as much information as possible about the source publication
 						(e.g., the publisher, date, edition, and binding).</p>
 
-					<aside class="example">
-						<p>The following example shows a <code>dc:source</code> element containing a text description of
-							the source.</p>
-						<pre>&lt;metadata
-    xmlns:dc="http://purl.org/dc/elements/1.1/">
+					<aside class="example" title="Text description of the source">
+						<pre>&lt;metadata …>
    …
    &lt;dc:source>
       ACME Publishing, 1945, 2nd Edition, Softcover
@@ -1758,10 +1731,10 @@
 						is always available with the publication.</p>
 				</div>
 
-				<aside class="example">
-					<p>The following example shows an ONIX record with accessibility metadata that states that the EPUB
-						Publication has no accessibility features disabled (10), a table of contents (11) and a correct
-						reading order (13).</p>
+				<aside class="example" title="ONIX accessibility metadata">
+					<p>In this example, the ONIX record includes accessibility metadata that states that the EPUB
+						Publication has no accessibility features disabled (10), includes a table of contents (11) and
+						has a correct reading order (13).</p>
 					<pre>&lt;ONIXMessage release="3.0">
    &lt;Header>
       …

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1036,21 +1036,18 @@
 						<p>The list of valid conformance strings will increase as W3C releases new versions of WCAG.</p>
 					</div>
 
-					<aside class="example">
-						<p>The following example shows a conformance statement for an EPUB 3 Publication that conforms
-							to the EPUB Accessibility 1.1 specification at WCAG 2.1 Level AA.</p>
-						<pre>&lt;package …>
-   &lt;metadata>
-      …
-      &lt;meta 
-          property="dcterms:conformsTo"
-          id="conf">
-         EPUB-A11Y-11_WCAG-21-AA
-      &lt;/meta>
-      …
-   &lt;/metadata>
+					<aside class="example" title="A basic conformance statement">
+						<p>In this example, the EPUB Creator is stating that publication conforms to the EPUB
+							Accessibility 1.1 specification at WCAG 2.1 Level AA.</p>
+						<pre>&lt;metadata …>
    …
-&lt;/package></pre>
+   &lt;meta 
+       property="dcterms:conformsTo"
+       id="conf">
+      EPUB-A11Y-11_WCAG-21-AA
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
 					</aside>
 
 					<div class="note">
@@ -1083,11 +1080,11 @@
 							party that created the EPUB Publication or a third party.</p>
 					</div>
 
-					<aside class="example">
-						<p>The following example shows an EPUB 3 Publication that has been self-evaluated by the
-							publisher (the values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code>
-							property are the same).</p>
-						<pre>&lt;metadata>
+					<aside class="example" title="A self evaluation">
+						<p>In this example, the publisher is stating they self-evaluated the EPUB Publication (the
+							values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code> property are the
+							same).</p>
+						<pre>&lt;metadata …>
   …
   &lt;dc:publisher>
      Acme Publishing Inc.
@@ -1098,6 +1095,7 @@
       id="conf">
      EPUB-A11Y-11_WCAG-21-AA
   &lt;/meta>
+  
   &lt;meta
       property="a11y:certifiedBy"
       refines="#conf">
@@ -1107,11 +1105,10 @@
 &lt;/metadata></pre>
 					</aside>
 
-					<aside class="example">
-						<p>The following example shows an EPUB 3 Publication that has been evaluated by a third party
-							(the values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code> property
-							differ).</p>
-						<pre>&lt;metadata>
+					<aside class="example" title="Third-party evaluation">
+						<p>In this example, a third party has evaluated the EPUB 3 Publication (the values of the
+								<code>dc:publisher</code> and <code>a11y:certifiedBy</code> property differ).</p>
+						<pre>&lt;metadata …>
   …
   &lt;dc:publisher>
      Acme Publishing Inc.
@@ -1131,10 +1128,8 @@
 &lt;/metadata></pre>
 					</aside>
 
-					<aside class="example">
-						<p>The following example shows an EPUB 3 Publication that has been self-evaluated by the EPUB
-							Creator.</p>
-						<pre>&lt;metadata>
+					<aside class="example" title="A self-evaluated EPUB 3 Publication">
+						<pre>&lt;metadata …>
   …
   &lt;dc:creator>
      Jane Doe
@@ -1145,6 +1140,7 @@
       id="conf">
      EPUB-A11Y-11_WCAG-21-AA
   &lt;/meta>
+  
   &lt;meta
       property="a11y:certifiedBy"
       refines="#conf">
@@ -1154,9 +1150,8 @@
 &lt;/metadata></pre>
 					</aside>
 
-					<aside class="example">
-						<p>The following example shows a self-evaluated EPUB 2 Publication.</p>
-						<pre>&lt;metadata>
+					<aside class="example" title="A self-evaluated EPUB 2 Publication">
+						<pre>&lt;metadata …>
   …
   &lt;dc:publisher>
      Acme Publishing Inc.
@@ -1165,6 +1160,7 @@
   &lt;meta
       name="dcterms:conformsTo"
       content="EPUB-A11Y-11_WCAG-21-AA"/>
+  
   &lt;meta
       name="a11y:certifiedBy"
       content="Acme Publishing Inc."/>
@@ -1183,18 +1179,22 @@
 							href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/date"
 								><code>dcterms:date</code> property</a> [[DCTERMS]] to the certifier.</p>
 
-					<aside class="example">
-						<p>The following example shows the date an evaluation was carried out on.</p>
-						<pre>&lt;meta
-    property="a11y:certifiedBy"
-    id="certifier">
-   EPUB Accessibility Evaluator
-&lt;/meta>
-&lt;meta
-    property="dcterms:date"
-    refines="#certifier">
-   2021-09-07
-&lt;/meta></pre>
+					<aside class="example" title="Expressing the evaluation date">
+						<pre>&lt;metadata …>
+   …
+   &lt;meta
+       property="a11y:certifiedBy"
+       id="certifier">
+      EPUB Accessibility Evaluator
+   &lt;/meta>
+   
+   &lt;meta
+       property="dcterms:date"
+       refines="#certifier">
+      2021-09-07
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
 					</aside>
 
 					<p>If the party that evaluates the content has a credential or badge that establishes their
@@ -1204,64 +1204,76 @@
 					<aside class="example">
 						<p>The following example shows a credential. The <code>refines</code> attribute associates the
 							credential with the certifier.</p>
-						<pre>&lt;meta
-    property="dcterms:conformsTo"
-    id="conf">
-   EPUB-A11Y-11_WCAG-21-AA
-&lt;/meta>
-&lt;meta
-    property="a11y:certifiedBy"
-    refines="#conf"
-    id="certifier">
-   EPUB Accessibility Evaluator
-&lt;/meta>
-&lt;meta
-    property="a11y:certifierCredential"
-    refines="#certifier">
-   A+ Accessibility Rating
-&lt;/meta></pre>
+						<pre>&lt;metadata …>
+   …
+   &lt;meta
+       property="dcterms:conformsTo"
+       id="conf">
+      EPUB-A11Y-11_WCAG-21-AA
+   &lt;/meta>
+   
+   &lt;meta
+       property="a11y:certifiedBy"
+       refines="#conf"
+       id="certifier">
+      EPUB Accessibility Evaluator
+   &lt;/meta>
+   
+   &lt;meta
+       property="a11y:certifierCredential"
+       refines="#certifier">
+      A+ Accessibility Rating
+   &lt;/meta>
+&lt;/metadata></pre>
 					</aside>
 
 					<p>If the party that evaluated the content provides a publicly-readable report of its assessment,
 						provide a link to the assessment in an <a href="#certifierReport"
 								><code>a11y:certifierReport</code> property</a>.</p>
 
-					<aside class="example">
+					<aside class="example" title="A remotely hosted accessibility report">
 						<p>The following example shows a link to a remotely hosted accessibility report.</p>
-						<pre>&lt;meta
-    property="dcterms:conformsTo"
-    id="conf">
-   EPUB-A11Y-11_WCAG-21-AA
-&lt;/meta>
-&lt;meta
-    property="a11y:certifiedBy"
-    refines="#conf"
-    id="certifier">
-   EPUB Accessibility Evaluator
-&lt;/meta>
-&lt;link
-    rel="a11y:certifierReport"
-    refines="#certifier"
-    href="http://www.example.com/a11y/report/9780000000001"/></pre>
+						<pre>&lt;metadata …>
+   &lt;meta
+       property="dcterms:conformsTo"
+       id="conf">
+      EPUB-A11Y-11_WCAG-21-AA
+   &lt;/meta>
+
+   &lt;meta
+       property="a11y:certifiedBy"
+       refines="#conf"
+       id="certifier">
+      EPUB Accessibility Evaluator
+   &lt;/meta>
+   
+   &lt;link
+       rel="a11y:certifierReport"
+       refines="#certifier"
+       href="http://www.example.com/a11y/report/9780000000001"/>
+&lt;/metadata></pre>
 					</aside>
 
-					<aside class="example">
-						<p>The following example shows a link to a locally hosted accessibility report.</p>
-						<pre>&lt;meta
-    property="dcterms:conformsTo"
-    id="conf">
-   EPUB-A11Y-11_WCAG-21-AA
-&lt;/meta>
-&lt;meta
-    property="a11y:certifiedBy"
-    refines="#conf"
-    id="certifier">
-   EPUB Accessibility Evaluator
-&lt;/meta>
-&lt;link
-    rel="a11y:certifierReport"
-    refines="#certifier"
-    href="reports/a11y.xhtml"/></pre>
+					<aside class="example" title="A locally hosted accessibility report">
+						<pre>&lt;metadata …>
+   &lt;meta
+       property="dcterms:conformsTo"
+       id="conf">
+      EPUB-A11Y-11_WCAG-21-AA
+   &lt;/meta>
+   
+   &lt;meta
+       property="a11y:certifiedBy"
+       refines="#conf"
+       id="certifier">
+      EPUB Accessibility Evaluator
+   &lt;/meta>
+
+   &lt;link
+       rel="a11y:certifierReport"
+       refines="#certifier"
+       href="reports/a11y.xhtml"/>
+&lt;/metadata></pre>
 					</aside>
 
 					<div class="note">
@@ -1391,44 +1403,47 @@
 						Publication Standards</a> for an informative list of standards.</p>
 			</div>
 
-			<aside class="example">
-				<p>The following example shows a conformance statement for an EPUB 3 Publication that conforms to the
-					DAISY Navigable Audio-only EPUB 3 Guidelines [[DAISYAudio]].</p>
-				<pre>&lt;package …>
-   &lt;metadata>
-      …
-      &lt;link
-          rel="dcterms:conformsTo"
-          href="http://www.daisy.org/guidelines/epub/navigable-audio-only-epub3-guidelines"/>
-      …
-   &lt;/metadata>
+			<aside class="example" title="Expressing conformance to an optimization standard">
+				<p>In this example, the conformance statement indicates the EPUB 3 Publication conforms to the DAISY
+					Navigable Audio-only EPUB 3 Guidelines [[DAISYAudio]].</p>
+				<pre>&lt;metadata …>
    …
-&lt;/package></pre>
+   &lt;link
+       rel="dcterms:conformsTo"
+       href="http://www.daisy.org/guidelines/epub/navigable-audio-only-epub3-guidelines"/>
+   …
+&lt;/metadata></pre>
 			</aside>
 
-			<aside class="example">
-				<p>The following example shows an accessibility summary for an EPUB Publication optimized for braille
-					rendering.</p>
-				<pre>&lt;meta property="schema:accessibilitySummary">
-    This publication is optimized for braille readers. It will not be 
-    usable by persons who cannot read braille. The publication is designed
-    for braille reading devices capable of displaying 6-character cells and
-    40-character line lengths. The text is not contracted, and follows 
-    Unified English Braille formatting conventions. All characters are
-    encoded using the Unicode braille character set.
-&lt;/meta></pre>
+			<aside class="example" title="Describing conformance in a summery">
+				<p>In this example, the accessibility summary for an EPUB Publication explains that it is optimized for
+					braille rendering.</p>
+				<pre>&lt;metadata …>
+   …
+   &lt;meta property="schema:accessibilitySummary">
+       This publication is optimized for braille readers. It will not be 
+       usable by persons who cannot read braille. The publication is designed
+       for braille reading devices capable of displaying 6-character cells and
+       40-character line lengths. The text is not contracted, and follows 
+       Unified English Braille formatting conventions. All characters are
+       encoded using the Unicode braille character set.
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
 			</aside>
 
-			<aside class="example">
-				<p>The following example shows an accessibility summary for an EPUB Publication optimized for audio
-					rendering.</p>
-				<pre>&lt;meta property="schema:accessibilitySummary">
-    This publication is an audio book. It will not be usable by persons who 
-    cannot hear the audio. The publication is recorded by a professional
-    narrator. There is navigation to the beginning of each chapter. The text
-    of the publication is not included. Images are not included, but the
-    photo captions are narrated at the end of the chapter where they occur.
-&lt;/meta></pre>
+			<aside class="example" title="Summary for a publication optimized for audio rendering">
+				<pre>&lt;metadata …>
+   …
+   &lt;meta property="schema:accessibilitySummary">
+       This publication is an audio book. It will not be usable by persons who 
+       cannot hear the audio. The publication is recorded by a professional
+       narrator. There is navigation to the beginning of each chapter. The text
+       of the publication is not included. Images are not included, but the
+       photo captions are narrated at the end of the chapter where they occur.
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
 			</aside>
 		</section>
 		<section id="sec-distribution" class="informative">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -111,10 +111,6 @@
 			}
 			.varlist {
 				margin-left: 3rem;
-			}
-			pre,
-			code {
-				white-space: break-spaces !important;
 			}</style>
 	</head>
 	<body>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1201,9 +1201,9 @@
 						authority to evaluate content, include that information in an <a href="#certifierCredential"
 								><code>a11y:certifierCredential</code> property</a>.</p>
 
-					<aside class="example">
-						<p>The following example shows a credential. The <code>refines</code> attribute associates the
-							credential with the certifier.</p>
+					<aside class="example" title="Expressing a basic credential">
+						<p>In this example, the <code>refines</code> attribute associates the credential with the
+							certifier.</p>
 						<pre>&lt;metadata …>
    …
    &lt;meta
@@ -1415,7 +1415,7 @@
 &lt;/metadata></pre>
 			</aside>
 
-			<aside class="example" title="Describing conformance in a summery">
+			<aside class="example" title="Describing conformance in a summary">
 				<p>In this example, the accessibility summary for an EPUB Publication explains that it is optimized for
 					braille rendering.</p>
 				<pre>&lt;metadata …>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -111,6 +111,10 @@
 			}
 			.varlist {
 				margin-left: 3rem;
+			}
+			pre,
+			code {
+				white-space: break-spaces !important;
 			}</style>
 	</head>
 	<body>

--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -356,14 +356,3 @@ details.desc > summary {
     font-weight: normal !important;
     font-style: italic;
 }
-
-/*
- * line breaking for examples
- * remove when respec supports
- * 
- */
-
-pre,
-code {
-	white-space: break-spaces !important;
-}

--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -356,3 +356,14 @@ details.desc > summary {
     font-weight: normal !important;
     font-style: italic;
 }
+
+/*
+ * line breaking for examples
+ * remove when respec supports
+ * 
+ */
+
+pre,
+code {
+	white-space: break-spaces !important;
+}

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1052,16 +1052,36 @@
 					<p>EPUB Creators should locate these resources inside the EPUB Container whenever feasible to allow
 						users access to the entire presentation regardless of connectivity status.</p>
 
-					<aside class="example">
-						<p>The following example shows a reference to an audio file in an <a>XHTML Content Document</a>
-							that is located inside the EPUB Container.</p>
-						<pre>&lt;audio src="audio/ch01.mp4" controls="controls"/&gt;</pre>
+					<aside class="example" title="Referencing a local resource">
+						<p>In this example, the audio file referenced from the [[HTML]] <a
+								href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
+									><code>audio</code> element</a> is located inside the <a>EPUB Container</a>.</p>
+						<pre>&lt;html …>
+   …
+   &lt;body>
+      …
+      &lt;audio
+          src="audio/ch01.mp4"
+          controls="controls"/>
+      …
+   &lt;/body>
+&lt;/html></pre>
 					</aside>
 
-					<aside class="example">
-						<p>The following example shows a reference to an audio file in an XHTML Content Document that is
-							located outside the EPUB Container.</p>
-						<pre>&lt;audio src="http://www.example.com/book/audio/ch01.mp4" controls="controls"/&gt;</pre>
+					<aside class="example" title="Referencing a remote resource">
+						<p>In this example, the audio file referenced from the [[HTML]] <a
+								href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"
+									><code>audio</code> element</a> is hosted on the web.</p>
+						<pre>&lt;html …>
+   …
+   &lt;body>
+      …
+         &lt;audio
+             src="http://www.example.com/book/audio/ch01.mp4"
+             controls="controls"/>
+      …
+   &lt;/body>
+&lt;/html></pre>
 					</aside>
 
 					<div class="note">
@@ -1269,9 +1289,12 @@
 										of those runs and the placement of weak directional characters such as
 										punctuation.</p>
 								</div>
-								<div class="example">
-									<pre>&lt;package … dir="ltr"&gt;</pre>
-								</div>
+								<aside class="example"
+									title="Setting the global base direction for Package Dcument text">
+									<pre>&lt;package … dir="ltr">
+   …
+&lt;/package></pre>
+								</aside>
 								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
 										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
 										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
@@ -1294,11 +1317,19 @@
 									string</a> [[URL]] that references a resource. If the value is an <a
 										href="https://url.spec.whatwg.org/#absolute-url-string">absolute URL</a>, it
 									SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
-								<div class="example">
-									<pre>&lt;link rel="record"
-      href="meta/9780000000001.xml" 
-      media-type="application/marc"/&gt;</pre>
-								</div>
+								<aside class="example" title="Linking a metadata record">
+									<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;link
+          rel="record"
+          href="meta/9780000000001.xml" 
+          media-type="application/marc"/>
+      …
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+								</aside>
 								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
 										href="#sec-link-elem"><code>link</code></a>.</p>
 							</dd>
@@ -1308,9 +1339,9 @@
 							</dt>
 							<dd>
 								<p>The ID [[XML]] of the element, which MUST be unique within the document scope.</p>
-								<div class="example">
-									<pre>&lt;dc:identifier id="pub-id"&gt;urn:isbn:97800000000001&lt;/dc:identifier&gt;</pre>
-								</div>
+								<aside class="example" title="Adding an identifier attribute">
+									<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
+								</aside>
 								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
 										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
 										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
@@ -1340,12 +1371,20 @@
 							<dd>
 								<p>A media type [[RFC2046]] that specifies the type and format of the referenced
 									resource.</p>
-								<div class="example">
-									<pre>&lt;link rel="record"
-      href="http://example.org/meta/12389347?format=xmp"
-      media-type="application/xml"
-      properties="xmp"/&gt;</pre>
-								</div>
+								<aside class="example" title="Adding the media type for a linked record">
+									<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;link
+          rel="record"
+          href="http://example.org/meta/12389347?format=xmp"
+          media-type="application/xml"
+          properties="xmp"/>
+      …
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+								</aside>
 								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
 										href="#sec-link-elem"><code>link</code></a>.</p>
 							</dd>
@@ -1357,12 +1396,21 @@
 								<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
 								<p>Refer to each element's definition for the <a href="#sec-default-vocab">reserved
 										vocabulary</a> for the attribute.</p>
-								<div class="example">
-									<pre>&lt;item id="nav" 
-      href="nav.xhtml" 
-      properties="nav"
-      media-type="application/xhtml+xml"/&gt;</pre>
-								</div>
+								<aside class="example" title="Identifying the EPUB Navigation Document in the manifest">
+									<pre>&lt;package …>
+   …
+   &lt;manifest>
+      …
+      &lt;item
+          id="nav" 
+          href="nav.xhtml"
+          properties="nav"
+          media-type="application/xhtml+xml"/>
+      …
+   &lt;/manifest>
+   …
+&lt;/package></pre>
+								</aside>
 								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a
 										href="#sec-itemref-elem"><code>itemref</code></a> and <a href="#sec-link-elem"
 											><code>link</code></a>.</p>
@@ -1379,16 +1427,23 @@
 										<code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string"
 										>URL-fragment string</a> that references the resource or element they are
 									describing.</p>
-								<aside class="example">
-									<p>The following example shows the <code>refines</code> element used to indicate a
-										creator is the illustrator.</p>
-
-									<pre>&lt;metadata&gt;
+								<aside class="example" title="Specifying that a creator is the illustrator">
+									<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;dc:creator id="creator02">
+         E.H. Shepard
+      &lt;/dc:creator>
+      &lt;meta
+          refines="#creator02"
+          property="role"
+          scheme="marc:relators">
+         ill
+      &lt;/meta>
+      …
+   &lt;/metadata>
    …
-   &lt;dc:creator id="creator02">E.H. Shepard&lt;/dc:creator>
-   &lt;meta refines="#creator02" property="role" scheme="marc:relators">ill&lt;/meta>
-   …
-&lt;/metadata&gt;</pre>
+&lt;/package></pre>
 								</aside>
 								<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata
 									expressed. When omitted, the element defines a <a href="#primary-expression">primary
@@ -1396,22 +1451,27 @@
 								<p>When creating expressions about a <a>Publication Resource</a>, the
 										<code>refines</code> attribute SHOULD specify a fragment identifier that
 									references the ID of the resource's <a href="#sec-item-elem">manifest entry</a>.</p>
-								<aside class="example">
-									<p>The following example shows the <code>refines</code> element used to set the
-										duration of an Media Overlay Document.</p>
-
-									<pre>&lt;metadata&gt;
+								<aside class="example" title="Setting the duration of a Media Overlay Document">
+									<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="media:duration" 
+          refines="#c01_overlay">
+         0:32:29
+      &lt;/meta>
+      …
+   &lt;/metadata>
+   &lt;manifest>
+      …
+      &lt;item
+          id="c01_overlay"
+          href="overlays/chapter01.smil"
+          media-type="application/smil+xml"/>
+      …
+   &lt;/manifest>
    …
-   &lt;meta property="media:duration" refines="#c01_overlay">0:32:29&lt;/meta>
-   …
-&lt;/metadata&gt;
-&lt;manifest>
-   …
-   &lt;item id="c01_overlay"
-         href="overlays/chapter01.smil"
-         media-type="application/smil+xml"/>
-   …
-&lt;/manifest></pre>
+&lt;/package></pre>
 								</aside>
 								<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a
 										href="#sec-meta-elem"><code>meta</code></a>.</p>
@@ -1427,11 +1487,11 @@
 										Identification</a> of [[XML]]. The value of each <code>xml:lang</code> attribute
 									MUST be a <a href="https://www.rfc-editor.org/rfc/rfc5646.html#section-2.2.9"
 										>well-formed language tag</a> [[BCP47]].</p>
-								<div class="example">
-									<pre>&lt;package … xml:lang="ja"&gt;
-	…
-&lt;/package&gt;</pre>
-								</div>
+								<aside class="example" title="Setting the global language for Package Document text">
+									<pre>&lt;package … xml:lang="ja">
+   …
+&lt;/package></pre>
+								</aside>
 								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
 										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
 										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
@@ -1720,20 +1780,27 @@
 								[[DCTERMS]] <a href="#last-modified-date"><code>modified</code> property</a>. All other
 								metadata is OPTIONAL.</p>
 
-							<aside class="example">
-								<p>The following example shows the minimal set of metadata that EPUB Creators must
-									include in the Package Document.</p>
-
-								<pre>&lt;package … unique-identifier="pub-id"&gt;
+							<aside class="example" title="The minimal set of metadata required in the Package Document">
+								<pre>&lt;package … unique-identifier="pub-id">
     …
-    &lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-        &lt;dc:identifier id="pub-id"&gt;urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier&gt;
-        &lt;dc:title&gt;Norwegian Wood&lt;/dc:title&gt;
-        &lt;dc:language&gt;en&lt;/dc:language&gt;
-        &lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;
-    &lt;/metadata&gt;
+    &lt;metadata …>
+       &lt;dc:identifier
+           id="pub-id">
+          urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
+       &lt;/dc:identifier>
+       &lt;dc:title>
+          Norwegian Wood
+       &lt;/dc:title>
+       &lt;dc:language>
+          en
+       &lt;/dc:language>
+       &lt;meta
+           property="dcterms:modified">
+          2011-01-01T12:00:00Z
+       &lt;/meta>
+    &lt;/metadata>
     …
-&lt;/package&gt;
+&lt;/package>
 </pre>
 							</aside>
 
@@ -1827,17 +1894,15 @@
 									<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
 										attribute</a>.</p>
 
-								<aside class="example">
-									<p>The following example shows the unique <code>identifier</code> element.</p>
-
-									<pre>&lt;package … unique-identifier="pub-id"&gt;
-    &lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-        &lt;dc:identifier id="pub-id"&gt;
-            urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
-        &lt;/dc:identifier&gt;
-        …
-    &lt;/metadata&gt;
-&lt;/package&gt;</pre>
+								<aside class="example" title="Specifying the element with the unique identifier">
+									<pre>&lt;package … unique-identifier="pub-id">
+    &lt;metadata …>
+       &lt;dc:identifier id="pub-id">
+           urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
+       &lt;/dc:identifier>
+       …
+    &lt;/metadata>
+&lt;/package></pre>
 								</aside>
 
 								<p>Although not static, EPUB Creators should make changes to the Unique Identifier for
@@ -1853,16 +1918,24 @@
 										property</a> to indicate that an <code>identifier</code> conforms to an
 									established system or an issuing authority granted it.</p>
 
-								<aside class="example">
-									<p>The following example shows an identifier additionally marked as a <a
-											href="https://doi.org">DOI</a> using the identifier-type property. Here, <a
-											href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> describes the
-										product identifier type.</p>
+								<aside class="example" title="Specifying the type of identifier">
+									<p>In this example, the <code>identifier-type</code> property is used with the <a
+											href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> scheme to
+										indicate the product identifier type is a <a href="https://doi.org">DOI</a>
+										(i.e., the value <code>06</code> in codelist 5 is for DOIs).</p>
 
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    &lt;dc:identifier id="pub-id">urn:doi:10.1016/j.iheduc.2008.03.001&lt;/dc:identifier>
-    &lt;meta refines="#pub-id" property="identifier-type" scheme="onix:codelist5">06&lt;/meta>
-    …
+									<pre>&lt;metadata …>
+   &lt;dc:identifier
+       id="pub-id">
+      urn:doi:10.1016/j.iheduc.2008.03.001
+   &lt;/dc:identifier>
+   &lt;meta
+       refines="#pub-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      06
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 								</aside>
 							</section>
@@ -1933,13 +2006,13 @@
 								<p>The <code>metadata</code> section MUST contain at least one <code>title</code>
 									element containing the title for the EPUB Publication.</p>
 
-								<aside class="example">
-									<p>The following example shows a basic title element.</p>
-
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    &lt;dc:title&gt;Norwegian Wood&lt;/dc:title&gt;
-    …
-&lt;/metadata&gt;
+								<aside class="example" title="A basic title element">
+									<pre>&lt;metadata …>
+   &lt;dc:title>
+      Norwegian Wood
+   &lt;/dc:title>
+   …
+&lt;/metadata>
 </pre>
 								</aside>
 
@@ -1958,22 +2031,27 @@
 
 									<p>For example, the following example shows a basic multipart title:</p>
 
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    &lt;dc:title&gt;THE LORD OF THE RINGS&lt;/dc:title&gt;
-    &lt;dc:title&gt;Part One: The Fellowship of the Ring&lt;/dc:title&gt;
-    …
-&lt;/metadata&gt;
+									<pre>&lt;metadata …>
+   &lt;dc:title>
+      THE LORD OF THE RINGS
+   &lt;/dc:title>
+   &lt;dc:title>
+      Part One: The Fellowship of the Ring
+   &lt;/dc:title>
+   …
+&lt;/metadata>
 </pre>
 
 									<p>The same title could instead be expressed using a single <code>dc:title</code>
 										element as follows:</p>
 
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    &lt;dc:title&gt;
-        THE LORD OF THE RINGS, Part One: The Fellowship of the Ring
-    &lt;/dc:title&gt;
-    …
-&lt;/metadata&gt;
+									<pre>&lt;metadata …>
+   &lt;dc:title>
+       THE LORD OF THE RINGS, Part One:
+       The Fellowship of the Ring
+   &lt;/dc:title>
+   …
+&lt;/metadata>
 </pre>
 
 									<p>Previous versions of this specification recommended using the <a
@@ -2033,15 +2111,14 @@
 										href="https://www.rfc-editor.org/rfc/rfc5646.html#section-2.2.9">well-formed
 										language tag</a> [[BCP47]].</p>
 
-								<aside class="example">
-									<p>The following example shows an <a>EPUB Publication</a> is in U.S. English.</p>
-
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    …
-    &lt;dc:language&gt;en-US&lt;/dc:language&gt;
-    …
-&lt;/metadata&gt;
-</pre>
+								<aside class="example" title="Specifying an EPUB Publication is in U.S. English">
+									<pre>&lt;metadata …>
+   …
+   &lt;dc:language>
+      en-US
+   &lt;/dc:language>
+   …
+&lt;/metadata></pre>
 								</aside>
 
 								<p>Although EPUB Creators MAY specify additional <code>language</code> elements for
@@ -2148,16 +2225,25 @@
 										href="#subexpression">associate</a> a <a href="#role"><code>role</code>
 										property</a> with the element to indicate the function the creator played.</p>
 
-								<aside class="example">
-									<p>The following example shows how to represent a creator as an author using a <a
-											href="http://id.loc.gov/vocabulary/relators.html">MARC relators</a>
-										term.</p>
+								<aside class="example" title="Specifying a creator is an author">
+									<p>In this example, the <a href="http://id.loc.gov/vocabulary/relators.html">MARC
+											relators</a> scheme is used to indicate the role (i.e., the value
+											<code>aut</code> indicates an author in MARC).</p>
 
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:creator id="creator">Haruki Murakami&lt;/dc:creator>
-    &lt;meta refines="#creator" property="role" scheme="marc:relators" id="role">aut&lt;/meta>
-    …
+									<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator">
+      Haruki Murakami
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator"
+       property="role"
+       scheme="marc:relators"
+       id="role">
+      aut
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 								</aside>
 
@@ -2169,17 +2255,26 @@
 									and the <a href="#alternate-script"><code>alternate-script</code> property</a> to
 									represent the creator's name in another language or script.</p>
 
-								<aside class="example">
-									<p>The following example shows creator metadata that facilitates sorting and
-										rendering.</p>
-
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    …
-    &lt;dc:creator id="creator">Haruki Murakami&lt;/dc:creator>
-    &lt;meta refines="#creator" property="role" scheme="marc:relators" id="role">aut&lt;/meta>
-    &lt;meta refines="#creator" property="alternate-script" xml:lang="ja">村上 春樹&lt;/meta>
-    &lt;meta refines="#creator" property="file-as">Murakami, Haruki&lt;/meta>
-    …
+								<aside class="example"
+									title="Expressing sorting and rendering information for a creator">
+									<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator">
+      Haruki Murakami
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator"
+       property="alternate-script"
+       xml:lang="ja">
+      村上 春樹
+   &lt;/meta>
+   &lt;meta
+       refines="#creator"
+       property="file-as">
+      Murakami, Haruki
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 								</aside>
 
@@ -2190,17 +2285,22 @@
 									section determines the display priority, where the first <code>creator</code>
 									element encountered is the primary creator.</p>
 
-								<aside class="example">
-									<p>In the following example, Lewis Carroll, listed first, is the primary
-										creator.</p>
+								<aside class="example" title="Expressing the primary creator">
+									<p>In this example, Lewis Carroll is the primary creator because he is listed
+										first.</p>
 
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    …
-    &lt;dc:creator id="creator01"&gt;Lewis Carroll&lt;/dc:creator&gt;
-    &lt;dc:creator id="creator02"&gt;John Tenniel&lt;/dc:creator&gt;
-    …
-&lt;/metadata&gt;
-</pre>
+									<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator01">
+      Lewis Carroll
+   &lt;/dc:creator>
+   &lt;dc:creator
+       id="creator02">
+      John Tenniel
+   &lt;/dc:creator>
+   …
+&lt;/metadata></pre>
 								</aside>
 
 								<p>EPUB Creators SHOULD represent secondary contributors using the <a
@@ -2219,15 +2319,14 @@
 									subset expressed in W3C Date and Time Formats [[DateTime]], as such strings are both
 									human and machine readable.</p>
 
-								<aside class="example">
-									<p>The following example shows a publication date.</p>
-
-									<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    …
-    &lt;dc:date&gt;2000-01-01T00:00:00Z&lt;/dc:date&gt;
-    …
-&lt;/metadata&gt;
-</pre>
+								<aside class="example" title="Expressing the publication date">
+									<pre>&lt;metadata …>
+   …
+   &lt;dc:date>
+      2000-01-01T00:00:00Z
+   &lt;/dc:date>
+   …
+&lt;/metadata></pre>
 								</aside>
 
 								<p>EPUB Creators SHOULD express additional dates using the specialized date properties
@@ -2251,20 +2350,40 @@
 										>associate</a> a subject code using the <a href="#term"><code>term</code>
 										property</a>.</p>
 
-								<aside class="example">
-									<p>The following example shows a BISAC code and heading.</p>
-
-									<pre>&lt;dc:subject id="subject01"&gt;FICTION / Occult &amp;amp; Supernatural&lt;/dc:subject&gt;
-&lt;meta refines="#subject01" property="authority">BISAC&lt;/meta>
-&lt;meta refines="#subject01" property="term">FIC024000&lt;/meta></pre>
+								<aside class="example" title="Specifying a BISAC code and heading">
+									<pre>&lt;metadata …>
+   &lt;dc:subject id="subject01">
+      FICTION / Occult &amp;amp; Supernatural
+   &lt;/dc:subject>
+   &lt;meta
+       refines="#subject01"
+       property="authority">
+      BISAC
+   &lt;/meta>
+   &lt;meta
+       refines="#subject01"
+       property="term">
+      FIC024000
+   &lt;/meta>
+&lt;/metadata</pre>
 								</aside>
 
-								<aside class="example">
-									<p>The following example shows the use of a URL for the scheme.</p>
-
-									<pre>&lt;dc:subject id="sbj01"&gt;Number Theory&lt;/dc:subject&gt;
-&lt;meta refines="#sbj01" property="authority">http://www.ams.org/msc/msc2010.html&lt;/meta>
-&lt;meta refines="#sbj01" property="term">11&lt;/meta></pre>
+								<aside class="example" title="Specifying a URL for the scheme">
+									<pre>&lt;metadata …>
+   &lt;dc:subject id="sbj01">
+      Number Theory
+   &lt;/dc:subject>
+   &lt;meta
+       refines="#sbj01"
+       property="authority">
+      http://www.ams.org/msc/msc2010.html
+   &lt;/meta>
+   &lt;meta
+      refines="#sbj01"
+      property="term">
+     11
+  &lt;/meta>
+&lt;/metadata></pre>
 								</aside>
 
 								<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
@@ -2407,18 +2526,26 @@
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
 									href="#sec-vocab-assoc"></a>.</p>
 
-							<aside class="example">
-								<p>The following example shows various property declarations using <a
-										href="#sec-reserved-prefixes">reserved prefixes</a>.</p>
+							<aside class="example" title="Using properties with reserved prefixes">
+								<p>For the full list of reserved prefixes, refer to <a href="#sec-reserved-prefixes"
+									></a>.</p>
 
-								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    …
-    &lt;meta property="dcterms:modified"&gt;2016-02-29T12:34:56Z&lt;/meta&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="media:active-class"&gt;my-active-item&lt;/meta&gt;
-    …
-&lt;/metadata&gt;
-</pre>
+								<pre>&lt;metadata …>
+   …
+   &lt;meta
+       property="dcterms:modified">
+      2016-02-29T12:34:56Z
+   &lt;/meta>
+   &lt;meta
+       property="rendition:layout">
+      pre-paginated
+   &lt;/meta>
+   &lt;meta
+       property="media:active-class">
+      my-active-item
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
 							</aside>
 
 							<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme the
@@ -2426,10 +2553,20 @@
 								be a <a href="#sec-property-datatype"><var>property</var> data type value</a> that
 								resolves to the resource that defines the scheme.</p>
 
-							<aside class="example">
-								<p>The following example shows a <code>scheme</code> attribute that indicates [[ONIX]]
-									code list 5 is the source of the <a>value</a> of the <code>meta</code> tag.</p>
-								<pre>&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta></pre>
+							<aside class="example" title="Using values from a scheme">
+								<p>In this example, the <code>scheme</code> attribute indicates that the <a>value</a> of
+									the tag is from [[ONIX]] code list 5 (i.e., the value <code>15</code> indicates an
+									13 digit ISBN).</p>
+								<pre>&lt;metadata &#8230;>
+   &#8230;
+   &lt;meta
+       refines="#isbn-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      15
+   &lt;/meta>
+   &#8230;
+&lt;/metadata></pre>
 							</aside>
 						</section>
 
@@ -2444,14 +2581,15 @@
 							<p>EPUB Creators MUST express the last modification date in Coordinated Universal Time (UTC)
 								and MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>
 
-							<aside class="example">
-								<p>The following example shows a last modification date.</p>
-
-								<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-    …
-    &lt;meta property="dcterms:modified"&gt;2016-01-01T00:00:01Z&lt;/meta&gt;
-    …
-&lt;/metadata&gt;</pre>
+							<aside class="example" title="Expressing a last modification date">
+								<pre>&lt;metadata …>
+   …
+   &lt;meta
+       property="dcterms:modified">
+      2016-01-01T00:00:01Z
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
 							</aside>
 
 							<p>EPUB Creators should update the last modified date whenever they make changes to the EPUB
@@ -2582,36 +2720,43 @@
 									href="#sec-core-media-types">Core Media Type requirements</a>) and EPUB Creators
 								MUST NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
 
-							<aside class="example">
-								<p>The following example shows a reference to a metadata record embedded in a
-										<code>script</code> element inside an <a>XHTML Content Document</a>. Note that
-									the media type of the embedded record (i.e., <code>application/ld+json</code>) is
-									obtained from the <code>type</code> attribute on the <code>script</code> element; it
-									is not specified in the <code>link</code> element.</p>
+							<aside class="example" title="Reference to a record embedded in an XHTML Content Document">
+								<p>In this example, the metadata record is embedded in a <code>script</code> element.
+									Note that the media type of the embedded record (i.e.,
+										<code>application/ld+json</code>) is obtained from the <code>type</code>
+									attribute on the <code>script</code> element; it is not specified in the
+										<code>link</code> element.</p>
 
-								<pre>&lt;metadata&gt;
-    … 
-    &lt;link rel="record"
+								<pre>Package Document:
+
+&lt;package …>
+   &lt;metadata …>
+      … 
+      &lt;link rel="record"
           href="front.xhtml#meta-json"
           media-type="application/xhtml+xml"
-          hreflang="en"/&gt;
-    …
-&lt;/metadata&gt;
-…
-&lt;html …&gt;
-    &lt;head&gt;
-        …
-        &lt;script id="meta-json" type="application/ld+json"&gt;
-            "@context" : "http://schema.org",
-            "name" : "…",
-            …
-        &lt;/script&gt;
-        …
-    &lt;/head&gt;
-    &lt;body&gt;
-        …
-    &lt;/body&gt;
-&lt;/html&gt;</pre>
+          hreflang="en"/>
+      …
+   &lt;/metadata>
+   …
+&lt;/package>
+
+XHTML:
+
+&lt;html …>
+   &lt;head>
+      …
+      &lt;script id="meta-json" type="application/ld+json">
+          "@context" : "http://schema.org",
+          "name" : "…",
+         …
+      &lt;/script>
+      …
+   &lt;/head>
+   &lt;body>
+      …
+   &lt;/body>
+&lt;/html></pre>
 							</aside>
 
 							<p id="linked-res-location">EPUB Creators MAY locate linked resources <a
@@ -2633,13 +2778,15 @@
 								list of <a href="#sec-property-datatype">property</a> values that establish the
 								relationship the resource has with the EPUB Publication.</p>
 
-							<aside class="example">
-								<p>The following example shows the <code>link</code> element used to associate a local
-									MARC XML record.</p>
-
-								<pre>&lt;link rel="record"
-      href="meta/9780000000001.xml" 
-      media-type="application/marc"/&gt;</pre>
+							<aside class="example" title="Linking a MARC XML record">
+								<pre>&lt;metadata …>
+   …
+   &lt;link
+       rel="record"
+       href="meta/9780000000001.xml" 
+       media-type="application/marc"/>
+   …
+&lt;/metadata></pre>
 							</aside>
 
 							<p>The value of the <code>media-type</code> attribute is not always sufficient to identify
@@ -2648,14 +2795,18 @@
 								such generic resources, the <code>properties</code> attribute can specify a semantic
 								identifier.</p>
 
-							<aside class="example">
-								<p>The following example shows the <code>properties</code> attribute used to identify a
-									remote XMP record.</p>
+							<aside class="example" title="Identifying a record type via a property">
+								<p>In this example, the <code>properties</code> attribute identifies the link is to a
+									XMP record.</p>
 
-								<pre>&lt;link rel="record"
-      href="http://example.org/meta/12389347?format=xmp"
-      media-type="application/xml"
-      properties="xmp"/&gt;</pre>
+								<pre>&lt;metadata …>
+   …
+   &lt;link rel="record"
+       href="http://example.org/meta/12389347?format=xmp"
+       media-type="application/xml"
+       properties="xmp"/>
+   …
+&lt;/metadata></pre>
 							</aside>
 
 							<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a
@@ -2665,21 +2816,25 @@
 							<p><a>EPUB Creators</a> MAY add relationships and properties from other vocabularies as
 								defined in <a href="#sec-vocab-assoc"></a>.</p>
 
-							<aside class="example">
-								<p>The following example shows the <code>link</code> element used to associate an
-									informational web page. Note that as <code>foaf</code> is not a <a
-										href="#sec-metadata-reserved-prefixes">predefined prefix</a>, it MUST be
+							<aside class="example" title="Declaring a new link relationship">
+								<p>In this example, the <code>link</code> element is used to associate an author's home
+									page using the FOAF vocabulary. Note that as <code>foaf</code> is not a <a
+										href="#sec-metadata-reserved-prefixes">predefined prefix</a>, it must be
 									declared in the <a href="#attrdef-package-prefix">prefix attribute</a>.</p>
 
-								<pre>&lt;package … prefix="foaf: http://xmlns.com/foaf/spec/"&gt;
-    &lt;metadata&gt;
-        … 
-        &lt;link rel="foaf:homepage"
-              href="http://example.org/book-info/12389347" /&gt;
-        …
-    &lt;/metadata&gt; 
+								<pre>&lt;package
     …
-&lt;/package&gt;
+    prefix="foaf: http://xmlns.com/foaf/spec/">
+   &lt;metadata …>
+      … 
+      &lt;link
+          refines="#creator01"
+          rel="foaf:homepage"
+          href="http://example.org/book-info/12389347" />
+      …
+   &lt;/metadata> 
+   …
+&lt;/package>
 </pre>
 							</aside>
 
@@ -2692,23 +2847,23 @@
 									<code>link</code> elements is used to determine which has the highest priority in
 								the case of conflicts (i.e., first in document order has the highest priority).</p>
 
-							<aside class="example">
-								<p>The following example shows a remote record that has higher precedence than a local
-									record, which in turn has higher precedence than the metadata found in the
-										<code>metadata</code> element.</p>
+							<aside class="example" title="Specifying metadata precedence">
+								<p>In this example, the first remote record has the highest precedence, the local record
+									has the next highest, and the metadata in the <code>metadata</code> element the
+									lowest.</p>
 
-								<pre>&lt;metadata&gt;
-    … 
-    &lt;link rel="record"
-          href="http://example.org/onix/12389347"
-          media-type="application/xml"
-          properties="onix" /&gt;
+								<pre>&lt;metadata …>
+   &lt;link rel="record"
+       href="http://example.org/onix/12389347"
+       media-type="application/xml"
+       properties="onix" />
     
-    &lt;link rel="record"
-          href="meta/meta.jsonld"
-          media-type="application/ld+json" /&gt;
+   &lt;link rel="record"
+       href="meta/meta.jsonld"
+       media-type="application/ld+json" />
+    
     …
-&lt;/metadata&gt;</pre>
+&lt;/metadata></pre>
 							</aside>
 
 							<div class="note">
@@ -2721,13 +2876,18 @@
 							<p>In addition to full records, EPUB Creators MAY also use the <code>link</code> element to
 								identify individual metadata properties available in an alternative format.</p>
 
-							<aside class="example">
-								<p>The following example shows a link to an embedded [[HTML]] description of the EPUB
-									Publication.</p>
+							<aside class="example" title="Link to a description">
+								<p>In this example, the description of the EPUB Publication is contained in an HTML
+									document.</p>
 
-								<pre>&lt;link rel="dcterms:description"
+								<pre>&lt;metadata …>
+   …
+   &lt;link
+       rel="dcterms:description"
        href="description.html"
-       media-type="text/html" /&gt;</pre>
+       media-type="text/html"/>
+   …
+&lt;/metadata></pre>
 							</aside>
 						</section>
 					</section>
@@ -2993,12 +3153,10 @@
 							<section id="sec-item-elem-examples">
 								<h6>Examples</h6>
 
-								<aside class="example" id="example-manifest-cmt">
-									<p>The following example shows a <code>manifest</code> that contains only <a>Core
-											Media Type Resources</a>.</p>
-
-									<pre>&lt;package &#8230;>
-   &#8230;
+								<aside class="example" id="example-manifest-cmt"
+									title="A manifest with only Core Media Type Resources">
+									<pre>&lt;package …>
+   …
    &lt;manifest>
       &lt;item
           id="nav" 
@@ -3055,20 +3213,20 @@
           href="./style/book.css" 
           media-type="text/css"/>   
    &lt;/manifest>
-   &#8230;
+   …
 &lt;/package></pre>
 								</aside>
 
 								<aside class="example" id="example-manifest-flbk"
-									title="Foreign Resource with Fallback in Spine">
+									title="Foreign Resource in Spine with Fallback">
 									<p>The following example shows the <a href="#sec-foreign-restrictions-manifest"
 											>fallback chain mechanism</a> allowing a <a>Foreign Resource</a> (JPEG) to
 										be listed in the spine with fallback to an SVG Content Document.</p>
 
-									<pre>&lt;package &#8230;>
-   &#8230;
+									<pre>&lt;package …>
+   …
    &lt;manifest>
-      &#8230;
+      …
       &lt;item
           id="page-001"
           href="images/page-001.jpg"
@@ -3080,12 +3238,12 @@
           href="images/page-001.svg"
           media-type="image/svg+xml"/>
       … 
-      &#8230;
+      …
    &lt;/manifest>
    &lt;spine>
-      &#8230;
+      …
       &lt;itemref idref="page-001"/>
-      &#8230;
+      …
    &lt;/spine>
 &lt;/package></pre>
 								</aside>
@@ -3102,26 +3260,26 @@
 										EPUB Content Document.</p>
 
 									<pre>XHTML:
-&lt;html &#8230;>
-   &#8230;
+&lt;html …>
+   …
    &lt;body>
-      &#8230;
+      …
       &lt;img
           src="images/infographic.jpg"
-          alt="&#8230;"/>
+          alt="…"/>
       &lt;a
           href="images/infographic.jpg">
          Expand Image
       &lt;/a>
-      &#8230;
+      …
    &lt;/body>
 &lt;/html>
 
 Package Document:
-&lt;package &#8230;>
-   &#8230;
+&lt;package …>
+   …
    &lt;manifest>
-      &#8230;
+      …
       &lt;item
           id="img01"
           href="images/infographic.jpg"
@@ -3132,15 +3290,15 @@ Package Document:
           id="infographic-svg"
           href="images/infographic.svg"
           media-type="image/svg+xml"/>
-      &#8230;
+      …
    &lt;/manifest>
    &lt;spine>
-      &#8230;
+      …
       &lt;itemref
           idref="img01"
           properties="layout-pre-paginated"
           linear="no"/>
-      &#8230;
+      …
    &lt;/spine>
 &lt;/package></pre>
 								</aside>
@@ -3155,10 +3313,10 @@ Package Document:
 											Container</a> are also provided.</p>
 
 									<pre>XHTML:
-&lt;html &#8230;>
-   &#8230;
+&lt;html …>
+   …
    &lt;body>
-      &#8230;
+      …
       &lt;p>
          &lt;a href="../data/raw.csv">
             [Open the raw CSV data for this project.]
@@ -3169,15 +3327,15 @@ Package Document:
          The data is located in the
       	&lt;code>/EPUB/data/raw.csv&lt;/code> file.
       &lt;/p>
-      &#8230;
+      …
    &lt;/body>
 &lt;/html>
 
 Package Document:
-&lt;package &#8230;>
-   &#8230;
+&lt;package …>
+   …
    &lt;manifest>
-      &#8230;
+      …
       &lt;item
           id="data01"
           href="data/raw.csv"
@@ -3188,14 +3346,14 @@ Package Document:
           id="data-html"
           href="xhtml/data-table.html"
           media-type="application/xhtml+xml"/>
-      &#8230;
+      …
    &lt;/manifest>
    &lt;spine>
-      &#8230;
+      …
       &lt;itemref
           idref="data01"
           linear="no"/>
-      &#8230;
+      …
    &lt;/spine>
 &lt;/package></pre>
 								</aside>
@@ -3208,22 +3366,22 @@ Package Document:
 										Document contains a remote resource.</p>
 
 									<pre>XHTML:
-&lt;html &#8230;>
-   &#8230;
+&lt;html …>
+   …
    &lt;body>
-      &#8230;
+      …
       &lt;audio
           src="http://www.example.com/book/audio/ch01.mp4"
           controls="controls"/>
-      &#8230;
+      …
    &lt;/body>
 &lt;/html>
 
 Package Document:
-&lt;package &#8230;>
-   &#8230;
+&lt;package …>
+   …
    &lt;manifest>
-      &#8230;
+      …
       &lt;item
           id="audio01"
           href="http://www.example.com/book/audio/ch01.mp4"
@@ -3234,9 +3392,9 @@ Package Document:
           href="XHTML/chapter001.xhtml"
           media-type="application/xhtml+xml"
           properties="remote-resources"/>
-      &#8230;
+      …
    &lt;/manifest>
-   &#8230;
+   …
 &lt;/package></pre>
 								</aside>
 
@@ -3247,15 +3405,15 @@ Package Document:
 										file in the manifest because it is not a Publication Resource.</p>
 
 									<pre>XHTML:
-&lt;html &#8230;>
-   &#8230;
+&lt;html …>
+   …
    &lt;body>
-      &#8230;
+      …
       &lt;a
           href="http://www.example.com/book/audio/ch01.mp4">
          Listen to audio
       &lt;/a>
-      &#8230;
+      …
    &lt;/body>
 &lt;/html>
 
@@ -3513,26 +3671,35 @@ No Entry</pre>
 							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
 									href="#sec-vocab-assoc"></a>.</p>
 
-							<section id="sec-itemref-elem-examples">
-								<h6>Examples</h6>
+							<aside class="example" title="A basic spine">
+								<p>In this example, the spine entries correspond to <a href="#example-manifest-cmt">the
+										manifest example above</a>.</p>
 
-								<aside class="example">
-									<p>The following example shows a <code>spine</code> element corresponding to <a
-											href="#example-manifest-cmt">the manifest example above</a>.</p>
-
-									<pre>&lt;spine page-progression-direction="ltr"&gt;
-    &lt;itemref idref="intro"/&gt;
-    &lt;itemref idref="c1"/&gt;
-    &lt;itemref idref="c1-answerkey" linear="no"/&gt;
-    &lt;itemref idref="c2"/&gt;
-    &lt;itemref idref="c2-answerkey" linear="no"/&gt;
-    &lt;itemref idref="c3"/&gt;
-    &lt;itemref idref="c3-answerkey" linear="no"/&gt;
-    &lt;itemref idref="notes" linear="no"/&gt;
-&lt;/spine&gt;
+								<pre>&lt;spine
+    page-progression-direction="ltr">
+   &lt;itemref
+       idref="intro"/>
+   &lt;itemref
+       idref="c1"/>
+   &lt;itemref
+       idref="c1-answerkey"
+       linear="no"/>
+   &lt;itemref
+       idref="c2"/>
+   &lt;itemref
+       idref="c2-answerkey"
+       linear="no"/>
+   &lt;itemref
+       idref="c3"/>
+   &lt;itemref
+       idref="c3-answerkey"
+       linear="no"/>
+   &lt;itemref
+       idref="notes"
+       linear="no"/>
+&lt;/spine>
 </pre>
-								</aside>
-							</section>
+							</aside>
 						</section>
 					</section>
 
@@ -3715,21 +3882,26 @@ No Entry</pre>
 									<code>collection</code> elements. The content MUST remain consumable by a user
 								without any information loss or other significant deterioration.</p>
 
-							<aside class="example" id="example-collection">
-								<p>The following example shows the assembly of two <a>XHTML Content Documents</a> that
-									represent a single unit.</p>
+							<aside class="example" id="example-collection" title="A basic collection">
+								<p>In this example, the two linked <a>XHTML Content Documents</a> represent a single
+									unit.</p>
 
-								<pre>&lt;package …&gt;
-    …
-    &lt;collection role="http://example.org/roles/unit"&gt;
-        &lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-            &lt;dc:title&gt;Foo Bar&lt;/dc:title&gt;
-        &lt;/metadata&gt;
-        &lt;link href="EPUB/xhtml/foo-1.xhtml"/&gt;
-        &lt;link href="EPUB/xhtml/foo-2.xhtml"/&gt;
-    &lt;/collection&gt;
-    …
-&lt;/package&gt;</pre>
+								<pre>&lt;package …>
+   …
+   &lt;collection
+       role="http://example.org/roles/unit">
+      &lt;metadata …>
+         &lt;dc:title>
+            Foo Bar
+         &lt;/dc:title>
+      &lt;/metadata>
+       &lt;link
+           href="EPUB/xhtml/foo-1.xhtml"/>
+       &lt;link
+           href="EPUB/xhtml/foo-2.xhtml"/>
+   &lt;/collection>
+   …
+&lt;/package></pre>
 							</aside>
 						</section>
 					</section>
@@ -4732,29 +4904,31 @@ No Entry</pre>
 								this section for constructing the primary navigation list.</p>
 						</li>
 					</ul>
-					<aside class="example">
-						<p>The following example shows the basic patterns of a navigation element.</p>
-
-						<pre>&lt;nav epub:type="…"&gt;
-  &lt;h1&gt;…&lt;/h1&gt;
-  &lt;ol&gt;
-    &lt;li&gt;
-      &lt;a href="chap1.xhtml"&gt;A basic leaf node&lt;/a&gt;
-    &lt;/li&gt;
-    &lt;li&gt;
-      &lt;a href="chap2.xhtml"&gt;A linked heading&lt;/a&gt;
-      &lt;ol&gt;
-        …
-      &lt;/ol&gt;
-    &lt;li&gt;
-      &lt;span&gt;An unlinked heading&lt;/span&gt;
-      &lt;ol&gt;
-        …
-      &lt;/ol&gt;
-    &lt;/li&gt;
-  &lt;/ol&gt;
-&lt;/nav&gt;
-</pre>
+					<aside class="example" title="Basic patterns of a navigation element">
+						<pre>&lt;nav epub:type="…">
+   &lt;h1>…&lt;/h1>
+   &lt;ol>
+      &lt;li>
+         &lt;a href="chap1.xhtml">
+            A basic leaf node
+         &lt;/a>
+      &lt;/li>
+      &lt;li>
+         &lt;a href="chap2.xhtml">
+            A linked heading
+         &lt;/a>
+         &lt;ol>
+            …
+         &lt;/ol>
+      &lt;/li>
+      &lt;li>
+         &lt;span>An unlinked heading&lt;/span>
+         &lt;ol>
+            …
+         &lt;/ol>
+      &lt;/li>
+   &lt;/ol>
+&lt;/nav></pre>
 					</aside>
 
 					<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, EPUB Creators MAY
@@ -4885,18 +5059,33 @@ No Entry</pre>
 								<code>landmarks</code>
 							<code>nav</code> element is determined by the value of this attribute.</p>
 
-						<aside class="example">
-							<p>The following example shows a <code>landmarks</code>
-								<code>nav</code> element with structural semantics drawn from [[?EPUB-SSV-11]].</p>
+						<aside class="example" title="A basic landmarks nav">
+							<p>In this example, the <code>epub:type</code> attribute value are drawn from structural
+								semantics drawn from [[EPUB-SSV-11]].</p>
 
-							<pre>&lt;nav epub:type="landmarks"&gt;
-    &lt;h2&gt;Guide&lt;/h2&gt;
-    &lt;ol&gt;
-        &lt;li&gt;&lt;a epub:type="toc" href="#toc"&gt;Table of Contents&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a epub:type="loi" href="content.html#loi"&gt;List of Illustrations&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a epub:type="bodymatter" href="content.html#bodymatter"&gt;Start of Content&lt;/a&gt;&lt;/li&gt;
-    &lt;/ol&gt;
-&lt;/nav&gt;</pre>
+							<pre>&lt;nav epub:type="landmarks">
+   &lt;h2>Guide&lt;/h2>
+   &lt;ol>
+       &lt;li>
+          &lt;a epub:type="toc"
+             href="#toc">
+            Table of Contents
+          &lt;/a>
+       &lt;/li>
+       &lt;li>
+          &lt;a epub:type="loi"
+             href="content.html#loi">
+            List of Illustrations
+          &lt;/a>
+       &lt;/li>
+       &lt;li>
+          &lt;a epub:type="bodymatter"
+             href="content.html#bodymatter">
+            Start of Content
+          &lt;/a>
+       &lt;/li>
+   &lt;/ol>
+&lt;/nav></pre>
 						</aside>
 
 						<p>The <code>landmarks</code>
@@ -4947,22 +5136,28 @@ No Entry</pre>
 								<code>nav</code> elements: they MAY represent navigational semantics for any information
 							domain, and they MAY contain link targets with homogeneous or heterogeneous semantics.</p>
 
-						<aside class="example">
-							<p>The following example shows a custom list of tables navigation element.</p>
-
-							<pre>&lt;nav aria-labelledby="lot"&gt;
-    &lt;h2 id="lot"&gt;List of tables&lt;/h2&gt;
-    &lt;ol&gt;
-        &lt;li&gt;&lt;span&gt;Tables in Chapter 1&lt;/span&gt;
-            &lt;ol&gt;
-                &lt;li&gt;&lt;a href="chap1.xhtml#table-1.1"&gt;Table 1.1&lt;/a&gt;
-                &lt;/li&gt;
-                &lt;li&gt;&lt;a href="chap1.xhtml#table-1.2"&gt;Table 1.2&lt;/a&gt;&lt;/li&gt;
-            &lt;/ol&gt;
-        &lt;/li&gt;
-    	…
-    &lt;/ol&gt;
-&lt;/nav&gt;</pre>
+						<aside class="example" title="A list of tables navigation element">
+							<pre>&lt;nav aria-labelledby="lot">
+   &lt;h2 id="lot">List of tables&lt;/h2>
+   &lt;ol>
+      &lt;li>
+         &lt;span>Tables in Chapter 1&lt;/span>
+         &lt;ol>
+            &lt;li>
+               &lt;a href="chap1.xhtml#table-1.1">
+                  Table 1.1
+               &lt;/a>
+            &lt;/li>
+            &lt;li>
+               &lt;a href="chap1.xhtml#table-1.2">
+                  Table 1.2
+               &lt;/a>
+            &lt;/li>
+         &lt;/ol>
+      &lt;/li>
+      …
+   &lt;/ol>
+&lt;/nav></pre>
 						</aside>
 					</section>
 				</section>
@@ -4985,56 +5180,61 @@ No Entry</pre>
 						effect on how Reading Systems render the navigation data outside of the content flow (such as in
 						dedicated navigation user interfaces provided by Reading Systems).</p>
 
-					<aside class="example">
-						<p>The following example shows a partial <code>page-list</code>
-							<code>nav</code> element. The presence of the <code>hidden</code> attribute on the root
-							indicates to exclude the list from rendering in the content flow.</p>
+					<aside class="example" title="Hiding a nav element in spine">
+						<p>In this example, the presence of the <code>hidden</code> attribute on the <code>nav</code>
+							element indicates the page list will be excluded from rendering in the content flow when the
+							document is rendered in the spine.</p>
 
-						<pre>&lt;nav epub:type="page-list" hidden=""&gt;
-    &lt;h2&gt;Pagebreaks of the print version, third edition&lt;/h2&gt;
-    &lt;ol&gt;
-        &lt;li&gt;&lt;a href="frontmatter.xhtml#pi"&gt;I&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a href="frontmatter.xhtml#pii"&gt;II&lt;/a&gt;&lt;/li&gt;
-        …
-        &lt;li&gt;&lt;a href="chap1.xhtml#p1"&gt;1&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a href="chap1.xhtml#p2"&gt;2&lt;/a&gt;&lt;/li&gt; … &lt;/ol&gt;
-&lt;/nav&gt;
+						<pre>&lt;nav
+    epub:type="page-list"
+    hidden="">
+   &lt;h2>Pagebreaks of the print version, third edition&lt;/h2>
+   &lt;ol>
+      &lt;li>
+         &lt;a href="frontmatter.xhtml#pi">
+            I
+         &lt;/a>
+      &lt;/li>
+      …
+   &lt;/ol>
+&lt;/nav>
 </pre>
 					</aside>
 
-					<aside class="example">
-						<p>The following example shows a partial <code>toc</code>
-							<code>nav</code> element where the <code>hidden</code> attribute limits content flow
-							rendering to the two topmost hierarchical levels.</p>
+					<aside class="example" title="Hiding branches of a nav element">
+						<p>In this example, the branch (<code>ol</code> element) not wanted for rendering in the spine
+							has the <code>hidden</code> attribute on it. When rendered, this limits the table of content
+							to the two top-most hierarchical levels.</p>
 
-						<pre>&lt;nav epub:type="toc" id="toc"&gt;
-  &lt;h1&gt;Table of contents&lt;/h1&gt;
-  &lt;ol&gt;
-    &lt;li&gt;
-      &lt;a href="chap1.xhtml"&gt;Chapter 1&lt;/a&gt;
-      &lt;ol&gt;
-        &lt;li&gt;
-          &lt;a href="chap1.xhtml#sec-1.1"&gt;Chapter 1.1&lt;/a&gt;
-          &lt;ol hidden=""&gt;
-            &lt;li&gt;
-              &lt;a href="chap1.xhtml#sec-1.1.1"&gt;Section 1.1.1&lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li&gt;
-              &lt;a href="chap1.xhtml#sec-1.1.2"&gt;Section 1.1.2&lt;/a&gt;
-            &lt;/li&gt;
-          &lt;/ol&gt;
-         &lt;/li&gt;
-         &lt;li&gt;
-           &lt;a href="chap1.xhtml#sec-1.2"&gt;Chapter 1.2&lt;/a&gt;
-         &lt;/li&gt;
-       &lt;/ol&gt;
-     &lt;/li&gt;
-    &lt;li&gt;
-      &lt;a href="chap2.xhtml"&gt;Chapter 2&lt;/a&gt;
-    &lt;/li&gt;
-  &lt;/ol&gt;
-&lt;/nav&gt;
-</pre>
+						<pre>&lt;nav
+    epub:type="toc"
+    id="toc">
+   &lt;h1>Table of contents&lt;/h1>
+   &lt;ol>
+      &lt;li>
+         &lt;a href="chap1.xhtml">
+            Chapter 1
+         &lt;/a>
+         &lt;ol>
+            &lt;li>
+               &lt;a href="chap1.xhtml#sec-1.1">
+                  Chapter 1.1
+               &lt;/a>
+               &lt;ol hidden="">
+                  &lt;li>
+                     &lt;a href="chap1.xhtml#sec-1.1.1">
+                        Section 1.1.1
+                     &lt;/a>
+                  &lt;/li>
+                  …
+               &lt;/ol>
+            &lt;/li>
+            …
+         &lt;/ol>
+      &lt;/li>
+      …
+   &lt;/ol>
+&lt;/nav></pre>
 					</aside>
 				</section>
 			</section>
@@ -5115,30 +5315,54 @@ No Entry</pre>
 
 					<p>The <code>rendition:layout</code> property MUST NOT be declared more than once.</p>
 
-					<aside class="example" id="fxl-ex1">
-						<p>The following example demonstrates fully fixed-layout content, using [[CSS3-MediaQueries]] to
-							apply different style sheets for three different device categories. Note that the Media
-							Queries only affect the style sheet applied to the document; the size of the content area
-							set in the <code>viewport</code>
+					<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
+						<p>In this example, media queries [[CSS3-MediaQueries]] are used to apply different style sheets
+							for three different device categories. Note that the media queries only affect the style
+							sheet applied to the document; the size of the content area set in the <code>viewport</code>
 							<code>meta</code> tag is static.</p>
 
-						<p><strong>Package Document</strong></p>
+						<p>Package Document</p>
 
-						<pre>&lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;</pre>
-						<p><strong>XHTML</strong></p>
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      …
+   &lt;/metadata>
+   …
+&lt;/package></pre>
 
-						<pre>&lt;head&gt;
-    &lt;meta name="viewport" content="width=1200, height=900"/&gt;
-	
-    &lt;link rel="stylesheet" href="eink-style.css" media="(max-monochrome: 3)"/&gt;
-    &lt;link rel="stylesheet" href="skinnytablet-style.css" media="((color) and
-        (max-height:600px) and (orientation:landscape), (color) and (max-width:600px)
-        and (orientation:portrait))"/&gt;
-    &lt;link rel="stylesheet" href="fattablet-style.css" media="((color) and
-        (min-height:601px) and (orientation:landscape), (color) and (min-width:601px)
-        and (orientation:portrait)"/&gt;	
-&lt;/head&gt;
-</pre>
+						<p>XHTML</p>
+
+						<pre>&lt;html …>
+   &lt;head>
+      &lt;meta
+          name="viewport"
+          content="width=1200,
+          height=900"/>
+      
+      &lt;link
+          rel="stylesheet"
+          href="eink-style.css"
+          media="(max-monochrome: 3)"/>
+         
+      &lt;link
+          rel="stylesheet"
+          href="skinnytablet-style.css"
+          media="((color) and (max-height:600px) and (orientation:landscape),
+                  (color) and (max-width:600px) and (orientation:portrait))"/>
+      
+      &lt;link
+          rel="stylesheet"
+          href="fattablet-style.css"
+          media="((color) and (min-height:601px) and (orientation:landscape),
+                  (color) and (min-width:601px) and (orientation:portrait))"/>	
+   &lt;/head>
+   …
+&lt;/html></pre>
 					</aside>
 
 					<section id="layout-overrides">
@@ -5194,16 +5418,29 @@ No Entry</pre>
 					<p>EPUB Creators MUST NOT declare the <code>rendition:orientation</code> property more than
 						once.</p>
 
-					<aside class="example" id="fxl-ex2">
-						<p>The following example demonstrates fully fixed-layout content Reading Systems should render
-							without synthetic spreads and locked to landscape orientation.</p>
+					<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
+						<p>In this example, the content should also render without synthetic spreads.</p>
 
-						<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;none&lt;/meta&gt;
-    
-    &lt;meta property="rendition:orientation"&gt;landscape&lt;/meta&gt;
-&lt;/metadata&gt;</pre>
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      
+      &lt;meta
+          property="rendition:spread">
+         none
+      &lt;/meta>
+   
+      &lt;meta
+          property="rendition:orientation">
+         landscape
+      &lt;/meta>
+   &lt;/metadata>
+   …
+&lt;/package</pre>
 					</aside>
 
 					<section id="orientation-overrides">
@@ -5292,33 +5529,56 @@ No Entry</pre>
 
 					</div>
 
-					<aside class="example" id="fxl-ex3">
-						<p>The following example demonstrates fully fixed-layout content intended for Reading Systems to
-							render using synthetic spreads in landscape orientation, and with no spreads in portrait
-							orientation.</p>
+					<aside class="example" id="fxl-ex3" title="Specifying to use spreads only in landscape orientation">
 
-						<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;landscape&lt;/meta&gt;
-&lt;/metadata&gt;</pre>
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      &lt;meta
+          property="rendition:spread">
+         landscape
+      &lt;/meta>
+   &lt;/metadata>
+   …
+&lt;/package></pre>
 					</aside>
 
-					<aside class="example" id="fxl-ex4">
-						<p>The following example demonstrates reflowable content with a single fixed-layout title page,
-							where the EPUB Creator intends the fixed-layout page for a right-hand spread slot.</p>
+					<aside class="example" id="fxl-ex4" title="Overriding the global spread behavior">
+						<p>In this example, the EPUB Creator overrides the global reflowable setting in the spine for
+							the title page. The intention is for Reading Systems to render it as a Fixed-Layout Document
+							in a right-hand spread slot.</p>
 
-						<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;reflowable&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
-&lt;/metadata&gt;
-
-&lt;spine&gt;
-    &lt;itemref idref="titlepage" properties="page-spread-right rendition:layout-pre-paginated"/&gt;
-&lt;/spine&gt;</pre>
 						<p>Note that the EPUB Creator could use the alias <a href="#page-spread"
 									><code>rendition:page-spread-right</code></a> in place of
 								<code>page-spread-right</code>.</p>
 
+
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         reflowable
+      &lt;/meta>
+      &lt;meta
+          property="rendition:spread">
+         auto
+      &lt;/meta>
+   &lt;/metadata>
+   
+   &lt;spine>
+      &lt;itemref
+          idref="titlepage"
+          properties="page-spread-right
+                      rendition:layout-pre-paginated"/>
+      …
+   &lt;/spine>
+   …
+&lt;/package></pre>
 					</aside>
 
 					<section id="spread-overrides">
@@ -5370,7 +5630,7 @@ No Entry</pre>
 							<code>rendition:page-spread-center</code>
 						</dt>
 						<dd>The <code>rendition:page-spread-center</code> property specifies the forced placement of a
-							Content Document in a <a>Synthetic Spread</a>. </dd>
+							Content Document in a <a>Synthetic Spread</a>.</dd>
 
 						<dt id="fxl-page-spread-left">
 							<code>rendition:page-spread-left</code>
@@ -5418,37 +5678,54 @@ No Entry</pre>
 							property.</p>
 
 					</div>
-					<aside class="example" id="fxl-ex5">
-						<p>The following example demonstrates reflowable content with a two-page fixed-layout center
-							plate that the EPUB Creator intends Reading Systems to render using synthetic spreads in any
-							device orientation. Note that the EPUB Creator has left spread behavior for the other
-							(reflowable) parts undefined, since the global value of <code>rendition:spread</code>
-							initializes to <code>auto</code> by default.</p>
+					<aside class="example" id="fxl-ex5" title="Placing individual spine items in a spread">
+						<p>In this example, the EPUB Creator intends the Reading System to create a two-page
+							fixed-layout center plate using synthetic spreads in any device orientation. Note that the
+							EPUB Creator has left spread behavior for the other (reflowable) parts undefined, since the
+							global value of <code>rendition:spread</code> initializes to <code>auto</code> by
+							default.</p>
 
-						<pre>&lt;spine page-progression-direction="ltr"&gt;
-    …
-    &lt;itemref idref="center-plate-left"
-             properties="rendition:spread-both rendition:page-spread-left"/&gt;
-    &lt;itemref idref="center-plate-right"
-             properties="rendition:spread-both rendition:page-spread-right"/&gt;
-    …
-&lt;/spine&gt;</pre>
+						<pre>&lt;package …>
+   …
+   &lt;spine page-progression-direction="ltr">
+      …
+      &lt;itemref
+          idref="center-plate-left"
+          properties="rendition:spread-both rendition:page-spread-left"/>
+      &lt;itemref
+          idref="center-plate-right"
+          properties="rendition:spread-both rendition:page-spread-right"/>
+      …
+   &lt;/spine>
+&lt;/package></pre>
 					</aside>
 
-					<aside class="example" id="fxl-ex6">
-						<p>The following example demonstrates fixed-layout content where Reading Systems must disable
-							synthetic spreads for a center plate. Note that the <code>rendition:spread</code>
-							declaration <code>none</code> expression is not needed on the center plate item, as the
-								<code>rendition:page-spread-center</code> property already specifies semantics that
-							dictates that synthetic spreads be disabled.</p>
+					<aside class="example" id="fxl-ex6" title="Creating a centered layout">
+						<p>Note that it is not necessary to specify the <code>spread-none</code> override on the
+							centered plate, as the <code>rendition:page-spread-center</code> property already specifies
+							semantics that dictates that synthetic spreads be disabled.</p>
 
-						<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:layout"&gt;pre-paginated&lt;/meta&gt;
-    &lt;meta property="rendition:spread"&gt;auto&lt;/meta&gt;
-&lt;/metadata&gt;
-&lt;spine&gt;
-    &lt;itemref idref="center-plate" properties="rendition:page-spread-center"/&gt;
-&lt;/spine&gt;</pre>
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      &lt;meta
+          property="rendition:spread">
+         auto
+      &lt;/meta>
+   &lt;/metadata>
+   &lt;spine>
+      …
+      &lt;itemref
+          idref="center-plate"
+          properties="rendition:page-spread-center"/>
+      …
+   &lt;/spine>
+   …
+&lt;/package></pre>
 					</aside>
 				</section>
 
@@ -5481,16 +5758,17 @@ No Entry</pre>
 								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
 								containing block</a> [[CSS2]] dimensions MUST be expressed in a <code>viewport</code>
 							<code>meta</code> tag using the syntax defined in [[CSS-Device-Adapt-1]].</p>
-						<aside class="example">
-							<p>The following example shows a <code>viewport</code>
-								<code>meta</code> tag.</p>
-
-							<pre>
-&lt;head&gt;
+						<aside class="example" title="Specifying the initial containing block in a viewport meta tag">
+							<pre>&lt;html …>
+   &lt;head>
+      …
+      &lt;meta
+          name="viewport"
+          content="width=1200, height=600"/>
+      …
+   &lt;/head>
    …
-   &lt;meta name="viewport" content="width=1200, height=600"/&gt;
-   …
-&lt;/head&gt;</pre>
+&lt;/html></pre>
 						</aside>
 					</dd>
 
@@ -5499,16 +5777,16 @@ No Entry</pre>
 						<p>For SVG <a>Fixed-Layout Documents</a>, the initial containing block [[CSS2]] dimensions MUST
 							be expressed using the <a href="http://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
 									><code>viewBox</code> attribute</a> [[SVG]].</p>
-						<aside class="example">
-							<p>The following example shows a <code>viewBox</code> attribute declaration for an SVG
-								Content Document with an aspect ratio of 844 pixels wide by 1200 pixels high.</p>
+						<aside class="example" title="Specifying the initial containing block in the viewBox attribute">
+							<p>In this example, the <code>viewBox</code> attribute sets the ICB to an aspect ratio of
+								844 pixels wide by 1200 pixels high.</p>
 
 							<pre>
 &lt;svg xmlns="http://www.w3.org/2000/svg"
      version="1.1" 
-     viewBox="0 0 844 1200"&gt;
+     viewBox="0 0 844 1200">
    …
-&lt;/svg&gt;</pre>
+&lt;/svg></pre>
 						</aside>
 					</dd>
 				</dl>
@@ -5661,7 +5939,7 @@ No Entry</pre>
 									<p>LESS-THAN SIGN: <code>&lt;</code> (<code>U+003C</code>)</p>
 								</li>
 								<li>
-									<p>GREATER-THAN SIGN: <code>&gt;</code> (<code>U+003E</code>)</p>
+									<p>GREATER-THAN SIGN: <code>></code> (<code>U+003E</code>)</p>
 								</li>
 								<li>
 									<p>QUESTION MARK: <code>?</code> (<code>U+003F</code>)</p>
@@ -5798,12 +6076,19 @@ No Entry</pre>
 							>path-relative-scheme-less-URL string</a>, optionally followed by <code>U+0023 (#)</code>
 						and a <a data-cite="url#url-fragment-string">URL-fragment string</a>. </p>
 
-					<aside class="example">
-						<p>The following example shows how to reference, from an [[HTML]] <code>img</code> element, a
-							file named <code>image1.jpg</code> in the same directory as an <a>XHTML Content
-							Document</a>.</p>
+					<aside class="example" title="Referencing a file in the same directory">
+						<p>In this example, the file <code>image1.jpg</code> is in the same directory as the <a>XHTML
+								Content Document</a>.</p>
 
-						<pre>&lt;img src="image1.jpg" alt="…" /&gt;</pre>
+						<pre>&lt;html …>
+   …
+   &lt;body>
+      &lt;img
+          src="image1.jpg"
+          alt="…" />
+   …
+   &lt;/body>
+&lt;/html></pre>
 					</aside>
 
 					<p class="note"> The properties of the <a>container root URL</a> are such that whatever the amount
@@ -5836,23 +6121,21 @@ No Entry</pre>
 								<var>url</var>, with the <a>container root URL</a> as <a
 								data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
-						<aside class="example">
-							<p>For example, if <code>META-INF/container.xml</code> has the following content:</p>
+						<aside class="example" title="Resolving paths in the container file">
+							<p>If container file (<code>META-INF/container.xml</code>) has the following content:</p>
 
-							<pre class="example">
-	&lt;?xml version="1.0"?&gt;
-	&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
-		&lt;rootfiles&gt;
-			&lt;rootfile full-path="EPUB/Great_Expectations.opf"
-				  media-type="application/oebps-package+xml" /&gt;	
-		&lt;/rootfiles&gt;
-	&lt;/container&gt;
-				</pre>
+							<pre>&lt;?xml version="1.0"?>
+&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   &lt;rootfiles>
+      &lt;rootfile
+          full-path="EPUB/Great_Expectations.opf"
+          media-type="application/oebps-package+xml" />	
+   &lt;/rootfiles>
+&lt;/container></pre>
 
 							<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the root directory
 								for the OCF Abstract Container and not relative to the <code>META-INF</code>
 								directory.</p>
-
 						</aside>
 					</section>
 
@@ -6122,21 +6405,18 @@ No Entry</pre>
 							</section>
 
 							<section id="sec-container-container.xml-example" class="informative">
-								<h6>Container Example</h6>
+								<h6>Examples</h6>
 
-								<p>The following example shows a sample <code>container.xml</code> file for an EPUB
-									Publication with the root file <code>EPUB/My Crazy Life.opf</code> (the Package
-									Document):</p>
-
-								<pre class="example">
-&lt;?xml version="1.0"?&gt;
-&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
-    &lt;rootfiles&gt;
-        &lt;rootfile full-path="EPUB/My_Crazy_Life.opf"
-            media-type="application/oebps-package+xml" /&gt;
-    &lt;/rootfiles&gt;
-&lt;/container&gt;
-                    </pre>
+								<aside class="example" title="A basic container file">
+									<pre>&lt;?xml version="1.0"?>
+&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   &lt;rootfiles>
+      &lt;rootfile
+          full-path="EPUB/My_Crazy_Life.opf"
+          media-type="application/oebps-package+xml" />
+   &lt;/rootfiles>
+&lt;/container></pre>
+								</aside>
 							</section>
 						</section>
 
@@ -6260,40 +6540,46 @@ No Entry</pre>
 									System to distinguish data encrypted before signing from data encrypted after
 									signing.</p>
 
-								<aside class="example">
-									<p>In the following example, adapted from <a
+								<aside class="example" title="An encrypted image">
+									<p>In this example, adapted from <a
 											href="https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/#sec-eg-Symmetric-Key"
-											>Section 2.2.1 </a> of [[XMLENC-CORE1]] the resource <code>image.jpeg</code>
-										is encrypted using a symmetric key algorithm (AES) and the symmetric key is
-										further encrypted using an asymmetric key algorithm (RSA) with a key of John
-										Smith.</p>
+											>Section 2.2.1 </a> of [[XMLENC-CORE1]], the resource
+											<code>image.jpeg</code> is encrypted using a symmetric key algorithm (AES)
+										and the symmetric key is further encrypted using an asymmetric key algorithm
+										(RSA) with a key of "John Smith".</p>
 
-									<pre>
-&lt;encryption
+									<pre>&lt;encryption
     xmlns ="urn:oasis:names:tc:opendocument:xmlns:container"
     xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
-    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"&gt;
-    &lt;enc:EncryptedKey Id="EK"&gt;
-        &lt;enc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
-        &lt;ds:KeyInfo&gt;
-            &lt;ds:KeyName&gt;John Smith&lt;/ds:KeyName&gt;
-        &lt;/ds:KeyInfo&gt;
-        &lt;enc:CipherData&gt;
-            &lt;enc:CipherValue&gt;xyzabc&lt;/enc:CipherValue&gt;
-        &lt;/enc:CipherData&gt;
-    &lt;/enc:EncryptedKey&gt;
-    &lt;enc:EncryptedData Id="ED1"&gt;
-        &lt;enc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/&gt;
-        &lt;ds:KeyInfo&gt;
-            &lt;ds:RetrievalMethod URI="#EK"
-                Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/&gt;
-        &lt;/ds:KeyInfo&gt;
-        &lt;enc:CipherData&gt;
-            &lt;enc:CipherReference URI="image.jpeg"/&gt;
-        &lt;/enc:CipherData&gt;
-    &lt;/enc:EncryptedData&gt;
-&lt;/encryption&gt;
-                    </pre>
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+   &lt;enc:EncryptedKey Id="EK">
+      &lt;enc:EncryptionMethod
+          Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+      &lt;ds:KeyInfo>
+         &lt;ds:KeyName>
+            John Smith
+         &lt;/ds:KeyName>
+      &lt;/ds:KeyInfo>
+      &lt;enc:CipherData>
+         &lt;enc:CipherValue>
+            xyzabc
+         &lt;/enc:CipherValue>
+      &lt;/enc:CipherData>
+   &lt;/enc:EncryptedKey>
+   &lt;enc:EncryptedData Id="ED1">
+      &lt;enc:EncryptionMethod
+          Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/>
+      &lt;ds:KeyInfo>
+         &lt;ds:RetrievalMethod
+             URI="#EK"
+             Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/>
+      &lt;/ds:KeyInfo>
+      &lt;enc:CipherData>
+         &lt;enc:CipherReference
+             URI="image.jpeg"/>
+      &lt;/enc:CipherData>
+   &lt;/enc:EncryptedData>
+&lt;/encryption></pre>
 								</aside>
 							</section>
 
@@ -6366,24 +6652,30 @@ No Entry</pre>
 									</dd>
 								</dl>
 
-								<aside class="example">
-									<p>The following example shows an MP4 file that that has been Deflate compressed and
-										whose original size was 3500000 bytes.</p>
+								<aside class="example" title="A compressed video">
+									<p>In this example, the EPUB Creator has Deflate compressed the MP4 file. Its
+										original size was 3500000 bytes.</p>
 
-									<pre>&lt;encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
-    &lt;enc:EncryptedData xmlns:enc="http://www.w3.org/2001/04/xmlenc#"&gt;
-        &#8230;
-        &lt;enc:CipherData&gt;
-            &lt;enc:CipherReference URI="OEPBS/video.mp4"/&gt;
-        &lt;/enc:CipherData&gt;
-        &lt;enc:EncryptionProperties&gt;
-            &lt;enc:EncryptionProperty xmlns:ns="http://www.idpf.org/2016/encryption#compression"&gt;
-                &lt;ns:Compression Method="8" OriginalLength="3500000"/&gt;
-            &lt;/enc:EncryptionProperty&gt;
-        &lt;/enc:EncryptionProperties&gt;
-        &#8230;
-    &lt;/enc:EncryptedData&gt;
-&lt;/encryption&gt;</pre>
+									<pre>&lt;encryption
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   &lt;enc:EncryptedData 
+       xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
+      …
+      &lt;enc:CipherData>
+         &lt;enc:CipherReference
+             URI="OEPBS/video.mp4"/>
+      &lt;/enc:CipherData>
+      &lt;enc:EncryptionProperties>
+         &lt;enc:EncryptionProperty
+             xmlns:ns="http://www.idpf.org/2016/encryption#compression">
+            &lt;ns:Compression
+                Method="8"
+                OriginalLength="3500000"/>
+         &lt;/enc:EncryptionProperty>
+      &lt;/enc:EncryptionProperties>
+      …
+   &lt;/enc:EncryptedData>
+&lt;/encryption></pre>
 								</aside>
 							</section>
 						</section>
@@ -6541,58 +6833,72 @@ No Entry</pre>
 									[[XMLDSIG-CORE1]] specification describes how additional information can be added to
 									a signature, such as by use the <code>SignatureProperties</code> element.</p>
 
-								<aside class="example">
-									<p>The following XML expression shows the content of an example
-											<code>signatures.xml</code> file. It is based on the examples found in <a
+								<aside class="example" title="Signing resources">
+									<p>In this example, based on the examples found in <a
 											href="https://www.w3.org/TR/2008/REC-xmldsig-core-20080610/#sec-Overview"
-											>Section 2</a> of [[XMLDSIG-CORE1]]. It contains one signature, and the
-										signature applies to two resources, <code class="filename"
-											>EPUB/book.xhtml</code> and <code>EPUB/images/cover.jpeg</code>, in the
-										container.</p>
+											>Section 2</a> of [[XMLDSIG-CORE1]], one signature applies to two resources
+											(<code>EPUB/book.xhtml</code> and <code>EPUB/images/cover.jpeg</code>).</p>
 
-									<pre>
-&lt;signatures xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
-    &lt;Signature Id="sig" xmlns="http://www.w3.org/2000/09/xmldsig#"&gt;
-        &lt;SignedInfo&gt;
-            &lt;CanonicalizationMethod 
-                Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
-            &lt;SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/&gt;
-            &lt;Reference URI="#Manifest1"&gt;
-                &lt;DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
-                &lt;DigestValue&gt;j6lwx3rvEPO0vKtMup4NbeVu8nk=&lt;/DigestValue&gt;
-            &lt;/Reference&gt;
-        &lt;/SignedInfo&gt;
-        &lt;SignatureValue&gt;…&lt;/SignatureValue&gt;
-        &lt;KeyInfo&gt;
-            &lt;KeyValue&gt;
-                &lt;DSAKeyValue&gt;
-                    &lt;P&gt;…&lt;/P&gt;&lt;Q&gt;…&lt;/Q&gt;&lt;G&gt;…&lt;/G&gt;&lt;Y&gt;…&lt;/Y&gt; 
-                &lt;/DSAKeyValue&gt;
-            &lt;/KeyValue&gt;
-        &lt;/KeyInfo&gt;
-        &lt;Object&gt;
-            &lt;Manifest Id="Manifest1"&gt;
-                &lt;Reference URI="EPUB/book.xhtml"&gt;                    
-                    &lt;Transforms&gt;                                                
-                        &lt;Transform
-                            Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;                        
-                    &lt;/Transforms&gt;
-                    &lt;DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
-                    &lt;DigestValue&gt;&lt;/DigestValue&gt;
-                &lt;/Reference&gt;
-                &lt;Reference URI="EPUB/images/cover.jpeg"&gt;
-                    &lt;Transforms&gt;                                                
-                        &lt;Transform
-                            Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;                        
-                    &lt;/Transforms&gt;
-                    &lt;DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
-                    &lt;DigestValue&gt;&lt;/DigestValue&gt;
-                &lt;/Reference&gt;
-            &lt;/Manifest&gt;
-        &lt;/Object&gt;
-    &lt;/Signature&gt; 
-&lt;/signatures&gt;
-                    </pre>
+									<pre>&lt;signatures
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   &lt;Signature
+       Id="sig"
+       xmlns="http://www.w3.org/2000/09/xmldsig#">
+      &lt;SignedInfo>
+         &lt;CanonicalizationMethod 
+             Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+            &lt;SignatureMethod
+                Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/>
+            &lt;Reference
+                URI="#Manifest1">
+               &lt;DigestMethod
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+               &lt;DigestValue>
+                  j6lwx3rvEPO0vKtMup4NbeVu8nk=
+               &lt;/DigestValue>
+            &lt;/Reference>
+      &lt;/SignedInfo>
+      &lt;SignatureValue>
+         …
+      &lt;/SignatureValue>
+      &lt;KeyInfo>
+         &lt;KeyValue>
+            &lt;DSAKeyValue>
+               &lt;P>…&lt;/P>
+               &lt;Q>…&lt;/Q>
+               &lt;G>…&lt;/G>
+               &lt;Y>…&lt;/Y> 
+            &lt;/DSAKeyValue>
+         &lt;/KeyValue>
+      &lt;/KeyInfo>
+      &lt;Object>
+         &lt;Manifest
+             Id="Manifest1">
+            &lt;Reference
+                URI="EPUB/book.xhtml">                    
+               &lt;Transforms>                                                
+                  &lt;Transform
+                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>                        
+               &lt;/Transforms>
+               &lt;DigestMethod
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+               &lt;DigestValue>
+               &lt;/DigestValue>
+            &lt;/Reference>
+            &lt;Reference URI="EPUB/images/cover.jpeg">
+               &lt;Transforms>                                                
+                  &lt;Transform
+                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>                        
+               &lt;/Transforms>
+               &lt;DigestMethod
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+               &lt;DigestValue>
+               &lt;/DigestValue>
+            &lt;/Reference>
+         &lt;/Manifest>
+      &lt;/Object>
+   &lt;/Signature> 
+&lt;/signatures></pre>
 								</aside>
 							</section>
 						</section>
@@ -6794,35 +7100,47 @@ No Entry</pre>
 							href="#sec-container-metainf-encryption.xml"></a> to compress fonts before encrypting
 						them.</p>
 
-					<aside class="example">
-						<p>The following pseudo-code exemplifies the obfuscation algorithm.</p>
+					<p>The following pseudo-code exemplifies the obfuscation algorithm.</p>
 
-						<pre class="programlisting">
-set ocf to OCF container file
-set source to font file
-set destination to obfuscated font file
-set keyData to key for file
-set outer to 0
-while outer &lt; 52 and not (source at EOF)
-    set inner to 0
-    while inner &lt; 20 and not (source at EOF)
-        read 1 byte from source     //Assumes read advances file position
-        set sourceByte to result of read
-        set keyByte to byte inner of keyData
-        set obfuscatedByte to (sourceByte XOR keyByte)
-        write obfuscatedByte to destination
-        increment inner
-    end while
-    increment outer
-end while
-if not (source at EOF) then
-    read source to EOF
-    write result of read to destination
-end if
-Deflate destination
-store destination as source in ocf
-            </pre>
-					</aside>
+					<ol class="algorithm">
+						<li>set <var>ocf</var> to OCF container file</li>
+						<li>set <var>source</var> to font file</li>
+						<li>set <var>destination</var> to obfuscated font file</li>
+						<li>set <var>keyData</var> to key for file</li>
+						<li>set <var>outer</var> to 0</li>
+						<li>
+							<span>while <var>outer</var> &lt; 52 and not (<var>source</var> at EOF)</span>
+							<ol>
+								<li>set <var>inner</var> to 0</li>
+								<li>
+									<span>while <var>inner</var> &lt; 20 and not (<var>source</var> at EOF)</span>
+									<ol>
+										<li>read 1 byte from <var>source</var> (Assumes read advances file
+											position)</li>
+										<li>set <var>sourceByte</var> to result of read</li>
+										<li>set <var>keyByte</var> to byte <var>inner</var> of <var>keyData</var></li>
+										<li>set <var>obfuscatedByte</var> to (<var>sourceByte</var> XOR
+												<var>keyByte</var>)</li>
+										<li>write <var>obfuscatedByte</var> to <var>destination</var></li>
+										<li>increment <var>inner</var></li>
+									</ol>
+									<span>end while</span>
+								</li>
+								<li>increment <var>outer</var></li>
+							</ol>
+							<span>end while</span>
+						</li>
+						<li>
+							<span>if not (<var>source</var> at EOF) then</span>
+							<ol>
+								<li>read <var>source</var> to EOF</li>
+								<li>write result of read to <var>destination</var></li>
+							</ol>
+							<span>end if</span>
+						</li>
+						<li>Deflate <var>destination</var></li>
+						<li>store <var>destination</var> as <var>source</var> in <var>ocf</var></li>
+					</ol>
 				</section>
 
 				<section id="obfus-specifying">
@@ -6843,23 +7161,19 @@ store destination as source in ocf
 							<code>URI</code> attribute of the <code>CipherReference</code> element MUST reference a <a
 							href="#cmt-grp-font">Font Core Media Type</a>.</p>
 
-					<aside class="example">
-						<p>The following example shows an entry for an obfuscated font in the
-								<code>encryption.xml</code> file.</p>
-
-						<pre>
-&lt;encryption 
+					<aside class="example" title="An entry for an obfuscated font">
+						<pre>&lt;encryption 
     xmlns="urn:oasis:names:tc:opendocument:xmlns:container" 
-    xmlns:enc="http://www.w3.org/2001/04/xmlenc#"&gt;
-    &lt;enc:EncryptedData&gt; 
-        &lt;enc:EncryptionMethod Algorithm="http://www.idpf.org/2008/embedding"/&gt; 
-        &lt;enc:CipherData&gt; 
-            &lt;enc:CipherReference URI="EPUB/Fonts/BKANT.TTF"/&gt;  
-        &lt;/enc:CipherData&gt; 
-    &lt;/enc:EncryptedData&gt;  
-&lt;/encryption&gt; 
-
-                </pre>
+    xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
+   &lt;enc:EncryptedData> 
+      &lt;enc:EncryptionMethod
+          Algorithm="http://www.idpf.org/2008/embedding"/> 
+      &lt;enc:CipherData> 
+         &lt;enc:CipherReference
+             URI="EPUB/Fonts/BKANT.TTF"/>  
+      &lt;/enc:CipherData> 
+   &lt;/enc:EncryptedData>  
+&lt;/encryption></pre>
 					</aside>
 
 					<p>To prevent trivial copying of the embedded font to other EPUB Publications, EPUB Creators MUST
@@ -7506,40 +7820,55 @@ store destination as source in ocf
 								><code>clipBegin</code></a> and <a href="#attrdef-smil-clipEnd"><code>clipEnd</code></a>
 						attributes to indicate a specific offset within the clip.</p>
 
-					<aside class="example">
-						<p>The following example shows the Media Overlays markup for a single phrase or sentence.</p>
-
-						<pre>&lt;par&gt;                        
-    &lt;text src="chapter1.xhtml#sentence1"/&gt;
-    &lt;audio src="chapter1_audio.mp3" clipBegin="23s" clipEnd="30s"/&gt;
-&lt;/par&gt;</pre>
+					<aside class="example" title="Media Overlays markup for a single phrase or sentence">
+						<pre>&lt;par>                        
+   &lt;text
+       src="chapter1.xhtml#sentence1"/>
+   &lt;audio
+       src="chapter1_audio.mp3"
+       clipBegin="23s"
+       clipEnd="30s"/>
+&lt;/par></pre>
 					</aside>
 					<p>EPUB Creators place <code>par</code> elements together sequentially to form a series of phrases
 						or sentences. Not every element of the EPUB Content Document will have a corresponding
 							<code>par</code> element in the Media Overlay, only those relevant to the audio
 						narration.</p>
 
-					<aside class="example">
-						<p>The following example shows a basic Media Overlay Document containing a sequence of phrases.
-							The <code>body</code> element acts as the main sequence for the whole document.</p>
+					<aside class="example" title="A basic Media Overlay Document containing a sequence of phrases">
+						<p>In this example, the <code>body</code> element acts as the main sequence for the whole
+							document.</p>
 
-						<pre>&lt;smil xmlns="http://www.w3.org/ns/SMIL" 
-      version="3.0"&gt;
-    &lt;body&gt;
-        &lt;par id="par1"&gt;
-            &lt;text src="chapter1.xhtml#sentence1"/&gt;
-            &lt;audio src="chapter1_audio.mp3" clipBegin="0s" clipEnd="10s"/&gt;
-        &lt;/par&gt;
-        &lt;par id="par2"&gt;
-            &lt;text src="chapter1.xhtml#sentence2"/&gt;
-            &lt;audio src="chapter1_audio.mp3" clipBegin="10s" clipEnd="20s"/&gt;
-        &lt;/par&gt;
-        &lt;par id="par3"&gt;
-            &lt;text src="chapter1.xhtml#sentence3"/&gt;
-            &lt;audio src="chapter1_audio.mp3" clipBegin="20s" clipEnd="30s"/&gt;
-        &lt;/par&gt;
-    &lt;/body&gt;
-&lt;/smil&gt;</pre>
+						<pre>&lt;smil
+    xmlns="http://www.w3.org/ns/SMIL" 
+    version="3.0">
+   &lt;body>
+      &lt;par id="par1">
+         &lt;text
+             src="chapter1.xhtml#sentence1"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0s"
+             clipEnd="10s"/>
+      &lt;/par>
+      &lt;par id="par2">
+         &lt;text
+             src="chapter1.xhtml#sentence2"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="10s"
+             clipEnd="20s"/>
+      &lt;/par>
+      &lt;par id="par3">
+         &lt;text
+             src="chapter1.xhtml#sentence3"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="20s"
+             clipEnd="30s"/>
+      &lt;/par>
+   &lt;/body>
+&lt;/smil></pre>
 					</aside>
 					<p>EPUB Creators can also add <code>par</code> elements to <code>seq</code> elements to define more
 						complex structures such as parts and chapters (see <a href="#sec-media-overlays-structure"
@@ -7582,74 +7911,6 @@ store destination as source in ocf
 							provide synchronization instructions, this attribute allows a Reading System to match the
 							fragment to a location in the text.</p>
 
-						<div class="example" id="example-mo-nesting">
-							<p>The following example shows a Media Overlay Document with nested <code>seq</code>
-								elements, representing a chapter with both a section header and a figure.</p>
-
-							<pre>&lt;smil xmlns="http://www.w3.org/ns/SMIL" xmlns:epub="http://www.idpf.org/2007/ops" version="3.0"&gt;
-    &lt;body&gt;
-
-        &lt;!-- a chapter --&gt;
-        &lt;seq id="id1" epub:textref="chapter1.xhtml#sectionstart" epub:type="chapter"&gt;
-
-            &lt;!-- the section title --&gt;
-            &lt;par id="id2"&gt;
-                &lt;text src="chapter1.xhtml#section1_title"/&gt;
-                &lt;audio src="chapter1_audio.mp3"
-                       clipBegin="0:23:23.84"
-                       clipEnd="0:23:34.221"/&gt;
-            &lt;/par&gt;
-
-            &lt;!-- some sentences in the chapter --&gt;
-            &lt;par id="id3"&gt;
-                &lt;text src="chapter1.xhtml#text1"/&gt;
-                &lt;audio src="chapter1_audio.mp3"
-                       clipBegin="0:23:34.221"
-                       clipEnd="0:23:59.003"/&gt;
-            &lt;/par&gt;
-            &lt;par id="id4"&gt;
-                &lt;text src="chapter1.xhtml#text2"/&gt;
-                &lt;audio src="chapter1_audio.mp3"
-                       clipBegin="0:23:59.003"
-                       clipEnd="0:24:15.000"/&gt;
-            &lt;/par&gt;
-
-            &lt;!-- a figure --&gt;
-            &lt;seq id="id7" epub:textref="chapter1.xhtml#figure"&gt;
-                &lt;par id="id8"&gt;
-                    &lt;text src="chapter1.xhtml#photo"/&gt;
-                    &lt;audio src="chapter1_audio.mp3"
-                           clipBegin="0:24:18.123"
-                           clipEnd="0:24:28.764"/&gt;
-                &lt;/par&gt;
-                &lt;par id="id9"&gt;
-                    &lt;text src="chapter1.xhtml#caption"/&gt;
-                    &lt;audio src="chapter1_audio.mp3"
-                           clipBegin="0:24:28.764"
-                           clipEnd="0:24:50.010"/&gt;
-                &lt;/par&gt;
-            &lt;/seq&gt;
-
-            &lt;!-- more sentences in the chapter (outside the figure) --&gt;
-            &lt;par id="id12"&gt;
-                &lt;text src="chapter1.xhtml#text3"/&gt;
-                &lt;audio src="chapter1_audio.mp3"
-                       clipBegin="0:25:45.515"
-                       clipEnd="0:26:30.203"/&gt;
-            &lt;/par&gt;
-            &lt;par id="id13"&gt;
-                &lt;text src="chapter1.xhtml#text4"/&gt;
-                &lt;audio src="chapter1_audio.mp3"
-                       clipBegin="0:26:30.203"
-                       clipEnd="0:27:15.000"/&gt;
-            &lt;/par&gt;
-
-        &lt;/seq&gt;
-    &lt;/body&gt;
-&lt;/smil&gt;
-</pre>
-						</div>
-
 						<div class="note">
 							<p>The reason for grouping structures like sections, figures, tables, and footnotes in a
 									<code>seq</code> element is so that Reading Systems can identify their start and end
@@ -7657,35 +7918,148 @@ store destination as source in ocf
 								the layout of the content, such as jumping past a long figure, turning off rendering of
 								page break announcements (see <a href="#sec-behaviors-skip-escape"></a>), or customizing
 								the reading mode to suit structures such as tables.</p>
-
 						</div>
-						<aside class="example">
-							<p>The following example shows the EPUB Content Document that corresponds to the <a
-									href="#example-mo-nesting">previous Media Overlay example</a>.</p>
 
-							<pre>&lt;html xmlns="http://www.w3.org/1999/xhtml" 
-      xmlns:epub="http://www.idpf.org/2007/ops" 
-      xml:lang="en" 
-     &gt;
-    &lt;head&gt;
-        &lt;title&gt;Media Overlays Example of EPUB Content Document&lt;/title&gt;
-    &lt;/head&gt;
-    &lt;body id="sec1"&gt;
-        &lt;section id="sectionstart" epub:type="chapter"&gt;
-            &lt;h1 id="section1_title"&gt;The Section Title&lt;/h1&gt;
-            &lt;p id="text1"&gt;The first phrase of the main text body.&lt;/p&gt;
-            &lt;p id="text2"&gt;The second phrase of the main text body.&lt;/p&gt;
-            &lt;figure id="figure"&gt;
-                &lt;img id="photo" 
-                     src="photo.png" 
-                     alt="a photograph for which there is a caption" /&gt;
-                &lt;figcaption id="caption"&gt;The photo caption&lt;/figcaption&gt;
-            &lt;/figure&gt;
-            &lt;p id="text3"&gt;The third phrase of the main text body.&lt;/p&gt;
-            &lt;p id="text4"&gt;The fourth phrase of the main text body.&lt;/p&gt;
-        &lt;/section&gt;
-    &lt;/body&gt;
-&lt;/html&gt;</pre>
+						<aside class="example" id="example-mo-nesting" title="A Media Overlay with nested seq
+							elements">
+							<p>This example shows a chapter with both a section header and a figure.</p>
+
+							<p>Media Overlay Document:</p>
+
+							<pre>&lt;smil
+    xmlns="http://www.w3.org/ns/SMIL"
+    xmlns:epub="http://www.idpf.org/2007/ops"
+    version="3.0">
+   &lt;body>
+
+      &lt;!-- a chapter -->
+      
+      &lt;seq
+          id="id1"
+          epub:textref="chapter1.xhtml#sectionstart"
+          epub:type="chapter">
+
+         &lt;!-- the section title -->
+         
+         &lt;par id="id2">
+            &lt;text
+                src="chapter1.xhtml#section1_title"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:23:23.84"
+                clipEnd="0:23:34.221"/>
+         &lt;/par>
+
+         &lt;!-- some sentences in the chapter -->
+         
+         &lt;par id="id3">
+            &lt;text
+                src="chapter1.xhtml#text1"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:23:34.221"
+                clipEnd="0:23:59.003"/>
+         &lt;/par>
+         &lt;par id="id4">
+            &lt;text
+                src="chapter1.xhtml#text2"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:23:59.003"
+                clipEnd="0:24:15.000"/>
+         &lt;/par>
+
+         &lt;!-- a figure -->
+         
+         &lt;seq
+             id="id7"
+             epub:textref="chapter1.xhtml#figure">
+            &lt;par id="id8">
+               &lt;text
+                   src="chapter1.xhtml#photo"/>
+               &lt;audio
+                   src="chapter1_audio.mp3"
+                   clipBegin="0:24:18.123"
+                   clipEnd="0:24:28.764"/>
+            &lt;/par>
+            &lt;par id="id9">
+               &lt;text
+                   src="chapter1.xhtml#caption"/>
+               &lt;audio
+                   src="chapter1_audio.mp3"
+                   clipBegin="0:24:28.764"
+                   clipEnd="0:24:50.010"/>
+            &lt;/par>
+         &lt;/seq>
+
+         &lt;!-- more sentences in the chapter (outside the figure) -->
+         
+         &lt;par id="id12">
+            &lt;text
+                src="chapter1.xhtml#text3"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:25:45.515"
+                clipEnd="0:26:30.203"/>
+         &lt;/par>
+         &lt;par id="id13">
+            &lt;text
+                src="chapter1.xhtml#text4"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:26:30.203"
+                clipEnd="0:27:15.000"/>
+         &lt;/par>
+      &lt;/seq>
+   &lt;/body>
+&lt;/smil></pre>
+
+							<p>XHTML Content Document:</p>
+
+							<pre>&lt;html …>
+   &lt;head>
+      &lt;title>
+         Media Overlays Example of
+         EPUB Content Document
+      &lt;/title>
+   &lt;/head>
+   &lt;body id="sec1">
+      &lt;section
+          id="sectionstart"
+          epub:type="chapter">
+         
+         &lt;h1 id="section1_title">
+            The Section Title
+         &lt;/h1>
+         
+         &lt;p id="text1">
+            The first phrase of the main text body.
+         &lt;/p>
+         
+         &lt;p id="text2">
+            The second phrase of the main text body.
+         &lt;/p>
+         
+         &lt;figure id="figure">
+            &lt;img id="photo"
+                src="photo.png" 
+                alt="a photograph for which there is a caption" />
+            
+            &lt;figcaption id="caption">
+               The photo caption
+            &lt;/figcaption>
+         &lt;/figure>
+         
+         &lt;p id="text3">
+            The third phrase of the main text body.
+         &lt;/p>
+         
+         &lt;p id="text4">
+            The fourth phrase of the main text body.
+         &lt;/p>
+      &lt;/section>
+   &lt;/body>
+&lt;/html></pre>
 						</aside>
 					</section>
 
@@ -7805,32 +8179,47 @@ store destination as source in ocf
 							href="https://www.w3.org/TR/epub-rs-33/#note-table-reading-mode">table reading mode</a>
 						[[?EPUB-RS-33]].</p>
 
-					<aside class="example">
-						<p>The following example shows the semantic markup for a Media Overlay containing a figure.</p>
-
-						<pre>&lt;smil xmlns="http://www.w3.org/ns/SMIL" 
-      xmlns:epub="http://www.idpf.org/2007/ops"
-      version="3.0"&gt;
-    &lt;body&gt;
-        &lt;seq id="id1" epub:textref="chapter1.xhtml#figure" epub:type="figure"&gt;
-            &lt;par id="id2"&gt;
-                &lt;text src="chapter1.xhtml#figuretitle"/&gt;
-                &lt;audio src="chapter1_audio.mp3" clipBegin="0:24:15.000" clipEnd="0:24:18.123"/&gt;
-            &lt;/par&gt;
-            &lt;par id="id3"&gt;
-                &lt;text src="chapter1.xhtml#figurecaption"/&gt;
-                &lt;audio src="chapter1_audio.mp3" clipBegin="0:24:18.123" clipEnd="0:24:38.530"/&gt;
-            &lt;/par&gt;
-            &lt;par id="id4"&gt;
-                &lt;text src="chapter1.xhtml#figuretext1"/&gt;
-                &lt;audio src="chapter1_audio.mp3" clipBegin="0:24:38.530" clipEnd="0:25:00.515"/&gt;
-            &lt;/par&gt;
-        &lt;/seq&gt;
-    &lt;/body&gt;
-&lt;/smil&gt;</pre>
-					</aside>
 					<p>Media Overlays MAY use the applicable <a href="#sec-vocab-assoc">vocabulary association
 							mechanisms</a> for the <code>epub:type</code> attribute to define additional semantics.</p>
+
+					<aside class="example" title="Semantic markup for a Media Overlay containing a figure">
+						<pre>&lt;smil
+    xmlns="http://www.w3.org/ns/SMIL" 
+    xmlns:epub="http://www.idpf.org/2007/ops"
+    version="3.0">
+   &lt;body>
+      &lt;seq
+          id="id1"
+          epub:textref="chapter1.xhtml#figure"
+          epub:type="figure">
+         &lt;par id="id2">
+            &lt;text
+                src="chapter1.xhtml#figuretitle"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:24:15.000"
+                clipEnd="0:24:18.123"/>
+         &lt;/par>
+         &lt;par id="id3">
+            &lt;text
+                src="chapter1.xhtml#figurecaption"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:24:18.123"
+                clipEnd="0:24:38.530"/>
+         &lt;/par>
+         &lt;par id="id4">
+            &lt;text
+                src="chapter1.xhtml#figuretext1"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:24:38.530"
+                clipEnd="0:25:00.515"/>
+         &lt;/par>
+      &lt;/seq>
+   &lt;/body>
+&lt;/smil></pre>
+					</aside>
 				</section>
 
 				<section id="sec-docs-assoc-style">
@@ -7858,16 +8247,29 @@ store destination as source in ocf
 						properties in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a>
 						as they always apply to the entire <a>EPUB Publication</a>.</p>
 
-					<aside class="example">
-						<p>This example demonstrates how EPUB Creators can associate style information with the
-							currently playing EPUB Content Document.</p>
+					<aside class="example" title="Associating style information with the
+						currently playing EPUB Content Document">
 
-						<p>The author-defined CSS class names, declared using the metadata properties <a
+						<p>The author-defined CSS class names are declared using the metadata properties <a
 								href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 									><code>playback-active-class</code></a> in the Package Document:</p>
 
-						<pre>&lt;meta property="media:active-class"&gt;my-active-item&lt;/meta&gt;
-&lt;meta property="media:playback-active-class"&gt;my-document-playing&lt;/meta&gt;</pre>
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="media:active-class">
+         my-active-item
+      &lt;/meta>
+      &lt;meta
+          property="media:playback-active-class">
+         my-document-playing
+      &lt;/meta>
+      …
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+
 						<p>The CSS Style Sheet containing the author-defined class names:</p>
 
 						<pre>/* emphasize the active element */
@@ -7881,15 +8283,26 @@ html.my-document-playing * {
     color: gray;
 }
 </pre>
+
 						<p>The relevant EPUB Content Document excerpt:</p>
 
-						<pre>&lt;html&gt;
-    …
-    &lt;span id="txt1"&gt;This is the first phrase.&lt;/span&gt;
-    &lt;span id="txt2"&gt;This is the second phrase.&lt;/span&gt;
-    &lt;span id="txt3"&gt;This is the third phrase.&lt;/span&gt;
-    …
-&lt;/html&gt;</pre>
+						<pre>&lt;html>
+   …
+   &lt;body>
+      …
+      &lt;span id="txt1">
+         This is the first phrase.
+      &lt;/span>
+      &lt;span id="txt2">
+         This is the second phrase.
+      &lt;/span>
+      &lt;span id="txt3">
+         This is the third phrase.
+      &lt;/span>
+      …
+   &lt;/body>
+&lt;/html></pre>
+
 						<p>In this example, the Reading System would apply the author-defined
 								<code>my-active-item</code> class to each text element in the EPUB Content Document as
 							it became active during playback. Conversely, Reading Systems would remove the class name
@@ -7926,21 +8339,24 @@ html.my-document-playing * {
 						<p>Manifest items for Media Overlay Documents MUST have the media type
 								<code>application/smil+xml</code>.</p>
 
-						<aside class="example">
-							<p>The following example shows the entries for an EPUB Content Document and its associated
-								Media Overlay in the manifest of a Package Document.</p>
-
-							<pre>&lt;manifest&gt;
-   &lt;item id="ch1" 
-         href="chapter1.xhtml" 
-         media-type="application/xhtml+xml" 
-         media-overlay="ch1_audio"/&gt;
-   
-   &lt;item id="ch1_audio" 
-         href="chapter1_audio.smil" 
-         media-type="application/smil+xml"/&gt;
+						<aside class="example" title="Entries for an EPUB Content Document and its associated
+							Media Overlay in the Package Document manifest">
+							<pre>&lt;package …>
    …
-&lt;/manifest&gt;</pre>
+   &lt;manifest>
+      &lt;item
+          id="ch1" 
+          href="chapter1.xhtml" 
+          media-type="application/xhtml+xml" 
+          media-overlay="ch1_audio"/>
+   
+      &lt;item
+          id="ch1_audio" 
+          href="chapter1_audio.smil" 
+          media-type="application/smil+xml"/>
+      …
+   &lt;/manifest>
+&lt;/package></pre>
 						</aside>
 					</section>
 
@@ -7965,20 +8381,50 @@ html.my-document-playing * {
 								>author-defined CSS class names</a> to apply to the currently playing EPUB Content
 							Document element.</p>
 
-						<aside class="example">
-							<p>The following example shows a Package Document with metadata about Media Overlays.</p>
-
-							<pre>&lt;metadata&gt;
-   …
-   &lt;meta property="media:duration" refines="#ch1_audio">0:32:29&lt;/meta>
-   &lt;meta property="media:duration" refines="#ch2_audio">0:34:02&lt;/meta>
-   &lt;meta property="media:duration" refines="#ch3_audio">0:29:49&lt;/meta>
-   &lt;meta property="media:duration"&gt;1:36:20&lt;/meta&gt;
-   &lt;meta property="media:narrator"&gt;Joe Speaker&lt;/meta&gt;
-   &lt;meta property="media:active-class"&gt;my-active-item&lt;/meta&gt;
-   &lt;meta property="media:playback-active-class"&gt;my-document-playing&lt;/meta&gt;
-   …
-&lt;/metadata&gt;</pre>
+						<aside class="example" title="Media Overlays metadata in the Package Document">
+							<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="media:duration"
+          refines="#ch1_audio">
+         0:32:29
+      &lt;/meta>
+      
+      &lt;meta
+          property="media:duration"
+          refines="#ch2_audio">
+         0:34:02
+      &lt;/meta>
+      
+      &lt;meta
+          property="media:duration"
+          refines="#ch3_audio">
+         0:29:49
+      &lt;/meta>
+      
+      &lt;meta
+          property="media:duration">
+         1:36:20
+      &lt;/meta>
+      
+      &lt;meta
+          property="media:narrator">
+         Joe Speaker
+      &lt;/meta>
+      
+      &lt;meta
+          property="media:active-class">
+         my-active-item
+      &lt;/meta>
+      
+      &lt;meta
+          property="media:playback-active-class">
+         my-document-playing
+      &lt;/meta>
+      …
+   &lt;/metadata>
+&lt;/package></pre>
 						</aside>
 						<div class="note">
 							<p>The <code>media:</code> prefix is <a href="#sec-metadata-reserved-prefixes">reserved</a>
@@ -8001,56 +8447,73 @@ html.my-document-playing * {
 							<a href="#sec-docs-structural-semantic"><code>epub:type</code></a> attribute to determine
 						when to offer users the option of skippable features.</p>
 
-					<aside class="example">
-						<p>The following example shows a Media Overlay Document with a page break. A Reading System
-							could offer the user the option of turning on and off the page break/page number
-							announcements, which are often cumbersome to listen to.</p>
+					<aside class="example" title="Media Overlay with a page break">
+						<p>In this example, a Reading System could offer the user the option of turning on and off the
+							page break/page number announcements, which are often cumbersome to listen to.</p>
 
-						<pre>&lt;smil xmlns="http://www.w3.org/ns/SMIL" 
-      xmlns:epub="http://www.idpf.org/2007/ops"
-      version="3.0"&gt;
-    &lt;body&gt;
-        &lt;!-- a paragraph --&gt;
-        &lt;par id="id1"&gt;
-            &lt;text src="chapter1.xhtml#para1"/&gt;
-            &lt;audio src="chapter1_audio.mp3"
-                   clipBegin="0:23:22.000"
-                   clipEnd="0:24:15.000"/&gt;
-        &lt;/par&gt;
+						<p>Media Overlay Document:</p>
 
-        &lt;!-- a page number --&gt;
-        &lt;par id="id2" epub:type="pagebreak"&gt;
-            &lt;text src="chapter1.xhtml#pgbreak1"/&gt;
-            &lt;audio src="chapter1_audio.mp3"
-                   clipBegin="0:24:15.000"
-                   clipEnd="0:24:18.123"/&gt;
-        &lt;/par&gt;
+						<pre>&lt;smil
+    xmlns="http://www.w3.org/ns/SMIL" 
+    xmlns:epub="http://www.idpf.org/2007/ops"
+    version="3.0">
+   &lt;body>
+      &lt;!-- a paragraph -->
+      &lt;par id="id1">
+         &lt;text
+             src="chapter1.xhtml#para1"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0:23:22.000"
+             clipEnd="0:24:15.000"/>
+      &lt;/par>
 
-        &lt;!-- another paragraph --&gt;
-        &lt;par id="id3"&gt;
-            &lt;text src="chapter1.xhtml#para2"/&gt;
-            &lt;audio src="chapter1_audio.mp3"
-                   clipBegin="0:24:18.123"
-                   clipEnd="0:25:28.530"/&gt;
-        &lt;/par&gt;
-    &lt;/body&gt;
-&lt;/smil&gt;
+      &lt;!-- a page number -->
+      &lt;par
+          id="id2"
+          epub:type="pagebreak">
+         &lt;text
+             src="chapter1.xhtml#pgbreak1"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0:24:15.000"
+             clipEnd="0:24:18.123"/>
+      &lt;/par>
+
+      &lt;!-- another paragraph -->
+      &lt;par id="id3">
+         &lt;text
+             src="chapter1.xhtml#para2"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0:24:18.123"
+             clipEnd="0:25:28.530"/>
+      &lt;/par>
+   &lt;/body>
+&lt;/smil>
 </pre>
-					</aside>
-					<aside class="example">
-						<p>The following example shows an EPUB Content Document with a page break.</p>
 
-						<pre>&lt;html … &gt;
-    …
-    &lt;body&gt;
-        &lt;p id="para1"&gt;This is the paragraph before the page break … &lt;/p&gt;
-        
-        &lt;span id="pgbreak1" role="doc-pagebreak" aria-label="14"/&gt;
-        
-        &lt;p id="para2"&gt;This is the paragraph after the page break …&lt;/p&gt;
-    &lt;/body&gt;
-&lt;/html&gt;</pre>
+						<p>EPUB Content Document:</p>
+
+						<pre>&lt;html … >
+   …
+   &lt;body>
+      &lt;p id="para1">
+         This is the paragraph before the page break …
+      &lt;/p>
+      
+      &lt;span
+          id="pgbreak1"
+          role="doc-pagebreak"
+          aria-label="14"/>
+      
+      &lt;p id="para2">
+         This is the paragraph after the page break …
+      &lt;/p>
+   &lt;/body>
+&lt;/html></pre>
 					</aside>
+
 					<p>The following non-exhaustive list represents terms from the Structural Semantics
 						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems may offer the option of skippability:</p>
 
@@ -8081,78 +8544,125 @@ html.my-document-playing * {
 						of items, but provides an exit from them (e.g., a user can listen to some of the content before
 						choosing to escape).</p>
 
-					<aside class="example">
-						<p>The following example shows the Media Overlay Document for an EPUB Content Document
-							containing a paragraph, a table, and another paragraph. A Reading System that supported
-							escapability would give the user the option to interrupt playback of the table to continue
-							playing the next paragraph.</p>
+					<aside class="example" title="Escapable structures">
+						<p>In this example, the Media Overlay Document for an EPUB Content Document contains a
+							paragraph, a table, and another paragraph. A Reading System that supported escapability
+							would give the user the option to interrupt playback of the table to continue playing the
+							next paragraph.</p>
 
-						<pre>&lt;smil xmlns="http://www.w3.org/ns/SMIL" 
-      xmlns:epub="http://www.idpf.org/2007/ops"
-      version="3.0"&gt;
-    &lt;body&gt;
-        &lt;!-- a paragraph, part of the regular document text --&gt;
-        &lt;par id="id1"&gt;
-            &lt;text src="c01.xhtml#para1"/&gt;
-            &lt;audio src="chapter1_audio.mp3"
-                   clipBegin="0:23:22.000"
-                   clipEnd="0:24:15.000"/&gt;
-        &lt;/par&gt;
+						<pre>&lt;smil
+    xmlns="http://www.w3.org/ns/SMIL" 
+    xmlns:epub="http://www.idpf.org/2007/ops"
+    version="3.0">
+   &lt;body>
+      &lt;!-- a paragraph, part of the regular document text -->
+      &lt;par id="id1">
+         &lt;text
+             src="c01.xhtml#para1"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0:23:22.000"
+             clipEnd="0:24:15.000"/>
+      &lt;/par>
 
-        &lt;!-- a table with two nested rows --&gt;
-        &lt;seq id="id2" epub:textref="c01.xhtml#t1" epub:type="table"&gt;
-            &lt;seq id="id3" epub:textref="c01.xhtml#tr1" epub:type="table-row"&gt;
-                &lt;par id="id4" epub:type="table-cell"&gt;
-                    &lt;text src="c01.xhtml#td1"/&gt;
-                    &lt;audio src="chapter1_audio.mp3"
-                           clipBegin="0:24:15.000"
-                           clipEnd="0:24:18.123"/&gt;
-                &lt;/par&gt;
-                &lt;par id="id5" epub:type="table-cell"&gt;
-                    &lt;text src="c01.xhtml#td2"/&gt;
-                    &lt;audio src="chapter1_audio.mp3"
-                           clipBegin="0:24:18.123"
-                           clipEnd="0:25:28.530"/&gt;
-                &lt;/par&gt;
-                &lt;par id="id6" epub:type="table-cell"&gt;
-                    &lt;text src="c01.xhtml#td3"/&gt;
-                    &lt;audio src="chapter1_audio.mp3"
-                           clipBegin="0:25:28.530"
-                           clipEnd="0:25:45.515"/&gt;
-                &lt;/par&gt;
-            &lt;/seq&gt;
-            &lt;seq id="id7" epub:textref="c01.xhtml#tr2" epub:type="table-row"&gt;
-                &lt;par id="id8" epub:type="table-cell"&gt;
-                    &lt;text src="c01.xhtml#td4"/&gt;
-                    &lt;audio src="chapter1_audio.mp3"
-                           clipBegin="0:25:45.515"
-                           clipEnd="0:26:45.700"/&gt;
-                &lt;/par&gt;
-                &lt;par id="id9" epub:type="table-cell"&gt;
-                    &lt;text src="chapter1.xhtml#td5"/&gt;
-                    &lt;audio src="chapter1_audio.mp3"
-                           clipBegin="0:26:45.700"
-                           clipEnd="0:28:02.033"/&gt;
-                &lt;/par&gt;
-                &lt;par id="id10" epub:type="table-cell"&gt;
-                    &lt;text src="chapter1.xhtml#td6"/&gt;
-                    &lt;audio src="chapter1_audio.mp3"
-                           clipBegin="0:28:02.033"
-                           clipEnd="0:28:52.207"/&gt;
-                &lt;/par&gt;
-            &lt;/seq&gt;
-        &lt;/seq&gt;
+      &lt;!-- a table with two nested rows -->
+      &lt;seq
+          id="id2"
+          epub:textref="c01.xhtml#t1"
+          epub:type="table">
+         
+         &lt;seq
+             id="id3"
+             epub:textref="c01.xhtml#tr1"
+             epub:type="table-row">
+            
+            &lt;par
+                id="id4"
+                epub:type="table-cell">
+               &lt;text
+                   src="c01.xhtml#td1"/>
+               &lt;audio
+                   src="chapter1_audio.mp3"
+                   clipBegin="0:24:15.000"
+                   clipEnd="0:24:18.123"/>
+            &lt;/par>
+            
+            &lt;par
+                id="id5"
+                epub:type="table-cell">
+               &lt;text
+                   src="c01.xhtml#td2"/>
+               &lt;audio
+                   src="chapter1_audio.mp3"
+                   clipBegin="0:24:18.123"
+                   clipEnd="0:25:28.530"/>
+            &lt;/par>
+            
+            &lt;par
+                id="id6"
+                epub:type="table-cell">
+               &lt;text
+                   src="c01.xhtml#td3"/>
+               &lt;audio
+                   src="chapter1_audio.mp3"
+                   clipBegin="0:25:28.530"
+                   clipEnd="0:25:45.515"/>
+            &lt;/par>
+         &lt;/seq>
+         
+         &lt;seq
+             id="id7"
+             epub:textref="c01.xhtml#tr2"
+             epub:type="table-row">
+            
+            &lt;par
+                id="id8"
+                epub:type="table-cell">
+               &lt;text
+                   src="c01.xhtml#td4"/>
+               &lt;audio
+                   src="chapter1_audio.mp3"
+                   clipBegin="0:25:45.515"
+                   clipEnd="0:26:45.700"/>
+            &lt;/par>
+            
+            &lt;par
+                id="id9"
+                epub:type="table-cell">
+               &lt;text
+                   src="chapter1.xhtml#td5"/>
+               &lt;audio
+                   src="chapter1_audio.mp3"
+                   clipBegin="0:26:45.700"
+                   clipEnd="0:28:02.033"/>
+            &lt;/par>
+            
+            &lt;par
+                id="id10"
+                epub:type="table-cell">
+               &lt;text
+                   src="chapter1.xhtml#td6"/>
+               &lt;audio
+                   src="chapter1_audio.mp3"
+                   clipBegin="0:28:02.033"
+                   clipEnd="0:28:52.207"/>
+            &lt;/par>
+         &lt;/seq>
+      &lt;/seq>
 
-        &lt;!-- another paragraph --&gt;
-        &lt;par id="id11"&gt;
-            &lt;text src="c01.xhtml#para2"/&gt;
-            &lt;audio src="chapter1_audio.mp3"
-                   clipBegin="0:28:52.207"
-                   clipEnd="0:30:01.000"/&gt;
-        &lt;/par&gt;
-    &lt;/body&gt;
-&lt;/smil&gt;</pre>
+      &lt;!-- another paragraph -->
+      &lt;par id="id11">
+         &lt;text
+             src="c01.xhtml#para2"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0:28:52.207"
+             clipEnd="0:30:01.000"/>
+      &lt;/par>
+   &lt;/body>
+&lt;/smil></pre>
 					</aside>
+
 					<p>The following non-exhaustive list represents terms from the Structural Semantics
 						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems may offer the option of escapability:</p>
 
@@ -8491,46 +9001,55 @@ html.my-document-playing * {
 					to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a href="#sec-vocab-assoc"></a>
 					for more information.</p>
 
-				<aside class="example" id="ex.epubtype.note">
-					<p>The following example shows how a preamble could be marked up with the <code>epub:type</code>
-						attribute on its containing [[HTML]] <code>section</code> element.</p>
-
-					<pre>
-&lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+				<aside class="example" id="ex.epubtype.note" title="Identifying a preamble">
+					<pre>&lt;html
     …
-    &lt;section epub:type="preamble"&gt;
-        …    
-    &lt;/section&gt;
-    …
-&lt;/html&gt;</pre>
-				</aside>
-
-				<aside class="example" id="ex.epubtype.gloss">
-					<p>The following example shows the <code>epub:type</code> attribute used to add glossary semantics
-						on an [[HTML]] definition list.</p>
-
-					<pre>
-&lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
-    …
-    &lt;dl epub:type="glossary"&gt;
-        …    
-    &lt;/dl&gt;        
-    …
-&lt;/html&gt;</pre>
-				</aside>
-
-				<aside class="example" id="ex.epubtype.pg">
-					<p>The following example shows the <code>epub:type</code> attribute used to add page break
-						semantics.</p>
-
-					<pre>
-&lt;html … xmlns:epub="http://www.idpf.org/2007/ops"&gt;
+    xmlns:epub="http://www.idpf.org/2007/ops">
    …
-  &lt;p&gt; … 
-     &lt;span epub:type="pagebreak" id="p234" role="doc-pagebreak" aria-label="234"/&gt;
-     … &lt;/p&gt;    
-   … 
-&lt;/html&gt;</pre>
+   &lt;body>
+      …
+      &lt;section epub:type="preamble">
+         …    
+      &lt;/section>
+      …
+   &lt;/body>
+&lt;/html></pre>
+				</aside>
+
+				<aside class="example" id="ex.epubtype.gloss" title="Identifying a glossary">
+					<pre>&lt;html
+    …
+    xmlns:epub="http://www.idpf.org/2007/ops">
+   …
+   &lt;body>
+      …
+      &lt;dl epub:type="glossary">
+         …    
+      &lt;/dl>        
+      …
+   &lt;/body>
+&lt;/html></pre>
+				</aside>
+
+				<aside class="example" id="ex.epubtype.pg" title="Adding page break semantics">
+					<pre>&lt;html
+    …
+    xmlns:epub="http://www.idpf.org/2007/ops">
+   …
+   &lt;body>
+      …
+      &lt;p>
+         … 
+         &lt;span
+            epub:type="pagebreak"
+            id="p234"
+            role="doc-pagebreak"
+            aria-label="234"/>
+         …
+      &lt;/p>    
+      …
+   &lt;/body>
+&lt;/html></pre>
 				</aside>
 			</section>
 		</section>
@@ -8623,30 +9142,30 @@ html.my-document-playing * {
 					<p>This specification derives the <var>property</var> data type from the CURIE data type defined in
 						[[RDFA-CORE]]. A <var>property</var> represents a subset of CURIEs.</p>
 
-					<aside class="example">
-						<p>The following example shows a <var>property</var> value composed of the prefix
-								<code>dcterms</code> and the reference <code>modified</code>.</p>
+					<aside class="example" title="Expanding a metadata property value">
+						<p>In this example, the <var>property</var> value is composed of the prefix <code>dcterms</code>
+							and the reference <code>modified</code>.</p>
 
-						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
+						<pre>&lt;meta property="dcterms:modified">2011-01-01T12:00:00Z&lt;/meta></pre>
+
+						<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-datatype">processing</a>
+							[[EPUB-RS-33]], this property would expand to the following URL:</p>
+
+						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
+
+						<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
+								prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
 					</aside>
-
-					<p>After <a href="https://www.w3.org/TR/epub-rs-33/#sec-property-datatype">processing</a>
-						[[EPUB-RS-33]], this property would expand to the following URL:</p>
-
-					<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
-
-					<p>as the <code>dcterms:</code> prefix is a <a href="#sec-metadata-reserved-prefixes">reserved
-							prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
 
 					<p>When an EPUB Creator omits a prefix from a <var>property</var> value, the expressed reference
 						represents a term from the <a href="#sec-default-vocab">default vocabulary</a> for that
 						attribute.</p>
 
-					<aside class="example">
-						<p>The following example shows the <a href="#mathml"><code>mathml</code> property</a> on a
+					<aside class="example" title="Expanding a manifest property value">
+						<p>In this example, the <a href="#mathml"><code>mathml</code> property</a> is specified on a
 							manifest <a href="#elemdef-package-item"><code>item</code></a> element:</p>
 
-						<pre>&lt;item … properties="mathml"/&gt;</pre>
+						<pre>&lt;item … properties="mathml"/></pre>
 
 						<p>This property expands to:</p>
 
@@ -8752,13 +9271,14 @@ html.my-document-playing * {
 
 					<p>The attribute is not namespaced when used in the <a>Package Document</a>.</p>
 
-					<aside class="example">
-						<p>The following example shows prefix declarations for the Friend of a Friend
-							(<code>foaf</code>) and DBPedia (<code>dbp</code>) vocabularies in the Package Document.</p>
+					<aside class="example" title="Declaring prefixes in the Package Document">
+						<p>In this example, the EPUB Creator declares prefixes for the Friend of a Friend
+								(<code>foaf</code>) and DBPedia (<code>dbp</code>) vocabularies.</p>
 
-						<pre>&lt;package … 
-         prefix="foaf: http://xmlns.com/foaf/spec/
-         dbp: http://dbpedia.org/ontology/">
+						<pre>&lt;package
+    … 
+    prefix="foaf: http://xmlns.com/foaf/spec/
+            dbp: http://dbpedia.org/ontology/">
    …
 &lt;/package></pre>
 					</aside>
@@ -8767,9 +9287,9 @@ html.my-document-playing * {
 							<code>http://www.idpf.org/2007/ops</code> in <a>EPUB Content Documents</a> and <a>Media
 							Overlay Documents</a>.</p>
 
-					<aside class="example">
-						<p>The following example shows the <code>prefix</code> attribute declared in an <a>XHTML Content
-								Document</a>.</p>
+					<aside class="example" title="Declaring prefixes in an XHTML Content Document">
+						<p>In this example, the EPUB Creator declares a prefix for the Z39.98 Structural Semantics
+							Vocabulary.</p>
 
 						<pre>&lt;html …
       xmlns:epub="http://www.idpf.org/2007/ops"
@@ -9025,7 +9545,7 @@ html.my-document-playing * {
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
-								<td> none | horizontal | horizontal &lt;number&gt; </td>
+								<td> none | horizontal | horizontal &lt;number> </td>
 							</tr>
 						</tbody>
 					</table>
@@ -9057,7 +9577,7 @@ html.my-document-playing * {
 								<td><code>text-combine-upright: all</code></td>
 							</tr>
 							<tr>
-								<td><code>-epub-text-combine: horizontal &lt;number&gt;</code></td>
+								<td><code>-epub-text-combine: horizontal &lt;number></code></td>
 								<td>Error</td>
 							</tr>
 						</tbody>
@@ -9216,7 +9736,7 @@ html.my-document-playing * {
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
-								<td> &lt;color&gt; </td>
+								<td> &lt;color> </td>
 							</tr>
 						</tbody>
 					</table>
@@ -9259,7 +9779,7 @@ html.my-document-playing * {
 							<tr class="value">
 								<th>Value:</th>
 								<td> none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ]
-									] | &lt;string&gt; </td>
+									] | &lt;string> </td>
 							</tr>
 						</tbody>
 					</table>
@@ -9385,55 +9905,55 @@ html.my-document-playing * {
 
 				<p>Consider the following example Package Document:</p>
 
-				<pre>&lt;package …&gt;
+				<pre>&lt;package …>
     …
-    &lt;manifest&gt;
+    &lt;manifest>
         …
         &lt;item id="chap01" 
             href="scripted01.xhtml" 
             media-type="application/xhtml+xml"
-            properties="scripted"/&gt;
+            properties="scripted"/>
         &lt;item id="inset01" 
             href="scripted02.xhtml" 
             media-type="application/xhtml+xml"
-            properties="scripted"/&gt;
+            properties="scripted"/>
         &lt;item id="slideshowjs" 
             href="slideshow.js" 
-            media-type="text/javascript"/&gt;
-    &lt;/manifest&gt;
+            media-type="text/javascript"/>
+    &lt;/manifest>
     
-    &lt;spine …&gt;
-        &lt;itemref idref="chap01"/&gt;
+    &lt;spine …>
+        &lt;itemref idref="chap01"/>
         …
-    &lt;/spine&gt;
+    &lt;/spine>
     …
-&lt;/package&gt;</pre>
+&lt;/package></pre>
 				<p>and the following file <code>scripted01.xhtml</code>:</p>
 
-				<pre>&lt;html …&gt;
-    &lt;head&gt;
+				<pre>&lt;html …>
+    &lt;head>
         …
-        &lt;script type="text/javascript"&gt;
+        &lt;script type="text/javascript">
             alert("Reading System name: " + navigator.epubReadingSystem.name);
-        &lt;/script&gt;
-    &lt;/head&gt;
-    &lt;body&gt;
+        &lt;/script>
+    &lt;/head>
+    &lt;body>
         …
-        &lt;iframe src="scripted02.xhtml" … /&gt;
+        &lt;iframe src="scripted02.xhtml" … />
         …
-    &lt;/body&gt;
-&lt;/html&gt;</pre>
+    &lt;/body>
+&lt;/html></pre>
 				<p>and the following file <code>scripted02.xhtml</code>:</p>
 
-				<pre>&lt;html …&gt;
-    &lt;head&gt;
+				<pre>&lt;html …>
+    &lt;head>
         …
-        &lt;script type="text/javascript" href="slideshow.js"&gt;&lt;/script&gt;
-    &lt;/head&gt;
-    &lt;body&gt;
+        &lt;script type="text/javascript" href="slideshow.js">&lt;/script>
+    &lt;/head>
+    &lt;body>
         …
-    &lt;/body&gt;
-&lt;/html&gt;</pre>
+    &lt;/body>
+&lt;/html></pre>
 				<p>From these examples, it is true that:</p>
 
 				<ul>
@@ -9453,13 +9973,12 @@ html.my-document-playing * {
 			<section id="ocf-example">
 				<h3>Packaged EPUB</h3>
 
-				<p>The following example demonstrates the use of the OCF format to contain a signed and encrypted EPUB
+				<p>This example demonstrates the use of the OCF format to contain a signed and encrypted EPUB
 					Publication within an <a>OCF ZIP Container</a>.</p>
 
-				<aside class="example">
-					<p>Ordered list of files in the OCF ZIP Container</p>
+				<p>Ordered list of files in the OCF ZIP Container:</p>
 
-					<pre>mimetype
+				<pre>mimetype
 META-INF/container.xml
 META-INF/signatures.xml
 META-INF/encryption.xml
@@ -9467,199 +9986,262 @@ EPUB/As_You_Like_It.opf
 EPUB/book.html
 EPUB/nav.html
 EPUB/images/cover.png</pre>
-				</aside>
 
-				<aside class="example">
-					<p>The contents of the <code>mimetype</code> file</p>
+				<p>The contents of the <code>mimetype</code> file</p>
 
-					<pre>application/epub+zip</pre>
-				</aside>
+				<pre>application/epub+zip</pre>
 
-				<aside class="example">
-					<p>The contents of the <code>META-INF/container.xml</code> file</p>
+				<p>The contents of the <code>META-INF/container.xml</code> file</p>
 
-					<pre>&lt;?xml version="1.0"?&gt;
-&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
-    &lt;rootfiles&gt;
-        &lt;rootfile full-path="EPUB/As_You_Like_It.opf"
-            media-type="application/oebps-package+xml"/&gt;
-    &lt;/rootfiles&gt;
-&lt;/container&gt;</pre>
-				</aside>
+				<pre>&lt;?xml version="1.0"?>
+&lt;container
+    version="1.0"
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   &lt;rootfiles>
+      &lt;rootfile
+          full-path="EPUB/As_You_Like_It.opf"
+          media-type="application/oebps-package+xml"/>
+   &lt;/rootfiles>
+&lt;/container></pre>
 
-				<aside class="example">
-					<p>The contents of the <code>META-INF/signatures.xml</code> file</p>
+				<p>The contents of the <code>META-INF/signatures.xml</code> file</p>
 
-					<pre>&lt;signatures xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
-    &lt;Signature Id="AsYouLikeItSignature" xmlns="http://www.w3.org/2000/09/xmldsig#"&gt;
+				<pre>&lt;signatures
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+   &lt;Signature
+       Id="AsYouLikeItSignature"
+       xmlns="http://www.w3.org/2000/09/xmldsig#">
         
-        &lt;!--
-             SignedInfo is the information that is actually signed.
-             In this case, the SHA-1 algorithm is used to sign the 
-             canonical form of the XML documents enumerated in the
-             Object element below.
-        --&gt;
-        &lt;SignedInfo&gt;
-            &lt;CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
-            &lt;SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/&gt;
-            &lt;Reference URI="#AsYouLikeIt"&gt;
-                &lt;DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
-                &lt;DigestValue&gt;…&lt;/DigestValue&gt;
-            &lt;/Reference&gt;
-        &lt;/SignedInfo&gt;
-        
-        &lt;!--
-             The signed value of the digest above, using the DSA 
-             algorithm
-        --&gt;
-        &lt;SignatureValue&gt;…&lt;/SignatureValue&gt;
-        
-        &lt;!--
-             The key used to validate the signature
-        --&gt;
-        &lt;KeyInfo&gt;
-            &lt;KeyValue&gt;
-                &lt;DSAKeyValue&gt;
-                    &lt;P&gt;…&lt;/P&gt;
-                    &lt;Q&gt;…&lt;/Q&gt;
-                    &lt;G&gt;…&lt;/G&gt;
-                    &lt;Y&gt;…&lt;/Y&gt;
-                &lt;/DSAKeyValue&gt;
-            &lt;/KeyValue&gt;
-        &lt;/KeyInfo&gt;
-        
-        &lt;!--
-             The list of resources to sign (note that the canonical
-             form of XML documents is signed, while the binary form
-             of all other resources is used)
-        --&gt;
-        &lt;Object&gt;
-            &lt;Manifest Id="AsYouLikeIt"&gt;
-                &lt;Reference URI="EPUB/As_You_Like_It.opf"&gt;
-                    &lt;Transforms&gt;
-                        &lt;Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
-                    &lt;/Transforms&gt;
-                    &lt;DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
-                    &lt;DigestValue&gt;&lt;/DigestValue&gt;
-                &lt;/Reference&gt;
-                &lt;Reference URI="EPUB/book.html"&gt;
-                    &lt;Transforms&gt;
-                        &lt;Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
-                    &lt;/Transforms&gt;
-                    &lt;DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
-                    &lt;DigestValue&gt;&lt;/DigestValue&gt;
-                &lt;/Reference&gt;
-                &lt;Reference URI="EPUB/images/cover.png"&gt;
-                    &lt;DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
-                    &lt;DigestValue&gt;&lt;/DigestValue&gt;
-                &lt;/Reference&gt;
-            &lt;/Manifest&gt;
-        &lt;/Object&gt;
-    &lt;/Signature&gt;
-&lt;/signatures&gt;</pre>
-				</aside>
+      &lt;!--
+           SignedInfo is the information that is actually signed.
+           In this case, the SHA-1 algorithm is used to sign the 
+           canonical form of the XML documents enumerated in the
+           Object element below.
+      -->
+      
+      &lt;SignedInfo>
+         &lt;CanonicalizationMethod
+             Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+         &lt;SignatureMethod
+             Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/>
+         &lt;Reference
+             URI="#AsYouLikeIt">
+            &lt;DigestMethod
+                Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+            &lt;DigestValue>
+               …
+            &lt;/DigestValue>
+         &lt;/Reference>
+      &lt;/SignedInfo>
+      
+      &lt;!--
+           The signed value of the digest above, using the DSA 
+           algorithm
+      -->
+      &lt;SignatureValue>
+         …
+      &lt;/SignatureValue>
+      
+      &lt;!--
+           The key used to validate the signature
+      -->
+      &lt;KeyInfo>
+         &lt;KeyValue>
+            &lt;DSAKeyValue>
+               &lt;P>…&lt;/P>
+               &lt;Q>…&lt;/Q>
+               &lt;G>…&lt;/G>
+               &lt;Y>…&lt;/Y>
+            &lt;/DSAKeyValue>
+         &lt;/KeyValue>
+      &lt;/KeyInfo>
+      
+      &lt;!--
+           The list of resources to sign (note that the canonical
+           form of XML documents is signed, while the binary form
+           of all other resources is used)
+      -->
+      &lt;Object>
+         &lt;Manifest
+             Id="AsYouLikeIt">
+            &lt;Reference
+                URI="EPUB/As_You_Like_It.opf">
+               &lt;Transforms>
+                  &lt;Transform
+                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+               &lt;/Transforms>
+               &lt;DigestMethod
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+               &lt;DigestValue>
+               &lt;/DigestValue>
+            &lt;/Reference>
+            
+            &lt;Reference URI="EPUB/book.html">
+               &lt;Transforms>
+                  &lt;Transform
+                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+               &lt;/Transforms>
+               &lt;DigestMethod
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+               &lt;DigestValue>
+               &lt;/DigestValue>
+            &lt;/Reference>
+            
+            &lt;Reference
+                URI="EPUB/images/cover.png">
+               &lt;DigestMethod
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+               &lt;DigestValue>
+               &lt;/DigestValue>
+            &lt;/Reference>
+         &lt;/Manifest>
+      &lt;/Object>
+   &lt;/Signature>
+&lt;/signatures></pre>
 
-				<aside class="example">
-					<p>The contents of the <code>META-INF/encryption.xml</code> file</p>
+				<p>The contents of the <code>META-INF/encryption.xml</code> file</p>
 
-					<pre>&lt;?xml version="1.0"?&gt;
-&lt;encryption xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
-    xmlns:enc="http://www.w3.org/2001/04/xmlenc#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"&gt;
+				<pre>&lt;?xml version="1.0"?>
+&lt;encryption
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
+    xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
 
-    &lt;!--
-         The RSA-encrypted AES-128 symmetric key used to encrypt
-         data enumerated in EncryptedData blocks below
-    --&gt;
-    &lt;enc:EncryptedKey Id="EK"&gt;
-        &lt;enc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
-        &lt;ds:KeyInfo&gt;
-            &lt;ds:KeyName&gt;John Smith&lt;/ds:KeyName&gt;
-        &lt;/ds:KeyInfo&gt;
-        &lt;enc:CipherData&gt;
-            &lt;enc:CipherValue&gt;xyzabc…&lt;/enc:CipherValue&gt;
-        &lt;/enc:CipherData&gt;
-    &lt;/enc:EncryptedKey&gt;
+   &lt;!--
+        The RSA-encrypted AES-128 symmetric key used to encrypt
+        data enumerated in EncryptedData blocks below
+   -->
+   &lt;enc:EncryptedKey
+       Id="EK">
+      &lt;enc:EncryptionMethod
+          Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
+      &lt;ds:KeyInfo>
+         &lt;ds:KeyName>
+            John Smith
+         &lt;/ds:KeyName>
+      &lt;/ds:KeyInfo>
+      &lt;enc:CipherData>
+         &lt;enc:CipherValue>
+            xyzabc…
+         &lt;/enc:CipherValue>
+      &lt;/enc:CipherData>
+   &lt;/enc:EncryptedKey>
 
-    &lt;!--
-         Each EncryptedData block identifies a single resource
-         that has been encrypted using the AES-128 algorithm.
-         The data remains stored, in its encrypted form, in the
-         original file within the container.
-    --&gt;
-    &lt;enc:EncryptedData Id="ED1"&gt;
-        &lt;enc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/&gt;
-        &lt;ds:KeyInfo&gt;
-            &lt;ds:RetrievalMethod URI="#EK" Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/&gt;
-        &lt;/ds:KeyInfo&gt;
-        &lt;enc:CipherData&gt;
-            &lt;enc:CipherReference URI="EPUB/book.html"/&gt;
-        &lt;/enc:CipherData&gt;
-    &lt;/enc:EncryptedData&gt;
+   &lt;!--
+        Each EncryptedData block identifies a single resource
+        that has been encrypted using the AES-128 algorithm.
+        The data remains stored, in its encrypted form, in the
+        original file within the container.
+   -->
+   &lt;enc:EncryptedData Id="ED1">
+      &lt;enc:EncryptionMethod
+          Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/>
+      &lt;ds:KeyInfo>
+         &lt;ds:RetrievalMethod
+             URI="#EK"
+             Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/>
+      &lt;/ds:KeyInfo>
+      &lt;enc:CipherData>
+         &lt;enc:CipherReference
+             URI="EPUB/book.html"/>
+      &lt;/enc:CipherData>
+   &lt;/enc:EncryptedData>
 
-    &lt;enc:EncryptedData Id="ED2"&gt;
-        &lt;enc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/&gt;
-        &lt;ds:KeyInfo&gt;
-            &lt;ds:RetrievalMethod URI="#EK" Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/&gt;
-        &lt;/ds:KeyInfo&gt;
-        &lt;enc:CipherData&gt;
-            &lt;enc:CipherReference URI="EPUB/images/cover.png"/&gt;
-        &lt;/enc:CipherData&gt;
-    &lt;/enc:EncryptedData&gt;
-&lt;/encryption&gt;</pre>
-				</aside>
+   &lt;enc:EncryptedData Id="ED2">
+      &lt;enc:EncryptionMethod
+          Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/>
+      &lt;ds:KeyInfo>
+         &lt;ds:RetrievalMethod
+             URI="#EK" Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/>
+      &lt;/ds:KeyInfo>
+      &lt;enc:CipherData>
+         &lt;enc:CipherReference
+             URI="EPUB/images/cover.png"/>
+      &lt;/enc:CipherData>
+   &lt;/enc:EncryptedData>
+&lt;/encryption></pre>
 
-				<aside class="example">
-					<p>The contents of the <code>EPUB/As_You_Like_It.opf</code> file</p>
+				<p>The contents of the <code>EPUB/As_You_Like_It.opf</code> file</p>
 
-					<pre>&lt;?xml version="1.0"?&gt;
-&lt;package version="3.0"
-         xml:lang="en"
-         xmlns="http://www.idpf.org/2007/opf"
-         unique-identifier="pub-id"&gt;
+				<pre>&lt;?xml version="1.0"?>
+&lt;package
+    version="3.0"
+    xml:lang="en"
+    xmlns="http://www.idpf.org/2007/opf"
+    unique-identifier="pub-id">
     
-    &lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-        &lt;dc:identifier id="pub-id"&gt;urn:uuid:B9B412F2-CAAD-4A44-B91F-A375068478A0&lt;/dc:identifier&gt;
-        
-        &lt;dc:language&gt;en&lt;/dc:language&gt;
-        
-        &lt;dc:title&gt;As You Like It&lt;/dc:title&gt;
-        
-        &lt;dc:creator id="creator"&gt;William Shakespeare&lt;/dc:creator&gt;
-        
-        &lt;meta property="dcterms:modified"&gt;2000-03-24T00:00:00Z&lt;/meta&gt;
-        
-        &lt;dc:publisher&gt;Project Gutenberg&lt;/dc:publisher&gt;
-        
-        &lt;dc:date&gt;2000-03-24&lt;/dc:date&gt;
-        
-        &lt;meta property="dcterms:dateCopyrighted"&gt;9999-01-01&lt;/meta&gt;
-        
-        &lt;dc:identifier id="isbn13"&gt;urn:isbn:9780741014559&lt;/dc:identifier&gt;
-        
-        &lt;dc:identifier id="isbn10"&gt;0-7410-1455-6&lt;/dc:identifier&gt;
-        
-        &lt;link rel="xml-signature"
-              href="../META-INF/signatures.xml#AsYouLikeItSignature"/&gt;
-    &lt;/metadata&gt;
+   &lt;metadata
+       xmlns:dc="http://purl.org/dc/elements/1.1/">
+      
+      &lt;dc:identifier
+          id="pub-id">
+         urn:uuid:B9B412F2-CAAD-4A44-B91F-A375068478A0
+      &lt;/dc:identifier>
+      
+      &lt;dc:language>
+         en
+      &lt;/dc:language>
+      
+      &lt;dc:title>
+         As You Like It
+      &lt;/dc:title>
+       
+      &lt;dc:creator
+          id="creator">
+         William Shakespeare
+      &lt;/dc:creator>
+      
+      &lt;meta
+          property="dcterms:modified">
+         2000-03-24T00:00:00Z
+      &lt;/meta>
+      
+      &lt;dc:publisher>
+         Project Gutenberg
+      &lt;/dc:publisher>
+      
+      &lt;dc:date>
+         2000-03-24
+      &lt;/dc:date>
+      
+      &lt;meta
+          property="dcterms:dateCopyrighted">
+         9999-01-01
+      &lt;/meta>
+      
+      &lt;dc:identifier
+          id="isbn13">
+         urn:isbn:9780741014559
+      &lt;/dc:identifier>
+      
+      &lt;dc:identifier
+          id="isbn10">
+         0-7410-1455-6
+      &lt;/dc:identifier>
+      
+      &lt;link
+          rel="xml-signature"
+          href="../META-INF/signatures.xml#AsYouLikeItSignature"/>
+   &lt;/metadata>
     
-    &lt;manifest&gt;
-        &lt;item id="r4915" 
-              href="book.html" 
-              media-type="application/xhtml+xml"/&gt;
-        &lt;item id="r7184" 
-              href="images/cover.png" 
-              media-type="image/png"/&gt;
-        &lt;item id="nav" 
-              href="nav.html" 
-              media-type="application/xhtml+xml" 
-              properties="nav"/&gt;
-    &lt;/manifest&gt;
-    
-    &lt;spine&gt;
-        &lt;itemref idref="r4915"/&gt;
-    &lt;/spine&gt;
-&lt;/package&gt;</pre>
-				</aside>
+   &lt;manifest>
+      &lt;item id="r4915" 
+          href="book.html" 
+          media-type="application/xhtml+xml"/>
+      &lt;item id="r7184" 
+          href="images/cover.png" 
+          media-type="image/png"/>
+      &lt;item id="nav" 
+          href="nav.html" 
+          media-type="application/xhtml+xml" 
+          properties="nav"/>
+   &lt;/manifest>
+   
+   &lt;spine>
+      &lt;itemref
+          idref="r4915"/>
+   &lt;/spine>
+&lt;/package></pre>
 			</section>
 
 			<section id="clock-examples">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1295,7 +1295,7 @@
 										punctuation.</p>
 								</div>
 								<aside class="example"
-									title="Setting the global base direction for Package Dcument text">
+									title="Setting the global base direction for Package Document text">
 									<pre>&lt;package … dir="ltr">
    …
 &lt;/package></pre>
@@ -1923,7 +1923,7 @@
 										property</a> to indicate that an <code>identifier</code> conforms to an
 									established system or an issuing authority granted it.</p>
 
-								<aside class="example" title="Specifying the type of identifier">
+								<aside class="example" title="Specifying the type of the identifier">
 									<p>In this example, the <code>identifier-type</code> property is used with the <a
 											href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> scheme to
 										indicate the product identifier type is a <a href="https://doi.org">DOI</a>
@@ -2116,7 +2116,7 @@
 										href="https://www.rfc-editor.org/rfc/rfc5646.html#section-2.2.9">well-formed
 										language tag</a> [[BCP47]].</p>
 
-								<aside class="example" title="Specifying an EPUB Publication is in U.S. English">
+								<aside class="example" title="Specifying U.S. English as the language of the EPUB Publication">
 									<pre>&lt;metadata …>
    …
    &lt;dc:language>
@@ -2230,7 +2230,7 @@
 										href="#subexpression">associate</a> a <a href="#role"><code>role</code>
 										property</a> with the element to indicate the function the creator played.</p>
 
-								<aside class="example" title="Specifying a creator is an author">
+								<aside class="example" title="Specifying that a creator is an author">
 									<p>In this example, the <a href="http://id.loc.gov/vocabulary/relators.html">MARC
 											relators</a> scheme is used to indicate the role (i.e., the value
 											<code>aut</code> indicates an author in MARC).</p>
@@ -2783,7 +2783,7 @@ XHTML:
 								list of <a href="#sec-property-datatype">property</a> values that establish the
 								relationship the resource has with the EPUB Publication.</p>
 
-							<aside class="example" title="Linking a MARC XML record">
+							<aside class="example" title="Linking to a MARC XML record">
 								<pre>&lt;metadata …>
    …
    &lt;link
@@ -5141,8 +5141,13 @@ No Entry</pre>
 								<code>nav</code> elements: they MAY represent navigational semantics for any information
 							domain, and they MAY contain link targets with homogeneous or heterogeneous semantics.</p>
 
-						<aside class="example" title="A list of tables navigation element">
-							<pre>&lt;nav aria-labelledby="lot">
+						<aside class="example" title="Adding a custom navigation element">
+							<p>In this example, the <code>lot</code> semantic indicates that the EPUB Creator is
+								adding a "list of tables" navigation element.</p>
+							
+							<pre>&lt;nav
+    epub:type="lot"
+    aria-labelledby="lot">
    &lt;h2 id="lot">List of tables&lt;/h2>
    &lt;ol>
       &lt;li>
@@ -5534,7 +5539,7 @@ No Entry</pre>
 
 					</div>
 
-					<aside class="example" id="fxl-ex3" title="Specifying to use spreads only in landscape orientation">
+					<aside class="example" id="fxl-ex3" title="Specifying to use spreads in landscape orientation only">
 
 						<pre>&lt;package …>
    &lt;metadata …>
@@ -5543,6 +5548,7 @@ No Entry</pre>
           property="rendition:layout">
          pre-paginated
       &lt;/meta>
+      
       &lt;meta
           property="rendition:spread">
          landscape

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -73,7 +73,12 @@
                      "wpt-tests-exist": true,
 		}
             };//]]>
-      </script>
+		</script>
+		<style>
+			pre,
+			code {
+				white-space: break-spaces !important;
+			}</style>
 	</head>
 	<body>
 		<section id="abstract">

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -270,25 +270,27 @@
 	</section>
 	<section id="examples-item-properties">
 		<h4>Examples</h4>
-		<figure class="example" id="example-item-properties-nav">
-			<figcaption>The following example shows a <code>manifest</code>
-				<a href="#sec-item-elem"><code>item</code> element</a> that represents the <a>EPUB Navigation
-					Document</a>.</figcaption>
-			<pre class="synopsis">&lt;item properties="nav" id="c1" href="c1.xhtml" media-type="application/xhtml+xml" /&gt;
+		<aside class="example" id="example-item-properties-nav" title="Identifying the EPUB Navigation Document">
+			<pre class="synopsis">&lt;item
+    properties="nav"
+    id="c1"
+    href="c1.xhtml"
+    media-type="application/xhtml+xml" /&gt;</pre>
+		</aside>
+		<aside class="example" id="example-item-properties-cover-image" title="Identifying the cover image">
+			<pre class="synopsis">&lt;item
+    properties="cover-image"
+    id="ci"
+    href="cover.svg"
+    media-type="image/svg+xml" /&gt;</pre>
+		</aside>
+		<aside class="example" id="example-item-properties-scripted-mathml" title="Identifying a Scripted Content Document with embedded MathML">
+			<pre class="synopsis">&lt;item
+    properties="scripted mathml"
+    id="c2"
+    href="c2.xhtml"
+    media-type="application/xhtml+xml" /&gt;
 </pre>
-		</figure>
-		<figure class="example" id="example-item-properties-cover-image">
-			<figcaption>The following example shows a <code>manifest</code>
-				<code>item</code> element that represents the cover image.</figcaption>
-			<pre class="synopsis">&lt;item properties="cover-image" id="ci" href="cover.svg" media-type="image/svg+xml" /&gt;
-</pre>
-		</figure>
-		<figure class="example" id="example-item-properties-scripted-mathml">
-			<figcaption>The following example shows a <code>manifest</code>
-				<code>item</code> element representing a <a>Scripted Content Document</a> that also contains
-				embedded MathML.</figcaption>
-			<pre class="synopsis">&lt;item properties="scripted mathml" id="c2" href="c2.xhtml" media-type="application/xhtml+xml" /&gt;
-</pre>
-		</figure>
+		</aside>
 	</section>
 </section>

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -49,16 +49,20 @@
 	</section>
 	<section id="examples-itemref-properties">
 		<h4>Examples</h4>
-		<figure class="example" id="example-itemref-multicol">
-			<figcaption>The following example shows how a two-page spread of a map might be indicated in the
-					<code>spine</code>.</figcaption>
+		<aside class="example" id="example-itemref-multicol" title="Identifying a two-page spread in the spine">
 			<pre class="synopsis">&lt;spine&gt;
-&lt;itemref idref="title"/&gt;
-&lt;itemref idref="ps-1-l" properties="page-spread-left"/&gt;
-&lt;itemref idref="ps-1-r" properties="page-spread-right"/&gt;
-&lt;itemref idref="toc"/&gt;
+&lt;itemref
+    idref="title"/&gt;
+&lt;itemref
+    idref="ps-1-l"
+    properties="page-spread-left"/&gt;
+&lt;itemref
+    idref="ps-1-r"
+    properties="page-spread-right"/&gt;
+&lt;itemref
+    idref="toc"/&gt;
 …
 &lt;/spine&gt;</pre>
-		</figure>
+		</aside>
 	</section>
 </section>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -57,13 +57,19 @@
 				</tr>
 			</tbody>
 		</table>
-		<aside class="example">
-			<p>The following example shows the author name in English and alternatively in Japanese.</p>
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-…
-&lt;dc:creator id="creator">Haruki Murakami&lt;/dc:creator>
-&lt;meta refines="#creator" property="alternate-script" xml:lang="ja">村上 春樹&lt;/meta>
-…
+		<aside class="example" title="Author name expressed in English and Japanese">
+			<pre>&lt;metadata …>
+   …
+   &lt;dc:creator id="creator">
+      Haruki Murakami
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator"
+       property="alternate-script"
+       xml:lang="ja">
+      村上 春樹
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -200,13 +206,19 @@
 				</tr>
 			</tbody>
 		</table>
-		<aside class="example">
-			<p>The following example shows a BISAC subject heading.</p>
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-…
-&lt;dc:subject id="subject01"&gt;FICTION / Occult &amp;amp; Supernatural&lt;/dc:subject&gt;
-&lt;meta refines="#subject01" property="authority">BISAC&lt;/meta>
-…
+		<aside class="example" title="Expressing A BISAC subject heading">
+			<pre>&lt;metadata …>
+   …
+   &lt;dc:subject
+      id="subject01"&gt;
+     FICTION / Occult &amp;amp; Supernatural
+   &lt;/dc:subject&gt;
+   &lt;meta
+       refines="#subject01"
+       property="authority">
+      BISAC
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -258,13 +270,21 @@
 				</tr>
 			</tbody>
 		</table>
-		<aside class="example">
-			<p>The following example shows that the publication belongs to the Harry Potter set of books.</p>
+		<aside class="example" title="Indicating a publication belongs to a set">
+			<p>In this example, the publication belongs to the Harry Potter set of books.</p>
 			<pre>&lt;metadata&gt;
-…
-&lt;meta property="belongs-to-collection" id="c02"&gt;Harry Potter&lt;/meta&gt;
-&lt;meta refines="#c02" property="collection-type"&gt;set&lt;/meta&gt;
-…
+   …
+   &lt;meta
+       property="belongs-to-collection"
+       id="c02"&gt;
+      Harry Potter
+   &lt;/meta&gt;
+   &lt;meta
+       refines="#c02"
+       property="collection-type"&gt;
+      set
+   &lt;/meta&gt;
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -328,16 +348,22 @@
 				</tr>
 			</tbody>
 		</table>
-		<aside class="example">
-			<p>The following examples shows that a publication belongs to the series The New French Cuisine
+		<aside class="example" title="Identifying a publication belongs to a series">
+			<p>In this example, the publication belongs to the series The New French Cuisine
 				Masters.</p>
-			<pre>&lt;metadata>
-…
-&lt;meta property="belongs-to-collection" id="c01"&gt;
-The New French Cuisine Masters
-&lt;/meta&gt;
-&lt;meta refines="#c01" property="collection-type"&gt;series&lt;/meta&gt;
-…
+			<pre>&lt;metadata …>
+   …
+   &lt;meta
+       property="belongs-to-collection"
+       id="c01"&gt;
+      The New French Cuisine Masters
+   &lt;/meta&gt;
+   &lt;meta
+       refines="#c01"
+       property="collection-type"&gt;
+      series
+   &lt;/meta&gt;
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -413,12 +439,20 @@ The New French Cuisine Masters
 				</tr>
 			</tbody>
 		</table>
-		<aside class="example">
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-…
-&lt;dc:creator id="creator01">Lewis Carroll&lt;/dc:creator>
-&lt;meta refines="#creator01" property="file-as">Carroll, Lewis&lt;/meta>
-…
+		
+		<aside class="example" title="Expressing an author name for sorting">
+			<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator01">
+      Lewis Carroll
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator01"
+       property="file-as">
+      Carroll, Lewis
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -462,28 +496,48 @@ The New French Cuisine Masters
 				</tr>
 			</tbody>
 		</table>
-		<aside class="example">
-			<p>The following examples shows that a publication is second in the Lord of the Rings set of
+		<aside class="example" title="Identifying a publication's position in a set">
+			<p>In this example, the publication is the second in the Lord of the Rings set of
 				books.</p>
-			<pre>&lt;metadata>
-…
-&lt;meta property="belongs-to-collection" id="c01"&gt;
-The Lord of the Rings
-&lt;/meta&gt;
-&lt;meta refines="#c01" property="collection-type"&gt;set&lt;/meta&gt;
-&lt;meta refines="#c01" property="group-position"&gt;2&lt;/meta&gt;
-…
+			<pre>&lt;metadata …>
+   …
+   &lt;meta property="belongs-to-collection" id="c01"&gt;
+      The Lord of the Rings
+   &lt;/meta&gt;
+   &lt;meta
+       refines="#c01"
+       property="collection-type"&gt;
+      set
+   &lt;/meta&gt;
+   &lt;meta
+       refines="#c01"
+       property="group-position"&gt;
+      2
+   &lt;/meta&gt;
+   …
 &lt;/metadata></pre>
 		</aside>
-		<aside class="example">
-			<p>The following example uses a decimal-separated value for <code>group-position</code>, in this
-				case volume 98, issue 4 of a periodical.</p>
-			<pre>&lt;metadata&gt;
-…
-&lt;meta property="belongs-to-collection" id="cygnus-x-1">Physical Review D&lt;/meta>
-&lt;meta refines="#cygnus-x-1" property="collection-type">series&lt;/meta>
-&lt;meta refines="#cygnus-x-1" property="group-position">98.4&lt;/meta>
-…
+		<aside class="example" title="Expressing a decimal-separated value for position">
+			<p>In this example, the decimal-separated value in the <code>group-position</code> attribute indicates this
+				publication is volume 98, issue 4 of a periodical.</p>
+			<pre>&lt;metadata …&gt;
+   …
+   &lt;meta
+       property="belongs-to-collection"
+       id="cygnus-x-1">
+      Physical Review D
+   &lt;/meta>
+   &lt;meta
+       refines="#cygnus-x-1"
+       property="collection-type">
+      series
+   &lt;/meta>
+   &lt;meta
+       refines="#cygnus-x-1"
+       property="group-position">
+      98.4
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -528,14 +582,21 @@ The Lord of the Rings
 				</tr>
 			</tbody>
 		</table>
-		<aside class="example">
-			<p>The following example shows how to indicate that an identifier is an ISBN using the ONIX code
-				list 5 numeric value.</p>
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-…
-&lt;dc:identifier id="isbn-id">urn:isbn:9780101010101&lt;/dc:identifier>
-&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
-…
+		<aside class="example" title="Indicating an identifier is an ISBN">
+			<p>In this example, the ONIX code list 5 scheme defines the meaning of the numeric value <code>15</code>.</p>
+			<pre>&lt;metadata …>
+   …
+   &lt;dc:identifier
+       id="isbn-id">
+      urn:isbn:9780101010101
+   &lt;/dc:identifier>
+   &lt;meta
+      refines="#isbn-id"
+      property="identifier-type"
+      scheme="onix:codelist5">
+     15
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -592,27 +653,56 @@ The Lord of the Rings
 				</tr>
 			</tbody>
 		</table>
-		<aside class="example">
-			<p>The following example uses the MARC Relators vocabulary to differentiate the author from the
+		<aside class="example" title="Differentiating creator roles">
+			<p>In this example, MARC Relators vocabulary values differentiate the author from the
 				illustrator of a work.</p>
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-…
-&lt;dc:creator id="creator01">Lewis Carroll&lt;/dc:creator>
-&lt;meta refines="#creator01" property="role" scheme="marc:relators">aut&lt;/meta>
+			<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+      id="creator01">
+     Lewis Carroll
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator01"
+       property="role"
+       scheme="marc:relators">
+      aut
+   &lt;/meta>
 
-&lt;dc:creator id="creator02">John Tenniel&lt;/dc:creator>
-&lt;meta refines="#creator02" property="role" scheme="marc:relators">ill&lt;/meta>
-…
+   &lt;dc:creator
+       id="creator02">
+      John Tenniel
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator02"
+       property="role"
+       scheme="marc:relators">
+      ill
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
-		<aside class="example">
-			<p>The following example shows that an individual was both the author and illustrator of a work.</p>
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-…
-&lt;dc:creator id="creator01">Maurice Sendak&lt;/dc:creator>
-&lt;meta refines="#creator01" property="role" scheme="marc:relators">aut&lt;/meta>
-&lt;meta refines="#creator01" property="role" scheme="marc:relators">ill&lt;/meta>
-…
+		<aside class="example" title="Identifying a creator has multiple roles">
+			<p>In this example, the creator is both the author and illustrator of the work.</p>
+			<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator01">
+      Maurice Sendak
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator01"
+       property="role"
+       scheme="marc:relators">
+      aut
+   &lt;/meta>
+   &lt;meta
+       refines="#creator01"
+       property="role"
+       scheme="marc:relators">
+      ill
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -659,19 +749,37 @@ The Lord of the Rings
 				</tr>
 			</tbody>
 		</table>
-		<p class="note"> See [[EPUB-A11Y-TECH-11]] for information on how to provide accessible page navigation. </p>
-		<aside class="example">
-			<p>The following example shows the ISBN identifier for an EPUB Publication together with the source
-				ISBN identifier for the print work it was derived from.</p>
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-…
-&lt;dc:identifier id="isbn-id">urn:isbn:9780101010101&lt;/dc:identifier>
-&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
+		<p class="note">See [[EPUB-A11Y-TECH-11]] for information on how to provide accessible page navigation.</p>
+		<aside class="example" title="Identifying the print pagination source of a publication">
+			<pre>&lt;metadata …>
+   …
+   &lt;dc:identifier
+       id="isbn-id">
+      urn:isbn:9780101010101
+   &lt;/dc:identifier>
+   &lt;meta
+       refines="#isbn-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      15
+   &lt;/meta>
 
-&lt;dc:source id="src-id">urn:isbn:9780375704024&lt;/dc:source>
-&lt;meta refines="#src-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
-&lt;meta refines="#src-id" property="source-of">pagination&lt;/meta>
-…
+   &lt;dc:source
+       id="src-id">
+      urn:isbn:9780375704024
+   &lt;/dc:source>
+   &lt;meta
+       refines="#src-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      15
+   &lt;/meta>
+   &lt;meta
+       refines="#src-id"
+       property="source-of">
+      pagination
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -713,14 +821,25 @@ The Lord of the Rings
 				</tr>
 			</tbody>
 		</table>
-		<aside class="example">
+		<aside class="example" title="Expressing a BISAC code for a subject heading">
 			<p>The following example shows a BISAC code for a subject heading.</p>
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-…
-&lt;dc:subject id="subject01"&gt;FICTION / Occult &amp;amp; Supernatural&lt;/dc:subject&gt;
-&lt;meta refines="#subject01" property="authority">BISAC&lt;/meta>
-&lt;meta refines="#subject01" property="term">FIC024000&lt;/meta>
-…
+			<pre>&lt;metadata …>
+   …
+   &lt;dc:subject
+       id="subject01"&gt;
+      FICTION / Occult &amp;amp; Supernatural
+   &lt;/dc:subject&gt;
+   &lt;meta
+       refines="#subject01"
+       property="authority">
+      BISAC
+   &lt;/meta>
+   &lt;meta
+       refines="#subject01"
+       property="term">
+      FIC024000
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -770,77 +889,185 @@ The Lord of the Rings
 				</tr>
 			</tbody>
 		</table>
-		<aside class="example">
-			<p>The following example shows how to identify different title types.</p>
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-…
-&lt;dc:title id="t1">A Dictionary of Modern English Usage&lt;/dc:title>
-&lt;meta refines="#t1" property="title-type">main&lt;/meta>
+		<aside class="example" title="Expressing different title types">
+			<pre>&lt;metadata …>
+   …
+   &lt;dc:title id="t1">
+      A Dictionary of Modern English Usage
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t1"
+       property="title-type">
+      main
+   &lt;/meta>
 
-&lt;dc:title id="t2">First Edition&lt;/dc:title>
-&lt;meta refines="#t2" property="title-type">edition&lt;/meta>
+   &lt;dc:title id="t2">
+      First Edition
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t2"
+       property="title-type">
+      edition
+   &lt;/meta>
 
-&lt;dc:title id="t3">Fowler's&lt;/dc:title>
-&lt;meta refines="#t3" property="title-type">short&lt;/meta>
-…
+   &lt;dc:title id="t3">
+      Fowler's
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t3"
+       property="title-type">
+      short
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
-		<aside class="example">
-			<p id="cookbook-ex">The following example shows how the complex title "The Great Cookbooks of the
+		<aside class="example" title="Expressing complex titles">
+			<p id="cookbook-ex">This example shows how to classify the title "The Great Cookbooks of the
 				World: Mon premier guide de cuisson, un Mémoire. The New French Cuisine Masters, Volume Two.
-				Special Anniversary Edition" could be classified.</p>
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-&lt;dc:title id="t1" xml:lang="fr">Mon premier guide de cuisson, un Mémoire&lt;/dc:title>
-&lt;meta refines="#t1" property="title-type">main&lt;/meta>
-&lt;meta refines="#t1" property="display-seq">2&lt;/meta>
+				Special Anniversary Edition".</p>
+			<pre>&lt;metadata …>
+   &lt;dc:title
+       id="t1"
+       xml:lang="fr">
+      Mon premier guide de cuisson, un Mémoire
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t1"
+       property="title-type">
+      main
+   &lt;/meta>
+   &lt;meta
+       refines="#t1"
+       property="display-seq">
+      2
+   &lt;/meta>
 
-&lt;dc:title id="t2">The Great Cookbooks of the World&lt;/dc:title>
-&lt;meta refines="#t2" property="title-type">collection&lt;/meta>
-&lt;meta refines="#t2" property="display-seq">1&lt;/meta>
+   &lt;dc:title id="t2">
+      The Great Cookbooks of the World
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t2"
+       property="title-type">
+      collection
+   &lt;/meta>
+   &lt;meta
+       refines="#t2"
+       property="display-seq">
+      1
+   &lt;/meta>
 
-&lt;dc:title id="t3">The New French Cuisine Masters&lt;/dc:title>
-&lt;meta refines="#t3" property="title-type">collection&lt;/meta>
-&lt;meta refines="#t3" property="display-seq">3&lt;/meta>
+   &lt;dc:title id="t3">
+      The New French Cuisine Masters
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t3"
+       property="title-type">
+      collection
+   &lt;/meta>
+   &lt;meta
+       refines="#t3"
+       property="display-seq">
+      3
+   &lt;/meta>
 
-&lt;dc:title id="t4">Special Anniversary Edition&lt;/dc:title>
-&lt;meta refines="#t4" property="title-type">edition&lt;/meta>
-&lt;meta refines="#t4" property="display-seq">4&lt;/meta>
+   &lt;dc:title id="t4">
+      Special Anniversary Edition
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t4"
+       property="title-type">
+      edition
+   &lt;/meta>
+   &lt;meta
+       refines="#t4"
+       property="display-seq">
+      4
+   &lt;/meta>
 
-&lt;dc:title id="t5">The Great Cookbooks of the World: 
-Mon premier guide de cuisson, un Mémoire. 
-The New French Cuisine Masters, Volume Two. 
-Special Anniversary Edition&lt;/dc:title>
-&lt;meta refines="#t5" property="title-type">expanded&lt;/meta>
-…
+   &lt;dc:title id="t5">
+      The Great Cookbooks of the World: 
+      Mon premier guide de cuisson, un Mémoire. 
+      The New French Cuisine Masters, Volume Two. 
+      Special Anniversary Edition
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t5"
+       property="title-type">
+      expanded
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
 	<section id="sec-property-examples">
 		<h5>Examples</h5>
-		<aside class="example">
-			<p>The following example represents a typical set of refined metadata an <a>EPUB Publication</a>
-				might contain.</p>
-			<pre>&lt;metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+		<aside class="example" title="A typical set of refines metadata in an EPUB Publication">
+			<pre>&lt;metadata …>
 
-&lt;dc:identifier id="pub-id">urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809&lt;/dc:identifier>
+   &lt;dc:identifier id="pub-id">
+      urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
+   &lt;/dc:identifier>
 
-&lt;dc:identifier id="isbn-id">urn:isbn:9780101010101&lt;/dc:identifier>
-&lt;meta refines="#isbn-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
+   &lt;dc:identifier id="isbn-id">
+      urn:isbn:9780101010101
+   &lt;/dc:identifier>
+   &lt;meta
+       refines="#isbn-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      15
+   &lt;/meta>
 
-&lt;dc:source id="src-id">urn:isbn:9780375704024&lt;/dc:source>
-&lt;meta refines="#src-id" property="identifier-type" scheme="onix:codelist5">15&lt;/meta>
+   &lt;dc:source id="src-id">
+      urn:isbn:9780375704024
+   &lt;/dc:source>
+   &lt;meta
+       refines="#src-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      15
+   &lt;/meta>
 
-&lt;dc:title id="title">Norwegian Wood&lt;/dc:title>
-&lt;meta refines="#title" property="title-type">main&lt;/meta>
+   &lt;dc:title id="title">
+      Norwegian Wood
+   &lt;/dc:title>
+   &lt;meta
+       refines="#title"
+       property="title-type">
+      main
+   &lt;/meta>
 
-&lt;dc:language>en&lt;/dc:language>
+   &lt;dc:language>
+      en
+   &lt;/dc:language>
 
-&lt;dc:creator id="creator">Haruki Murakami&lt;/dc:creator>
-&lt;meta refines="#creator" property="role" scheme="marc:relators" id="role">aut&lt;/meta>
-&lt;meta refines="#creator" property="alternate-script" xml:lang="ja">村上 春樹&lt;/meta>
-&lt;meta refines="#creator" property="file-as">Murakami, Haruki&lt;/meta>
+   &lt;dc:creator
+       id="creator">
+      Haruki Murakami
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator"
+       property="role"
+       scheme="marc:relators"
+       id="role">
+      aut
+   &lt;/meta>
+   &lt;meta
+       refines="#creator"
+       property="alternate-script"
+       xml:lang="ja">
+      村上 春樹
+   &lt;/meta>
+   &lt;meta
+       refines="#creator"
+       property="file-as">
+      Murakami, Haruki
+   &lt;/meta>
 
-&lt;meta property="dcterms:modified">2011-01-01T12:00:00Z&lt;/meta>
+   &lt;meta
+       property="dcterms:modified">
+      2011-01-01T12:00:00Z
+   &lt;/meta>
 
 &lt;/metadata></pre>
 		</aside>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -166,17 +166,29 @@
 				
 				<p>Only one of these overrides is allowed on any given spine item.</p>
 
-				<aside class="example" id="property-flow-ex1">
-					<p>The following example demonstrates an EPUB Creator's intent to have a paginated EPUB Publication
+				<aside class="example" id="property-flow-ex1" title="Overriding a global paginated flow declaration">
+					<p>In this example, the EPUB Creator's intent is to have a paginated EPUB Publication
 						with a scrollable table of contents.</p>
-					<pre>&lt;metadata&gt;
-    &lt;meta property="rendition:flow"&gt;paginated&lt;/meta&gt;
-&lt;/metadata&gt;
+					<pre>&lt;package …>
+   &lt;metadata …&gt;
+      …
+      &lt;meta
+          property="rendition:flow"&gt;
+         paginated
+      &lt;/meta&gt;
+      …
+   &lt;/metadata&gt;
 
-&lt;spine&gt;
-    &lt;itemref idref="toc" properties="rendition:flow-scrolled-doc"/&gt;
-    &lt;itemref idref="c01"/&gt;
-&lt;/spine&gt;</pre>
+   …
+
+   &lt;spine&gt;
+      &lt;itemref
+          idref="toc"
+          properties="rendition:flow-scrolled-doc"/&gt;
+      &lt;itemref
+          idref="c01"/&gt;
+   &lt;/spine&gt;
+&lt;/package></pre>
 				</aside>
 			</section>
 		</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -202,8 +202,8 @@
 		<section id="sec-pub-resources">
 			<h3>Publication Resource Processing</h3>
 
-			<p id="confreq-rs-epub-pub-res" class="support" data-tests="#cnt-xhtml-support">Reading Systems MUST process <a
-					href="https://www.w3.org/TR/epub-33/#sec-publication-resources">Publication Resources</a>
+			<p id="confreq-rs-epub-pub-res" class="support" data-tests="#cnt-xhtml-support">Reading Systems MUST process
+					<a href="https://www.w3.org/TR/epub-33/#sec-publication-resources">Publication Resources</a>
 				[[EPUB-33]].</p>
 
 			<section id="sec-epub-rs-conf-foreign-res">
@@ -326,8 +326,8 @@
 		<section id="sec-package-doc">
 			<h2>Package Document Processing</h2>
 
-			<p id="confreq-rs-epub-pub" class="support" data-tests="#pkg-manifest-url">Reading Systems MUST process the <a
-					href="https://www.w3.org/TR/epub-33/#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
+			<p id="confreq-rs-epub-pub" class="support" data-tests="#pkg-manifest-url">Reading Systems MUST process the
+					<a href="https://www.w3.org/TR/epub-33/#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
 
 			<section id="sec-pkg-doc-base-dir">
 				<h4>Base Direction</h4>
@@ -433,10 +433,10 @@
 							resource, a Reading System must only use the language information associated with the
 							resource to determine its language, not the metadata included in the link to the resource. </p>
 						<p id="sec-linked-records" data-tests="#pkg-linked-records"> In the case of a <a
-							href="https://www.w3.org/TR/epub-33/#record">linked metadata record</a> [[EPUB-33]], Reading
-							Systems MUST NOT skip processing the metadata expressed in the Package Document and only use the
-							information expressed in the record. Reading Systems MAY compile metadata from multiple linked
-							records.</p>
+								href="https://www.w3.org/TR/epub-33/#record">linked metadata record</a> [[EPUB-33]],
+							Reading Systems MUST NOT skip processing the metadata expressed in the Package Document and
+							only use the information expressed in the record. Reading Systems MAY compile metadata from
+							multiple linked records.</p>
 						<p>When it comes to resolving discrepancies and conflicts between metadata expressed in the
 							Package Document and in linked metadata records, Reading Systems MUST use the document order
 							of <code>link</code> elements in the Package Document to establish precedence (i.e.,
@@ -540,15 +540,15 @@
 
 				<p>
 					<span id="confreq-rs-pkg-duplicate-item-rendering" data-tests="#pkg-spine-duplicate-item-rendering">
-						Reading Systems MUST NOT skip spine references to duplicate manifest items when rendering the linear
-						reading order.</span>
-					<span id="confreq-rs-pkg-duplicate-item-ui" data-tests="#pkg-spine-duplicate-item-ui">The Reading System
-						MUST treat these as distinct items for UI purposes (for example, each occurrence could be
+						Reading Systems MUST NOT skip spine references to duplicate manifest items when rendering the
+						linear reading order.</span>
+					<span id="confreq-rs-pkg-duplicate-item-ui" data-tests="#pkg-spine-duplicate-item-ui">The Reading
+						System MUST treat these as distinct items for UI purposes (for example, each occurrence could be
 						independently bookmarked or annotated).</span>
-					<span id="confreq-rs-pkg-duplicate-item-hyperlink" data-tests="#pkg-spine-duplicate-item-hyperlink">When
-						a Reading System follows a hyperlink to a resource referenced multiple times in the spine, the
-						Reading System MUST move to the position of the first occurrence of the document in the linear
-						reading order.</span>
+					<span id="confreq-rs-pkg-duplicate-item-hyperlink" data-tests="#pkg-spine-duplicate-item-hyperlink"
+						>When a Reading System follows a hyperlink to a resource referenced multiple times in the spine,
+						the Reading System MUST move to the position of the first occurrence of the document in the
+						linear reading order.</span>
 				</p>
 			</section>
 
@@ -1146,8 +1146,8 @@
 		<section id="sec-ocf">
 			<h2>Open Container Format Processing</h2>
 
-			<p id="confreq-rs-epub3-ocf" class="support" data-tests="#ocf-package_arbitrary">Reading Systems MUST process the
-				<a href="https://www.w3.org/TR/epub-33/#sec-ocf">EPUB Container</a> [[EPUB-33]].</p>
+			<p id="confreq-rs-epub3-ocf" class="support" data-tests="#ocf-package_arbitrary">Reading Systems MUST
+				process the <a href="https://www.w3.org/TR/epub-33/#sec-ocf">EPUB Container</a> [[EPUB-33]].</p>
 
 			<div class="note">
 				<p>An application that processes OCF Containers does not have to be a full-fledged Reading System (e.g.,
@@ -1162,32 +1162,37 @@
 				<section id="sec-container-iri">
 					<h4>URL of the Root Directory</h4>
 
-					<p>Reading Systems MUST assign a URL [[URL]] to the <a>Root Directory</a> of the <a>OCF Abstract Container</a>. This URL is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a>. It is implementation specific, but the implementation MUST have the following properties:</p>
+					<p>Reading Systems MUST assign a URL [[URL]] to the <a>Root Directory</a> of the <a>OCF Abstract
+							Container</a>. This URL is called the <a data-cite="epub-33#dfn-container-root-url"
+							>container root URL</a>. It is implementation specific, but the implementation MUST have the
+						following properties:</p>
 
 					<ul>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>/</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
-						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>..</code>" with the <a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root URL</a>.</li>
-						<li>The <a href="https://url.spec.whatwg.org/#origin">origin</a> of the <a>container root URL</a> is unique for each EPUB Publication instance.</li>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>/</code>"
+							with the <a>container root URL</a> as <a data-cite="url#concept-base-url"
+								><var>base</var></a> is the <a>container root URL</a>.</li>
+						<li>The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>..</code>"
+							with the <a>container root URL</a> as <a data-cite="url#concept-base-url"
+								><var>base</var></a> is the <a>container root URL</a>.</li>
+						<li>The <a href="https://url.spec.whatwg.org/#origin">origin</a> of the <a>container root
+								URL</a> is unique for each EPUB Publication instance.</li>
 					</ul>
 
-					<p class="note">The unicity of the <a href="https://url.spec.whatwg.org/#origin">origin</a> per EPUB Publication
-						instance means that if two different users acquire a copy of the same EPUB Publication, the
-						origins will be different for the two users on those copies even if the same Reading System is
-						used.</p>
+					<p class="note">The unicity of the <a href="https://url.spec.whatwg.org/#origin">origin</a> per EPUB
+						Publication instance means that if two different users acquire a copy of the same EPUB
+						Publication, the origins will be different for the two users on those copies even if the same
+						Reading System is used.</p>
 
 					<div class="note">
-						<p>The required properties of the container root URL are such that it behaves similarly to a URL defined as follows:</p>
+						<p>The required properties of the container root URL are such that it behaves similarly to a URL
+							defined as follows:</p>
 
 						<table class="zebra">
 							<thead>
 								<tr>
-									<td style="font-weight: bold; text-align: center;">
-										URL component
-									</td>
-									<td style="font-weight: bold; text-align: center;">
-										Values
-									</td>
-								</tr>	
+									<td style="font-weight: bold; text-align: center;"> URL component </td>
+									<td style="font-weight: bold; text-align: center;"> Values </td>
+								</tr>
 							</thead>
 							<tbody>
 								<tr>
@@ -1201,7 +1206,7 @@
 								<tr>
 									<td>port</td>
 									<td>a dynamic port uniquely assigned to the EPUB instance</td>
-								</tr>	
+								</tr>
 							</tbody>
 						</table>
 
@@ -1217,9 +1222,7 @@
 							</thead>
 							<tbody>
 								<tr>
-									<td>
-										Root Directory
-									</td>
+									<td> Root Directory </td>
 									<td>
 										<var>empty string</var>
 									</td>
@@ -1228,9 +1231,7 @@
 									</td>
 								</tr>
 								<tr>
-									<td>
-										Package Document
-									</td>
+									<td> Package Document </td>
 									<td>
 										<code>OPS/package.opf</code>
 									</td>
@@ -1239,9 +1240,7 @@
 									</td>
 								</tr>
 								<tr>
-									<td>
-										Content Document
-									</td>
+									<td> Content Document </td>
 									<td>
 										<code>HTML/file name.xhtml</code>
 									</td>
@@ -1259,30 +1258,28 @@
 							for content in that particular language.</p>
 					</div>
 
-					<p class="note">Unlike most language specifications, Reading Systems must use the 
-						<a>container root URL</a> as the <a href="https://url.spec.whatwg.org/#concept-base-url">base
-							URL</a> [[URL]] for all files within the <code>META-INF</code> directory.
-							See also the section on <a href="https://www.w3.org/TR/epub-33/#sec-parsing-urls-metainf">Parsing URLs in the <code>META-INF</code> Directory</a> in [[!EPUB-33]].
-					</p>
+					<p class="note">Unlike most language specifications, Reading Systems must use the <a>container root
+							URL</a> as the <a href="https://url.spec.whatwg.org/#concept-base-url">base URL</a> [[URL]]
+						for all files within the <code>META-INF</code> directory. See also the section on <a
+							href="https://www.w3.org/TR/epub-33/#sec-parsing-urls-metainf">Parsing URLs in the
+								<code>META-INF</code> Directory</a> in [[!EPUB-33]]. </p>
 
-					<p class="ednote">
-						We may have to say a few words on what exactly an "EPUB Publication instance" mean.
-					</p>
+					<p class="ednote"> We may have to say a few words on what exactly an "EPUB Publication instance"
+						mean. </p>
 
 					<div class="ednote">
 						<p>The previous version contained this note:</p>
 
-						<p class="note">
-							This specification does not mandate any particular implementation technique for the creation of
-							a unique <a href="https://url.spec.whatwg.org/#origin">origin</a> in the absence of a reliable
-							Web origin (e.g., HTTP URL scheme + host + port). The necessary heuristics may include the
-							combination of the Publication's <a href="https://www.w3.org/TR/epub-33/#dfn-unique-identifier"
-								>Unique Identifier</a> (although, in practice, these identifiers may in fact not guarantee
-							globally-unique identification, that is why it is recommended to combine multiple techniques),
-							filesystem path, <a href="https://www.w3.org/TR/epub-33/#dfn-zip-container">OCF Zip
-								Container</a> checksum, etc. 
-						</p>
-	
+						<p class="note"> This specification does not mandate any particular implementation technique for
+							the creation of a unique <a href="https://url.spec.whatwg.org/#origin">origin</a> in the
+							absence of a reliable Web origin (e.g., HTTP URL scheme + host + port). The necessary
+							heuristics may include the combination of the Publication's <a
+								href="https://www.w3.org/TR/epub-33/#dfn-unique-identifier">Unique Identifier</a>
+							(although, in practice, these identifiers may in fact not guarantee globally-unique
+							identification, that is why it is recommended to combine multiple techniques), filesystem
+							path, <a href="https://www.w3.org/TR/epub-33/#dfn-zip-container">OCF Zip Container</a>
+							checksum, etc. </p>
+
 						<p>This note may not be relevant any more...</p>
 					</div>
 
@@ -1299,8 +1296,8 @@
 						to process File Names and Paths that are not valid to these requirements. Invalid File Names and
 						Paths may only be problematic on some operating systems.</p>
 
-					<p>This specification does not specify how a Reading System that is unable to represent OCF File Names and
-						Paths would compensate for this incompatibility.</p>
+					<p>This specification does not specify how a Reading System that is unable to represent OCF File
+						Names and Paths would compensate for this incompatibility.</p>
 
 					<p>If a Reading System cannot preserve the names of files during an unzipping process, it will have
 						to compensate for any name translation that took place in the content (i.e., in any URIs that
@@ -2140,9 +2137,7 @@ partial interface Navigator {
 					version), and provides the <a href="#app-ers-hasFeature"><code>hasFeature</code> method</a> which
 					can be invoked to determine the features it supports.</p>
 
-				<aside class="example">
-					<p>Example JavaScript function that displays the name of the current Reading System.</p>
-
+				<aside class="example" title="JavaScript function to display the name of the current Reading System">
 					<pre>alert("Reading System name: " + navigator.epubReadingSystem.name);</pre>
 				</aside>
 
@@ -2230,10 +2225,8 @@ partial interface Navigator {
 							versionless. If a Reading System supports a feature defined in this specification, it MUST
 							ignore any supplied <code>version</code> parameter and return a <code>true</code> value.</p>
 
-						<aside class="example">
-							<p>Example JavaScript function that displays whether the current Reading System supports
-								scripted manipulation of the DOM.</p>
-
+						<aside class="example"
+							title="JavaScript function to display support for scripted manipulation of the DOM">
 							<pre>var feature = "dom-manipulation";
 
 var conformTest = navigator.epubReadingSystem.hasFeature(feature);
@@ -2329,10 +2322,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 
 			<ul>
 				<li>10-Nov-2021: Proper definition of the Content URL and handling of relative URLs. See <a
-					href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and 
-          <a href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
-				<li>01-Nov-2021: Added a statement on the Reading System behavior when item references are repeated in the 
-					spine. See <a href="https://github.com/w3c/epub-specs/issues/1686">issue 1686</a>.</li>
+						href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and <a
+						href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
+				<li>01-Nov-2021: Added a statement on the Reading System behavior when item references are repeated in
+					the spine. See <a href="https://github.com/w3c/epub-specs/issues/1686">issue 1686</a>.</li>
 				<li> 01-Nov-2021: Added a statement on the Reading System behavior when item references are repeated in
 					the spine. See <a href="https://github.com/w3c/epub-specs/issues/1686">issue 1686</a>. </li>
 				<li>25-Oct-2021: Clarify that reading systems must render non-linear resources when they are hyperlinked


### PR DESCRIPTION
As mentioned in #1926, this PR adds titles for all the examples.

I also reformatted the examples per the a11y horizontal review feedback we got for the accessibility specs (i.e., to break attributes onto separate lines, etc. to meet WCAG's reflow requirement).

The only notable change is probably the pseudo-code for the obfuscation algorithm. This was formatted using pre tags in IDPF, so looks like it got translated to an example when we moved to W3C. I've formatted it to a list, like the infra algorithm.

Fixes #1926


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1930.html" title="Last updated on Nov 23, 2021, 1:30 PM UTC (61d6521)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1930/314625e...61d6521.html" title="Last updated on Nov 23, 2021, 1:30 PM UTC (61d6521)">Diff</a>