### PR TITLE
Updated privacy and security sections

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8911,7 +8911,7 @@ html.my-document-playing * {
 					</ul>
 
 					<p>The one potential exception is the <a data-cite="epub-rs-33#app-epubReadingSystem"
-								><code>epubReadingSystem</code> object</a> [[EPUB-RS-33]] allows EPUB Creators to query
+								><code>epubReadingSystem</code> object</a> [[EPUB-RS-33]] that allows EPUB Creators to query
 						information about the current Reading System. EPUB Creators need to be mindful that they only
 						use the information exposed by this object to improve the rendering of their content (i.e.,
 						avoid using the information to profile the user and their environment).</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8911,9 +8911,9 @@ html.my-document-playing * {
 					</ul>
 
 					<p>The one potential exception is the <a data-cite="epub-rs-33#app-epubReadingSystem"
-								><code>epubReadingSystem</code> object</a> [[EPUB-RS-33]] that allows EPUB Creators to query
-						information about the current Reading System. EPUB Creators need to be mindful that they only
-						use the information exposed by this object to improve the rendering of their content (i.e.,
+								><code>epubReadingSystem</code> object</a> [[EPUB-RS-33]] that allows EPUB Creators to
+						query information about the current Reading System. EPUB Creators need to be mindful that they
+						only use the information exposed by this object to improve the rendering of their content (i.e.,
 						avoid using the information to profile the user and their environment).</p>
 				</section>
 			</section>
@@ -10717,14 +10717,18 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>04-Feb-2021: Expanded the section on security and privacy to include new sections on the threat
+					model for EPUB Publications and additional recommendations for ensuring security and privacy. See <a
+						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a
+						href="https://github.com/w3c/epub-specs/issues/1872">issue 1872</a>, <a
+						href="https://github.com/w3c/epub-specs/issues/1875">issue 1875</a> and <a
+						href="https://github.com/w3c/epub-specs/issues/1876">issue 1876</a>.</li>
 				<li>03-Dec-2021: Added a new risky class for unsupported features. See <a
 						href="https://github.com/w3c/epub-specs/issues/1944">issue 1944</a>.</li>
-
 				<li>03-Dec-2021: Remove the element-based restrictions on remote resources. See <a
 						href="https://github.com/w3c/epub-specs/issues/1913">issue 1913</a>.</li>
 				<li>26-Nov-2021: A requirement and an algorithm to detect out-of-container URLs has been added to the
-					specification. See <a href="https://github.com/w3c/epub-specs/issues/1912">issue 1912</a>
-				</li>
+					specification. See <a href="https://github.com/w3c/epub-specs/issues/1912">issue 1912</a>.</li>
 				<li>18-Nov-2021: Change to only disallow deprecated characters in the Tags and Variation Selectors
 					Supplement. See <a href="https://github.com/w3c/epub-specs/issues/1885">issue 1885</a>.</li>
 				<li>12-Nov-2021: Change the recommendation to use SHA-1 to encrypt the obfuscation key to a requirement.

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8957,6 +8957,12 @@ html.my-document-playing * {
 				<p>When publishers and vendors must use digital rights management schemes, they should prefer schemes
 					that do not utilize or transmit information about the user or their content to external parties to
 					perform encryption or decryption.</p>
+
+				<p>EPUB Creators who want to maximally limit the privacy and security issues in their EPUB Publications
+					should work to make the content as self-contained as possible. An EPUB Publication that comes with
+					all its needed resources and has no dependencies on network access or external content provides
+					security for users and has the added benefits of reducing future maintenance and improving
+					archivability.</p>
 			</section>
 		</section>
 		<section id="app-overview-unsupported" class="appendix">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3002,9 +3002,10 @@ XHTML:
 							<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL
 								[[URL]] in its <code>href</code> attribute. The value MUST be an <a
 									data-cite="url#absolute-url-string">absolute-</a> or <a
-									data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL</a>
-								string [[URL]]. EPUB Creators MUST ensure each URL is unique within the <code>manifest</code>
-								scope after <a href="#sec-parse-package-urls">parsing</a>.</p>
+									data-cite="url#path-relative-scheme-less-url-string"
+									>path-relative-scheme-less-URL</a> string [[URL]]. EPUB Creators MUST ensure each
+								URL is unique within the <code>manifest</code> scope after <a
+									href="#sec-parse-package-urls">parsing</a>.</p>
 
 							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
 								element MUST conform to the applicable specification(s) as inferred from the MIME media
@@ -8754,9 +8755,9 @@ html.my-document-playing * {
 				W3C's <a href="https://www.w3.org/TR/wcag2/">Web Content Accessibility Guidelines (WCAG)</a> [[WCAG2]].
 				These guidelines also form the basis for defining accessibility in EPUB Publications.</p>
 
-			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, 
-				<a data-cite="epub-a11y-11#">EPUB Accessibility</a> [[EPUB-A11Y-11]], defines how to apply the standard to
-					<a>EPUB Publications</a>. It also adds EPUB-specific requirements and recommendations for metadata,
+			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, <a
+					data-cite="epub-a11y-11#">EPUB Accessibility</a> [[EPUB-A11Y-11]], defines how to apply the standard
+				to <a>EPUB Publications</a>. It also adds EPUB-specific requirements and recommendations for metadata,
 				pagination, and media overlays.</p>
 
 			<p>This specification recommends that EPUB Publications <a href="#confreq-a11y">conform to the EPUB
@@ -8825,6 +8826,60 @@ html.my-document-playing * {
 						System.</p>
 				</li>
 			</ul>
+
+			<section>
+				<h2>EPUB Threat Model / Privacy Advice</h2>
+
+				<section>
+					<h3>Security/Privacy Objectives</h3>
+
+					<ol>
+						<li>EPUB should preserve content author and end user confidentiality where possible.</li>
+						<li>Content integrity.</li>
+						<li>Reading Systems should advise users of their data policies, and protect content integrity
+							and user data.</li>
+					</ol>
+				</section>
+
+				<section>
+					<h3>Threats</h3>
+
+					<ul>
+						<li>falsified creator information (including identifiers, DRM licenses, etc.)</li>
+						<li>remote resources come from compromised or risky sources</li>
+						<li>links to remote resources that compromise user or platform security</li>
+						<li>container contains malicious content, or links to it</li>
+						<li>spoofed platforms (where content is designed to imitate or replicate a platform's experience
+							in order to trick a user into providing data)</li>
+						<li>scripting: <ul>
+								<li>serving information to remote receivers</li>
+								<li>local storage</li>
+								<li>unauthorized collection of user data</li>
+							</ul>
+						</li>
+					</ul>
+				</section>
+
+				<section>
+					<h3>Recommendations</h3>
+
+					<ul>
+						<li>Content authors are responsible for the development and construction of their content. As
+							such, authors should do their best to ensure that end users are not exposed to any of the
+							threats. This includes the responsible use of scripting, remote resources, and URLs within
+							content.</li>
+						<li>Content authors are advised to avoid the use of any means of collecting user information. If
+							user information needs to be collected for any reason, it is strongly advised that the
+							content author inform the user of the reason and intended usage for the information, and
+							provide an opt-out option as the default.</li>
+						<li>Content processors, defined as entities that handle the ingestion of EPUB content for
+							distribution, display or sale, should also be aware of the potential risks in ingestion. It
+							is advised that content processors should check content for malicious content on ingestion,
+							in addition to the validation steps that usually occur. This could include running virus
+							scans, validating external links and remote resources, or other precautions.</li>
+					</ul>
+				</section>
+			</section>
 		</section>
 		<section id="app-overview-unsupported" class="appendix">
 			<h2>Unsupported Features</h2>
@@ -10650,8 +10705,8 @@ EPUB/images/cover.png</pre>
 				<li>23-June-2021: Added the <code>base</code> element to the list of discouraged XHTML constructs. See
 						<a href="https://github.com/w3c/epub-specs/issues/1699">issue 1699</a>.</li>
 				<li>18-June-2021: Moved requirements for authoring SSML, PLS lexicons and CSS 3 Speech to the <a
-						href="https://www.w3.org/TR/epub-tts-10">EPUB 3 Text-to-Speech Enhancements</a> note. The ability
-					to use these technologies in EPUB 3 Publications remains unchanged. See <a
+						href="https://www.w3.org/TR/epub-tts-10">EPUB 3 Text-to-Speech Enhancements</a> note. The
+					ability to use these technologies in EPUB 3 Publications remains unchanged. See <a
 						href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
 				<li>16-June-2021: Absolute URLs with <code>file</code> scheme should not be used on manifest items. See
 						<a href="https://github.com/w3c/epub-specs/issues/1688">issue 1688</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4488,10 +4488,10 @@ No Entry</pre>
 						<p>EPUB 3 defines two contexts for script execution:</p>
 
 						<ul>
-							<li><a href="#sec-scripted-container-constrained">container constrained</a> &#8212;
-								when the execution of a script occurs within an <code>iframe</code>; and</li>
-							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a
-								script occurs directly within a <a>Top-level Content Document</a>.</li>
+							<li><a href="#sec-scripted-container-constrained">container constrained</a> &#8212; when the
+								execution of a script occurs within an <code>iframe</code>; and</li>
+							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a script
+								occurs directly within a <a>Top-level Content Document</a>.</li>
 						</ul>
 						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference
 							it via the element's <code>src</code> attribute makes no difference to its executing
@@ -8773,103 +8773,170 @@ html.my-document-playing * {
 		<section id="sec-security-privacy" class="informative">
 			<h2>Security and Privacy</h2>
 
-			<div class="ednote">
-				<p>This is a very initial draft intended only as a starting point. It is inspired by the <a
-						href="https://www.w3.org/TR/pub-manifest/#security-privacy">relevant section of the Publication
-						Manifest</a> specification. It will require more work.</p>
+			<section id="security-privacy-overview">
+				<h3>Overview</h3>
 
-			</div>
+				<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
+					representing, packaging, and encoding structured and semantically enhanced Web content — including
+					HTML, CSS, SVG, JavaScript, and other resources — for distribution in a single-file container.</p>
 
-			<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
-				representing, packaging, and encoding structured and semantically enhanced Web content — including HTML,
-				CSS, SVG, JavaScript, and other resources — for distribution in a single-file container.</p>
+				<p>This means that, essentially, the security and privacy issues are reliant on the features of those
+					formats. In particular:</p>
 
-			<p>This means that, essentially, the security and privacy issues are reliant on the features of those
-				formats. In particular:</p>
+				<ul>
+					<li>EPUB 3 allows references to remotely hosted resources from within <a>EPUB Content Documents</a>,
+						but also from the <a>Package Document</a> (e.g., in a <a href="#sec-item-elem"
+							><code>item</code></a> element which allows both local and remote references). This is not
+						unlike any external reference from an average Web site that potentially exposes users to
+						malicious content, and EPUB Creators should take general Web security principles into account
+						(e.g., cross-origin resource sharing).</li>
+					<li>The <a href="#sec-package-doc">Package Document</a> allows personally identifiable information
+						about an EPUB Publication's creator(s) (e.g., names, identifying URLs) to be included, so
+						authoring tools could expose unexpected information if explicit author approval of metadata is
+						not required.</li>
+				</ul>
 
-			<ul>
-				<li>EPUB 3 allows references to remotely hosted resources from within <a>EPUB Content Documents</a>, but
-					also from the <a>Package Document</a> (e.g., in a <a href="#sec-item-elem"><code>item</code></a>
-					element which allows both local and remote references). This is not unlike any external reference
-					from an average Web site that potentially exposes users to malicious content, and EPUB Creators
-					should take general Web security principles into account (e.g., cross-origin resource sharing).</li>
-				<li>The <a href="#sec-package-doc">Package Document</a> allows personally identifiable information about
-					an EPUB Publication's creator(s) (e.g., names, identifying URLs) to be included, so authoring tools
-					could expose unexpected information if explicit author approval of metadata is not required.</li>
-			</ul>
-			<p>In general, EPUB 3 tries to avoid extending the underlying technologies it builds on, but it has
-				introduced some new features. These additions are not known to present any new privacy or security
-				issues:</p>
+				<p>In general, EPUB 3 tries to avoid extending the underlying technologies it builds on, but it has
+					introduced some new features. These additions are not known to present any new privacy or security
+					issues:</p>
 
-			<ul>
-				<li>
-					<p><a href="#sec-xhtml-content-switch">Content switching</a> and <a href="#sec-xhtml-epub-trigger"
-							>multimedia control elements</a> (both now deprecated) only allow hiding of content and
-						script-less control of playback in HTML.</p>
-				</li>
-				<li>
-					<p>The <a href="#sec-epub-type-attribute">expression of structural semantics</a> in HTML and SVG
-						only allows the annotation of elements.</p>
-				</li>
-				<li>
-					<p>The <a data-cite="epub-rs-33#app-epubReadingSystem"><code>epubReadingSystem</code> object</a>
-						[[EPUB-RS-33]] only allows EPUB Creators to query information about the current Reading
-						System.</p>
-				</li>
-			</ul>
+				<ul>
+					<li>
+						<p><a href="#sec-xhtml-content-switch">Content switching</a> and <a
+								href="#sec-xhtml-epub-trigger">multimedia control elements</a> (both now deprecated)
+							only allow hiding of content and script-less control of playback in HTML.</p>
+					</li>
+					<li>
+						<p>The <a href="#sec-epub-type-attribute">expression of structural semantics</a> in HTML and SVG
+							only allows the annotation of elements.</p>
+					</li>
+					<li>
+						<p>The <a data-cite="epub-rs-33#app-epubReadingSystem"><code>epubReadingSystem</code> object</a>
+							[[EPUB-RS-33]] only allows EPUB Creators to query information about the current Reading
+							System.</p>
+					</li>
+				</ul>
 
-			<section>
-				<h2>EPUB Threat Model / Privacy Advice</h2>
+				<p>But although the format does introduce inherent private and security risks, EPUB Creators must be
+					aware of the privacy and security risks that the authoring of their content can introduce. The rest
+					of this section explores some of the known risks and the steps to mitigate them.</p>
 
-				<section>
-					<h3>Security/Privacy Objectives</h3>
+				<div class="note">
+					<p>For the risks associated with Reading Systems, refer to the <a
+							href="https://www.w3.org/TR/epub-rs-33/#sec-security-privacy">security and privacy
+							section</a> of [[EPUB-RS-33]].</p>
+				</div>
+			</section>
 
-					<ol>
-						<li>EPUB should preserve content author and end user confidentiality where possible.</li>
-						<li>Content integrity.</li>
-						<li>Reading Systems should advise users of their data policies, and protect content integrity
-							and user data.</li>
-					</ol>
-				</section>
+			<section id="epub-threat-model">
+				<h3>EPUB Threat Model</h3>
 
-				<section>
-					<h3>Threats</h3>
+				<p>There are two primary ways that EPUB Publications present risks to users. The first is to trick the
+					user in believing that they are interacting with content from a trustworthy source. These deceptions
+					can take the following forms:</p>
 
-					<ul>
-						<li>falsified creator information (including identifiers, DRM licenses, etc.)</li>
-						<li>remote resources come from compromised or risky sources</li>
-						<li>links to remote resources that compromise user or platform security</li>
-						<li>container contains malicious content, or links to it</li>
-						<li>spoofed platforms (where content is designed to imitate or replicate a platform's experience
-							in order to trick a user into providing data)</li>
-						<li>scripting: <ul>
-								<li>serving information to remote receivers</li>
-								<li>local storage</li>
-								<li>unauthorized collection of user data</li>
-							</ul>
-						</li>
-					</ul>
-				</section>
+				<dl>
+					<dt>Falsified publication information</dt>
+					<dd>
+						<p>The EPUB Publication may include false information about itself in order to trick users into
+							believing that it comes from a legitimate source. A malicious EPUB Creator might, for
+							example, use the title, authors, identifiers, publisher to identify the work.</p>
+						<p>Although this misinformation itself is generally harmless, it could lead users to trust
+							malicious forms, links and other content within the EPUB Publication believing it comes from
+							a reliable source.</p>
+					</dd>
 
-				<section>
-					<h3>Recommendations</h3>
+					<dt>Spoofed platforms</dt>
+					<dd>
+						<p>Malicious EPUB Creators may also design their content to imitate or replicate a platform's
+							experience in order to trick users into providing data.</p>
+					</dd>
+				</dl>
 
-					<ul>
-						<li>Content authors are responsible for the development and construction of their content. As
-							such, authors should do their best to ensure that end users are not exposed to any of the
-							threats. This includes the responsible use of scripting, remote resources, and URLs within
-							content.</li>
-						<li>Content authors are advised to avoid the use of any means of collecting user information. If
-							user information needs to be collected for any reason, it is strongly advised that the
-							content author inform the user of the reason and intended usage for the information, and
-							provide an opt-out option as the default.</li>
-						<li>Content processors, defined as entities that handle the ingestion of EPUB content for
-							distribution, display or sale, should also be aware of the potential risks in ingestion. It
-							is advised that content processors should check content for malicious content on ingestion,
-							in addition to the validation steps that usually occur. This could include running virus
-							scans, validating external links and remote resources, or other precautions.</li>
-					</ul>
-				</section>
+				<p>With or without such trust-building tricks, there are still various ways that unsuspecting users can
+					be duped in accessing malicious content or providing sensitive information. These include:</p>
+
+				<dl>
+					<dt>Remote resources</dt>
+					<dd>
+						<p>EPUB Publications allow some hosting of <a>remote resources</a> for files whose sizes can
+							negatively affect the downloading of the content. These exemptions can be used to inject
+							malicious content into a publication, both by bad actors distributing malicious content and
+							when EPUB Creators use content from untrustworthy sources.</p>
+						<p>Checking for malware and exploits may not be reliable, as the malicious content can be
+							swapped in any time after publication, unlike resources that come embedded in the EPUB
+							Container.</p>
+					</dd>
+
+					<dt>External links</dt>
+					<dd>
+						<p>A malicious EPUB Creator could include links to web sites and resources that compromise the
+							Reading System or operating system security. Although external links will typically open in
+							a web browser, and be subject to the browser security model, this does not protect users
+							from all exploits.</p>
+						<p>Even if the intentions of the EPUB Creator are not malicious, adding tracking information to
+							external links is problematic for user privacy. Broken-link hijacking can also lead to users
+							being taken to resources the EPUB Creator did not intend.</p>
+					</dd>
+
+					<dt>Malicious content</dt>
+					<dd>
+						<p>Resources embedded in the EPUB Container are not immune to malicious actors, especially when
+							EPUB Publications are obtained from untrusted sources. Resources may contain exploits, or
+							forms may submit sensitive information to unexpected sources.</p>
+						<p>The use of third-party resources may also lead to security and privacy issues if the EPUB
+							Creator is not able to fully vet the content.</p>
+					</dd>
+
+					<dt>Network scripting</dt>
+					<dd>
+						<p>When scripts can access a device's network, it provides EPUB Creators with a number of
+							channels to exploit the user:</p>
+						<ul>
+							<li>collecting information about the user and their activities, whether malicious or
+								not;</li>
+							<li>attempting to access the file system and local storage to harvest information;</li>
+							<li>phishing attempts (e.g., making an EPUB Content Document appear like a trusted web site
+								to get the user to submit login information); and</li>
+							<li>injecting malicious content from external sites into the EPUB Publication.</li>
+						</ul>
+						<p>Network access may allow third-party content an EPUB Creator uses to exploit the user even if
+							it was never the EPUB Creators intent.</p>
+					</dd>
+				</dl>
+			</section>
+
+			<section id="security-privacy-recommendations">
+				<h3>Recommendations</h3>
+
+				<p>Although EPUB Creators cannot prevent every method of exploiting users described in the preceding
+					section, they are ultimately responsible for the secure construction of their content. That means
+					that they should take precautions to limit the exposure of their EPUB Publications to the types of
+						<a href="#epub-threat-model">malicious exploits</a> described in the previous section.</p>
+
+				<p>Some practical steps for avoiding malicious content include:</p>
+
+				<ul>
+					<li>Ensure the use of stable links to <a>remote resources</a>.</li>
+					<li>Avoid third-party resources, especially those hosted on servers outside the control of the EPUB
+						Creator.</li>
+					<li>Avoid links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
+					<li>Avoid embedding content not provided by reputable organizations or individuals.</li>
+				</ul>
+
+				<p>EPUB Creators also need to take into account the privacy rights of users and avoid situations where
+					they are intentionally collecting data. Ideally, EPUB Creators should not track their users, but
+					this is not realistic for all types of publishing.</p>
+
+				<p>When tracking must occur, EPUB Creators should obtain the approval of the user to collect information
+					prior to opening the EPUB Publication (e.g., in educational course work). If this is not possible,
+					they should obtain permission when the EPUB Publication is accessed for the first time. EPUB
+					Creators should also allow users to opt out of tracking, when feasible, and provide users the
+					ability to manage and delete any data that is collected about them.</p>
+
+				<p>Content authors also need to consider the inadvertent collection of information about users. Linking
+					to content on a publisher's web site, or remotely hosting resources on their servers, can lead to
+					profiling users, especially if unique tracking identifiers are added to the URLs.</p>
 			</section>
 		</section>
 		<section id="app-overview-unsupported" class="appendix">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8798,38 +8798,20 @@ html.my-document-playing * {
 			<section id="epub-threat-model">
 				<h3>Threat Model</h3>
 
-				<p>There are two primary ways that EPUB Publications present risks to users. The first is to trick the
-					user into believing that they are interacting with content from a trustworthy source. These
-					deceptions can take the following forms:</p>
-
-				<dl>
-					<dt>Falsified publication information</dt>
-					<dd>
-						<p>The EPUB Publication may include false information about itself to trick users into believing
-							that it comes from a legitimate source. A malicious EPUB Creator might, for example, fake
-							the title, authors, identifiers, and publisher for the work.</p>
-						<p>Although this misinformation itself does not present an immediate harm, it could lead users
-							to trust malicious forms, links, and other content within the EPUB Publication believing it
-							comes from a reliable source.</p>
-					</dd>
-
-					<dt>Spoofed platforms</dt>
-					<dd>
-						<p>Malicious EPUB Creators may also design their content to imitate or replicate a platform's
-							experience to trick users into trusting their content.</p>
-					</dd>
-				</dl>
-
-				<p>With or without such trust-building tricks, there are still various ways that unsuspecting users can
-					be tricked into accessing malicious content or providing sensitive information. These include:</p>
+				<p>EPUB Publications pose a variety of privacy and security threats to unsuspecting users. Many of these
+					threats intersect with web content generally, but EPUB also introduces its own unique methods of
+					attack that can be used to trick users into accessing malicious content or into providing sensitive
+					information. Some of the more important attack vectors that EPUB Creators and users need to be aware
+					of include:</p>
 
 				<dl>
 					<dt>Embedding of remote resources</dt>
 					<dd>
 						<p>EPUB 3 allows some resources to be <a href="#dfn-remote-resource">remotely hosted</a>,
 							specifically resources whose sizes can negatively affect the downloading and opening of the
-							EPUB Publication. Although helpful for users when used as intended, these exemptions can
-							also be used to inject malicious content into a publication.</p>
+							EPUB Publication (e.g., audio, video, and fonts). Although helpful for users when used as
+							intended, these exemptions can also be used to inject malicious content into a
+							publication.</p>
 						<p>This threat is not limited to accessing content created by a bad actor. If EPUB Creators
 							embed content from untrustworthy sources (e.g., third party audio and video), there is
 							always the possibility that users may receive compromised resources.</p>
@@ -8885,6 +8867,28 @@ html.my-document-playing * {
 					</dd>
 				</dl>
 
+				<p>The effectiveness of these attacks also often depends on tricking users into believing that the
+					publication they are interacting with is from a trustworthy source. These deceptions can take the
+					following forms:</p>
+
+				<dl>
+					<dt>Falsified publication information</dt>
+					<dd>
+						<p>The EPUB Publication may include false information about itself to trick users into believing
+							that it comes from a legitimate source. A malicious EPUB Creator might, for example, fake
+							the title, authors, identifiers, and publisher for the work.</p>
+						<p>Although this misinformation itself does not present an immediate harm, it could lead users
+							to trust malicious forms, links, and other content within the EPUB Publication believing it
+							comes from a reliable source.</p>
+					</dd>
+
+					<dt>Spoofed platforms</dt>
+					<dd>
+						<p>Malicious EPUB Creators may also design their content to imitate or replicate a platform's
+							experience to trick users into trusting their content.</p>
+					</dd>
+				</dl>
+
 				<section id="privacy-security-epub-features">
 					<h4>EPUB-Specific Features</h4>
 
@@ -8895,8 +8899,10 @@ html.my-document-playing * {
 					<ul>
 						<li>
 							<p><a href="#sec-xhtml-content-switch">Content switching</a> and <a
-									href="#sec-xhtml-epub-trigger">multimedia control elements</a> (both now deprecated)
-								only allow hiding of content and script-less control of playback in HTML.</p>
+									href="#sec-xhtml-epub-trigger">multimedia control elements</a> only allow hiding of
+								content and script-less control of playback in HTML. Moreover these features, introduced
+								in the first release of EPUB 3.0, are <a href="#deprecated">deprecated</a> and no longer
+								recommended for use.</p>
 						</li>
 						<li>
 							<p>The <a href="#sec-epub-type-attribute">expression of structural semantics</a> in HTML and
@@ -8906,10 +8912,9 @@ html.my-document-playing * {
 
 					<p>The one potential exception is the <a data-cite="epub-rs-33#app-epubReadingSystem"
 								><code>epubReadingSystem</code> object</a> [[EPUB-RS-33]] allows EPUB Creators to query
-						information about the current Reading System. As described in the threat model, EPUB Creators
-						need to be mindful that they only use the information exposed by this object to improve the
-						rendering of their content (i.e., avoid using the information to profile the user and their
-						environment).</p>
+						information about the current Reading System. EPUB Creators need to be mindful that they only
+						use the information exposed by this object to improve the rendering of their content (i.e.,
+						avoid using the information to profile the user and their environment).</p>
 				</section>
 			</section>
 
@@ -8929,7 +8934,10 @@ html.my-document-playing * {
 						EPUB Creator.</li>
 					<li>Avoiding links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
 					<li>Using secure connections to external sites and resources (i.e., using the HTTPS protocol).</li>
+					<li>Not using scripts to send or receive data over the network without the consent of the user.</li>
 					<li>Avoiding embedding content not provided by reputable organizations or individuals.</li>
+					<li>Avoiding deprecated features of EPUB due to the potential for undiscovered bugs in
+						implementations.</li>
 				</ul>
 
 				<p>EPUB Creators also need to consider the privacy rights of users and avoid situations where they are

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8777,49 +8777,16 @@ html.my-document-playing * {
 				<h3>Overview</h3>
 
 				<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
-					representing, packaging, and encoding structured and semantically enhanced Web content — including
+					representing, packaging, and encoding structured and semantically enhanced web content — including
 					HTML, CSS, SVG, JavaScript, and other resources — for distribution in a single-file container.</p>
 
-				<p>This means that, essentially, the security and privacy issues are reliant on the features of those
-					formats. In particular:</p>
+				<p>This means that EPUB 3's security and privacy issues are primarily linked to the features of those
+					formats, and closely mirror the threats presented by web content generally.</p>
 
-				<ul>
-					<li>EPUB 3 allows references to remotely hosted resources from within <a>EPUB Content Documents</a>,
-						but also from the <a>Package Document</a> (e.g., in a <a href="#sec-item-elem"
-							><code>item</code></a> element which allows both local and remote references). This is not
-						unlike any external reference from an average Web site that potentially exposes users to
-						malicious content, and EPUB Creators should take general Web security principles into account
-						(e.g., cross-origin resource sharing).</li>
-					<li>The <a href="#sec-package-doc">Package Document</a> allows personally identifiable information
-						about an EPUB Publication's creator(s) (e.g., names, identifying URLs) to be included, so
-						authoring tools could expose unexpected information if explicit author approval of metadata is
-						not required.</li>
-				</ul>
-
-				<p>In general, EPUB 3 tries to avoid extending the underlying technologies it builds on, but it has
-					introduced some new features. These additions are not known to present any new privacy or security
-					issues:</p>
-
-				<ul>
-					<li>
-						<p><a href="#sec-xhtml-content-switch">Content switching</a> and <a
-								href="#sec-xhtml-epub-trigger">multimedia control elements</a> (both now deprecated)
-							only allow hiding of content and script-less control of playback in HTML.</p>
-					</li>
-					<li>
-						<p>The <a href="#sec-epub-type-attribute">expression of structural semantics</a> in HTML and SVG
-							only allows the annotation of elements.</p>
-					</li>
-					<li>
-						<p>The <a data-cite="epub-rs-33#app-epubReadingSystem"><code>epubReadingSystem</code> object</a>
-							[[EPUB-RS-33]] only allows EPUB Creators to query information about the current Reading
-							System.</p>
-					</li>
-				</ul>
-
-				<p>But although the format does introduce inherent private and security risks, EPUB Creators must be
-					aware of the privacy and security risks that the authoring of their content can introduce. The rest
-					of this section explores some of the known risks and the steps to mitigate them.</p>
+				<p>Although content risks are often equated with deliberately malicious authoring intent, EPUB Creators
+					need to be aware that many practices followed with the best of intentions may expose users to
+					privacy and security issues. The rest of this section explores the risk model of EPUB 3 with the aim
+					of helping EPUB Creators recognize and mitigate these risks.</p>
 
 				<div class="note">
 					<p>For the risks associated with Reading Systems, refer to the <a
@@ -8832,66 +8799,72 @@ html.my-document-playing * {
 				<h3>Threat Model</h3>
 
 				<p>There are two primary ways that EPUB Publications present risks to users. The first is to trick the
-					user in believing that they are interacting with content from a trustworthy source. These deceptions
-					can take the following forms:</p>
+					user into believing that they are interacting with content from a trustworthy source. These
+					deceptions can take the following forms:</p>
 
 				<dl>
 					<dt>Falsified publication information</dt>
 					<dd>
-						<p>The EPUB Publication may include false information about itself in order to trick users into
-							believing that it comes from a legitimate source. A malicious EPUB Creator might, for
-							example, use the title, authors, identifiers, publisher to identify the work.</p>
-						<p>Although this misinformation itself is generally harmless, it could lead users to trust
-							malicious forms, links and other content within the EPUB Publication believing it comes from
-							a reliable source.</p>
+						<p>The EPUB Publication may include false information about itself to trick users into believing
+							that it comes from a legitimate source. A malicious EPUB Creator might, for example, fake
+							the title, authors, identifiers, and publisher for the work.</p>
+						<p>Although this misinformation itself does not present an immediate harm, it could lead users
+							to trust malicious forms, links, and other content within the EPUB Publication believing it
+							comes from a reliable source.</p>
 					</dd>
 
 					<dt>Spoofed platforms</dt>
 					<dd>
 						<p>Malicious EPUB Creators may also design their content to imitate or replicate a platform's
-							experience in order to trick users into providing data.</p>
+							experience to trick users into trusting their content.</p>
 					</dd>
 				</dl>
 
 				<p>With or without such trust-building tricks, there are still various ways that unsuspecting users can
-					be duped in accessing malicious content or providing sensitive information. These include:</p>
+					be tricked into accessing malicious content or providing sensitive information. These include:</p>
 
 				<dl>
-					<dt>Remote resources</dt>
+					<dt>Embedding of remote resources</dt>
 					<dd>
-						<p>EPUB Publications allow some hosting of <a>remote resources</a> for files whose sizes can
-							negatively affect the downloading of the content. These exemptions can be used to inject
-							malicious content into a publication, both by bad actors distributing malicious content and
-							when EPUB Creators use content from untrustworthy sources.</p>
-						<p>Checking for malware and exploits may not be reliable, as the malicious content can be
-							swapped in any time after publication, unlike resources that come embedded in the EPUB
-							Container.</p>
+						<p>EPUB 3 allows some resources to be <a href="#dfn-remote-resource">remotely hosted</a>,
+							specifically resources whose sizes can negatively affect the downloading and opening of the
+							EPUB Publication. Although helpful for users when used as intended, these exemptions can
+							also be used to inject malicious content into a publication.</p>
+						<p>This threat is not limited to accessing content created by a bad actor. If EPUB Creators
+							embed content from untrustworthy sources (e.g., third party audio and video), there is
+							always the possibility that users may receive compromised resources.</p>
+						<p>Checking for malware and exploits at distribution time is not always reliable, either, as the
+							malicious content can be swapped in any time after publication, unlike resources that come
+							embedded in the EPUB Container.</p>
 					</dd>
 
-					<dt>External links</dt>
+					<dt>Linking to external resources</dt>
 					<dd>
-						<p>A malicious EPUB Creator could include links to web sites and resources that compromise the
-							Reading System or operating system security. Although external links will typically open in
-							a web browser, and be subject to the browser security model, this does not protect users
-							from all exploits.</p>
+						<p>Whether intentional or not, links to external web sites and resources expose users to
+							potential exploits that can compromise their Reading System or operating system. Although
+							external links will typically open in a web browser, and be subject to the browser security
+							model, this does not protect users from all exploits.</p>
 						<p>Even if the intentions of the EPUB Creator are not malicious, adding tracking information to
-							external links is problematic for user privacy. Broken-link hijacking can also lead to users
-							being taken to resources the EPUB Creator did not intend.</p>
+							external links is problematic for user privacy as it can allow a user's activity to be
+							tracked without their consent.</p>
+						<p>Broken-link hijacking &#8212; when a domain expires and is bought by another party to exploit
+							the links to it &#8212; can also lead to users being taken to resources the EPUB Creator did
+							not intend.</p>
 					</dd>
 
-					<dt>Malicious content</dt>
+					<dt>Including malicious content</dt>
 					<dd>
 						<p>Resources embedded in the EPUB Container are not immune to malicious actors, especially when
-							EPUB Publications are obtained from untrusted sources. Resources may contain exploits, or
-							forms may submit sensitive information to unexpected sources.</p>
-						<p>The use of third-party resources may also lead to security and privacy issues if the EPUB
-							Creator is not able to fully vet the content.</p>
+							EPUB Publications are obtained from untrusted sources. Resources may contain exploits or
+							forms may submit sensitive information to unintended parties.</p>
+						<p>The use of third-party content, such as games and quizzes, may also lead to security and
+							privacy issues if the EPUB Creator is not able to fully vet the content.</p>
 					</dd>
 
-					<dt>Network scripting</dt>
+					<dt>Allowing scripts network access</dt>
 					<dd>
-						<p>When scripts can access a device's network, it provides EPUB Creators with a number of
-							channels to exploit the user:</p>
+						<p>When scripts can access a device's network, it provides a variety channels to exploit the
+							user:</p>
 						<ul>
 							<li>collecting information about the user and their activities, whether malicious or
 								not;</li>
@@ -8904,36 +8877,64 @@ html.my-document-playing * {
 							it was never the EPUB Creators intent.</p>
 					</dd>
 
-					<dt>Digital rights management</dt>
+					<dt>Securing content with digital rights management</dt>
 					<dd>
 						<p>The encryption and decryption of EPUB Publications using digital rights management schemes
-							may allow personally-identifiable information about the user, what vendors they use, and
+							may allow personally identifiable information about the user, what vendors they use, and
 							their reading choices to be relayed to third parties.</p>
 					</dd>
 				</dl>
+
+				<section id="privacy-security-epub-features">
+					<h4>EPUB-Specific Features</h4>
+
+					<p>EPUB 3 tries to avoid extending the underlying technologies it builds on, but it has introduced
+						some new features. The restricted scope of these features generally limits the threats they
+						might pose, however:</p>
+
+					<ul>
+						<li>
+							<p><a href="#sec-xhtml-content-switch">Content switching</a> and <a
+									href="#sec-xhtml-epub-trigger">multimedia control elements</a> (both now deprecated)
+								only allow hiding of content and script-less control of playback in HTML.</p>
+						</li>
+						<li>
+							<p>The <a href="#sec-epub-type-attribute">expression of structural semantics</a> in HTML and
+								SVG only allows the annotation of elements.</p>
+						</li>
+					</ul>
+
+					<p>The one potential exception is the <a data-cite="epub-rs-33#app-epubReadingSystem"
+								><code>epubReadingSystem</code> object</a> [[EPUB-RS-33]] allows EPUB Creators to query
+						information about the current Reading System. As described in the threat model, EPUB Creators
+						need to be mindful that they only use the information exposed by this object to improve the
+						rendering of their content (i.e., avoid using the information to profile the user and their
+						environment).</p>
+				</section>
 			</section>
 
 			<section id="security-privacy-recommendations">
 				<h3>Recommendations</h3>
 
-				<p>Although EPUB Creators cannot prevent every method of exploiting users described in the preceding
-					section, they are ultimately responsible for the secure construction of their content. That means
-					that they should take precautions to limit the exposure of their EPUB Publications to the types of
-						<a href="#epub-threat-model">malicious exploits</a> described in the previous section.</p>
+				<p>Although EPUB Creators cannot prevent every method of exploiting users, they are ultimately
+					responsible for the secure construction of their content. That means that they should take
+					precautions to limit the exposure of their EPUB Publications to the types of <a
+						href="#epub-threat-model">malicious exploits</a> described in the previous section.</p>
 
-				<p>Some practical steps for avoiding malicious content include:</p>
+				<p>Some practical steps include:</p>
 
 				<ul>
-					<li>Ensure the use of stable links to <a>remote resources</a>.</li>
-					<li>Avoid third-party resources, especially those hosted on servers outside the control of the EPUB
-						Creator.</li>
-					<li>Avoid links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
-					<li>Avoid embedding content not provided by reputable organizations or individuals.</li>
+					<li>Ensuring the use of stable links to <a>remote resources</a>.</li>
+					<li>Avoiding third-party resources, especially those hosted on servers outside the control of the
+						EPUB Creator.</li>
+					<li>Avoiding links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
+					<li>Using secure connections to external sites and resources (i.e., using the HTTPS protocol).</li>
+					<li>Avoiding embedding content not provided by reputable organizations or individuals.</li>
 				</ul>
 
-				<p>EPUB Creators also need to take into account the privacy rights of users and avoid situations where
-					they are intentionally collecting data. Ideally, EPUB Creators should not track their users, but
-					this is not realistic for all types of publishing.</p>
+				<p>EPUB Creators also need to consider the privacy rights of users and avoid situations where they are
+					intentionally collecting data. Ideally, EPUB Creators should not track their users, but this is not
+					realistic for all types of publishing.</p>
 
 				<p>When tracking must occur, EPUB Creators should obtain the approval of the user to collect information
 					prior to opening the EPUB Publication (e.g., in educational course work). If this is not possible,
@@ -8945,9 +8946,9 @@ html.my-document-playing * {
 					to content on a publisher's web site, or remotely hosting resources on their servers, can lead to
 					profiling users, especially if unique tracking identifiers are added to the URLs.</p>
 
-				<p>Publishers and vendors should avoid the use of digital rights management schemes whenever possible,
-					or use schemes that do not utilize or transmit information about the user or their content to
-					external parties to perform encryption or decryption.</p>
+				<p>When publishers and vendors must use digital rights management schemes, they should prefer schemes
+					that do not utilize or transmit information about the user or their content to external parties to
+					perform encryption or decryption.</p>
 			</section>
 		</section>
 		<section id="app-overview-unsupported" class="appendix">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8960,9 +8960,8 @@ html.my-document-playing * {
 
 				<p>EPUB Creators who want to maximally limit the privacy and security issues in their EPUB Publications
 					should work to make the content as self-contained as possible. An EPUB Publication that comes with
-					all its needed resources and has no dependencies on network access or external content provides
-					security for users and has the added benefits of reducing future maintenance and improving
-					archivability.</p>
+					all its needed resources and has no dependencies on network access or links to external content not
+					only benefits users but reduces future maintenance and improves archivability.</p>
 			</section>
 		</section>
 		<section id="app-overview-unsupported" class="appendix">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8829,7 +8829,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="epub-threat-model">
-				<h3>EPUB Threat Model</h3>
+				<h3>Threat Model</h3>
 
 				<p>There are two primary ways that EPUB Publications present risks to users. The first is to trick the
 					user in believing that they are interacting with content from a trustworthy source. These deceptions
@@ -8903,6 +8903,13 @@ html.my-document-playing * {
 						<p>Network access may allow third-party content an EPUB Creator uses to exploit the user even if
 							it was never the EPUB Creators intent.</p>
 					</dd>
+
+					<dt>Digital rights management</dt>
+					<dd>
+						<p>The encryption and decryption of EPUB Publications using digital rights management schemes
+							may allow personally-identifiable information about the user, what vendors they use, and
+							their reading choices to be relayed to third parties.</p>
+					</dd>
 				</dl>
 			</section>
 
@@ -8937,6 +8944,10 @@ html.my-document-playing * {
 				<p>Content authors also need to consider the inadvertent collection of information about users. Linking
 					to content on a publisher's web site, or remotely hosting resources on their servers, can lead to
 					profiling users, especially if unique tracking identifiers are added to the URLs.</p>
+
+				<p>Publishers and vendors should avoid the use of digital rights management schemes whenever possible,
+					or use schemes that do not utilize or transmit information about the user or their content to
+					external parties to perform encryption or decryption.</p>
 			</section>
 		</section>
 		<section id="app-overview-unsupported" class="appendix">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2015,6 +2015,48 @@
 					environment should be able to cancel the default action of any event, some events either might not
 					be passed through or might not be cancelable.</p>
 			</section>
+
+			<section>
+				<h2>EPUB Threat Model / Privacy Advice</h2>
+				<section>
+					<h3>Threats</h3>
+
+					<ul>
+						<li>scripting:</li>
+						<li>compromised local storage</li>
+						<li>unauthorized collection of user data</li>
+						<li>sending of information to remote receivers</li>
+						<li>spoofed platforms</li>
+						<li>malicious content within containers</li>
+						<li>accessing malicious remote resources</li>
+						<li>collection of user data</li>
+						<li>user-generated content</li>
+						<li>digital rights management</li>
+					</ul>
+				</section>
+
+				<section>
+					<h3>Recommendations</h3>
+
+					<ul>
+						<li>Reading systems are responsible for the display of EPUB documents. Reading systems should do
+							their best to ensure that end users are not exposed to any of the threats by building
+							protections against them into their reading systems. Reading systems should also provide
+							clarity and personalization to the data they may want to collect and use about the user
+							and/or their reading behaviour.</li>
+						<li>It is understood that the collection of some user data may be required for the sale,
+							delivery, and operation of an EPUB file, particularly on platforms where the sale of an EPUB
+							file and the method of reading it are connected. In these cases, it is recommended that the
+							reading system or retailer be clear about the data being collected, how it is used, and
+							allow for user opt-outs where possible. Anonymization of data is strongly recommended for
+							the privacy and the security of the user and reading system.</li>
+						<li>It is also understood that user data may be required or helpful for some reading system
+							affordances. In these cases, anonymization is strongly recommended. It is also recommended
+							that reading systems inform users of what data is needed, what it is to be used for, and to
+							provide methods to opt-out.</li>
+					</ul>
+				</section>
+			</section>
 		</section>
 		<section id="app-epubReadingSystem">
 			<h2><dfn>epubReadingSystem</dfn> Object</h2>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2106,6 +2106,11 @@
 						<p>Reading Systems that allow local storage should also provide methods for users to inspect or
 							delete that data.</p>
 					</li>
+
+					<li>
+						<p>Reading Systems should open links outside the EPUB Publication in a new browser instance to
+							ensure that the security and privacy controls of the browser are available to users.</p>
+					</li>
 				</ul>
 
 				<p>It is understood that the collection of some user data may be required for the sale, delivery, and

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2029,46 +2029,48 @@
 					be passed through or might not be cancelable.</p>
 			</section>
 
-			<section>
-				<h2>EPUB Threat Model / Privacy Advice</h2>
-				<section>
-					<h3>Threats</h3>
+			<section id="epub-threat-model">
+				<h3>EPUB Threat Model</h3>
 
-					<ul>
-						<li>scripting:</li>
-						<li>compromised local storage</li>
-						<li>unauthorized collection of user data</li>
-						<li>sending of information to remote receivers</li>
-						<li>spoofed platforms</li>
-						<li>malicious content within containers</li>
-						<li>accessing malicious remote resources</li>
-						<li>collection of user data</li>
-						<li>user-generated content</li>
-						<li>digital rights management</li>
-					</ul>
-				</section>
+				<ul>
+					<li>scripting:</li>
+					<li>compromised local storage</li>
+					<li>unauthorized collection of user data</li>
+					<li>sending of information to remote receivers</li>
+					<li>spoofed platforms</li>
+					<li>malicious content within containers</li>
+					<li>accessing malicious remote resources</li>
+					<li>collection of user data</li>
+					<li>user-generated content</li>
+					<li>digital rights management</li>
+				</ul>
+			</section>
 
-				<section>
-					<h3>Recommendations</h3>
+			<section id="security-privacy-recommendations">
+				<h3>Recommendations</h3>
 
-					<ul>
-						<li>Reading systems are responsible for the display of EPUB documents. Reading systems should do
-							their best to ensure that end users are not exposed to any of the threats by building
-							protections against them into their reading systems. Reading systems should also provide
-							clarity and personalization to the data they may want to collect and use about the user
-							and/or their reading behaviour.</li>
-						<li>It is understood that the collection of some user data may be required for the sale,
-							delivery, and operation of an EPUB file, particularly on platforms where the sale of an EPUB
-							file and the method of reading it are connected. In these cases, it is recommended that the
-							reading system or retailer be clear about the data being collected, how it is used, and
-							allow for user opt-outs where possible. Anonymization of data is strongly recommended for
-							the privacy and the security of the user and reading system.</li>
-						<li>It is also understood that user data may be required or helpful for some reading system
-							affordances. In these cases, anonymization is strongly recommended. It is also recommended
-							that reading systems inform users of what data is needed, what it is to be used for, and to
-							provide methods to opt-out.</li>
-					</ul>
-				</section>
+				<ul>
+					<li>Reading systems are responsible for the display of EPUB documents. Reading systems should do
+						their best to ensure that end users are not exposed to any of the threats by building
+						protections against them into their reading systems. Reading systems should also provide clarity
+						and personalization to the data they may want to collect and use about the user and/or their
+						reading behaviour.</li>
+					<li>It is understood that the collection of some user data may be required for the sale, delivery,
+						and operation of an EPUB file, particularly on platforms where the sale of an EPUB file and the
+						method of reading it are connected. In these cases, it is recommended that the reading system or
+						retailer be clear about the data being collected, how it is used, and allow for user opt-outs
+						where possible. Anonymization of data is strongly recommended for the privacy and the security
+						of the user and reading system.</li>
+					<li>It is also understood that user data may be required or helpful for some reading system
+						affordances. In these cases, anonymization is strongly recommended. It is also recommended that
+						reading systems inform users of what data is needed, what it is to be used for, and to provide
+						methods to opt-out.</li>
+					<li>Content processors, defined as entities that handle the ingestion of EPUB content for
+						distribution, display or sale, should also be aware of the potential risks in ingestion. It is
+						advised that content processors should check content for malicious content on ingestion, in
+						addition to the validation steps that usually occur. This could include running virus scans,
+						validating external links and remote resources, or other precautions.</li>
+				</ul>
 			</section>
 		</section>
 		<section id="app-epubReadingSystem">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2130,7 +2130,7 @@
 					Consideration" sections of the Media Type registrations for the <a
 						data-cite="epub-33#app-media-type-app-oebps-package"
 						><code>application/oebps-package+xml</code></a> and the <a
-						data-cite="epub-33#app-media-type-app-oebps-package"><code>application/epub+zip</code></a>
+						data-cite="epub-33#app-media-type"><code>application/epub+zip</code></a>
 					formats for further details. </p>
 			</section>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1908,42 +1908,116 @@
 		<section id="sec-security-privacy" class="informative">
 			<h2>Security and Privacy</h2>
 
-			<div class="ednote">
-				<p>This section currently combines an overview of security and privacy considerations with issues
-					previously cited in the specification.</p>
-				<p>The Working Group intends to develop this section throughout the revision to further expand on the
-					issues and provide it with a more structured narrative.</p>
-			</div>
+			<section id="security-privacy-overview">
+				<h3>Overview</h3>
 
-			<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
-				representing, packaging, and encoding structured and semantically enhanced Web content — including HTML,
-				CSS, SVG, and other resources — for distribution in a single-file container. This specification does not
-					<em>add</em> any new features, complex APIs, etc. This also means that, essentially, the security
-				and privacy issues are reliant on the features of those formats. In particular:</p>
+				<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
+					representing, packaging, and encoding structured and semantically enhanced Web content — including
+					HTML, CSS, SVG, and other resources — for distribution in a single-file container. This
+					specification does not <em>add</em> any new features, complex APIs, etc. This also means that,
+					essentially, the security and privacy issues are reliant on the features of those formats. In
+					particular:</p>
 
-			<ul>
-				<li>EPUB 3 allows references to remotely hosted resources from within <a>EPUB Content Documents</a>, but
-					also from the <a>Package Document</a> (e.g., in a <a data-cite="epub-33#sec-item-elem"
-							><code>item</code></a> element which allows both local and remote references). This is not
-					unlike any external reference from an average Web site that potentially exposes users to malicious
-					content, and the general Web security principles should be taken into account (e.g., cross-origin
-					resource sharing).</li>
-				<li>The <a data-cite="epub-33#sec-package-doc">Package Document</a> allows personally identifiable
-					information about an EPUB Publication's creator(s) (e.g., names, identifying URLs) to be included,
-					so authoring tools could expose unexpected information if explicit author approval of metadata is
-					not required.</li>
-			</ul>
+				<ul>
+					<li>EPUB 3 allows references to remotely hosted resources from within <a>EPUB Content Documents</a>,
+						but also from the <a>Package Document</a> (e.g., in a <a data-cite="epub-33#sec-item-elem"
+								><code>item</code></a> element which allows both local and remote references). This is
+						not unlike any external reference from an average Web site that potentially exposes users to
+						malicious content, and the general Web security principles should be taken into account (e.g.,
+						cross-origin resource sharing).</li>
+					<li>The <a data-cite="epub-33#sec-package-doc">Package Document</a> allows personally identifiable
+						information about an EPUB Publication's creator(s) (e.g., names, identifying URLs) to be
+						included, so authoring tools could expose unexpected information if explicit author approval of
+						metadata is not required.</li>
+				</ul>
 
-			<p>Additionally, the security considerations that apply to XML [[XML]] and ZIP [[ZIP]] files also apply to
-				the <a data-cite="epub-33#sec-package-doc">Package Document</a> and the <a data-cite="epub-33#sec-ocf"
-					>Open Container Format</a>, respectively. See the "Security Consideration" sections of the Media
-				Type registrations for the <a data-cite="epub-33#app-media-type-app-oebps-package"
+				<p>Additionally, the security considerations that apply to XML [[XML]] and ZIP [[ZIP]] files also apply
+					to the <a data-cite="epub-33#sec-package-doc">Package Document</a> and the <a
+						data-cite="epub-33#sec-ocf">Open Container Format</a>, respectively. See the "Security
+					Consideration" sections of the Media Type registrations for the <a
+						data-cite="epub-33#app-media-type-app-oebps-package"
 						><code>application/oebps-package+xml</code></a> and the <a
-					data-cite="epub-33#app-media-type-app-oebps-package"><code>application/epub+zip</code></a> formats
-				for further details. </p>
+						data-cite="epub-33#app-media-type-app-oebps-package"><code>application/epub+zip</code></a>
+					formats for further details. </p>
+			</section>
+
+			<section id="epub-threat-model">
+				<h3>Threat Model</h3>
+
+				<p>The greatest threats to users come from the <a
+						href="https://www.w3.org/TR/epub-33/#epub-threat-model">content they read</a> [[EPUB-33]], and
+					the first line of defence against these attacks is the Reading Systems they use. Users expect that
+					Reading Systems act as safeguards against malicious content, and are often unaware that EPUB
+					Publications are susceptible to the same security risks as web sites.</p>
+
+				<p>But although Reading Systems are relied on to provide security and privacy, they can also can pose
+					unintended threats to user depending on how information is handled. Tracking user information to
+					optimize experiences is a common need, for example, but done without user permission and Reading
+					Systems can run afoul of legal privacy requirements.</p>
+
+				<p>This section outlines some of the key threats that Reading System developers must take into
+					consideration, with further details and recommendations in the following sections.</p>
+
+				<dl>
+					<dt>Scripting</dt>
+					<dd>
+						<p>Malicious scripts present a number of attack vectors against reading systems. If local
+							storage is not secure, for example, they can attempt to compromise the user's data. Provided
+							with network access, they may attempt unauthorized collection of user data.</p>
+						<p>More detailed discussion of these issues and how to mitigate them is provided in <a
+								href="#sec-scripted-content-security"></a>.</p>
+					</dd>
+
+					<dt>Malicious content</dt>
+					<dd>
+						<p>EPUB Publications may contain resources designed to exploit security flaws in Reading Systems
+							or the operating systems they run on.</p>
+					</dd>
+
+					<dt>Remote resources</dt>
+					<dd>
+						<p>Remote resources present the same risks as any EPUB Publication loaded from an untrusted
+							source. Even if the publisher of the EPUB Publication is trusted, remote resources may be
+							compromised.</p>
+						<p>Calls to remote resources can also be used to track information about users (e.g., through
+							server logs). Reading Systems should limit the information they expose through HTTP requests
+							to only what is essential to obtain the resource.</p>
+					</dd>
+
+					<dt>External links</dt>
+					<dd>
+						<p>Similar to remote resources, external links may be used to trick unwitting users into opening
+							malicious resources on the web designed to exploit the Reading System or operating
+							system.</p>
+						<p>Likewise, Reading Systems should also avoid exposing potentially identifying information
+							about users through the traversal of links (e.g., not using tracking identifiers or exposing
+							unnecessary information about the user's environment).</p>
+					</dd>
+
+					<dt>User-generated content</dt>
+					<dd>
+						<p class="ednote">Not sure I can explain this exploit without more info. I know uploaded content
+							can't be trusted, but is that the concern?</p>
+					</dd>
+
+					<dt>Collection of user data</dt>
+					<dd>
+						<p>Collecting information about the user and their reading habits without obtaining their
+							permission can violate privacy laws, even if the information is only intended for internal
+							use.</p>
+						<p>Attempting to profile users based on their reading habits or through metadata in their
+							publication (e.g., accessibility preferences) can expose users to unintended harms.</p>
+					</dd>
+
+					<dt>Spoofed platforms</dt>
+					<dd>
+						<p class="ednote">Is this one reading system spoofing another? Do we need to detail that?</p>
+					</dd>
+				</dl>
+			</section>
 
 			<section id="sec-scripted-content-security">
-				<h4>Scripting Considerations</h4>
+				<h3>Scripting Considerations</h3>
 
 				<p>Reading System developers who also support scripting must be aware of the security issues that arise
 					when Reading Systems execute scripted content. As the underlying scripting model employed by Reading
@@ -1989,12 +2063,39 @@
 					re-imported into the content library. Conversely, Reading Systems may create a new unique origin for
 					every newly-added publication.</p>
 
-				<p>In addition, this specification recommends the following privacy practices:</p>
+				<p>Note that compliance with these recommendations does not guarantee protection from the possible
+					attacks listed above; developers must examine each potential vulnerability within the context of
+					their Reading System.</p>
+
+				<section id="sec-scripted-content-events">
+					<h4>Event Model</h4>
+
+					<p>Reading Systems should follow the DOM Event model as per [[HTML]] and pass UI events to the
+						scripting environment before performing any default action associated with these events. Reading
+						System implementers should ensure that scripts cannot disable critical functionality (such as
+						navigation) to constrain the extent to which a <a href="#sec-scripted-content-security"
+							>potentially malicious</a> script could impact their Reading Systems. As a result, although
+						the scripting environment should be able to cancel the default action of any event, some events
+						either might not be passed through or might not be cancelable.</p>
+				</section>
+			</section>
+
+			<section id="security-privacy-recommendations">
+				<h3>Additional Recommendations</h3>
+
+				<p>Arguably the strongest measure that Reading System developers can take for privacy is to specify the
+					data they intend to collect and use about the user and/or their reading behaviour and seek the
+					consent of users to obtain it. They should also allow personalization and control over this
+					information.</p>
+
+				<p>In addition, the following practices should be followed to help further limit security and privacy
+					issues:</p>
 
 				<ul>
 					<li>
-						<p>Reading Systems that support scripting and network access should also include methods to
-							notify the user that network activity is occurring and/or that allow them to disable it.</p>
+						<p>Reading Systems that support scripting and network access, as well as the retrieval of remote
+							resources, should include methods to notify the user that network activity is occurring
+							and/or that allow them to disable it.</p>
 					</li>
 
 					<li>
@@ -2012,65 +2113,23 @@
 					</li>
 				</ul>
 
-				<p>Note that compliance with these recommendations does not guarantee protection from the possible
-					attacks listed above; developers must examine each potential vulnerability within the context of
-					their Reading System.</p>
-			</section>
+				<p>It is understood that the collection of some user data may be required for the sale, delivery, and
+					operation of an EPUB Publication, particularly on platforms where the sale of an EPUB Publication
+					and the method of reading it are connected. In these cases, it is recommended that the Reading
+					System or retailer be clear about the data being collected, how it is used, and allow for user
+					opt-outs where possible. Anonymization of data is strongly recommended for the privacy and the
+					security of the user and Reading System.</p>
 
-			<section id="sec-scripted-content-events">
-				<h4>Event Model Considerations</h4>
+				<p>It is also understood that user data may be required or helpful for some Reading System affordances.
+					In these cases, anonymization is strongly recommended. It is also recommended that Reading Systems
+					inform users of what data is needed, what it is to be used for, and to provide methods to
+					opt-out.</p>
 
-				<p>Reading Systems should follow the DOM Event model as per [[HTML]] and pass UI events to the scripting
-					environment before performing any default action associated with these events. Reading System
-					implementers should ensure that scripts cannot disable critical functionality (such as navigation)
-					to constrain the extent to which a <a href="#sec-scripted-content-security">potentially
-						malicious</a> script could impact their Reading Systems. As a result, although the scripting
-					environment should be able to cancel the default action of any event, some events either might not
-					be passed through or might not be cancelable.</p>
-			</section>
-
-			<section id="epub-threat-model">
-				<h3>EPUB Threat Model</h3>
-
-				<ul>
-					<li>scripting:</li>
-					<li>compromised local storage</li>
-					<li>unauthorized collection of user data</li>
-					<li>sending of information to remote receivers</li>
-					<li>spoofed platforms</li>
-					<li>malicious content within containers</li>
-					<li>accessing malicious remote resources</li>
-					<li>collection of user data</li>
-					<li>user-generated content</li>
-					<li>digital rights management</li>
-				</ul>
-			</section>
-
-			<section id="security-privacy-recommendations">
-				<h3>Recommendations</h3>
-
-				<ul>
-					<li>Reading systems are responsible for the display of EPUB documents. Reading systems should do
-						their best to ensure that end users are not exposed to any of the threats by building
-						protections against them into their reading systems. Reading systems should also provide clarity
-						and personalization to the data they may want to collect and use about the user and/or their
-						reading behaviour.</li>
-					<li>It is understood that the collection of some user data may be required for the sale, delivery,
-						and operation of an EPUB file, particularly on platforms where the sale of an EPUB file and the
-						method of reading it are connected. In these cases, it is recommended that the reading system or
-						retailer be clear about the data being collected, how it is used, and allow for user opt-outs
-						where possible. Anonymization of data is strongly recommended for the privacy and the security
-						of the user and reading system.</li>
-					<li>It is also understood that user data may be required or helpful for some reading system
-						affordances. In these cases, anonymization is strongly recommended. It is also recommended that
-						reading systems inform users of what data is needed, what it is to be used for, and to provide
-						methods to opt-out.</li>
-					<li>Content processors, defined as entities that handle the ingestion of EPUB content for
-						distribution, display or sale, should also be aware of the potential risks in ingestion. It is
-						advised that content processors should check content for malicious content on ingestion, in
-						addition to the validation steps that usually occur. This could include running virus scans,
-						validating external links and remote resources, or other precautions.</li>
-				</ul>
+				<p>Content processors, defined as entities that handle the ingestion of EPUB content for distribution,
+					display or sale, should also be aware of the potential risks in ingestion. It is advised that
+					content processors check content for malicious content on ingestion, in addition to the validation
+					steps that usually occur. This could include running virus scans, validating external links and
+					remote resources, and other precautions.</p>
 			</section>
 		</section>
 		<section id="app-epubReadingSystem">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -291,9 +291,11 @@
 
 			<section id="sec-epub-rs-i18n">
 				<h2>Internationalization</h2>
+
 				<p>A Reading System MUST process, for all <a data-cite="epub-33#dfn-publication-resource">Publication
 						Resources</a>, the attributes that set the language for the documents' contents, when
 					applicable. This includes:</p>
+
 				<ul>
 					<li>the <code>xml:lang</code> attribute for all XML documents like the <a
 							data-cite="epub-33#attrdef-xml-lang">Package Document</a> or the <a
@@ -324,6 +326,50 @@
 					attributes on link elements, or from <code>dc:language</code> elements). Refer to a resource's
 					formal specification for more information about to handle the absence of explicit language or
 					direction information.</p>
+			</section>
+
+			<section id="sec-epub-rs-network-access">
+				<h3>Network Access</h3>
+
+				<p>Reading Systems may support network access to enable the <a href="#sec-epub-rs-conf-remote-res"
+						>retrieval of remote resources</a> and to allow <a>Scripted Content Documents</a>
+					<a href="#confreq-rs-scripted-limit">to communicate with web-hosted APIs and retrieve
+					resources</a>.</p>
+
+				<p>Providing network access, however, increases both the security risks to the Reading Systems and the
+					security and privacy risks to users. These risks are often unique to Reading Systems and the
+					platforms they run on &#8212; the browser cores most dedicated Reading System apps are built on do
+					not offer the same security and privacy controls as web browsers themselves. Consequently,
+					developers need to use extra caution when allowing network access, and more thoroughly test that
+					their Reading Systems are not vulnerable to attacks. More information about these risks is provided
+					in <a href="#sec-security-privacy"></a>.</p>
+
+				<p>If Reading System developers opt to allow network access, it is strongly RECOMMENDED that they
+					include methods to notify the user that network activity is occurring and/or that allow them to
+					disable it.</p>
+
+				<p>For example, users might be presented with a global setting that disables all network access on a
+					Reading System-wide or publication-by-publication basis (i.e., no downloading of remote resources or
+					scripting access). Users could also be provided the option to block or terminate network access
+					occurring within a publication to prevent unwanted scripting interactions.</p>
+			</section>
+
+			<section id="sec-epub-rs-external-links">
+				<h3>External Links</h3>
+
+				<p>Reading Systems SHOULD open links that resolve outside the <a>EPUB Publication</a> in a new browser
+					instance to ensure that the security and privacy controls of the browser are available to users.</p>
+
+				<p>Although links to external web sites and resources are commonly found in <a>EPUB Content
+						Documents</a>, these are not the only sources. If a Reading System provides access to <a
+						href="https://www.w3.org/TR/epub-33/#sec-link-elem">linked records</a> [[EPUB-33]] in the
+						<a>Package Document</a> metadata, for example, it should similarly open the links in a new
+					browser instance.</p>
+
+				<div class="note">
+					<p>For more information about the security and privacy issues related to external links, see <a
+							href="#epub-threat-model"></a>.</p>
+				</div>
 			</section>
 		</section>
 		<section id="sec-package-doc">
@@ -891,6 +937,84 @@
 				<p id="confreq-rs-scripted-flbk">If a Reading System does not support scripting, it MUST process
 					fallbacks for scripted content as defined in <a data-cite="epub-33#confreq-cd-scripted-flbk"
 						>Fallbacks for Scripted Content Documents</a> [[EPUB-33]].</p>
+
+				<section id="sec-local-storage">
+					<h4>Local Storage</h4>
+
+					<p>Scripts may save persistent data through cookies and DOM storage, but Reading Systems MAY block
+						such attempts. Reading Systems that allow users to store data MUST ensure they do not make that
+						data available to other unrelated documents (e.g., ones that could be spoofed). In particular,
+						checking for a matching document identifier (or similar metadata) is not a valid method to
+						control access to persistent data.</p>
+
+					<p>Reading Systems that allow local storage SHOULD provide methods for users to inspect or delete
+						that data.</p>
+				</section>
+
+				<section id="sec-scripted-content-events">
+					<h4>Event Model</h4>
+
+					<p>Reading Systems SHOULD follow the DOM Event model as per [[HTML]] and pass UI events to the
+						scripting environment before performing any default action associated with these events.</p>
+
+					<p>Reading System developers must ensure that scripts cannot disable critical functionality (such as
+						navigation) to constrain the extent to which a <a href="#sec-scripted-content-security"
+							>potentially malicious</a> script could impact their Reading Systems. As a result, although
+						the scripting environment should be able to cancel the default action of any event, some events
+						either might not be passed through or might not be cancelable.</p>
+				</section>
+
+				<section id="sec-scripted-content-security" class="informative">
+					<h3>Security Considerations</h3>
+
+					<p>Reading System developers who also support scripting must be aware of the security issues that
+						arise when Reading Systems execute scripted content. As the underlying scripting model employed
+						by Reading Systems and browsers is the same, developers must take into consideration the same
+						kinds of issues encountered in Web contexts.</p>
+
+					<p>Each Reading System must establish if it can trust the scripts in a particular document. Reading
+						Systems should treat all scripts as untrusted (and potentially malicious), and developers should
+						examine all vectors of attack and protect against them. In particular, developers should
+						consider the following:</p>
+
+					<ul>
+						<li>
+							<p>an attack against the runtime environment (e.g., stealing files from a user's hard
+								drive);</p>
+						</li>
+						<li>
+							<p>an attack against the Reading System itself (e.g., stealing a list of a user's books or
+								causing unexpected behavior);</p>
+						</li>
+						<li>
+							<p>an attack of one Content Document against another (e.g., stealing data that originated in
+								a different document);</p>
+						</li>
+						<li>
+							<p>an attack of an unencrypted script against an encrypted portion of a document (e.g., an
+								injected malicious script extracting protected content);</p>
+						</li>
+						<li>
+							<p>an attack against the local network (e.g., stealing data from a server behind a
+								firewall).</p>
+						</li>
+					</ul>
+
+					<p>To limit the possible damage of untrusted scripts, this specification recommends that Reading
+						Systems establish a unique <a data-cite="url#origin">origin</a> [[URL]] allocated to each
+							<a>EPUB Publication</a> (see <a href="#sec-container-iri"></a>). Adopting this approach
+						isolates publications from each other, thereby limiting access to cookies, DOM storage, etc.
+						Examples of Web APIs that are tied to the concept of "origin" include Web Storage [[WEBSTORAGE]]
+						and IndexedDB [[INDEXEDDB]], which EPUB Content Documents can interact with via scripting.
+						Reading Systems that allow users to add/remove publications from a managed library (their
+						"bookshelf") may maintain the publication’s unique origin when the publication is removed and
+						subsequently re-imported into the content library. Conversely, Reading Systems may create a new
+						unique origin for every newly added publication.</p>
+
+					<p>Note that compliance with these recommendations does not guarantee protection from the possible
+						attacks listed above; developers must examine each potential vulnerability within the context of
+						their Reading System.</p>
+				</section>
 			</section>
 		</section>
 		<section id="sec-nav">
@@ -939,7 +1063,6 @@
 			<p id="confreq-nav-spine" data-tests="#nav-spine_in-spine,#nav-spine_not-in-spine">Reading Systems MUST
 				honor the above requirements irrespective of whether the EPUB Navigation Document is part of the <a
 					data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]].</p>
-
 		</section>
 		<section id="sec-fixed-layouts">
 			<h2>Fixed-Layout Documents Processing</h2>
@@ -2011,107 +2134,16 @@
 					formats for further details. </p>
 			</section>
 
-			<section id="sec-scripted-content-security">
-				<h3>Scripting Considerations</h3>
-
-				<p>Reading System developers who also support scripting must be aware of the security issues that arise
-					when Reading Systems execute scripted content. As the underlying scripting model employed by Reading
-					Systems and browsers is the same, developers must take into consideration the same kinds of issues
-					encountered in Web contexts.</p>
-
-				<p>Each Reading System must establish if it can trust the scripts in a particular document. Reading
-					Systems should treat all scripts as untrusted (and potentially malicious), and developers should
-					examine all vectors of attack and protect against them. In particular, developers should consider
-					the following:</p>
-
-				<ul>
-					<li>
-						<p>an attack against the runtime environment (e.g., stealing files from a user's hard
-							drive);</p>
-					</li>
-					<li>
-						<p>an attack against the Reading System itself (e.g., stealing a list of a user's books or
-							causing unexpected behavior);</p>
-					</li>
-					<li>
-						<p>an attack of one Content Document against another (e.g., stealing data that originated in a
-							different document);</p>
-					</li>
-					<li>
-						<p>an attack of an unencrypted script against an encrypted portion of a document (e.g., an
-							injected malicious script extracting protected content);</p>
-					</li>
-					<li>
-						<p>an attack against the local network (e.g., stealing data from a server behind a
-							firewall).</p>
-					</li>
-				</ul>
-
-				<p>To limit the possible damage of untrusted scripts, this specification recommends that Reading Systems
-					establish a unique <a data-cite="url#origin">origin</a> [[URL]] allocated to each <a>EPUB
-						Publication</a> (see <a href="#sec-container-iri"></a>). Adopting this approach isolates
-					publications from each other, thereby limiting access to cookies, DOM storage, etc. Examples of Web
-					APIs that are tied to the concept of "origin" include Web Storage [[WEBSTORAGE]] and
-					IndexedDB [[INDEXEDDB]], which EPUB Content Documents can interact with via scripting. Reading
-					Systems that allow users to add/remove publications from a managed library (their "bookshelf") may
-					maintain the publication’s unique origin when the publication is removed and subsequently
-					re-imported into the content library. Conversely, Reading Systems may create a new unique origin for
-					every newly added publication.</p>
-
-				<p>Note that compliance with these recommendations does not guarantee protection from the possible
-					attacks listed above; developers must examine each potential vulnerability within the context of
-					their Reading System.</p>
-
-				<section id="sec-scripted-content-events">
-					<h4>Event Model</h4>
-
-					<p>Reading Systems should follow the DOM Event model as per [[HTML]] and pass UI events to the
-						scripting environment before performing any default action associated with these events. Reading
-						System implementers should ensure that scripts cannot disable critical functionality (such as
-						navigation) to constrain the extent to which a <a href="#sec-scripted-content-security"
-							>potentially malicious</a> script could impact their Reading Systems. As a result, although
-						the scripting environment should be able to cancel the default action of any event, some events
-						either might not be passed through or might not be cancelable.</p>
-				</section>
-			</section>
-
 			<section id="security-privacy-recommendations">
-				<h3>Additional Recommendations</h3>
+				<h3>Recommendations</h3>
 
 				<p>Arguably the strongest measure that Reading System developers can take for privacy is to specify the
 					data they intend to collect and use about the user and/or their reading behaviour and seek the
 					consent of users to obtain it. They should also allow personalization and control over this
 					information.</p>
 
-				<p>In addition, the following practices should be followed to help further limit security and privacy
-					issues:</p>
-
-				<ul>
-					<li>
-						<p>Reading Systems that support scripting and network access, as well as the retrieval of remote
-							resources, should include methods to notify the user that network activity is occurring
-							and/or that allow them to disable it.</p>
-					</li>
-
-					<li>
-						<p>If a Reading System allows users/scripts to store persistent data, it must treat that data as
-							sensitive. Scripts may save persistent data through cookies and DOM storage, but Reading
-							Systems may block such attempts. Reading Systems that allow users to store data must ensure
-							they do not make that data available to other unrelated documents (e.g., ones that could be
-							spoofed). In particular, checking for a matching document identifier (or similar metadata)
-							is not a valid method to control access to persistent data.</p>
-					</li>
-
-					<li>
-						<p>Reading Systems that allow local storage should also provide methods for users to inspect or
-							delete that data.</p>
-					</li>
-
-					<li>
-						<p>Reading Systems should open links outside the EPUB Publication in a new browser instance to
-							ensure that the security and privacy controls of the browser are available to users.</p>
-					</li>
-				</ul>
+				<p>If a Reading System allows users to store persistent data, especially personally identifiable
+					information, it must treat that data as sensitive.</p>
 
 				<p>It is understood that the collection of some user data may be required for the sale, delivery, and
 					operation of an EPUB Publication, particularly on platforms where the sale of an EPUB Publication

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2397,9 +2397,18 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>04-Feb-2021: Changed the informative security considerations for controlling network access, opening
+					external links, and managing local storage to normative recommendations. See <a
+						href="https://github.com/w3c/epub-specs/issues/1957">issue 1957</a>.</li>
+				<li>04-Feb-2021: Expanded the section on security and privacy to include new sections on the threat
+					model for Reading Systems and additional recommendations for ensuring security and privacy. See <a
+						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a
+						href="https://github.com/w3c/epub-specs/issues/1872">issue 1872</a>, <a
+						href="https://github.com/w3c/epub-specs/issues/1875">issue 1875</a> and <a
+						href="https://github.com/w3c/epub-specs/issues/1876">issue 1876</a>.</li>
 				<li>10-Nov-2021: Proper definition of the Content URL and handling of relative URLs. See <a
 						href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and <a
-						href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
+						href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a>.</li>
 				<li>01-Nov-2021: Added a statement on the Reading System behavior when item references are repeated in
 					the spine. See <a href="https://github.com/w3c/epub-specs/issues/1686">issue 1686</a>.</li>
 				<li> 01-Nov-2021: Added a statement on the Reading System behavior when item references are repeated in

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1996,8 +1996,10 @@
 
 					<dt>User-generated content</dt>
 					<dd>
-						<p class="ednote">Not sure I can explain this exploit without more info. I know uploaded content
-							can't be trusted, but is that the concern?</p>
+						<p>User-generated content within a reading experience, for example through text areas or other 
+							interactive components, could pose a threat to reading system security or user privacy if the 
+							content is not properly secured. More details on scripting security are provided in <a 
+							href="#sec-scripted-content-security"></a>.</p>
 					</dd>
 
 					<dt>Collection of user data</dt>
@@ -2007,11 +2009,6 @@
 							use.</p>
 						<p>Attempting to profile users based on their reading habits or through metadata in their
 							publication (e.g., accessibility preferences) can expose users to unintended harms.</p>
-					</dd>
-
-					<dt>Spoofed platforms</dt>
-					<dd>
-						<p class="ednote">Is this one reading system spoofing another? Do we need to detail that?</p>
 					</dd>
 				</dl>
 			</section>
@@ -2026,7 +2023,7 @@
 
 				<p>Each Reading System must establish if it can trust the scripts in a particular document. Reading
 					Systems should treat all scripts as untrusted (and potentially malicious), and developers should
-					examine all vectors of attack and protected against them. In particular, developers should consider
+					examine all vectors of attack and protect against them. In particular, developers should consider
 					the following:</p>
 
 				<ul>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1002,14 +1002,22 @@
 
 					<p>To limit the possible damage of untrusted scripts, this specification recommends that Reading
 						Systems establish a unique <a data-cite="url#origin">origin</a> [[URL]] allocated to each
-							<a>EPUB Publication</a> (see <a href="#sec-container-iri"></a>). Adopting this approach
-						isolates publications from each other, thereby limiting access to cookies, DOM storage, etc.
-						Examples of Web APIs that are tied to the concept of "origin" include Web Storage [[WEBSTORAGE]]
+							<a>EPUB Publication</a> (see <a href="#sec-container-iri"></a>). Assigning a unique origin
+						ensures that <a href="https://www.w3.org/TR/epub-33/#sec-scripted-spine">spine-level scripts</a>
+						[[EPUB-33]] are isolated from other EPUB Publications, and limits access to cookies, DOM
+						storage, etc.</p>
+
+					<p>Examples of Web APIs that are tied to the concept of "origin" include Web Storage [[WEBSTORAGE]]
 						and IndexedDB [[INDEXEDDB]], which EPUB Content Documents can interact with via scripting.
 						Reading Systems that allow users to add/remove publications from a managed library (their
-						"bookshelf") may maintain the publication’s unique origin when the publication is removed and
+						"bookshelf") may maintain the publication's unique origin when the publication is removed and
 						subsequently re-imported into the content library. Conversely, Reading Systems may create a new
 						unique origin for every newly added publication.</p>
+
+					<p>This specification also recommends that <a href="#sec-scripted-container-constrained"
+							>container-constrained scripts</a> [[EPUB-33]] not be allowed to modify the DOM of the
+						parent EPUB Content Document and/or manipulate the containing rectangle (see <a
+							href="#sec-scripted-content"></a>).</p>
 
 					<p>Note that compliance with these recommendations does not guarantee protection from the possible
 						attacks listed above; developers must examine each potential vulnerability within the context of
@@ -2088,9 +2096,9 @@
 
 					<dt>Remote resources</dt>
 					<dd>
-						<p><a>Remote resources</a> present the same risks as any EPUB Publication loaded from an untrusted
-							source. Even if the publisher of the EPUB Publication is trusted, remote resources may be
-							compromised.</p>
+						<p><a>Remote resources</a> present the same risks as any EPUB Publication loaded from an
+							untrusted source. Even if the publisher of the EPUB Publication is trusted, remote resources
+							may be compromised.</p>
 						<p>Calls to remote resources can also be used to track information about users (e.g., through
 							server logs). Reading Systems should limit the information they expose through HTTP requests
 							to only what is essential to obtain the resource.</p>
@@ -2129,9 +2137,8 @@
 						data-cite="epub-33#sec-ocf">Open Container Format</a>, respectively. See the "Security
 					Consideration" sections of the Media Type registrations for the <a
 						data-cite="epub-33#app-media-type-app-oebps-package"
-						><code>application/oebps-package+xml</code></a> and the <a
-						data-cite="epub-33#app-media-type"><code>application/epub+zip</code></a>
-					formats for further details. </p>
+						><code>application/oebps-package+xml</code></a> and the <a data-cite="epub-33#app-media-type"
+							><code>application/epub+zip</code></a> formats for further details. </p>
 			</section>
 
 			<section id="security-privacy-recommendations">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1912,33 +1912,22 @@
 				<h3>Overview</h3>
 
 				<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
-					representing, packaging, and encoding structured and semantically enhanced Web content — including
-					HTML, CSS, SVG, and other resources — for distribution in a single-file container. This
-					specification does not <em>add</em> any new features, complex APIs, etc. This also means that,
-					essentially, the security and privacy issues are reliant on the features of those formats. In
-					particular:</p>
+					representing, packaging, and encoding structured and semantically enhanced web content — including
+					HTML, CSS, SVG, and other resources — for distribution in a single-file container.</p>
 
-				<ul>
-					<li>EPUB 3 allows references to remotely hosted resources from within <a>EPUB Content Documents</a>,
-						but also from the <a>Package Document</a> (e.g., in a <a data-cite="epub-33#sec-item-elem"
-								><code>item</code></a> element which allows both local and remote references). This is
-						not unlike any external reference from an average Web site that potentially exposes users to
-						malicious content, and the general Web security principles should be taken into account (e.g.,
-						cross-origin resource sharing).</li>
-					<li>The <a data-cite="epub-33#sec-package-doc">Package Document</a> allows personally identifiable
-						information about an EPUB Publication's creator(s) (e.g., names, identifying URLs) to be
-						included, so authoring tools could expose unexpected information if explicit author approval of
-						metadata is not required.</li>
-				</ul>
+				<p>For Reading Systems, this means that the security and privacy issues are primarily reliant on the
+					features of those formats, and closely mirror the threats presented by web content generally.</p>
 
-				<p>Additionally, the security considerations that apply to XML [[XML]] and ZIP [[ZIP]] files also apply
-					to the <a data-cite="epub-33#sec-package-doc">Package Document</a> and the <a
-						data-cite="epub-33#sec-ocf">Open Container Format</a>, respectively. See the "Security
-					Consideration" sections of the Media Type registrations for the <a
-						data-cite="epub-33#app-media-type-app-oebps-package"
-						><code>application/oebps-package+xml</code></a> and the <a
-						data-cite="epub-33#app-media-type-app-oebps-package"><code>application/epub+zip</code></a>
-					formats for further details. </p>
+				<p>Reading System developers also have a dual responsibility of both ensuring the security and privacy
+					of their applications and helping limit the threats to users from the content that renders within
+					them. The rest of this section explores the risk model of EPUB 3 with the aim of helping developers
+					recognize and mitigate these risks.</p>
+
+				<div class="note">
+					<p>For the risks associated with the authoring of EPUB Publications, refer to the <a
+							href="https://www.w3.org/TR/epub-33/#sec-security-privacy">security and privacy section</a>
+						of [[EPUB-33]].</p>
+				</div>
 			</section>
 
 			<section id="epub-threat-model">
@@ -1947,10 +1936,10 @@
 				<p>The greatest threats to users come from the <a
 						href="https://www.w3.org/TR/epub-33/#epub-threat-model">content they read</a> [[EPUB-33]], and
 					the first line of defence against these attacks is the Reading Systems they use. Users expect that
-					Reading Systems act as safeguards against malicious content, and are often unaware that EPUB
+					Reading Systems act as safeguards against malicious content and are often unaware that EPUB
 					Publications are susceptible to the same security risks as web sites.</p>
 
-				<p>But although Reading Systems are relied on to provide security and privacy, they can also can pose
+				<p>But although Reading Systems are relied on to provide security and privacy, they can also pose
 					unintended threats to user depending on how information is handled. Tracking user information to
 					optimize experiences is a common need, for example, but done without user permission and Reading
 					Systems can run afoul of legal privacy requirements.</p>
@@ -1961,9 +1950,9 @@
 				<dl>
 					<dt>Scripting</dt>
 					<dd>
-						<p>Malicious scripts present a number of attack vectors against reading systems. If local
-							storage is not secure, for example, they can attempt to compromise the user's data. Provided
-							with network access, they may attempt unauthorized collection of user data.</p>
+						<p>Malicious scripts present several attack vectors against reading systems. If local storage is
+							not secure, for example, they can attempt to compromise the user's data. Provided with
+							network access, they may attempt unauthorized collection of user data.</p>
 						<p>More detailed discussion of these issues and how to mitigate them is provided in <a
 								href="#sec-scripted-content-security"></a>.</p>
 					</dd>
@@ -1986,7 +1975,7 @@
 
 					<dt>External links</dt>
 					<dd>
-						<p>Similar to remote resources, external links may be used to trick unwitting users into opening
+						<p>Like remote resources, external links may be used to trick unwitting users into opening
 							malicious resources on the web designed to exploit the Reading System or operating
 							system.</p>
 						<p>Likewise, Reading Systems should also avoid exposing potentially identifying information
@@ -2014,6 +2003,15 @@
 						<p class="ednote">Is this one reading system spoofing another? Do we need to detail that?</p>
 					</dd>
 				</dl>
+
+				<p>Additionally, the security considerations that apply to XML [[XML]] and ZIP [[ZIP]] files also apply
+					to the <a data-cite="epub-33#sec-package-doc">Package Document</a> and the <a
+						data-cite="epub-33#sec-ocf">Open Container Format</a>, respectively. See the "Security
+					Consideration" sections of the Media Type registrations for the <a
+						data-cite="epub-33#app-media-type-app-oebps-package"
+						><code>application/oebps-package+xml</code></a> and the <a
+						data-cite="epub-33#app-media-type-app-oebps-package"><code>application/epub+zip</code></a>
+					formats for further details. </p>
 			</section>
 
 			<section id="sec-scripted-content-security">
@@ -2058,10 +2056,10 @@
 					publications from each other, thereby limiting access to cookies, DOM storage, etc. Examples of Web
 					APIs that are tied to the concept of "origin" include Web Storage [[WEBSTORAGE]] and
 					IndexedDB [[INDEXEDDB]], which EPUB Content Documents can interact with via scripting. Reading
-					Systems that allow users to add/remove publications from a managed library (a.k.a "bookshelf") may
+					Systems that allow users to add/remove publications from a managed library (their "bookshelf") may
 					maintain the publication’s unique origin when the publication is removed and subsequently
 					re-imported into the content library. Conversely, Reading Systems may create a new unique origin for
-					every newly-added publication.</p>
+					every newly added publication.</p>
 
 				<p>Note that compliance with these recommendations does not guarantee protection from the possible
 					attacks listed above; developers must examine each potential vulnerability within the context of
@@ -2100,7 +2098,7 @@
 
 					<li>
 						<p>If a Reading System allows users/scripts to store persistent data, it must treat that data as
-							sensitive. Scripts may save persistent data through cookies and DOM storage but Reading
+							sensitive. Scripts may save persistent data through cookies and DOM storage, but Reading
 							Systems may block such attempts. Reading Systems that allow users to store data must ensure
 							they do not make that data available to other unrelated documents (e.g., ones that could be
 							spoofed). In particular, checking for a matching document identifier (or similar metadata)
@@ -2108,7 +2106,7 @@
 					</li>
 
 					<li>
-						<p>Reading Systems that allow local storage should also provide methods for users to inspect, or
+						<p>Reading Systems that allow local storage should also provide methods for users to inspect or
 							delete that data.</p>
 					</li>
 				</ul>
@@ -2125,11 +2123,11 @@
 					inform users of what data is needed, what it is to be used for, and to provide methods to
 					opt-out.</p>
 
-				<p>Content processors, defined as entities that handle the ingestion of EPUB content for distribution,
-					display or sale, should also be aware of the potential risks in ingestion. It is advised that
-					content processors check content for malicious content on ingestion, in addition to the validation
-					steps that usually occur. This could include running virus scans, validating external links and
-					remote resources, and other precautions.</p>
+				<p>Content processors &#8212; defined as entities that handle the ingestion of EPUB content for
+					distribution, display, or sale &#8212; should also be aware of the potential risks in ingestion. It
+					is advised that content processors check content for malicious content on ingestion, in addition to
+					the validation steps that usually occur. This could include running virus scans, validating external
+					links and remote resources, and other precautions.</p>
 			</section>
 		</section>
 		<section id="app-epubReadingSystem">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1014,7 +1014,8 @@
 						subsequently re-imported into the content library. Conversely, Reading Systems may create a new
 						unique origin for every newly added publication.</p>
 
-					<p>This specification also recommends that <a href="#sec-scripted-container-constrained"
+					<p>This specification also recommends that <a
+							href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained"
 							>container-constrained scripts</a> [[EPUB-33]] not be allowed to modify the DOM of the
 						parent EPUB Content Document and/or manipulate the containing rectangle (see <a
 							href="#sec-scripted-content"></a>).</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2088,7 +2088,7 @@
 
 					<dt>Remote resources</dt>
 					<dd>
-						<p>Remote resources present the same risks as any EPUB Publication loaded from an untrusted
+						<p><a>Remote resources</a> present the same risks as any EPUB Publication loaded from an untrusted
 							source. Even if the publisher of the EPUB Publication is trusted, remote resources may be
 							compromised.</p>
 						<p>Calls to remote resources can also be used to track information about users (e.g., through

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1915,7 +1915,7 @@
 					representing, packaging, and encoding structured and semantically enhanced web content — including
 					HTML, CSS, SVG, and other resources — for distribution in a single-file container.</p>
 
-				<p>For Reading Systems, this means that the security and privacy issues are primarily reliant on the
+				<p>For Reading Systems, this means that the security and privacy issues are primarily based on the
 					features of those formats, and closely mirror the threats presented by web content generally.</p>
 
 				<p>Reading System developers also have a dual responsibility of both ensuring the security and privacy
@@ -1940,7 +1940,7 @@
 					Publications are susceptible to the same security risks as web sites.</p>
 
 				<p>But although Reading Systems are relied on to provide security and privacy, they can also pose
-					unintended threats to user depending on how information is handled. Tracking user information to
+					unintended threats to users depending on how information is handled. Tracking user information to
 					optimize experiences is a common need, for example, but done without user permission and Reading
 					Systems can run afoul of legal privacy requirements.</p>
 
@@ -1985,10 +1985,10 @@
 
 					<dt>User-generated content</dt>
 					<dd>
-						<p>User-generated content within a reading experience, for example through text areas or other 
-							interactive components, could pose a threat to reading system security or user privacy if the 
-							content is not properly secured. More details on scripting security are provided in <a 
-							href="#sec-scripted-content-security"></a>.</p>
+						<p>User-generated content within a reading experience, for example through text areas or other
+							interactive components, could pose a threat to reading system security or user privacy if
+							the content is not properly secured. More details on scripting security are provided in <a
+								href="#sec-scripted-content-security"></a>.</p>
 					</dd>
 
 					<dt>Collection of user data</dt>


### PR DESCRIPTION
This PR takes the work that @wareid did and integrates it into the core and reading system specs.

I don't expect it's perfect at this point, but hopefully we can use the PR to keep refining the sections.

- Reading Systems [preview](https://raw.githack.com/w3c/epub-specs/update/privacy-security/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/update/privacy-security/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1972.html" title="Last updated on Feb 4, 2022, 12:52 PM UTC (2033c02)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1972/9738448...2033c02.html" title="Last updated on Feb 4, 2022, 12:52 PM UTC (2033c02)">Diff</a>