### PR TITLE
Make page-spread-center an alias for spread-none

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5542,32 +5542,29 @@ No Entry</pre>
 
 					<dl>
 						<dt id="page-spread-center">
-							<code>rendition:page-spread-center</code> (deprecated)</dt>
-						<dd>Use of the <code>rendition:page-spread-center</code> property is <a href="#deprecated"
-								>deprecated</a>. EPUB Creators should use the <a href="#spread-none"
-									><code>spread-none</code> property</a> to disable spread behavior in Reading
-							Systems.</dd>
+							<code>rendition:page-spread-center</code></dt>
+						<dd>The <code>rendition:page-spread-center</code> property is an alias of the <a
+								href="#spread-none"><code>spread-none</code> property</a> for centering a spine
+							item.</dd>
 
 						<dt id="fxl-page-spread-left">
 							<code>rendition:page-spread-left</code>
 						</dt>
-						<dd>The <code>rendition:page-spread-left</code> property is an alias for the <code><a
-									href="#page-spread-left">page-spread-left</a></code> property.</dd>
+						<dd>The <code>rendition:page-spread-left</code> property is an alias of the <code><a
+									href="#page-spread-left">page-spread-left</a></code> property for placing a spine
+							item in the left-hand slot of a two-page spread.</dd>
 
 						<dt id="fxl-page-spread-right">
 							<code>rendition:page-spread-right</code>
 						</dt>
-						<dd>The <code>rendition:page-spread-right</code> property is an alias for the <code><a
-									href="#page-spread-right">page-spread-right</a></code> property.</dd>
+						<dd>The <code>rendition:page-spread-right</code> property is an alias of the <code><a
+									href="#page-spread-right">page-spread-right</a></code> property for placing a spine
+							item in the right-hand slot of a two-page spread.</dd>
 					</dl>
 
-					<p>The <code>rendition:page-spread-left</code> property indicates that the given spine item is to be
-						rendered in the left-hand slot in the spread, and <code>rendition:page-spread-right</code> that
-						it be rendered in the right-hand slot.</p>
-
-					<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-						properties apply to both pre-paginated and reflowable content, and they only apply when the
-						Reading System is creating Synthetic Spreads.</p>
+					<p>The <code>rendition:page-spread-center</code>, <code>rendition:page-spread-left</code>, and
+							<code>rendition:page-spread-right</code> properties apply to both pre-paginated and
+						reflowable content. They only apply when the Reading System is creating Synthetic Spreads.</p>
 
 					<p>Although EPUB Creators often indicate to use a spread in certain device orientations, the content
 						itself does not represent true spreads (i.e., two consecutive pages that Reading Systems must
@@ -5582,11 +5579,14 @@ No Entry</pre>
 
 					<div class="note" id="note-page-spread-aliases">
 						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-							properties are aliases for the <a href="#page-spread-left"><code>page-spread-left</code></a>
-							and <a href="#page-spread-right"><code>page-spread-right</code></a> properties. They allow
-							the use of a single vocabulary for all fixed-layout properties. EPUB Creators can use either
-							property set, but older Reading Systems might only recognize the unprefixed versions.</p>
+							properties were created to allow the use of a single vocabulary for all fixed-layout
+							properties. EPUB Creators can use either property set, but older Reading Systems might only
+							recognize the unprefixed versions.</p>
 
+						<p>The <code>rendition:page-spread-center</code> was created to make it easier for EPUB Creators
+							to understand the process of switching between two-page spreads and single centered pages.
+							EPUB Creators can use either <code>rendition:page-spread-center</code> or
+								<code>spread-none</code> to disable spread behavior in Reading Systems.</p>
 					</div>
 
 					<aside class="example" id="fxl-ex5" title="Placing individual spine items in a spread">
@@ -10420,7 +10420,7 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>01-Dec-2021: Deprecated the use of <code>page-spread-center</code>. It is now an alias for
+				<li>08-Dec-2021: The <code>page-spread-center</code> property is now an alias for
 						<code>spread-none</code>. See <a href="https://github.com/w3c/epub-specs/issues/1929">issue
 						1929</a>.</li>
 				<li>18-Nov-2021: Change to only disallow deprecated characters in the Tags and Variation Selectors

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5542,7 +5542,7 @@ No Entry</pre>
 
 					<dl>
 						<dt id="page-spread-center">
-							<code>rendition:page-spread-center</code> [DEPRECATED] </dt>
+							<code>rendition:page-spread-center</code> (deprecated)</dt>
 						<dd>Use of the <code>rendition:page-spread-center</code> property is <a href="#deprecated"
 								>deprecated</a>. EPUB Creators should use the <a href="#spread-none"
 									><code>spread-none</code> property</a> to disable spread behavior in Reading

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5399,7 +5399,8 @@ No Entry</pre>
 					<dl class="variablelist">
 						<dt>none</dt>
 						<dd>
-							<p>Do not incorporate spine items in a Synthetic Spread.</p>
+							<p>Do not incorporate spine items in a Synthetic Spread. Reading Systems should display the
+								items in a single viewport positioned at the center of the screen.</p>
 						</dd>
 
 						<dt>landscape</dt>
@@ -5435,18 +5436,15 @@ No Entry</pre>
 							dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
 								<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"><code>viewBox</code>
 								attribute</a> represents the size of one page in the spread, respectively.</p>
-
 					</div>
 
 					<div class="note">
 						<p>Refer to <a href="#sec-spine-elem">spine</a> for information about declaration of global flow
 							directionality using the <code>page-progression-direction</code> attribute and that of local
 							page-progression-direction within content documents.</p>
-
 					</div>
 
 					<aside class="example" id="fxl-ex3" title="Specifying to use spreads in landscape orientation only">
-
 						<pre>&lt;package …>
    &lt;metadata …>
       …
@@ -5544,10 +5542,11 @@ No Entry</pre>
 
 					<dl>
 						<dt id="page-spread-center">
-							<code>rendition:page-spread-center</code>
-						</dt>
-						<dd>The <code>rendition:page-spread-center</code> property specifies the forced placement of a
-							Content Document in a <a>Synthetic Spread</a>.</dd>
+							<code>rendition:page-spread-center</code> [DEPRECATED] </dt>
+						<dd>Use of the <code>rendition:page-spread-center</code> property is <a href="#deprecated"
+								>deprecated</a>. EPUB Creators should use the <a href="#spread-none"
+									><code>spread-none</code> property</a> to disable spread behavior in Reading
+							Systems.</dd>
 
 						<dt id="fxl-page-spread-left">
 							<code>rendition:page-spread-left</code>
@@ -5564,18 +5563,15 @@ No Entry</pre>
 
 					<p>The <code>rendition:page-spread-left</code> property indicates that the given spine item is to be
 						rendered in the left-hand slot in the spread, and <code>rendition:page-spread-right</code> that
-						it be rendered in the right-hand slot. The <code>rendition:page-spread-center</code> property
-						indicates to override the synthetic spread mode and render a single viewport positioned at the
-						center of the screen.</p>
+						it be rendered in the right-hand slot.</p>
 
-					<p>The <code>rendition:page-spread-left</code>, <code>rendition:page-spread-right</code> and
-							<code>rendition:page-spread-center</code> properties apply to both pre-paginated and
-						reflowable content, and they only apply when the Reading System is creating Synthetic
-						Spreads.</p>
+					<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
+						properties apply to both pre-paginated and reflowable content, and they only apply when the
+						Reading System is creating Synthetic Spreads.</p>
 
 					<p>Although EPUB Creators often indicate to use a spread in certain device orientations, the content
 						itself does not represent true spreads (i.e., two consecutive pages that Reading Systems must
-						rendered side-by-side for readability, such as a two-page map). To indicate that two consecutive
+						render side-by-side for readability, such as a two-page map). To indicate that two consecutive
 						pages represent a true spread, EPUB Creators SHOULD use the
 							<code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 						properties on the spine items for the two adjacent EPUB Content Documents, and omit the
@@ -5589,12 +5585,10 @@ No Entry</pre>
 							properties are aliases for the <a href="#page-spread-left"><code>page-spread-left</code></a>
 							and <a href="#page-spread-right"><code>page-spread-right</code></a> properties. They allow
 							the use of a single vocabulary for all fixed-layout properties. EPUB Creators can use either
-							property set, but older Reading Systems might only recognize the unprefixed versions. The
-							Working Group is not going to extend the <a href="#app-itemref-properties-vocab">EPUB Spine
-								Properties Vocabulary</a> to add an unprefixed <code>page-spread-center</code>
-							property.</p>
+							property set, but older Reading Systems might only recognize the unprefixed versions.</p>
 
 					</div>
+
 					<aside class="example" id="fxl-ex5" title="Placing individual spine items in a spread">
 						<p>In this example, the EPUB Creator intends the Reading System to create a two-page
 							fixed-layout center plate using synthetic spreads in any device orientation. Note that the
@@ -5614,34 +5608,6 @@ No Entry</pre>
           properties="rendition:spread-both rendition:page-spread-right"/>
       …
    &lt;/spine>
-&lt;/package></pre>
-					</aside>
-
-					<aside class="example" id="fxl-ex6" title="Creating a centered layout">
-						<p>Note that it is not necessary to specify the <code>spread-none</code> override on the
-							centered plate, as the <code>rendition:page-spread-center</code> property already specifies
-							semantics that dictates that synthetic spreads be disabled.</p>
-
-						<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;meta
-          property="rendition:layout">
-         pre-paginated
-      &lt;/meta>
-      &lt;meta
-          property="rendition:spread">
-         auto
-      &lt;/meta>
-   &lt;/metadata>
-   &lt;spine>
-      …
-      &lt;itemref
-          idref="center-plate"
-          properties="rendition:page-spread-center"/>
-      …
-   &lt;/spine>
-   …
 &lt;/package></pre>
 					</aside>
 				</section>
@@ -10454,8 +10420,11 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>01-Dec-2021: Deprecated the use of <code>page-spread-center</code>. It is now an alias for
+						<code>spread-none</code>. See <a href="https://github.com/w3c/epub-specs/issues/1929">issue
+						1929</a>.</li>
 				<li>18-Nov-2021: Change to only disallow deprecated characters in the Tags and Variation Selectors
-					Supplement. See <a href="https://github.com/w3c/epub-specs/issues/1885">issue 1885</a></li>
+					Supplement. See <a href="https://github.com/w3c/epub-specs/issues/1885">issue 1885</a>.</li>
 				<li>12-Nov-2021: Change the recommendation to use SHA-1 to encrypt the obfuscation key to a requirement.
 					See <a href="https://github.com/w3c/epub-specs/issues/1873">issue 1873</a>.</li>
 				<li>12-Nov-2021: Restrict the obfuscation algorithm to fonts and add caution to use better protection

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5601,6 +5601,30 @@ No Entry</pre>
    &lt;/spine>
 &lt;/package></pre>
 					</aside>
+
+					<aside class="example" id="fxl-ex6" title="Creating a centered layout">
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      &lt;meta
+          property="rendition:spread">
+         auto
+      &lt;/meta>
+   &lt;/metadata>
+   &lt;spine>
+      …
+      &lt;itemref
+          idref="center-plate"
+          properties="rendition:page-spread-center"/>
+      …
+   &lt;/spine>
+   …
+&lt;/package></pre>
+					</aside>
 				</section>
 
 				<section id="viewport">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -846,12 +846,11 @@
 					</li>
 
 					<li>
-
-						<p id="confreq-rs-scripted-origin"> It MUST assign a unique <a
-								data-cite="url#origin">origin</a> [[URL]], shared by all <a
-								data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> of the
-							EPUB Publication. That <a data-cite="url#origin">origin</a> [[URL]] MUST
-							be <em>unique</em> for each user-specific instance of an EPUB Publication in a Reading System. </p>
+						<p id="confreq-rs-scripted-origin"> It MUST assign a unique <a data-cite="url#origin"
+							>origin</a> [[URL]], shared by all <a data-cite="epub-33#sec-scripted-spine">spine-level
+								scripts</a> of the EPUB Publication. That <a data-cite="url#origin">origin</a> [[URL]]
+							MUST be <em>unique</em> for each user-specific instance of an EPUB Publication in a Reading
+							System. </p>
 					</li>
 
 					<li>
@@ -991,7 +990,8 @@
 					<dl class="variablelist">
 						<dt id="def-spread-none">none</dt>
 						<dd>
-							<p>Reading Systems MUST NOT incorporate spine items in a Synthetic Spread.</p>
+							<p>Reading Systems MUST NOT incorporate spine items in a Synthetic Spread. Reading Systems
+								SHOULD create a single viewport positioned at the center of the screen.</p>
 						</dd>
 						<dt id="def-spread-landscape">landscape</dt>
 						<dd>
@@ -1021,28 +1021,22 @@
 					<p>The <span id="page-spread-left"><code>rendition:page-spread-left</code></span> property indicates
 						that the given spine item SHOULD be rendered in the left-hand slot in the spread, and <span
 							id="page-spread-right"><code>rendition:page-spread-right</code></span> that it SHOULD be
-						rendered in the right-hand slot. The <span id="page-spread-center"
-								><code>rendition:page-spread-center</code></span> property indicates that the synthetic
-						spread mode SHOULD be overridden and a single viewport rendered and positioned at the center of
-						the screen.</p>
+						rendered in the right-hand slot.</p>
 
-					<p>The <code>rendition:page-spread-left</code>, <code>rendition:page-spread-right</code>, and
-							<code>rendition:page-spread-center</code> properties apply to both pre-paginated and
-						reflowable content, and they only apply when the Reading System is creating Synthetic
-						Spreads.</p>
+					<p>Reading Systems MUST handle the <span id="page-spread-center"
+								><code>rendition:page-spread-center</code></span> property as though the EPUB Creator
+						has specified the <a href="#def-spread-none"><code>spread-none</code> property</a> on the
+							<code>itemref</code> element.</p>
+
+					<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
+						properties apply to both pre-paginated and reflowable content, and they only apply when the
+						Reading System is creating Synthetic Spreads.</p>
 
 					<p>The <code id="page-break-precedence">rendition:page-spread-*</code> properties MUST take
 						precedence over whatever value of the <a
 							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
 								><code>page-break-before</code> property</a> [[CSSSnapshot]] has been set for an
 							<a>XHTML Content Document</a>.</p>
-
-					<div class="note">
-						<p>The presence of <code>rendition:page-spread-center</code> does not change the viewport
-							dimensions. It does not indicate that a Reading System must create a viewport with the size
-							of the whole spread. This is important so that the scale factor stays consistent between
-							regular and center-spread pages.</p>
-					</div>
 
 					<p id="page-layout-both">When a <a href="#def-layout-reflowable">reflowable</a> spine item follows a
 							<a href="#def-layout-pre-paginated">pre-paginated</a> one, the reflowable one SHOULD start
@@ -1147,12 +1141,12 @@
 							with the <a>container root URL</a> as <a data-cite="url#concept-base-url"
 								><var>base</var></a> is the <a>container root URL</a>.</li>
 
-						<li>The <a data-cite="url#origin">origin</a> of the <a>container root
-								URL</a> is unique for each user-specific instance of an EPUB Publication in a Reading System.</li>
+						<li>The <a data-cite="url#origin">origin</a> of the <a>container root URL</a> is unique for each
+							user-specific instance of an EPUB Publication in a Reading System.</li>
 					</ul>
 
-					<p class="note">The unicity of the <a data-cite="url#origin">origin</a> per 
-						each user-specific instance of an EPUB Publication in a Reading System means that if two different users acquire a 
+					<p class="note">The unicity of the <a data-cite="url#origin">origin</a> per each user-specific
+						instance of an EPUB Publication in a Reading System means that if two different users acquire a
 						copy of the same EPUB Publication, the origins will be different for the two users on those
 						copies even if the same Reading System is used.</p>
 
@@ -2245,9 +2239,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>01-Dec-2021: <code>page-spread-center</code> is now an alias for <code>spread-none</code>. See <a
+						href="https://github.com/w3c/epub-specs/issues/1929">issue 1929</a>.</li>
 				<li>10-Nov-2021: Proper definition of the Content URL and handling of relative URLs. See <a
 						href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and <a
-						href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
+						href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a>.</li>
 				<li>01-Nov-2021: Added a statement on the Reading System behavior when item references are repeated in
 					the spine. See <a href="https://github.com/w3c/epub-specs/issues/1686">issue 1686</a>.</li>
 				<li> 01-Nov-2021: Added a statement on the Reading System behavior when item references are repeated in

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2236,7 +2236,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>01-Dec-2021: <code>page-spread-center</code> is now an alias for <code>spread-none</code>. See <a
+				<li>08-Dec-2021: <code>page-spread-center</code> is now an alias for <code>spread-none</code>. See <a
 						href="https://github.com/w3c/epub-specs/issues/1929">issue 1929</a>.</li>
 				<li>10-Nov-2021: Proper definition of the Content URL and handling of relative URLs. See <a
 						href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1023,10 +1023,10 @@
 							id="page-spread-right"><code>rendition:page-spread-right</code></span> that it SHOULD be
 						rendered in the right-hand slot.</p>
 
-					<p>Reading Systems MUST handle the <span id="page-spread-center"
-								><code>rendition:page-spread-center</code></span> property as though the EPUB Creator
-						has specified the <a href="#def-spread-none"><code>spread-none</code> property</a> on the
-							<code>itemref</code> element.</p>
+					<p>Reading Systems that support the <a href="#def-spread-none"><code>spread-none</code> property</a>
+						MUST recognize the <span id="page-spread-center"
+							><code>rendition:page-spread-center</code></span> as an alias for it, otherwise they MUST
+						ignore the <code>rendition:page-spread-center</code> property.</p>
 
 					<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 						properties apply to both pre-paginated and reflowable content, and they only apply when the


### PR DESCRIPTION
The only concern I have now that I'm opening the PR is whether we should formally deprecate page-spread-center or if we should "discourage" its use. I don't know if anyone has used it that we'd affect by this change.

Otherwise, the PR itself removes all traces of page-spread-center except to deprecate and make it an alias and adds the centering prose to the rendition:spread none processing requirements.


- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1929/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-1929/epub33/rs/index.html)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1950.html" title="Last updated on Dec 10, 2021, 1:32 PM UTC (e472d62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1950/a6e27d4...e472d62.html" title="Last updated on Dec 10, 2021, 1:32 PM UTC (e472d62)">Diff</a>