### PR TITLE
Remove element restrictions from remote resource locations

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1011,38 +1011,40 @@
 				<section id="sec-resource-locations">
 					<h4>Resource Locations</h4>
 
-					<p>EPUB Creators MUST <a href="#sec-container-iri">locate all Publication Resources in the EPUB
-							Container</a>, with the following exceptions:</p>
+					<p>EPUB Creators MAY host the following types of Publication Resources outside the EPUB
+						Container:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a> referenced
-								from the [[HTML]] <a data-cite="html#the-audio-element"><code>audio</code> element</a>
-								(either from its <code>src</code> attribute or a child <a
-									data-cite="html#the-track-element"><code>track</code> element</a>) and from the
-								Media Overlays <a href="#sec-smil-audio-elem"><code>audio</code> element</a>.</p>
+							<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a>.</p>
 						</li>
 						<li>
-							<p id="sec-resource-locations-video"><a href="#cmt-grp-video">Video resources</a> referenced
-								from the [[HTML]] <a data-cite="html#the-video-element"><code>video</code> element</a>
-								(either from its <code>src</code> attribute or a child <a
-									data-cite="html#the-track-element"><code>track</code> element</a>).</p>
+							<p id="sec-resource-locations-video"><a href="#cmt-grp-video">Video resources</a>.</p>
 						</li>
 						<li>
 							<p id="sec-resource-locations-script">Resources retrieved via scripting APIs (e.g.,
 								XmlHttpRequest [[?XHR]] and Fetch [[?FETCH]]).</p>
 						</li>
 						<li>
-							<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a> referenced
-								from <a data-cite="css-fonts-5#font-face-rule"><code>@font-face</code> rules</a>
-								[[CSS-FONTS-5]], <a data-cite="css-cascade-4#at-import"><code>@import</code> rules</a>
-								[[CSS-CASCADE-4]], and the [[HTML]] <a data-cite="html#the-link-element"
-										><code>link</code> element</a>.</p>
+							<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a>.</p>
 						</li>
 					</ul>
 
-					<p>EPUB Creators should locate these resources inside the EPUB Container whenever feasible to allow
-						users access to the entire presentation regardless of connectivity status.</p>
+					<p>EPUB Creators MUST store all other resources within the EPUB Container.</p>
+
+					<p>These rules for locating Publication Resource apply regardless of whether the given resource is a
+							<a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
+
+					<div class="note">
+						<p>EPUB Creators should store all resources inside the EPUB Container whenever feasible to allow
+							users access to the entire presentation regardless of connectivity status.</p>
+					</div>
+
+					<div class="note">
+						<p>Refer to the <a href="#remote-resources"><code>remote-resources</code> property</a> for more
+							information on how to indicate that a <a>manifest</a>
+							<a href="#sec-item-elem"><code>item</code></a> references a <a>Remote Resource</a>.</p>
+					</div>
 
 					<aside class="example" title="Referencing a local resource">
 						<p>In this example, the audio file referenced from the [[HTML]] <a
@@ -1075,17 +1077,6 @@
    &lt;/body>
 &lt;/html></pre>
 					</aside>
-
-					<div class="note">
-						<p>The rules in this section for Publication Resource locations apply regardless of whether the
-							given resource is a <a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
-					</div>
-
-					<div class="note">
-						<p>The inclusion of Remote Resources is indicated via the <a href="#remote-resources"
-									><code>remote-resources</code> property</a> on the <a>manifest</a>
-							<a href="#sec-item-elem"><code>item</code> element</a>.</p>
-					</div>
 				</section>
 
 				<section id="sec-data-urls">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10443,8 +10443,10 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>03-Dec-2021: Remove the element-based restrictions on remote resources. See <a
+						href="https://github.com/w3c/epub-specs/issues/1913">issue 1913</a>.</li>
 				<li>18-Nov-2021: Change to only disallow deprecated characters in the Tags and Variation Selectors
-					Supplement. See <a href="https://github.com/w3c/epub-specs/issues/1885">issue 1885</a></li>
+					Supplement. See <a href="https://github.com/w3c/epub-specs/issues/1885">issue 1885</a>.</li>
 				<li>12-Nov-2021: Change the recommendation to use SHA-1 to encrypt the obfuscation key to a requirement.
 					See <a href="https://github.com/w3c/epub-specs/issues/1873">issue 1873</a>.</li>
 				<li>12-Nov-2021: Restrict the obfuscation algorithm to fonts and add caution to use better protection

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1032,13 +1032,11 @@
 
 					<p>EPUB Creators MUST store all other resources within the EPUB Container.</p>
 
+					<p>Storing all resources inside the EPUB Container allows users access to the entire presentation
+						regardless of connectivity status so is strongly encouraged whenever possible.</p>
+
 					<p>These rules for locating Publication Resource apply regardless of whether the given resource is a
 							<a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
-
-					<div class="note">
-						<p>EPUB Creators should store all resources inside the EPUB Container whenever feasible to allow
-							users access to the entire presentation regardless of connectivity status.</p>
-					</div>
 
 					<div class="note">
 						<p>Refer to the <a href="#remote-resources"><code>remote-resources</code> property</a> for more


### PR DESCRIPTION
Although there's a security advantage in saying where remote resources can be used, rather than relying solely on media type to allow them (which people periodically try to fake to get through epubcheck), this PR undoes our earlier change because I don't see a simple way to account for custom elements or dynamic writing of content generally.

Trying to be overly-restrictive always has a way of coming back and biting us, too, when some new technique comes along that we haven't accounted for, so this is probably the better long-term option.

I also moved up the notes that were after the examples, as it was a weird place for them (usually we put examples last). I also removed the note formatting from the one that says the rules apply to both CMT and foreign resource types as it is more of a normative statement than an informative one.

Fixes #1913


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1943.html" title="Last updated on Dec 3, 2021, 4:19 PM UTC (f615706)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1943/3afeba7...f615706.html" title="Last updated on Dec 3, 2021, 4:19 PM UTC (f615706)">Diff</a>