### PR TITLE
Removed a reference to obfuscation

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6518,7 +6518,7 @@ No Entry</pre>
 										href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify fonts to
 									deobfuscated.</p>
 
-								<p id="encryption-restrictions">EPUB Creators MUST NOT encrypt or obfuscate the
+								<p id="encryption-restrictions">EPUB Creators MUST NOT encrypt the
 									following files:</p>
 
 								<ul class="nomark">


### PR DESCRIPTION
Fix #1996


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/1998.html" title="Last updated on Feb 18, 2022, 5:33 AM UTC (503fa1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/1998/5ba7886...503fa1e.html" title="Last updated on Feb 18, 2022, 5:33 AM UTC (503fa1e)">Diff</a>