### PR TITLE
Add ncx doctype to allowed external identifiers

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1202,9 +1202,10 @@
 				<section id="sec-parse-package-urls">
 					<h4>Parsing URLs in the Package Document</h4>
 
-					<p id="pkg-parse-package-url" data-tests="#ocf-url_link_relative,#ocf-url_relative"> To parse a URL string <var>url</var> used in the Package Document, the <a
-								data-cite="url#concept-url-parser">URL Parser</a> [[URL]] MUST be applied to
-								<var>url</var>, with the <a>content URL</a> of the Package Document as <var>base</var>.</p>
+					<p id="pkg-parse-package-url" data-tests="#ocf-url_link_relative,#ocf-url_relative"> To parse a URL
+						string <var>url</var> used in the Package Document, the <a data-cite="url#concept-url-parser"
+							>URL Parser</a> [[URL]] MUST be applied to <var>url</var>, with the <a>content URL</a> of
+						the Package Document as <var>base</var>.</p>
 				</section>
 
 				<section id="sec-shared-attrs">
@@ -5952,18 +5953,23 @@ No Entry</pre>
 				<section id="sec-container-iri">
 					<h4>URLs in the OCF Abstract Container</h4>
 
-					<p id="sec-container-iri-root" data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link_relative">The <a>container root
+					<p id="sec-container-iri-root"
+						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link_relative">The <a>container root
 							URL</a> is the <a data-cite="url#concept-url">URL</a> [[URL]] of the <a>Root Directory</a>.
 						It is implementation-specific, but EPUB Creators MUST assume it has the following
 						properties:</p>
 
 					<ul>
-						<li id="sec-container-iri-root-parse" data-tests="#ocf-url_link_path_absolute,#ocf-url_parse_path_absolute">The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>/</code>" with the
-								<a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is
-							the <a>container root URL</a>.</li>
-						<li id="sec-container-iri-step-parse" data-tests="#ocf-url_link_leaking_relative,#ocf-url_parse_leaking_relative">The result of <a data-cite="url#concept-url-parser">parsing</a> "<code>..</code>" with the
-								<a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is
-							the <a>container root URL</a>.</li>
+						<li id="sec-container-iri-root-parse"
+							data-tests="#ocf-url_link_path_absolute,#ocf-url_parse_path_absolute">The result of <a
+								data-cite="url#concept-url-parser">parsing</a> "<code>/</code>" with the <a>container
+								root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the
+								<a>container root URL</a>.</li>
+						<li id="sec-container-iri-step-parse"
+							data-tests="#ocf-url_link_leaking_relative,#ocf-url_parse_leaking_relative">The result of <a
+								data-cite="url#concept-url-parser">parsing</a> "<code>..</code>" with the <a>container
+								root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the
+								<a>container root URL</a>.</li>
 					</ul>
 
 					<p>The <a>content URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result
@@ -6078,18 +6084,19 @@ No Entry</pre>
 						<p>These constraints on URL strings mean that:</p>
 
 						<ul>
-							<li>relative URL strings starting with a <code>/</code> (<code>U+002F</code>) (for example, <code>/EPUB/content.xhtml</code>) are disallowed;
-							</li>
-							<li>relative URL strings containing more <a
-								data-cite="url#double-dot-path-segment">double-dot path segments</a> than needed to reach the target
-								file (for example, <code>EPUB/../../../../config.xml</code>) are disallowed;
-							</li>
+							<li>relative URL strings starting with a <code>/</code> (<code>U+002F</code>) (for example,
+									<code>/EPUB/content.xhtml</code>) are disallowed; </li>
+							<li>relative URL strings containing more <a data-cite="url#double-dot-path-segment"
+									>double-dot path segments</a> than needed to reach the target file (for example,
+									<code>EPUB/../../../../config.xml</code>) are disallowed; </li>
 							<li>any other absolute or relative URL string is allowed.</li>
 						</ul>
 
-						<p>
-							Note that in any case, to avoid potential run-time security issues, the properties of the <a>container root URL</a> are such that a conforming Reading System will parse any relative URL string to a <a>content URL</a>. In other words, even the disallowed URL strings described above will not "leak" outside the container. They are still disallowed for better interoperability with non-conforming or legacy Reading Systems and toolchains.
-						</p>
+						<p> Note that in any case, to avoid potential run-time security issues, the properties of the
+								<a>container root URL</a> are such that a conforming Reading System will parse any
+							relative URL string to a <a>content URL</a>. In other words, even the disallowed URL strings
+							described above will not "leak" outside the container. They are still disallowed for better
+							interoperability with non-conforming or legacy Reading Systems and toolchains. </p>
 					</div>
 
 					<aside class="example" title="Referencing a file in the same directory">
@@ -6143,10 +6150,11 @@ No Entry</pre>
 					<section id="sec-parsing-urls-metainf">
 						<h5>Parsing URLs in the <code>META-INF</code> Directory</h5>
 
-						<p id="sec-container-metainf-url-parsing" data-tests="#ocf-url_relative">To parse a URL string <var>url</var> used in files located in the <code>META-INF</code>
-							directory the <a data-cite="url#concept-url-parser">URL Parser</a> MUST be applied to
-								<var>url</var>, with the <a>container root URL</a> as <a
-								data-cite="url#concept-base-url"><var>base</var></a>.</p>
+						<p id="sec-container-metainf-url-parsing" data-tests="#ocf-url_relative">To parse a URL string
+								<var>url</var> used in files located in the <code>META-INF</code> directory the <a
+								data-cite="url#concept-url-parser">URL Parser</a> MUST be applied to <var>url</var>,
+							with the <a>container root URL</a> as <a data-cite="url#concept-base-url"
+								><var>base</var></a>.</p>
 
 						<aside class="example" title="Resolving paths in the container file">
 							<p>If container file (<code>META-INF/container.xml</code>) has the following content:</p>
@@ -9133,6 +9141,17 @@ html.my-document-playing * {
 					</tr>
 					<tr>
 						<td>
+							<code>application/x-dtbncx+xml</code>
+						</td>
+						<td>
+							<code>-//NISO//DTD ncx 2005-1//EN</code>
+						</td>
+						<td>
+							<code>http://www.daisy.org/z3986/2005/ncx-2005-1.dtd</code>
+						</td>
+					</tr>
+					<tr>
+						<td>
 							<code>application/svg+xml</code>
 						</td>
 						<td>
@@ -10751,6 +10770,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>09-Mar-2022: Added NCX doctype to allowed external identifiers. See <a
+						href="https://github.com/w3c/epub-specs/issues/2045">issue 2045</a>.</li>
 				<li>08-Mar-2022: Require use of the fixed layout property values defined in this specification. See <a
 						href="https://github.com/w3c/epub-specs/issues/2039">issue 2039</a>.</li>
 				<li>08-Mar-2022: Clarified that the refines attribute must not be used with global fixed layout property

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9109,7 +9109,7 @@ html.my-document-playing * {
 				media types specified in their <a href="#sec-manifest-elem">manifest</a> declarations. (Refer to <a
 					href="#sec-xml-constraints"></a> for more information.)</p>
 
-			<table>
+			<table class="zebra">
 				<thead>
 					<tr>
 						<th>Media Type(s)</th>


### PR DESCRIPTION
Fixes #2045


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2047.html" title="Last updated on Mar 10, 2022, 11:27 AM UTC (1b1de14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2047/f8a9622...1b1de14.html" title="Last updated on Mar 10, 2022, 11:27 AM UTC (1b1de14)">Diff</a>