### PR TITLE
Updates to obfuscation

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7076,8 +7076,7 @@ No Entry</pre>
 						through such alternative means as:</p>
 
 					<ul>
-						<li>applying the deobfuscation algorithm to extract the raw font file, whether done through
-							software intentionally designed to break the obfuscation or not;</li>
+						<li>applying the deobfuscation algorithm to extract the raw font file;</li>
 						<li>accessing the deobfuscated font through a Reading System that must dedobfuscate it to render
 							the content (e.g., by accessing the resources through a browser-based Reading System);
 							or</li>
@@ -7090,9 +7089,8 @@ No Entry</pre>
 						ensuring their use of obfuscation meets font licensing requirements.</p>
 
 					<p>EPUB Creators should also be aware that obfuscation may lead to interoperability issues in
-						Reading Systems. Reading Systems are not required to deobfuscate fonts, and in some cases may
-						opt to avoid deobfuscation to avoid legal complications. As a result, the visual presentation of
-						their publications may differ from Reading System to Reading System.</p>
+						Reading Systems as Reading Systems are not required to deobfuscate fonts. As a result, the
+						visual presentation of their publications may differ from Reading System to Reading System.</p>
 
 					<p>Also note that the algorithm is restricted to obfuscating fonts. It is not intended as a
 						general-purpose mechanism for obfuscating any resource in the EPUB Container.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4488,10 +4488,10 @@ No Entry</pre>
 						<p>EPUB 3 defines two contexts for script execution:</p>
 
 						<ul>
-							<li><a href="#sec-scripted-container-constrained">container constrained</a> &#8212;
-								when the execution of a script occurs within an <code>iframe</code>; and</li>
-							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a
-								script occurs directly within a <a>Top-level Content Document</a>.</li>
+							<li><a href="#sec-scripted-container-constrained">container constrained</a> &#8212; when the
+								execution of a script occurs within an <code>iframe</code>; and</li>
+							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a script
+								occurs directly within a <a>Top-level Content Document</a>.</li>
 						</ul>
 						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference
 							it via the element's <code>src</code> attribute makes no difference to its executing
@@ -6516,7 +6516,7 @@ No Entry</pre>
 									difficult to extract for unrestricted use. Although obfuscation is not encryption,
 									Reading Systems use the <code>encryption.xml</code> file in conjunction with the <a
 										href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify fonts to
-									de-obfuscated.</p>
+									deobfuscated.</p>
 
 								<p id="encryption-restrictions">EPUB Creators MUST NOT encrypt or obfuscate the
 									following files:</p>
@@ -7026,7 +7026,8 @@ No Entry</pre>
 						the embedding of licensing information and also provide some protection through font table
 						compression. The use of remotely hosted fonts also allows for font subsetting. EPUB Creators are
 						advised to use font obfuscation as defined in this section only when no other options are
-						available to them.</p>
+						available to them. See also the <a href="#fobfus-limitations">limitations of
+						obfuscation</a>.</p>
 
 				</div>
 
@@ -7050,8 +7051,8 @@ No Entry</pre>
 						This uncertainty can undermine the otherwise useful font embedding capability of EPUB
 						Publications.</p>
 
-					<p>To discourage reuse of the font, some font vendors might only allow use of their fonts in EPUB
-						Publications if those fonts are bound in some way to the EPUB Publication. That is, if the font
+					<p>To discourage reuse of their fonts, some font vendors might only allow their use in EPUB
+						Publications if the fonts are bound in some way to the EPUB Publication. That is, if the font
 						file cannot be installed directly for use on an operating system with the built-in tools of that
 						computing device, and it cannot be directly used by other EPUB Publications.</p>
 
@@ -7059,20 +7060,42 @@ No Entry</pre>
 						enforcement system for fonts. This section instead defines a method of obfuscation that will
 						require additional work on the part of the final OCF recipient to gain general access to any
 						obfuscated fonts.</p>
+				</section>
 
-					<p>Note this specification does not claim that this constitutes encryption, nor does it guarantee
-						that the resource will be secure from copyright infringement. The hope is that this algorithm
-						will meet the requirements of most vendors who require some assurance that their fonts cannot
-						simply be extracted by unzipping the Container.</p>
+				<section id="fobfus-limitations" class="informative">
+					<h4>Limitations</h4>
 
-					<p>Also note that the algorithm is restricted to obfuscating fonts. It is not intended as a general
-						purpose mechanism for obfuscating any resource in the EPUB Container.</p>
+					<p>This specification does not claim that obfuscation constitutes encryption, nor does it guarantee
+						that the resource will be secure from copyright infringement. The hope is only that this
+						algorithm will meet the requirements of vendors who require some assurance that their fonts
+						cannot be extracted simply by unzipping the OCF Container and copying the resource.</p>
 
-					<p>In the case of fonts, this mechanism simply provides a stumbling block for those who are unaware
-						of the license details. It will not prevent a determined user from gaining full access to the
-						font. Given an OCF Container, it is possible to apply the algorithms defined to extract the raw
-						font file. Whether this method of obfuscation satisfies the requirements of individual font
-						licenses remains a question for the licensor and licensee.</p>
+					<p>Obfuscation, like any protection scheme, cannot fully protect fonts from being accessed in their
+						deobfuscated state. The mechanism only provides a stumbling block for those who are unaware of
+						the license details. It will not prevent a determined user from gaining full access to the font
+						through such alternative means as:</p>
+
+					<ul>
+						<li>applying the deobfuscation algorithm to extract the raw font file, whether done through
+							software intentionally designed to break the obfuscation or not;</li>
+						<li>accessing the deobfuscated font through a Reading System that must dedobfuscate it to render
+							the content (e.g., by accessing the resources through a browser-based Reading System);
+							or</li>
+						<li>accessing the deobfuscated font through authoring tools that provide the visual rendering of
+							the content.</li>
+					</ul>
+
+					<p>As a result, whether this method of obfuscation satisfies the requirements of individual font
+						licenses remains a question for the licensor and licensee. EPUB Creators are responsible for
+						ensuring their use of obfuscation meets font licensing requirements.</p>
+
+					<p>EPUB Creators should also be aware that obfuscation may lead to interoperability issues in
+						Reading Systems. Reading Systems are not required to deobfuscate fonts, and in some cases may
+						opt to avoid deobfuscation to avoid legal complications. As a result, the visual presentation of
+						their publications may differ from Reading System to Reading System.</p>
+
+					<p>Also note that the algorithm is restricted to obfuscating fonts. It is not intended as a
+						general-purpose mechanism for obfuscating any resource in the EPUB Container.</p>
 				</section>
 
 				<section id="obfus-keygen">
@@ -8819,8 +8842,8 @@ html.my-document-playing * {
 			<section id="under-implemented">
 				<h3>Under-implemented Features</h3>
 
-				<p>A <strong>under-implemented</strong> feature is a feature introduced prior to EPUB 3.3 for which the Working
-					Group has not been able to establish enough <a
+				<p>A <strong>under-implemented</strong> feature is a feature introduced prior to EPUB 3.3 for which the
+					Working Group has not been able to establish enough <a
 						href="https://www.w3.org/Consortium/Process/#adequate-implementation">implementation
 						experience</a>.</p>
 
@@ -8839,20 +8862,21 @@ html.my-document-playing * {
 					</li>
 				</ul>
 
-				<p>Validation tools SHOULD alert EPUB Creators to the presence of under-implemented features when encountered in
-					EPUB Publications but MUST NOT treat their inclusion as a violation of the standard (i.e., not emit
-					errors or warnings).</p>
+				<p>Validation tools SHOULD alert EPUB Creators to the presence of under-implemented features when
+					encountered in EPUB Publications but MUST NOT treat their inclusion as a violation of the standard
+					(i.e., not emit errors or warnings).</p>
 
 				<div class="caution">
-					<p>Whether under-implemented labels are removed or replaced by deprecation in a future version of the standard
-						cannot be determined at this time. EPUB Creators should strongly consider the interoperability
-						problems that may arise both now and in the future when using these features.</p>
+					<p>Whether under-implemented labels are removed or replaced by deprecation in a future version of
+						the standard cannot be determined at this time. EPUB Creators should strongly consider the
+						interoperability problems that may arise both now and in the future when using these
+						features.</p>
 				</div>
 
 				<div class="note">
-					<p>The marking of features as under-implemented is a one-time event to account for the different process under
-						which EPUB was developed prior to being brought into W3C. This label will not be used for new
-						features developed under W3C processes.</p>
+					<p>The marking of features as under-implemented is a one-time event to account for the different
+						process under which EPUB was developed prior to being brought into W3C. This label will not be
+						used for new features developed under W3C processes.</p>
 				</div>
 			</section>
 
@@ -10561,8 +10585,10 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>21-January-2022: term "risky", used for the class of unsupported features, has been renamed to "under-implemented". 
-					See the <a href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-01-20-epub#resolution1">WG resolution</a>.</li>
+				<li>21-January-2022: term "risky", used for the class of unsupported features, has been renamed to
+					"under-implemented". See the <a
+						href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-01-20-epub#resolution1"
+						>WG resolution</a>.</li>
 				<li>08-Dec-2021: The <code>page-spread-center</code> property is now an alias for
 						<code>spread-none</code>. See <a href="https://github.com/w3c/epub-specs/issues/1929">issue
 						1929</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1412,14 +1412,6 @@
 			<section id="sec-container-fobfus">
 				<h3>Font Obfuscation</h3>
 
-				<div class="caution">
-					<p>Support for deobfuscation is not a requirement as deobfuscation may have legal ramifications in
-						some jurisdictions. Reading System developers need to consider the impacts of copyright laws on
-						their use of obfuscated fonts. For example, making a deobfuscated font easily available as part
-						of rendering the content may be interpreted as a violation (e.g., saving to a device's hard
-						drive or hosting the file on a web server in its deobfuscated state).</p>
-				</div>
-
 				<p id="confreq-ocf-fobfus">Reading Systems SHOULD support deobfuscation of fonts as defined in <a
 						data-cite="epub-33#sec-font-obfuscation"><em>Font Obfuscation</em></a> [[EPUB-33]].</p>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -238,12 +238,13 @@
 			<section id="sec-epub-rs-conf-data-urls">
 				<h4>Data URLs</h4>
 
-				<p id="confreq-rs-data-urls" data-tests="#pub-data-urls_browsing-context,#pub-data-urls_top-level-content">Reading Systems MUST prevent data URLs
-					[[RFC2397]] from opening in <a data-cite="html#top-level-browsing-context">top-level browsing
-						contexts</a> [[HTML]], except when initiated through a Reading System affordance such as a
-					context menu. If a Reading System does not use a top-level browsing context for <a>Top-level Content
-						Documents</a>, for example if the <a>Top-level Content Document</a> is an SVG, it MUST also
-					prevent data URLs from opening as though they are Top-level Content Documents.</p>
+				<p id="confreq-rs-data-urls"
+					data-tests="#pub-data-urls_browsing-context,#pub-data-urls_top-level-content">Reading Systems MUST
+					prevent data URLs [[RFC2397]] from opening in <a data-cite="html#top-level-browsing-context"
+						>top-level browsing contexts</a> [[HTML]], except when initiated through a Reading System
+					affordance such as a context menu. If a Reading System does not use a top-level browsing context for
+						<a>Top-level Content Documents</a>, for example if the <a>Top-level Content Document</a> is an
+					SVG, it MUST also prevent data URLs from opening as though they are Top-level Content Documents.</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-cmt">
@@ -555,10 +556,10 @@
 							property</a> [[EPUB-33]], Reading Systems MUST follow the requirements for the override's
 						global value when displaying that spine item.</p>
 
-					<p>For example, a spine item that contains the <a href="https://www.w3.org/TR/epub-33/#layout-overrides"
-								><code>layout-pre-paginated</code> override</a> [[EPUB-33]] is rendered following the
-						requirements of the global <a href="#def-layout-pre-paginated"><code>pre-paginated</code>
-							value</a>.</p>
+					<p>For example, a spine item that contains the <a
+							href="https://www.w3.org/TR/epub-33/#layout-overrides"><code>layout-pre-paginated</code>
+							override</a> [[EPUB-33]] is rendered following the requirements of the global <a
+							href="#def-layout-pre-paginated"><code>pre-paginated</code> value</a>.</p>
 
 					<p>If more than one override for the same property is specified in a <code>properties</code>
 						attribute, Reading Systems MUST only process the first value listed in the attribute.</p>
@@ -831,7 +832,8 @@
 			<section id="sec-scripted-content">
 				<h3>Scripting</h3>
 
-				<p id="confreq-rs-scripted" class="support" data-test="#scr-support,#scr-support_iframe,#scr-support_svg">Reading Systems SHOULD support <a
+				<p id="confreq-rs-scripted" class="support"
+					data-test="#scr-support,#scr-support_iframe,#scr-support_svg">Reading Systems SHOULD support <a
 						data-cite="epub-33#sec-scripted-content">scripting</a> [[EPUB-33]].</p>
 
 				<p>Reading System support for scripting depends on its usage context:</p>
@@ -892,12 +894,14 @@
 							provided to scripts during execution (e.g., limiting networking).</p>
 					</li>
 					<li>
-						<p id="confreq-rs-scripted-readingsystem-object" data-tests="#scr-readingsystem-features,#scr-readingsystem-support,#scr-readingsystem-support_svg">It MUST extend the <a
-								data-cite="html#the-navigator-object">navigator object</a> [[!HTML]] with the
-								<code>epubReadingSystem</code> interface defined in <a href="#app-epubReadingSystem"
-							></a>. It also MUST support the <code>dom-manipulation</code> and <code>layout-change</code>
-							features defined in <a href="#app-ers-hasFeature-features"></a> in container-constrained
-							scripting contexts.</p>
+						<p id="confreq-rs-scripted-readingsystem-object"
+							data-tests="#scr-readingsystem-features,#scr-readingsystem-support,#scr-readingsystem-support_svg"
+							>It MUST extend the <a data-cite="html#the-navigator-object">navigator object</a> [[!HTML]]
+							with the <code>epubReadingSystem</code> interface defined in <a
+								href="#app-epubReadingSystem"></a>. It also MUST support the
+								<code>dom-manipulation</code> and <code>layout-change</code> features defined in <a
+								href="#app-ers-hasFeature-features"></a> in container-constrained scripting
+							contexts.</p>
 					</li>
 				</ul>
 
@@ -1006,10 +1010,13 @@
 				<section id="orientation">
 					<h4>The <code>rendition:orientation</code> Property</h4>
 
-					<p id="fxl-orientation-default" data-tests="#fxl-orientation-default">The default value <code>auto</code> MUST be assumed by EPUB Reading Systems as the global value if no <code>meta</code> element carrying this
-						property occurs in the <code>metadata</code> section.</p>
+					<p id="fxl-orientation-default" data-tests="#fxl-orientation-default">The default value
+							<code>auto</code> MUST be assumed by EPUB Reading Systems as the global value if no
+							<code>meta</code> element carrying this property occurs in the <code>metadata</code>
+						section.</p>
 
-					<p>The <code>rendition:orientation</code> property values have the following processing requirements:</p>
+					<p>The <code>rendition:orientation</code> property values have the following processing
+						requirements:</p>
 
 					<dl class="variablelist">
 						<dt id="def-orientation-auto">auto</dt>
@@ -1036,8 +1043,9 @@
 				<section id="spread">
 					<h4>The <code>rendition:spread</code> Property</h4>
 
-					<p id="fxl-spread-default" data-tests="#fxl-spread-default">The default value <code>auto</code> MUST be assumed by EPUB Reading Systems as the global value if no <code>meta</code> element carrying this
-						property occurs in the <code>metadata</code> section.</p>
+					<p id="fxl-spread-default" data-tests="#fxl-spread-default">The default value <code>auto</code> MUST
+						be assumed by EPUB Reading Systems as the global value if no <code>meta</code> element carrying
+						this property occurs in the <code>metadata</code> section.</p>
 
 					<p>The <code>rendition:spread</code> property values have the following processing requirements:</p>
 
@@ -1400,10 +1408,19 @@
 					</li>
 				</ul>
 			</section>
+
 			<section id="sec-container-fobfus">
 				<h3>Font Obfuscation</h3>
 
-				<p id="confreq-ocf-fobfus">Reading Systems MUST support deobfuscation of fonts as defined in <a
+				<div class="caution">
+					<p>Support for deobfuscation is not a requirement as deobfuscation may have legal ramifications in
+						some jurisdictions. Reading System developers need to consider the impacts of copyright laws on
+						their use of obfuscated fonts. For example, making a deobfuscated font easily available as part
+						of rendering the content may be interpreted as a violation (e.g., saving to a device's hard
+						drive or hosting the file on a web server in its deobfuscated state).</p>
+				</div>
+
+				<p id="confreq-ocf-fobfus">Reading Systems SHOULD support deobfuscation of fonts as defined in <a
 						data-cite="epub-33#sec-font-obfuscation"><em>Font Obfuscation</em></a> [[EPUB-33]].</p>
 
 				<p>For Reading Systems to get the original obfuscated data back, simply reverse the process: the source
@@ -1412,7 +1429,7 @@
 				<div class="note">
 					<p>EPUB 3 allowed the obfuscation of fonts prior to EPUB 3.0.1, but did not specify the order of
 						obfuscation and compression. As a result, Reading Systems might encounter invalid fonts after
-						decompression and de-obfuscation. In such instances, de-obfuscating the data before inflating it
+						decompression and deobfuscation. In such instances, deobfuscating the data before inflating it
 						may return a valid font. Reading Systems do not have to support this method of retrieval, but
 						developers must consider it when supporting EPUB 3 content generally.</p>
 				</div>
@@ -2116,7 +2133,9 @@ partial interface Navigator {
 					<pre>alert("Reading System name: " + navigator.epubReadingSystem.name);</pre>
 				</aside>
 
-				<p id="scripting-req-readingsystem" data-tests="#scr-readingsystem-support,#scr-readingsystem-support_svg,#scr-readingsystem-support_iframe,#scr-readingsystem-support_iframe_svg">Reading Systems MUST expose the <code>epubReadingSystem</code> object on the <code>navigator</code>
+				<p id="scripting-req-readingsystem"
+					data-tests="#scr-readingsystem-support,#scr-readingsystem-support_svg,#scr-readingsystem-support_iframe,#scr-readingsystem-support_iframe_svg"
+					>Reading Systems MUST expose the <code>epubReadingSystem</code> object on the <code>navigator</code>
 					object of all loaded Scripted Content Documents, including any nested <a
 						data-cite="epub-33#sec-scripted-container-constrained">container-constrained scripting
 						contexts</a> [[EPUB-33]]. Reading Systems MUST ensure that the <code>epubReadingSystem</code>
@@ -2134,7 +2153,9 @@ partial interface Navigator {
 			<section id="app-ers-properties">
 				<h3>Properties</h3>
 
-				<p id="scripting-req-readingsystem-properties" data-tests="#scr-readingsystem-support,#scr-readingsystem-support_svg,#scr-readingsystem-support_iframe,#scr-readingsystem-support_iframe_svg">The Reading System MUST make the following properties available for retrieving information about
+				<p id="scripting-req-readingsystem-properties"
+					data-tests="#scr-readingsystem-support,#scr-readingsystem-support_svg,#scr-readingsystem-support_iframe,#scr-readingsystem-support_iframe_svg"
+					>The Reading System MUST make the following properties available for retrieving information about
 					it.</p>
 
 				<table data-dfn-for="EpubReadingSystem">
@@ -2207,12 +2228,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						<h5>Features</h5>
 
 
-						<p id="scripting-req-readingsystem-features" data-tests="#scr-readingsystem-features">
-							The following table lists the set of features that Reading Systems that support the
-							<code>epubReadingSystem</code> object MUST recognize.
-							When the features are queried from the <code>hasFeature</code> method, 
-							Reading Systems MUST return a boolean value indicating their support.
-						</p>
+						<p id="scripting-req-readingsystem-features" data-tests="#scr-readingsystem-features"> The
+							following table lists the set of features that Reading Systems that support the
+								<code>epubReadingSystem</code> object MUST recognize. When the features are queried from
+							the <code>hasFeature</code> method, Reading Systems MUST return a boolean value indicating
+							their support. </p>
 
 
 						<table>
@@ -2293,7 +2313,13 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>19-Jan-2022: Elevated default statements for the <code>rendition:spread</code> and <code>rendition:orientation</code> properties to MUSTs, to align with <code>rendition:layout</code>. See <a href="https://github.com/w3c/epub-specs/issues/1936">issue 1936</a>.</li>
+				<li>30-Jan-2022: Reduced the requirement to support deobfuscation to a recommendation and added a
+					caution about possible legal ramifications. See <a
+						href="https://github.com/w3c/epub-specs/issues/1873">issue 1873</a>.</li>
+				<li>19-Jan-2022: Elevated default statements for the <code>rendition:spread</code> and
+						<code>rendition:orientation</code> properties to requirements, to align with
+						<code>rendition:layout</code>. See <a href="https://github.com/w3c/epub-specs/issues/1936">issue
+						1936</a>.</li>
 				<li>08-Dec-2021: <code>page-spread-center</code> is now an alias for <code>spread-none</code>. See <a
 						href="https://github.com/w3c/epub-specs/issues/1929">issue 1929</a>.</li>
 				<li>10-Nov-2021: Proper definition of the Content URL and handling of relative URLs. See <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2305,8 +2305,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>30-Jan-2022: Reduced the requirement to support deobfuscation to a recommendation and added a
-					caution about possible legal ramifications. See <a
+				<li>03-Feb-2022: Reduced the requirement to support deobfuscation to a recommendation. See <a
 						href="https://github.com/w3c/epub-specs/issues/1873">issue 1873</a>.</li>
 				<li>19-Jan-2022: Elevated default statements for the <code>rendition:spread</code> and
 						<code>rendition:orientation</code> properties to requirements, to align with


### PR DESCRIPTION
This PR makes the following changes:

- creates a new "Limitations" section to separate the obfuscation introduction from the discussion of its drawbacks. Also extends the discussion a bit as per #1873  
- adds a caution box to rs spec about potential legal ramifications to match the caution in the core spec
- reduces the requirement to deobfuscate to recommendation
- harmonizes spelling of deobfuscation

Addresses #1873 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1873/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1873/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1980.html" title="Last updated on Feb 4, 2022, 1:28 AM UTC (4877dae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1980/8b395ea...4877dae.html" title="Last updated on Feb 4, 2022, 1:28 AM UTC (4877dae)">Diff</a>