### PR TITLE
Restore requirement that relative URLs resolve to resources

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6045,12 +6045,13 @@ No Entry</pre>
 						<li>Return <var>false</var>.</li>
 					</ol>
 
-					<p> In the <a>OCF Abstract Container</a>, any URL string MUST be an <a
+					<p>In the <a>OCF Abstract Container</a>, any URL string MUST be an <a
 							data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment-string</a> or a
-							<a>valid-relative-container-URL-with-fragment string</a>. </p>
+							<a>valid-relative-container-URL-with-fragment string</a>.</p>
 
-					<p>In addition, all <a>valid-relative-container-URL-with-fragment strings</a> MUST resolve to
-						resources within the OCF Abstract Container.</p>
+					<p>In addition, all <a data-cite="url#relative-url-with-fragment-string">relative-URL-with-fragment
+							strings</a> [[URL]] MUST, after <a data-cite="url#concept-url-parser">parsing</a>, be equal
+						to the <a>Content URL</a> of an existing file in the OCF Abstract Container.</p>
 
 					<div class="note">
 						<p> The properties of the <a>container root URL</a> are such that whatever the amount of <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6049,6 +6049,9 @@ No Entry</pre>
 							data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment-string</a> or a
 							<a>valid-relative-container-URL-with-fragment string</a>. </p>
 
+					<p>In addition, all <a>valid-relative-container-URL-with-fragment strings</a> MUST resolve to
+						resources within the OCF Abstract Container.</p>
+
 					<div class="note">
 						<p> The properties of the <a>container root URL</a> are such that whatever the amount of <a
 								data-cite="url#double-dot-path-segment">double-dot path segments</a> in a URL string
@@ -10725,10 +10728,13 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's
-					definition by making it optional, and adapt the specification's text elsewhere to address the
-					situation when the element is indeed not present. See <a
-						href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>.</li>
+				<li>03-Mar-2022: Restore requirement that valid-relative-container-URL-with-fragment strings resolve to
+					resources in the OCF Abstract Container. See <a href="https://github.com/w3c/epub-specs/issues/2024"
+						>issue 2024</a>.</li>
+				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's definition
+					by making it optional, and adapt the specification's text elsewhere to address the situation when
+					the element is indeed not present. See <a href="https://github.com/w3c/epub-specs/issues/1986">issue
+						1986</a>.</li>
 				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
 					model for EPUB Publications and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a


### PR DESCRIPTION
I've added a requirement that valid-relative-container-URL-with-fragment strings resolve to resources in the OCF Abstract Container to the end of 6.1.5.

Fixes #2024


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2028.html" title="Last updated on Mar 10, 2022, 11:30 AM UTC (e574bae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2028/ec5a4a3...e574bae.html" title="Last updated on Mar 10, 2022, 11:30 AM UTC (e574bae)">Diff</a>