### PR TITLE
Updated the text on FXL and page progression direction

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -568,10 +568,9 @@
 					implicitly, the Reading System can choose rendering direction.</p>
 
 				<p id="confreq-rs-spine-progression-pre-paginated" data-tests="#pkg-spine-progression-pre-paginated"
-					>Reading Systems MUST ignore the page progression direction defined in <a href="#layout"
-							><code>pre-paginated</code></a> XHTML Content Documents. The
-						<code>page-progression-direction</code> attribute defines the flow direction from one
-					fixed-layout page to the next.</p>
+					>If <code>page-progression-direction</code> has a value other than <code>default</code>, the Reading System 
+					MUST ignore any directionality computed from <a href="#layout"><code>pre-paginated</code></a> XHTML Content Documents.
+				</p>
 
 				<p>If any of the <code>properties</code> attribute's values do not include a prefix, Reading Systems
 					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a


### PR DESCRIPTION
Follows the [WG resolution](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-02-17-epub#resolution1) for issue #1483, adopting the text proposed by @bduga.

Fix #1483


See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/issue1483-ppd-fxl/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/issue1483-ppd-fxl/epub33/rs/index.html)
