### PR TITLE
Add processing requirements for spine overrides

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -545,8 +545,8 @@
 							property</a> [[EPUB-33]], Reading Systems MUST follow the requirements for the override's
 						global value when displaying that spine item.</p>
 
-					<p>For example, a spine item that contains the <a href="def-layout-pre-paginated"
-								><code>layout-prepaginated</code> override</a> [[EPUB-33]] is rendered following the
+					<p>For example, a spine item that contains the <a href="https://www.w3.org/TR/epub-33/#layout-overrides"
+								><code>layout-pre-paginated</code> override</a> [[EPUB-33]] is rendered following the
 						requirements of the global <a href="#def-layout-pre-paginated"><code>pre-paginated</code>
 							value</a>.</p>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -941,6 +941,7 @@
 
 				<section id="layout">
 					<h4>The <code>rendition:layout</code> Property</h4>
+
 					<p> The default value <code>reflowable</code> MUST be assumed by EPUB Reading Systems as the global
 						value if no meta element carrying this property occurs in the <a
 							data-cite="epub-33#elemdef-opf-metadata"><code>metadata</code> section</a> section
@@ -965,6 +966,15 @@
 								rendering.</p>
 						</dd>
 					</dl>
+
+					<p>When one of the <a href="https://www.w3.org/TR/epub-33/#layout-overrides"
+								><code>rendition:layout</code> overrides</a> [[EPUB-33]] is specified in the
+							<code>properties</code> attribute on a spine <code>itemref</code> element, Reading Systems
+						MUST apply the same rendering logic to the referenced resource.</p>
+
+					<p>If more than one <code>rendition:layout</code> override is specified in the
+							<code>properties</code> attribute, Reading Systems MUST only process the first value listed
+						in the attribute.</p>
 				</section>
 
 				<section id="orientation">
@@ -976,6 +986,15 @@
 					<p>Reading Systems that support multiple orientations SHOULD convey the intended orientation to the
 						user unless the given value is <code>auto</code>. The means by which they convey the intent is
 						implementation specific.</p>
+
+					<p>When one of the <a href="https://www.w3.org/TR/epub-33/#orientation-overrides"
+								><code>rendition:orientation</code> overrides</a> [[EPUB-33]] is specified in the
+							<code>properties</code> attribute on a spine <code>itemref</code> element, Reading Systems
+						MUST apply the same rendering logic to the referenced resource.</p>
+
+					<p>If more than one <code>rendition:orientation</code> override is specified in the
+							<code>properties</code> attribute, Reading Systems MUST only process the first value listed
+						in the attribute.</p>
 				</section>
 
 				<section id="spread">
@@ -1011,6 +1030,15 @@
 								of a <a>Content Display Area</a> utilization optimization process.</p>
 						</dd>
 					</dl>
+
+					<p>When one of the <a href="https://www.w3.org/TR/epub-33/#spread-overrides"
+								><code>rendition:spread</code> overrides</a> [[EPUB-33]] is specified in the
+							<code>properties</code> attribute on a spine <code>itemref</code> element, Reading Systems
+						MUST apply the same rendering logic to the referenced resource.</p>
+
+					<p>If more than one <code>rendition:spread</code> override is specified in the
+							<code>properties</code> attribute, Reading Systems MUST only process the first override
+						listed in the attribute.</p>
 				</section>
 
 				<section id="page-spread">
@@ -1757,11 +1785,6 @@
 					occurs in the <a data-cite="epub-33#elemdef-opf-metadata"><code>metadata</code> section</a>
 					[[EPUB-33]]. Reading Systems MAY support only this default value.</p>
 
-				<p>If a Reading Systems supports the <a href="#layout"><code>rendition:layout</code></a> property, it
-					MUST ignore the <code>rendition:flow</code> property when it has been set on a spine item that also
-					specifies the <a href="#layout"><code>rendition:layout</code></a> value
-					<code>pre-paginated</code>.</p>
-
 				<p>The <code>rendition:flow</code> property values have the following processing requirements:</p>
 
 				<dl class="variablelist">
@@ -1794,6 +1817,18 @@
 					[[EPUB-33]]. The scroll direction MUST be vertical if the block flow direction is downward
 					(top-to-bottom). It MUST be horizontal if the block flow direction of the root element is rightward
 					(left-to-right) or leftward (right-to-left).</p>
+
+				<p>When one of the <a href="https://www.w3.org/TR/epub-33/#layout-property-flow-overrides"
+							><code>rendition:flow</code> overrides</a> [[EPUB-33]] is specified in the
+						<code>properties</code> attribute on a spine <code>itemref</code> element, Reading Systems MUST
+					apply the same rendering logic to the referenced resource.</p>
+
+				<p>If more than one <code>rendition:layout</code> override is specified in the <code>properties</code>
+					attribute, Reading Systems MUST only process the first value listed in the attribute.</p>
+
+				<p>Reading Systems MUST ignore the <code>rendition:flow</code> property and its overrides when
+					processing <a href="https://www.w3.org/TR/epub-33/#def-layout-pre-paginated">pre-paginated spine
+						items</a> [[EPUB-33]].</p>
 			</section>
 
 			<section id="align-x-center">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -536,6 +536,23 @@
 						the Reading System MUST move to the position of the first occurrence of the document in the
 						linear reading order.</span>
 				</p>
+
+				<section id="spine-overrides">
+					<h4>Spine Overrides</h4>
+
+					<p>When a spine <code>itemref</code> element's <code>properties</code> attribute contains an
+						override of a <a href="https://www.w3.org/TR/epub-33/#app-rendering-vocab">global rendering
+							property</a> [[EPUB-33]], Reading Systems MUST follow the requirements for the override's
+						global value when displaying that spine item.</p>
+
+					<p>For example, a spine item that contains the <a href="def-layout-pre-paginated"
+								><code>layout-prepaginated</code> override</a> [[EPUB-33]] is rendered following the
+						requirements of the global <a href="#def-layout-pre-paginated"><code>pre-paginated</code>
+							value</a>.</p>
+
+					<p>If more than one override for the same property is specified in a <code>properties</code>
+						attribute, Reading Systems MUST only process the first value listed in the attribute.</p>
+				</section>
 			</section>
 
 			<section id="sec-pkg-doc-collections">
@@ -967,14 +984,12 @@
 						</dd>
 					</dl>
 
-					<p>When one of the <a href="https://www.w3.org/TR/epub-33/#layout-overrides"
-								><code>rendition:layout</code> overrides</a> [[EPUB-33]] is specified in the
-							<code>properties</code> attribute on a spine <code>itemref</code> element, Reading Systems
-						MUST apply the same rendering logic to the referenced resource.</p>
-
-					<p>If more than one <code>rendition:layout</code> override is specified in the
-							<code>properties</code> attribute, Reading Systems MUST only process the first value listed
-						in the attribute.</p>
+					<p>When a spine <code>itemref</code> element's <code>properties</code> attribute contains an <a
+							href="https://www.w3.org/TR/epub-33/#layout-overrides">override of the global
+							rendition:layout property</a> [[EPUB-33]], Reading Systems MUST follow the requirements for
+						the override's global value when displaying that spine item (e.g., a spine item that specifies
+							<code>layout-prepaginated</code> is rendered following the requirements of the global
+							<code>pre-paginated</code> value).</p>
 				</section>
 
 				<section id="orientation">
@@ -983,18 +998,29 @@
 					<p>The default global value is <code>auto</code> if no <code>meta</code> element carrying this
 						property occurs in the <code>metadata</code> section.</p>
 
-					<p>Reading Systems that support multiple orientations SHOULD convey the intended orientation to the
-						user unless the given value is <code>auto</code>. The means by which they convey the intent is
-						implementation specific.</p>
+					<p>The <code>rendition:layout</code> property values have the following processing requirements:</p>
 
-					<p>When one of the <a href="https://www.w3.org/TR/epub-33/#orientation-overrides"
-								><code>rendition:orientation</code> overrides</a> [[EPUB-33]] is specified in the
-							<code>properties</code> attribute on a spine <code>itemref</code> element, Reading Systems
-						MUST apply the same rendering logic to the referenced resource.</p>
+					<dl class="variablelist">
+						<dt id="def-orientation-auto">auto</dt>
+						<dd>
+							<p>The Reading System determines the orientation in which to render the content.</p>
+						</dd>
 
-					<p>If more than one <code>rendition:orientation</code> override is specified in the
-							<code>properties</code> attribute, Reading Systems MUST only process the first value listed
-						in the attribute.</p>
+						<dt id="def-orientation-landscape">landscape</dt>
+						<dd>
+							<p>Reading Systems that support multiple orientations SHOULD render the content in lanscape
+								orientation.</p>
+						</dd>
+
+						<dt id="def-orientation-portrait">portrait</dt>
+						<dd>
+							<p>Reading Systems that support multiple orientations SHOULD render the content in portrait
+								orientation.</p>
+						</dd>
+					</dl>
+
+					<p>The means by which Reading Systems convey the EPUB Creator's intent is implementation
+						specific.</p>
 				</section>
 
 				<section id="spread">
@@ -1030,15 +1056,6 @@
 								of a <a>Content Display Area</a> utilization optimization process.</p>
 						</dd>
 					</dl>
-
-					<p>When one of the <a href="https://www.w3.org/TR/epub-33/#spread-overrides"
-								><code>rendition:spread</code> overrides</a> [[EPUB-33]] is specified in the
-							<code>properties</code> attribute on a spine <code>itemref</code> element, Reading Systems
-						MUST apply the same rendering logic to the referenced resource.</p>
-
-					<p>If more than one <code>rendition:spread</code> override is specified in the
-							<code>properties</code> attribute, Reading Systems MUST only process the first override
-						listed in the attribute.</p>
 				</section>
 
 				<section id="page-spread">
@@ -1817,14 +1834,6 @@
 					[[EPUB-33]]. The scroll direction MUST be vertical if the block flow direction is downward
 					(top-to-bottom). It MUST be horizontal if the block flow direction of the root element is rightward
 					(left-to-right) or leftward (right-to-left).</p>
-
-				<p>When one of the <a href="https://www.w3.org/TR/epub-33/#layout-property-flow-overrides"
-							><code>rendition:flow</code> overrides</a> [[EPUB-33]] is specified in the
-						<code>properties</code> attribute on a spine <code>itemref</code> element, Reading Systems MUST
-					apply the same rendering logic to the referenced resource.</p>
-
-				<p>If more than one <code>rendition:layout</code> override is specified in the <code>properties</code>
-					attribute, Reading Systems MUST only process the first value listed in the attribute.</p>
 
 				<p>Reading Systems MUST ignore the <code>rendition:flow</code> property and its overrides when
 					processing <a href="https://www.w3.org/TR/epub-33/#def-layout-pre-paginated">pre-paginated spine

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1019,8 +1019,7 @@
 						</dd>
 					</dl>
 
-					<p>The means by which Reading Systems convey the EPUB Creator's intent is implementation
-						specific.</p>
+					<p>The means by which they convey the intent is implementation specific.</p>
 				</section>
 
 				<section id="spread">


### PR DESCRIPTION
Here's my best attempt at adding processing requirements for the various spine overrides. I tried breaking out each override, but that led to a lot of duplication with the primary values so I ended up making it a single statement to process the overrides per the existing requirements. There's also a requirement to ignore additional overrides for the same property type.

Fixes #1941 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1941/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1941/epub33/rs/index.html)
