### PR TITLE
Fix unlinked definitions

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4488,9 +4488,9 @@ No Entry</pre>
 						<p>EPUB 3 defines two contexts for script execution:</p>
 
 						<ul>
-							<li><a href="#sec-scripted-container-constrained">container-constrained scripts</a> &#8212;
+							<li><a href="#sec-scripted-container-constrained">container constrained</a> &#8212;
 								when the execution of a script occurs within an <code>iframe</code>; and</li>
-							<li><a href="#sec-scripted-spine">spine-level scripts</a> &#8212; when the execution of a
+							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a
 								script occurs directly within a <a>Top-level Content Document</a>.</li>
 						</ul>
 						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference
@@ -9720,7 +9720,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td><code>-epub-text-transform</code></td>
+								<td><code>text-transform</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -305,16 +305,6 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-content-display-area">Content Display Area</dfn>
-					</dt>
-					<dd>
-						<p>The area within the <a>Viewport</a> dedicated to the display of <a>EPUB Content
-							Documents</a>. The Content Display Area excludes any borders, margins, headers, footers, or
-							other decoration a <a>EPUB Reading System</a> might inject into the Viewport.</p>
-						<p>In the case of <a>synthetic spreads</a>, the Viewport contains two Content Display Areas.</p>
-					</dd>
-
-					<dt>
 						<dfn id="dfn-core-media-type-resource" data-lt="Core Media Type Resources">Core Media Type
 							Resource</dfn>
 					</dt>
@@ -358,8 +348,8 @@
 							to responsibilities of the organization (e.g., the publisher) or the individuals preparing
 							the publication (e.g., technical editors).</p>
 						<div class="note">
-							<p>Previous versions of this specification referred to the EPUB Creator as the <dfn
-									id="dfn-author">Author</dfn>.</p>
+							<p>Previous versions of this specification referred to the EPUB Creator as the <span
+									id="dfn-author">Author</span>.</p>
 						</div>
 					</dd>
 
@@ -3002,9 +2992,10 @@ XHTML:
 							<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL
 								[[URL]] in its <code>href</code> attribute. The value MUST be an <a
 									data-cite="url#absolute-url-string">absolute-</a> or <a
-									data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL</a>
-								string [[URL]]. EPUB Creators MUST ensure each URL is unique within the <code>manifest</code>
-								scope after <a href="#sec-parse-package-urls">parsing</a>.</p>
+									data-cite="url#path-relative-scheme-less-url-string"
+									>path-relative-scheme-less-URL</a> string [[URL]]. EPUB Creators MUST ensure each
+								URL is unique within the <code>manifest</code> scope after <a
+									href="#sec-parse-package-urls">parsing</a>.</p>
 
 							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
 								element MUST conform to the applicable specification(s) as inferred from the MIME media
@@ -4497,10 +4488,10 @@ No Entry</pre>
 						<p>EPUB 3 defines two contexts for script execution:</p>
 
 						<ul>
-							<li><a href="#sec-scripted-container-constrained">container-constrained</a> &#8212; when the
-								execution of a script occurs within an <code>iframe</code>; and</li>
-							<li><a href="#sec-scripted-spine">spine-level</a> &#8212; when the execution of a script
-								occurs directly within a <a>Top-level Content Document</a>.</li>
+							<li><a href="#sec-scripted-container-constrained">container-constrained scripts</a> &#8212;
+								when the execution of a script occurs within an <code>iframe</code>; and</li>
+							<li><a href="#sec-scripted-spine">spine-level scripts</a> &#8212; when the execution of a
+								script occurs directly within a <a>Top-level Content Document</a>.</li>
 						</ul>
 						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference
 							it via the element's <code>src</code> attribute makes no difference to its executing
@@ -4518,7 +4509,7 @@ No Entry</pre>
 						<section id="sec-scripted-container-constrained">
 							<h5>Container-Constrained Scripts</h5>
 
-							<p>A <dfn>container-constrained script</dfn> is either of the following:</p>
+							<p>A <em>container-constrained script</em> is either of the following:</p>
 
 							<ul>
 								<li>
@@ -4537,6 +4528,7 @@ No Entry</pre>
 										element.</p>
 								</li>
 							</ul>
+
 							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
 								instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e.,
 								the one that contains the <code>iframe</code> element). It also MUST NOT contain
@@ -4561,7 +4553,7 @@ No Entry</pre>
 						<section id="sec-scripted-spine">
 							<h5>Spine-Level Scripts</h5>
 
-							<p>A <dfn>spine-level script</dfn> is an instance of the [[HTML]] <a
+							<p>A <em>spine-level script</em> is an instance of the [[HTML]] <a
 									data-cite="html#the-script-element"><code>script</code></a> or [[SVG]] <a
 									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 								element contained in a <a>Top-level Content Document</a>.</p>
@@ -5937,9 +5929,9 @@ No Entry</pre>
 				<section id="sec-file-names-to-path-names">
 					<h4>Deriving File Paths</h4>
 
-					<p>To <dfn id="dfn-derive-the-file-path">derive the File Path</dfn>, given a file or directory
-							<var>file</var> in the <a href="#sec-container-abstract">OCF Abstract Container</a>, apply
-						the following steps (expressed using the terminology of [[INFRA]]):</p>
+					<p>To <dfn class="lint-ignore">derive the File Path</dfn>, given a file or directory <var>file</var>
+						in the <a href="#sec-container-abstract">OCF Abstract Container</a>, apply the following steps
+						(expressed using the terminology of [[INFRA]]):</p>
 
 					<ol class="algorithm">
 						<!-- <li>Let <var>file</var> be the directory or file to parse</li> -->
@@ -8754,9 +8746,9 @@ html.my-document-playing * {
 				W3C's <a href="https://www.w3.org/TR/wcag2/">Web Content Accessibility Guidelines (WCAG)</a> [[WCAG2]].
 				These guidelines also form the basis for defining accessibility in EPUB Publications.</p>
 
-			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, 
-				<a data-cite="epub-a11y-11#">EPUB Accessibility</a> [[EPUB-A11Y-11]], defines how to apply the standard to
-					<a>EPUB Publications</a>. It also adds EPUB-specific requirements and recommendations for metadata,
+			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, <a
+					data-cite="epub-a11y-11#">EPUB Accessibility</a> [[EPUB-A11Y-11]], defines how to apply the standard
+				to <a>EPUB Publications</a>. It also adds EPUB-specific requirements and recommendations for metadata,
 				pagination, and media overlays.</p>
 
 			<p>This specification recommends that EPUB Publications <a href="#confreq-a11y">conform to the EPUB
@@ -9510,9 +9502,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-text-orientation</dfn>
-								</td>
+								<td><code>-epub-text-orientation</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9558,9 +9548,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-writing-mode</dfn>
-								</td>
+								<td><code>-epub-writing-mode</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9582,9 +9570,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-text-combine-horizontal</dfn>
-								</td>
+								<td><code>-epub-text-combine-horizontal</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9597,8 +9583,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-text-combine</dfn> (deprecated) </td>
+								<td><code>-epub-text-combine</code> (deprecated)</td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9657,9 +9642,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-hyphens</dfn>
-								</td>
+								<td><code>-epub-hyphens</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9680,9 +9663,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-line-break</dfn>
-								</td>
+								<td><code>-epub-line-break</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9701,9 +9682,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-text-align-last</dfn>
-								</td>
+								<td><code>-epub-text-align-last</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9722,9 +9701,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-word-break</dfn>
-								</td>
+								<td><code>-epub-word-break</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9743,9 +9720,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>text-transform</dfn>
-								</td>
+								<td><code>-epub-text-transform</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9787,9 +9762,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-text-emphasis-color</dfn>
-								</td>
+								<td><code>-epub-text-emphasis-color</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9808,9 +9781,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-text-emphasis-position</dfn>
-								</td>
+								<td><code>-epub-text-emphasis-position</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9829,9 +9800,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-text-emphasis-style</dfn>
-								</td>
+								<td><code>-epub-text-emphasis-style</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -9852,9 +9821,7 @@ html.my-document-playing * {
 						<tbody>
 							<tr>
 								<th>Name: </th>
-								<td>
-									<dfn>-epub-text-underline-position</dfn>
-								</td>
+								<td><code>-epub-text-underline-position</code></td>
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
@@ -10016,13 +9983,14 @@ html.my-document-playing * {
 				<ul>
 					<li>
 						<p>the code in the <code>script</code> element in the <code>head</code> in
-								<code>scripted01.xhtml</code> is a spine-level script because the document is referenced
-							from the spine; and</p>
+								<code>scripted01.xhtml</code> is a <a href="#sec-scripted-spine">spine-level script</a>
+							because the document is referenced from the spine; and</p>
 					</li>
 					<li>
-						<p>the code in the <code>script</code> element in <code>scripted02.xhtml</code> is a
-							container-constrained script because the HTML file it occurs in is included in
-								<code>scripted01.xhtml</code> via the <code>iframe</code> element.</p>
+						<p>the code in the <code>script</code> element in <code>scripted02.xhtml</code> is a <a
+								href="#sec-scripted-container-constrained">container-constrained script</a> because the
+							HTML file it occurs in is included in <code>scripted01.xhtml</code> via the
+								<code>iframe</code> element.</p>
 					</li>
 				</ul>
 			</section>
@@ -10650,8 +10618,8 @@ EPUB/images/cover.png</pre>
 				<li>23-June-2021: Added the <code>base</code> element to the list of discouraged XHTML constructs. See
 						<a href="https://github.com/w3c/epub-specs/issues/1699">issue 1699</a>.</li>
 				<li>18-June-2021: Moved requirements for authoring SSML, PLS lexicons and CSS 3 Speech to the <a
-						href="https://www.w3.org/TR/epub-tts-10">EPUB 3 Text-to-Speech Enhancements</a> note. The ability
-					to use these technologies in EPUB 3 Publications remains unchanged. See <a
+						href="https://www.w3.org/TR/epub-tts-10">EPUB 3 Text-to-Speech Enhancements</a> note. The
+					ability to use these technologies in EPUB 3 Publications remains unchanged. See <a
 						href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
 				<li>16-June-2021: Absolute URLs with <code>file</code> scheme should not be used on manifest items. See
 						<a href="https://github.com/w3c/epub-specs/issues/1688">issue 1688</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -157,10 +157,23 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This specification uses terminology defined in EPUB 3.3 [[EPUB-33]]. These terms appear capitalized
-					wherever used.</p>
+				<p>This specification uses <a href="https://www.w3.org/TR/epub-33/#sec-terminology">terminology defined
+						in EPUB 3.3</a> [[EPUB-33]] as well as the terms defined in this section. Terms appear
+					capitalized wherever used.</p>
 
 				<p>Only the first instance of a term in a section links to its definition.</p>
+
+				<dl>
+					<dt>
+						<dfn id="dfn-content-display-area">Content Display Area</dfn>
+					</dt>
+					<dd>
+						<p>The area within the <a>Viewport</a> dedicated to the display of <a>EPUB Content
+							Documents</a>. The Content Display Area excludes any borders, margins, headers, footers, or
+							other decoration a <a>EPUB Reading System</a> might inject into the Viewport.</p>
+						<p>In the case of <a>synthetic spreads</a>, the Viewport contains two Content Display Areas.</p>
+					</dd>
+				</dl>
 			</section>
 
 			<section id="conformance"></section>


### PR DESCRIPTION
Another new respec check: issues warning if a term in dfn tags isn't linked to.

Most of these errors were caused by using dfn tags on the epub-created css definitions. I changed them to use code tags to match the other element, attribute and property definitions.

The scripting context definitions (container-constrained and spine-level) had the same issue, but as these terms are only used once outside their section -- in the extended example in the appendix -- I just dropped the dfn tags.

The "Content Display Area" term was also flagged as it is not used in the core spec, so I moved it to the RS spec's terminology section (it's the only unique term to that specification). I also added a link across to the core terminology section, as not having one wasn't very helpful.

And, finally, the "derive a file path" function got flagged but I put the css class to hide the tag on it as the function should have a definition.

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/unlinked-dfn/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/unlinked-dfn/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1967.html" title="Last updated on Jan 12, 2022, 12:09 PM UTC (a4a07ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1967/503c4b7...a4a07ec.html" title="Last updated on Jan 12, 2022, 12:09 PM UTC (a4a07ec)">Diff</a>