### PR TITLE
Minor change on the definition of the smil body element

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7450,8 +7450,8 @@ No Entry</pre>
 
 							<dt>Usage</dt>
 							<dd>
-								<p>The <code>body</code> element is the REQUIRED second child of the <a
-										href="#elemdef-smil"><code>smil</code></a> element.</p>
+								<p>The <code>body</code> element is a REQUIRED child of the <a
+									href="#elemdef-smil"><code>smil</code></a> element. It follows the <a href="#elemdef-smil-head"><code>head</code></a> element, when that element is present.</p>
 							</dd>
 
 							<dt>Attributes</dt>


### PR DESCRIPTION
Adopts https://github.com/w3c/epub-specs/issues/1983#issuecomment-1029265558

Fix #1983


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1984.html" title="Last updated on Feb 4, 2022, 7:57 AM UTC (08894bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1984/9738448...08894bb.html" title="Last updated on Feb 4, 2022, 7:57 AM UTC (08894bb)">Diff</a>