### PR TITLE
Generalize the note about file naming restrictions

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2789,15 +2789,6 @@
 								<p>Failure to provide a complete manifest of resources may lead to rendering issues.
 									Reading Systems might not unzip such resources or could prevent access to them for
 									security reasons.</p>
-
-							</div>
-
-							<div class="note">
-								<p>This specification supports internationalized resource naming, so elements and
-									attributes that reference Publication Resources accept URLs [[URL]] as their value.
-									For compatibility with older Reading Systems that only accept URIs, EPUB Creators
-									should restrict resource names to the ASCII character set.</p>
-
 							</div>
 						</section>
 
@@ -5736,10 +5727,17 @@ No Entry</pre>
 					</div>
 
 					<div class="note">
-						<p>Some commercial ZIP tools do not support the full Unicode range for File Names. <a>EPUB
-								Creators</a> who want to use ZIP tools that have these restrictions may find it best to
-							restrict their File Names to the [[US-ASCII]] range.</p>
-
+						<p>EPUB Creators should use an abundance of caution in their file naming when interoperability
+							of content is key. The <a href="#ocf-fn-chars">list of restricted characters</a> is
+							intended to help avoid some known problem areas, but it does not ensure that all other
+							Unicode characters are supported. Although Unicode support is much better now than in
+							earlier iterations of EPUB, older tools and toolchains may still be encountered (e.g., ZIP
+							tools that only support [[US-ASCII]]).</p>
+						
+						
+						<p>If EPUB Creators need to ensure compatibility with EPUB 2 Reading Systems that
+							only accept URIs [[RFC3986]], they should further consider restricting resource names to
+							the ASCII character set [[US-ASCII]].</p>
 					</div>
 				</section>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -96,9 +96,6 @@
 						"href": "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=13189",
 						"date": "2017-04-13"
 					},
-					"US-ASCII": {
-						"title": "&quot;Coded Character Set - 7-bit American Standard Code for Information Interchange&quot;, ANSI X3.4, 1986."
-					},
 					"W3CProcess": {
 						"title": "W3C Process Document",
 						"href": "https://www.w3.org/Consortium/Process/"


### PR DESCRIPTION
This PR implements the text in #1922.

I've also merged the note mentioned in #1917, since it similarly cautions about file names, and made clear that it only applies when compatibility with EPUB 2 is needed.

I'm easily convinced that we shouldn't be concerned about EPUB 2 compatibility and can throw it out entirely, though.

Fixes #1922 
Fixes #1917 
