### PR TITLE
Clarify fxl properties must not be used with the refines attribute

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10694,6 +10694,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>08-Mar-2022: Clarified that the refines attribute must not be used with global fixed layout property
+					declarations. See <a href="https://github.com/w3c/epub-specs/issues/2036">issue 2036</a>.</li>
 				<li>05-Mar-2022: Forbid circular references and self-references in refinement chains. See <a
 						href="https://github.com/w3c/epub-specs/issues/2031">issue 2031</a>.</li>
 				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's definition

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2444,9 +2444,9 @@
 								contributor expression by defining the role of the person.</li>
 						</ul>
 
-						<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions,
-								thereby creating chains of information. Refinement chains MUST NOT contain circular
-								references or self-references.</p>
+						<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions, thereby
+							creating chains of information. Refinement chains MUST NOT contain circular references or
+							self-references.</p>
 
 						<p class="note">All the DCMES [[DCTERMS]] elements represent primary expressions, and permit
 							refinement by meta element subexpressions.</p>
@@ -5156,7 +5156,11 @@ No Entry</pre>
 							<code>pre-paginated</code> for a spine item, its content dimensions MUST be set as defined
 						in <a href="#sec-fixed-layouts"></a>.</p>
 
-					<p>The <code>rendition:layout</code> property MUST NOT be declared more than once.</p>
+					<p>EPUB Creators MUST NOT declare the <code>rendition:layout</code> property more than once.</p>
+
+					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
+							attribute</a>. Refer to <a href="#layout-overrides"></a> for setting the property for
+						individual <a>EPUB Content Documents</a>.</p>
 
 					<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
 						<p>In this example, media queries [[CSS3-MediaQueries]] are used to apply different style sheets
@@ -5261,6 +5265,10 @@ No Entry</pre>
 					<p id="fxl-orientation-duplication" data-tests="#fxl-orientation-duplication">EPUB Creators MUST NOT
 						declare the <code>rendition:orientation</code> property more than once.</p>
 
+					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
+							attribute</a>. Refer to <a href="#orientation-overrides"></a> for setting the property for
+						individual <a>EPUB Content Documents</a>.</p>
+
 					<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
 						<p>In this example, the content should also render without synthetic spreads.</p>
 
@@ -5356,7 +5364,11 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p>The <code>rendition:spread</code> property MUST NOT be declared more than once.</p>
+					<p>EPUB Creators MUST NOT declare the <code>rendition:spread</code> property more than once.</p>
+
+					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
+							attribute</a>. Refer to <a href="#spread-overrides"></a> for setting the property for
+						individual <a>EPUB Content Documents</a>.</p>
 
 					<div class="note">
 						<p>When Synthetic Spreads are used in the context of HTML and SVG Content Documents, the

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -73,8 +73,12 @@
 					EPUB Creators MAY override this behavior through an appropriate style sheet declaration, if
 					the Reading System supports such overrides.</p>
 				
-			<p>The <code>rendition:flow</code> property MUST NOT be declared more than once.</p>
-
+			<p>EPUB Creators MUST NOT delcare the <code>rendition:flow</code> property more than once.</p>
+			
+			<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
+				attribute</a>. Refer to <a href="#flow-overrides"></a> for setting the property for
+				individual <a>EPUB Content Documents</a>.</p>
+			
 			<figure id="fig-flow-paginated-single">
 				<figcaption>Rendering of an EPUB publication with a single spine item, and with the
 					<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -76,7 +76,7 @@
 			<p>EPUB Creators MUST NOT delcare the <code>rendition:flow</code> property more than once.</p>
 			
 			<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
-				attribute</a>. Refer to <a href="#flow-overrides"></a> for setting the property for
+				attribute</a>. Refer to <a href="#layout-property-flow-overrides"></a> for setting the property for
 				individual <a>EPUB Content Documents</a>.</p>
 			
 			<figure id="fig-flow-paginated-single">


### PR DESCRIPTION
Fixes #2036


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2040.html" title="Last updated on Mar 8, 2022, 9:48 PM UTC (f9e2245)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2040/32c7963...f9e2245.html" title="Last updated on Mar 8, 2022, 9:48 PM UTC (f9e2245)">Diff</a>