### PR TITLE
Changed the term 'risky' to 'under-implemented'

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8816,10 +8816,10 @@ html.my-document-playing * {
 				2 Reading Systems. This section defines the meanings of the designations attached to these features and
 				their support expectations.</p>
 
-			<section id="risky">
-				<h3>Risky Features</h3>
+			<section id="under-implemented">
+				<h3>Under-implemented Features</h3>
 
-				<p>A <strong>risky</strong> feature is a feature introduced prior to EPUB 3.3 for which the Working
+				<p>A <strong>under-implemented</strong> feature is a feature introduced prior to EPUB 3.3 for which the Working
 					Group has not been able to establish enough <a
 						href="https://www.w3.org/Consortium/Process/#adequate-implementation">implementation
 						experience</a>.</p>
@@ -8828,7 +8828,7 @@ html.my-document-playing * {
 					be implemented by EPUB Creators (i.e., their deprecation would invalidate existing content) and/or
 					they are integral to the content model on which EPUB is built.</p>
 
-				<p>If this specification designates a feature as risky, the following hold true:</p>
+				<p>If this specification designates a feature as under-implemented, the following hold true:</p>
 
 				<ul>
 					<li>
@@ -8839,18 +8839,18 @@ html.my-document-playing * {
 					</li>
 				</ul>
 
-				<p>Validation tools SHOULD alert EPUB Creators to the presence of risky features when encountered in
+				<p>Validation tools SHOULD alert EPUB Creators to the presence of under-implemented features when encountered in
 					EPUB Publications but MUST NOT treat their inclusion as a violation of the standard (i.e., not emit
 					errors or warnings).</p>
 
 				<div class="caution">
-					<p>Whether risky labels are removed or replaced by deprecation in a future version of the standard
+					<p>Whether under-implemented labels are removed or replaced by deprecation in a future version of the standard
 						cannot be determined at this time. EPUB Creators should strongly consider the interoperability
 						problems that may arise both now and in the future when using these features.</p>
 				</div>
 
 				<div class="note">
-					<p>The marking of features as risky is a one-time event to account for the different process under
+					<p>The marking of features as under-implemented is a one-time event to account for the different process under
 						which EPUB was developed prior to being brought into W3C. This label will not be used for new
 						features developed under W3C processes.</p>
 				</div>
@@ -10561,6 +10561,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>21-January-2022: term "risky", used for the class of unsupported features, has been renamed to "under-implemented". 
+					See the <a href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-01-20-epub#resolution1">WG resolution</a>.</li>
 				<li>08-Dec-2021: The <code>page-spread-center</code> property is now an alias for
 						<code>spread-none</code>. See <a href="https://github.com/w3c/epub-specs/issues/1929">issue
 						1929</a>.</li>


### PR DESCRIPTION
This implements the WG resolution of Jan 20: 

https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-01-20-epub#resolution1

Fix #1944


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1976.html" title="Last updated on Jan 21, 2022, 7:58 AM UTC (1dc9f77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1976/2d53e2e...1dc9f77.html" title="Last updated on Jan 21, 2022, 7:58 AM UTC (1dc9f77)">Diff</a>