### PR TITLE
Consolidate the usage requirements for manifest item properties

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2963,7 +2963,7 @@ XHTML:
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-properties">
+												<a href="#sec-item-resource-properties">
 													<code>properties</code>
 												</a>
 												<code>[optional]</code>
@@ -2997,22 +2997,6 @@ XHTML:
 									<code>item</code> element, as defined in <a
 									href="#sec-foreign-restrictions-manifest"></a>.</p>
 
-							<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
-									Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
-									<code>properties</code> attribute.</p>
-
-							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
-									href="#sec-vocab-assoc"></a>.</p>
-
-							<p>EPUB Creators MUST declare all applicable descriptive metadata properties for each
-								Publication Resource in this attribute (e.g., if the resource is the <a
-									href="#sec-cover-image">cover image</a>, contains <a href="#sec-scripted"
-									>scripting</a>, or references <a href="#sec-remote-resources">remote
-								resources</a>).</p>
-
-							<p>EPUB Creators MUST declare exactly one <code>item</code> as the <a>EPUB Navigation
-									Document</a> using the <code>nav</code> property.</p>
-
 							<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF
 								[[XML]] that identifies the <a>Media Overlay Document</a> for the resource described by
 								this <code>item</code>. Refer to <a href="#sec-docs-package"></a> for more
@@ -3023,6 +3007,76 @@ XHTML:
 									significant. The <a class="codelink" href="#sec-spine-elem"><code>spine</code>
 										element</a> provides the presentation sequence of content documents.</p>
 							</div>
+
+							<section id="sec-item-resource-properties">
+								<h6>Resource Properties</h6>
+
+								<p>The <a href="#attrdef-properties"><code>properties</code> attribute</a> provides
+									information to <a>Reading Systems</a> about the content of a resource. This
+									information enables discovery of key resources, such as the cover image and <a>EPUB
+										Navigation Document</a>. It also allows Reading Systems to optimize rendering by
+									indicating, for example, whether the resource contains embedded scripting, MathML,
+									or SVG.</p>
+
+								<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest
+										Properties Vocabulary</a> is the <a href="#sec-default-vocab">default
+										vocabulary</a> for the <code>properties</code> attribute.</p>
+
+								<p>EPUB Creators MUST set the following properties whenever a resource referenced by an
+										<code>item</code> element matches their respective definitions:</p>
+
+								<ul>
+									<li><a href="#sec-mathml">mathml</a></li>
+									<li><a href="#sec-remote-resources">remote-resources</a></li>
+									<li><a href="#sec-scripted">scripted</a></li>
+									<li><a href="#sec-svg">svg</a></li>
+									<li><a href="#sec-switch">switch</a></li>
+								</ul>
+
+								<aside class="example" id="example-item-properties-scripted-mathml"
+									title="Identifying a Scripted Content Document with embedded MathML">
+									<pre class="synopsis">&lt;item
+    properties="scripted mathml"
+    id="c2"
+    href="c2.xhtml"
+    media-type="application/xhtml+xml" /&gt;
+</pre>
+								</aside>
+
+								<p>These properties do not apply recursively to content included into a resource (e.g.,
+									via the HTML <code>iframe</code> element). For example, if a non-scripted XHTML
+									Content Document embeds a scripted Content Document, only the embedded document's
+									manifest <code>item</code>
+									<code>properties</code> attribute will have the <code>scripted</code> value.</p>
+
+								<p>EPUB Creators MUST declare exactly one <code>item</code> as the EPUB Navigation
+									Document using the <a href="#sec-nav-prop"><code>nav</code> property</a>.</p>
+
+								<aside class="example" id="example-item-properties-nav"
+									title="Identifying the EPUB Navigation Document">
+									<pre class="synopsis">&lt;item
+    properties="nav"
+    id="c1"
+    href="c1.xhtml"
+    media-type="application/xhtml+xml" /&gt;</pre>
+								</aside>
+
+								<p>If an EPUB Publication contains a cover image, it is recommended to set the <a
+										href="#sec-cover-image"><code>cover-image</code> property</a>, but setting this
+									property is OPTIONAL.</p>
+
+								<aside class="example" id="example-item-properties-cover-image"
+									title="Identifying the cover image">
+									<pre class="synopsis">&lt;item
+    properties="cover-image"
+    id="ci"
+    href="cover.svg"
+    media-type="image/svg+xml" /&gt;</pre>
+								</aside>
+
+								<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
+										href="#sec-vocab-assoc"></a>.</p>
+							</section>
 
 							<section id="sec-foreign-restrictions-manifest">
 								<h6>Manifest Fallbacks</h6>
@@ -10722,10 +10776,12 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's
-					definition by making it optional, and adapt the specification's text elsewhere to address the
-					situation when the element is indeed not present. See <a
-						href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>.</li>
+				<li>05-Mar-2022: Consolidated the usage requirements for manifest properties into a new Resource
+					Properties section. See <a href="https://github.com/w3c/epub-specs/issues/2030">issue 2030</a>.</li>
+				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's definition
+					by making it optional, and adapt the specification's text elsewhere to address the situation when
+					the element is indeed not present. See <a href="https://github.com/w3c/epub-specs/issues/1986">issue
+						1986</a>.</li>
 				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
 					model for EPUB Publications and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2979,7 +2979,13 @@ XHTML:
 								[[XML]] that identifies the <a>Media Overlay Document</a> for the resource described by
 								this <code>item</code>. Refer to <a href="#sec-docs-package"></a> for more
 								information.</p>
-
+							
+							<div class="note">
+								<p>The order of <code>item</code> elements in the <code>manifest</code> is not
+									significant. The <a class="codelink" href="#sec-spine-elem"><code>spine</code>
+										element</a> provides the presentation sequence of content documents.</p>
+							</div>
+						
 							<section id="sec-item-resource-properties">
 								<h6>Resource Properties</h6>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2444,9 +2444,9 @@
 								contributor expression by defining the role of the person.</li>
 						</ul>
 
-						<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions,
-								thereby creating chains of information. Refinement chains MUST NOT contain circular
-								references or self-references.</p>
+						<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions, thereby
+							creating chains of information. Refinement chains MUST NOT contain circular references or
+							self-references.</p>
 
 						<p class="note">All the DCMES [[DCTERMS]] elements represent primary expressions, and permit
 							refinement by meta element subexpressions.</p>
@@ -2956,108 +2956,104 @@ XHTML:
 							</dd>
 						</dl>
 
-							<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL
-								[[URL]] in its <code>href</code> attribute. The value MUST be an <a
-									data-cite="url#absolute-url-string">absolute-</a> or <a
-									data-cite="url#path-relative-scheme-less-url-string"
-									>path-relative-scheme-less-URL</a> string [[URL]]. EPUB Creators MUST ensure each
-								URL is unique within the <code>manifest</code> scope after <a
-									href="#sec-parse-package-urls">parsing</a>.</p>
+						<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL [[URL]] in
+							its <code>href</code> attribute. The value MUST be an <a data-cite="url#absolute-url-string"
+								>absolute-</a> or <a data-cite="url#path-relative-scheme-less-url-string"
+								>path-relative-scheme-less-URL</a> string [[URL]]. EPUB Creators MUST ensure each URL is
+							unique within the <code>manifest</code> scope after <a href="#sec-parse-package-urls"
+								>parsing</a>.</p>
 
-							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
-								element MUST conform to the applicable specification(s) as inferred from the MIME media
-								type provided in the <a href="#attrdef-media-type"><code>media-type</code>
-								attribute</a>. For <a>Core Media Type Resources</a>, EPUB Creators MUST use the media
-								type designated in <a href="#sec-cmt-supported"></a>.</p>
+						<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
+							element MUST conform to the applicable specification(s) as inferred from the MIME media type
+							provided in the <a href="#attrdef-media-type"><code>media-type</code> attribute</a>. For
+								<a>Core Media Type Resources</a>, EPUB Creators MUST use the media type designated in <a
+								href="#sec-cmt-supported"></a>.</p>
 
-							<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[XML]]
-								that identifies a fallback for the Publication Resource referenced from the
-									<code>item</code> element, as defined in <a
-									href="#sec-foreign-restrictions-manifest"></a>.</p>
+						<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[XML]] that
+							identifies a fallback for the Publication Resource referenced from the <code>item</code>
+							element, as defined in <a href="#sec-foreign-restrictions-manifest"></a>.</p>
 
-							<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF
-								[[XML]] that identifies the <a>Media Overlay Document</a> for the resource described by
-								this <code>item</code>. Refer to <a href="#sec-docs-package"></a> for more
-								information.</p>
-							
-							<div class="note">
-								<p>The order of <code>item</code> elements in the <code>manifest</code> is not
-									significant. The <a class="codelink" href="#sec-spine-elem"><code>spine</code>
-										element</a> provides the presentation sequence of content documents.</p>
-							</div>
-						
-							<section id="sec-item-resource-properties">
-								<h6>Resource Properties</h6>
+						<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF
+							[[XML]] that identifies the <a>Media Overlay Document</a> for the resource described by this
+								<code>item</code>. Refer to <a href="#sec-docs-package"></a> for more information.</p>
 
-								<p>The <a href="#attrdef-properties"><code>properties</code> attribute</a> provides
-									information to <a>Reading Systems</a> about the content of a resource. This
-									information enables discovery of key resources, such as the cover image and <a>EPUB
-										Navigation Document</a>. It also allows Reading Systems to optimize rendering by
-									indicating, for example, whether the resource contains embedded scripting, MathML,
-									or SVG.</p>
+						<div class="note">
+							<p>The order of <code>item</code> elements in the <code>manifest</code> is not significant.
+								The <a class="codelink" href="#sec-spine-elem"><code>spine</code> element</a> provides
+								the presentation sequence of content documents.</p>
+						</div>
 
-								<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest
-										Properties Vocabulary</a> is the <a href="#sec-default-vocab">default
-										vocabulary</a> for the <code>properties</code> attribute.</p>
+						<section id="sec-item-resource-properties">
+							<h6>Resource Properties</h6>
 
-								<p>EPUB Creators MUST set the following properties whenever a resource referenced by an
-										<code>item</code> element matches their respective definitions:</p>
+							<p>The <a href="#attrdef-properties"><code>properties</code> attribute</a> provides
+								information to <a>Reading Systems</a> about the content of a resource. This information
+								enables discovery of key resources, such as the cover image and <a>EPUB Navigation
+									Document</a>. It also allows Reading Systems to optimize rendering by indicating,
+								for example, whether the resource contains embedded scripting, MathML, or SVG.</p>
 
-								<ul>
-									<li><a href="#sec-mathml">mathml</a></li>
-									<li><a href="#sec-remote-resources">remote-resources</a></li>
-									<li><a href="#sec-scripted">scripted</a></li>
-									<li><a href="#sec-svg">svg</a></li>
-									<li><a href="#sec-switch">switch</a></li>
-								</ul>
+							<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
+									Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
+									<code>properties</code> attribute.</p>
 
-								<aside class="example" id="example-item-properties-scripted-mathml"
-									title="Identifying a Scripted Content Document with embedded MathML">
-									<pre class="synopsis">&lt;item
+							<p>EPUB Creators MUST set the following properties whenever a resource referenced by an
+									<code>item</code> element matches their respective definitions:</p>
+
+							<ul>
+								<li><a href="#sec-mathml">mathml</a></li>
+								<li><a href="#sec-remote-resources">remote-resources</a></li>
+								<li><a href="#sec-scripted">scripted</a></li>
+								<li><a href="#sec-svg">svg</a></li>
+								<li><a href="#sec-switch">switch</a></li>
+							</ul>
+
+							<aside class="example" id="example-item-properties-scripted-mathml"
+								title="Identifying a Scripted Content Document with embedded MathML">
+								<pre class="synopsis">&lt;item
     properties="scripted mathml"
     id="c2"
     href="c2.xhtml"
     media-type="application/xhtml+xml" /&gt;
 </pre>
-								</aside>
+							</aside>
 
-								<p>These properties do not apply recursively to content included into a resource (e.g.,
-									via the HTML <code>iframe</code> element). For example, if a non-scripted XHTML
-									Content Document embeds a scripted Content Document, only the embedded document's
-									manifest <code>item</code>
-									<code>properties</code> attribute will have the <code>scripted</code> value.</p>
+							<p>These properties do not apply recursively to content included into a resource (e.g., via
+								the HTML <code>iframe</code> element). For example, if a non-scripted XHTML Content
+								Document embeds a scripted Content Document, only the embedded document's manifest
+									<code>item</code>
+								<code>properties</code> attribute will have the <code>scripted</code> value.</p>
 
-								<p>EPUB Creators MUST declare exactly one <code>item</code> as the EPUB Navigation
-									Document using the <a href="#sec-nav-prop"><code>nav</code> property</a>.</p>
+							<p>EPUB Creators MUST declare exactly one <code>item</code> as the EPUB Navigation Document
+								using the <a href="#sec-nav-prop"><code>nav</code> property</a>.</p>
 
-								<aside class="example" id="example-item-properties-nav"
-									title="Identifying the EPUB Navigation Document">
-									<pre class="synopsis">&lt;item
+							<aside class="example" id="example-item-properties-nav"
+								title="Identifying the EPUB Navigation Document">
+								<pre class="synopsis">&lt;item
     properties="nav"
     id="c1"
     href="c1.xhtml"
     media-type="application/xhtml+xml" /&gt;</pre>
-								</aside>
+							</aside>
 
-								<p>If an EPUB Publication contains a cover image, it is recommended to set the <a
-										href="#sec-cover-image"><code>cover-image</code> property</a>, but setting this
-									property is OPTIONAL.</p>
+							<p>If an EPUB Publication contains a cover image, it is recommended to set the <a
+									href="#sec-cover-image"><code>cover-image</code> property</a>, but setting this
+								property is OPTIONAL.</p>
 
-								<aside class="example" id="example-item-properties-cover-image"
-									title="Identifying the cover image">
-									<pre class="synopsis">&lt;item
+							<aside class="example" id="example-item-properties-cover-image"
+								title="Identifying the cover image">
+								<pre class="synopsis">&lt;item
     properties="cover-image"
     id="ci"
     href="cover.svg"
     media-type="image/svg+xml" /&gt;</pre>
-								</aside>
+							</aside>
 
-								<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
-										href="#sec-vocab-assoc"></a>.</p>
-							</section>
+							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
+									href="#sec-vocab-assoc"></a>.</p>
+						</section>
 
-							<section id="sec-foreign-restrictions-manifest">
-								<h6>Manifest Fallbacks</h6>
+						<section id="sec-foreign-restrictions-manifest">
+							<h6>Manifest Fallbacks</h6>
 
 							<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback
 								chains to Core Media Type Resources. They are used to create fallbacks for Foreign

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -38,10 +38,6 @@
 						<code>Zero or one</code>
 					</td>
 				</tr>
-				<tr>
-					<th>Usage:</th>
-					<td>Optional.</td>
-				</tr>
 			</tbody>
 		</table>
 	</section>
@@ -72,10 +68,6 @@
 						<code>Zero or more</code>
 					</td>
 				</tr>
-				<tr>
-					<th>Usage:</th>
-					<td>MUST be set if and only if the criterion specified in the description is met.</td>
-				</tr>
 			</tbody>
 		</table>
 	</section>
@@ -104,10 +96,6 @@
 					<td>
 						<code>Exactly one</code>
 					</td>
-				</tr>
-				<tr>
-					<th>Usage:</th>
-					<td>Required.</td>
 				</tr>
 			</tbody>
 		</table>
@@ -143,10 +131,6 @@
 						<code>Zero or more</code>
 					</td>
 				</tr>
-				<tr>
-					<th>Usage:</th>
-					<td>MUST be set if and only if the criterion specified in the description is met.</td>
-				</tr>
 			</tbody>
 		</table>
 	</section>
@@ -177,10 +161,6 @@
 					<td>
 						<code>Zero or more</code>
 					</td>
-				</tr>
-				<tr>
-					<th>Usage:</th>
-					<td>MUST be set if and only if the criterion specified in the description is met.</td>
 				</tr>
 			</tbody>
 		</table>
@@ -216,10 +196,6 @@
 						<code>Zero or more</code>
 					</td>
 				</tr>
-				<tr>
-					<th>Usage:</th>
-					<td>MUST be set if and only if the criterion specified in the description is met.</td>
-				</tr>
 			</tbody>
 		</table>
 	</section>
@@ -251,46 +227,7 @@
 						<code>Zero or more</code>
 					</td>
 				</tr>
-				<tr>
-					<th>Usage:</th>
-					<td>MUST be set if and only if the criterion specified in the description is met.</td>
-				</tr>
 			</tbody>
 		</table>
-	</section>
-	<section id="manifest-item-properties-recursive">
-		<h4>Usage</h4>
-		<p>The <code>mathml</code>, <code>remote-resources</code>, <code>scripted</code> and <code>switch</code>
-			properties MUST be specified whenever the resource referenced by an <code>item</code> matches their
-			respective definitions. These properties do not apply recursively to content included into a
-			resource (e.g., via the HTML <code>iframe</code> element). For example, if a non-scripted XHTML
-			Content Document embeds a scripted Content Document, only the embedded document's manifest
-				<code>item</code>
-			<code>properties</code> attribute will have the <code>scripted</code> value. </p>
-	</section>
-	<section id="examples-item-properties">
-		<h4>Examples</h4>
-		<aside class="example" id="example-item-properties-nav" title="Identifying the EPUB Navigation Document">
-			<pre class="synopsis">&lt;item
-    properties="nav"
-    id="c1"
-    href="c1.xhtml"
-    media-type="application/xhtml+xml" /&gt;</pre>
-		</aside>
-		<aside class="example" id="example-item-properties-cover-image" title="Identifying the cover image">
-			<pre class="synopsis">&lt;item
-    properties="cover-image"
-    id="ci"
-    href="cover.svg"
-    media-type="image/svg+xml" /&gt;</pre>
-		</aside>
-		<aside class="example" id="example-item-properties-scripted-mathml" title="Identifying a Scripted Content Document with embedded MathML">
-			<pre class="synopsis">&lt;item
-    properties="scripted mathml"
-    id="c2"
-    href="c2.xhtml"
-    media-type="application/xhtml+xml" /&gt;
-</pre>
-		</aside>
 	</section>
 </section>


### PR DESCRIPTION
This PR creates a Resource Properties section under the manifest item element's definition. I've consolidated the many statements requiring the use of these properties into this one section, but otherwise nothing significant changes.

Fixes #2030


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2033.html" title="Last updated on Mar 7, 2022, 1:29 PM UTC (914790e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2033/2283319...914790e.html" title="Last updated on Mar 7, 2022, 1:29 PM UTC (914790e)">Diff</a>