### PR TITLE
Require use of the fxl property values defined in the specification

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2444,9 +2444,9 @@
 								contributor expression by defining the role of the person.</li>
 						</ul>
 
-						<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions,
-								thereby creating chains of information. Refinement chains MUST NOT contain circular
-								references or self-references.</p>
+						<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions, thereby
+							creating chains of information. Refinement chains MUST NOT contain circular references or
+							self-references.</p>
 
 						<p class="note">All the DCMES [[DCTERMS]] elements represent primary expressions, and permit
 							refinement by meta element subexpressions.</p>
@@ -5125,7 +5125,8 @@ No Entry</pre>
 						is specified on a <code>meta</code> element, it indicates that the paginated or reflowable
 						layout style applies globally (i.e., for all spine items).</p>
 
-					<p>EPUB Creators MAY use the following values with the <code>rendition:layout</code> property:</p>
+					<p>EPUB Creators MUST use one of the following values with the <code>rendition:layout</code>
+						property:</p>
 
 					<dl class="variablelist">
 						<dt id="def-layout-reflowable">reflowable</dt>
@@ -5238,7 +5239,7 @@ No Entry</pre>
 						element, it indicates that the intended orientation applies globally (i.e., for all spine
 						items).</p>
 
-					<p>EPUB Creators MAY use the following values with the <code>rendition:orientation</code>
+					<p>EPUB Creators MUST use one of the following values with the <code>rendition:orientation</code>
 						property:</p>
 
 					<dl class="variablelist">
@@ -5321,7 +5322,8 @@ No Entry</pre>
 							<code>meta</code> element, it indicates that the intended <a>Synthetic Spread</a> behavior
 						applies globally (i.e., for all spine items).</p>
 
-					<p>EPUB Creators MAY use the following values with the <code>rendition:spread</code> property:</p>
+					<p>EPUB Creators MUST use one of the following values with the <code>rendition:spread</code>
+						property:</p>
 
 					<dl class="variablelist">
 						<dt>none</dt>
@@ -10682,6 +10684,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>08-Mar-2022: Require use of the fixed layout property values defined in this specification. See <a
+						href="https://github.com/w3c/epub-specs/issues/2039">issue 2039</a>.</li>
 				<li>05-Mar-2022: Forbid circular references and self-references in refinement chains. See <a
 						href="https://github.com/w3c/epub-specs/issues/2031">issue 2031</a>.</li>
 				<li>19-Feb-2022: Clarified the <a href="#elemdef-smil-audio"><code>audio</code></a> element's definition

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -34,7 +34,7 @@
 					rendered as a continuous scrolling view or whether each is to be rendered separately
 					(i.e., with a dynamic page break between each).</p>
 				
-			<p>The following values are defined for use with the <code>rendition:flow</code>
+			<p>EPUB Creators MUST use one of the following values with the <code>rendition:flow</code>
 				property:</p>
 			
 			<dl class="variablelist">


### PR DESCRIPTION
Going on the assumption that we don't want open-ended values.

Fixes #2039


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2041.html" title="Last updated on Mar 8, 2022, 9:52 PM UTC (ebb6525)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2041/0b547ef...ebb6525.html" title="Last updated on Mar 8, 2022, 9:52 PM UTC (ebb6525)">Diff</a>