### PR TITLE
Removing the paragraph mentioned in 1918

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -452,7 +452,7 @@
 
 				<p id="confreq-rs-pkg-manifest-url" data-tests="#pkg-manifest-url,#pkg-relative-url">When an
 						<code>href</code> attribute contains a <a data-cite="url#relative-url-string">relative-URL
-						string</a>, Reading Systems MUST use the URL of the Package Document as the <a
+						string</a>, Reading Systems MUST use the <a data-cite="epub-33#dfn-content-url">content URL</a> of the Package Document as the <a
 						data-cite="url#concept-base-url">base URL</a> when <a data-cite="url#concept-url-parser"
 						>parsing</a> to a <a data-cite="url#concept-url">URL record</a> [[URL]].</p>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -314,7 +314,7 @@
 		<section id="sec-package-doc">
 			<h2>Package Document Processing</h2>
 
-			<p id="confreq-rs-epub-pub" class="support" data-tests="#pkg-manifest-url">Reading Systems MUST process the
+			<p id="confreq-rs-epub-pub" class="support" data-tests="#pkg-manifest-url,#pkg-relative-url">Reading Systems MUST process the
 					<a data-cite="epub-33#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
 
 			<section id="sec-pkg-doc-base-dir">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -450,11 +450,6 @@
 			<section id="sec-pkg-doc-manifest">
 				<h3>Manifest</h3>
 
-				<p id="confreq-rs-pkg-manifest-url" data-tests="#pkg-manifest-url,#pkg-relative-url">When an
-						<code>href</code> attribute contains a <a data-cite="url#relative-url-string">relative-URL
-						string</a>, Reading Systems MUST use the <a data-cite="epub-33#dfn-content-url">content URL</a> of the Package Document as the <a
-						data-cite="url#concept-base-url">base URL</a> when <a data-cite="url#concept-url-parser"
-						>parsing</a> to a <a data-cite="url#concept-url">URL record</a> [[URL]].</p>
 
 				<p>Reading Systems MAY optimize the rendering depending on the properties set in the
 						<code>properties</code> attribute (e.g., disable a rendering process or use a fallback). <span


### PR DESCRIPTION
This to make the statement in [§3.4](https://www.w3.org/TR/epub-rs-33/#sec-pkg-doc-manifest) more precise.

Fixes #1918




See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/remove-paragraph-1918/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/remove-paragraph-1918/epub33/rs/index.html)
