### PR TITLE
Fix 2021 dates in change log

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8817,13 +8817,14 @@ html.my-document-playing * {
 						<p>Checking for malware and exploits at distribution time is not always reliable, either, as the
 							malicious content can be swapped in any time after publication, unlike resources that come
 							embedded in the EPUB Container.</p>
-						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB Creator and
-							specific to each Reading System implementation. Consequently, if the EPUB Creator hosts remote
-							resources on a web server they control, the server effectively cannot use security features that
-							require specifying allowable origins, such as headers for
-							<a href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>,
-							<a href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>,
-							or <a href="https://www.rfc-editor.org/rfc/rfc7034"><code>X-Frame-Options</code></a>.</p>
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB Creator
+							and specific to each Reading System implementation. Consequently, if the EPUB Creator hosts
+							remote resources on a web server they control, the server effectively cannot use security
+							features that require specifying allowable origins, such as headers for <a
+								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
+								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
+									><code>Content-Security-Policy</code></a>, or <a
+								href="https://www.rfc-editor.org/rfc/rfc7034"><code>X-Frame-Options</code></a>.</p>
 					</dd>
 
 					<dt>Linking to external resources</dt>
@@ -10724,11 +10725,11 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li> 19-Feb-2021: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's
+				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's
 					definition by making it optional, and adapt the specification's text elsewhere to address the
 					situation when the element is indeed not present. See <a
-						href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>. </li>
-				<li>04-Feb-2021: Expanded the section on security and privacy to include new sections on the threat
+						href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>.</li>
+				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
 					model for EPUB Publications and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a
 						href="https://github.com/w3c/epub-specs/issues/1872">issue 1872</a>, <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -570,10 +570,10 @@
 						<code>page-progression-direction</code> to <code>default</code>, either explicitly or
 					implicitly, the Reading System can choose rendering direction.</p>
 
-				<p id="confreq-rs-spine-progression-pre-paginated" data-tests="#pkg-spine-progression-pre-paginated"
-					>If <code>page-progression-direction</code> has a value other than <code>default</code>, the Reading System 
-					MUST ignore any directionality computed from <a href="#layout"><code>pre-paginated</code></a> XHTML Content Documents.
-				</p>
+				<p id="confreq-rs-spine-progression-pre-paginated" data-tests="#pkg-spine-progression-pre-paginated">If
+						<code>page-progression-direction</code> has a value other than <code>default</code>, the Reading
+					System MUST ignore any directionality computed from <a href="#layout"><code>pre-paginated</code></a>
+					XHTML Content Documents. </p>
 
 				<p>If any of the <code>properties</code> attribute's values do not include a prefix, Reading Systems
 					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
@@ -1710,11 +1710,10 @@
 
 					<p>An <a>EPUB Content Document</a> with which a Media Overlay is associated MAY itself contain
 						embedded video and audio media. The Media Overlay elements MAY point to these elements. Unlike
-						text and images, video and audio media have an intrinsic duration. 
-						<span id="mol-embed-override" data-tests="#mol-embed,#mol-embed_fxl">Consequently, when a Reading
-						System renders the synchronization described by a Media Overlay, it MUST override the default
-						playback behavior of audio and video media embedded within the associated EPUB Content
-						Document.</span></p>
+						text and images, video and audio media have an intrinsic duration. <span id="mol-embed-override"
+							data-tests="#mol-embed,#mol-embed_fxl">Consequently, when a Reading System renders the
+							synchronization described by a Media Overlay, it MUST override the default playback behavior
+							of audio and video media embedded within the associated EPUB Content Document.</span></p>
 
 					<p>Note that the rules below apply only to <em>referenced</em> [[HTML]] <a
 							data-cite="html#the-video-element"><code>video</code></a> or <a
@@ -1726,13 +1725,13 @@
 
 					<ul>
 						<li>
-							<p id="mol-embed-deactivate-playback" data-tests="#mol-embed_deactivate_playback">Reading Systems MUST 
-								deactivate the public playback interface for all referenced audio
-								and video media embedded within an EPUB Content Document (typically: play/pause control,
-								time slider, volume level, etc.). This behavior avoids interference between the
-								scheduled playback sequence defined by the Media Overlay, and the arbitrary playback
-								behavior due to user interaction or script execution. As a result, when the Reading
-								System is in playback mode, it SHOULD:</p>
+							<p id="mol-embed-deactivate-playback" data-tests="#mol-embed_deactivate_playback">Reading
+								Systems MUST deactivate the public playback interface for all referenced audio and video
+								media embedded within an EPUB Content Document (typically: play/pause control, time
+								slider, volume level, etc.). This behavior avoids interference between the scheduled
+								playback sequence defined by the Media Overlay, and the arbitrary playback behavior due
+								to user interaction or script execution. As a result, when the Reading System is in
+								playback mode, it SHOULD:</p>
 							<ul>
 								<li>
 									<p>Hide the individual video/audio UI controls from the page, which overrides the
@@ -1763,11 +1762,11 @@
 								EPUB Content Document).</p>
 						</li>
 						<li>
-							<p id="mol-embed-start-and-stop" data-tests="#mol-embed,#mol-embed_fxl">In addition to the default behavior of 
-								Media Overlay activation for textual fragments and
-								images, audio and video playback MUST be started and stopped according to the duration
-								implied by the authored Media Overlay synchronization (as per the standard [[SMIL3]]
-								timing model). There are two possible scenarios:</p>
+							<p id="mol-embed-start-and-stop" data-tests="#mol-embed,#mol-embed_fxl">In addition to the
+								default behavior of Media Overlay activation for textual fragments and images, audio and
+								video playback MUST be started and stopped according to the duration implied by the
+								authored Media Overlay synchronization (as per the standard [[SMIL3]] timing model).
+								There are two possible scenarios:</p>
 							<ul>
 								<li>
 									<p>When a Media Overlay <code>text</code> element has no <a
@@ -1818,11 +1817,11 @@
 				<section id="sec-text-to-speech">
 					<h5>Text-to-Speech</h5>
 
-					<p id="mol-tts" data-tests="#mol-tts_multi,#mol-tts_single">When a Media Overlay 
-						<a data-cite="epub-33#elemdef-smil-text"><code>text</code> element</a>
-						[[EPUB-33]] with no <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code></a> [[EPUB-33]]
-						sibling element references text within the target <a>EPUB Content Document</a>, Reading Systems
-						capable of text-to-speech (TTS) playback SHOULD render the referenced text using TTS.</p>
+					<p id="mol-tts" data-tests="#mol-tts_multi,#mol-tts_single">When a Media Overlay <a
+							data-cite="epub-33#elemdef-smil-text"><code>text</code> element</a> [[EPUB-33]] with no <a
+							data-cite="epub-33#elemdef-smil-audio"><code>audio</code></a> [[EPUB-33]] sibling element
+						references text within the target <a>EPUB Content Document</a>, Reading Systems capable of
+						text-to-speech (TTS) playback SHOULD render the referenced text using TTS.</p>
 
 					<p>Reading Systems SHOULD use the speech-related information provided in the target EPUB Content
 						Document to play the audio stream as part of the Media Overlay rendering.</p>
@@ -2156,13 +2155,14 @@
 						<p>Calls to remote resources can also be used to track information about users (e.g., through
 							server logs). Reading Systems should limit the information they expose through HTTP requests
 							to only what is essential to obtain the resource.</p>
-						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB Creator and
-							specific to each Reading System implementation. Consequently, if the EPUB Creator hosts remote
-							resources on a web server they control, the server effectively cannot use security features that
-							require specifying allowable origins, such as headers for
-							<a href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>,
-							<a href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>,
-							or <a href="https://www.rfc-editor.org/rfc/rfc7034"><code>X-Frame-Options</code></a>.</p>
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB Creator
+							and specific to each Reading System implementation. Consequently, if the EPUB Creator hosts
+							remote resources on a web server they control, the server effectively cannot use security
+							features that require specifying allowable origins, such as headers for <a
+								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
+								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
+									><code>Content-Security-Policy</code></a>, or <a
+								href="https://www.rfc-editor.org/rfc/rfc7034"><code>X-Frame-Options</code></a>.</p>
 					</dd>
 
 					<dt>External links</dt>
@@ -2464,13 +2464,13 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>11-Feb-2021: Fix the contradictory support statements for Media Overlays. Support is recommended
+				<li>11-Feb-2022: Fix the contradictory support statements for Media Overlays. Support is recommended
 					when rendering of prerecorded audio is supported, as in previous versions of EPUB 3. See <a
 						href="https://github.com/w3c/epub-specs/issues/1991">issue 1991</a>.</li>
-				<li>04-Feb-2021: Changed the informative security considerations for controlling network access, opening
+				<li>04-Feb-2022: Changed the informative security considerations for controlling network access, opening
 					external links, and managing local storage to normative recommendations. See <a
 						href="https://github.com/w3c/epub-specs/issues/1957">issue 1957</a>.</li>
-				<li>04-Feb-2021: Expanded the section on security and privacy to include new sections on the threat
+				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
 					model for Reading Systems and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a
 						href="https://github.com/w3c/epub-specs/issues/1872">issue 1872</a>, <a


### PR DESCRIPTION
The last few changes in the core and rs specs had the wrong year. 2021 was worth forgetting... 😉


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2026.html" title="Last updated on Mar 2, 2022, 1:33 PM UTC (12ed440)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2026/19b9eac...12ed440.html" title="Last updated on Mar 2, 2022, 1:33 PM UTC (12ed440)">Diff</a>