### PR TITLE
Made the changes accepted on the WG call for the 'affordance' term

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -286,9 +286,11 @@
 					metadata.</p>
 
 				<p>Ensuring that any interested party can discover the accessible qualities of an EPUB Publication is
-					therefore a primary concern. Users must be able to gauge the usability of an EPUB Publication when
-					they purchase, borrow, or otherwise obtain it, a determination that requires knowing the affordances
-					made to meet the accessibility requirements.</p>
+					therefore a primary concern. An EPUB Publication can have more than one set of sufficient
+					<a href="#confreq-schema-accessMode">access modes</a> depending on the alternatives
+					provided to enable reading in another mode. For example, if alternative text and descriptions are provided
+					for all the images in a publication, it would have both its default textual and visual sufficient access
+					mode <em>and</em> a purely textual sufficient access mode.</p>
 
 				<p>Similarly, content that does not meet the accessibility requirements of this specification does not
 					necessarily fail to meet the needs of individual users.</p>
@@ -343,7 +345,7 @@
 							content without significant loss of information. An EPUB Publication can have more than one
 							set of sufficient access modes for its consumption depending on the types of content it
 							includes (i.e., unlike <a href="#confreq-schema-accessMode">access modes</a>, this property
-							takes into account any affordances for content that is not broadly accessible, such as the
+							takes into account any alternatives for content that is not broadly accessible, such as the
 							inclusion of transcripts for audio content).</p>
 					</li>
 				</ul>


### PR DESCRIPTION
Executing what has been agreen upon on the [WG Call](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-02-17-epub#section4), taking over the text proposed by @mattgarrish.

Fix #1961


See:

* For EPUB Accessibility 1.1:
    * [Preview](https://raw.githack.com/w3c/epub-specs/alternative-to-affordance-issue1961/epub33/a11y/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/alternative-to-affordance-issue1961/epub33/a11y/index.html)
