### PR TITLE
Add reporting document for package metadata

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -990,8 +990,8 @@
 					<h4>Publication Conformance</h4>
 
 					<p>To indicate that an EPUB Publication conforms to the accessibility requirements of this
-						specification, it MUST include a <code>conformsTo</code> property whose value MUST exactly match
-						(i.e., both in case and spacing) the following pattern:</p>
+						specification, it MUST include a <code id="dcterms-conformsTo">conformsTo</code> property whose
+						value MUST exactly match (i.e., both in case and spacing) the following pattern:</p>
 
 					<p class="conf-pattern">EPUB-A11Y-<a href="#acc-ver"><var>A11Y-VER</var></a>_WCAG-<a
 							href="#wcag-ver"><var>WCAG-VER</var></a>-<a href="#wcag-lvl"><var>WCAG-LVL</var></a></p>
@@ -1069,8 +1069,9 @@
 				<section id="sec-conf-reporting-eval">
 					<h4>Evaluator Information</h4>
 
-					<p>EPUB Publications MUST include an <a href="#certifiedBy"><code>a11y:certifiedBy</code></a>
-						property that specifies the name of the party that evaluated the EPUB Publication.</p>
+					<p>EPUB Publications MUST include an <a href="#certifiedBy"><code id="a11y-certifiedBy"
+								>a11y:certifiedBy</code></a> property that specifies the name of the party that
+						evaluated the EPUB Publication.</p>
 
 					<div class="note">
 						<p>Any individual or party can perform a conformance evaluation. The evaluator can be the same
@@ -1196,7 +1197,7 @@
 
 					<p>If the party that evaluates the content has a credential or badge that establishes their
 						authority to evaluate content, include that information in an <a href="#certifierCredential"
-								><code>a11y:certifierCredential</code> property</a>.</p>
+								><code id="a11y-certifierCredential">a11y:certifierCredential</code> property</a>.</p>
 
 					<aside class="example" title="Expressing a basic credential">
 						<p>In this example, the <code>refines</code> attribute associates the credential with the
@@ -1225,8 +1226,8 @@
 					</aside>
 
 					<p>If the party that evaluated the content provides a publicly-readable report of its assessment,
-						provide a link to the assessment in an <a href="#certifierReport"
-								><code>a11y:certifierReport</code> property</a>.</p>
+						provide a link to the assessment in an <a href="#certifierReport"><code
+								id="a11y-certifierReport">a11y:certifierReport</code> property</a>.</p>
 
 					<aside class="example" title="A remotely hosted accessibility report">
 						<p>The following example shows a link to a remotely hosted accessibility report.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2015,11 +2015,11 @@
 </pre>
 
 									<p>Previous versions of this specification recommended using the <a
-											href="#sec-property-title-type"><code>title-type</code></a> and <a
-											href="#sec-property-display-seq"><code>display-seq</code></a> properties to
-										identify and format the segments of multipart titles (see the <a
-											href="#cookbook-ex">Great Cookbooks example</a>). It is still possible to
-										add these semantics but they are also not well supported.</p>
+											href="#sec-title-type"><code>title-type</code></a> and <a
+											href="#sec-display-seq"><code>display-seq</code></a> properties to identify
+										and format the segments of multipart titles (see the <a href="#cookbook-ex"
+											>Great Cookbooks example</a>). It is still possible to add these semantics
+										but they are also not well supported.</p>
 								</div>
 							</section>
 

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -19,7 +19,7 @@
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 		<code>http://idpf.org/epub/vocab/package/meta/#</code>.</p>
 	
-	<section id="sec-property-alternate-script">
+	<section id="sec-alternate-script">
 		<h5>alternate-script</h5>
 		<table id="alternate-script">
 			<tbody>
@@ -73,7 +73,7 @@
 &lt;/metadata></pre>
 		</aside>
 	</section>
-	<section id="sec-property-authority">
+	<section id="sec-authority">
 		<h5>authority</h5>
 		<table id="authority">
 			<tbody>
@@ -222,7 +222,7 @@
 &lt;/metadata></pre>
 		</aside>
 	</section>
-	<section id="sec-property-belongs-to-collection">
+	<section id="sec-belongs-to-collection">
 		<h5>belongs-to-collection</h5>
 		<table id="belongs-to-collection">
 			<tbody>
@@ -288,7 +288,7 @@
 &lt;/metadata></pre>
 		</aside>
 	</section>
-	<section id="sec-property-collection-type">
+	<section id="sec-collection-type">
 		<h5>collection-type</h5>
 		<table id="collection-type">
 			<tbody>
@@ -367,7 +367,7 @@
 &lt;/metadata></pre>
 		</aside>
 	</section>
-	<section id="sec-property-display-seq">
+	<section id="sec-display-seq">
 		<h5>display-seq</h5>
 		<table id="display-seq">
 			<tbody>
@@ -406,7 +406,7 @@
 			</tbody>
 		</table>
 	</section>
-	<section id="sec-property-file-as">
+	<section id="sec-file-as">
 		<h5>file-as</h5>
 		<table id="file-as">
 			<tbody>
@@ -456,7 +456,7 @@
 &lt;/metadata></pre>
 		</aside>
 	</section>
-	<section id="sec-property-group-position">
+	<section id="sec-group-position">
 		<h5>group-position</h5>
 		<table id="group-position">
 			<tbody>
@@ -541,7 +541,7 @@
 &lt;/metadata></pre>
 		</aside>
 	</section>
-	<section id="sec-property-identifier-type">
+	<section id="sec-identifier-type">
 		<h5>identifier-type</h5>
 		<table id="identifier-type">
 			<tbody>
@@ -600,13 +600,13 @@
 &lt;/metadata></pre>
 		</aside>
 	</section>
-	<section id="sec-property-meta-auth">
+	<section id="sec-meta-auth">
 		<h5>meta-auth (Deprecated)</h5>
 		<p id="meta-auth">Use of the <code>meta-auth</code> property is <a href="#deprecated"
 			>deprecated</a>.</p>
 		<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
 	</section>
-	<section id="sec-property-role">
+	<section id="sec-role">
 		<h5>role</h5>
 		<table id="role">
 			<tbody>
@@ -706,7 +706,7 @@
 &lt;/metadata></pre>
 		</aside>
 	</section>
-	<section id="sec-property-source-of">
+	<section id="sec-source-of">
 		<h5>source-of</h5>
 		<table id="source-of">
 			<tbody>
@@ -783,7 +783,7 @@
 &lt;/metadata></pre>
 		</aside>
 	</section>
-	<section id="sec-property-term">
+	<section id="sec-term">
 		<h5>term</h5>
 		<table id="term">
 			<tbody>
@@ -843,7 +843,7 @@
 &lt;/metadata></pre>
 		</aside>
 	</section>
-	<section id="sec-property-title-type">
+	<section id="sec-title-type">
 		<h5>title-type</h5>
 		<table id="title-type">
 			<tbody>

--- a/epub33/reports/a11y-properties-use.md
+++ b/epub33/reports/a11y-properties-use.md
@@ -29,29 +29,49 @@ out their implementations.
     <thead>
         <tr>
             <th>Role</th>
-            <th>[Publisher]</th>
+            <th>Used By</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <th>schema:accessibilityFeature</th>
-            <td></td>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
         </tr>
         <tr>
             <th>schema:accessibilityHazard</th>
-            <td></td>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
         </tr>
         <tr>
             <th>schema:accessibilitySummary</th>
-            <td></td>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
         </tr>
         <tr>
             <th>schema:accessMode</th>
-            <td></td>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
         </tr>
         <tr>
             <th>schema:accessModeSufficient</th>
-            <td></td>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
         </tr>
     </tbody>
 </table>
@@ -66,25 +86,41 @@ implementations.
     <thead>
         <tr>
             <th>Role</th>
-            <th>[Publisher]</th>
+            <th>Used By</th>
         </tr>
     </thead>
     <tbody>
         <tr>
         	<td>dcterms:conformsTo</td>
-        	<td></td>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
         </tr>
         <tr>
         	<td>a11y:certifiedBy</td>
-        	<td></td>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
         </tr>
         <tr>
         	<td>a11y:certifierCredential</td>
-        	<td></td>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
         </tr>
         <tr>
         	<td>a11y:certifierReport</td>
-        	<td></td>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
         </tr>
     </tbody>
 </table>

--- a/epub33/reports/a11y-properties-use.md
+++ b/epub33/reports/a11y-properties-use.md
@@ -3,8 +3,8 @@
 ## Candidate Recommendation Exit Criteria
 
 The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
-the EPUB Accessibility 1.1 specification for consideration as a W3C Proposed Recommendation
-after documenting implementation of each feature.
+the [EPUB Accessibility 1.1](https://w3c.github.io/epub-specs/epub33/a11y/) specification for
+consideration as a W3C Proposed Recommendation after documenting implementation of each feature.
 
 For this specification to advance to Proposed Recommendation, it has to be
 proven that metadata defined and required in this specification have sufficient usage by the
@@ -22,8 +22,11 @@ metadata for their EPUB Publications (as appropriate for each title).
 ### Schema.org discovery metadata
 
 The following table provides a list of publishers who have stated that they are currently using
-the schema.org discovery metadata properties in production or who are in the process of rolling
-out their implementations.
+the [schema.org discovery metadata properties](https://w3c.github.io/epub-specs/epub33/a11y/#sec-disc-package)
+in production or who are in the process of rolling out their implementations.
+
+Discovery properties are expressed in the
+[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property).
 
 <table>
     <thead>
@@ -34,7 +37,7 @@ out their implementations.
     </thead>
     <tbody>
         <tr>
-            <th>schema:accessibilityFeature</th>
+            <th>[schema:accessibilityFeature](https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilityFeature)</th>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -61,7 +64,7 @@ out their implementations.
             </td>
         </tr>
         <tr>
-            <th>schema:accessibilityHazard</th>
+            <th>[schema:accessibilityHazard](https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilityHazard)</th>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -88,7 +91,7 @@ out their implementations.
             </td>
         </tr>
         <tr>
-            <th>schema:accessibilitySummary</th>
+            <th>[schema:accessibilitySummary](https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilitySummary)</th>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -115,7 +118,7 @@ out their implementations.
             </td>
         </tr>
         <tr>
-            <th>schema:accessMode</th>
+            <th>[schema:accessMode](https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessMode)</th>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -142,7 +145,7 @@ out their implementations.
             </td>
         </tr>
         <tr>
-            <th>schema:accessModeSufficient</th>
+            <th>[schema:accessModeSufficient](https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessModeSufficient)</th>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -174,8 +177,13 @@ out their implementations.
 ### Conformance metadata
 
 The following table provides a list of publishers who have stated that they are currently using
-the conformance metadata properties in production or who are in the process of rolling out their
-implementations.
+the [conformance reporting metadata properties](https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting)
+in production or who are in the process of rolling out their implementations.
+
+Conformance properties are expressed in the
+[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property)
+and in the
+[`link` element's `rel` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-link-rel).
 
 <table>
     <thead>
@@ -186,7 +194,7 @@ implementations.
     </thead>
     <tbody>
         <tr>
-        	<td>dcterms:conformsTo</td>
+        	<td>[dcterms:conformsTo](https://w3c.github.io/epub-specs/epub33/a11y/#dcterms-conformsTo)</td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -213,7 +221,7 @@ implementations.
             </td>
         </tr>
         <tr>
-        	<td>a11y:certifiedBy</td>
+        	<td>[a11y:certifiedBy](https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifiedBy)</td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -240,7 +248,7 @@ implementations.
             </td>
         </tr>
         <tr>
-        	<td>a11y:certifierCredential</td>
+        	<td>[a11y:certifierCredential](https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifierCredential)</td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -267,7 +275,7 @@ implementations.
             </td>
         </tr>
         <tr>
-        	<td>a11y:certifierReport</td>
+        	<td>[a11y:certifierReport](https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifierReport)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -279,12 +287,12 @@ implementations.
 
 ## Validation and Authoring Tool Implementations
 
-The Ace by DAISY validator provides machine checking of the EPUB Accessibility specification requirements.
-A new version that supports the 1.1 specification will be released in 2022.
+The [Ace by DAISY](https://daisy.github.io/ace/) validator provides machine checking of the EPUB Accessibility
+specification requirements. A new version that supports the 1.1 specification will be released in 2022.
 
-The Ace SMART tool assists users with carrying out manual verification of the EPUB Accessibility specification.
-A new version that supports the 1.1 specification will also be released in early 2022. The tool additionally
-allows authors to generate discovery and certifier metadata for use in their publications.
+The [Ace SMART](https://smart.daisy.org) tool assists users with carrying out manual verification of the EPUB
+Accessibility specification. A new version that supports the 1.1 specification will also be released in early 2022.
+The tool additionally allows authors to generate discovery and certifier metadata for use in their publications.
 
 
 ## Vendor Implementations

--- a/epub33/reports/a11y-properties-use.md
+++ b/epub33/reports/a11y-properties-use.md
@@ -37,7 +37,26 @@ out their implementations.
             <th>schema:accessibilityFeature</th>
             <td>
             	<ul>
-            		<li>TBD</li>
+            		<li>Acorn Press</li>
+            		<li>House of Anansi Press</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+            		<li>Goose Lane</li>
+            		<li>Guilford Press</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+            		<li>Macmillan Learning</li>
+            		<li>Playwrights Canada</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+            		<li>Tidewater Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
             	</ul>
             </td>
         </tr>
@@ -45,7 +64,26 @@ out their implementations.
             <th>schema:accessibilityHazard</th>
             <td>
             	<ul>
-            		<li>TBD</li>
+            		<li>Acorn Press</li>
+            		<li>House of Anansi Press</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+            		<li>Goose Lane</li>
+            		<li>Guilford Press</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+            		<li>Macmillan Learning</li>
+            		<li>Playwrights Canada</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+            		<li>Tidewater Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
             	</ul>
             </td>
         </tr>
@@ -53,7 +91,26 @@ out their implementations.
             <th>schema:accessibilitySummary</th>
             <td>
             	<ul>
-            		<li>TBD</li>
+            		<li>Acorn Press</li>
+            		<li>House of Anansi Press</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+            		<li>Goose Lane</li>
+            		<li>Guilford Press</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+            		<li>Macmillan Learning</li>
+            		<li>Playwrights Canada</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+            		<li>Tidewater Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
             	</ul>
             </td>
         </tr>
@@ -61,7 +118,26 @@ out their implementations.
             <th>schema:accessMode</th>
             <td>
             	<ul>
-            		<li>TBD</li>
+            		<li>Acorn Press</li>
+            		<li>House of Anansi Press</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+            		<li>Goose Lane</li>
+            		<li>Guilford Press</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+            		<li>Macmillan Learning</li>
+            		<li>Playwrights Canada</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+            		<li>Tidewater Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
             	</ul>
             </td>
         </tr>
@@ -69,7 +145,26 @@ out their implementations.
             <th>schema:accessModeSufficient</th>
             <td>
             	<ul>
-            		<li>TBD</li>
+            		<li>Acorn Press</li>
+            		<li>House of Anansi Press</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+            		<li>Goose Lane</li>
+            		<li>Guilford Press</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+            		<li>Macmillan Learning</li>
+            		<li>Playwrights Canada</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+            		<li>Tidewater Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
             	</ul>
             </td>
         </tr>
@@ -94,7 +189,26 @@ implementations.
         	<td>dcterms:conformsTo</td>
             <td>
             	<ul>
-            		<li>TBD</li>
+            		<li>Acorn Press</li>
+            		<li>House of Anansi Press</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+            		<li>Goose Lane</li>
+            		<li>Guilford Press</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+            		<li>Macmillan Learning</li>
+            		<li>Playwrights Canada</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+            		<li>Tidewater Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
             	</ul>
             </td>
         </tr>
@@ -102,7 +216,26 @@ implementations.
         	<td>a11y:certifiedBy</td>
             <td>
             	<ul>
-            		<li>TBD</li>
+            		<li>Acorn Press</li>
+            		<li>House of Anansi Press</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+            		<li>Goose Lane</li>
+            		<li>Guilford Press</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+            		<li>Macmillan Learning</li>
+            		<li>Playwrights Canada</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+            		<li>Tidewater Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
             	</ul>
             </td>
         </tr>
@@ -110,7 +243,26 @@ implementations.
         	<td>a11y:certifierCredential</td>
             <td>
             	<ul>
-            		<li>TBD</li>
+            		<li>Acorn Press</li>
+            		<li>House of Anansi Press</li>
+            		<li>Annick Press</li>
+            		<li>Au Press</li>
+            		<li>Book*hug Press</li>
+            		<li>ECW Press</li>
+            		<li>Éditions Bourton d'or Acadie</li>
+            		<li>Goose Lane</li>
+            		<li>Guilford Press</li>
+            		<li>Invisible Publishing</li>
+            		<li>Jones and Bartlett Learning</li>
+            		<li>Kogan Page</li>
+            		<li>Macmillan Learning</li>
+            		<li>Playwrights Canada</li>
+            		<li>Radiant Press</li>
+            		<li>Saint Jean</li>
+            		<li>Tidewater Press</li>
+            		<li>University of Michigan Press</li>
+            		<li>Wiley</li>
+            		<li>Wilfred Laurier University Press</li>
             	</ul>
             </td>
         </tr>

--- a/epub33/reports/a11y-properties-use.md
+++ b/epub33/reports/a11y-properties-use.md
@@ -37,7 +37,7 @@ Discovery properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <th>[schema:accessibilityFeature](https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilityFeature)</th>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilityFeature">schema:accessibilityFeature</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -64,7 +64,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <th>[schema:accessibilityHazard](https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilityHazard)</th>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilityHazard">schema:accessibilityHazard</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -91,7 +91,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <th>[schema:accessibilitySummary](https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilitySummary)</th>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilitySummary">schema:accessibilitySummary</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -118,7 +118,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <th>[schema:accessMode](https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessMode)</th>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessMode">schema:accessMode</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -145,7 +145,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <th>[schema:accessModeSufficient](https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessModeSufficient)</th>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessModeSufficient">schema:accessModeSufficient</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -194,7 +194,7 @@ and in the
     </thead>
     <tbody>
         <tr>
-        	<td>[dcterms:conformsTo](https://w3c.github.io/epub-specs/epub33/a11y/#dcterms-conformsTo)</td>
+        	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#dcterms-conformsTo">dcterms:conformsTo</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -221,7 +221,7 @@ and in the
             </td>
         </tr>
         <tr>
-        	<td>[a11y:certifiedBy](https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifiedBy)</td>
+        	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifiedBy">a11y:certifiedBy</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -248,7 +248,7 @@ and in the
             </td>
         </tr>
         <tr>
-        	<td>[a11y:certifierCredential](https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifierCredential)</td>
+        	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifierCredential">a11y:certifierCredential</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -275,7 +275,7 @@ and in the
             </td>
         </tr>
         <tr>
-        	<td>[a11y:certifierReport](https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifierReport)</td>
+        	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifierReport">a11y:certifierReport</a></td>
             <td>
             	<ul>
             		<li>TBD</li>

--- a/epub33/reports/a11y-properties-use.md
+++ b/epub33/reports/a11y-properties-use.md
@@ -40,26 +40,7 @@ Discovery properties are expressed in the
             <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilityFeature">schema:accessibilityFeature</a></td>
             <td>
             	<ul>
-            		<li>Acorn Press</li>
-            		<li>House of Anansi Press</li>
-            		<li>Annick Press</li>
-            		<li>Au Press</li>
-            		<li>Book*hug Press</li>
-            		<li>ECW Press</li>
-            		<li>Éditions Bourton d'or Acadie</li>
-            		<li>Goose Lane</li>
-            		<li>Guilford Press</li>
-            		<li>Invisible Publishing</li>
-            		<li>Jones and Bartlett Learning</li>
-            		<li>Kogan Page</li>
-            		<li>Macmillan Learning</li>
-            		<li>Playwrights Canada</li>
-            		<li>Radiant Press</li>
-            		<li>Saint Jean</li>
-            		<li>Tidewater Press</li>
-            		<li>University of Michigan Press</li>
-            		<li>Wiley</li>
-            		<li>Wilfred Laurier University Press</li>
+            		<li>TBD</li>
             	</ul>
             </td>
         </tr>
@@ -67,26 +48,7 @@ Discovery properties are expressed in the
             <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilityHazard">schema:accessibilityHazard</a></td>
             <td>
             	<ul>
-            		<li>Acorn Press</li>
-            		<li>House of Anansi Press</li>
-            		<li>Annick Press</li>
-            		<li>Au Press</li>
-            		<li>Book*hug Press</li>
-            		<li>ECW Press</li>
-            		<li>Éditions Bourton d'or Acadie</li>
-            		<li>Goose Lane</li>
-            		<li>Guilford Press</li>
-            		<li>Invisible Publishing</li>
-            		<li>Jones and Bartlett Learning</li>
-            		<li>Kogan Page</li>
-            		<li>Macmillan Learning</li>
-            		<li>Playwrights Canada</li>
-            		<li>Radiant Press</li>
-            		<li>Saint Jean</li>
-            		<li>Tidewater Press</li>
-            		<li>University of Michigan Press</li>
-            		<li>Wiley</li>
-            		<li>Wilfred Laurier University Press</li>
+            		<li>TBD</li>
             	</ul>
             </td>
         </tr>
@@ -94,26 +56,7 @@ Discovery properties are expressed in the
             <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilitySummary">schema:accessibilitySummary</a></td>
             <td>
             	<ul>
-            		<li>Acorn Press</li>
-            		<li>House of Anansi Press</li>
-            		<li>Annick Press</li>
-            		<li>Au Press</li>
-            		<li>Book*hug Press</li>
-            		<li>ECW Press</li>
-            		<li>Éditions Bourton d'or Acadie</li>
-            		<li>Goose Lane</li>
-            		<li>Guilford Press</li>
-            		<li>Invisible Publishing</li>
-            		<li>Jones and Bartlett Learning</li>
-            		<li>Kogan Page</li>
-            		<li>Macmillan Learning</li>
-            		<li>Playwrights Canada</li>
-            		<li>Radiant Press</li>
-            		<li>Saint Jean</li>
-            		<li>Tidewater Press</li>
-            		<li>University of Michigan Press</li>
-            		<li>Wiley</li>
-            		<li>Wilfred Laurier University Press</li>
+            		<li>TBD</li>
             	</ul>
             </td>
         </tr>
@@ -121,26 +64,7 @@ Discovery properties are expressed in the
             <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessMode">schema:accessMode</a></td>
             <td>
             	<ul>
-            		<li>Acorn Press</li>
-            		<li>House of Anansi Press</li>
-            		<li>Annick Press</li>
-            		<li>Au Press</li>
-            		<li>Book*hug Press</li>
-            		<li>ECW Press</li>
-            		<li>Éditions Bourton d'or Acadie</li>
-            		<li>Goose Lane</li>
-            		<li>Guilford Press</li>
-            		<li>Invisible Publishing</li>
-            		<li>Jones and Bartlett Learning</li>
-            		<li>Kogan Page</li>
-            		<li>Macmillan Learning</li>
-            		<li>Playwrights Canada</li>
-            		<li>Radiant Press</li>
-            		<li>Saint Jean</li>
-            		<li>Tidewater Press</li>
-            		<li>University of Michigan Press</li>
-            		<li>Wiley</li>
-            		<li>Wilfred Laurier University Press</li>
+            		<li>TBD</li>
             	</ul>
             </td>
         </tr>
@@ -148,26 +72,7 @@ Discovery properties are expressed in the
             <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessModeSufficient">schema:accessModeSufficient</a></td>
             <td>
             	<ul>
-            		<li>Acorn Press</li>
-            		<li>House of Anansi Press</li>
-            		<li>Annick Press</li>
-            		<li>Au Press</li>
-            		<li>Book*hug Press</li>
-            		<li>ECW Press</li>
-            		<li>Éditions Bourton d'or Acadie</li>
-            		<li>Goose Lane</li>
-            		<li>Guilford Press</li>
-            		<li>Invisible Publishing</li>
-            		<li>Jones and Bartlett Learning</li>
-            		<li>Kogan Page</li>
-            		<li>Macmillan Learning</li>
-            		<li>Playwrights Canada</li>
-            		<li>Radiant Press</li>
-            		<li>Saint Jean</li>
-            		<li>Tidewater Press</li>
-            		<li>University of Michigan Press</li>
-            		<li>Wiley</li>
-            		<li>Wilfred Laurier University Press</li>
+            		<li>TBD</li>
             	</ul>
             </td>
         </tr>
@@ -197,26 +102,7 @@ and in the
         	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#dcterms-conformsTo">dcterms:conformsTo</a></td>
             <td>
             	<ul>
-            		<li>Acorn Press</li>
-            		<li>House of Anansi Press</li>
-            		<li>Annick Press</li>
-            		<li>Au Press</li>
-            		<li>Book*hug Press</li>
-            		<li>ECW Press</li>
-            		<li>Éditions Bourton d'or Acadie</li>
-            		<li>Goose Lane</li>
-            		<li>Guilford Press</li>
-            		<li>Invisible Publishing</li>
-            		<li>Jones and Bartlett Learning</li>
-            		<li>Kogan Page</li>
-            		<li>Macmillan Learning</li>
-            		<li>Playwrights Canada</li>
-            		<li>Radiant Press</li>
-            		<li>Saint Jean</li>
-            		<li>Tidewater Press</li>
-            		<li>University of Michigan Press</li>
-            		<li>Wiley</li>
-            		<li>Wilfred Laurier University Press</li>
+            		<li>TBD</li>
             	</ul>
             </td>
         </tr>
@@ -224,26 +110,7 @@ and in the
         	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifiedBy">a11y:certifiedBy</a></td>
             <td>
             	<ul>
-            		<li>Acorn Press</li>
-            		<li>House of Anansi Press</li>
-            		<li>Annick Press</li>
-            		<li>Au Press</li>
-            		<li>Book*hug Press</li>
-            		<li>ECW Press</li>
-            		<li>Éditions Bourton d'or Acadie</li>
-            		<li>Goose Lane</li>
-            		<li>Guilford Press</li>
-            		<li>Invisible Publishing</li>
-            		<li>Jones and Bartlett Learning</li>
-            		<li>Kogan Page</li>
-            		<li>Macmillan Learning</li>
-            		<li>Playwrights Canada</li>
-            		<li>Radiant Press</li>
-            		<li>Saint Jean</li>
-            		<li>Tidewater Press</li>
-            		<li>University of Michigan Press</li>
-            		<li>Wiley</li>
-            		<li>Wilfred Laurier University Press</li>
+            		<li>TBD</li>
             	</ul>
             </td>
         </tr>
@@ -251,26 +118,7 @@ and in the
         	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifierCredential">a11y:certifierCredential</a></td>
             <td>
             	<ul>
-            		<li>Acorn Press</li>
-            		<li>House of Anansi Press</li>
-            		<li>Annick Press</li>
-            		<li>Au Press</li>
-            		<li>Book*hug Press</li>
-            		<li>ECW Press</li>
-            		<li>Éditions Bourton d'or Acadie</li>
-            		<li>Goose Lane</li>
-            		<li>Guilford Press</li>
-            		<li>Invisible Publishing</li>
-            		<li>Jones and Bartlett Learning</li>
-            		<li>Kogan Page</li>
-            		<li>Macmillan Learning</li>
-            		<li>Playwrights Canada</li>
-            		<li>Radiant Press</li>
-            		<li>Saint Jean</li>
-            		<li>Tidewater Press</li>
-            		<li>University of Michigan Press</li>
-            		<li>Wiley</li>
-            		<li>Wilfred Laurier University Press</li>
+            		<li>TBD</li>
             	</ul>
             </td>
         </tr>

--- a/epub33/reports/epub-properties-use.md
+++ b/epub33/reports/epub-properties-use.md
@@ -3,8 +3,8 @@
 ## Candidate Recommendation Exit Criteria
 
 The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
-the EPUB 3.3 specification for consideration as a W3C Proposed Recommendation
-after documenting implementation of each feature.
+the [EPUB 3.3](https://w3c.github.io/epub-specs/epub33/core/) specification for consideration
+as a W3C Proposed Recommendation after documenting implementation of each feature.
 
 For this specification to advance to Proposed Recommendation, it has to be
 proven that metadata defined and required in this specification have sufficient usage by the
@@ -21,7 +21,11 @@ metadata for their EPUB Publications (as appropriate for each title).
 ### Meta Properties Vocabulary
 
 The following table lists publishers who have stated that they are currently using
-the meta properties in production.
+the [meta properties](https://w3c.github.io/epub-specs/epub33/core/#app-meta-property-vocab)
+in production.
+
+Manifest properties are expressed in the
+[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property).
 
 <table>
     <thead>
@@ -32,7 +36,7 @@ the meta properties in production.
     </thead>
     <tbody>
         <tr>
-            <th>alternate-script</th>
+            <td>[alternate-script](https://w3c.github.io/epub-specs/epub33/core/#sec-alternate-script)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -40,7 +44,7 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>authority</th>
+            <td>[authority](https://w3c.github.io/epub-specs/epub33/core/#sec-authority)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -48,7 +52,7 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>belongs-to-collection</th>
+            <td>[belongs-to-collection](https://w3c.github.io/epub-specs/epub33/core/#sec-belongs-to-collection)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -56,7 +60,7 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>collection-type</th>
+            <td>[collection-type](https://w3c.github.io/epub-specs/epub33/core/#sec-collection-type)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -64,7 +68,7 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>display-seq</th>
+            <td>[display-seq](https://w3c.github.io/epub-specs/epub33/core/#sec-display-seq)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -72,7 +76,7 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>file-as</th>
+            <td>[file-as](https://w3c.github.io/epub-specs/epub33/core/#sec-file-as)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -80,7 +84,7 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>group-position</th>
+            <td>[group-position](https://w3c.github.io/epub-specs/epub33/core/#sec-group-position)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -88,7 +92,7 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>identifier-type</th>
+            <td>[identifier-type](https://w3c.github.io/epub-specs/epub33/core/#sec-identifier-type)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -96,7 +100,14 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>meta-auth (deprecated)</th>
+            <td>[<s>meta-auth</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-meta-auth)</td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td>[role](https://w3c.github.io/epub-specs/epub33/core/#sec-role)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -104,7 +115,7 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>role</th>
+            <td>[source-of](https://w3c.github.io/epub-specs/epub33/core/#sec-source-of)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -112,7 +123,7 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>source-of</th>
+            <td>[term](https://w3c.github.io/epub-specs/epub33/core/#sec-term)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -120,15 +131,7 @@ the meta properties in production.
             </td>
         </tr>
         <tr>
-            <th>term</th>
-            <td>
-            	<ul>
-            		<li>TBD</li>
-            	</ul>
-            </td>
-        </tr>
-        <tr>
-            <th>title-type</th>
+            <td>[title-type](https://w3c.github.io/epub-specs/epub33/core/#sec-title-type)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -142,7 +145,11 @@ the meta properties in production.
 #### Link Relationships
 
 The following table lists publishers who have stated that they are currently using
-the link relationships in production.
+the [link relationships](https://w3c.github.io/epub-specs/epub33/core/#sec-link-rel)
+in production.
+
+Link relationships are expressed in the
+[`link` element's `rel` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-link-rel).
 
 <table>
     <thead>
@@ -153,7 +160,7 @@ the link relationships in production.
     </thead>
     <tbody>
         <tr>
-            <th>acquire</th>
+            <td>[acquire](https://w3c.github.io/epub-specs/epub33/core/#sec-acquire)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -161,7 +168,7 @@ the link relationships in production.
             </td>
         </tr>
         <tr>
-            <th>alternate</th>
+            <td>[alternate](https://w3c.github.io/epub-specs/epub33/core/#sec-alternate)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -169,7 +176,28 @@ the link relationships in production.
             </td>
         </tr>
         <tr>
-            <th>marc21xml-record (deprecated)</th>
+            <td>[<s>marc21xml-record</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-marc21xml-record)</td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td>[<s>mods-record</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-mods-record)</td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td>[<s>onix-record</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-onix-record)</td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td>[record](https://w3c.github.io/epub-specs/epub33/core/#sec-record)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -177,7 +205,7 @@ the link relationships in production.
             </td>
         </tr>
         <tr>
-            <th>mods-record (deprecated)</th>
+            <td>[voicing](https://w3c.github.io/epub-specs/epub33/core/#sec-voicing)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -185,43 +213,17 @@ the link relationships in production.
             </td>
         </tr>
         <tr>
-            <th>onix-record (deprecated)</th>
+            <td>[<s>xml-signature</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-xml-signature)</td>
             <td>
-            	<ul>
-            		<li>TBD</li>
-            	</ul>
+            	<p>This property deprecated and is no longer recommended for use in EPUB Publications.
+            		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <th>record</th>
+            <td>[<s>xmp-record</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-xmp-record)</td>
             <td>
-            	<ul>
-            		<li>TBD</li>
-            	</ul>
-            </td>
-        </tr>
-        <tr>
-            <th>voicing</th>
-            <td>
-            	<ul>
-            		<li>TBD</li>
-            	</ul>
-            </td>
-        </tr>
-        <tr>
-            <th>xml-signature (deprecated)</th>
-            <td>
-            	<ul>
-            		<li>TBD</li>
-            	</ul>
-            </td>
-        </tr>
-        <tr>
-            <th>xmp-record (deprecated)</th>
-            <td>
-            	<ul>
-            		<li>TBD</li>
-            	</ul>
+            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
     </tbody>
@@ -230,7 +232,11 @@ the link relationships in production.
 #### Link Properties
 
 The following table lists publishers who have stated that they are currently using
-the link properties in production.
+the [link properties](https://w3c.github.io/epub-specs/epub33/core/#sec-link-properties)
+in production.
+
+Link properties are expressed in the
+[`link` element's `properties` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-properties).
 
 <table>
     <thead>
@@ -241,7 +247,7 @@ the link properties in production.
     </thead>
     <tbody>
         <tr>
-            <th>onix</th>
+            <td>[onix](https://w3c.github.io/epub-specs/epub33/core/#sec-onix)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -249,7 +255,7 @@ the link properties in production.
             </td>
         </tr>
         <tr>
-            <th>xmp</th>
+            <td>[xmp](https://w3c.github.io/epub-specs/epub33/core/#sec-xmp)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -263,7 +269,13 @@ the link properties in production.
 #### General Properties
 
 The following table lists publishers who have stated that they are currently using
-the general package rendering properties in production.
+the [general package rendering properties](https://w3c.github.io/epub-specs/epub33/core/#sec-rendering-general)
+in production.
+
+General package rendering properties are expressed both globally in the
+[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property)
+and as overrides in the
+[`itemref` element's `properties` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-properties).
 
 <table>
     <thead>
@@ -274,7 +286,7 @@ the general package rendering properties in production.
     </thead>
     <tbody>
         <tr>
-            <th>rendition:flow</th>
+            <td>[rendition:flow](https://w3c.github.io/epub-specs/epub33/core/#sec-flow)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -282,7 +294,7 @@ the general package rendering properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:align-x-center</th>
+            <td>[rendition:align-x-center](https://w3c.github.io/epub-specs/epub33/core/#sec-align-x-center)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -295,7 +307,13 @@ the general package rendering properties in production.
 #### Fixed-Layout Properties
 
 The following table lists publishers who have stated that they are currently using
-the fixed-layout properties in production.
+the [fixed-layout rendering properties](https://w3c.github.io/epub-specs/epub33/core/#sec-rendering-fxl)
+in production.
+
+Fixed-layout properties are expressed both globally in the
+[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property)
+and as overrides in the
+[`itemref` element's `properties` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-properties).
 
 <table>
     <thead>
@@ -306,7 +324,7 @@ the fixed-layout properties in production.
     </thead>
     <tbody>
         <tr>
-            <th>rendition:layout</th>
+            <td>[rendition:layout](https://w3c.github.io/epub-specs/epub33/core/#layout)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -314,7 +332,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:layout-pre-paginated</th>
+            <td>[rendition:layout-pre-paginated](https://w3c.github.io/epub-specs/epub33/core/#layout-pre-paginated)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -322,7 +340,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:layout-reflowable</th>
+            <td>[rendition:layout-reflowable](https://w3c.github.io/epub-specs/epub33/core/#layout-reflowable)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -330,7 +348,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:orientation</th>
+            <td>[rendition:orientation](https://w3c.github.io/epub-specs/epub33/core/#orientation)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -338,7 +356,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:orientation-auto</th>
+            <td>[rendition:orientation-auto](https://w3c.github.io/epub-specs/epub33/core/#orientation-auto)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -346,7 +364,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:orientation-landscape</th>
+            <td>[rendition:orientation-landscape](https://w3c.github.io/epub-specs/epub33/core/#orientation-landscape)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -354,7 +372,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:orientation-portrait</th>
+            <td>[rendition:orientation-portrait](https://w3c.github.io/epub-specs/epub33/core/#orientation-portrait)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -362,7 +380,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:spread</th>
+            <td>[rendition:spread](https://w3c.github.io/epub-specs/epub33/core/#spread)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -370,7 +388,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:spread-auto</th>
+            <td>[rendition:spread-auto](https://w3c.github.io/epub-specs/epub33/core/#spread-auto)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -378,7 +396,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:spread-both</th>
+            <td>[rendition:spread-both](https://w3c.github.io/epub-specs/epub33/core/#spread-both)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -386,7 +404,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:spread-landscape</th>
+            <td>[rendition:spread-landscape](https://w3c.github.io/epub-specs/epub33/core/#spread-landscape)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -394,7 +412,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:spread-none</th>
+            <td>[rendition:spread-none](https://w3c.github.io/epub-specs/epub33/core/#spread-none)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -402,7 +420,14 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:spread-portrait (deprecated)</th>
+            <td>[<s>rendition:spread-portrait</s>](https://w3c.github.io/epub-specs/epub33/core/#spread-portrait)</td>
+            <td>
+            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            		It is only listed for completeness of reporting.</p>
+            </td>
+        </tr>
+        <tr>
+            <td>[rendition:page-spread-center](https://w3c.github.io/epub-specs/epub33/core/#page-spread-center)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -410,7 +435,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:page-spread-center</th>
+            <td>[rendition:page-spread-left](https://w3c.github.io/epub-specs/epub33/core/#page-spread-left)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -418,7 +443,7 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:page-spread-left</th>
+            <td>[rendition:page-spread-right](https://w3c.github.io/epub-specs/epub33/core/#page-spread-right)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -426,19 +451,10 @@ the fixed-layout properties in production.
             </td>
         </tr>
         <tr>
-            <th>rendition:page-spread-right</th>
+            <td>[<s>rendition:viewport</s>](https://w3c.github.io/epub-specs/epub33/core/#viewport)</td>
             <td>
-            	<ul>
-            		<li>TBD</li>
-            	</ul>
-            </td>
-        </tr>
-        <tr>
-            <th>rendition:viewport (deprecated)</th>
-            <td>
-            	<ul>
-            		<li>TBD</li>
-            	</ul>
+            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
     </tbody>
@@ -447,7 +463,11 @@ the fixed-layout properties in production.
 ### Manifest Properties Vocabulary
 
 The following table lists publishers who have stated that they are currently using
-the manifest properties in production.
+the [manifest properties](https://w3c.github.io/epub-specs/epub33/core/#app-item-properties-vocab)
+in production.
+
+Manifest properties are expressed in the
+[`item` element's `properties` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-properties).
 
 <table>
     <thead>
@@ -458,7 +478,7 @@ the manifest properties in production.
     </thead>
     <tbody>
         <tr>
-            <th>cover-image</th>
+            <td>[cover-image](https://w3c.github.io/epub-specs/epub33/core/#sec-cover-image)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -466,7 +486,7 @@ the manifest properties in production.
             </td>
         </tr>
         <tr>
-            <th>mathml</th>
+            <td>[mathml](https://w3c.github.io/epub-specs/epub33/core/#sec-mathml)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -474,7 +494,7 @@ the manifest properties in production.
             </td>
         </tr>
         <tr>
-            <th>nav</th>
+            <td>[nav](https://w3c.github.io/epub-specs/epub33/core/#sec-nav)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -482,7 +502,7 @@ the manifest properties in production.
             </td>
         </tr>
         <tr>
-            <th>remote-resources</th>
+            <td>[remote-resources](https://w3c.github.io/epub-specs/epub33/core/#sec-remote-resources)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -490,7 +510,7 @@ the manifest properties in production.
             </td>
         </tr>
         <tr>
-            <th>scripted</th>
+            <td>[scripted](https://w3c.github.io/epub-specs/epub33/core/#sec-scripted)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -498,7 +518,7 @@ the manifest properties in production.
             </td>
         </tr>
         <tr>
-            <th>svg</th>
+            <td>[svg](https://w3c.github.io/epub-specs/epub33/core/#sec-svg)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -506,7 +526,7 @@ the manifest properties in production.
             </td>
         </tr>
         <tr>
-            <th>switch</th>
+            <td>[switch](https://w3c.github.io/epub-specs/epub33/core/#sec-switch)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -519,7 +539,11 @@ the manifest properties in production.
 ### Spine Properties Vocabulary
 
 The following table lists publishers who have stated that they are currently using
-the spine properties in production.
+the [spine properties](https://w3c.github.io/epub-specs/epub33/core/#app-itemref-properties-vocab)
+in production.
+
+Spine properties are expressed in the
+[`itemref` element's `properties` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-properties).
 
 <table>
     <thead>
@@ -530,7 +554,7 @@ the spine properties in production.
     </thead>
     <tbody>
         <tr>
-            <th>page-spread-left</th>
+            <td>[page-spread-left](https://w3c.github.io/epub-specs/epub33/core/#sec-page-spread-left)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -538,7 +562,7 @@ the spine properties in production.
             </td>
         </tr>
         <tr>
-            <th>page-spread-right</th>
+            <td>[page-spread-right](https://w3c.github.io/epub-specs/epub33/core/#sec-page-spread-right)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -551,7 +575,11 @@ the spine properties in production.
 ### Media Overlays Vocabulary
 
 The following table lists publishers who have stated that they are currently using
-the media overlays properties in production.
+the [Media Overlays properties](https://w3c.github.io/epub-specs/epub33/core/#app-overlays-vocab)
+in production.
+
+Media Overlays properties are expressed in the
+[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property).
 
 <table>
     <thead>
@@ -562,7 +590,7 @@ the media overlays properties in production.
     </thead>
     <tbody>
         <tr>
-            <th>active-class</th>
+            <td>[active-class](https://w3c.github.io/epub-specs/epub33/core/#sec-active-class)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -570,7 +598,7 @@ the media overlays properties in production.
             </td>
         </tr>
         <tr>
-            <th>duration</th>
+            <td>[duration](https://w3c.github.io/epub-specs/epub33/core/#sec-duration)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -578,7 +606,7 @@ the media overlays properties in production.
             </td>
         </tr>
         <tr>
-            <th>narrator</th>
+            <td>[narrator](https://w3c.github.io/epub-specs/epub33/core/#sec-narrator)</td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -586,7 +614,7 @@ the media overlays properties in production.
             </td>
         </tr>
         <tr>
-            <th>playback-active-class</th>
+            <td>[playback-active-class](https://w3c.github.io/epub-specs/epub33/core/#sec-playback-active-class)</td>
             <td>
             	<ul>
             		<li>TBD</li>

--- a/epub33/reports/epub-properties-use.md
+++ b/epub33/reports/epub-properties-use.md
@@ -36,7 +36,7 @@ Manifest properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td>[alternate-script](https://w3c.github.io/epub-specs/epub33/core/#sec-alternate-script)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-alternate-script">alternate-script</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -44,7 +44,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[authority](https://w3c.github.io/epub-specs/epub33/core/#sec-authority)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-authority">authority</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -52,7 +52,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[belongs-to-collection](https://w3c.github.io/epub-specs/epub33/core/#sec-belongs-to-collection)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-belongs-to-collection">belongs-to-collection</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -60,7 +60,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[collection-type](https://w3c.github.io/epub-specs/epub33/core/#sec-collection-type)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-collection-type">collection-type</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -68,7 +68,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[display-seq](https://w3c.github.io/epub-specs/epub33/core/#sec-display-seq)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-display-seq">display-seq</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -76,7 +76,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[file-as](https://w3c.github.io/epub-specs/epub33/core/#sec-file-as)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-file-as">file-as</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -84,7 +84,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[group-position](https://w3c.github.io/epub-specs/epub33/core/#sec-group-position)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-group-position">group-position</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -92,7 +92,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[identifier-type](https://w3c.github.io/epub-specs/epub33/core/#sec-identifier-type)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-identifier-type">identifier-type</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -100,14 +100,14 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[<s>meta-auth</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-meta-auth)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-meta-auth"><s>meta-auth</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td>[role](https://w3c.github.io/epub-specs/epub33/core/#sec-role)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-role">role</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -115,7 +115,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[source-of](https://w3c.github.io/epub-specs/epub33/core/#sec-source-of)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-source-of">source-of</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -123,7 +123,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[term](https://w3c.github.io/epub-specs/epub33/core/#sec-term)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-term">term</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -131,7 +131,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[title-type](https://w3c.github.io/epub-specs/epub33/core/#sec-title-type)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-title-type">title-type</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -160,7 +160,7 @@ Link relationships are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td>[acquire](https://w3c.github.io/epub-specs/epub33/core/#sec-acquire)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-acquire">acquire</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -168,7 +168,7 @@ Link relationships are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[alternate](https://w3c.github.io/epub-specs/epub33/core/#sec-alternate)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-alternate">alternate</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -176,28 +176,28 @@ Link relationships are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[<s>marc21xml-record</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-marc21xml-record)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-marc21xml-record"><s>marc21xml-record</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td>[<s>mods-record</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-mods-record)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-mods-record"><s>mods-record</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td>[<s>onix-record</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-onix-record)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-onix-record"><s>onix-record</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td>[record](https://w3c.github.io/epub-specs/epub33/core/#sec-record)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-record">record</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -205,7 +205,7 @@ Link relationships are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[voicing](https://w3c.github.io/epub-specs/epub33/core/#sec-voicing)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-voicing">voicing</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -213,14 +213,14 @@ Link relationships are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[<s>xml-signature</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-xml-signature)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xml-signature"><s>xml-signature</s></a></td>
             <td>
             	<p>This property deprecated and is no longer recommended for use in EPUB Publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td>[<s>xmp-record</s>](https://w3c.github.io/epub-specs/epub33/core/#sec-xmp-record)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xmp-record"><s>xmp-record</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
             		It is only listed for completeness of reporting.</p>
@@ -247,7 +247,7 @@ Link properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td>[onix](https://w3c.github.io/epub-specs/epub33/core/#sec-onix)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-onix">onix</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -255,7 +255,7 @@ Link properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[xmp](https://w3c.github.io/epub-specs/epub33/core/#sec-xmp)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xmp">xmp</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -286,7 +286,7 @@ and as overrides in the
     </thead>
     <tbody>
         <tr>
-            <td>[rendition:flow](https://w3c.github.io/epub-specs/epub33/core/#sec-flow)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-flow">rendition:flow</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -294,7 +294,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:align-x-center](https://w3c.github.io/epub-specs/epub33/core/#sec-align-x-center)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-align-x-center">rendition:align-x-center</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -324,7 +324,7 @@ and as overrides in the
     </thead>
     <tbody>
         <tr>
-            <td>[rendition:layout](https://w3c.github.io/epub-specs/epub33/core/#layout)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#layout">rendition:layout</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -332,7 +332,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:layout-pre-paginated](https://w3c.github.io/epub-specs/epub33/core/#layout-pre-paginated)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#layout-pre-paginated">rendition:layout-pre-paginated</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -340,7 +340,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:layout-reflowable](https://w3c.github.io/epub-specs/epub33/core/#layout-reflowable)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#layout-reflowable">rendition:layout-reflowable</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -348,7 +348,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:orientation](https://w3c.github.io/epub-specs/epub33/core/#orientation)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#orientation">rendition:orientation</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -356,7 +356,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:orientation-auto](https://w3c.github.io/epub-specs/epub33/core/#orientation-auto)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#orientation-auto">rendition:orientation-auto</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -364,7 +364,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:orientation-landscape](https://w3c.github.io/epub-specs/epub33/core/#orientation-landscape)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#orientation-landscape">rendition:orientation-landscape</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -372,7 +372,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:orientation-portrait](https://w3c.github.io/epub-specs/epub33/core/#orientation-portrait)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#orientation-portrait">rendition:orientation-portrait</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -380,7 +380,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:spread](https://w3c.github.io/epub-specs/epub33/core/#spread)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread">rendition:spread</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -388,7 +388,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:spread-auto](https://w3c.github.io/epub-specs/epub33/core/#spread-auto)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-auto">rendition:spread-auto</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -396,7 +396,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:spread-both](https://w3c.github.io/epub-specs/epub33/core/#spread-both)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-both">rendition:spread-both</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -404,7 +404,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:spread-landscape](https://w3c.github.io/epub-specs/epub33/core/#spread-landscape)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-landscape">rendition:spread-landscape</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -412,7 +412,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:spread-none](https://w3c.github.io/epub-specs/epub33/core/#spread-none)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-none">rendition:spread-none</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -420,14 +420,14 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[<s>rendition:spread-portrait</s>](https://w3c.github.io/epub-specs/epub33/core/#spread-portrait)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-portrait"><s>rendition:spread-portrait</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td>[rendition:page-spread-center](https://w3c.github.io/epub-specs/epub33/core/#page-spread-center)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#page-spread-center">rendition:page-spread-center</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -435,7 +435,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:page-spread-left](https://w3c.github.io/epub-specs/epub33/core/#page-spread-left)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#page-spread-left">rendition:page-spread-left</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -443,7 +443,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[rendition:page-spread-right](https://w3c.github.io/epub-specs/epub33/core/#page-spread-right)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#page-spread-right">rendition:page-spread-right</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -451,7 +451,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td>[<s>rendition:viewport</s>](https://w3c.github.io/epub-specs/epub33/core/#viewport)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#viewport"><s>rendition:viewport</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
             		It is only listed for completeness of reporting.</p>
@@ -478,7 +478,7 @@ Manifest properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td>[cover-image](https://w3c.github.io/epub-specs/epub33/core/#sec-cover-image)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-cover-image">cover-image</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -486,7 +486,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[mathml](https://w3c.github.io/epub-specs/epub33/core/#sec-mathml)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-mathml">mathml</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -494,7 +494,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[nav](https://w3c.github.io/epub-specs/epub33/core/#sec-nav)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-nav">nav</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -502,7 +502,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[remote-resources](https://w3c.github.io/epub-specs/epub33/core/#sec-remote-resources)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-remote-resources">remote-resources</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -510,7 +510,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[scripted](https://w3c.github.io/epub-specs/epub33/core/#sec-scripted)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-scripted">scripted</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -518,7 +518,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[svg](https://w3c.github.io/epub-specs/epub33/core/#sec-svg)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-svg">svg</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -526,7 +526,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[switch](https://w3c.github.io/epub-specs/epub33/core/#sec-switch)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-switch">switch</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -554,7 +554,7 @@ Spine properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td>[page-spread-left](https://w3c.github.io/epub-specs/epub33/core/#sec-page-spread-left)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-page-spread-left">page-spread-left</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -562,7 +562,7 @@ Spine properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[page-spread-right](https://w3c.github.io/epub-specs/epub33/core/#sec-page-spread-right)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-page-spread-right">page-spread-right</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -590,7 +590,7 @@ Media Overlays properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td>[active-class](https://w3c.github.io/epub-specs/epub33/core/#sec-active-class)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-active-class">active-class</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -598,7 +598,7 @@ Media Overlays properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[duration](https://w3c.github.io/epub-specs/epub33/core/#sec-duration)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-duration">duration</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -606,7 +606,7 @@ Media Overlays properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[narrator](https://w3c.github.io/epub-specs/epub33/core/#sec-narrator)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-narrator">narrator</a></td>
             <td>
             	<ul>
             		<li>TBD</li>
@@ -614,7 +614,7 @@ Media Overlays properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td>[playback-active-class](https://w3c.github.io/epub-specs/epub33/core/#sec-playback-active-class)</td>
+            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-playback-active-class">playback-active-class</a></td>
             <td>
             	<ul>
             		<li>TBD</li>

--- a/epub33/reports/epub-properties-use.md
+++ b/epub33/reports/epub-properties-use.md
@@ -1,0 +1,604 @@
+# EPUB 3.3 Metadata Usage Report
+
+## Candidate Recommendation Exit Criteria
+
+The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
+the EPUB 3.3 specification for consideration as a W3C Proposed Recommendation
+after documenting implementation of each feature.
+
+For this specification to advance to Proposed Recommendation, it has to be
+proven that metadata defined and required in this specification have sufficient usage by the
+target communities. This metadata falls into two categories:
+
+1. metadata for expressing information about the publication in the package document; and
+2. metadata for expressing preferred rendering of the content
+
+Usage of these properties means that they are regularly included in the Package Document
+metadata for their EPUB Publications (as appropriate for each title).
+
+## Publisher Implementations
+
+### Meta Properties Vocabulary
+
+The following table lists publishers who have stated that they are currently using
+the meta properties in production.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>alternate-script</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>authority</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>belongs-to-collection</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>collection-type</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>display-seq</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>file-as</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>group-position</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>identifier-type</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>meta-auth (deprecated)</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>role</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>source-of</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>term</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>title-type</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Link Vocabulary
+#### Link Relationships
+
+The following table lists publishers who have stated that they are currently using
+the link relationships in production.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>acquire</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>alternate</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>marc21xml-record (deprecated)</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>mods-record (deprecated)</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>onix-record (deprecated)</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>record</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>voicing</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>xml-signature (deprecated)</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>xmp-record (deprecated)</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+#### Link Properties
+
+The following table lists publishers who have stated that they are currently using
+the link properties in production.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>onix</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>xmp</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Package Rendering Vocabulary
+#### General Properties
+
+The following table lists publishers who have stated that they are currently using
+the general package rendering properties in production.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>rendition:flow</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:align-x-center</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+#### Fixed-Layout Properties
+
+The following table lists publishers who have stated that they are currently using
+the fixed-layout properties in production.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>rendition:layout</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:layout-pre-paginated</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:layout-reflowable</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:orientation</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:orientation-auto</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:orientation-landscape</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:orientation-portrait</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:spread</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:spread-auto</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:spread-both</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:spread-landscape</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:spread-none</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:spread-portrait (deprecated)</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:page-spread-center</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:page-spread-left</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:page-spread-right</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>rendition:viewport (deprecated)</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Manifest Properties Vocabulary
+
+The following table lists publishers who have stated that they are currently using
+the manifest properties in production.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>cover-image</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>mathml</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>nav</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>remote-resources</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>scripted</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>svg</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>switch</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Spine Properties Vocabulary
+
+The following table lists publishers who have stated that they are currently using
+the spine properties in production.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>page-spread-left</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>page-spread-right</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Media Overlays Vocabulary
+
+The following table lists publishers who have stated that they are currently using
+the media overlays properties in production.
+
+<table>
+    <thead>
+        <tr>
+            <th>Property</th>
+            <th>Used By</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th>active-class</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>duration</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>narrator</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+        <tr>
+            <th>playback-active-class</th>
+            <td>
+            	<ul>
+            		<li>TBD</li>
+            	</ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+## Validation and Authoring Tool Implementations
+
+Where machine-testable assertions are made about the use of this metadata, conformance is checked by EPUBCheck.
+In particular, it is able to determine if authors have not set manifest properties correctly.
+
+(TBD what authoring tools support the metadata.)


### PR DESCRIPTION
This is a palceholder document to use to report on authoring of the various package metadata.

One modification I've made is to ensure these will only ever be two-column tables. The dpub model used a column for each publisher because we knew before making the report document only three publishers were needed to cover the full range of values. Given there will be different uptake of different properties here, and we'll probably need to talk to a lot more people to get sufficient coverage of each property, using the column approach could get ugly to read.

In place of that approach, I've labelled the second column "used by" and added a placeholder list to each row where we can identify who is using each property. I've done the same to the a11y report for consistency.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2002.html" title="Last updated on Feb 25, 2022, 5:06 PM UTC (fa3eee9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2002/5ba7886...fa3eee9.html" title="Last updated on Feb 25, 2022, 5:06 PM UTC (fa3eee9)">Diff</a>