### PR TITLE
limit wrapping to pre elements

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -98,8 +98,7 @@
 				}
 			};</script>
 		<style>
-			pre,
-			code {
+			pre {
 				white-space: break-spaces !important;
 			}</style>
 	</head>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -112,8 +112,7 @@
 			.varlist {
 				margin-left: 3rem;
 			}
-			pre,
-			code {
+			pre {
 				white-space: break-spaces !important;
 			}</style>
 	</head>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -75,8 +75,7 @@
             };//]]>
 		</script>
 		<style>
-			pre,
-			code {
+			pre {
 				white-space: break-spaces !important;
 			}</style>
 	</head>

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -46,8 +46,7 @@
       </script>
         
         <style> /*prevent examples from horizontal scrolling*/
-			pre,
-			code {
+			pre {
 				white-space: break-spaces !important;
 			}
         </style>


### PR DESCRIPTION
There was never a need to include `code` in the white-space handling as `code` is only used for inline element/attribute/property names and similar. It doesn't have the line handling issues of `pre`.

This PR removes code from the CSS declaration, leaving the line breaking only for `pre` tags.

Fixes #2018


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2020.html" title="Last updated on Mar 1, 2022, 3:22 PM UTC (6eabb7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2020/8af3f43...6eabb7c.html" title="Last updated on Mar 1, 2022, 3:22 PM UTC (6eabb7c)">Diff</a>