### PR TITLE
New anchor and test references in the I18N section

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -309,7 +309,7 @@
 					contents, when applicable. This includes:</p>
 
 				<ul>
-					<li>the <code>dir</code> attribute for the <a data-cite="epub-33#attrdef-dir">Package
+					<li id="confreq-rs-pkg-dir-intro" data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">the <code>dir</code> attribute for the <a data-cite="epub-33#attrdef-dir">Package
 						Document</a> [[EPUB-33]]. (See also <a href="#sec-pkg-doc-base-dir"></a> for further
 						details.)</li>
 					<li>the <code>dir</code> attribute for <a data-cite="html#the-dir-attribute"


### PR DESCRIPTION
This is the counterpart of the [PR No. 108 in the testing repo](https://github.com/w3c/epub-tests/pull/108). Should be merged when that one is.