### PR TITLE
Hack on data-test display: show real test id

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -5,6 +5,7 @@
 		<title>EPUB Accessibility 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/data-test-display.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
 				subtitle: "Conformance and Discoverability Requirements for EPUB Publications",
@@ -100,7 +101,8 @@
 						"publisher": "W3C"
 					}
 				},
-				preProcess:[inlineCustomCSS]
+				preProcess:[inlineCustomCSS],
+				postProcess: [data_test_display],
 			};</script>
 		<style>
 			.conf-pattern {

--- a/epub33/common/js/data-test-display.js
+++ b/epub33/common/js/data-test-display.js
@@ -1,0 +1,8 @@
+function data_test_display() {
+    const test_references = document.querySelectorAll('details.respec-tests-details a');
+    for( const a of test_references ) {
+        const href = a.href;
+        const test_reference = href.split('#')[1];
+        a.textContent = test_reference;
+    }    
+}

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7,6 +7,7 @@
 		<script src="./biblio.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/add-caution-hd.js" class="remove"></script>
+		<script src="../common/js/data-test-display.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
             var respecConfig = {
@@ -66,7 +67,7 @@
                 },
                 localBiblio: biblio,
                 preProcess:[inlineCustomCSS],
-                postProcess:[addCautionHeaders],
+                postProcess:[addCautionHeaders, data_test_display],
                 testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
                 lint: {
                      "wpt-tests-exist": true,

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -6,6 +6,7 @@
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/dfn-crossref.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/data-test-display.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
@@ -105,6 +106,7 @@
 					},
 				},
 				preProcess:[inlineCustomCSS, fixDefinitionCrossrefs],
+				postProcess: [data_test_display],
 				testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
 				lint: {
 					"wpt-tests-exist": true,


### PR DESCRIPTION
Adding a simple javascript hack that displays the real test id-s in the pull down lists of tests instead of simply their number.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1955.html" title="Last updated on Dec 7, 2021, 8:29 AM UTC (0e7312a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1955/8d607e1...0e7312a.html" title="Last updated on Dec 7, 2021, 8:29 AM UTC (0e7312a)">Diff</a>