### PR TITLE
Forbid circular references and self-references in refinement chains

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2463,7 +2463,8 @@
 							</ul>
 
 							<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions,
-								thereby creating chains of information.</p>
+								thereby creating chains of information. Refinement chains MUST NOT contain circular
+								references or self-references.</p>
 
 							<p class="note">All the DCMES [[DCTERMS]] elements represent primary expressions, and permit
 								refinement by meta element subexpressions.</p>
@@ -10722,10 +10723,12 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's
-					definition by making it optional, and adapt the specification's text elsewhere to address the
-					situation when the element is indeed not present. See <a
-						href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>.</li>
+				<li>05-Mar-2022: Forbid circular references and self-references in refinement chains. See <a
+						href="https://github.com/w3c/epub-specs/issues/2031">issue 2031</a>.</li>
+				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's definition
+					by making it optional, and adapt the specification's text elsewhere to address the situation when
+					the element is indeed not present. See <a href="https://github.com/w3c/epub-specs/issues/1986">issue
+						1986</a>.</li>
 				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
 					model for EPUB Publications and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a


### PR DESCRIPTION
Fixes #2031


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2034.html" title="Last updated on Mar 5, 2022, 3:49 PM UTC (49fd8c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2034/1da0078...49fd8c7.html" title="Last updated on Mar 5, 2022, 3:49 PM UTC (49fd8c7)">Diff</a>