### PR TITLE
Removing editor's notes

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1263,9 +1263,6 @@
 						for all files within the <code>META-INF</code> directory. See also the section on <a
 							href="https://www.w3.org/TR/epub-33/#sec-parsing-urls-metainf">Parsing URLs in the
 								<code>META-INF</code> Directory</a> in [[!EPUB-33]]. </p>
-					</div>
-
-
 
 				</section>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1263,24 +1263,6 @@
 						for all files within the <code>META-INF</code> directory. See also the section on <a
 							href="https://www.w3.org/TR/epub-33/#sec-parsing-urls-metainf">Parsing URLs in the
 								<code>META-INF</code> Directory</a> in [[!EPUB-33]]. </p>
-
-					<p class="ednote"> We may have to say a few words on what exactly an "EPUB Publication instance"
-						mean. </p>
-
-					<div class="ednote">
-						<p>The previous version contained this note:</p>
-
-						<p class="note"> This specification does not mandate any particular implementation technique for
-							the creation of a unique <a href="https://url.spec.whatwg.org/#origin">origin</a> in the
-							absence of a reliable Web origin (e.g., HTTP URL scheme + host + port). The necessary
-							heuristics may include the combination of the Publication's <a
-								href="https://www.w3.org/TR/epub-33/#dfn-unique-identifier">Unique Identifier</a>
-							(although, in practice, these identifiers may in fact not guarantee globally-unique
-							identification, that is why it is recommended to combine multiple techniques), filesystem
-							path, <a href="https://www.w3.org/TR/epub-33/#dfn-zip-container">OCF Zip Container</a>
-							checksum, etc. </p>
-
-						<p>This note may not be relevant any more...</p>
 					</div>
 
 


### PR DESCRIPTION
Two editors' notes have been added in #1898. Those two notes have been turned into explicit issues (see #1932 and #1933), and this PR removes those two notes from the spec.