### PR TITLE
Add section on conformance checking

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10765,10 +10765,12 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li> 19-Feb-2021: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's
-					definition by making it optional, and adapt the specification's text elsewhere to address the
-					situation when the element is indeed not present. See <a
-						href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>. </li>
+				<li>02-Mar-2022: Add new section on conformance checking and definition for EPUB Validator. See <a
+						href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
+				<li>19-Feb-2021: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's definition
+					by making it optional, and adapt the specification's text elsewhere to address the situation when
+					the element is indeed not present. See <a href="https://github.com/w3c/epub-specs/issues/1986">issue
+						1986</a>.</li>
 				<li>04-Feb-2021: Expanded the section on security and privacy to include new sections on the threat
 					model for EPUB Publications and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -683,10 +683,10 @@
 						improve the interoperability of EPUB Publications across <a>Reading Systems</a>.</p>
 
 					<p>An EPUB Validator MUST be capable of checking the machine-processable normative requirements of
-						this specification and reporting on their presence. As these types of issues will generally
-						result in EPUB Publications not rendering, or rendering in inconsistent ways, it is RECOMMENDED
-						that EPUB Validators report them at the highest severity (e.g., as errors and/or critical
-						errors).</p>
+						this specification (practices identified by the keywords "MUST", "MUST NOT", and "REQUIRED") and
+						reporting on their presence. As these types of issues will generally result in EPUB Publications
+						not rendering, or rendering in inconsistent ways, it is RECOMMENDED that EPUB Validators report
+						them at the highest severity (e.g., as errors and/or critical errors).</p>
 
 					<div class="note">
 						<p>It will not be possible for an EPUB Validator to check all the requirements as some issues
@@ -694,10 +694,11 @@
 							are rendered (i.e., due to scripting), etc.</p>
 					</div>
 
-					<p>Although an EPUB Validator SHOULD also check the machine-processable normative recommendations of
-						this specification, not following recommended practices does not result in an invalid EPUB
-						Publication. It is RECOMMENDED that EPUB Validators report these types of issues at a lower
-						severity (e.g., as warnings).</p>
+					<p>An EPUB Validator SHOULD also check the machine-processable normative recommendations of this
+						specification (practices identified by the keywords "SHOULD", "SHOULD NOT", and "RECOMMENDED").
+						Not following recommended practices does not result in an invalid EPUB Publication, however. It
+						is RECOMMENDED that EPUB Validators report these types of issues at a lower severity (e.g., as
+						warnings).</p>
 
 					<div class="note">
 						<p>Vendors, distributors, and other retailers of EPUB Publications should consider the

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -379,6 +379,12 @@
 							conformant with this specification.</p>
 					</dd>
 
+					<dt><dfn id="dfn-epub-validator" data-lt="EPUB Validators">EPUB Validator</dfn></dt>
+					<dd>
+						<p>An application that verifies the requirements of this specification against <a>EPUB
+								Publications</a> and reports on their conformance.</p>
+					</dd>
+
 					<dt>
 						<dfn id="dfn-file-name" data-lt="File Names">File Name</dfn>
 					</dt>
@@ -667,6 +673,47 @@
 						<a href="#sec-publication-resources"></a>.</p>
 
 				<p>The rest of this specification covers specific conformance details.</p>
+
+				<section id="sec-conformance-validation">
+					<h4>Conformance Checking</h4>
+
+					<p>Due to the complexity of this specification and number of technologies used in <a>EPUB
+							Publications</a>, <a>EPUB Creators</a> are advised to use an <a>EPUB Validator</a> to check
+						the conformance of their content prior to distributing it. Finding and fixing errors will help
+						improve the interoperability of EPUB Publications across <a>Reading Systems</a>.</p>
+
+					<p>An EPUB Validator MUST be capable of checking the machine-processable normative requirements of
+						this specification and reporting on their presence. As these types of issues will generally
+						result in EPUB Publications not rendering, or rendering in inconsistent ways, it is RECOMMENDED
+						that EPUB Validators report them at the highest severity (e.g., as errors and/or critical
+						errors).</p>
+
+					<div class="note">
+						<p>It will not be possible for an EPUB Validator to check all the requirements as some issues
+							may require human inspection, some may not be checkable until <a>EPUB Content Documents</a>
+							are rendered (i.e., due to scripting), etc.</p>
+					</div>
+
+					<p>Although an EPUB Validator SHOULD also check the machine-processable normative recommendations of
+						this specification, not following recommended practices does not result in an invalid EPUB
+						Publication. It is RECOMMENDED that EPUB Validators report these types of issues at a lower
+						severity (e.g., as warnings).</p>
+
+					<div class="note">
+						<p>Vendors, distributors, and other retailers of EPUB Publications should consider the
+							importance of recommended practices before basing their acceptance or rejection on a
+							zero-issue outcome from an EPUB Validator. There will be legitimate reasons why recommended
+							practices cannot be followed by EPUB Creators in all cases.</p>
+					</div>
+
+					<div class="note">
+						<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto validation
+							tool used by the publishing industry. It is integrated into a number of authoring tools and
+							also available in alternative interfaces and other languages (for more information, refer to
+							its <a href="https://www.w3.org/publishing/epubcheck/docs/apps-and-tools/">Apps and Tools
+								page</a>). EPUBCheck is updated to reflect each new version of EPUB.</p>
+					</div>
+				</section>
 			</section>
 
 			<section id="sec-publication-resources">
@@ -8994,7 +9041,7 @@ html.my-document-playing * {
 					</li>
 				</ul>
 
-				<p>Validation tools SHOULD alert EPUB Creators to the presence of under-implemented features when
+				<p><a>EPUB Validators</a> SHOULD alert EPUB Creators to the presence of under-implemented features when
 					encountered in EPUB Publications but MUST NOT treat their inclusion as a violation of the standard
 					(i.e., not emit errors or warnings).</p>
 
@@ -9030,8 +9077,8 @@ html.my-document-playing * {
 							deprecated features before adding new support for them.</p>
 					</li>
 				</ul>
-				<p>Validation tools SHOULD alert EPUB Creators to the presence of deprecated features when encountered
-					in EPUB Publications.</p>
+				<p><a>EPUB Validators</a> SHOULD alert EPUB Creators to the presence of deprecated features when
+					encountered in EPUB Publications.</p>
 			</section>
 
 			<section id="legacy">
@@ -9050,10 +9097,10 @@ html.my-document-playing * {
 							version of EPUB.</p>
 					</li>
 				</ul>
-				<p>Validation tools SHOULD NOT alert EPUB Creators about the presence of legacy features in an <a>EPUB
-						Publication</a>, as their inclusion is valid for backwards compatibility. Validation tools MUST
-					alert EPUB Creators if a legacy feature does not conform to its definition or otherwise breaks a
-					usage requirement.</p>
+				<p><a>EPUB Validators</a> SHOULD NOT alert EPUB Creators about the presence of legacy features in an
+						<a>EPUB Publication</a>, as their inclusion is valid for backwards compatibility. EPUB
+					Validators MUST alert EPUB Creators if a legacy feature does not conform to its definition or
+					otherwise breaks a usage requirement.</p>
 			</section>
 		</section>
 		<section id="app-identifiers-allowed" class="appendix">
@@ -9529,9 +9576,10 @@ html.my-document-playing * {
 
 					<div class="caution">
 						<p>Although reserved prefixes are an authoring convenience, EPUB Creators should avoid relying
-							on them as they may cause interoperability issues. Validation tools will often reject new
-							prefixes until their developers update the tools to the latest version of the specification,
-							for example. EPUB Creators should declare all prefixes they use to avoid such issues.</p>
+							on them as they may cause interoperability issues. <a>EPUB Validators</a> will often reject
+							new prefixes until their developers update the tools to the latest version of the
+							specification, for example. EPUB Creators should declare all prefixes they use to avoid such
+							issues.</p>
 
 					</div>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -680,7 +680,7 @@
 
 					<p>Due to the complexity of this specification and number of technologies used in <a>EPUB
 							Publications</a>, <a>EPUB Creators</a> are advised to use an <a>EPUB Conformance Checker</a>
-						to check the conformance of their content prior to distributing it.</p>
+						to verify the conformance of their content prior to distributing it.</p>
 
 					<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto EPUB Conformance
 						Checker used by the publishing industry and has been updated with each new version of EPUB. It

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -674,37 +674,42 @@
 
 				<p>The rest of this specification covers specific conformance details.</p>
 
-				<section id="sec-conformance-validation">
-					<h4>Conformance Checking</h4>
+				<section id="sec-conformance-checking-validators" class="informative">
+					<h4>Conformance Checking and Validators</h4>
 
 					<p>Due to the complexity of this specification and number of technologies used in <a>EPUB
 							Publications</a>, <a>EPUB Creators</a> are advised to use an <a>EPUB Validator</a> to check
 						the conformance of their content prior to distributing it. Finding and fixing errors will help
 						improve the interoperability of EPUB Publications across <a>Reading Systems</a>.</p>
 
-					<p>An EPUB Validator MUST be capable of checking the machine-processable normative requirements of
-						this specification (practices identified by the keywords "MUST", "MUST NOT", and "REQUIRED") and
-						reporting on their presence. As these types of issues will generally result in EPUB Publications
-						not rendering, or rendering in inconsistent ways, it is RECOMMENDED that EPUB Validators report
-						them at the highest severity (e.g., as errors and/or critical errors).</p>
+					<p>Although this specification does not define specific conformance requirements for EPUB
+						Validators, the utility of any EPUB Validator will depend on its ability to check the normative
+						statements expressed in this document. Conversely, the ability to author conforming content will
+						depend on the ease with which the rules can be checked by an EPUB Validator.</p>
 
-					<div class="note">
-						<p>It will not be possible for an EPUB Validator to check all the requirements as some issues
-							may require human inspection, some may not be checkable until <a>EPUB Content Documents</a>
-							are rendered (i.e., due to scripting), etc.</p>
-					</div>
+					<p>Consequently, an EPUB Validator must be capable of checking the machine-processable requirements
+						of this specification (practices identified by the keywords "MUST", "MUST NOT", and "REQUIRED")
+						and reporting on their presence. As these types of issues will generally result in EPUB
+						Publications not rendering, or rendering in inconsistent ways, EPUB Creators need to be notified
+						of their presence.</p>
 
-					<p>An EPUB Validator SHOULD also check the machine-processable normative recommendations of this
-						specification (practices identified by the keywords "SHOULD", "SHOULD NOT", and "RECOMMENDED").
-						Not following recommended practices does not result in an invalid EPUB Publication, however. It
-						is RECOMMENDED that EPUB Validators report these types of issues at a lower severity (e.g., as
-						warnings).</p>
+					<p>An EPUB Validator should also check the machine-processable recommendations of this specification
+						(practices identified by the keywords "SHOULD", "SHOULD NOT", and "RECOMMENDED"). Not following
+						these practices does not result in an invalid EPUB Publication, but may lead to interoperability
+						and other issues that impact the user reading experience.</p>
 
 					<div class="note">
 						<p>Vendors, distributors, and other retailers of EPUB Publications should consider the
 							importance of recommended practices before basing their acceptance or rejection on a
 							zero-issue outcome from an EPUB Validator. There will be legitimate reasons why EPUB
 							Creators cannot follow recommended practices in all cases.</p>
+					</div>
+
+					<div class="note">
+						<p>It is not possible for an EPUB Validator to check all the requirements of this specification,
+							as some issues are not enforceable (practices identified by "MAY" or "OPTIONAL"), some will
+							require human inspection, some may not be checkable until <a>EPUB Content Documents</a> are
+							rendered (i.e., due to scripting), etc.</p>
 					</div>
 
 					<div class="note">
@@ -9050,9 +9055,11 @@ html.my-document-playing * {
 					</li>
 				</ul>
 
-				<p><a>EPUB Validators</a> SHOULD alert EPUB Creators to the presence of under-implemented features when
-					encountered in EPUB Publications but MUST NOT treat their inclusion as a violation of the standard
-					(i.e., not emit errors or warnings).</p>
+				<div class="note">
+					<p><a>EPUB Validators</a> should alert EPUB Creators to the presence of under-implemented features
+						when encountered in EPUB Publications but must not treat their inclusion as a violation of the
+						standard (i.e., not emit errors or warnings).</p>
+				</div>
 
 				<div class="caution">
 					<p>Whether under-implemented labels are removed or replaced by deprecation in a future version of
@@ -9086,8 +9093,11 @@ html.my-document-playing * {
 							deprecated features before adding new support for them.</p>
 					</li>
 				</ul>
-				<p><a>EPUB Validators</a> SHOULD alert EPUB Creators to the presence of deprecated features when
-					encountered in EPUB Publications.</p>
+
+				<div class="note">
+					<p><a>EPUB Validators</a> should alert EPUB Creators to the presence of deprecated features when
+						encountered in EPUB Publications.</p>
+				</div>
 			</section>
 
 			<section id="legacy">
@@ -9106,10 +9116,13 @@ html.my-document-playing * {
 							version of EPUB.</p>
 					</li>
 				</ul>
-				<p><a>EPUB Validators</a> SHOULD NOT alert EPUB Creators about the presence of legacy features in an
-						<a>EPUB Publication</a>, as their inclusion is valid for backwards compatibility. EPUB
-					Validators MUST alert EPUB Creators if a legacy feature does not conform to its definition or
-					otherwise breaks a usage requirement.</p>
+
+				<div class="note">
+					<p><a>EPUB Validators</a> should not alert EPUB Creators about the presence of legacy features in an
+							<a>EPUB Publication</a>, as their inclusion is valid for backwards compatibility. EPUB
+						Validators must alert EPUB Creators if a legacy feature does not conform to its definition or
+						otherwise breaks a usage requirement.</p>
+				</div>
 			</section>
 		</section>
 		<section id="app-identifiers-allowed" class="appendix">
@@ -10776,10 +10789,10 @@ EPUB/images/cover.png</pre>
 			<ul>
 				<li>02-Mar-2022: Add new section on conformance checking and definition for EPUB Validator. See <a
 						href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
-				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's
-					definition by making it optional, and adapt the specification's text elsewhere to address the
-					situation when the element is indeed not present. See <a
-						href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>.</li>
+				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's definition
+					by making it optional, and adapt the specification's text elsewhere to address the situation when
+					the element is indeed not present. See <a href="https://github.com/w3c/epub-specs/issues/1986">issue
+						1986</a>.</li>
 				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
 					model for EPUB Publications and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -702,8 +702,8 @@
 					<div class="note">
 						<p>Vendors, distributors, and other retailers of EPUB Publications should consider the
 							importance of recommended practices before basing their acceptance or rejection on a
-							zero-issue outcome from an EPUB Validator. There will be legitimate reasons why recommended
-							practices cannot be followed by EPUB Creators in all cases.</p>
+							zero-issue outcome from an EPUB Validator. There will be legitimate reasons why EPUB
+							Creators cannot follow recommended practices in all cases.</p>
 					</div>
 
 					<div class="note">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -379,7 +379,8 @@
 							conformant with this specification.</p>
 					</dd>
 
-					<dt><dfn id="dfn-epub-validator" data-lt="EPUB Validators">EPUB Validator</dfn></dt>
+					<dt><dfn id="dfn-epub-conformance-checker" data-lt="EPUB Conformance Checkers">EPUB Conformance
+							Checker</dfn></dt>
 					<dd>
 						<p>An application that verifies the requirements of this specification against <a>EPUB
 								Publications</a> and reports on their conformance.</p>
@@ -674,50 +675,37 @@
 
 				<p>The rest of this specification covers specific conformance details.</p>
 
-				<section id="sec-conformance-checking-validators" class="informative">
-					<h4>Conformance Checking and Validators</h4>
+				<section id="sec-conformance-checking" class="informative">
+					<h4>Conformance Checking</h4>
 
 					<p>Due to the complexity of this specification and number of technologies used in <a>EPUB
-							Publications</a>, <a>EPUB Creators</a> are advised to use an <a>EPUB Validator</a> to check
-						the conformance of their content prior to distributing it. Finding and fixing errors will help
-						improve the interoperability of EPUB Publications across <a>Reading Systems</a>.</p>
+							Publications</a>, <a>EPUB Creators</a> are advised to use an <a>EPUB Conformance Checker</a>
+						to check the conformance of their content prior to distributing it.</p>
 
-					<p>Although this specification does not define specific conformance requirements for EPUB
-						Validators, the utility of any EPUB Validator will depend on its ability to check the normative
-						statements expressed in this document. Conversely, the ability to author conforming content will
-						depend on the ease with which the rules can be checked by an EPUB Validator.</p>
+					<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto EPUB Conformance
+						Checker used by the publishing industry and has been updated with each new version of EPUB. It
+						is integrated into a number of authoring tools and also available in alternative interfaces and
+						other languages (for more information, refer to its <a
+							href="https://www.w3.org/publishing/epubcheck/docs/apps-and-tools/">Apps and Tools
+						page</a>).</p>
 
-					<p>Consequently, an EPUB Validator must be capable of checking the machine-processable requirements
-						of this specification (practices identified by the keywords "MUST", "MUST NOT", and "REQUIRED")
-						and reporting on their presence. As these types of issues will generally result in EPUB
-						Publications not rendering, or rendering in inconsistent ways, EPUB Creators need to be notified
-						of their presence.</p>
+					<p>When verifying their EPUB Publications, EPUB Creators should ensure they do not violate the
+						requirements of this specification (practices identified by the keywords "MUST", "MUST NOT", and
+						"REQUIRED"). These types of issues will generally result in EPUB Publications not rendering, or
+						rendering in inconsistent ways. These issues are typically reported as errors or critical
+						errors.</p>
 
-					<p>An EPUB Validator should also check the machine-processable recommendations of this specification
-						(practices identified by the keywords "SHOULD", "SHOULD NOT", and "RECOMMENDED"). Not following
-						these practices does not result in an invalid EPUB Publication, but may lead to interoperability
-						and other issues that impact the user reading experience.</p>
+					<p>They should also ensure that their EPUB Publications do not violate the recommendations of this
+						specification (practices identified by the keywords "SHOULD", "SHOULD NOT", and "RECOMMENDED").
+						Not following these practices does not result in an invalid EPUB Publication, but may lead to
+						interoperability and other issues that impact the user reading experience. These issues are
+						typically reported as warnings.</p>
 
 					<div class="note">
 						<p>Vendors, distributors, and other retailers of EPUB Publications should consider the
 							importance of recommended practices before basing their acceptance or rejection on a
-							zero-issue outcome from an EPUB Validator. There will be legitimate reasons why EPUB
-							Creators cannot follow recommended practices in all cases.</p>
-					</div>
-
-					<div class="note">
-						<p>It is not possible for an EPUB Validator to check all the requirements of this specification,
-							as some issues are not enforceable (practices identified by "MAY" or "OPTIONAL"), some will
-							require human inspection, some may not be checkable until <a>EPUB Content Documents</a> are
-							rendered (i.e., due to scripting), etc.</p>
-					</div>
-
-					<div class="note">
-						<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto validation
-							tool used by the publishing industry. It is integrated into a number of authoring tools and
-							also available in alternative interfaces and other languages (for more information, refer to
-							its <a href="https://www.w3.org/publishing/epubcheck/docs/apps-and-tools/">Apps and Tools
-								page</a>). EPUBCheck is updated to reflect each new version of EPUB.</p>
+							zero-issue outcome from an EPUB Conformance Checker. There will be legitimate reasons why
+							EPUB Creators cannot follow recommended practices in all cases.</p>
 					</div>
 				</section>
 			</section>
@@ -9056,9 +9044,9 @@ html.my-document-playing * {
 				</ul>
 
 				<div class="note">
-					<p><a>EPUB Validators</a> should alert EPUB Creators to the presence of under-implemented features
-						when encountered in EPUB Publications but must not treat their inclusion as a violation of the
-						standard (i.e., not emit errors or warnings).</p>
+					<p><a>EPUB Conformance Checkers</a> should alert EPUB Creators to the presence of under-implemented
+						features when encountered in EPUB Publications but must not treat their inclusion as a violation
+						of the standard (i.e., not emit errors or warnings).</p>
 				</div>
 
 				<div class="caution">
@@ -9095,8 +9083,8 @@ html.my-document-playing * {
 				</ul>
 
 				<div class="note">
-					<p><a>EPUB Validators</a> should alert EPUB Creators to the presence of deprecated features when
-						encountered in EPUB Publications.</p>
+					<p><a>EPUB Conformance Checkers</a> should alert EPUB Creators to the presence of deprecated
+						features when encountered in EPUB Publications.</p>
 				</div>
 			</section>
 
@@ -9118,10 +9106,10 @@ html.my-document-playing * {
 				</ul>
 
 				<div class="note">
-					<p><a>EPUB Validators</a> should not alert EPUB Creators about the presence of legacy features in an
-							<a>EPUB Publication</a>, as their inclusion is valid for backwards compatibility. EPUB
-						Validators must alert EPUB Creators if a legacy feature does not conform to its definition or
-						otherwise breaks a usage requirement.</p>
+					<p><a>EPUB Conformance Checkers</a> should not alert EPUB Creators about the presence of legacy
+						features in an <a>EPUB Publication</a>, as their inclusion is valid for backwards compatibility.
+						EPUB Conformance Checkers must alert EPUB Creators if a legacy feature does not conform to its
+						definition or otherwise breaks a usage requirement.</p>
 				</div>
 			</section>
 		</section>
@@ -9598,10 +9586,10 @@ html.my-document-playing * {
 
 					<div class="caution">
 						<p>Although reserved prefixes are an authoring convenience, EPUB Creators should avoid relying
-							on them as they may cause interoperability issues. <a>EPUB Validators</a> will often reject
-							new prefixes until their developers update the tools to the latest version of the
-							specification, for example. EPUB Creators should declare all prefixes they use to avoid such
-							issues.</p>
+							on them as they may cause interoperability issues. <a>EPUB Conformance Checkers</a> will
+							often reject new prefixes until their developers update the tools to the latest version of
+							the specification, for example. EPUB Creators should declare all prefixes they use to avoid
+							such issues.</p>
 
 					</div>
 
@@ -10787,8 +10775,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>02-Mar-2022: Add new section on conformance checking and definition for EPUB Validator. See <a
-						href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
+				<li>02-Mar-2022: Add new section on conformance checking and definition for EPUB Conformance Checker.
+					See <a href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
 				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's definition
 					by making it optional, and adapt the specification's text elsewhere to address the situation when
 					the element is indeed not present. See <a href="https://github.com/w3c/epub-specs/issues/1986">issue


### PR DESCRIPTION
This PR comes out of a discussion we had in the epubcheck group about using that tool to help with CR exit criteria.

In a nutshell, the specification doesn't currently say anything about validators except for the abrupt inclusion of requirements on "validation tools" in the sections on deprecated features.

To try and better address conformance checking as an outcome of the specification, I've made the following changes:

- added a formal definition of an "EPUB Validator" and used the term to replace "validation tools" (intentionally trying to keep the definition lightweight, as I didn't want to start spewing lexical constraints and stuff like that!)
- added a new section under the conformance criteria section that explains the requirements for conformance validation

I've also tried to address various issues that come up around validation - like how not all requirements are testable and why not following recommendations does not make a publication invalid (i.e., blanket rejection of warnings isn't a good idea).

I'm open to this being both too much and not enough. More of a starting point.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2025.html" title="Last updated on Mar 16, 2022, 1:44 PM UTC (62fd1dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2025/75fe0c3...62fd1dd.html" title="Last updated on Mar 16, 2022, 1:44 PM UTC (62fd1dd)">Diff</a>