### PR TITLE
Leftover reference to the old ssv text

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4932,7 +4932,7 @@ No Entry</pre>
 							nested sublists).</p>
 
 						<p>EPUB Creators MAY identify the destinations of the <code>page-list</code> references in their
-							respective EPUB Content Documents using the <a data-cite="epub-ssv/#pagebreak"
+							respective EPUB Content Documents using the <a data-cite="epub-ssv-11/#pagebreak"
 									><code>pagebreak</code> term</a> [[EPUB-SSV-11]].</p>
 					</section>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1985.html" title="Last updated on Feb 4, 2022, 1:26 PM UTC (dd9a638)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1985/9738448...dd9a638.html" title="Last updated on Feb 4, 2022, 1:26 PM UTC (dd9a638)">Diff</a>