### PR TITLE
Fix normative statements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7428,7 +7428,7 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p>This specification defines no metadata properties that MUST occur in the Media Overlay
+						<p>This specification defines not require any metadata properties in the Media Overlay
 							Document; the <code>metadata</code> element is provided for custom metadata
 							requirements.</p>
 					</section>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -716,7 +716,7 @@
 					<section id="sec-cmt-supported">
 						<h5>Supported Media Types</h5>
 
-						<p><a>EPUB Creators</a> may include <a>Publication Resources</a> that conform to the following
+						<p><a>EPUB Creators</a> MAY include <a>Publication Resources</a> that conform to the following
 							MIME media type [[RFC2046]] specifications in <a>EPUB Publications</a> without
 							fallbacks.</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7428,9 +7428,8 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p>This specification defines not require any metadata properties in the Media Overlay
-							Document; the <code>metadata</code> element is provided for custom metadata
-							requirements.</p>
+						<p>This specification does not require any metadata properties in the Media Overlay Document;
+							the <code>metadata</code> element is provided for custom metadata requirements.</p>
 					</section>
 
 					<section id="sec-smil-body-elem">
@@ -7450,8 +7449,9 @@ No Entry</pre>
 
 							<dt>Usage</dt>
 							<dd>
-								<p>The <code>body</code> element is a REQUIRED child of the <a
-									href="#elemdef-smil"><code>smil</code></a> element. It follows the <a href="#elemdef-smil-head"><code>head</code></a> element, when that element is present.</p>
+								<p>The <code>body</code> element is a REQUIRED child of the <a href="#elemdef-smil"
+											><code>smil</code></a> element. It follows the <a href="#elemdef-smil-head"
+											><code>head</code></a> element, when that element is present.</p>
 							</dd>
 
 							<dt>Attributes</dt>
@@ -8267,10 +8267,9 @@ No Entry</pre>
 						properties.</p>
 
 					<p>EPUB Creators MAY define any CSS properties for the specified CSS classes, but must ensure that
-						each EPUB Content Document with an associated Media Overlay Document includes 
-						a CSS stylesheet (either embedded or linked) containing the class definitions. 
-						In the absence of such definitions Reading Systems might provide their own styling, or 
-						no styling at all.</p>
+						each EPUB Content Document with an associated Media Overlay Document includes a CSS stylesheet
+						(either embedded or linked) containing the class definitions. In the absence of such definitions
+						Reading Systems might provide their own styling, or no styling at all.</p>
 
 					<p>EPUB Creators MUST NOT use the <code>active-class</code> and <code>playback-active-class</code>
 						properties in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a>
@@ -8279,7 +8278,7 @@ No Entry</pre>
 					<aside class="example" title="Associating style information with the
 						currently playing EPUB Content Document">
 
-					<p>The author-defined CSS class names are declared using the metadata properties <a
+						<p>The author-defined CSS class names are declared using the metadata properties <a
 								href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 									><code>playback-active-class</code></a> in the Package Document:</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4434,7 +4434,7 @@ No Entry</pre>
 						</div>
 
 						<p class="note">In some cases, the unprefixed versions of these properties now support
-							additional values. Reading Systems MAY support these values even with the prefixed
+							additional values. Reading Systems may support these values even with the prefixed
 							property.</p>
 					</section>
 				</section>


### PR DESCRIPTION
Reviewing the requirements against epubchecks tests, I've already noticed a non-normative "may" in the core media types section that should be normative.

I'm going to leave this PR open in case I find others.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1995.html" title="Last updated on Mar 2, 2022, 1:53 PM UTC (d715228)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1995/19b9eac...d715228.html" title="Last updated on Mar 2, 2022, 1:53 PM UTC (d715228)">Diff</a>