### PR TITLE
Added a document on testing strategy and exit criteria

### DIFF
--- a/epub33/reports/exit_criteria.html
+++ b/epub33/reports/exit_criteria.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>EPUB 3.3 Testing Strategies and Exit Criteria</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <style>
+      .todo {
+        background-color: yellow;
+        color: #900;
+      }
+
+    </style>
+    <script class="remove">
+        // All config options at https://respec.org/docs/
+        var respecConfig = {
+            group: "epub",
+            wgPublicList: "public-epub-wg",
+            specStatus: "base",
+            noRecTrack: true,
+            editors: [{
+                name: "Ivan Herman",
+                url: "https://www.w3.org/People/Ivan/",
+                company: "W3C",
+                w3cid: 7382,
+                orcid: "0000-0003-0782-2704",
+                companyURL: "https://www.w3.org",
+            }],
+            github: {
+                repoURL: "https://github.com/w3c/epub-specs",
+                branch: "main"
+            },
+            shortName: "exit-criteria",
+            format: "markdown"
+        };
+    </script>
+</head>
+
+<body>
+    <section id="abstract">
+        <p>
+            This document outlines the testing strategies and specifies the <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation (CR)</a> exit criteria for the EPUB 3.3 specifications. The three Recommendation-track specifications that are subject to testing and CR review are:
+        </p>
+        <ol>
+            <li><a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB Reading Systems 3.3</a></li>
+            <li><a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a></li>
+            <li><a href="https://w3c.github.io/epub-specs/epub33/a11y/"></a>EPUB Accessibility 1.1</li>
+        </ol>
+    </section>
+    <section id="sotd">
+    </section>
+
+    <section>
+        <h1 id="introduction">Introduction</h1>
+        <p>
+          At the core, an EPUB 3.3 publication consists of a number of <a href="https://w3c.github.io/epub-specs/epub33/core/#dfn-publication-resource">Publications Resources</a> that are in XHTML, SVG, CSS, or various media formats. Beyond these Publication Resources the EPUB publication includes some EPUB-specific files (e.g, a <a href="https://w3c.github.io/epub-specs/epub33/core/#dfn-package-document">Package Document</a>) whose formats are defined by the EPUB 3.3 standard family. Accordingly, an EPUB 3.3 Reading System has to:
+        </p>
+
+        <ul>
+            <li>interpret and render these standard formats, much like Web browsers do; and</li>
+            <li>provide some additional features <em>“on top”</em> of that renderer.</li>
+        </ul>
+
+        <p>
+          What this also means is that the validity and conformance of an EPUB 3.3 publication, as well as a Reading System implementation, <em>includes</em> the requirement of valid and conformant Publication Resources, and the conformant rendering thereof.
+        </p>
+
+        <p>
+          Comprehensive testing would require to include the union of all HTML, SVG, or CSS tests both on the content side as well as the implementation side <em>as well as</em> testing the unique, EPUB 3.3 specific features. The industry standard checking tools, like <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> or <a href="https://daisy.github.io/ace/">ACE, by Daisy</a> indeed <em>include</em> standard, and externally developed, HTML, CSS, or accessibility checkers, which would check the validity or conformance of the Publication Resources. Similarly, today’s Reading Systems do not develop an HTML renderer themselves; they, rather, rely on external tools (typically a webview implementation) that can be assumed to conform to the relevant W3C specifications.
+        </p>
+
+        <p>
+          However, taking into account these additional test would be quite unnecessary for the purpose of testing the EPUB 3.3 specification (which is the main purpose of a <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation</a>). As a consequence, the <em><strong>testing strategy of EPUB 3.3 concentrates on the unique EPUB 3.3 features only</strong></em>, and considers the Publication Resources, as well as the Reading Systems, to conform to the relevant Open Web Platform  specifications.
+        </p>
+    </section>
+
+    <section>
+        <h1 id="testing-strategies">Testing strategies</h1>
+
+        <p>EPUB 3.3 consists of three recommendation-track documents:</p>
+
+        <ol type="1">
+            <li><a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a></li>
+            <li><a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a></li>
+            <li><a href="https://w3c.github.io/epub-specs/epub33/a11y/">EPUB Accessibility 1.1</a></li>
+        </ol>
+
+        <p>The strategy for each of these are a bit different and are detailed below.</p>
+
+        <section>
+            <h2 id="epub-3.3-reading-systems">EPUB 3.3 Reading Systems</h2>
+
+            <p>
+              Interested implementers for the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> are provided with a <a href="https://github.com/w3c/epub-tests">test suite</a> that follows the examples of the Web Platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for all <em>MUST</em> statements, as well as for many <em>SHOULD</em> and for some <em>MAY</em> statements, that appear in the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> specification.
+            </p>
+
+            <p>
+              The <a href="https://w3c.github.io/epub-tests/">test suite documentation</a> describes the individual tests, linking them to the relevant section(s) of the specifications. The <em>editors’ draft</em> (as opposed to the official, published version) also has a pull-down menu attached to each <em>MUST</em> statement providing the references to the relevant tests.
+            </p>
+            <section>
+                <h3 id="exit-criteria-rs">Exit criteria</h3>
+
+                <p>
+                  The <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading System</a> document must have at least two passing, independent implementations for <a href="https://w3c.github.io/epub-tests/">each test</a> linked to a <em>MUST</em> statement in the specification. The results of testing are available in a separate <a href="https://w3c.github.io/epub-tests/results">implementation report</a>.
+                </p>
+            </section>
+        </section>
+
+        <section>
+            <h2 id="epub-3.3-core">EPUB 3.3 (Core)</h2>
+            <p>
+              The normative features of the <a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a> document can be divided, roughly, into the following categories:
+            </p>
+
+            <ol>
+                <li>
+                    <p>
+                      Features that have a direct effect on the reading system behavior, and whose behavioral details are mostly specified by <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a>. Examples are the list of <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-cmt-supported">supported media types</a>, semantics of some <a href="https://w3c.github.io/epub-specs/epub33/core/#attrdef-dir">internationalization features</a>, or the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-container-iri">specificities of URLs</a> in the case of packaged contents. These features have their counterpart in the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> document and they share the relevant tests. In other words, some of the aforementioned tests, and their implementations, are also relevant for the core <a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a> document.
+                    </p>
+                </li>
+                <li>
+                    <p>
+                      Structural constraints on a the EPUB-specific files of the publication; examples include the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-ocf">structure of the container format (OCF)</a> or of the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-package-doc">Package Document</a>.
+                    </p>
+                </li>
+                <li>
+                    <p>
+                      Extra restrictions concerning content documents such as the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xhtml-deviations">restrictions on HTML</a>, the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-nav">format of an XHTML navigation document</a>, or the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xml-constraints">requirements on XML conformance</a>.
+                    </p>
+                </li>
+                <li>
+                    <p>
+                      Vocabulary items which serve as metadata for the publication, and added to the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-package-doc">EPUB 3.3 package document</a>. Although only few of those vocabulary items are <em>required</em> in a conformant EPUB specification, their formats, value constraints, etc., are normatively specified in the standard and these <em>must</em> be followed for a publication to be valid if they are used.
+                    </p>
+                </li>
+            </ol>
+            <section>
+                <h3 id="exit-criteria-core">Exit criteria</h3>
+                <p>The criteria are different for each category of the normative features:</p>
+                <ol>
+                    <li>
+                        <p>
+                          Features in category 1 share the testing methodology, as well as the <a href="https://w3c.github.io/epub-tests/">tests</a> and <a href="https://w3c.github.io/epub-tests/results">implementation</a>, with the <a href="#exit-criteria-rs">criteria</a> of <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a>.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                          Testing the features in categories 2 and 3 concentrates on whether these restrictions are <em>feasible</em> in practice, i.e., whether they are enforceable when checking validity. The main tool to check this is <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>, which is being upgraded for EPUB 3.3, and whose earlier versions for EPUB 3.2 have been extensively used throughout the industry for several years now; EPUBCheck <em>must</em> be able to validate a valid EPUB 3.3 Publication as well as report an error or warning for invalid publications. The relevant tests themselves are part of the <a href="https://github.com/w3c/epub-tests">test suite</a> and reporting should be part of the <a href="https://w3c.github.io/epub-tests/results">implementation report</a>.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                          Testing the features in category 4 concentrates on vocabulary term <em>usage</em>, i.e., whether real-world publishers use those terms. Each term must have at least two independent publishers using those terms in production. The results of testing are available in a separate <span class="todo">implementation report to be done</span>.
+                        </p>
+                    </li>
+                </ol>
+            </section>
+        </section>
+        <section>
+            <h2 id="epub-accessibility-1.1">EPUB Accessibility 1.1</h2>
+            <p>
+              The goals of the <a href="https://w3c.github.io/epub-specs/epub33/a11y/">EPUB Accessibility 1.1</a> document is to define accessibility conformance of EPUB Publications beyond the accessibility requirements defined by WCAG for Publication Resources. The normative features of this specification can be divided, roughly, into the following categories:
+            </p>
+            <ol>
+                <li>
+                    <p>
+                      Additional structural constraints on a publication; examples include the <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-page-list">requirement on page lists</a> or <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-mo-order">reading order</a>. Through those constraints the document defines accessibility <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting-pub">conformance requirements</a> on top of the conformance levels defined by <a href="https://www.w3.org/TR/WCAG21/">WCAG</a>.
+                    </p>
+                </li>
+                <li>
+                    <p>
+                      Vocabulary items which serve as metadata for reporting; for example, <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting-pub">conformance levels</a>, or disclosing the <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-disc-package">accessibility features</a> related to this publication.
+                    </p>
+                </li>
+            </ol>
+            <section>
+                <h3 id="exit-criteria-a11y">Exit criteria</h3>
+                <ol>
+                    <li>
+                        <p>
+                          Testing the features in category 1 tests whether these restrictions are <em>feasible</em> and <em>used</em> in practice. This is achieved by the requirement that at least 5 publishers will produce at least 1 EPUB each that conform to <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting-pub">EPUB-A11Y-11_WCAG-21-AA</a>.
+                        </p> 
+                          
+                        <p>
+                          Note that these conformance levels rely on each Publication Resource to be conform to WCAG 2.1 AA, when applicable; there are only a few EPUB specific features like page numbering. An EPUB Accessibility 1.1 Usage Report <span class="todo">to be done!!</span> shows that conformance table.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                          Testing the features in category 2 concentrates on vocabulary term <em>usage</em>, i.e., that real-world publishers use those terms. Each term must have at least two independent publishers using those terms in production. A separate <a href="https://w3c.github.io/epub-specs/epub33/reports/a11y-properties-use">EPUB Accessibility 1.1 Metadata Usage Report</a> shows that implementation table.
+                        </p>
+                    </li>
+                </ol>
+            </section>
+        </section>
+    </section>
+</body>
+
+</html>


### PR DESCRIPTION
The WG must have a clear testing strategy _and_ exit criteria before going to Candidate Recommendation; this information must be provided to the Director. Furthermore, in this WG, this may be even more important than usual: the very reason for this WG is to have a clear testing strategy for the EPUB spec in general after all...

This is just a first proposal, that has been reviewed by some (Dan, Matt, Avneesh) but need a thorough WG review.

There is a [preview version](https://raw.githack.com/w3c/epub-specs/exit-criteria/epub33/reports/exit_criteria.html).