### PR TITLE
Remove the unnecessary "Package Document Definition" section wrapper

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1148,6 +1148,9 @@
 			<section id="sec-package-doc">
 				<h3>Package Document</h3>
 
+				<p>All [[XML]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
+					namespace [[XML-NAMES]] unless otherwise specified.</p>
+
 				<section id="sec-package-intro" class="informative">
 					<h4>Introduction</h4>
 
@@ -1196,81 +1199,71 @@
 					</div>
 				</section>
 
-				<section id="sec-package-def">
-					<h4>Package Document Definition</h4>
+				<section id="sec-parse-package-urls">
+					<h4>Parsing URLs in the Package Document</h4>
 
-					<p>All [[XML]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
-						namespace [[XML-NAMES]] unless otherwise specified.</p>
+					<p> To parse a URL string <var>url</var> used in the Package Document, the <a
+							data-cite="url#concept-url-parser">URL Parser</a> [[URL]] MUST be applied to <var>url</var>,
+						with the <a>content URL</a> of the Package Document as <var>base</var>. </p>
+				</section>
 
-					<section id="sec-parse-package-urls">
-						<h5>Parsing URLs in the Package Document</h5>
+				<section id="sec-shared-attrs">
+					<h4>Shared Attributes</h4>
 
-						<p> To parse a URL string <var>url</var> used in the Package Document, the <a
-								data-cite="url#concept-url-parser">URL Parser</a> [[URL]] MUST be applied to
-								<var>url</var>, with the <a>content URL</a> of the Package Document as <var>base</var>.
-						</p>
-					</section>
+					<p>This section provides definitions for shared attributes (i.e., attributes allowed on two or more
+						elements).</p>
 
-					<section id="sec-shared-attrs">
-						<h5>Shared Attributes</h5>
-
-						<p>This section provides definitions for shared attributes (i.e., attributes allowed on two or
-							more elements).</p>
-
-						<dl class="variablelist">
-							<dt id="attrdef-dir">
-								<code>dir</code>
-							</dt>
-							<dd>
-								<p
-									data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
-									>Specifies the <a data-cite="bidi#BD5">base direction</a> [[BIDI]] of the textual
-									content and attribute values of the carrying element and its descendants</p>
-								<p>Allowed values are:</p>
-								<ul>
-									<li><code>ltr</code> &#8212; left-to-right base direction;</li>
-									<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
-									<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
-										Algorithm [[BIDI]].</li>
-								</ul>
-								<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will
-									assume the value <code>auto</code> when EPUB Creators omit the attribute or use an
-									invalid value.</p>
-								<div class="note">
-									<p>The base direction specified in the <code>dir</code> attribute does not affect
-										the ordering of characters within directional runs, only the relative ordering
-										of those runs and the placement of weak directional characters such as
-										punctuation.</p>
-								</div>
-								<aside class="example"
-									title="Setting the global base direction for Package Document text">
-									<pre>&lt;package … dir="ltr">
+					<dl class="variablelist">
+						<dt id="attrdef-dir">
+							<code>dir</code>
+						</dt>
+						<dd>
+							<p
+								data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
+								>Specifies the <a data-cite="bidi#BD5">base direction</a> [[BIDI]] of the textual
+								content and attribute values of the carrying element and its descendants</p>
+							<p>Allowed values are:</p>
+							<ul>
+								<li><code>ltr</code> &#8212; left-to-right base direction;</li>
+								<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
+								<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
+									Algorithm [[BIDI]].</li>
+							</ul>
+							<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will assume
+								the value <code>auto</code> when EPUB Creators omit the attribute or use an invalid
+								value.</p>
+							<div class="note">
+								<p>The base direction specified in the <code>dir</code> attribute does not affect the
+									ordering of characters within directional runs, only the relative ordering of those
+									runs and the placement of weak directional characters such as punctuation.</p>
+							</div>
+							<aside class="example" title="Setting the global base direction for Package Document text">
+								<pre>&lt;package … dir="ltr">
    …
 &lt;/package></pre>
-								</aside>
-								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-										href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-										href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a
-										href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-meta-elem"
-											><code>meta</code></a> and <a href="#sec-package-elem"
-										><code>package</code></a>.</p>
-							</dd>
+							</aside>
+							<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+									href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+									href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
+									href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
+										><code>dc:title</code></a>, <a href="#sec-meta-elem"><code>meta</code></a> and
+									<a href="#sec-package-elem"><code>package</code></a>.</p>
+						</dd>
 
-							<dt id="attrdef-href">
-								<code>href</code>
-							</dt>
-							<dd>
-								<p>A <a data-cite="url#valid-url-string">valid URL string</a> [[URL]] that references a
-									resource. If the value is an <a data-cite="url#absolute-url-string">absolute
-									URL</a>, it SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
-								<aside class="example" title="Linking a metadata record">
-									<pre>&lt;package …>
+						<dt id="attrdef-href">
+							<code>href</code>
+						</dt>
+						<dd>
+							<p>A <a data-cite="url#valid-url-string">valid URL string</a> [[URL]] that references a
+								resource. If the value is an <a data-cite="url#absolute-url-string">absolute URL</a>, it
+								SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
+							<aside class="example" title="Linking a metadata record">
+								<pre>&lt;package …>
    &lt;metadata …>
       …
       &lt;link
@@ -1281,50 +1274,49 @@
    &lt;/metadata>
    …
 &lt;/package></pre>
-								</aside>
-								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
-										href="#sec-link-elem"><code>link</code></a>.</p>
-							</dd>
+							</aside>
+							<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
+										><code>link</code></a>.</p>
+						</dd>
 
-							<dt id="attrdef-id">
-								<code>id</code>
-							</dt>
-							<dd>
-								<p>The ID [[XML]] of the element, which MUST be unique within the document scope.</p>
-								<aside class="example" title="Adding an identifier attribute">
-									<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
-								</aside>
-								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-										href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:date</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, <a
-										href="#sec-opf-dcidentifier"><code>dc:identifier</code></a>, <a
-										href="#sec-opf-dclanguage"><code>dc:language</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, <a
-										href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a
-										href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-opf-dctype"
-											><code>dc:type</code></a>, <a href="#sec-item-elem"><code>item</code></a>,
-										<a href="#sec-itemref-elem"><code>itemref</code></a>, <a href="#sec-link-elem"
-											><code>link</code></a>, <a href="#sec-manifest-elem"
-										><code>manifest</code></a>, <a href="#sec-meta-elem"><code>meta</code></a>, <a
-										href="#sec-package-elem"><code>package</code></a> and <a href="#sec-spine-elem"
-											><code>spine</code></a>.</p>
-							</dd>
+						<dt id="attrdef-id">
+							<code>id</code>
+						</dt>
+						<dd>
+							<p>The ID [[XML]] of the element, which MUST be unique within the document scope.</p>
+							<aside class="example" title="Adding an identifier attribute">
+								<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
+							</aside>
+							<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+									href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+									href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:date</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, <a
+									href="#sec-opf-dcidentifier"><code>dc:identifier</code></a>, <a
+									href="#sec-opf-dclanguage"><code>dc:language</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, <a
+									href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
+										><code>dc:title</code></a>, <a href="#sec-opf-dctype"><code>dc:type</code></a>,
+									<a href="#sec-item-elem"><code>item</code></a>, <a href="#sec-itemref-elem"
+										><code>itemref</code></a>, <a href="#sec-link-elem"><code>link</code></a>, <a
+									href="#sec-manifest-elem"><code>manifest</code></a>, <a href="#sec-meta-elem"
+										><code>meta</code></a>, <a href="#sec-package-elem"><code>package</code></a> and
+									<a href="#sec-spine-elem"><code>spine</code></a>.</p>
+						</dd>
 
-							<dt id="attrdef-media-type">
-								<code>media-type</code>
-							</dt>
-							<dd>
-								<p>A media type [[RFC2046]] that specifies the type and format of the referenced
-									resource.</p>
-								<aside class="example" title="Adding the media type for a linked record">
-									<pre>&lt;package …>
+						<dt id="attrdef-media-type">
+							<code>media-type</code>
+						</dt>
+						<dd>
+							<p>A media type [[RFC2046]] that specifies the type and format of the referenced
+								resource.</p>
+							<aside class="example" title="Adding the media type for a linked record">
+								<pre>&lt;package …>
    &lt;metadata …>
       …
       &lt;link
@@ -1336,20 +1328,20 @@
    &lt;/metadata>
    …
 &lt;/package></pre>
-								</aside>
-								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a
-										href="#sec-link-elem"><code>link</code></a>.</p>
-							</dd>
+							</aside>
+							<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
+										><code>link</code></a>.</p>
+						</dd>
 
-							<dt id="attrdef-properties">
-								<code>properties</code>
-							</dt>
-							<dd>
-								<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
-								<p>Refer to each element's definition for the <a href="#sec-default-vocab">reserved
-										vocabulary</a> for the attribute.</p>
-								<aside class="example" title="Identifying the EPUB Navigation Document in the manifest">
-									<pre>&lt;package …>
+						<dt id="attrdef-properties">
+							<code>properties</code>
+						</dt>
+						<dd>
+							<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
+							<p>Refer to each element's definition for the <a href="#sec-default-vocab">reserved
+									vocabulary</a> for the attribute.</p>
+							<aside class="example" title="Identifying the EPUB Navigation Document in the manifest">
+								<pre>&lt;package …>
    …
    &lt;manifest>
       …
@@ -1362,25 +1354,24 @@
    &lt;/manifest>
    …
 &lt;/package></pre>
-								</aside>
-								<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a
-										href="#sec-itemref-elem"><code>itemref</code></a> and <a href="#sec-link-elem"
-											><code>link</code></a>.</p>
-							</dd>
+							</aside>
+							<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a href="#sec-itemref-elem"
+										><code>itemref</code></a> and <a href="#sec-link-elem"
+								><code>link</code></a>.</p>
+						</dd>
 
-							<dt id="attrdef-refines">
-								<code>refines</code>
-							</dt>
-							<dd>
-								<p>Establishes an association between the current expression and the element or resource
-									identified by its value. EPUB Creators MUST use as the value a <a
-										data-cite="url#path-relative-scheme-less-url-string"
-										>path-relative-scheme-less-URL string</a>, optionally followed by
-										<code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string"
-										>URL-fragment string</a> that references the resource or element they are
-									describing.</p>
-								<aside class="example" title="Specifying that a creator is the illustrator">
-									<pre>&lt;package …>
+						<dt id="attrdef-refines">
+							<code>refines</code>
+						</dt>
+						<dd>
+							<p>Establishes an association between the current expression and the element or resource
+								identified by its value. EPUB Creators MUST use as the value a <a
+									data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL
+									string</a>, optionally followed by <code>U+0023 (#)</code> and a <a
+									data-cite="url#url-fragment-string">URL-fragment string</a> that references the
+								resource or element they are describing.</p>
+							<aside class="example" title="Specifying that a creator is the illustrator">
+								<pre>&lt;package …>
    &lt;metadata …>
       …
       &lt;dc:creator id="creator02">
@@ -1396,15 +1387,15 @@
    &lt;/metadata>
    …
 &lt;/package></pre>
-								</aside>
-								<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata
-									expressed. When omitted, the element defines a <a href="#primary-expression">primary
-										expression</a>.</p>
-								<p>When creating expressions about a <a>Publication Resource</a>, the
-										<code>refines</code> attribute SHOULD specify a fragment identifier that
-									references the ID of the resource's <a href="#sec-item-elem">manifest entry</a>.</p>
-								<aside class="example" title="Setting the duration of a Media Overlay Document">
-									<pre>&lt;package …>
+							</aside>
+							<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata
+								expressed. When omitted, the element defines a <a href="#primary-expression">primary
+									expression</a>.</p>
+							<p>When creating expressions about a <a>Publication Resource</a>, the <code>refines</code>
+								attribute SHOULD specify a fragment identifier that references the ID of the resource's
+									<a href="#sec-item-elem">manifest entry</a>.</p>
+							<aside class="example" title="Setting the duration of a Media Overlay Document">
+								<pre>&lt;package …>
    &lt;metadata …>
       …
       &lt;meta
@@ -1424,163 +1415,272 @@
    &lt;/manifest>
    …
 &lt;/package></pre>
-								</aside>
-								<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a
-										href="#sec-meta-elem"><code>meta</code></a>.</p>
-							</dd>
+							</aside>
+							<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a href="#sec-meta-elem"
+										><code>meta</code></a>.</p>
+						</dd>
 
-							<dt id="attrdef-xml-lang">
-								<code>xml:lang</code>
-							</dt>
-							<dd>
-								<p>Specifies the language of the textual content and attribute values of the carrying
-									element and its descendants, as defined in section <a data-cite="xml#sec-lang-tag"
-										>2.12 Language Identification</a> of [[XML]]. The value of each
-										<code>xml:lang</code> attribute MUST be a <a data-cite="bcp47#section-2.2.9"
-										>well-formed language tag</a> [[BCP47]].</p>
-								<aside class="example" title="Setting the global language for Package Document text">
-									<pre>&lt;package … xml:lang="ja">
+						<dt id="attrdef-xml-lang">
+							<code>xml:lang</code>
+						</dt>
+						<dd>
+							<p>Specifies the language of the textual content and attribute values of the carrying
+								element and its descendants, as defined in section <a data-cite="xml#sec-lang-tag">2.12
+									Language Identification</a> of [[XML]]. The value of each <code>xml:lang</code>
+								attribute MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language tag</a>
+								[[BCP47]].</p>
+							<aside class="example" title="Setting the global language for Package Document text">
+								<pre>&lt;package … xml:lang="ja">
    …
 &lt;/package></pre>
-								</aside>
-								<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-										href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-										href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-										href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-										href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a
-										href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-meta-elem"
-											><code>meta</code></a> and <a href="#sec-package-elem"
-										><code>package</code></a>.</p>
-							</dd>
-						</dl>
-					</section>
+							</aside>
+							<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+									href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+									href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+									href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
+									href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
+										><code>dc:title</code></a>, <a href="#sec-meta-elem"><code>meta</code></a> and
+									<a href="#sec-package-elem"><code>package</code></a>.</p>
+						</dd>
+					</dl>
+				</section>
 
-					<section id="sec-package-elem">
-						<h5>The <code>package</code> Element</h5>
+				<section id="sec-package-elem">
+					<h4>The <code>package</code> Element</h4>
 
-						<p>The <code>package</code> element is the root element of the <a>Package Document</a>.</p>
+					<p>The <code>package</code> element is the root element of the <a>Package Document</a>.</p>
 
-						<dl id="elemdef-opf-package" class="elemdef">
+					<dl id="elemdef-opf-package" class="elemdef">
+						<dt>Element Name</dt>
+						<dd>
+							<p>
+								<code>package</code>
+							</p>
+						</dd>
+
+						<dt>Usage</dt>
+						<dd>
+							<p>The <code>package</code> element is the root element of the Package Document.</p>
+						</dd>
+
+						<dt>Attributes</dt>
+						<dd>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#attrdef-dir">
+											<code>dir</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-id">
+											<code>id</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-package-prefix">
+											<code>prefix</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-xml-lang">
+											<code>xml:lang</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-package-unique-identifier">
+											<code>unique-identifier</code>
+										</a>
+										<code>[required]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-package-version">
+											<code>version</code>
+										</a>
+										<code>[required]</code>
+									</p>
+								</li>
+							</ul>
+						</dd>
+
+						<dt>Content Model</dt>
+						<dd>
+							<p>In this order:</p>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a class="codelink" href="#elemdef-opf-metadata">
+											<code>metadata</code>
+										</a>
+										<code>[exactly 1]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-opf-manifest">
+											<code>manifest</code>
+										</a>
+										<code>[exactly 1]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-opf-spine">
+											<code>spine</code>
+										</a>
+										<code>[exactly 1]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#sec-opf2-guide">
+											<code>guide</code>
+										</a>
+										<code>[0 or 1]</code>
+										<a href="#legacy" class="legacy">(legacy)</a>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#sec-opf-bindings">
+											<code>bindings</code>
+										</a>
+										<code>[0 or 1]</code>
+										<a href="#deprecated" class="deprecated">(deprecated)</a>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-collection">
+											<code>collection</code>
+										</a>
+										<code>[0 or more]</code>
+									</p>
+								</li>
+							</ul>
+						</dd>
+					</dl>
+
+					<p id="attrdef-package-version">The <code>version</code> attribute specifies the EPUB specification
+						version to which the given EPUB Publication conforms. The attribute MUST have the value
+							"<code>3.0</code>" to indicate conformance with EPUB 3.</p>
+
+					<div class="note">
+						<p>Updates to this specification do not represent new versions of EPUB 3 (i.e., each new 3.X
+							specification is a continuation of the EPUB 3 format). The Working Group is committed to
+							minimizing any changes that would invalidate existing content, allowing the
+								<code>version</code> attribute value to remain unchanged.</p>
+					</div>
+
+					<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an
+						IDREF [[XML]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"
+								><code>dc:identifier</code></a> element that provides the preferred, or primary,
+						identifier.</p>
+
+					<p id="attrdef-package-prefix">The <code>prefix</code> attribute provides a declaration mechanism
+						for prefixes not <a href="#sec-metadata-reserved-prefixes">reserved by this specification</a>.
+						Refer to <a href="#sec-prefix-attr"></a> for more information.</p>
+				</section>
+
+				<section id="sec-pkg-metadata">
+					<h4>Metadata Section</h4>
+
+					<section id="sec-metadata-elem">
+						<h5>The <code>metadata</code> Element</h5>
+
+						<p>The <code>metadata</code> element encapsulates meta information.</p>
+
+						<dl id="elemdef-opf-metadata" class="elemdef">
 							<dt>Element Name</dt>
 							<dd>
 								<p>
-									<code>package</code>
+									<code>metadata</code>
 								</p>
 							</dd>
 
 							<dt>Usage</dt>
 							<dd>
-								<p>The <code>package</code> element is the root element of the Package Document.</p>
+								<p>REQUIRED first child of <a href="#elemdef-opf-package"><code>package</code></a>.</p>
 							</dd>
 
 							<dt>Attributes</dt>
 							<dd>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#attrdef-dir">
-												<code>dir</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-id">
-												<code>id</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-package-prefix">
-												<code>prefix</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-xml-lang">
-												<code>xml:lang</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-package-unique-identifier">
-												<code>unique-identifier</code>
-											</a>
-											<code>[required]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-package-version">
-												<code>version</code>
-											</a>
-											<code>[required]</code>
-										</p>
-									</li>
-								</ul>
+								<p>None</p>
 							</dd>
 
 							<dt>Content Model</dt>
 							<dd>
-								<p>In this order:</p>
+								<p>In any order:</p>
 								<ul class="nomark">
 									<li>
 										<p>
-											<a class="codelink" href="#elemdef-opf-metadata">
-												<code>metadata</code>
+											<a class="codelink" href="#elemdef-opf-dcidentifier">
+												<code>dc:identifier</code>
 											</a>
-											<code>[exactly 1]</code>
+											<code>[1 or more]</code>
 										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#elemdef-opf-manifest">
-												<code>manifest</code>
+											<a href="#elemdef-opf-dctitle">
+												<code>dc:title</code>
 											</a>
-											<code>[exactly 1]</code>
+											<code>[1 or more]</code>
 										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#elemdef-opf-spine">
-												<code>spine</code>
+											<a href="#elemdef-opf-dclanguage">
+												<code>dc:language</code>
 											</a>
-											<code>[exactly 1]</code>
+											<code>[1 or more]</code>
 										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#sec-opf2-guide">
-												<code>guide</code>
+											<a href="#sec-opf-dcmes-optional">
+												<code>DCMES Optional Elements</code>
 											</a>
-											<code>[0 or 1]</code>
+											<code>[0 or more]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#elemdef-meta">
+												<code>meta</code>
+											</a>
+											<code>[1 or more]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#sec-opf2-meta">OPF2 <code>meta</code></a>
+											<code>[0 or more]</code>
 											<a href="#legacy" class="legacy">(legacy)</a>
 										</p>
 									</li>
 									<li>
 										<p>
-											<a href="#sec-opf-bindings">
-												<code>bindings</code>
-											</a>
-											<code>[0 or 1]</code>
-											<a href="#deprecated" class="deprecated">(deprecated)</a>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#elemdef-collection">
-												<code>collection</code>
+											<a href="#elemdef-opf-link">
+												<code>link</code>
 											</a>
 											<code>[0 or more]</code>
 										</p>
@@ -1589,150 +1689,38 @@
 							</dd>
 						</dl>
 
-						<p id="attrdef-package-version">The <code>version</code> attribute specifies the EPUB
-							specification version to which the given EPUB Publication conforms. The attribute MUST have
-							the value "<code>3.0</code>" to indicate conformance with EPUB 3.</p>
+						<p>The Package Document <code>metadata</code> element has two primary functions:</p>
 
-						<div class="note">
-							<p>Updates to this specification do not represent new versions of EPUB 3 (i.e., each new 3.X
-								specification is a continuation of the EPUB 3 format). The Working Group is committed to
-								minimizing any changes that would invalidate existing content, allowing the
-									<code>version</code> attribute value to remain unchanged.</p>
-						</div>
+						<ol>
+							<li>
+								<p>to provide a minimal set of meta information for Reading Systems to use to internally
+									catalogue an <a>EPUB Publication</a> and make it available to a user (e.g., to
+									present in a bookshelf).</p>
+							</li>
+							<li>
+								<p>to provide access to all rendering metadata needed to control the layout and display
+									of the content (e.g., <a href="#sec-fxl-package">fixed-layout properties</a>).</p>
+							</li>
+						</ol>
 
-						<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an
-							IDREF [[XML]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"
-									><code>dc:identifier</code></a> element that provides the preferred, or primary,
-							identifier.</p>
+						<p>The Package Document does not provide complex metadata encoding capabilities. If EPUB
+							Creators need to provide more detailed information, they can associate metadata records
+							(e.g., that conform to an international standard such as [[ONIX]] or are created for custom
+							purposes) using the <a href="#sec-link-elem"><code>link</code></a> element. This approach
+							allows Reading Systems to process the metadata in its native form, avoiding the potential
+							problems and information loss caused by translating to use the minimal Package Document
+							structure.</p>
 
-						<p id="attrdef-package-prefix">The <code>prefix</code> attribute provides a declaration
-							mechanism for prefixes not <a href="#sec-metadata-reserved-prefixes">reserved by this
-								specification</a>. Refer to <a href="#sec-prefix-attr"></a> for more information.</p>
-					</section>
+						<p id="core-metadata-reqs">In keeping with this philosophy, the Package Document only has the
+							following minimal metadata requirements: it MUST contain the [[DCTERMS]] <a
+								href="#sec-opf-dcidentifier"><code>title</code></a>, <a href="#elemdef-opf-dcidentifier"
+									><code>identifier</code></a>, and <a href="#elemdef-opf-dclanguage"
+									><code>language</code></a> elements together with the [[DCTERMS]] <a
+								href="#last-modified-date"><code>modified</code> property</a>. All other metadata is
+							OPTIONAL.</p>
 
-					<section id="sec-pkg-metadata">
-						<h5>Metadata Section</h5>
-
-						<section id="sec-metadata-elem">
-							<h6>The <code>metadata</code> Element</h6>
-
-							<p>The <code>metadata</code> element encapsulates meta information.</p>
-
-							<dl id="elemdef-opf-metadata" class="elemdef">
-								<dt>Element Name</dt>
-								<dd>
-									<p>
-										<code>metadata</code>
-									</p>
-								</dd>
-
-								<dt>Usage</dt>
-								<dd>
-									<p>REQUIRED first child of <a href="#elemdef-opf-package"
-										><code>package</code></a>.</p>
-								</dd>
-
-								<dt>Attributes</dt>
-								<dd>
-									<p>None</p>
-								</dd>
-
-								<dt>Content Model</dt>
-								<dd>
-									<p>In any order:</p>
-									<ul class="nomark">
-										<li>
-											<p>
-												<a class="codelink" href="#elemdef-opf-dcidentifier">
-													<code>dc:identifier</code>
-												</a>
-												<code>[1 or more]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#elemdef-opf-dctitle">
-													<code>dc:title</code>
-												</a>
-												<code>[1 or more]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#elemdef-opf-dclanguage">
-													<code>dc:language</code>
-												</a>
-												<code>[1 or more]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#sec-opf-dcmes-optional">
-													<code>DCMES Optional Elements</code>
-												</a>
-												<code>[0 or more]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#elemdef-meta">
-													<code>meta</code>
-												</a>
-												<code>[1 or more]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#sec-opf2-meta">OPF2 <code>meta</code></a>
-												<code>[0 or more]</code>
-												<a href="#legacy" class="legacy">(legacy)</a>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#elemdef-opf-link">
-													<code>link</code>
-												</a>
-												<code>[0 or more]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
-							</dl>
-
-							<p>The Package Document <code>metadata</code> element has two primary functions:</p>
-
-							<ol>
-								<li>
-									<p>to provide a minimal set of meta information for Reading Systems to use to
-										internally catalogue an <a>EPUB Publication</a> and make it available to a user
-										(e.g., to present in a bookshelf).</p>
-								</li>
-								<li>
-									<p>to provide access to all rendering metadata needed to control the layout and
-										display of the content (e.g., <a href="#sec-fxl-package">fixed-layout
-											properties</a>).</p>
-								</li>
-							</ol>
-
-							<p>The Package Document does not provide complex metadata encoding capabilities. If EPUB
-								Creators need to provide more detailed information, they can associate metadata records
-								(e.g., that conform to an international standard such as [[ONIX]] or are created for
-								custom purposes) using the <a href="#sec-link-elem"><code>link</code></a> element. This
-								approach allows Reading Systems to process the metadata in its native form, avoiding the
-								potential problems and information loss caused by translating to use the minimal Package
-								Document structure.</p>
-
-							<p id="core-metadata-reqs">In keeping with this philosophy, the Package Document only has
-								the following minimal metadata requirements: it MUST contain the [[DCTERMS]] <a
-									href="#sec-opf-dcidentifier"><code>title</code></a>, <a
-									href="#elemdef-opf-dcidentifier"><code>identifier</code></a>, and <a
-									href="#elemdef-opf-dclanguage"><code>language</code></a> elements together with the
-								[[DCTERMS]] <a href="#last-modified-date"><code>modified</code> property</a>. All other
-								metadata is OPTIONAL.</p>
-
-							<aside class="example" title="The minimal set of metadata required in the Package Document">
-								<pre>&lt;package … unique-identifier="pub-id">
+						<aside class="example" title="The minimal set of metadata required in the Package Document">
+							<pre>&lt;package … unique-identifier="pub-id">
     …
     &lt;metadata …>
        &lt;dc:identifier
@@ -1753,98 +1741,98 @@
     …
 &lt;/package>
 </pre>
-							</aside>
+						</aside>
 
-							<p>The <a href="#sec-meta-elem"><code>meta</code> element</a> provides a generic mechanism
-								for including <a href="#sec-vocab-assoc">metadata properties from any vocabulary</a>.
-								Although EPUB Creators MAY use this mechanism for any metadata purposes, they will
-								typically use it to include rendering metadata defined in EPUB specifications.</p>
+						<p>The <a href="#sec-meta-elem"><code>meta</code> element</a> provides a generic mechanism for
+							including <a href="#sec-vocab-assoc">metadata properties from any vocabulary</a>. Although
+							EPUB Creators MAY use this mechanism for any metadata purposes, they will typically use it
+							to include rendering metadata defined in EPUB specifications.</p>
 
-							<div class="note">
-								<p>See [[EPUB-A11Y-11]] for accessibility metadata recommendations.</p>
-							</div>
-						</section>
+						<div class="note">
+							<p>See [[EPUB-A11Y-11]] for accessibility metadata recommendations.</p>
+						</div>
+					</section>
 
-						<section id="sec-metadata-values">
-							<h5>Metadata Values</h5>
+					<section id="sec-metadata-values">
+						<h5>Metadata Values</h5>
 
-							<p>The Dublin Core elements [[DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code>
-									element</a> have mandatory <a data-cite="dom#concept-child-text-content">child text
-									content</a> [[DOM]]. This specification refers to this content as the
-									<dfn>value</dfn> of the element in their descriptions.</p>
+						<p>The Dublin Core elements [[DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code>
+								element</a> have mandatory <a data-cite="dom#concept-child-text-content">child text
+								content</a> [[DOM]]. This specification refers to this content as the <dfn>value</dfn>
+							of the element in their descriptions.</p>
 
-							<p>These elements MUST have non-empty values after <a
-									data-cite="infra#strip-leading-and-trailing-ascii-whitespace">leading and trailing
-									ASCII whitespace</a> [[Infra]] is stripped (i.e., they must consist of at least one
-								non-whitespace character).</p>
+						<p>These elements MUST have non-empty values after <a
+								data-cite="infra#strip-leading-and-trailing-ascii-whitespace">leading and trailing ASCII
+								whitespace</a> [[Infra]] is stripped (i.e., they must consist of at least one
+							non-whitespace character).</p>
 
-							<p>Whitespace within these element values are not significant. Sequences of one or more
-								whitespace characters are <a data-cite="infra#strip-and-collapse-ascii-whitespace"
-									>collapsed to a single space</a> [[Infra]] during processing .</p>
-						</section>
+						<p>Whitespace within these element values are not significant. Sequences of one or more
+							whitespace characters are <a data-cite="infra#strip-and-collapse-ascii-whitespace">collapsed
+								to a single space</a> [[Infra]] during processing .</p>
+					</section>
 
-						<section id="sec-opf-dcmes-required">
-							<h6>DCMES Required Elements</h6>
+					<section id="sec-opf-dcmes-required">
+						<h5>DCMES Required Elements</h5>
 
-							<section id="sec-opf-dcidentifier">
-								<h6>The <code>identifier</code> Element</h6>
+						<section id="sec-opf-dcidentifier">
+							<h6>The <code>identifier</code> Element</h6>
 
-								<p>The [[DCTERMS]] <code>identifier</code> element contains an identifier such as a
-										<abbr title="Universally Unique Identifier">UUID</abbr>, <abbr
-										title="Digital Object Identfier">DOI</abbr> or <abbr
-										title="International Standard Book Number">ISBN</abbr>.</p>
+							<p>The [[DCTERMS]] <code>identifier</code> element contains an identifier such as a <abbr
+									title="Universally Unique Identifier">UUID</abbr>, <abbr
+									title="Digital Object Identfier">DOI</abbr> or <abbr
+									title="International Standard Book Number">ISBN</abbr>.</p>
 
-								<dl id="elemdef-opf-dcidentifier" class="elemdef">
-									<dt>Element Name</dt>
-									<dd>
-										<p>
-											<code>dc:identifier</code>
-										</p>
-									</dd>
+							<dl id="elemdef-opf-dcidentifier" class="elemdef">
+								<dt>Element Name</dt>
+								<dd>
+									<p>
+										<code>dc:identifier</code>
+									</p>
+								</dd>
 
-									<dt>Namespace</dt>
-									<dd>
-										<p>
-											<code>http://purl.org/dc/elements/1.1/</code>
-										</p>
-									</dd>
+								<dt>Namespace</dt>
+								<dd>
+									<p>
+										<code>http://purl.org/dc/elements/1.1/</code>
+									</p>
+								</dd>
 
-									<dt>Usage</dt>
-									<dd>
-										<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
-													><code>metadata</code></a>.</p>
-									</dd>
+								<dt>Usage</dt>
+								<dd>
+									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
+												><code>metadata</code></a>.</p>
+								</dd>
 
-									<dt>Attributes</dt>
-									<dd>
-										<ul class="nomark">
-											<li>
-												<p>
-													<a href="#attrdef-id">
-														<code>id</code>
-													</a>
-													<code>[conditionally required]</code>
-												</p>
-											</li>
-										</ul>
-									</dd>
+								<dt>Attributes</dt>
+								<dd>
+									<ul class="nomark">
+										<li>
+											<p>
+												<a href="#attrdef-id">
+													<code>id</code>
+												</a>
+												<code>[conditionally required]</code>
+											</p>
+										</li>
+									</ul>
+								</dd>
 
-									<dt>Content Model</dt>
-									<dd>
-										<p>Text</p>
-									</dd>
-								</dl>
+								<dt>Content Model</dt>
+								<dd>
+									<p>Text</p>
+								</dd>
+							</dl>
 
-								<p>The <a>EPUB Creator</a> MUST provide an identifier that is unique to one and only one
-										<a>EPUB Publication</a> &#8212; its <a>Unique Identifier</a> &#8212; in an
-										<code>identifier</code> element. This <code>identifier</code> element MUST
-									specify an <code>id</code> attribute whose value is referenced from the <a
-										href="#elemdef-opf-package"><code>package</code> element's</a>
-									<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
-										attribute</a>.</p>
+							<p>The <a>EPUB Creator</a> MUST provide an identifier that is unique to one and only one
+									<a>EPUB Publication</a> &#8212; its <a>Unique Identifier</a> &#8212; in an
+									<code>identifier</code> element. This <code>identifier</code> element MUST specify
+								an <code>id</code> attribute whose value is referenced from the <a
+									href="#elemdef-opf-package"><code>package</code> element's</a>
+								<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
+									attribute</a>.</p>
 
-								<aside class="example" title="Specifying the element with the unique identifier">
-									<pre>&lt;package … unique-identifier="pub-id">
+							<aside class="example" title="Specifying the element with the unique identifier">
+								<pre>&lt;package … unique-identifier="pub-id">
     &lt;metadata …>
        &lt;dc:identifier id="pub-id">
            urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
@@ -1852,28 +1840,28 @@
        …
     &lt;/metadata>
 &lt;/package></pre>
-								</aside>
+							</aside>
 
-								<p>Although not static, EPUB Creators should make changes to the Unique Identifier for
-									an EPUB Publication as infrequently as possible. Unique Identifiers should have
-									maximal persistence both for referencing and distribution purposes. EPUB Creators
-									should not issue new identifiers when making minor revisions such as updating
-									metadata, fixing errata, or making similar minor changes.</p>
+							<p>Although not static, EPUB Creators should make changes to the Unique Identifier for an
+								EPUB Publication as infrequently as possible. Unique Identifiers should have maximal
+								persistence both for referencing and distribution purposes. EPUB Creators should not
+								issue new identifiers when making minor revisions such as updating metadata, fixing
+								errata, or making similar minor changes.</p>
 
-								<p>EPUB Creators MAY specify additional identifiers. The identifiers should be fully
-									qualified URIs.</p>
+							<p>EPUB Creators MAY specify additional identifiers. The identifiers should be fully
+								qualified URIs.</p>
 
-								<p>EPUB Creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
-										property</a> to indicate that an <code>identifier</code> conforms to an
-									established system or an issuing authority granted it.</p>
+							<p>EPUB Creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
+									property</a> to indicate that an <code>identifier</code> conforms to an established
+								system or an issuing authority granted it.</p>
 
-								<aside class="example" title="Specifying the type of the identifier">
-									<p>In this example, the <code>identifier-type</code> property is used with the <a
-											href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> scheme to
-										indicate the product identifier type is a <a href="https://doi.org">DOI</a>
-										(i.e., the value <code>06</code> in codelist 5 is for DOIs).</p>
+							<aside class="example" title="Specifying the type of the identifier">
+								<p>In this example, the <code>identifier-type</code> property is used with the <a
+										href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> scheme to indicate
+									the product identifier type is a <a href="https://doi.org">DOI</a> (i.e., the value
+										<code>06</code> in codelist 5 is for DOIs).</p>
 
-									<pre>&lt;metadata …>
+								<pre>&lt;metadata …>
    &lt;dc:identifier
        id="pub-id">
       urn:doi:10.1016/j.iheduc.2008.03.001
@@ -1886,499 +1874,34 @@
    &lt;/meta>
    …
 &lt;/metadata></pre>
-								</aside>
-							</section>
-
-							<section id="sec-opf-dctitle">
-								<h6>The <code>title</code> Element</h6>
-
-								<p>The [[DCTERMS]] <code>title</code> element represents an instance of a name for the
-										<a>EPUB Publication</a>.</p>
-
-								<dl id="elemdef-opf-dctitle" class="elemdef">
-									<dt>Element Name</dt>
-									<dd>
-										<p>
-											<code>dc:title</code>
-										</p>
-									</dd>
-
-									<dt>Namespace</dt>
-									<dd>
-										<p>
-											<code>http://purl.org/dc/elements/1.1/</code>
-										</p>
-									</dd>
-
-									<dt>Usage</dt>
-									<dd>
-										<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
-													><code>metadata</code></a>.</p>
-									</dd>
-
-									<dt>Attributes</dt>
-									<dd>
-										<ul class="nomark">
-											<li>
-												<p>
-													<a href="#attrdef-dir">
-														<code>dir</code>
-													</a>
-													<code>[optional]</code>
-												</p>
-											</li>
-											<li>
-												<p>
-													<a href="#attrdef-id">
-														<code>id</code>
-													</a>
-													<code>[optional]</code>
-												</p>
-											</li>
-											<li>
-												<p>
-													<a href="#attrdef-xml-lang">
-														<code>xml:lang</code>
-													</a>
-													<code>[optional]</code>
-												</p>
-											</li>
-										</ul>
-									</dd>
-
-									<dt>Content Model</dt>
-									<dd>
-										<p>Text</p>
-									</dd>
-								</dl>
-
-								<p>The <code>metadata</code> section MUST contain at least one <code>title</code>
-									element containing the title for the EPUB Publication.</p>
-
-								<aside class="example" title="A basic title element">
-									<pre>&lt;metadata …>
-   &lt;dc:title>
-      Norwegian Wood
-   &lt;/dc:title>
-   …
-&lt;/metadata>
-</pre>
-								</aside>
-
-								<p id="title-order">The first <code>title</code> element in document order is the main
-									title of the EPUB Publication (i.e., the primary one Reading Systems present to
-									users).</p>
-
-								<p>EPUB Creators should use only a single <code>title</code> element to ensure
-									consistent rendering of the title in Reading Systems.</p>
-
-								<div class="note">
-									<p>Although it is possible to include more than one <code>title</code> element for
-										multipart titles, Reading System support for additional <code>title</code>
-										elements is inconsistent. Reading Systems may ignore the additional segments or
-										combine them in unexpected ways.</p>
-
-									<p>For example, the following example shows a basic multipart title:</p>
-
-									<pre>&lt;metadata …>
-   &lt;dc:title>
-      THE LORD OF THE RINGS
-   &lt;/dc:title>
-   &lt;dc:title>
-      Part One: The Fellowship of the Ring
-   &lt;/dc:title>
-   …
-&lt;/metadata>
-</pre>
-
-									<p>The same title could instead be expressed using a single <code>dc:title</code>
-										element as follows:</p>
-
-									<pre>&lt;metadata …>
-   &lt;dc:title>
-       THE LORD OF THE RINGS, Part One:
-       The Fellowship of the Ring
-   &lt;/dc:title>
-   …
-&lt;/metadata>
-</pre>
-
-									<p>Previous versions of this specification recommended using the <a
-											href="#sec-title-type"><code>title-type</code></a> and <a
-											href="#sec-display-seq"><code>display-seq</code></a> properties to identify
-										and format the segments of multipart titles (see the <a href="#cookbook-ex"
-											>Great Cookbooks example</a>). It is still possible to add these semantics
-										but they are also not well supported.</p>
-								</div>
-							</section>
-
-							<section id="sec-opf-dclanguage">
-								<h6>The <code>language</code> Element</h6>
-
-								<p>The [[DCTERMS]] <code>language</code> element specifies the language of the content
-									of the <a>EPUB Publication</a>.</p>
-
-								<dl id="elemdef-opf-dclanguage" class="elemdef">
-									<dt>Element Name</dt>
-									<dd>
-										<p>
-											<code>dc:language</code>
-										</p>
-									</dd>
-
-									<dt>Namespace</dt>
-									<dd>
-										<p>
-											<code>http://purl.org/dc/elements/1.1/</code>
-										</p>
-									</dd>
-
-									<dt>Usage</dt>
-									<dd>
-										<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
-													><code>metadata</code></a>. Repeatable.</p>
-									</dd>
-
-									<dt>Attributes</dt>
-									<dd>
-										<p>
-											<a href="#attrdef-id">
-												<code>id</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</dd>
-
-									<dt>Content Model</dt>
-									<dd>
-										<p>Text</p>
-									</dd>
-								</dl>
-
-								<p>The <code>metadata</code> section MUST contain at least one <code>language</code>
-									element. The <a>value</a> of each <code>language</code> element MUST be a <a
-										data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
-
-								<aside class="example"
-									title="Specifying U.S. English as the language of the EPUB Publication">
-									<pre>&lt;metadata …>
-   …
-   &lt;dc:language>
-      en-US
-   &lt;/dc:language>
-   …
-&lt;/metadata></pre>
-								</aside>
-
-								<p>Although EPUB Creators MAY specify additional <code>language</code> elements for
-									multilingual Publications, Reading Systems will treat the first
-										<code>language</code> element in document order as the primary language of the
-									EPUB Publication.</p>
-
-								<div class="note">
-									<p><a>Publication Resources</a> do not inherit their language from the
-											<code>dc:language</code> element(s). EPUB Creators must set the language of
-										a resource using the intrinsic methods of the format.</p>
-								</div>
-							</section>
+							</aside>
 						</section>
 
-						<section id="sec-opf-dcmes-optional">
-							<h6>DCMES Optional Elements</h6>
+						<section id="sec-opf-dctitle">
+							<h6>The <code>title</code> Element</h6>
 
-							<section id="sec-opf-dcmes-optional-def">
-								<h6>General Definition</h6>
+							<p>The [[DCTERMS]] <code>title</code> element represents an instance of a name for the
+									<a>EPUB Publication</a>.</p>
 
-								<p>All [[DCTERMS]] elements except for <a href="#sec-opf-dcidentifier"
-											><code>identifier</code></a>, <a href="#sec-opf-dclanguage"
-											><code>language</code></a>, and <a href="#sec-opf-dctitle"
-											><code>title</code></a> are designated as OPTIONAL. These elements conform
-									to the following generalized definition:</p>
-
-								<dl class="elemdef">
-									<dt>Element Name</dt>
-									<dd>
-										<p>
-											<code>contributor</code> | <code>coverage</code> | <code>creator</code> |
-												<code>date</code> | <code>description</code> | <code>format</code> |
-												<code>publisher</code> | <code>relation</code> | <code>rights</code> |
-												<code>source</code> | <code>subject</code> | <code>type</code></p>
-									</dd>
-
-									<dt>Namespace</dt>
-									<dd>
-										<p>
-											<code>http://purl.org/dc/elements/1.1/</code>
-										</p>
-									</dd>
-
-									<dt>Usage</dt>
-									<dd>
-										<p>OPTIONAL child of <a class="codelink" href="#elemdef-opf-metadata"
-													><code>metadata</code></a>. Repeatable.</p>
-									</dd>
-
-									<dt>Attributes</dt>
-									<dd>
-										<ul class="nomark">
-											<li>
-												<p><a href="#attrdef-dir"><code>dir</code></a>
-													<code>[optional]</code> – only allowed on <code>contributor</code>,
-														<code>coverage</code>, <code>creator</code>,
-														<code>description</code>, <code>publisher</code>,
-														<code>relation</code>, <code>rights</code>, and
-														<code>subject</code>.</p>
-											</li>
-											<li>
-												<p><a href="#attrdef-id"><code>id</code></a>
-													<code>[optional]</code> – allowed on any element.</p>
-											</li>
-											<li>
-												<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-													<code>[optional]</code> – only allowed on <code>contributor</code>,
-														<code>coverage</code>, <code>creator</code>,
-														<code>description</code>, <code>publisher</code>,
-														<code>relation</code>, <code>rights</code>, and
-														<code>subject</code>.</p>
-											</li>
-										</ul>
-									</dd>
-
-									<dt>Content Model</dt>
-									<dd>
-										<p>Text</p>
-									</dd>
-								</dl>
-
-								<p>This specification does not modify the [[DCTERMS]] element definitions except as
-									noted in the following sections.</p>
-							</section>
-
-							<section id="sec-opf-dccontributor">
-								<h6>The <code>contributor</code> Element</h6>
-
-								<p>The [[DCTERMS]] <code>contributor</code> element is used to represent the name of a
-									person, organization, etc. that played a secondary role in the creation of the
-									content.</p>
-
-								<p>The requirements for the <code>contributor</code> element are identical to those for
-									the <a href="#sec-opf-dccreator"><code>creator</code> element</a> in all other
-									respects.</p>
-							</section>
-
-							<section id="sec-opf-dccreator">
-								<h6>The <code>creator</code> Element</h6>
-
-								<p>The [[DCTERMS]] <code>creator</code> element represents the name of a person,
-									organization, etc. responsible for the creation of the content. EPUB Creators can <a
-										href="#subexpression">associate</a> a <a href="#role"><code>role</code>
-										property</a> with the element to indicate the function the creator played.</p>
-
-								<aside class="example" title="Specifying that a creator is an author">
-									<p>In this example, the <a href="http://id.loc.gov/vocabulary/relators.html">MARC
-											relators</a> scheme is used to indicate the role (i.e., the value
-											<code>aut</code> indicates an author in MARC).</p>
-
-									<pre>&lt;metadata …>
-   …
-   &lt;dc:creator
-       id="creator">
-      Haruki Murakami
-   &lt;/dc:creator>
-   &lt;meta
-       refines="#creator"
-       property="role"
-       scheme="marc:relators"
-       id="role">
-      aut
-   &lt;/meta>
-   …
-&lt;/metadata></pre>
-								</aside>
-
-								<p>The <code>creator</code> element SHOULD contain the name of the creator as EPUB
-									Creators intend Reading Systems to display it to users.</p>
-
-								<p>EPUB Creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
-									<a href="#subexpression">to associate</a> a normalized form of the creator's name,
-									and the <a href="#alternate-script"><code>alternate-script</code> property</a> to
-									represent the creator's name in another language or script.</p>
-
-								<aside class="example"
-									title="Expressing sorting and rendering information for a creator">
-									<pre>&lt;metadata …>
-   …
-   &lt;dc:creator
-       id="creator">
-      Haruki Murakami
-   &lt;/dc:creator>
-   &lt;meta
-       refines="#creator"
-       property="alternate-script"
-       xml:lang="ja">
-      村上 春樹
-   &lt;/meta>
-   &lt;meta
-       refines="#creator"
-       property="file-as">
-      Murakami, Haruki
-   &lt;/meta>
-   …
-&lt;/metadata></pre>
-								</aside>
-
-								<p>If an EPUB Publication has more than one creator, EPUB Creators SHOULD specify each
-									in a separate <code>creator</code> element.</p>
-
-								<p>The document order of <code>creator</code> elements in the <code>metadata</code>
-									section determines the display priority, where the first <code>creator</code>
-									element encountered is the primary creator.</p>
-
-								<aside class="example" title="Expressing the primary creator">
-									<p>In this example, Lewis Carroll is the primary creator because he is listed
-										first.</p>
-
-									<pre>&lt;metadata …>
-   …
-   &lt;dc:creator
-       id="creator01">
-      Lewis Carroll
-   &lt;/dc:creator>
-   &lt;dc:creator
-       id="creator02">
-      John Tenniel
-   &lt;/dc:creator>
-   …
-&lt;/metadata></pre>
-								</aside>
-
-								<p>EPUB Creators SHOULD represent secondary contributors using the <a
-										href="#sec-opf-dccontributor"><code>contributor</code> element</a>.</p>
-							</section>
-
-							<section id="sec-opf-dcdate">
-								<h6>The <code>date</code> Element</h6>
-
-								<p>The [[DCTERMS]] <code>date</code> element MUST only be used to define the publication
-									date of the <a>EPUB Publication</a>. The publication date is not the same as the <a
-										href="#last-modified-date">last modified date</a> (the last time the EPUB
-									Creator changed the EPUB Publication).</p>
-
-								<p>It is RECOMMENDED that the date string conform to [[ISO8601]], particularly the
-									subset expressed in W3C Date and Time Formats [[DateTime]], as such strings are both
-									human and machine readable.</p>
-
-								<aside class="example" title="Expressing the publication date">
-									<pre>&lt;metadata …>
-   …
-   &lt;dc:date>
-      2000-01-01T00:00:00Z
-   &lt;/dc:date>
-   …
-&lt;/metadata></pre>
-								</aside>
-
-								<p>EPUB Creators SHOULD express additional dates using the specialized date properties
-									available in the [[DCTERMS]] vocabulary, or similar.</p>
-
-								<p>EPUB Publications MUST NOT contain more than one <code>date</code> element.</p>
-							</section>
-
-							<section id="sec-opf-dcsubject">
-								<h6>The <code>subject</code> Element</h6>
-
-								<p>The [[DCTERMS]] <code>subject</code> element identifies the subject of the EPUB
-									Publication. EPUB Creators SHOULD set the <a>value</a> of the element to the
-									human-readable heading or label, but MAY use a code value if the subject taxonomy
-									does not provide a separate descriptive label.</p>
-
-								<p>EPUB Creators MAY identify the system or scheme they drew the element's <a>value</a>
-									from using the <a href="#authority"><code>authority</code> property</a>.</p>
-
-								<p>When a scheme is identified, EPUB Creators MUST <a href="#subexpression"
-										>associate</a> a subject code using the <a href="#term"><code>term</code>
-										property</a>.</p>
-
-								<aside class="example" title="Specifying a BISAC code and heading">
-									<pre>&lt;metadata …>
-   &lt;dc:subject id="subject01">
-      FICTION / Occult &amp;amp; Supernatural
-   &lt;/dc:subject>
-   &lt;meta
-       refines="#subject01"
-       property="authority">
-      BISAC
-   &lt;/meta>
-   &lt;meta
-       refines="#subject01"
-       property="term">
-      FIC024000
-   &lt;/meta>
-&lt;/metadata</pre>
-								</aside>
-
-								<aside class="example" title="Specifying a URL for the scheme">
-									<pre>&lt;metadata …>
-   &lt;dc:subject id="sbj01">
-      Number Theory
-   &lt;/dc:subject>
-   &lt;meta
-       refines="#sbj01"
-       property="authority">
-      http://www.ams.org/msc/msc2010.html
-   &lt;/meta>
-   &lt;meta
-      refines="#sbj01"
-      property="term">
-     11
-  &lt;/meta>
-&lt;/metadata></pre>
-								</aside>
-
-								<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
-											<code>subject</code> element</a> that does not specify a scheme.</p>
-
-								<p>The <a>values</a> of the <code>subject</code> element and <code>term</code> property
-									are case sensitive only when the designated scheme requires.</p>
-							</section>
-
-							<section id="sec-opf-dctype">
-								<h6>The <code>type</code> Element</h6>
-
-								<p>The [[DCTERMS]] <code>type</code> element is used to indicate that the EPUB
-									Publication is of a specialized type (e.g., annotations or a dictionary packaged in
-									EPUB format).</p>
-
-								<p>EPUB Creators MAY use any text string as a <a>value</a>.</p>
-
-								<div class="note">
-									<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB
-										3 Working Group maintained an <a
-											href="http://www.idpf.org/epub/vocab/package/types">informative registry of
-											specialized EPUB Publication types</a> for use with this element. This
-										Working Group no longer maintains this registry and does not anticipate
-										developing new specialized publication types.</p>
-								</div>
-							</section>
-						</section>
-
-						<section id="sec-meta-elem">
-							<h6>The <code>meta</code> Element</h6>
-
-							<p>The <code>meta</code> element provides a generic means of including package metadata.</p>
-
-							<dl id="elemdef-meta" class="elemdef">
+							<dl id="elemdef-opf-dctitle" class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
 									<p>
-										<code>meta</code>
+										<code>dc:title</code>
+									</p>
+								</dd>
+
+								<dt>Namespace</dt>
+								<dd>
+									<p>
+										<code>http://purl.org/dc/elements/1.1/</code>
 									</p>
 								</dd>
 
 								<dt>Usage</dt>
 								<dd>
-									<p>As child of the <a class="codelink" href="#elemdef-opf-metadata"
-												><code>metadata</code></a> element. Repeatable.</p>
+									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
+												><code>metadata</code></a>.</p>
 								</dd>
 
 								<dt>Attributes</dt>
@@ -2402,30 +1925,6 @@
 										</li>
 										<li>
 											<p>
-												<a href="#attrdef-meta-property">
-													<code>property</code>
-												</a>
-												<code>[required]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-refines">
-													<code>refines</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-scheme">
-													<code>scheme</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
 												<a href="#attrdef-xml-lang">
 													<code>xml:lang</code>
 												</a>
@@ -2441,45 +1940,528 @@
 								</dd>
 							</dl>
 
-							<p id="attrdef-meta-property">Each <code>meta</code> element defines a metadata expression.
-								The <code>property</code> attribute takes a <a href="#sec-property-datatype"
-										><var>property</var> data type value</a> that defines the statement made in the
-								expression, and the text content of the element represents the assertion. (Refer to <a
-									href="#sec-vocab-assoc"></a> for more information.)</p>
+							<p>The <code>metadata</code> section MUST contain at least one <code>title</code> element
+								containing the title for the EPUB Publication.</p>
 
-							<p>This specification defines two types of metadata expressions that EPUB Creators can
-								define using the <code>meta</code> element:</p>
+							<aside class="example" title="A basic title element">
+								<pre>&lt;metadata …>
+   &lt;dc:title>
+      Norwegian Wood
+   &lt;/dc:title>
+   …
+&lt;/metadata>
+</pre>
+							</aside>
 
-							<ul>
-								<li id="primary-expression">A <em>primary expression</em> is one in which the expression
-									defined in the <code>meta</code> element establishes some aspect of the <a>EPUB
-										Publication</a>. A <code>meta</code> element that omits a refines attribute
-									defines a primary expression.</li>
-								<li id="subexpression">A <em>subexpression</em> is one in which the expression defined
-									in the <code>meta</code> element is associated with another expression or resource
-									using the <code>refines</code> attribute to enhance its meaning. A subexpression
-									might refine a media clip, for example, by expressing its duration, or refine a
-									creator or contributor expression by defining the role of the person.</li>
-							</ul>
+							<p id="title-order">The first <code>title</code> element in document order is the main title
+								of the EPUB Publication (i.e., the primary one Reading Systems present to users).</p>
 
-							<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions,
-								thereby creating chains of information.</p>
+							<p>EPUB Creators should use only a single <code>title</code> element to ensure consistent
+								rendering of the title in Reading Systems.</p>
 
-							<p class="note">All the DCMES [[DCTERMS]] elements represent primary expressions, and permit
-								refinement by meta element subexpressions.</p>
+							<div class="note">
+								<p>Although it is possible to include more than one <code>title</code> element for
+									multipart titles, Reading System support for additional <code>title</code> elements
+									is inconsistent. Reading Systems may ignore the additional segments or combine them
+									in unexpected ways.</p>
 
-							<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a
-									href="#sec-default-vocab">default vocabulary</a> for use with the
-									<code>property</code> attribute.</p>
-
-							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
-									href="#sec-vocab-assoc"></a>.</p>
-
-							<aside class="example" title="Using properties with reserved prefixes">
-								<p>For the full list of reserved prefixes, refer to <a href="#sec-reserved-prefixes"
-									></a>.</p>
+								<p>For example, the following example shows a basic multipart title:</p>
 
 								<pre>&lt;metadata …>
+   &lt;dc:title>
+      THE LORD OF THE RINGS
+   &lt;/dc:title>
+   &lt;dc:title>
+      Part One: The Fellowship of the Ring
+   &lt;/dc:title>
+   …
+&lt;/metadata>
+</pre>
+
+								<p>The same title could instead be expressed using a single <code>dc:title</code>
+									element as follows:</p>
+
+								<pre>&lt;metadata …>
+   &lt;dc:title>
+       THE LORD OF THE RINGS, Part One:
+       The Fellowship of the Ring
+   &lt;/dc:title>
+   …
+&lt;/metadata>
+</pre>
+
+								<p>Previous versions of this specification recommended using the <a
+										href="#sec-title-type"><code>title-type</code></a> and <a
+										href="#sec-display-seq"><code>display-seq</code></a> properties to identify and
+									format the segments of multipart titles (see the <a href="#cookbook-ex">Great
+										Cookbooks example</a>). It is still possible to add these semantics but they are
+									also not well supported.</p>
+							</div>
+						</section>
+
+						<section id="sec-opf-dclanguage">
+							<h6>The <code>language</code> Element</h6>
+
+							<p>The [[DCTERMS]] <code>language</code> element specifies the language of the content of
+								the <a>EPUB Publication</a>.</p>
+
+							<dl id="elemdef-opf-dclanguage" class="elemdef">
+								<dt>Element Name</dt>
+								<dd>
+									<p>
+										<code>dc:language</code>
+									</p>
+								</dd>
+
+								<dt>Namespace</dt>
+								<dd>
+									<p>
+										<code>http://purl.org/dc/elements/1.1/</code>
+									</p>
+								</dd>
+
+								<dt>Usage</dt>
+								<dd>
+									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
+												><code>metadata</code></a>. Repeatable.</p>
+								</dd>
+
+								<dt>Attributes</dt>
+								<dd>
+									<p>
+										<a href="#attrdef-id">
+											<code>id</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</dd>
+
+								<dt>Content Model</dt>
+								<dd>
+									<p>Text</p>
+								</dd>
+							</dl>
+
+							<p>The <code>metadata</code> section MUST contain at least one <code>language</code>
+								element. The <a>value</a> of each <code>language</code> element MUST be a <a
+									data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
+
+							<aside class="example"
+								title="Specifying U.S. English as the language of the EPUB Publication">
+								<pre>&lt;metadata …>
+   …
+   &lt;dc:language>
+      en-US
+   &lt;/dc:language>
+   …
+&lt;/metadata></pre>
+							</aside>
+
+							<p>Although EPUB Creators MAY specify additional <code>language</code> elements for
+								multilingual Publications, Reading Systems will treat the first <code>language</code>
+								element in document order as the primary language of the EPUB Publication.</p>
+
+							<div class="note">
+								<p><a>Publication Resources</a> do not inherit their language from the
+										<code>dc:language</code> element(s). EPUB Creators must set the language of a
+									resource using the intrinsic methods of the format.</p>
+							</div>
+						</section>
+					</section>
+
+					<section id="sec-opf-dcmes-optional">
+						<h5>DCMES Optional Elements</h5>
+
+						<section id="sec-opf-dcmes-optional-def">
+							<h6>General Definition</h6>
+
+							<p>All [[DCTERMS]] elements except for <a href="#sec-opf-dcidentifier"
+										><code>identifier</code></a>, <a href="#sec-opf-dclanguage"
+										><code>language</code></a>, and <a href="#sec-opf-dctitle"
+									><code>title</code></a> are designated as OPTIONAL. These elements conform to the
+								following generalized definition:</p>
+
+							<dl class="elemdef">
+								<dt>Element Name</dt>
+								<dd>
+									<p>
+										<code>contributor</code> | <code>coverage</code> | <code>creator</code> |
+											<code>date</code> | <code>description</code> | <code>format</code> |
+											<code>publisher</code> | <code>relation</code> | <code>rights</code> |
+											<code>source</code> | <code>subject</code> | <code>type</code></p>
+								</dd>
+
+								<dt>Namespace</dt>
+								<dd>
+									<p>
+										<code>http://purl.org/dc/elements/1.1/</code>
+									</p>
+								</dd>
+
+								<dt>Usage</dt>
+								<dd>
+									<p>OPTIONAL child of <a class="codelink" href="#elemdef-opf-metadata"
+												><code>metadata</code></a>. Repeatable.</p>
+								</dd>
+
+								<dt>Attributes</dt>
+								<dd>
+									<ul class="nomark">
+										<li>
+											<p><a href="#attrdef-dir"><code>dir</code></a>
+												<code>[optional]</code> – only allowed on <code>contributor</code>,
+													<code>coverage</code>, <code>creator</code>,
+													<code>description</code>, <code>publisher</code>,
+													<code>relation</code>, <code>rights</code>, and
+												<code>subject</code>.</p>
+										</li>
+										<li>
+											<p><a href="#attrdef-id"><code>id</code></a>
+												<code>[optional]</code> – allowed on any element.</p>
+										</li>
+										<li>
+											<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
+												<code>[optional]</code> – only allowed on <code>contributor</code>,
+													<code>coverage</code>, <code>creator</code>,
+													<code>description</code>, <code>publisher</code>,
+													<code>relation</code>, <code>rights</code>, and
+												<code>subject</code>.</p>
+										</li>
+									</ul>
+								</dd>
+
+								<dt>Content Model</dt>
+								<dd>
+									<p>Text</p>
+								</dd>
+							</dl>
+
+							<p>This specification does not modify the [[DCTERMS]] element definitions except as noted in
+								the following sections.</p>
+						</section>
+
+						<section id="sec-opf-dccontributor">
+							<h6>The <code>contributor</code> Element</h6>
+
+							<p>The [[DCTERMS]] <code>contributor</code> element is used to represent the name of a
+								person, organization, etc. that played a secondary role in the creation of the
+								content.</p>
+
+							<p>The requirements for the <code>contributor</code> element are identical to those for the
+									<a href="#sec-opf-dccreator"><code>creator</code> element</a> in all other
+								respects.</p>
+						</section>
+
+						<section id="sec-opf-dccreator">
+							<h6>The <code>creator</code> Element</h6>
+
+							<p>The [[DCTERMS]] <code>creator</code> element represents the name of a person,
+								organization, etc. responsible for the creation of the content. EPUB Creators can <a
+									href="#subexpression">associate</a> a <a href="#role"><code>role</code> property</a>
+								with the element to indicate the function the creator played.</p>
+
+							<aside class="example" title="Specifying that a creator is an author">
+								<p>In this example, the <a href="http://id.loc.gov/vocabulary/relators.html">MARC
+										relators</a> scheme is used to indicate the role (i.e., the value
+										<code>aut</code> indicates an author in MARC).</p>
+
+								<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator">
+      Haruki Murakami
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator"
+       property="role"
+       scheme="marc:relators"
+       id="role">
+      aut
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
+							</aside>
+
+							<p>The <code>creator</code> element SHOULD contain the name of the creator as EPUB Creators
+								intend Reading Systems to display it to users.</p>
+
+							<p>EPUB Creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
+								<a href="#subexpression">to associate</a> a normalized form of the creator's name, and
+								the <a href="#alternate-script"><code>alternate-script</code> property</a> to represent
+								the creator's name in another language or script.</p>
+
+							<aside class="example" title="Expressing sorting and rendering information for a creator">
+								<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator">
+      Haruki Murakami
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator"
+       property="alternate-script"
+       xml:lang="ja">
+      村上 春樹
+   &lt;/meta>
+   &lt;meta
+       refines="#creator"
+       property="file-as">
+      Murakami, Haruki
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
+							</aside>
+
+							<p>If an EPUB Publication has more than one creator, EPUB Creators SHOULD specify each in a
+								separate <code>creator</code> element.</p>
+
+							<p>The document order of <code>creator</code> elements in the <code>metadata</code> section
+								determines the display priority, where the first <code>creator</code> element
+								encountered is the primary creator.</p>
+
+							<aside class="example" title="Expressing the primary creator">
+								<p>In this example, Lewis Carroll is the primary creator because he is listed first.</p>
+
+								<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator01">
+      Lewis Carroll
+   &lt;/dc:creator>
+   &lt;dc:creator
+       id="creator02">
+      John Tenniel
+   &lt;/dc:creator>
+   …
+&lt;/metadata></pre>
+							</aside>
+
+							<p>EPUB Creators SHOULD represent secondary contributors using the <a
+									href="#sec-opf-dccontributor"><code>contributor</code> element</a>.</p>
+						</section>
+
+						<section id="sec-opf-dcdate">
+							<h6>The <code>date</code> Element</h6>
+
+							<p>The [[DCTERMS]] <code>date</code> element MUST only be used to define the publication
+								date of the <a>EPUB Publication</a>. The publication date is not the same as the <a
+									href="#last-modified-date">last modified date</a> (the last time the EPUB Creator
+								changed the EPUB Publication).</p>
+
+							<p>It is RECOMMENDED that the date string conform to [[ISO8601]], particularly the subset
+								expressed in W3C Date and Time Formats [[DateTime]], as such strings are both human and
+								machine readable.</p>
+
+							<aside class="example" title="Expressing the publication date">
+								<pre>&lt;metadata …>
+   …
+   &lt;dc:date>
+      2000-01-01T00:00:00Z
+   &lt;/dc:date>
+   …
+&lt;/metadata></pre>
+							</aside>
+
+							<p>EPUB Creators SHOULD express additional dates using the specialized date properties
+								available in the [[DCTERMS]] vocabulary, or similar.</p>
+
+							<p>EPUB Publications MUST NOT contain more than one <code>date</code> element.</p>
+						</section>
+
+						<section id="sec-opf-dcsubject">
+							<h6>The <code>subject</code> Element</h6>
+
+							<p>The [[DCTERMS]] <code>subject</code> element identifies the subject of the EPUB
+								Publication. EPUB Creators SHOULD set the <a>value</a> of the element to the
+								human-readable heading or label, but MAY use a code value if the subject taxonomy does
+								not provide a separate descriptive label.</p>
+
+							<p>EPUB Creators MAY identify the system or scheme they drew the element's <a>value</a> from
+								using the <a href="#authority"><code>authority</code> property</a>.</p>
+
+							<p>When a scheme is identified, EPUB Creators MUST <a href="#subexpression">associate</a> a
+								subject code using the <a href="#term"><code>term</code> property</a>.</p>
+
+							<aside class="example" title="Specifying a BISAC code and heading">
+								<pre>&lt;metadata …>
+   &lt;dc:subject id="subject01">
+      FICTION / Occult &amp;amp; Supernatural
+   &lt;/dc:subject>
+   &lt;meta
+       refines="#subject01"
+       property="authority">
+      BISAC
+   &lt;/meta>
+   &lt;meta
+       refines="#subject01"
+       property="term">
+      FIC024000
+   &lt;/meta>
+&lt;/metadata</pre>
+							</aside>
+
+							<aside class="example" title="Specifying a URL for the scheme">
+								<pre>&lt;metadata …>
+   &lt;dc:subject id="sbj01">
+      Number Theory
+   &lt;/dc:subject>
+   &lt;meta
+       refines="#sbj01"
+       property="authority">
+      http://www.ams.org/msc/msc2010.html
+   &lt;/meta>
+   &lt;meta
+      refines="#sbj01"
+      property="term">
+     11
+  &lt;/meta>
+&lt;/metadata></pre>
+							</aside>
+
+							<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
+										<code>subject</code> element</a> that does not specify a scheme.</p>
+
+							<p>The <a>values</a> of the <code>subject</code> element and <code>term</code> property are
+								case sensitive only when the designated scheme requires.</p>
+						</section>
+
+						<section id="sec-opf-dctype">
+							<h6>The <code>type</code> Element</h6>
+
+							<p>The [[DCTERMS]] <code>type</code> element is used to indicate that the EPUB Publication
+								is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
+								format).</p>
+
+							<p>EPUB Creators MAY use any text string as a <a>value</a>.</p>
+
+							<div class="note">
+								<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
+									Working Group maintained an <a href="http://www.idpf.org/epub/vocab/package/types"
+										>informative registry of specialized EPUB Publication types</a> for use with
+									this element. This Working Group no longer maintains this registry and does not
+									anticipate developing new specialized publication types.</p>
+							</div>
+						</section>
+					</section>
+
+					<section id="sec-meta-elem">
+						<h5>The <code>meta</code> Element</h5>
+
+						<p>The <code>meta</code> element provides a generic means of including package metadata.</p>
+
+						<dl id="elemdef-meta" class="elemdef">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>meta</code>
+								</p>
+							</dd>
+
+							<dt>Usage</dt>
+							<dd>
+								<p>As child of the <a class="codelink" href="#elemdef-opf-metadata"
+											><code>metadata</code></a> element. Repeatable.</p>
+							</dd>
+
+							<dt>Attributes</dt>
+							<dd>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#attrdef-dir">
+												<code>dir</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-id">
+												<code>id</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-meta-property">
+												<code>property</code>
+											</a>
+											<code>[required]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-refines">
+												<code>refines</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-scheme">
+												<code>scheme</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-xml-lang">
+												<code>xml:lang</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
+
+							<dt>Content Model</dt>
+							<dd>
+								<p>Text</p>
+							</dd>
+						</dl>
+
+						<p id="attrdef-meta-property">Each <code>meta</code> element defines a metadata expression. The
+								<code>property</code> attribute takes a <a href="#sec-property-datatype"
+									><var>property</var> data type value</a> that defines the statement made in the
+							expression, and the text content of the element represents the assertion. (Refer to <a
+								href="#sec-vocab-assoc"></a> for more information.)</p>
+
+						<p>This specification defines two types of metadata expressions that EPUB Creators can define
+							using the <code>meta</code> element:</p>
+
+						<ul>
+							<li id="primary-expression">A <em>primary expression</em> is one in which the expression
+								defined in the <code>meta</code> element establishes some aspect of the <a>EPUB
+									Publication</a>. A <code>meta</code> element that omits a refines attribute defines
+								a primary expression.</li>
+							<li id="subexpression">A <em>subexpression</em> is one in which the expression defined in
+								the <code>meta</code> element is associated with another expression or resource using
+								the <code>refines</code> attribute to enhance its meaning. A subexpression might refine
+								a media clip, for example, by expressing its duration, or refine a creator or
+								contributor expression by defining the role of the person.</li>
+						</ul>
+
+						<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions, thereby
+							creating chains of information.</p>
+
+						<p class="note">All the DCMES [[DCTERMS]] elements represent primary expressions, and permit
+							refinement by meta element subexpressions.</p>
+
+						<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a
+								href="#sec-default-vocab">default vocabulary</a> for use with the <code>property</code>
+							attribute.</p>
+
+						<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+							></a>.</p>
+
+						<aside class="example" title="Using properties with reserved prefixes">
+							<p>For the full list of reserved prefixes, refer to <a href="#sec-reserved-prefixes"
+								></a>.</p>
+
+							<pre>&lt;metadata …>
    …
    &lt;meta
        property="dcterms:modified">
@@ -2495,18 +2477,18 @@
    &lt;/meta>
    …
 &lt;/metadata></pre>
-							</aside>
+						</aside>
 
-							<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme the
-								EPUB Creator obtained the element's <a>value</a> from. The value of the attribute MUST
-								be a <a href="#sec-property-datatype"><var>property</var> data type value</a> that
-								resolves to the resource that defines the scheme.</p>
+						<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme the
+							EPUB Creator obtained the element's <a>value</a> from. The value of the attribute MUST be a
+								<a href="#sec-property-datatype"><var>property</var> data type value</a> that resolves
+							to the resource that defines the scheme.</p>
 
-							<aside class="example" title="Using values from a scheme">
-								<p>In this example, the <code>scheme</code> attribute indicates that the <a>value</a> of
-									the tag is from [[ONIX]] code list 5 (i.e., the value <code>15</code> indicates an
-									13 digit ISBN).</p>
-								<pre>&lt;metadata &#8230;>
+						<aside class="example" title="Using values from a scheme">
+							<p>In this example, the <code>scheme</code> attribute indicates that the <a>value</a> of the
+								tag is from [[ONIX]] code list 5 (i.e., the value <code>15</code> indicates an 13 digit
+								ISBN).</p>
+							<pre>&lt;metadata &#8230;>
    &#8230;
    &lt;meta
        refines="#isbn-id"
@@ -2516,22 +2498,22 @@
    &lt;/meta>
    &#8230;
 &lt;/metadata></pre>
-							</aside>
-						</section>
+						</aside>
+					</section>
 
-						<section id="sec-metadata-last-modified">
-							<h6>Last Modified Date</h6>
+					<section id="sec-metadata-last-modified">
+						<h5>Last Modified Date</h5>
 
-							<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one
-								[[DCTERMS]] <code>modified</code> property containing the last modification date. The
-									<a>value</a> of this property MUST be an [[XMLSCHEMA-2]] dateTime conformant date of
-								the form: <code>CCYY-MM-DDThh:mm:ssZ</code></p>
+						<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one
+							[[DCTERMS]] <code>modified</code> property containing the last modification date. The
+								<a>value</a> of this property MUST be an [[XMLSCHEMA-2]] dateTime conformant date of the
+							form: <code>CCYY-MM-DDThh:mm:ssZ</code></p>
 
-							<p>EPUB Creators MUST express the last modification date in Coordinated Universal Time (UTC)
-								and MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>
+						<p>EPUB Creators MUST express the last modification date in Coordinated Universal Time (UTC) and
+							MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>
 
-							<aside class="example" title="Expressing a last modification date">
-								<pre>&lt;metadata …>
+						<aside class="example" title="Expressing a last modification date">
+							<pre>&lt;metadata …>
    …
    &lt;meta
        property="dcterms:modified">
@@ -2539,143 +2521,141 @@
    &lt;/meta>
    …
 &lt;/metadata></pre>
-							</aside>
+						</aside>
 
-							<p>EPUB Creators should update the last modified date whenever they make changes to the EPUB
-								Publication.</p>
+						<p>EPUB Creators should update the last modified date whenever they make changes to the EPUB
+							Publication.</p>
 
-							<p>EPUB Creators MAY specify additional modified properties in the Package Document
-								metadata, but they MUST have a different subject (i.e., they require a
-									<code>refines</code> attribute that references an element or resource).</p>
+						<p>EPUB Creators MAY specify additional modified properties in the Package Document metadata,
+							but they MUST have a different subject (i.e., they require a <code>refines</code> attribute
+							that references an element or resource).</p>
 
-							<div class="note">
-								<p>The requirements for the last modification date are to ensure compatibility with
-									earlier versions of EPUB 3 that defined a <a
-										href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
-										>release identifier</a> [[EPUBPackages-32]] for EPUB Publications.</p>
-							</div>
-						</section>
+						<div class="note">
+							<p>The requirements for the last modification date are to ensure compatibility with earlier
+								versions of EPUB 3 that defined a <a
+									href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
+									>release identifier</a> [[EPUBPackages-32]] for EPUB Publications.</p>
+						</div>
+					</section>
 
-						<section id="sec-link-elem">
-							<h6>The <code>link</code> Element</h6>
+					<section id="sec-link-elem">
+						<h5>The <code>link</code> Element</h5>
 
-							<p>The <code>link</code> element associates resources with an <a>EPUB Publication</a>, such
-								as metadata records.</p>
+						<p>The <code>link</code> element associates resources with an <a>EPUB Publication</a>, such as
+							metadata records.</p>
 
-							<dl id="elemdef-opf-link" class="elemdef">
-								<dt>Element Name</dt>
-								<dd>
-									<p>
-										<code>link</code>
-									</p>
-								</dd>
+						<dl id="elemdef-opf-link" class="elemdef">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>link</code>
+								</p>
+							</dd>
 
-								<dt>Usage</dt>
-								<dd>
-									<p>As a child of <a class="codelink" href="#elemdef-opf-metadata"
-												><code>metadata</code></a>. Repeatable.</p>
-								</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>As a child of <a class="codelink" href="#elemdef-opf-metadata"
+										><code>metadata</code></a>. Repeatable.</p>
+							</dd>
 
-								<dt>Attributes</dt>
-								<dd>
-									<ul class="nomark">
-										<li>
-											<p>
-												<a href="#attrdef-href">
-													<code>href</code>
-												</a>
-												<code>[required]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-hreflang">
-													<code>hreflang</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-id">
-													<code>id</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-link-media-type">
-													<code>media-type</code>
-												</a>
-												<code>[conditionally required]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-properties">
-													<code>properties</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-refines">
-													<code>refines</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-link-rel">
-													<code>rel</code>
-												</a>
-												<code>[required]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#attrdef-href">
+												<code>href</code>
+											</a>
+											<code>[required]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-hreflang">
+												<code>hreflang</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-id">
+												<code>id</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-link-media-type">
+												<code>media-type</code>
+											</a>
+											<code>[conditionally required]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-properties">
+												<code>properties</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-refines">
+												<code>refines</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-link-rel">
+												<code>rel</code>
+											</a>
+											<code>[required]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
 
-								<dt>Content Model</dt>
-								<dd>
-									<p>Empty</p>
-								</dd>
-							</dl>
+							<dt>Content Model</dt>
+							<dd>
+								<p>Empty</p>
+							</dd>
+						</dl>
 
-							<p>The <a href="#sec-metadata-elem"><code>metadata</code> element</a> MAY contain zero or
-								more <code>link</code> elements, each of which identifies the location of a linked
-								resource in its REQUIRED <code>href</code> attribute</p>
+						<p>The <a href="#sec-metadata-elem"><code>metadata</code> element</a> MAY contain zero or more
+								<code>link</code> elements, each of which identifies the location of a linked resource
+							in its REQUIRED <code>href</code> attribute</p>
 
-							<p id="linked-res-manifest">Linked Resources are <a>Publication Resources</a> only when they
-								are:</p>
+						<p id="linked-res-manifest">Linked Resources are <a>Publication Resources</a> only when they
+							are:</p>
 
-							<ul>
-								<li>
-									<p>referenced from the <a href="#sec-spine-elem">spine</a>; or</p>
-								</li>
-								<li>
-									<p>included or embedded in an EPUB Content Document (e.g., a metadata record
-										serialized as RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]] embedded in an
-										[[HTML]] <a data-cite="html#the-script-element"><code>script</code>
-										element</a>).</p>
-								</li>
-							</ul>
+						<ul>
+							<li>
+								<p>referenced from the <a href="#sec-spine-elem">spine</a>; or</p>
+							</li>
+							<li>
+								<p>included or embedded in an EPUB Content Document (e.g., a metadata record serialized
+									as RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]] embedded in an [[HTML]] <a
+										data-cite="html#the-script-element"><code>script</code> element</a>).</p>
+							</li>
+						</ul>
 
-							<p>In all other cases (e.g., when linking to standalone [[?ONIX]] or [[?XMP]] records), the
-								linked resources are not Publication Resources (i.e., are not subject to <a
-									href="#sec-core-media-types">Core Media Type requirements</a>) and EPUB Creators
-								MUST NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
+						<p>In all other cases (e.g., when linking to standalone [[?ONIX]] or [[?XMP]] records), the
+							linked resources are not Publication Resources (i.e., are not subject to <a
+								href="#sec-core-media-types">Core Media Type requirements</a>) and EPUB Creators MUST
+							NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
 
-							<aside class="example" title="Reference to a record embedded in an XHTML Content Document">
-								<p>In this example, the metadata record is embedded in a <code>script</code> element.
-									Note that the media type of the embedded record (i.e.,
-										<code>application/ld+json</code>) is obtained from the <code>type</code>
-									attribute on the <code>script</code> element; it is not specified in the
-										<code>link</code> element.</p>
+						<aside class="example" title="Reference to a record embedded in an XHTML Content Document">
+							<p>In this example, the metadata record is embedded in a <code>script</code> element. Note
+								that the media type of the embedded record (i.e., <code>application/ld+json</code>) is
+								obtained from the <code>type</code> attribute on the <code>script</code> element; it is
+								not specified in the <code>link</code> element.</p>
 
-								<pre>Package Document:
+							<pre>Package Document:
 
 &lt;package …>
    &lt;metadata …>
@@ -2705,28 +2685,28 @@ XHTML:
       …
    &lt;/body>
 &lt;/html></pre>
-							</aside>
+						</aside>
 
-							<p id="linked-res-location">EPUB Creators MAY locate linked resources <a
-									data-lt="Local Resource">locally</a> or <a data-lt="Remote Resource">remotely</a>,
-								but should consider that <a>Reading Systems</a> are not required to retrieve to Remote
-								Resources (i.e., Reading Systems might not make Remote Resources available).</p>
+						<p id="linked-res-location">EPUB Creators MAY locate linked resources <a
+								data-lt="Local Resource">locally</a> or <a data-lt="Remote Resource">remotely</a>, but
+							should consider that <a>Reading Systems</a> are not required to retrieve to Remote Resources
+							(i.e., Reading Systems might not make Remote Resources available).</p>
 
-							<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
-									attribute</a> is OPTIONAL when a linked resource is located outside the EPUB
-								Container, as more than one media type could be served from the same URL [[URL]]. EPUB
-								Creators MUST specify the attribute for all <a>Local Resources</a>.</p>
+						<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
+								attribute</a> is OPTIONAL when a linked resource is located outside the EPUB Container,
+							as more than one media type could be served from the same URL [[URL]]. EPUB Creators MUST
+							specify the attribute for all <a>Local Resources</a>.</p>
 
-							<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the
-								language of the linked resource. The value MUST be a <a data-cite="bcp47#section-2.2.9"
-									>well-formed language tag</a> [[BCP47]].</p>
+						<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of
+							the linked resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed
+								language tag</a> [[BCP47]].</p>
 
-							<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated
-								list of <a href="#sec-property-datatype">property</a> values that establish the
-								relationship the resource has with the EPUB Publication.</p>
+						<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated list of
+								<a href="#sec-property-datatype">property</a> values that establish the relationship the
+							resource has with the EPUB Publication.</p>
 
-							<aside class="example" title="Linking to a MARC XML record">
-								<pre>&lt;metadata …>
+						<aside class="example" title="Linking to a MARC XML record">
+							<pre>&lt;metadata …>
    …
    &lt;link
        rel="record"
@@ -2734,19 +2714,19 @@ XHTML:
        media-type="application/marc"/>
    …
 &lt;/metadata></pre>
-							</aside>
+						</aside>
 
-							<p>The value of the <code>media-type</code> attribute is not always sufficient to identify
-								the type of linked resource (e.g., many XML-based record formats use the media type
-									"<code>application/xml</code>"). To aid Reading Systems in the identification of
-								such generic resources, the <code>properties</code> attribute can specify a semantic
-								identifier.</p>
+						<p>The value of the <code>media-type</code> attribute is not always sufficient to identify the
+							type of linked resource (e.g., many XML-based record formats use the media type
+								"<code>application/xml</code>"). To aid Reading Systems in the identification of such
+							generic resources, the <code>properties</code> attribute can specify a semantic
+							identifier.</p>
 
-							<aside class="example" title="Identifying a record type via a property">
-								<p>In this example, the <code>properties</code> attribute identifies the link is to a
-									XMP record.</p>
+						<aside class="example" title="Identifying a record type via a property">
+							<p>In this example, the <code>properties</code> attribute identifies the link is to a XMP
+								record.</p>
 
-								<pre>&lt;metadata …>
+							<pre>&lt;metadata …>
    …
    &lt;link rel="record"
        href="http://example.org/meta/12389347?format=xmp"
@@ -2754,22 +2734,22 @@ XHTML:
        properties="xmp"/>
    …
 &lt;/metadata></pre>
-							</aside>
+						</aside>
 
-							<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a
-									href="#sec-default-vocab">default vocabulary</a> for the <code>rel</code> and
-									<code>properties</code> attributes.</p>
+						<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a
+								href="#sec-default-vocab">default vocabulary</a> for the <code>rel</code> and
+								<code>properties</code> attributes.</p>
 
-							<p><a>EPUB Creators</a> MAY add relationships and properties from other vocabularies as
-								defined in <a href="#sec-vocab-assoc"></a>.</p>
+						<p><a>EPUB Creators</a> MAY add relationships and properties from other vocabularies as defined
+							in <a href="#sec-vocab-assoc"></a>.</p>
 
-							<aside class="example" title="Declaring a new link relationship">
-								<p>In this example, the <code>link</code> element is used to associate an author's home
-									page using the FOAF vocabulary. Note that as <code>foaf</code> is not a <a
-										href="#sec-metadata-reserved-prefixes">predefined prefix</a>, it must be
-									declared in the <a href="#attrdef-package-prefix">prefix attribute</a>.</p>
+						<aside class="example" title="Declaring a new link relationship">
+							<p>In this example, the <code>link</code> element is used to associate an author's home page
+								using the FOAF vocabulary. Note that as <code>foaf</code> is not a <a
+									href="#sec-metadata-reserved-prefixes">predefined prefix</a>, it must be declared in
+								the <a href="#attrdef-package-prefix">prefix attribute</a>.</p>
 
-								<pre>&lt;package
+							<pre>&lt;package
     …
     prefix="foaf: http://xmlns.com/foaf/spec/">
    &lt;metadata …>
@@ -2783,23 +2763,22 @@ XHTML:
    …
 &lt;/package>
 </pre>
-							</aside>
+						</aside>
 
-							<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB Creators MAY provide one or
-								more <a href="#record">linked metadata records</a> to enhance the information available
-								to Reading Systems, but Reading Systems may ignore these records.</p>
+						<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB Creators MAY provide one or
+							more <a href="#record">linked metadata records</a> to enhance the information available to
+							Reading Systems, but Reading Systems may ignore these records.</p>
 
-							<p>When a Reading System <a data-cite="epub-rs-33#sec-linked-records">processes linked
-									records</a> [[EPUB-RS-33]], the document order of <code>link</code> elements is used
-								to determine which has the highest priority in the case of conflicts (i.e., first in
-								document order has the highest priority).</p>
+						<p>When a Reading System <a data-cite="epub-rs-33#sec-linked-records">processes linked
+								records</a> [[EPUB-RS-33]], the document order of <code>link</code> elements is used to
+							determine which has the highest priority in the case of conflicts (i.e., first in document
+							order has the highest priority).</p>
 
-							<aside class="example" title="Specifying metadata precedence">
-								<p>In this example, the first remote record has the highest precedence, the local record
-									has the next highest, and the metadata in the <code>metadata</code> element the
-									lowest.</p>
+						<aside class="example" title="Specifying metadata precedence">
+							<p>In this example, the first remote record has the highest precedence, the local record has
+								the next highest, and the metadata in the <code>metadata</code> element the lowest.</p>
 
-								<pre>&lt;metadata …>
+							<pre>&lt;metadata …>
    &lt;link rel="record"
        href="http://example.org/onix/12389347"
        media-type="application/xml"
@@ -2811,23 +2790,22 @@ XHTML:
     
     …
 &lt;/metadata></pre>
-							</aside>
+						</aside>
 
-							<div class="note">
-								<p>Due to the variety of metadata record formats and serializations that an EPUB Creator
-									can link to an EPUB Publication, and the complexity of comparing metadata properties
-									between them, this specification does not require Reading Systems to process linked
-									records.</p>
-							</div>
+						<div class="note">
+							<p>Due to the variety of metadata record formats and serializations that an EPUB Creator can
+								link to an EPUB Publication, and the complexity of comparing metadata properties between
+								them, this specification does not require Reading Systems to process linked records.</p>
+						</div>
 
-							<p>In addition to full records, EPUB Creators MAY also use the <code>link</code> element to
-								identify individual metadata properties available in an alternative format.</p>
+						<p>In addition to full records, EPUB Creators MAY also use the <code>link</code> element to
+							identify individual metadata properties available in an alternative format.</p>
 
-							<aside class="example" title="Link to a description">
-								<p>In this example, the description of the EPUB Publication is contained in an HTML
-									document.</p>
+						<aside class="example" title="Link to a description">
+							<p>In this example, the description of the EPUB Publication is contained in an HTML
+								document.</p>
 
-								<pre>&lt;metadata …>
+							<pre>&lt;metadata …>
    …
    &lt;link
        rel="dcterms:description"
@@ -2835,259 +2813,252 @@ XHTML:
        media-type="text/html"/>
    …
 &lt;/metadata></pre>
-							</aside>
-						</section>
+						</aside>
+					</section>
+				</section>
+
+				<section id="sec-pkg-manifest">
+					<h4>Manifest Section</h4>
+
+					<section id="sec-manifest-elem">
+						<h5>The <code>manifest</code> Element</h5>
+
+						<p>The <code>manifest</code> element provides an exhaustive list of <a>Publication Resources</a>
+							used in the rendering of the content.</p>
+
+						<dl id="elemdef-opf-manifest" class="elemdef">
+							<dt>Element name</dt>
+							<dd>
+								<p>
+									<code>manifest</code>
+								</p>
+							</dd>
+
+							<dt>Usage</dt>
+							<dd>
+								<p>REQUIRED second child of <a class="codelink" href="#elemdef-opf-package"
+											><code>package</code></a>, following <a class="codelink"
+										href="#elemdef-opf-metadata"><code>metadata</code></a>.</p>
+							</dd>
+
+							<dt>Attributes</dt>
+							<dd>
+								<p>
+									<a href="#attrdef-id">
+										<code>id</code>
+									</a>
+									<code>[optional]</code>
+								</p>
+							</dd>
+
+							<dt>Content Model</dt>
+							<dd>
+								<p>
+									<a class="codelink" href="#elemdef-package-item">
+										<code>item</code>
+									</a>
+									<code>[1 or more]</code>
+								</p>
+							</dd>
+						</dl>
+
+						<p id="confreq-rendition-manifest">EPUB Creators MUST list all <a>Publication Resources</a> in
+							the <code>manifest</code>, regardless of whether they are <a data-lt="Local Resource"
+								>Local</a> or <a>Remote Resources</a>, using <a class="codelink" href="#sec-item-elem"
+									><code>item</code> elements</a>.</p>
+
+						<p>Note that the <code>manifest</code> is not self-referencing: EPUB Creators MUST NOT specify
+							an <code>item</code> element that refers to the Package Document itself.</p>
+
+						<div class="note">
+							<p>Failure to provide a complete manifest of resources may lead to rendering issues. Reading
+								Systems might not unzip such resources or could prevent access to them for security
+								reasons.</p>
+						</div>
 					</section>
 
-					<section id="sec-pkg-manifest">
-						<h5>Manifest Section</h5>
+					<section id="sec-item-elem">
+						<h5>The <code>item</code> Element</h5>
 
-						<section id="sec-manifest-elem">
-							<h6>The <code>manifest</code> Element</h6>
+						<p>The <code>item</code> element represents a <a>Publication Resource</a>.</p>
 
-							<p>The <code>manifest</code> element provides an exhaustive list of <a>Publication
-									Resources</a> used in the rendering of the content.</p>
+						<dl id="elemdef-package-item" class="elemdef">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>item</code>
+								</p>
+							</dd>
 
-							<dl id="elemdef-opf-manifest" class="elemdef">
-								<dt>Element name</dt>
-								<dd>
-									<p>
-										<code>manifest</code>
-									</p>
-								</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>As a child of <a class="codelink" href="#elemdef-opf-manifest"
+										><code>manifest</code></a>. Repeatable.</p>
+							</dd>
 
-								<dt>Usage</dt>
-								<dd>
-									<p>REQUIRED second child of <a class="codelink" href="#elemdef-opf-package"
-												><code>package</code></a>, following <a class="codelink"
-											href="#elemdef-opf-metadata"><code>metadata</code></a>.</p>
-								</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#attrdef-item-fallback">
+												<code>fallback</code>
+											</a>
+											<code>[conditionally required]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-href">
+												<code>href</code>
+											</a>
+											<code>[required]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-id">
+												<code>id</code>
+											</a>
+											<code>[required]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-item-media-overlay">
+												<code>media-overlay</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-item-media-type">
+												<code>media-type</code>
+											</a>
+											<code>[required]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-properties">
+												<code>properties</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
 
-								<dt>Attributes</dt>
-								<dd>
-									<p>
-										<a href="#attrdef-id">
-											<code>id</code>
-										</a>
-										<code>[optional]</code>
-									</p>
-								</dd>
+							<dt>Content Model</dt>
+							<dd>
+								<p>Empty</p>
+							</dd>
+						</dl>
 
-								<dt>Content Model</dt>
-								<dd>
-									<p>
-										<a class="codelink" href="#elemdef-package-item">
-											<code>item</code>
-										</a>
-										<code>[1 or more]</code>
-									</p>
-								</dd>
-							</dl>
+						<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL [[URL]] in
+							its <code>href</code> attribute. The value MUST be an <a data-cite="url#absolute-url-string"
+								>absolute-</a> or <a data-cite="url#path-relative-scheme-less-url-string"
+								>path-relative-scheme-less-URL</a> string [[URL]]. EPUB Creators MUST ensure each URL is
+							unique within the <code>manifest</code> scope after <a href="#sec-parse-package-urls"
+								>parsing</a>.</p>
 
-							<p id="confreq-rendition-manifest">EPUB Creators MUST list all <a>Publication Resources</a>
-								in the <code>manifest</code>, regardless of whether they are <a data-lt="Local Resource"
-									>Local</a> or <a>Remote Resources</a>, using <a class="codelink"
-									href="#sec-item-elem"><code>item</code> elements</a>.</p>
+						<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
+							element MUST conform to the applicable specification(s) as inferred from the MIME media type
+							provided in the <a href="#attrdef-media-type"><code>media-type</code> attribute</a>. For
+								<a>Core Media Type Resources</a>, EPUB Creators MUST use the media type designated in <a
+								href="#sec-cmt-supported"></a>.</p>
 
-							<p>Note that the <code>manifest</code> is not self-referencing: EPUB Creators MUST NOT
-								specify an <code>item</code> element that refers to the Package Document itself.</p>
+						<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[XML]] that
+							identifies a fallback for the Publication Resource referenced from the <code>item</code>
+							element, as defined in <a href="#sec-foreign-restrictions-manifest"></a>.</p>
+
+						<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
+								Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
+								<code>properties</code> attribute.</p>
+
+						<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+							></a>.</p>
+
+						<p>EPUB Creators MUST declare all applicable descriptive metadata properties for each
+							Publication Resource in this attribute (e.g., if the resource is the <a
+								href="#sec-cover-image">cover image</a>, contains <a href="#sec-scripted">scripting</a>,
+							or references <a href="#sec-remote-resources">remote resources</a>).</p>
+
+						<p>EPUB Creators MUST declare exactly one <code>item</code> as the <a>EPUB Navigation
+								Document</a> using the <code>nav</code> property.</p>
+
+						<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF
+							[[XML]] that identifies the <a>Media Overlay Document</a> for the resource described by this
+								<code>item</code>. Refer to <a href="#sec-docs-package"></a> for more information.</p>
+
+						<div class="note">
+							<p>The order of <code>item</code> elements in the <code>manifest</code> is not significant.
+								The <a class="codelink" href="#sec-spine-elem"><code>spine</code> element</a> provides
+								the presentation sequence of content documents.</p>
+						</div>
+
+						<section id="sec-foreign-restrictions-manifest">
+							<h6>Manifest Fallbacks</h6>
+
+							<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback
+								chains to Core Media Type Resources. They are used to create fallbacks for Foreign
+								Resources in the <a href="#sec-spine-elem">spine</a> and when intrinsic fallback
+								capabilities are not available (e.g., for the [[HTML]] <a
+									data-cite="html#the-img-element"><code>img</code></a> element) in order to satisfy
+								the requirements in <a href="#sec-foreign-restrictions"></a>.</p>
+
+							<p>The <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> on the
+									<a>manifest</a>
+								<a href="#elemdef-package-item"><code>item</code></a> element specifies the fallback for
+								the referenced Publication Resource. The <code>fallback</code> attribute's IDREF [[XML]]
+								value MUST resolve to another <code>item</code> in the <code>manifest</code>. This
+								fallback <code>item</code> MAY itself specify another fallback <code>item</code>, and so
+								on.</p>
+
+							<p>The ordered list of all the ID references that a Reading System can reach, starting from
+								a given item's <code>fallback</code> attribute, represents the <em>fallback chain</em>
+								for that item. The order of the resources in the fallback chain represents the EPUB
+								Creator's preferred fallback order.</p>
+
+							<p>Fallback chains MUST conform to one of the following requirements, as appropriate:</p>
+
+							<ul>
+								<li>
+									<p>For Foreign Resources referenced directly from spine <a
+											href="#elemdef-spine-itemref"><code>itemref</code> elements</a>, the chain
+										MUST contain at least one <a>EPUB Content Document</a>.</p>
+								</li>
+								<li>
+									<p>For Foreign Resources for which an EPUB Creator cannot provide an intrinsic
+										fallback, the chain MUST contain at least one <a>Core Media Type
+										Resource</a>.</p>
+								</li>
+							</ul>
+
+							<p>Fallback chains MUST NOT contain circular or self-references to <code>item</code>
+								elements in the chain.</p>
+
+							<p>EPUB Creators MAY provide fallbacks for <a>Top-Level Content Documents</a> that are EPUB
+								Content Documents (e.g., to provide <a href="#confreq-cd-scripted-flbk">fallbacks for
+									scripted content</a>).</p>
+
+							<p>EPUB Creators MAY also provide manifest fallbacks for <a>Core Media Type Resources</a>
+								(e.g., to provide a static alternative to a <a>Scripted Content Document</a>).</p>
 
 							<div class="note">
-								<p>Failure to provide a complete manifest of resources may lead to rendering issues.
-									Reading Systems might not unzip such resources or could prevent access to them for
-									security reasons.</p>
+								<p>As it is not possible to use manifest fallbacks for resources represented in <a
+										href="#sec-data-urls">data URLs</a>, EPUB Creators can only represent Foreign
+									Resources as data URLs where an intrinsic fallback mechanism is available.</p>
 							</div>
 						</section>
 
-						<section id="sec-item-elem">
-							<h6>The <code>item</code> Element</h6>
+						<section id="sec-item-elem-examples">
+							<h6>Examples</h6>
 
-							<p>The <code>item</code> element represents a <a>Publication Resource</a>.</p>
-
-							<dl id="elemdef-package-item" class="elemdef">
-								<dt>Element Name</dt>
-								<dd>
-									<p>
-										<code>item</code>
-									</p>
-								</dd>
-
-								<dt>Usage</dt>
-								<dd>
-									<p>As a child of <a class="codelink" href="#elemdef-opf-manifest"
-												><code>manifest</code></a>. Repeatable.</p>
-								</dd>
-
-								<dt>Attributes</dt>
-								<dd>
-									<ul class="nomark">
-										<li>
-											<p>
-												<a href="#attrdef-item-fallback">
-													<code>fallback</code>
-												</a>
-												<code>[conditionally required]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-href">
-													<code>href</code>
-												</a>
-												<code>[required]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-id">
-													<code>id</code>
-												</a>
-												<code>[required]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-item-media-overlay">
-													<code>media-overlay</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-item-media-type">
-													<code>media-type</code>
-												</a>
-												<code>[required]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-properties">
-													<code>properties</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
-
-								<dt>Content Model</dt>
-								<dd>
-									<p>Empty</p>
-								</dd>
-							</dl>
-
-							<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL
-								[[URL]] in its <code>href</code> attribute. The value MUST be an <a
-									data-cite="url#absolute-url-string">absolute-</a> or <a
-									data-cite="url#path-relative-scheme-less-url-string"
-									>path-relative-scheme-less-URL</a> string [[URL]]. EPUB Creators MUST ensure each
-								URL is unique within the <code>manifest</code> scope after <a
-									href="#sec-parse-package-urls">parsing</a>.</p>
-
-							<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
-								element MUST conform to the applicable specification(s) as inferred from the MIME media
-								type provided in the <a href="#attrdef-media-type"><code>media-type</code>
-								attribute</a>. For <a>Core Media Type Resources</a>, EPUB Creators MUST use the media
-								type designated in <a href="#sec-cmt-supported"></a>.</p>
-
-							<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[XML]]
-								that identifies a fallback for the Publication Resource referenced from the
-									<code>item</code> element, as defined in <a
-									href="#sec-foreign-restrictions-manifest"></a>.</p>
-
-							<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
-									Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
-									<code>properties</code> attribute.</p>
-
-							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
-									href="#sec-vocab-assoc"></a>.</p>
-
-							<p>EPUB Creators MUST declare all applicable descriptive metadata properties for each
-								Publication Resource in this attribute (e.g., if the resource is the <a
-									href="#sec-cover-image">cover image</a>, contains <a href="#sec-scripted"
-									>scripting</a>, or references <a href="#sec-remote-resources">remote
-								resources</a>).</p>
-
-							<p>EPUB Creators MUST declare exactly one <code>item</code> as the <a>EPUB Navigation
-									Document</a> using the <code>nav</code> property.</p>
-
-							<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF
-								[[XML]] that identifies the <a>Media Overlay Document</a> for the resource described by
-								this <code>item</code>. Refer to <a href="#sec-docs-package"></a> for more
-								information.</p>
-
-							<div class="note">
-								<p>The order of <code>item</code> elements in the <code>manifest</code> is not
-									significant. The <a class="codelink" href="#sec-spine-elem"><code>spine</code>
-										element</a> provides the presentation sequence of content documents.</p>
-							</div>
-
-							<section id="sec-foreign-restrictions-manifest">
-								<h6>Manifest Fallbacks</h6>
-
-								<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback
-									chains to Core Media Type Resources. They are used to create fallbacks for Foreign
-									Resources in the <a href="#sec-spine-elem">spine</a> and when intrinsic fallback
-									capabilities are not available (e.g., for the [[HTML]] <a
-										data-cite="html#the-img-element"><code>img</code></a> element) in order to
-									satisfy the requirements in <a href="#sec-foreign-restrictions"></a>.</p>
-
-								<p>The <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> on the
-										<a>manifest</a>
-									<a href="#elemdef-package-item"><code>item</code></a> element specifies the fallback
-									for the referenced Publication Resource. The <code>fallback</code> attribute's IDREF
-									[[XML]] value MUST resolve to another <code>item</code> in the
-									<code>manifest</code>. This fallback <code>item</code> MAY itself specify another
-									fallback <code>item</code>, and so on.</p>
-
-								<p>The ordered list of all the ID references that a Reading System can reach, starting
-									from a given item's <code>fallback</code> attribute, represents the <em>fallback
-										chain</em> for that item. The order of the resources in the fallback chain
-									represents the EPUB Creator's preferred fallback order.</p>
-
-								<p>Fallback chains MUST conform to one of the following requirements, as
-									appropriate:</p>
-
-								<ul>
-									<li>
-										<p>For Foreign Resources referenced directly from spine <a
-												href="#elemdef-spine-itemref"><code>itemref</code> elements</a>, the
-											chain MUST contain at least one <a>EPUB Content Document</a>.</p>
-									</li>
-									<li>
-										<p>For Foreign Resources for which an EPUB Creator cannot provide an intrinsic
-											fallback, the chain MUST contain at least one <a>Core Media Type
-												Resource</a>.</p>
-									</li>
-								</ul>
-
-								<p>Fallback chains MUST NOT contain circular or self-references to <code>item</code>
-									elements in the chain.</p>
-
-								<p>EPUB Creators MAY provide fallbacks for <a>Top-Level Content Documents</a> that are
-									EPUB Content Documents (e.g., to provide <a href="#confreq-cd-scripted-flbk"
-										>fallbacks for scripted content</a>).</p>
-
-								<p>EPUB Creators MAY also provide manifest fallbacks for <a>Core Media Type
-										Resources</a> (e.g., to provide a static alternative to a <a>Scripted Content
-										Document</a>).</p>
-
-								<div class="note">
-									<p>As it is not possible to use manifest fallbacks for resources represented in <a
-											href="#sec-data-urls">data URLs</a>, EPUB Creators can only represent
-										Foreign Resources as data URLs where an intrinsic fallback mechanism is
-										available.</p>
-								</div>
-							</section>
-
-							<section id="sec-item-elem-examples">
-								<h6>Examples</h6>
-
-								<aside class="example" id="example-manifest-cmt"
-									title="A manifest with only Core Media Type Resources">
-									<pre>&lt;package …>
+							<aside class="example" id="example-manifest-cmt"
+								title="A manifest with only Core Media Type Resources">
+								<pre>&lt;package …>
    …
    &lt;manifest>
       &lt;item
@@ -3147,15 +3118,15 @@ XHTML:
    &lt;/manifest>
    …
 &lt;/package></pre>
-								</aside>
+							</aside>
 
-								<aside class="example" id="example-manifest-flbk"
-									title="Foreign Resource in Spine with Fallback">
-									<p>The following example shows the <a href="#sec-foreign-restrictions-manifest"
-											>fallback chain mechanism</a> allowing a <a>Foreign Resource</a> (JPEG) to
-										be listed in the spine with fallback to an SVG Content Document.</p>
+							<aside class="example" id="example-manifest-flbk"
+								title="Foreign Resource in Spine with Fallback">
+								<p>The following example shows the <a href="#sec-foreign-restrictions-manifest">fallback
+										chain mechanism</a> allowing a <a>Foreign Resource</a> (JPEG) to be listed in
+									the spine with fallback to an SVG Content Document.</p>
 
-									<pre>&lt;package …>
+								<pre>&lt;package …>
    …
    &lt;manifest>
       …
@@ -3178,20 +3149,19 @@ XHTML:
       …
    &lt;/spine>
 &lt;/package></pre>
-								</aside>
+							</aside>
 
-								<aside class="example"
-									title="Embedded Core Media Type with Link to View as Top-Level Content Document">
-									<p>The following example shows a JPEG embedded in an EPUB Content Document (via the
-											<code>img</code> tag) with a hyperlink that allows it to open as a separate
-										page (e.g., for easier zooming). Although embedding the image using the
-											<code>img</code> tag does not require it to be listed in the <a
-											href="#sec-spine-elem">spine</a> or have a fallback, adding the hyperlink
-										causes the document to open as a <a>Top-Level Content Document</a>. As a result,
-										the EPUB Creator must list the image in the spine and include a fallback to an
-										EPUB Content Document.</p>
+							<aside class="example"
+								title="Embedded Core Media Type with Link to View as Top-Level Content Document">
+								<p>The following example shows a JPEG embedded in an EPUB Content Document (via the
+										<code>img</code> tag) with a hyperlink that allows it to open as a separate page
+									(e.g., for easier zooming). Although embedding the image using the <code>img</code>
+									tag does not require it to be listed in the <a href="#sec-spine-elem">spine</a> or
+									have a fallback, adding the hyperlink causes the document to open as a <a>Top-Level
+										Content Document</a>. As a result, the EPUB Creator must list the image in the
+									spine and include a fallback to an EPUB Content Document.</p>
 
-									<pre>XHTML:
+								<pre>XHTML:
 &lt;html …>
    …
    &lt;body>
@@ -3233,18 +3203,17 @@ Package Document:
       …
    &lt;/spine>
 &lt;/package></pre>
-								</aside>
+							</aside>
 
-								<aside class="example"
-									title="Link to View Foreign Resource as Top-Level Content Document">
-									<p>The following example shows a link to the raw CSV data file. The data will open
-										in the Reading System as a <a>Top-Level Content Document</a> so EPUB Creators
-										must list it in the spine and provide a fallback to an <a>EPUB Content
-											Document</a>. Because there is no guarantee users will be able to access the
-										data in its raw form, instructions on how to extract the file from the <a>EPUB
-											Container</a> are also provided.</p>
+							<aside class="example" title="Link to View Foreign Resource as Top-Level Content Document">
+								<p>The following example shows a link to the raw CSV data file. The data will open in
+									the Reading System as a <a>Top-Level Content Document</a> so EPUB Creators must list
+									it in the spine and provide a fallback to an <a>EPUB Content Document</a>. Because
+									there is no guarantee users will be able to access the data in its raw form,
+									instructions on how to extract the file from the <a>EPUB Container</a> are also
+									provided.</p>
 
-									<pre>XHTML:
+								<pre>XHTML:
 &lt;html …>
    …
    &lt;body>
@@ -3288,16 +3257,16 @@ Package Document:
       …
    &lt;/spine>
 &lt;/package></pre>
-								</aside>
+							</aside>
 
-								<aside class="example" title="Remote Resources that are Publication Resources">
-									<p>The following example shows a reference to a remote audio file. Because the
-											<code>audio</code> element embeds the audio in its EPUB Content Document,
-										the file is considered a Publication Resource. EPUB Creators therefore must list
-										the audio file in the manifest and indicate that its parent EPUB Content
-										Document contains a remote resource.</p>
+							<aside class="example" title="Remote Resources that are Publication Resources">
+								<p>The following example shows a reference to a remote audio file. Because the
+										<code>audio</code> element embeds the audio in its EPUB Content Document, the
+									file is considered a Publication Resource. EPUB Creators therefore must list the
+									audio file in the manifest and indicate that its parent EPUB Content Document
+									contains a remote resource.</p>
 
-									<pre>XHTML:
+								<pre>XHTML:
 &lt;html …>
    …
    &lt;body>
@@ -3328,15 +3297,15 @@ Package Document:
    &lt;/manifest>
    …
 &lt;/package></pre>
-								</aside>
+							</aside>
 
-								<aside class="example" title="External Resources that are not Publication Resources">
-									<p>The following example shows a hyperlink to an audio file hosted on the web.
-										Reading Systems will open such external content in a new browser window; it is
-										not rendered within the publication. In this case, EPUB Creators do not list the
-										file in the manifest because it is not a Publication Resource.</p>
+							<aside class="example" title="External Resources that are not Publication Resources">
+								<p>The following example shows a hyperlink to an audio file hosted on the web. Reading
+									Systems will open such external content in a new browser window; it is not rendered
+									within the publication. In this case, EPUB Creators do not list the file in the
+									manifest because it is not a Publication Resource.</p>
 
-									<pre>XHTML:
+								<pre>XHTML:
 &lt;html …>
    …
    &lt;body>
@@ -3351,260 +3320,255 @@ Package Document:
 
 Manifest:
 No Entry</pre>
-								</aside>
-							</section>
-						</section>
-
-						<section id="sec-opf-bindings">
-							<h6>The <code>bindings</code> Element (Deprecated)</h6>
-
-							<p>The <code>bindings</code> element defines a set of custom handlers for media types not
-								supported by this specification. Its use is <a href="#deprecated">deprecated</a>.</p>
-
-							<p>Refer to [[EPUBPublications-301]] for more information about this element.</p>
+							</aside>
 						</section>
 					</section>
 
-					<section id="sec-pkg-spine">
-						<h5>Spine Section</h5>
+					<section id="sec-opf-bindings">
+						<h6>The <code>bindings</code> Element (Deprecated)</h6>
 
-						<section id="sec-spine-elem">
-							<h6>The <code>spine</code> Element</h6>
+						<p>The <code>bindings</code> element defines a set of custom handlers for media types not
+							supported by this specification. Its use is <a href="#deprecated">deprecated</a>.</p>
 
-							<p>The <code>spine</code> element defines an ordered list of <a href="#sec-itemref-elem"
-									>manifest <code>item</code> references</a> that represent the default reading
-								order.</p>
+						<p>Refer to [[EPUBPublications-301]] for more information about this element.</p>
+					</section>
+				</section>
 
-							<dl id="elemdef-opf-spine" class="elemdef">
-								<dt>Element name</dt>
-								<dd>
-									<p>
-										<code>spine</code>
-									</p>
-								</dd>
+				<section id="sec-pkg-spine">
+					<h4>Spine Section</h4>
 
-								<dt>Usage</dt>
-								<dd>
-									<p>REQUIRED third child of <a class="codelink" href="#elemdef-opf-package"
-												><code>package</code></a>, following <a class="codelink"
-											href="#elemdef-opf-manifest"><code>manifest</code></a>.</p>
-								</dd>
+					<section id="sec-spine-elem">
+						<h5>The <code>spine</code> Element</h5>
 
-								<dt>Attributes</dt>
-								<dd>
-									<ul class="nomark">
-										<li>
-											<p>
-												<a href="#attrdef-id">
-													<code>id</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-spine-page-progression-direction">
-													<code>page-progression-direction</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#sec-opf2-ncx">
-													<code>toc</code>
-												</a>
-												<code>[optional]</code>
-												<a href="#legacy" class="legacy">(legacy)</a>
-											</p>
-										</li>
-									</ul>
-								</dd>
+						<p>The <code>spine</code> element defines an ordered list of <a href="#sec-itemref-elem"
+								>manifest <code>item</code> references</a> that represent the default reading order.</p>
 
-								<dt>Content Model</dt>
-								<dd>
-									<p>
-										<a class="codelink" href="#elemdef-spine-itemref">
-											<code>itemref</code>
-										</a>
-										<code>[1 or more]</code>
-									</p>
-								</dd>
-							</dl>
+						<dl id="elemdef-opf-spine" class="elemdef">
+							<dt>Element name</dt>
+							<dd>
+								<p>
+									<code>spine</code>
+								</p>
+							</dd>
 
-							<p id="confreq-pub-resource">The <code>spine</code> MUST specify at least one <a>Publication
-									Resource</a>.</p>
+							<dt>Usage</dt>
+							<dd>
+								<p>REQUIRED third child of <a class="codelink" href="#elemdef-opf-package"
+											><code>package</code></a>, following <a class="codelink"
+										href="#elemdef-opf-manifest"><code>manifest</code></a>.</p>
+							</dd>
 
-							<p id="spine-inclusion-req">EPUB Creators MUST list in the <code>spine</code> all
-								Publication Resources that are hyperlinked to from Publication Resources in the
-									<code>spine</code>, where hyperlinking encompasses any linking mechanism that
-								requires the user to navigate away from the current resource. Common hyperlinking
-								mechanisms include the <code>href</code> attribute of the [[HTML]] <a
-									data-cite="html#the-a-element"><code>a</code></a> and <a
-									data-cite="html#the-area-element"><code>area</code></a> elements and scripted links
-								(e.g., using DOM Events and/or form elements). The requirement to list hyperlinked
-								resources applies recursively (i.e., EPUB Creators must list all Publication Resources
-								hyperlinked from hyperlinked Publication Resources, and so on.).</p>
+							<dt>Attributes</dt>
+							<dd>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#attrdef-id">
+												<code>id</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-spine-page-progression-direction">
+												<code>page-progression-direction</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#sec-opf2-ncx">
+												<code>toc</code>
+											</a>
+											<code>[optional]</code>
+											<a href="#legacy" class="legacy">(legacy)</a>
+										</p>
+									</li>
+								</ul>
+							</dd>
 
-							<p>EPUB Creators also MUST list in the <code>spine</code> all Publication Resources
-								hyperlinked to from the <a>EPUB Navigation Document</a>, regardless of whether EPUB
-								Creators include the Navigation Document in the <code>spine</code>.</p>
-
-							<div class="note">
-								<p>As <a>Remote Resources</a> referenced from hyperlinks are not Publication Resources,
-									they are not subject to the requirement to include in the spine (e.g., Web pages and
-									resources).</p>
-
-							</div>
-
-							<p>Embedded Publication Resources (e.g., via the [[HTML]] <a
-									data-cite="html#the-iframe-element"><code>iframe</code></a> element) must not be
-								listed in the <code>spine</code>.</p>
-
-							<p id="attrdef-spine-page-progression-direction">The <code>page-progression-direction</code>
-								attribute sets the global direction in which the content flows. Allowed values are
-									<code>ltr</code> (left-to-right), <code>rtl</code> (right-to-left) and
-									<code>default</code>. When EPUB Creators specify the <code>default</code> value,
-								they are expressing no preference and the Reading System can choose the rendering
-								direction.</p>
-
-							<p>Although the <code>page-progression-direction</code> attribute sets the global flow
-								direction, individual Content Documents and parts of Content Documents MAY override this
-								setting (e.g., via the <code>writing-mode</code> CSS property). Reading Systems can also
-								provide mechanisms to override the default direction (e.g., buttons or settings that
-								allow the application of alternate style sheets).</p>
-
-							<p>The <a href="#legacy">legacy</a>
-								<code>toc</code> attribute takes an IDREF [[XML]] that identifies the manifest item that
-								represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
-						</section>
-
-						<section id="sec-itemref-elem">
-							<h6>The <code>itemref</code> Element</h6>
-
-							<p>The <code>itemref</code> element identifies a <a>Publication Resource</a> in the default
-								reading order.</p>
-
-							<dl id="elemdef-spine-itemref" class="elemdef">
-								<dt>Element Name</dt>
-								<dd>
-									<p>
+							<dt>Content Model</dt>
+							<dd>
+								<p>
+									<a class="codelink" href="#elemdef-spine-itemref">
 										<code>itemref</code>
-									</p>
-								</dd>
+									</a>
+									<code>[1 or more]</code>
+								</p>
+							</dd>
+						</dl>
 
-								<dt>Usage</dt>
-								<dd>
-									<p>As a child of <a class="codelink" href="#elemdef-opf-spine"
-											><code>spine</code></a>. Repeatable.</p>
-								</dd>
+						<p id="confreq-pub-resource">The <code>spine</code> MUST specify at least one <a>Publication
+								Resource</a>.</p>
 
-								<dt>Attributes</dt>
-								<dd>
-									<ul class="nomark">
-										<li>
-											<p>
-												<a href="#attrdef-id">
-													<code>id</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-itemref-idref">
-													<code>idref</code>
-												</a>
-												<code>[required]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-itemref-linear">
-													<code>linear</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-properties">
-													<code>properties</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
+						<p id="spine-inclusion-req">EPUB Creators MUST list in the <code>spine</code> all Publication
+							Resources that are hyperlinked to from Publication Resources in the <code>spine</code>,
+							where hyperlinking encompasses any linking mechanism that requires the user to navigate away
+							from the current resource. Common hyperlinking mechanisms include the <code>href</code>
+							attribute of the [[HTML]] <a data-cite="html#the-a-element"><code>a</code></a> and <a
+								data-cite="html#the-area-element"><code>area</code></a> elements and scripted links
+							(e.g., using DOM Events and/or form elements). The requirement to list hyperlinked resources
+							applies recursively (i.e., EPUB Creators must list all Publication Resources hyperlinked
+							from hyperlinked Publication Resources, and so on.).</p>
 
-								<dt>Content Model</dt>
-								<dd>
-									<p>Empty</p>
-								</dd>
-							</dl>
+						<p>EPUB Creators also MUST list in the <code>spine</code> all Publication Resources hyperlinked
+							to from the <a>EPUB Navigation Document</a>, regardless of whether EPUB Creators include the
+							Navigation Document in the <code>spine</code>.</p>
 
-							<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an <a
-									href="#elemdef-package-item"><code>item</code></a> in the <a>manifest</a> via the
-								IDREF [[XML]] in its <code>idref</code> attribute, and item IDs MUST NOT be referenced
-								more than once. </p>
+						<div class="note">
+							<p>As <a>Remote Resources</a> referenced from hyperlinks are not Publication Resources, they
+								are not subject to the requirement to include in the spine (e.g., Web pages and
+								resources).</p>
 
-							<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a)
-								an <a>EPUB Content Document</a> or b) another type of <a>Publication Resource</a> which,
-									<em>regardless of whether it is a <a>Core Media Type Resource</a> or a <a>Foreign
-										Resource</a></em>, MUST include an EPUB Content Document in its <a
-									href="#sec-foreign-restrictions-manifest">fallback chain</a>.</p>
+						</div>
 
-							<div class="note">
-								<p>Although EPUB Publications <a href="#confreq-nav">require an EPUB Navigation
-										Document</a>, it is not mandatory to include it in the <code>spine</code>.</p>
+						<p>Embedded Publication Resources (e.g., via the [[HTML]] <a data-cite="html#the-iframe-element"
+									><code>iframe</code></a> element) must not be listed in the <code>spine</code>.</p>
 
-							</div>
+						<p id="attrdef-spine-page-progression-direction">The <code>page-progression-direction</code>
+							attribute sets the global direction in which the content flows. Allowed values are
+								<code>ltr</code> (left-to-right), <code>rtl</code> (right-to-left) and
+								<code>default</code>. When EPUB Creators specify the <code>default</code> value, they
+							are expressing no preference and the Reading System can choose the rendering direction.</p>
 
-							<p id="attrdef-itemref-linear">The <code>linear</code> attribute indicates whether the
-								referenced <code>item</code> contains content that contributes to the primary reading
-								order and that Reading Systems must read sequentially ("<code>yes</code>"), or auxiliary
-								content that enhances or augments the primary content that Reading Systems can access
-								out of sequence ("<code>no</code>"). Examples of auxiliary content include notes,
-								descriptions, and answer keys.</p>
+						<p>Although the <code>page-progression-direction</code> attribute sets the global flow
+							direction, individual Content Documents and parts of Content Documents MAY override this
+							setting (e.g., via the <code>writing-mode</code> CSS property). Reading Systems can also
+							provide mechanisms to override the default direction (e.g., buttons or settings that allow
+							the application of alternate style sheets).</p>
 
-							<p>The <code>linear</code> attribute allows Reading Systems to distinguish content that a
-								user should access as part of the default reading order from supplementary content which
-								a Reading System might, for example, present in a popup window or omit from an aural
-								rendering.</p>
+						<p>The <a href="#legacy">legacy</a>
+							<code>toc</code> attribute takes an IDREF [[XML]] that identifies the manifest item that
+							represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
+					</section>
 
-							<p>Specifying that content is non-linear does not require Reading Systems to present it in a
-								specific way, however; it is only a hint to the purpose. Reading Systems may present
-								non-linear content where it occurs in the spine, for example, or may skip it until users
-								reach the end of the spine.</p>
+					<section id="sec-itemref-elem">
+						<h5>The <code>itemref</code> Element</h5>
 
-							<div class="note">
-								<p>EPUB Creators should list non-linear content at the end of the spine except when it
-									makes sense for users to encounter it between linear spine items.</p>
+						<p>The <code>itemref</code> element identifies a <a>Publication Resource</a> in the default
+							reading order.</p>
 
-							</div>
+						<dl id="elemdef-spine-itemref" class="elemdef">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>itemref</code>
+								</p>
+							</dd>
 
-							<p id="linear-itemrefs">The <a>spine</a> MUST contain at least one linear
-									<code>itemref</code> element &#8212; whose <code>linear</code> attribute value is
-								either explicitly or implicitly set to "<code>yes</code>". Reading Systems will assume
-								the value "<code>yes</code>" for <code>itemref</code> elements without a
-									<code>linear</code> attribute.</p>
+							<dt>Usage</dt>
+							<dd>
+								<p>As a child of <a class="codelink" href="#elemdef-opf-spine"><code>spine</code></a>.
+									Repeatable.</p>
+							</dd>
 
-							<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide
-								a means of accessing all non-linear content (e.g., hyperlinks in the content or from the
-									<a href="#sec-nav">EPUB Navigation Document</a>).</p>
+							<dt>Attributes</dt>
+							<dd>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#attrdef-id">
+												<code>id</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-itemref-idref">
+												<code>idref</code>
+											</a>
+											<code>[required]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-itemref-linear">
+												<code>linear</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-properties">
+												<code>properties</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
 
-							<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine
-									Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a>
-								for the <code>properties</code> attribute.</p>
+							<dt>Content Model</dt>
+							<dd>
+								<p>Empty</p>
+							</dd>
+						</dl>
 
-							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
-									href="#sec-vocab-assoc"></a>.</p>
+						<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an <a
+								href="#elemdef-package-item"><code>item</code></a> in the <a>manifest</a> via the
+							IDREF [[XML]] in its <code>idref</code> attribute, and item IDs MUST NOT be referenced more
+							than once. </p>
 
-							<aside class="example" title="A basic spine">
-								<p>In this example, the spine entries correspond to <a href="#example-manifest-cmt">the
-										manifest example above</a>.</p>
+						<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a) an
+								<a>EPUB Content Document</a> or b) another type of <a>Publication Resource</a> which,
+								<em>regardless of whether it is a <a>Core Media Type Resource</a> or a <a>Foreign
+									Resource</a></em>, MUST include an EPUB Content Document in its <a
+								href="#sec-foreign-restrictions-manifest">fallback chain</a>.</p>
 
-								<pre>&lt;spine
+						<div class="note">
+							<p>Although EPUB Publications <a href="#confreq-nav">require an EPUB Navigation
+								Document</a>, it is not mandatory to include it in the <code>spine</code>.</p>
+
+						</div>
+
+						<p id="attrdef-itemref-linear">The <code>linear</code> attribute indicates whether the
+							referenced <code>item</code> contains content that contributes to the primary reading order
+							and that Reading Systems must read sequentially ("<code>yes</code>"), or auxiliary content
+							that enhances or augments the primary content that Reading Systems can access out of
+							sequence ("<code>no</code>"). Examples of auxiliary content include notes, descriptions, and
+							answer keys.</p>
+
+						<p>The <code>linear</code> attribute allows Reading Systems to distinguish content that a user
+							should access as part of the default reading order from supplementary content which a
+							Reading System might, for example, present in a popup window or omit from an aural
+							rendering.</p>
+
+						<p>Specifying that content is non-linear does not require Reading Systems to present it in a
+							specific way, however; it is only a hint to the purpose. Reading Systems may present
+							non-linear content where it occurs in the spine, for example, or may skip it until users
+							reach the end of the spine.</p>
+
+						<div class="note">
+							<p>EPUB Creators should list non-linear content at the end of the spine except when it makes
+								sense for users to encounter it between linear spine items.</p>
+
+						</div>
+
+						<p id="linear-itemrefs">The <a>spine</a> MUST contain at least one linear <code>itemref</code>
+							element &#8212; whose <code>linear</code> attribute value is either explicitly or implicitly
+							set to "<code>yes</code>". Reading Systems will assume the value "<code>yes</code>" for
+								<code>itemref</code> elements without a <code>linear</code> attribute.</p>
+
+						<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide a
+							means of accessing all non-linear content (e.g., hyperlinks in the content or from the <a
+								href="#sec-nav">EPUB Navigation Document</a>).</p>
+
+						<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine Properties
+								Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
+								<code>properties</code> attribute.</p>
+
+						<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+							></a>.</p>
+
+						<aside class="example" title="A basic spine">
+							<p>In this example, the spine entries correspond to <a href="#example-manifest-cmt">the
+									manifest example above</a>.</p>
+
+							<pre>&lt;spine
     page-progression-direction="ltr">
    &lt;itemref
        idref="intro"/>
@@ -3628,192 +3592,189 @@ No Entry</pre>
        linear="no"/>
 &lt;/spine>
 </pre>
-							</aside>
-						</section>
+						</aside>
 					</section>
+				</section>
 
-					<section id="sec-pkg-collections">
-						<h5>Collections</h5>
+				<section id="sec-pkg-collections">
+					<h4>Collections</h4>
 
-						<section id="sec-collection-elem">
-							<h6>The <code>collection</code> Element</h6>
+					<section id="sec-collection-elem">
+						<h5>The <code>collection</code> Element</h5>
 
-							<p>The <code>collection</code> element defines a related group of resources.</p>
+						<p>The <code>collection</code> element defines a related group of resources.</p>
 
-							<dl id="elemdef-collection" class="elemdef">
-								<dt>Element Name</dt>
-								<dd>
-									<p>
-										<code>collection</code>
-									</p>
-								</dd>
+						<dl id="elemdef-collection" class="elemdef">
+							<dt>Element Name</dt>
+							<dd>
+								<p>
+									<code>collection</code>
+								</p>
+							</dd>
 
-								<dt>Usage</dt>
-								<dd>
-									<p>OPTIONAL sixth element of <code>package</code>. Repeatable.</p>
-								</dd>
+							<dt>Usage</dt>
+							<dd>
+								<p>OPTIONAL sixth element of <code>package</code>. Repeatable.</p>
+							</dd>
 
-								<dt>Attributes</dt>
-								<dd>
-									<ul class="nomark">
-										<li>
-											<p>
-												<a href="#attrdef-dir">
-													<code>dir</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-id">
-													<code>id</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-collection-role">
-													<code>role</code>
-												</a>
-												<code>[required]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-xml-lang">
-													<code>xml:lang</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
+							<dt>Attributes</dt>
+							<dd>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#attrdef-dir">
+												<code>dir</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-id">
+												<code>id</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-collection-role">
+												<code>role</code>
+											</a>
+											<code>[required]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-xml-lang">
+												<code>xml:lang</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
 
-								<dt>Content Model</dt>
-								<dd>
-									<p>In this order: <a href="#elemdef-collection-metadata"><code>metadata</code></a>
-										<code>[0 or 1]</code>, ( <a href="#elemdef-collection"
-											><code>collection</code></a>
-										<code>[1 or more]</code> or ( <a href="#elemdef-collection"
-												><code>collection</code></a>
-										<code>[0 or more]</code>, <a href="#elemdef-collection-link"
-											><code>link</code></a>
-										<code>[1 or more]</code> ))</p>
-								</dd>
-							</dl>
+							<dt>Content Model</dt>
+							<dd>
+								<p>In this order: <a href="#elemdef-collection-metadata"><code>metadata</code></a>
+									<code>[0 or 1]</code>, ( <a href="#elemdef-collection"><code>collection</code></a>
+									<code>[1 or more]</code> or ( <a href="#elemdef-collection"
+										><code>collection</code></a>
+									<code>[0 or more]</code>, <a href="#elemdef-collection-link"><code>link</code></a>
+									<code>[1 or more]</code> ))</p>
+							</dd>
+						</dl>
 
-							<p>The <code>collection</code> element allows EPUB Creators to assemble resources into
-								logical groups for a variety of potential uses: enabling reassembly into a meaningful
-								unit of content split across multiple <a>EPUB Content Documents</a> (e.g., an index
-								split across multiple documents), identifying resources for specialized purposes (e.g.,
-								preview content), or collecting together resources that present additional information
-								about the <a>EPUB Publication</a>.</p>
+						<p>The <code>collection</code> element allows EPUB Creators to assemble resources into logical
+							groups for a variety of potential uses: enabling reassembly into a meaningful unit of
+							content split across multiple <a>EPUB Content Documents</a> (e.g., an index split across
+							multiple documents), identifying resources for specialized purposes (e.g., preview content),
+							or collecting together resources that present additional information about the <a>EPUB
+								Publication</a>.</p>
 
-							<p>The <code>collection</code> element, as defined in this section, represents a generic
-								framework from which specializations are intended to be derived (e.g., through EPUB
-								sub-specifications). Such specializations MUST define the purpose of the
-									<code>collection</code> element, as well as all requirements for its valid
-								production and use (specifically any requirements that differ from the general framework
-								presented below).</p>
+						<p>The <code>collection</code> element, as defined in this section, represents a generic
+							framework from which specializations are intended to be derived (e.g., through EPUB
+							sub-specifications). Such specializations MUST define the purpose of the
+								<code>collection</code> element, as well as all requirements for its valid production
+							and use (specifically any requirements that differ from the general framework presented
+							below).</p>
 
-							<p id="attrdef-collection-role">Each specialization MUST define a role value that uniquely
-								identifies all conformant <code>collection</code> elements. EPUB Creators MUST identify
-								the role of each <code>collection</code> element in its <code>role</code> attribute,
-								whose value MUST be one or more NMTOKENs [[XMLSCHEMA-2]] and/or <a
-									data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment
-									strings</a> [[URL]].</p>
+						<p id="attrdef-collection-role">Each specialization MUST define a role value that uniquely
+							identifies all conformant <code>collection</code> elements. EPUB Creators MUST identify the
+							role of each <code>collection</code> element in its <code>role</code> attribute, whose value
+							MUST be one or more NMTOKENs [[XMLSCHEMA-2]] and/or <a
+								data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment strings</a>
+							[[URL]].</p>
 
-							<p>This specification reserves the use of NMTOKEN values for roles defined in EPUB
-								specifications. NMTOKEN values not defined by a recognized specification are not valid.
-								This section does not define any roles.</p>
+						<p>This specification reserves the use of NMTOKEN values for roles defined in EPUB
+							specifications. NMTOKEN values not defined by a recognized specification are not valid. This
+							section does not define any roles.</p>
 
-							<p>Third parties MAY define custom roles for the <code>collection</code> element, but they
-								MUST identify such roles using <a data-cite="url#absolute-url-with-fragment-string"
-									>absolute-URL-with-fragment strings</a> [[URL]]. Custom roles MUST NOT incorporate
-								the string "<code>idpf.org</code>" in the <a data-cite="url#concept-host">host
-									component</a> [[URL]] of their identifying URL.</p>
+						<p>Third parties MAY define custom roles for the <code>collection</code> element, but they MUST
+							identify such roles using <a data-cite="url#absolute-url-with-fragment-string"
+								>absolute-URL-with-fragment strings</a> [[URL]]. Custom roles MUST NOT incorporate the
+							string "<code>idpf.org</code>" in the <a data-cite="url#concept-host">host component</a>
+							[[URL]] of their identifying URL.</p>
 
-							<div class="note">
-								<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
-									Working Group maintained both a <a href="http://www.idpf.org/epub/registries/roles"
-										>registry of role extensions</a> and a list of <a
-										href="http://www.idpf.org/epub/extensions/roles">custom extension roles</a>.
-									This Working Group no longer maintains these registries and does not anticipate
-									defining new types of collections.</p>
+						<div class="note">
+							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
+								Working Group maintained both a <a href="http://www.idpf.org/epub/registries/roles"
+									>registry of role extensions</a> and a list of <a
+									href="http://www.idpf.org/epub/extensions/roles">custom extension roles</a>. This
+								Working Group no longer maintains these registries and does not anticipate defining new
+								types of collections.</p>
 
-							</div>
+						</div>
 
-							<p id="elemdef-collection-metadata">The OPTIONAL <code>metadata</code> element child of
-									<code>collection</code> is an adaptation of the package <a
-									href="#elemdef-opf-metadata"><code>metadata</code> element</a>, with the following
-								differences in syntax and semantics:</p>
+						<p id="elemdef-collection-metadata">The OPTIONAL <code>metadata</code> element child of
+								<code>collection</code> is an adaptation of the package <a href="#elemdef-opf-metadata"
+									><code>metadata</code> element</a>, with the following differences in syntax and
+							semantics:</p>
 
-							<ul>
-								<li>
-									<p>No metadata is mandatory by default.</p>
-								</li>
-								<li>
-									<p>All <a href="#primary-expression">primary metadata expressions</a> apply to the
-											<code>collection</code>.</p>
-								</li>
-								<li>
-									<p>The <a href="#attrdef-refines"><code>refines</code> attribute</a> MUST NOT
-										reference elements outside the containing <code>collection</code>.</p>
-								</li>
-								<li>
-									<p>The <code>metadata</code> element MUST NOT contain <a href="#sec-opf2-meta">OPF2
-												<code>meta</code> elements</a>.</p>
-								</li>
-							</ul>
-							<p>EPUB specifications that implement collections MAY override package-level restrictions on
-								the use of metadata elements.</p>
+						<ul>
+							<li>
+								<p>No metadata is mandatory by default.</p>
+							</li>
+							<li>
+								<p>All <a href="#primary-expression">primary metadata expressions</a> apply to the
+										<code>collection</code>.</p>
+							</li>
+							<li>
+								<p>The <a href="#attrdef-refines"><code>refines</code> attribute</a> MUST NOT reference
+									elements outside the containing <code>collection</code>.</p>
+							</li>
+							<li>
+								<p>The <code>metadata</code> element MUST NOT contain <a href="#sec-opf2-meta">OPF2
+											<code>meta</code> elements</a>.</p>
+							</li>
+						</ul>
+						<p>EPUB specifications that implement collections MAY override package-level restrictions on the
+							use of metadata elements.</p>
 
-							<p>A <code>collection</code> MAY define sub-collections through the inclusion of one or more
-								child <code>collection</code> elements.</p>
+						<p>A <code>collection</code> MAY define sub-collections through the inclusion of one or more
+							child <code>collection</code> elements.</p>
 
-							<p id="elemdef-collection-link">The <code>link</code> element child of
-									<code>collection</code> is an adaptation of the metadata <a href="#elemdef-opf-link"
-										><code>link</code> element</a>, with the following differences in syntax and
-								semantics:</p>
+						<p id="elemdef-collection-link">The <code>link</code> element child of <code>collection</code>
+							is an adaptation of the metadata <a href="#elemdef-opf-link"><code>link</code> element</a>,
+							with the following differences in syntax and semantics:</p>
 
-							<ul>
-								<li>
-									<p>The <code>rel</code> attribute is OPTIONAL.</p>
-								</li>
-								<li>
-									<p>The <code>properties</code> attribute also accepts <a
-											href="#app-item-properties-vocab">manifest <code>item</code> properties</a>
-										without a prefix (e.g., so that a collection can declare its own Navigation
-										Document or cover image).</p>
-								</li>
-								<li>
-									<p>EPUB Creators MUST NOT specify the <code>refines</code> attribute.</p>
-								</li>
-							</ul>
-							<p>Each <code>link</code> element MUST reference a resource that is a member of the group.
-								The order of <code>link</code> elements is not significant.</p>
+						<ul>
+							<li>
+								<p>The <code>rel</code> attribute is OPTIONAL.</p>
+							</li>
+							<li>
+								<p>The <code>properties</code> attribute also accepts <a
+										href="#app-item-properties-vocab">manifest <code>item</code> properties</a>
+									without a prefix (e.g., so that a collection can declare its own Navigation Document
+									or cover image).</p>
+							</li>
+							<li>
+								<p>EPUB Creators MUST NOT specify the <code>refines</code> attribute.</p>
+							</li>
+						</ul>
+						<p>Each <code>link</code> element MUST reference a resource that is a member of the group. The
+							order of <code>link</code> elements is not significant.</p>
 
-							<p>Specializations of the <code>collection</code> element MAY tailor the requirements
-								defined above to better reflect their needs (e.g., requiring metadata, imposing further
-								restrictions on the use of elements and attributes, or making the order of
-									<code>link</code> elements significant). However, the resulting content model MUST
-								represent a valid subset of the one defined in this section (e.g., specializations
-								cannot introduce new elements or attributes, or re-introduce those expressly forbidden
-								above). Specializations MUST NOT define collections in a way that overrides the
-								requirements of the <a href="#elemdef-opf-manifest"><code>manifest</code></a> and <a
-									href="#elemdef-opf-spine"><code>spine</code></a>.</p>
+						<p>Specializations of the <code>collection</code> element MAY tailor the requirements defined
+							above to better reflect their needs (e.g., requiring metadata, imposing further restrictions
+							on the use of elements and attributes, or making the order of <code>link</code> elements
+							significant). However, the resulting content model MUST represent a valid subset of the one
+							defined in this section (e.g., specializations cannot introduce new elements or attributes,
+							or re-introduce those expressly forbidden above). Specializations MUST NOT define
+							collections in a way that overrides the requirements of the <a href="#elemdef-opf-manifest"
+									><code>manifest</code></a> and <a href="#elemdef-opf-spine"
+							><code>spine</code></a>.</p>
 
-							<p>The rendering of an EPUB Publication MUST NOT be dependent on the recognition of
-									<code>collection</code> elements. The content MUST remain consumable by a user
-								without any information loss or other significant deterioration.</p>
+						<p>The rendering of an EPUB Publication MUST NOT be dependent on the recognition of
+								<code>collection</code> elements. The content MUST remain consumable by a user without
+							any information loss or other significant deterioration.</p>
 
-							<aside class="example" id="example-collection" title="A basic collection">
-								<p>In this example, the two linked <a>XHTML Content Documents</a> represent a single
-									unit.</p>
+						<aside class="example" id="example-collection" title="A basic collection">
+							<p>In this example, the two linked <a>XHTML Content Documents</a> represent a single
+								unit.</p>
 
-								<pre>&lt;package …>
+							<pre>&lt;package …>
    …
    &lt;collection
        role="http://example.org/roles/unit">
@@ -3829,58 +3790,56 @@ No Entry</pre>
    &lt;/collection>
    …
 &lt;/package></pre>
-							</aside>
-						</section>
+						</aside>
+					</section>
+				</section>
+
+				<section id="sec-pkg-legacy">
+					<h4>Legacy Content</h4>
+
+					<section id="sec-opf2-meta">
+						<h5>The <code>meta</code> Element</h5>
+
+						<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
+									><code>meta</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a> feature
+							that previously provided a means of including generic metadata. The EPUB 3 <a
+								href="#sec-meta-elem"><code>meta</code> element</a>, which uses different attributes and
+							requires text content, replaces this attribute.</p>
+
+						<p>For more information about the <code>meta</code> element, refer to its definition in
+							[[OPF-201]].</p>
+
+						<div class="note">
+							<p>The [[OPF-201]] <code>meta</code> element is retained in EPUB 3 primarily so that EPUB
+								Creators can identify the cover image for compatibility with EPUB 2 Reading Systems. In
+								EPUB 3, the cover image must be identified using the <a href="#sec-cover-image"
+										><code>cover-image</code> property</a> on the <a href="#sec-item-elem">manifest
+										<code>item</code></a> for the image.</p>
+
+						</div>
 					</section>
 
-					<section id="sec-pkg-legacy">
-						<h5>Legacy Content</h5>
+					<section id="sec-opf2-guide">
+						<h5>The <code>guide</code> Element</h5>
 
-						<section id="sec-opf2-meta">
-							<h6>The <code>meta</code> Element</h6>
+						<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
+									><code>guide</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a>
+							feature that previously provided machine-processable navigation to key structures. The <a
+								href="#sec-nav-landmarks">landmarks nav</a> in the <a>EPUB Navigation Document</a>
+							replaces this element.</p>
 
-							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
-										><code>meta</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a>
-								feature that previously provided a means of including generic metadata. The EPUB 3 <a
-									href="#sec-meta-elem"><code>meta</code> element</a>, which uses different attributes
-								and requires text content, replaces this attribute.</p>
+						<p>For more information about the <code>guide</code> element, refer to its definition in
+							[[OPF-201]].</p>
+					</section>
 
-							<p>For more information about the <code>meta</code> element, refer to its definition in
-								[[OPF-201]].</p>
+					<section id="sec-opf2-ncx">
+						<h5>NCX</h5>
 
-							<div class="note">
-								<p>The [[OPF-201]] <code>meta</code> element is retained in EPUB 3 primarily so that
-									EPUB Creators can identify the cover image for compatibility with EPUB 2 Reading
-									Systems. In EPUB 3, the cover image must be identified using the <a
-										href="#sec-cover-image"><code>cover-image</code> property</a> on the <a
-										href="#sec-item-elem">manifest <code>item</code></a> for the image.</p>
+						<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a>
+							[[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table of
+							contents. The <a href="#sec-nav">EPUB Navigation Document</a> replaces this document.</p>
 
-							</div>
-						</section>
-
-						<section id="sec-opf2-guide">
-							<h6>The <code>guide</code> Element</h6>
-
-							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
-										><code>guide</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a>
-								feature that previously provided machine-processable navigation to key structures. The
-									<a href="#sec-nav-landmarks">landmarks nav</a> in the <a>EPUB Navigation
-									Document</a> replaces this element.</p>
-
-							<p>For more information about the <code>guide</code> element, refer to its definition in
-								[[OPF-201]].</p>
-						</section>
-
-						<section id="sec-opf2-ncx">
-							<h6>NCX</h6>
-
-							<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a>
-								[[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table
-								of contents. The <a href="#sec-nav">EPUB Navigation Document</a> replaces this
-								document.</p>
-
-							<p>For more information about the NCX, refer to its definition in [[OPF-201]].</p>
-						</section>
+						<p>For more information about the NCX, refer to its definition in [[OPF-201]].</p>
 					</section>
 				</section>
 			</section>
@@ -10722,10 +10681,10 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's
-					definition by making it optional, and adapt the specification's text elsewhere to address the
-					situation when the element is indeed not present. See <a
-						href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>.</li>
+				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's definition
+					by making it optional, and adapt the specification's text elsewhere to address the situation when
+					the element is indeed not present. See <a href="https://github.com/w3c/epub-specs/issues/1986">issue
+						1986</a>.</li>
 				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
 					model for EPUB Publications and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a


### PR DESCRIPTION
There aren't even any references to the section in any of the specifications. The parent section is always used.

Fixes #2032


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2035.html" title="Last updated on Mar 7, 2022, 1:11 PM UTC (b58d7a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2035/85c7059...b58d7a2.html" title="Last updated on Mar 7, 2022, 1:11 PM UTC (b58d7a2)">Diff</a>