### PR TITLE
Simplify the authoring shorthands section

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -596,38 +596,14 @@
 
 			<section id="conformance"></section>
 
-			<section id="sec-intro-shorthands">
+			<section id="sec-intro-shorthands" class="informative">
 				<h3>Authoring Shorthands</h3>
 
-				<section id="sec-shorthands-prefixes">
-					<h4>Prefixes</h4>
+				<p>In <a>Package Document</a> metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
+						prefixes</a> are used without declaration.</p>
 
-					<p>In <a>Package Document</a> metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
-							prefixes</a> are used without declaration.</p>
-				</section>
-
-				<section id="sec-shorthands-ns">
-					<h4>Namespaces</h4>
-
-					<p>For convenience, the following namespace prefixes [[XML-NAMES]] are used in this specification
-						without explicitly being declared. EPUB Creators MUST declare these prefixes to use them in an
-							<a>EPUB Content Document</a>.</p>
-
-					<table class="mapping">
-						<tr>
-							<th>prefix</th>
-							<th>URI</th>
-						</tr>
-						<tr>
-							<td>
-								<code>epub</code>
-							</td>
-							<td>
-								<code>http://www.idpf.org/2007/ops</code>
-							</td>
-						</tr>
-					</table>
-				</section>
+				<p>The <code>epub</code> namespace prefix [[XML-NAMES]] is also used on elements and attributes without
+					always having an explicit declaration (<code>xmlns:epub="http://www.idpf.org/2007/ops"</code>).</p>
 			</section>
 		</section>
 		<section id="sec-publications">


### PR DESCRIPTION
Looking at this section again, there's no need to have two subsections. There are only two brief statements being made.

The table of xml namespaces has also become pointless now that there's only the epub prefix left.

I'm also removing the requirement about having to declare xml prefixes as that's redundant with the xml conformance section requirements.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2049.html" title="Last updated on Mar 9, 2022, 1:56 PM UTC (0f6d3fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2049/1a51686...0f6d3fc.html" title="Last updated on Mar 9, 2022, 1:56 PM UTC (0f6d3fc)">Diff</a>