### PR TITLE
Editorial rephrase of epubReadingSystem property definitions

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2114,18 +2114,13 @@ partial interface Navigator {
 							<td>Returns a <code>String</code> value representing the version of the Reading System
 								(e.g., "<code>1.0</code>", "<code>2.1.1</code>").</td>
 						</tr>
-						<tr>
-							<td id="propdef-layoutStyle">
-								<code>
-									<dfn>layoutStyle</dfn>
-								</code>
-							</td>
-							<td>Use of the <code>layoutStyle</code> property is <a data-cite="epub-33#deprecated"
-									>deprecated</a> [[EPUB-33]]. Refer to its definition in [[EPUBContentDocs-301]] for
-								usage information.</td>
-						</tr>
 					</tbody>
 				</table>
+
+				<p>
+					This specification used to define a <code>layoutStyle</code> property, but it is now <a data-cite="epub-33#deprecated"
+					>deprecated</a> [[EPUB-33]]. Refer to its definition in [[EPUBContentDocs-301]] for more information.
+				</p>
 			</section>
 
 			<section id="app-ers-methods">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2015,7 +2015,7 @@
 					be passed through or might not be cancelable.</p>
 			</section>
 		</section>
-		<section id="app-epubReadingSystem" class="appendix">
+		<section id="app-epubReadingSystem">
 			<h2><dfn>epubReadingSystem</dfn> Object</h2>
 
 			<p class="issue atrisk" title="Are there enough implementations?">Although this section is
@@ -2158,9 +2158,12 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					<section id="app-ers-hasFeature-features">
 						<h5>Features</h5>
 
-						<p>The following table lists the set of features that Reading Systems that support the
-								<code>epubReadingSystem</code> object MUST recognize (i.e., provide a return value for).
-							Support for these features is OPTIONAL.</p>
+						<p>
+							The following table lists the set of features that Reading Systems that support the
+							<code>epubReadingSystem</code> object MUST recognize.
+							When the features are queried from the <code>hasFeature</code> method, 
+							Reading Systems MUST return a boolean value indicating their support.
+						</p>
 
 						<table>
 							<thead>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2174,7 +2174,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 									<td id="feature-dom-manipulation">
 										<code>dom-manipulation</code>
 									</td>
-									<td>Scripts MAY make structural changes to the document’s DOM (applies to <a
+									<td>Scripts may make structural changes to the document’s DOM (applies to <a
 											data-cite="epub-33#sec-scripted-spine">spine-level scripting</a> [[EPUB-33]]
 										only).</td>
 								</tr>
@@ -2182,7 +2182,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 									<td id="feature-layout-changes">
 										<code>layout-changes</code>
 									</td>
-									<td>Scripts MAY modify attributes and CSS styles that affect content layout (applies
+									<td>Scripts may modify attributes and CSS styles that affect content layout (applies
 										to <a data-cite="epub-33#sec-scripted-spine">spine-level scripting</a>
 										[[EPUB-33]] only).</td>
 								</tr>


### PR DESCRIPTION
There is a table in the definition of `epubReadingSystem` where a deprecated feature was listed as part of the required features. This is changed.

I have also changed two occurrences of _MAY_ into "may" in the table of [§A.4.1.2](https://w3c.github.io/epub-specs/epub33/rs/#app-ers-hasFeature-features). The term _MAY_ is used for the conformance clause of a Reading System, where, in this case, the "may" merely refers to what a script may or may not do, ie, it is the explanation of a property.

---

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/epubReadingSystem-updates/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/epubReadingSystem-updates/epub33/rs/index.html)
