### PR TITLE
Added an anchor and a link to test

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1609,7 +1609,7 @@
 				<section id="sec-rsconf-rendering-audio">
 					<h5>Rendering Audio</h5>
 
-					<p>When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
+					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
 							element</a> [[EPUB-33]], Reading Systems MUST play the audio resource referenced by the
 							<code>src</code> attribute, starting at the clip offset time given by the <a
 							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> [[EPUB-33]]

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1596,7 +1596,7 @@
 				<section id="sec-rsconf-timing-synch">
 					<h3>Timing and Synchronization</h3>
 
-					<p id="mo-timing-sync" data-tests="#mo-timing-synchronization">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
+					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
 								><code>body</code> element</a> [[EPUB-33]] in a sequence. A <a
 							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[EPUB-33]] children
 						MUST be rendered in sequence, and playback completes when the last child finishes playing.

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1596,7 +1596,7 @@
 				<section id="sec-rsconf-timing-synch">
 					<h3>Timing and Synchronization</h3>
 
-					<p>Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
+					<p id="mo-timing-sync" data-tests="#mo-timing-synchronization">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
 								><code>body</code> element</a> [[EPUB-33]] in a sequence. A <a
 							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[EPUB-33]] children
 						MUST be rendered in sequence, and playback completes when the last child finishes playing.


### PR DESCRIPTION
This is the counterpart for https://github.com/w3c/epub-tests/pull/115, should be merged when that one is merged.