### PR TITLE
Add risky class of unsupported features

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8720,8 +8720,8 @@ html.my-document-playing * {
 				<h3>Risky Features</h3>
 
 				<p>A <strong>risky</strong> feature is a feature introduced prior to EPUB 3.3 but that the Working Group
-					has not been able to establish is implemented in two or more Reading Systems as required by W3C
-					Process [[PROCESS]].</p>
+					has not been able to establish is implemented in two or more Reading Systems as required by <a
+						href="https://www.w3.org/Consortium/Process/">W3C Process</a>.</p>
 
 				<p>These features are considered important to retain despite this limitation because they are known to
 					be implemented by EPUB Creators (i.e., their deprecation would invalidate existing content) and/or

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8731,7 +8731,7 @@ html.my-document-playing * {
 
 				<ul>
 					<li>
-						<p><a>EPUB Creators</a> MAY use the features as described in their <a>EPUB Publications</a>.</p>
+						<p><a>EPUB Creators</a> MAY use the features as described.</p>
 					</li>
 					<li>
 						<p><a>Reading Systems</a> SHOULD support the feature as described.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5215,8 +5215,9 @@ No Entry</pre>
 
 					</div>
 
-					<p id="fxl-layout-duplication" data-tests="#fxl-layout-duplication">When the property is set to <code>pre-paginated</code> for a spine item, its content dimensions
-						MUST be set as defined in <a href="#sec-fixed-layouts"></a>.</p>
+					<p id="fxl-layout-duplication" data-tests="#fxl-layout-duplication">When the property is set to
+							<code>pre-paginated</code> for a spine item, its content dimensions MUST be set as defined
+						in <a href="#sec-fixed-layouts"></a>.</p>
 
 					<p>The <code>rendition:layout</code> property MUST NOT be declared more than once.</p>
 
@@ -5320,8 +5321,8 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p id="fxl-orientation-duplication" data-tests="#fxl-orientation-duplication">EPUB Creators MUST NOT declare the <code>rendition:orientation</code> property more than
-						once.</p>
+					<p id="fxl-orientation-duplication" data-tests="#fxl-orientation-duplication">EPUB Creators MUST NOT
+						declare the <code>rendition:orientation</code> property more than once.</p>
 
 					<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
 						<p>In this example, the content should also render without synthetic spreads.</p>
@@ -8710,9 +8711,49 @@ html.my-document-playing * {
 		<section id="app-overview-unsupported" class="appendix">
 			<h2>Unsupported Features</h2>
 
-			<p>This specification contains certain features the Working Group no longer recommends for use or that are
-				only retained for legacy support reasons. This section defines the meanings of the designations attached
-				to these features and their support expectations.</p>
+			<p>This specification contains certain features that are not yet fully supported in Reading Systems, that
+				the Working Group no longer recommends for use, or that are only retained for interoperability with EPUB
+				2 Reading Systems. This section defines the meanings of the designations attached to these features and
+				their support expectations.</p>
+
+			<section id="risky">
+				<h3>Risky Features</h3>
+
+				<p>A <strong>risky</strong> feature is a feature introduced prior to EPUB 3.3 but that the Working Group
+					has not been able to establish is implemented in two or more Reading Systems as required by W3C
+					Process [[PROCESS]].</p>
+
+				<p>These features are considered important to retain despite this limitation because they are known to
+					be implemented by EPUB Creators (i.e., their deprecation would invalidate existing content) and/or
+					they are integral to the content model on which EPUB is built.</p>
+
+				<p>If this specification designates a feature as risky, the following hold true:</p>
+
+				<ul>
+					<li>
+						<p><a>EPUB Creators</a> MAY use the features as described in their <a>EPUB Publications</a>.</p>
+					</li>
+					<li>
+						<p><a>Reading Systems</a> SHOULD support the feature as described.</p>
+					</li>
+				</ul>
+
+				<p>Validation tools SHOULD alert EPUB Creators to the presence of risky features when encountered in
+					EPUB Publications but MUST NOT treat their inclusion as a violation of the standard (i.e., not emit
+					errors or warnings).</p>
+
+				<div class="caution">
+					<p>Whether risky labels are removed or replaced by deprecation in a future version of the standard
+						cannot be determined at this time. EPUB Creators should strongly consider the interoperability
+						problems that may arise both now and in the future when using these features.</p>
+				</div>
+
+				<div class="note">
+					<p>The marking of features as risky is a one-time event to account for the different process under
+						which EPUB was developed prior to being brought into W3C. This label will not be used on
+						features in the future.</p>
+				</div>
+			</section>
 
 			<section id="deprecated">
 				<h3>Deprecated Features</h3>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8719,10 +8719,10 @@ html.my-document-playing * {
 			<section id="risky">
 				<h3>Risky Features</h3>
 
-				<p>A <strong>risky</strong> feature is a feature introduced prior to EPUB 3.3 that the Working Group has
-					not been able to establish enough <a
+				<p>A <strong>risky</strong> feature is a feature introduced prior to EPUB 3.3 for which the Working
+					Group has not been able to establish enough <a
 						href="https://www.w3.org/Consortium/Process/#adequate-implementation">implementation
-						experience</a> for.</p>
+						experience</a>.</p>
 
 				<p>These features are considered important to retain despite this limitation because they are known to
 					be implemented by EPUB Creators (i.e., their deprecation would invalidate existing content) and/or

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10484,6 +10484,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>03-Dec-2021: Added a new risky class for unsupported features. See <a
+						href="https://github.com/w3c/epub-specs/issues/1944">issue 1944</a>.</li>
 				<li>03-Dec-2021: Remove the element-based restrictions on remote resources. See <a
 						href="https://github.com/w3c/epub-specs/issues/1913">issue 1913</a>.</li>
 				<li>18-Nov-2021: Change to only disallow deprecated characters in the Tags and Variation Selectors

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8719,9 +8719,10 @@ html.my-document-playing * {
 			<section id="risky">
 				<h3>Risky Features</h3>
 
-				<p>A <strong>risky</strong> feature is a feature introduced prior to EPUB 3.3 but that the Working Group
-					has not been able to establish is implemented in two or more Reading Systems as required by <a
-						href="https://www.w3.org/Consortium/Process/">W3C Process</a>.</p>
+				<p>A <strong>risky</strong> feature is a feature introduced prior to EPUB 3.3 that the Working Group has
+					not been able to establish enough <a
+						href="https://www.w3.org/Consortium/Process/#adequate-implementation">implementation
+						experience</a> for.</p>
 
 				<p>These features are considered important to retain despite this limitation because they are known to
 					be implemented by EPUB Creators (i.e., their deprecation would invalidate existing content) and/or
@@ -8750,8 +8751,8 @@ html.my-document-playing * {
 
 				<div class="note">
 					<p>The marking of features as risky is a one-time event to account for the different process under
-						which EPUB was developed prior to being brought into W3C. This label will not be used on
-						features in the future.</p>
+						which EPUB was developed prior to being brought into W3C. This label will not be used for new
+						features developed under W3C processes.</p>
 				</div>
 			</section>
 


### PR DESCRIPTION
This PR implements the "risky" class as discussed on the WG telecon today.

The most confusing part to me was what reading systems should do with these features given that they may run a strange gamut of things we want implemented in the future to things that are maybe (?) just zombies. I made it a "should" to support them for now.

Feedback welcome.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1953.html" title="Last updated on Dec 6, 2021, 4:33 PM UTC (0287bd4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1953/34cffe4...0287bd4.html" title="Last updated on Dec 6, 2021, 4:33 PM UTC (0287bd4)">Diff</a>