### PR TITLE
Harmonize the fallback sections

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -937,7 +937,7 @@
 					<section id="sec-foreign-restrictions">
 						<h5>Foreign Resources</h5>
 
-						<p id="confreq-foreign-no-fallback">EPUB Creators MAY include Foreign Resources without
+						<p id="confreq-foreign-no-fallback">EPUB Creators MAY include <a>Foreign Resources</a> without
 							fallbacks provided they:</p>
 
 						<ul>
@@ -966,8 +966,8 @@
 							cases, Foreign Resources MAY be referenced without a fallback. For more information, refer
 							to <a href="#sec-xhtml-fallbacks"></a>.</p>
 
-						<p id="confreq-cmt">EPUB Creators MUST provide fallbacks for <a>Foreign Resources</a> in all
-							other cases. Fallbacks take one of the following forms:</p>
+						<p id="confreq-cmt">EPUB Creators MUST provide fallbacks for Foreign Resources in all other
+							cases. Fallbacks take one of the following forms:</p>
 
 						<ul>
 							<li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -962,9 +962,12 @@
 							scientific journal might include a data set with instructions on how to extract it from the
 							EPUB Container).</p>
 
-						<p id="confreq-cmt">When a <a>Foreign Resource</a> is included in the spine or directly rendered
-							in its native format in an EPUB Content Document, a fallback <a>Core Media Type Resource</a>
-							MUST be included. Fallbacks take one of the following forms:</p>
+						<p>This specification also exempts some elements from Core Media Type requirements. In these
+							cases, Foreign Resources MAY be referenced without a fallback. For more information, refer
+							to <a href="#sec-xhtml-fallbacks"></a>.</p>
+
+						<p id="confreq-cmt">EPUB Creators MUST provide fallbacks for <a>Foreign Resources</a> in all
+							other cases. Fallbacks take one of the following forms:</p>
 
 						<ul>
 							<li>
@@ -3029,17 +3032,8 @@ XHTML:
 									chains to Core Media Type Resources. They are used to create fallbacks for Foreign
 									Resources in the <a href="#sec-spine-elem">spine</a> and when intrinsic fallback
 									capabilities are not available (e.g., for the [[HTML]] <a
-										data-cite="html#the-img-element"><code>img</code></a> element).</p>
-
-								<p>EPUB Creators MAY reference Foreign Resources in contexts in which an intrinsic
-									fallback cannot be provided (e.g., directly from <a>spine</a>
-									<a href="#elemdef-spine-itemref"><code>itemref</code> elements</a>; from [[HTML]]
-										<code>img</code>, <code>iframe</code> and <code>link</code> elements in <a>XHTML
-										Content Documents</a>; and from <code>@import</code> rules in CSS Style Sheets).
-									EPUB Creators MUST provide manifest fallbacks in such cases.</p>
-
-								<p>EPUB Creators MAY also provide fallbacks for <a>Core Media Type Resources</a> (e.g.,
-									to provide a static alternative to a <a>Scripted Content Document</a>).</p>
+										data-cite="html#the-img-element"><code>img</code></a> element) in order to
+									satisfy the requirements in <a href="#sec-foreign-restrictions"></a>.</p>
 
 								<p>The <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> on the
 										<a>manifest</a>
@@ -3069,6 +3063,7 @@ XHTML:
 												Resource</a>.</p>
 									</li>
 								</ul>
+
 								<p>Fallback chains MUST NOT contain circular or self-references to <code>item</code>
 									elements in the chain.</p>
 
@@ -3076,12 +3071,15 @@ XHTML:
 									EPUB Content Documents (e.g., to provide <a href="#confreq-cd-scripted-flbk"
 										>fallbacks for scripted content</a>).</p>
 
+								<p>EPUB Creators MAY also provide manifest fallbacks for <a>Core Media Type
+										Resources</a> (e.g., to provide a static alternative to a <a>Scripted Content
+										Document</a>).</p>
+
 								<div class="note">
 									<p>As it is not possible to use manifest fallbacks for resources represented in <a
 											href="#sec-data-urls">data URLs</a>, EPUB Creators can only represent
 										Foreign Resources as data URLs where an intrinsic fallback mechanism is
 										available.</p>
-
 								</div>
 							</section>
 
@@ -6505,8 +6503,7 @@ No Entry</pre>
 										href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify fonts to
 									deobfuscated.</p>
 
-								<p id="encryption-restrictions">EPUB Creators MUST NOT encrypt the
-									following files:</p>
+								<p id="encryption-restrictions">EPUB Creators MUST NOT encrypt the following files:</p>
 
 								<ul class="nomark">
 									<li>
@@ -7666,13 +7663,11 @@ No Entry</pre>
 					<section id="sec-smil-text-elem">
 						<h5>The <code>text</code> Element</h5>
 
-						<p>
-							The <code>text</code> element references an element in an <a>EPUB Content Document</a>.
-							A <code>text</code> element typically refers to a textual element but can also refer to
-							other EPUB Content Document media elements (see <a href="#sec-embedded-media"></a>).
-							In the absence of a sibling <code>audio</code> element textual content referred to by this
-							element may be rendered via <a href="#sec-tts">text-to-speech</a>.
-						</p>
+						<p> The <code>text</code> element references an element in an <a>EPUB Content Document</a>. A
+								<code>text</code> element typically refers to a textual element but can also refer to
+							other EPUB Content Document media elements (see <a href="#sec-embedded-media"></a>). In the
+							absence of a sibling <code>audio</code> element textual content referred to by this element
+							may be rendered via <a href="#sec-tts">text-to-speech</a>. </p>
 
 						<dl class="elemdef" id="elemdef-smil-text">
 							<dt>Element Name</dt>
@@ -7720,15 +7715,14 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p class="note">
-							This specification places no restriction on the <code>src</code> attribute of a <code>text</code> element. 
-							Authors should, however, refer to a content that can be styled with CSS to make 
-							the <a href="#sec-docs-assoc-style">association with style information</a> effective, i.e., 
-								<a href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content">palpable content</a> for XHTML 
-								or <a href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, 
-								<a href="https://www.w3.org/TR/SVG11/shapes.html">basic shapes</a>, or 
-								<a href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG.
-						</p>
+						<p class="note"> This specification places no restriction on the <code>src</code> attribute of a
+								<code>text</code> element. Authors should, however, refer to a content that can be
+							styled with CSS to make the <a href="#sec-docs-assoc-style">association with style
+								information</a> effective, i.e., <a
+								href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content">palpable
+								content</a> for XHTML or <a href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a
+								href="https://www.w3.org/TR/SVG11/shapes.html">basic shapes</a>, or <a
+								href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG. </p>
 					</section>
 
 					<section id="sec-smil-audio-elem">
@@ -7746,7 +7740,8 @@ No Entry</pre>
 
 							<dt>Usage</dt>
 							<dd>
-								<p>An OPTIONAL child of the <a href="#elemdef-smil-par"><code>par</code> element</a>.</p>
+								<p>An OPTIONAL child of the <a href="#elemdef-smil-par"><code>par</code>
+									element</a>.</p>
 							</dd>
 
 							<dt>Attributes</dt>
@@ -8137,11 +8132,9 @@ No Entry</pre>
 						<section id="sec-emb-audio-video">
 							<h6>Embedded Audio and Video</h6>
 
-							<p>
-								When a <a href="#elemdef-smil-text"><code>text</code></a> element references embedded 
-								audio or video, Reading Systems will intiate playback of the media in the absence of an 
-								<a href="#elemdef-smil-audio"><code>audio</code></a> element sibling. 
-							</p>
+							<p> When a <a href="#elemdef-smil-text"><code>text</code></a> element references embedded
+								audio or video, Reading Systems will intiate playback of the media in the absence of an
+									<a href="#elemdef-smil-audio"><code>audio</code></a> element sibling. </p>
 
 							<p><a>EPUB Creators</a> SHOULD avoid using scripts to control playback of referenced
 								embedded EPUB Content Document media, as this might conflict with Media Overlays
@@ -8175,9 +8168,9 @@ No Entry</pre>
 
 						<p>When a Media Overlay <a href="#elemdef-smil-par"><code>par</code> element</a> omits its <a
 								href="#elemdef-smil-audio"><code>audio</code> element</a>, its <a
-								href="#elemdef-smil-text"><code>text</code> element</a> may be rendered in Reading Systems 
-								via TTS. If the text fragment is not appropriate for TTS rendering (e.g., is not a text 
-								element and/or has no text fallback), this may produce unexpected results.</p>
+								href="#elemdef-smil-text"><code>text</code> element</a> may be rendered in Reading
+							Systems via TTS. If the text fragment is not appropriate for TTS rendering (e.g., is not a
+							text element and/or has no text fallback), this may produce unexpected results.</p>
 
 						<div class="note">
 							<p>See <a data-cite="epub-tts-10#">EPUB 3 Text-to-Speech Support</a> [[EPUB-TTS-10]] for
@@ -10723,12 +10716,10 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>
-					19-Feb-2021: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's 
-					definition by making it optional, and adapt the specification's text elsewhere to address
-					the situation when the element is indeed not present. See <a
-					href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>.
-				</li>
+				<li> 19-Feb-2021: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's
+					definition by making it optional, and adapt the specification's text elsewhere to address the
+					situation when the element is indeed not present. See <a
+						href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>. </li>
 				<li>04-Feb-2021: Expanded the section on security and privacy to include new sections on the threat
 					model for EPUB Publications and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a


### PR DESCRIPTION
In reviewing the issue I raised in #2010, I noticed that the manifest fallbacks section really shouldn't be making a normative statement about when fallbacks are required. That information is already covered by 2.2.1.3 Foreign Resources.

So what I've done for this PR is:

1. removed the offending normative paragraph from the manifest fallbacks section (it's redundant with 2.2.1.3) and clarified that manifest fallbacks exist to satisfy the requiremets of 2.2.1.3.
2. added a new paragraph to 2.2.1.3 that notes that some elements are exempt from fallback requirements, and points to 3.1.4.4 where we define these

Hopefully, this will make reading the requirements easier as everything will flow from 2.2.1.3 now. It also doesn't change anything normatively - only simplifies where the statements are made.

I also made one minor editorial shuffle to move the paragraph about being able to use manifest fallbacks for core media types so it's later in the section with the other paragraphs that describe alternative use cases.

Fixes #2010


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2011.html" title="Last updated on Mar 1, 2022, 3:40 PM UTC (8aefc5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2011/8af3f43...8aefc5e.html" title="Last updated on Mar 1, 2022, 3:40 PM UTC (8aefc5e)">Diff</a>