### PR TITLE
Additional anchors for new mo tests

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1596,7 +1596,7 @@
 				<section id="sec-rsconf-timing-synch">
 					<h3>Timing and Synchronization</h3>
 
-					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization,#mol-css_classes,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
+					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
 								><code>body</code> element</a> [[EPUB-33]] in a sequence. A <a
 							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[EPUB-33]] children
 						MUST be rendered in sequence, and playback completes when the last child finishes playing.
@@ -1609,7 +1609,7 @@
 				<section id="sec-rsconf-rendering-audio">
 					<h5>Rendering Audio</h5>
 
-					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization,#mol-css_classes,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
+					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
 							element</a> [[EPUB-33]], Reading Systems MUST play the audio resource referenced by the
 							<code>src</code> attribute, starting at the clip offset time given by the <a
 							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> [[EPUB-33]]
@@ -1620,15 +1620,15 @@
 
 					<ul>
 						<li>
-							<p id="mol-audio-no-clipBegin" data-tests="#mol-audio_no_clipbegin">If the EPUB Creator has not specified a <code>clipBegin</code>, Reading Systems MUST
+							<p id="mol-audio-no-clipbegin" data-tests="#mol-audio-no-clipbegin">If the EPUB Creator has not specified a <code>clipBegin</code>, Reading Systems MUST
 								assume the value "<code>0</code>".</p>
 						</li>
 						<li>
-							<p id="mol-audio-no-clipEnd" data-tests="#mol-audio_no_clipend">If the EPUB Creator has not specified a <code>clipEnd</code>, Reading Systems MUST assume
+							<p id="mol-audio-no-clipend" data-tests="#mol-audio-no-clipend">If the EPUB Creator has not specified a <code>clipEnd</code>, Reading Systems MUST assume
 								the value to be the full duration of the physical media.</p>
 						</li>
 						<li>
-							<p id="mol-audio-exceeding-clipEnd" data-tests="#mol-audio_exceeding_clipend">If <code>clipEnd</code> exceeds the full duration of the physical media, Reading Systems
+							<p id="mol-audio-exceeding-clipend" data-tests="#mol-audio-exceeding-clipend">If <code>clipEnd</code> exceeds the full duration of the physical media, Reading Systems
 								MUST assume its value to be the full duration of the physical media.</p>
 						</li>
 					</ul>
@@ -1649,7 +1649,7 @@
 							Identifier</a> [[SVG]], Reading Systems SHOULD ensure the referenced element is visible in
 						the <a>Viewport</a>. Reading Systems MAY support other fragment identifier schemes.</p>
 
-					<p id="mol-rendering-with-styling" data-tests="#mol-css_classes,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg" >During Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given
+					<p id="mol-rendering-with-styling" data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg" >During Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given
 						by the metadata properties <a data-cite="epub-33#active-class"><code>active-class</code></a> and
 							<a data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a>
 						[[EPUB-33]] to the appropriate elements, when specified, in the EPUB Content Document.

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1596,7 +1596,7 @@
 				<section id="sec-rsconf-timing-synch">
 					<h3>Timing and Synchronization</h3>
 
-					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
+					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization,#mol-css_classes">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
 								><code>body</code> element</a> [[EPUB-33]] in a sequence. A <a
 							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[EPUB-33]] children
 						MUST be rendered in sequence, and playback completes when the last child finishes playing.
@@ -1609,7 +1609,7 @@
 				<section id="sec-rsconf-rendering-audio">
 					<h5>Rendering Audio</h5>
 
-					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
+					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization,#mol-css_classes">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
 							element</a> [[EPUB-33]], Reading Systems MUST play the audio resource referenced by the
 							<code>src</code> attribute, starting at the clip offset time given by the <a
 							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> [[EPUB-33]]
@@ -1649,7 +1649,7 @@
 							Identifier</a> [[SVG]], Reading Systems SHOULD ensure the referenced element is visible in
 						the <a>Viewport</a>. Reading Systems MAY support other fragment identifier schemes.</p>
 
-					<p>During Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given
+					<p id="mol-rendering-with-styling" data-tests="#mol-css_classes" >During Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given
 						by the metadata properties <a data-cite="epub-33#active-class"><code>active-class</code></a> and
 							<a data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a>
 						[[EPUB-33]] to the appropriate elements, when specified, in the EPUB Content Document.

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1596,7 +1596,7 @@
 				<section id="sec-rsconf-timing-synch">
 					<h3>Timing and Synchronization</h3>
 
-					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
+					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
 								><code>body</code> element</a> [[EPUB-33]] in a sequence. A <a
 							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[EPUB-33]] children
 						MUST be rendered in sequence, and playback completes when the last child finishes playing.
@@ -1609,7 +1609,7 @@
 				<section id="sec-rsconf-rendering-audio">
 					<h5>Rendering Audio</h5>
 
-					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
+					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
 							element</a> [[EPUB-33]], Reading Systems MUST play the audio resource referenced by the
 							<code>src</code> attribute, starting at the clip offset time given by the <a
 							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> [[EPUB-33]]
@@ -1620,15 +1620,15 @@
 
 					<ul>
 						<li>
-							<p id="mol-audio-no-clipbegin" data-tests="#mol-audio-no-clipbegin">If the EPUB Creator has not specified a <code>clipBegin</code>, Reading Systems MUST
+							<p>If the EPUB Creator has not specified a <code>clipBegin</code>, Reading Systems MUST
 								assume the value "<code>0</code>".</p>
 						</li>
 						<li>
-							<p id="mol-audio-no-clipend" data-tests="#mol-audio-no-clipend">If the EPUB Creator has not specified a <code>clipEnd</code>, Reading Systems MUST assume
+							<p>If the EPUB Creator has not specified a <code>clipEnd</code>, Reading Systems MUST assume
 								the value to be the full duration of the physical media.</p>
 						</li>
 						<li>
-							<p id="mol-audio-exceeding-clipend" data-tests="#mol-audio-exceeding-clipend">If <code>clipEnd</code> exceeds the full duration of the physical media, Reading Systems
+							<p>If <code>clipEnd</code> exceeds the full duration of the physical media, Reading Systems
 								MUST assume its value to be the full duration of the physical media.</p>
 						</li>
 					</ul>
@@ -1649,7 +1649,7 @@
 							Identifier</a> [[SVG]], Reading Systems SHOULD ensure the referenced element is visible in
 						the <a>Viewport</a>. Reading Systems MAY support other fragment identifier schemes.</p>
 
-					<p id="mol-rendering-with-styling" data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg" >During Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given
+					<p id="mol-rendering-with-styling" data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio" >During Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given
 						by the metadata properties <a data-cite="epub-33#active-class"><code>active-class</code></a> and
 							<a data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a>
 						[[EPUB-33]] to the appropriate elements, when specified, in the EPUB Content Document.

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1628,7 +1628,7 @@
 								the value to be the full duration of the physical media.</p>
 						</li>
 						<li>
-							<p>If <code>clipEnd</code> exceeds the full duration of the physical media, Reading Systems
+							<p id="mol-audio-exceeding-clipEnd" data-tests="#mol-audio_exceeding_clipend">If <code>clipEnd</code> exceeds the full duration of the physical media, Reading Systems
 								MUST assume its value to be the full duration of the physical media.</p>
 						</li>
 					</ul>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1609,7 +1609,7 @@
 				<section id="sec-rsconf-rendering-audio">
 					<h5>Rendering Audio</h5>
 
-					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
+					<p>When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
 							element</a> [[EPUB-33]], Reading Systems MUST play the audio resource referenced by the
 							<code>src</code> attribute, starting at the clip offset time given by the <a
 							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> [[EPUB-33]]
@@ -1649,7 +1649,7 @@
 							Identifier</a> [[SVG]], Reading Systems SHOULD ensure the referenced element is visible in
 						the <a>Viewport</a>. Reading Systems MAY support other fragment identifier schemes.</p>
 
-					<p id="mol-rendering-with-styling" data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio" >During Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given
+					<p id="mol-rendering-with-styling" data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg" >During Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given
 						by the metadata properties <a data-cite="epub-33#active-class"><code>active-class</code></a> and
 							<a data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a>
 						[[EPUB-33]] to the appropriate elements, when specified, in the EPUB Content Document.

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1596,7 +1596,7 @@
 				<section id="sec-rsconf-timing-synch">
 					<h3>Timing and Synchronization</h3>
 
-					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization,#mol-css_classes">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
+					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization,#mol-css_classes,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
 								><code>body</code> element</a> [[EPUB-33]] in a sequence. A <a
 							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[EPUB-33]] children
 						MUST be rendered in sequence, and playback completes when the last child finishes playing.
@@ -1609,7 +1609,7 @@
 				<section id="sec-rsconf-rendering-audio">
 					<h5>Rendering Audio</h5>
 
-					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization,#mol-css_classes">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
+					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization,#mol-css_classes,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
 							element</a> [[EPUB-33]], Reading Systems MUST play the audio resource referenced by the
 							<code>src</code> attribute, starting at the clip offset time given by the <a
 							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> [[EPUB-33]]
@@ -1649,7 +1649,7 @@
 							Identifier</a> [[SVG]], Reading Systems SHOULD ensure the referenced element is visible in
 						the <a>Viewport</a>. Reading Systems MAY support other fragment identifier schemes.</p>
 
-					<p id="mol-rendering-with-styling" data-tests="#mol-css_classes" >During Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given
+					<p id="mol-rendering-with-styling" data-tests="#mol-css_classes,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg" >During Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given
 						by the metadata properties <a data-cite="epub-33#active-class"><code>active-class</code></a> and
 							<a data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a>
 						[[EPUB-33]] to the appropriate elements, when specified, in the EPUB Content Document.

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1620,11 +1620,11 @@
 
 					<ul>
 						<li>
-							<p>If the EPUB Creator has not specified a <code>clipBegin</code>, Reading Systems MUST
+							<p id="mol-audio-no-clipBegin" data-tests="#mol-audio_no_clipbegin">If the EPUB Creator has not specified a <code>clipBegin</code>, Reading Systems MUST
 								assume the value "<code>0</code>".</p>
 						</li>
 						<li>
-							<p>If the EPUB Creator has not specified a <code>clipEnd</code>, Reading Systems MUST assume
+							<p id="mol-audio-no-clipEnd" data-tests="#mol-audio_no_clipend">If the EPUB Creator has not specified a <code>clipEnd</code>, Reading Systems MUST assume
 								the value to be the full duration of the physical media.</p>
 						</li>
 						<li>


### PR DESCRIPTION
Anchors and test references for https://github.com/w3c/epub-tests/pull/116. Should be merged when that one is merged.