### PR TITLE
Add paragraph about origin-specific security headers being hard to use in EPUB

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8818,10 +8818,11 @@ html.my-document-playing * {
 						<p>Checking for malware and exploits at distribution time is not always reliable, either, as the
 							malicious content can be swapped in any time after publication, unlike resources that come
 							embedded in the EPUB Container.</p>
-						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both opaque and inconsistent between
-							Reading Systems. Consequently, if the EPUB Creator hosts remote resources on a web server they
-							control, the server effectively cannot use security features that require specifying allowable
-							origins, such as headers for <a href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>,
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB Creator and
+							specific to each Reading System implementation. Consequently, if the EPUB Creator hosts remote
+							resources on a web server they control, the server effectively cannot use security features that
+							require specifying allowable origins, such as headers for
+							<a href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>,
 							<a href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>,
 							or <a href="https://www.rfc-editor.org/rfc/rfc7034"><code>X-Frame-Options</code></a>.</p>
 					</dd>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8818,6 +8818,12 @@ html.my-document-playing * {
 						<p>Checking for malware and exploits at distribution time is not always reliable, either, as the
 							malicious content can be swapped in any time after publication, unlike resources that come
 							embedded in the EPUB Container.</p>
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both opaque and inconsistent between
+							Reading Systems. Consequently, if the EPUB Creator hosts remote resources on a web server they
+							control, the server effectively cannot use security features that require specifying allowable
+							origins, such as headers for <a href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>,
+							<a href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>,
+							or <a href="https://www.rfc-editor.org/rfc/rfc7034"><code>X-Frame-Options</code></a>.</p>
 					</dd>
 
 					<dt>Linking to external resources</dt>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2156,10 +2156,11 @@
 						<p>Calls to remote resources can also be used to track information about users (e.g., through
 							server logs). Reading Systems should limit the information they expose through HTTP requests
 							to only what is essential to obtain the resource.</p>
-						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both opaque and inconsistent between
-							Reading Systems. Consequently, if the EPUB Creator hosts remote resources on a web server they
-							control, the server effectively cannot use security features that require specifying allowable
-							origins, such as headers for <a href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>,
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB Creator and
+							specific to each Reading System implementation. Consequently, if the EPUB Creator hosts remote
+							resources on a web server they control, the server effectively cannot use security features that
+							require specifying allowable origins, such as headers for
+							<a href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>,
 							<a href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>,
 							or <a href="https://www.rfc-editor.org/rfc/rfc7034"><code>X-Frame-Options</code></a>.</p>
 					</dd>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2156,6 +2156,12 @@
 						<p>Calls to remote resources can also be used to track information about users (e.g., through
 							server logs). Reading Systems should limit the information they expose through HTTP requests
 							to only what is essential to obtain the resource.</p>
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both opaque and inconsistent between
+							Reading Systems. Consequently, if the EPUB Creator hosts remote resources on a web server they
+							control, the server effectively cannot use security features that require specifying allowable
+							origins, such as headers for <a href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>,
+							<a href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>,
+							or <a href="https://www.rfc-editor.org/rfc/rfc7034"><code>X-Frame-Options</code></a>.</p>
 					</dd>
 
 					<dt>External links</dt>


### PR DESCRIPTION
As discussed in today's meeting, here is a draft that resolves #1843.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2013.html" title="Last updated on Mar 1, 2022, 8:20 PM UTC (37d730d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2013/8af3f43...37d730d.html" title="Last updated on Mar 1, 2022, 8:20 PM UTC (37d730d)">Diff</a>