### PR TITLE
Added an extra anchor for new test

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -318,7 +318,7 @@
 							href="https://www.w3.org/TR/SVG/text.html#DirectionProperty">SVG</a> [[SVG]].</li>
 				</ul>
 
-				<p>In the absence of this information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume
+				<p id="confreq-rs-pkg-lang-no-content" data-tests="#pkg-dir_pkg_non_content">In the absence of this information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume
 					either the language or the base direction of that resource from information expressed in the Package
 					Document (i.e., in <code>xml:lang</code> and <code>dir</code> attributes, in <code>hreflang</code>
 					attributes on link elements, or from <code>dc:language</code> elements). Refer to a resource's

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -318,7 +318,7 @@
 							href="https://www.w3.org/TR/SVG/text.html#DirectionProperty">SVG</a> [[SVG]].</li>
 				</ul>
 
-				<p id="confreq-rs-pkg-lang-no-content" data-tests="#pkg-dir_pkg_non_content,#pkg-lang_pkg_non_content">In the absence of this information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume
+				<p id="confreq-rs-pkg-lang-no-content" data-tests="#pgk-dir_pkg_non_content,#pgk-lang_pkg_non_content">In the absence of this information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume
 					either the language or the base direction of that resource from information expressed in the Package
 					Document (i.e., in <code>xml:lang</code> and <code>dir</code> attributes, in <code>hreflang</code>
 					attributes on link elements, or from <code>dc:language</code> elements). Refer to a resource's

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -318,7 +318,7 @@
 							href="https://www.w3.org/TR/SVG/text.html#DirectionProperty">SVG</a> [[SVG]].</li>
 				</ul>
 
-				<p id="confreq-rs-pkg-lang-no-content" data-tests="#pkg-dir_pkg_non_content">In the absence of this information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume
+				<p id="confreq-rs-pkg-lang-no-content" data-tests="#pkg-dir_pkg_non_content,#pkg-lang_pkg_non_content">In the absence of this information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume
 					either the language or the base direction of that resource from information expressed in the Package
 					Document (i.e., in <code>xml:lang</code> and <code>dir</code> attributes, in <code>hreflang</code>
 					attributes on link elements, or from <code>dc:language</code> elements). Refer to a resource's


### PR DESCRIPTION
This is the counterpart of https://github.com/w3c/epub-tests/pull/110 and should be merged when that one is.