### PR TITLE
disallow hgroup as heading for navigation document nav elements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4653,8 +4653,8 @@ No Entry</pre>
 									<ul class="nomark">
 										<li>
 											<p>
-												<a data-cite="html#heading-content">
-													<code>HTML Heading content</code>
+												<a data-cite="html##the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">
+													<code>h1-h6</code>
 												</a>
 												<code>[0 or 1]</code>
 											</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4653,7 +4653,7 @@ No Entry</pre>
 									<ul class="nomark">
 										<li>
 											<p>
-												<a data-cite="html##the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">
+												<a data-cite="html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">
 													<code>h1-h6</code>
 												</a>
 												<code>[0 or 1]</code>


### PR DESCRIPTION
This PR makes it explicit that only h1-h6 are allowed as the heading of a `nav` element in the navigation document content model.

This change brings us back into conformance with 3.2, so is not a new fix.

Fixes #2019


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2021.html" title="Last updated on Mar 1, 2022, 3:38 PM UTC (a64d278)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2021/8af3f43...a64d278.html" title="Last updated on Mar 1, 2022, 3:38 PM UTC (a64d278)">Diff</a>