### PR TITLE
Extended the note on URL-s

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6054,15 +6054,19 @@ No Entry</pre>
 								data-cite="url#double-dot-path-segment">double-dot path segments</a> in a URL string
 							(for example, <code>../../../secret</code>), it is parsed to a <a>content URL</a> (and not
 							"leak" outside the container). This avoids potential run-time security issues. The
-							additional constraint on <a>valid-relative-container-URL-with-fragment strings</a> ensures
-							that such potentially problematic URLs can also be detected when checking the EPUB
-							Publication. </p>
-
+							additional constraint on <a>valid-relative-container-URL-with-fragment strings</a> means
+							that such potentially problematic URLs are disallowed in an EPUB Publication,
+							and ensures that they can also be detected when checking the EPUB Publication. </p>
 
 						<p> For better interoperability with non-conforming or legacy Reading Systems and toolchains,
 							EPUB Creators should not use more <a data-cite="url#double-dot-path-segment">double-dot path
 								segments</a> than needed to reach the target container file. </p>
 
+						<p> The constraints on URL strings means that a <a data-cite="url#path-absolute-url-string">path-absolute-URL string</a>, i.e., a URL of the form 
+							<code>/A/B/C</code>, is also disallowed for EPUB Publications.
+							The reason is, again, a better interoperability with legacy Reading Systems and toolchains.
+						</p>
+			
 					</div>
 
 					<aside class="example" title="Referencing a file in the same directory">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6045,28 +6045,26 @@ No Entry</pre>
 						<li>Return <var>false</var>.</li>
 					</ol>
 
-					<p> In the <a>OCF Abstract Container</a>, any URL string MUST be an <a
+					<p id="urls-in-ocf-constraints"> In the <a>OCF Abstract Container</a>, any URL string MUST be an <a
 							data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment-string</a> or a
 							<a>valid-relative-container-URL-with-fragment string</a>. </p>
 
 					<div class="note">
-						<p> The properties of the <a>container root URL</a> are such that whatever the amount of <a
-								data-cite="url#double-dot-path-segment">double-dot path segments</a> in a URL string
-							(for example, <code>../../../secret</code>), it is parsed to a <a>content URL</a> (and not
-							"leak" outside the container). This avoids potential run-time security issues. The
-							additional constraint on <a>valid-relative-container-URL-with-fragment strings</a> means
-							that such potentially problematic URLs are disallowed in an EPUB Publication,
-							and ensures that they can also be detected when checking the EPUB Publication. </p>
+						<p>These constraints on URL strings mean that:</p>
 
-						<p> For better interoperability with non-conforming or legacy Reading Systems and toolchains,
-							EPUB Creators should not use more <a data-cite="url#double-dot-path-segment">double-dot path
-								segments</a> than needed to reach the target container file. </p>
+						<ul>
+							<li>relative URL strings starting with a <code>/</code> (<code>U+002F</code>) (for example, <code>/EPUB/content.xhtml</code>) are disallowed;
+							</li>
+							<li>relative URL strings containing more <a
+								data-cite="url#double-dot-path-segment">double-dot path segments</a> than needed to reach the target
+								file (for example, <code>EPUB/../../../../config.xml</code>) are disallowed;
+							</li>
+							<li>any other absolute or relative URL string is allowed.</li>
+						</ul>
 
-						<p> The constraints on URL strings means that a <a data-cite="url#path-absolute-url-string">path-absolute-URL string</a>, i.e., a URL of the form 
-							<code>/A/B/C</code>, is also disallowed for EPUB Publications.
-							The reason is, again, a better interoperability with legacy Reading Systems and toolchains.
+						<p>
+							Note that in any case, to avoid potential run-time security issues, the properties of the <a>container root URL</a> are such that a conforming Reading System will parse any relative URL string to a <a>content URL</a>. In other words, even the disallowed URL strings described above will not "leak" outside the container. They are still disallowed for better interoperability with non-conforming or legacy Reading Systems and toolchains.
 						</p>
-			
 					</div>
 
 					<aside class="example" title="Referencing a file in the same directory">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1348,19 +1348,14 @@
 						copy of the same EPUB Publication, the origins will be different for the two users on those
 						copies even if the same Reading System is used.</p>
 
-					<p class="note">
-						The properties of the <a>container root URL</a> are such that a conforming Reading System will parse any relative URL
-						string to a <a>content URL</a>. In other words, relative links do not "leak" outside the container content, which is an important
-						feature for security. This includes URLs strings starting with a
-						<code>/</code> character (for example, <code>/EPUB/content.xhtml</code>) or containing
-						more <a data-cite="url#double-dot-path-segment">double-dot path segments</a> than needed to reach the target
-						(for example, <code>EPUB/../../../../config.xml</code>). (Although those links are
-						<a data-cite="epub-33#urls-in-ocf-constraints">non-conformant</a> in an EPUB Publications.)
-					</p>
-
 					<div class="note">
-						<p>The required properties of the container root URL are such that it behaves similarly to a URL
-							defined as follows:</p>
+						<p>
+							The properties of the <a>container root URL</a> are such that a conforming Reading System will parse any relative URL
+							string to a <a>content URL</a>. In other words, relative links do not "leak" outside the container content, which is an important
+							feature for security.
+						</p>
+
+						<p>In practice, the container root URL behaves similarly to a URL defined as follows:</p>
 
 						<table class="zebra">
 							<thead>
@@ -1406,16 +1401,16 @@
 									</td>
 								</tr>
 								<tr>
-									<td> Package Document </td>
+									<td>Package Document</td>
 									<td>
-										<code>OPS/package.opf</code>
+										<code>EPUB/package.opf</code>
 									</td>
 									<td>
-										<code>http://localhost:49152/OPS/package.opf</code>
+										<code>http://localhost:49152/EPUB/package.opf</code>
 									</td>
 								</tr>
 								<tr>
-									<td> Content Document </td>
+									<td>Content Document</td>
 									<td>
 										<code>HTML/file name.xhtml</code>
 									</td>
@@ -1425,6 +1420,45 @@
 								</tr>
 							</tbody>
 						</table>
+
+						<table class="zebra">
+							<thead>
+								<tr>
+									<td style="font-weight: bold; text-align: center;">URL<br/>(relative to the package document)</td>
+									<td style="font-weight: bold; text-align: center;">Content URL</td>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>
+										<code>../HTML/file%20name.xhtml</code>
+									</td>
+									<td>
+										<code>http://localhost:49152/HTML/file%20name.xhtml</code>
+									</td>
+								</tr>
+								<tr>
+									<td>
+										<code>/Media/img.png</code>
+									</td>
+									<td>
+										<code>http://localhost:49152/Media/img.png</code>
+									</td>
+								</tr>
+								<tr>
+									<td>
+										<code>../../../Media/img.png</code>
+									</td>
+									<td>
+										<code>http://localhost:49152/Media/img.png</code>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+						<p>
+							Note that the last two links are <a data-cite="epub-33#urls-in-ocf-constraints">disallowed</a> in an 
+							EPUB Publications to ensure better interoperability with non-conforming or legacy Reading Systems and toolchains.
+						</p>
 					</div>
 
 					<div class="note">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1424,7 +1424,7 @@
 						<table class="zebra">
 							<thead>
 								<tr>
-									<td style="font-weight: bold; text-align: center;">URL<br/>(relative to the package document)</td>
+									<td style="font-weight: bold; text-align: center;">URL string<br/>(found for example in the package document)</td>
 									<td style="font-weight: bold; text-align: center;">Content URL</td>
 								</tr>
 							</thead>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1348,23 +1348,15 @@
 						copy of the same EPUB Publication, the origins will be different for the two users on those
 						copies even if the same Reading System is used.</p>
 
-					<div class="note">
-						<p>The <a data-cite="epub-33#urls-in-ocf-constraints">constraints</a> on URL strings in an EPUB Publication mean that:</p>
-
-						<ul>
-							<li>relative URL strings starting with a <code>/</code> (<code>U+002F</code>) (for example, <code>/EPUB/content.xhtml</code>) are disallowed;
-							</li>
-							<li>relative URL strings containing more <a
-								data-cite="url#double-dot-path-segment">double-dot path segments</a> than needed to reach the target
-								file (for example, <code>EPUB/../../../../config.xml</code>) are disallowed;
-							</li>
-							<li>any other absolute or relative URL string is allowed.</li>
-						</ul>
-
-						<p>
-							Note that in any case, to avoid potential run-time security issues, the properties of the <a>container root URL</a> are such that a conforming Reading System will parse any relative URL string to a <a>content URL</a>. In other words, even the disallowed URL strings described above will not "leak" outside the container. They are still disallowed for better interoperability with non-conforming or legacy Reading Systems and toolchains.
-						</p>
-					</div>
+					<p class="note">
+						The properties of the <a>container root URL</a> are such that a conforming Reading System will parse any relative URL
+						string to a <a>content URL</a>. In other words, relative links do not "leak" outside the container content, which is an important
+						feature for security. This includes URLs strings starting with a
+						<code>/</code> character (for example, <code>/EPUB/content.xhtml</code>) or containing
+						more <a data-cite="url#double-dot-path-segment">double-dot path segments</a> than needed to reach the target
+						(for example, <code>EPUB/../../../../config.xml</code>). (Although those links are
+						<a data-cite="epub-33#urls-in-ocf-constraints">non-conformant</a> in an EPUB Publications.)
+					</p>
 
 					<div class="note">
 						<p>The required properties of the container root URL are such that it behaves similarly to a URL

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1349,6 +1349,24 @@
 						copies even if the same Reading System is used.</p>
 
 					<div class="note">
+						<p>The <a data-cite="epub-33#urls-in-ocf-constraints">constraints</a> on URL strings in an EPUB Publication mean that:</p>
+
+						<ul>
+							<li>relative URL strings starting with a <code>/</code> (<code>U+002F</code>) (for example, <code>/EPUB/content.xhtml</code>) are disallowed;
+							</li>
+							<li>relative URL strings containing more <a
+								data-cite="url#double-dot-path-segment">double-dot path segments</a> than needed to reach the target
+								file (for example, <code>EPUB/../../../../config.xml</code>) are disallowed;
+							</li>
+							<li>any other absolute or relative URL string is allowed.</li>
+						</ul>
+
+						<p>
+							Note that in any case, to avoid potential run-time security issues, the properties of the <a>container root URL</a> are such that a conforming Reading System will parse any relative URL string to a <a>content URL</a>. In other words, even the disallowed URL strings described above will not "leak" outside the container. They are still disallowed for better interoperability with non-conforming or legacy Reading Systems and toolchains.
+						</p>
+					</div>
+
+					<div class="note">
 						<p>The required properties of the container root URL are such that it behaves similarly to a URL
 							defined as follows:</p>
 


### PR DESCRIPTION
This is a proposal to fix #2023.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2029.html" title="Last updated on Mar 8, 2022, 1:30 PM UTC (c7e472e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2029/47e0f2e...c7e472e.html" title="Last updated on Mar 8, 2022, 1:30 PM UTC (c7e472e)">Diff</a>