### PR TITLE
Content document may also embed stylesheets for MO purposes

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8267,9 +8267,10 @@ No Entry</pre>
 						properties.</p>
 
 					<p>EPUB Creators MAY define any CSS properties for the specified CSS classes, but must ensure that
-						each EPUB Content Document with an associated Media Overlay Document includes a link to the CSS
-						style sheet with the class definitions. Reading Systems might provide their own styling, or no
-						styling at all, in the absence of a linked definition.</p>
+						each EPUB Content Document with an associated Media Overlay Document includes 
+						a CSS stylesheet (either embedded or linked) containing the class definitions. 
+						In the absence of such definitions Reading Systems might provide their own styling, or 
+						no styling at all.</p>
 
 					<p>EPUB Creators MUST NOT use the <code>active-class</code> and <code>playback-active-class</code>
 						properties in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a>
@@ -8278,7 +8279,7 @@ No Entry</pre>
 					<aside class="example" title="Associating style information with the
 						currently playing EPUB Content Document">
 
-						<p>The author-defined CSS class names are declared using the metadata properties <a
+					<p>The author-defined CSS class names are declared using the metadata properties <a
 								href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 									><code>playback-active-class</code></a> in the Package Document:</p>
 


### PR DESCRIPTION
This is for #1987, and incorporates the text changes proposed in the comments.

Fix #1987

@mattgarrish, I consider this as handling a bug rather than a new feature, so I did not add an entry to the change history. Do you think we should do it?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1989.html" title="Last updated on Feb 6, 2022, 8:13 AM UTC (7128a15)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1989/cea3d5e...7128a15.html" title="Last updated on Feb 6, 2022, 8:13 AM UTC (7128a15)">Diff</a>