### PR TITLE
Update data-tests for #confreq-rs-data-urls

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -238,7 +238,7 @@
 			<section id="sec-epub-rs-conf-data-urls">
 				<h4>Data URLs</h4>
 
-				<p id="confreq-rs-data-urls" data-tests="#pub-data-urls">Reading Systems MUST prevent data URLs
+				<p id="confreq-rs-data-urls" data-tests="#pub-data-urls_browsing-context,#pub-data-urls_top-level-content">Reading Systems MUST prevent data URLs
 					[[RFC2397]] from opening in <a data-cite="html#top-level-browsing-context">top-level browsing
 						contexts</a> [[HTML]], except when initiated through a Reading System affordance such as a
 					context menu. If a Reading System does not use a top-level browsing context for <a>Top-level Content


### PR DESCRIPTION
I added a 2nd test in the tests repo related to the data URL related assertion at #confreq-rs-data-urls of the epub33-rs spec. This PR updates the corresponding data-tests attribute.