### PR TITLE
Harmonize media overlays support

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -256,9 +256,8 @@
 						Type Resources</a> [[EPUB-33]].</p>
 
 				<p id="confreq-rs-epub3-mp3-aac" data-tests="#pub-cmt-mp3,#pub-cmt-mp4,#pub-cmt-opus">If it has the
-					capability to render pre-recorded audio, it MUST support the <a data-cite="epub-33#cmt-grp-audio"
-						>audio Core Media Type Resources</a> [[EPUB-33]] and SHOULD support Media Overlays
-					[[EPUB-33]].</p>
+					capability to render prerecorded audio, it MUST support the <a data-cite="epub-33#cmt-grp-audio"
+						>audio Core Media Type Resources</a> [[EPUB-33]].</p>
 
 				<p class="note" id="note-video-codecs">It is recommended that Reading Systems support at least one of
 					the H.264 [[H264]] and VP8 [[RFC6386]] video codecs, but this is not a conformance requirement
@@ -312,7 +311,9 @@
 					contents, when applicable. This includes:</p>
 
 				<ul>
-					<li id="confreq-rs-pkg-dir-intro" data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">the <code>dir</code> attribute for the <a data-cite="epub-33#attrdef-dir">Package
+					<li id="confreq-rs-pkg-dir-intro"
+						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
+						>the <code>dir</code> attribute for the <a data-cite="epub-33#attrdef-dir">Package
 						Document</a> [[EPUB-33]]. (See also <a href="#sec-pkg-doc-base-dir"></a> for further
 						details.)</li>
 					<li>the <code>dir</code> attribute for <a data-cite="html#the-dir-attribute"
@@ -321,12 +322,14 @@
 							href="https://www.w3.org/TR/SVG/text.html#DirectionProperty">SVG</a> [[SVG]].</li>
 				</ul>
 
-				<p id="confreq-rs-pkg-lang-no-content" data-tests="#pgk-lang_pkg_non_content_dir,#pgk-lang_pkg_non_content">In the absence of this information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume
-					either the language or the base direction of that resource from information expressed in the Package
-					Document (i.e., in <code>xml:lang</code> and <code>dir</code> attributes, in <code>hreflang</code>
-					attributes on link elements, or from <code>dc:language</code> elements). Refer to a resource's
-					formal specification for more information about to handle the absence of explicit language or
-					direction information.</p>
+				<p id="confreq-rs-pkg-lang-no-content"
+					data-tests="#pgk-lang_pkg_non_content_dir,#pgk-lang_pkg_non_content">In the absence of this
+					information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume either the language or
+					the base direction of that resource from information expressed in the Package Document (i.e., in
+						<code>xml:lang</code> and <code>dir</code> attributes, in <code>hreflang</code> attributes on
+					link elements, or from <code>dc:language</code> elements). Refer to a resource's formal
+					specification for more information about to handle the absence of explicit language or direction
+					information.</p>
 			</section>
 
 			<section id="sec-epub-rs-network-access">
@@ -1082,9 +1085,9 @@
 							Resource</a>.</p>
 				</li>
 				<li>
-					<p id="confreq-nav-ol-style" data-tests="#nav-spine_in-spine-no-list-style">MUST NOT show list item numbering on <code>nav</code> elements when
-						presenting them outside of the spine, regardless of support for CSS, as the default display
-						style of list items is equivalent to the <a
+					<p id="confreq-nav-ol-style" data-tests="#nav-spine_in-spine-no-list-style">MUST NOT show list item
+						numbering on <code>nav</code> elements when presenting them outside of the spine, regardless of
+						support for CSS, as the default display style of list items is equivalent to the <a
 							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
 								none</code> property</a> [[CSSSnapshot]].).</p>
 				</li>
@@ -1562,8 +1565,8 @@
 		<section id="sec-media-overlays">
 			<h2>Media Overlays Processing</h2>
 
-			<p id="confreq-rs-epub3-mo" class="support">Reading Systems SHOULD support <a
-					data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[EPUB-33]].</p>
+			<p id="confreq-rs-epub3-mo" class="support">Reading Systems with the capability to render prerecorded audio
+				SHOULD support <a data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[EPUB-33]].</p>
 
 			<p>If a Reading System does not support Media Overlays, it MUST ignore both the <code>media-overlay</code>
 				attribute on <a>Manifest</a>
@@ -1596,25 +1599,27 @@
 				<section id="sec-rsconf-timing-synch">
 					<h3>Timing and Synchronization</h3>
 
-					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization">Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
-								><code>body</code> element</a> [[EPUB-33]] in a sequence. A <a
-							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[EPUB-33]] children
-						MUST be rendered in sequence, and playback completes when the last child finishes playing.
-						Reading System MUST render a <a data-cite="epub-33#elemdef-smil-par"><code>par</code>
-							element's</a> [[EPUB-33]] children in parallel (with each starting at the same time), and
-						playback completes when all the children finish playing. Reading System playback of the Media
-						Overlay Document completes when the <code>body</code> element's last child finishes playing.</p>
+					<p id="mol-timing-sync" data-tests="#mol-timing-synchronization">Reading Systems MUST render
+						immediate children of the <a data-cite="epub-33#elemdef-smil-body"><code>body</code> element</a>
+						[[EPUB-33]] in a sequence. A <a data-cite="epub-33#elemdef-smil-seq"><code>seq</code>
+							element's</a> [[EPUB-33]] children MUST be rendered in sequence, and playback completes when
+						the last child finishes playing. Reading System MUST render a <a
+							data-cite="epub-33#elemdef-smil-par"><code>par</code> element's</a> [[EPUB-33]] children in
+						parallel (with each starting at the same time), and playback completes when all the children
+						finish playing. Reading System playback of the Media Overlay Document completes when the
+							<code>body</code> element's last child finishes playing.</p>
 				</section>
 
 				<section id="sec-rsconf-rendering-audio">
 					<h5>Rendering Audio</h5>
 
-					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization">When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
-							element</a> [[EPUB-33]], Reading Systems MUST play the audio resource referenced by the
-							<code>src</code> attribute, starting at the clip offset time given by the <a
-							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> [[EPUB-33]]
-						and ending at the clip offset time given by the <a data-cite="epub-33#attrdef-smil-clipEnd"
-								><code>clipEnd</code> attribute</a> [[EPUB-33]].</p>
+					<p id="mol-rendering-audio" data-tests="#mol-timing-synchronization">When presented with a Media
+						Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code> element</a> [[EPUB-33]],
+						Reading Systems MUST play the audio resource referenced by the <code>src</code> attribute,
+						starting at the clip offset time given by the <a data-cite="epub-33#attrdef-smil-clipBegin"
+								><code>clipBegin</code> attribute</a> [[EPUB-33]] and ending at the clip offset time
+						given by the <a data-cite="epub-33#attrdef-smil-clipEnd"><code>clipEnd</code> attribute</a>
+						[[EPUB-33]].</p>
 
 					<p>In addition:</p>
 
@@ -2448,7 +2453,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>11-Feb-2021: Media Overlays are now required as a SHOULD instead of MAY. See <a
+				<li>11-Feb-2021: Fix the contradictory support statements for Media Overlays. Support is recommended
+					when rendering of prerecorded audio is supported, as in previous versions of EPUB 3. See <a
 						href="https://github.com/w3c/epub-specs/issues/1991">issue 1991</a>.</li>
 				<li>04-Feb-2021: Changed the informative security considerations for controlling network access, opening
 					external links, and managing local storage to normative recommendations. See <a


### PR DESCRIPTION
This PR corrects #1993 by removing the support statement for media overlays in the core media types section and updating the support statement at start of the media overlays section to be dependent on audio support.

Fixes #1991

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1991-update/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/issue-1991-update/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 16, 2022, 1:14 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2F74ef4c2ac4ba62cdfcd1709de6ec14681b4b4abe%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/oF6sSL/index.html?isPreview=true&publishDate=2022-02-16
ReSpec version: 31.0.2
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 28530ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:228:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%231994.)._
</details>
