### PR TITLE
Alternative remote resource rule for custom elements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1041,8 +1041,23 @@
 						</li>
 					</ul>
 
-					<p>EPUB Creators should locate these resources inside the EPUB Container whenever feasible to allow
+					<p>EPUB Creators MAY reference any of the Remote Reources listed above from a <a
+							href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements">custom
+							element</a> [[HTML]] provided the custom element extends a corresponding element (e.g.,
+							<code>HTMLAudioElement</code> for remote audio) or uses the Remote Resource in a
+						corresponding element in the DOM [[DOM]].</p>
+
+					<p>The rules in this section for Publication Resource locations apply regardless of whether the
+						given resource is a <a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
+
+					<p>EPUB Creators should locate all resources inside the EPUB Container whenever possible to allow
 						users access to the entire presentation regardless of connectivity status.</p>
+
+					<div class="note">
+						<p>Refer to the <a href="#remote-resources"><code>remote-resources</code> property</a> for more
+							information on how to indicate that a <a>manifest</a>
+							<a href="#sec-item-elem"><code>item</code></a> references a <a>Remote Resource</a>.</p>
+					</div>
 
 					<aside class="example" title="Referencing a local resource">
 						<p>In this example, the audio file referenced from the [[HTML]] <a
@@ -1075,17 +1090,6 @@
    &lt;/body>
 &lt;/html></pre>
 					</aside>
-
-					<div class="note">
-						<p>The rules in this section for Publication Resource locations apply regardless of whether the
-							given resource is a <a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
-					</div>
-
-					<div class="note">
-						<p>The inclusion of Remote Resources is indicated via the <a href="#remote-resources"
-									><code>remote-resources</code> property</a> on the <a>manifest</a>
-							<a href="#sec-item-elem"><code>item</code> element</a>.</p>
-					</div>
 				</section>
 
 				<section id="sec-data-urls">


### PR DESCRIPTION
Opening this for comparison with #1943.

Instead of throwing out all the element restrictions, this is my best attempt to word an allowance for custom elements. It's not going to be easily checkable, but we wouldn't lose the basic restrictions just to accommodate custom elements.

I'm still not sure how much restricting elements helps at the end of the day. It prevents the simple abuse case of putting a wrong media type in the manifest to get external resources past epubcheck that you can then use in an iframe to render, but it doesn't stop people from scripting the dom to add stuff at run time or using custom elements other than the way we say.

This probably also requires a reading system "should not" restriction against using remote resources outside the referenced elements if adopted. That also seems a bit unlikely, as I expect reading systems either blanket allow or disallow the classes of remote resources regardless of what element they're used in.

But worth the exercise to compare, I suppose.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1949.html" title="Last updated on Dec 1, 2021, 1:05 PM UTC (7a01257)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1949/97bae7f...7a01257.html" title="Last updated on Dec 1, 2021, 1:05 PM UTC (7a01257)">Diff</a>