### PR TITLE
Added styling to explanations

### DIFF
--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -356,3 +356,14 @@ details.desc > summary {
     font-weight: normal !important;
     font-style: italic;
 }
+
+details.explanation {
+	background-color: rgb(245,245,245);
+	border-left: 0.3em solid rgb(200,200,200);
+	padding: 0.3em;
+}
+
+details.explanation > summary {
+	font-size: small;
+}
+

--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -351,19 +351,16 @@ details.desc {
 	margin-left: 3rem !important;
 }
 
-details.desc > summary {
-	text-align: left;
-    font-weight: normal !important;
-    font-style: italic;
-}
-
-details.explanation {
+details.explanation, details.desc {
 	background-color: rgb(245,245,245);
 	border-left: 0.3em solid rgb(200,200,200);
 	padding: 0.3em;
 }
 
-details.explanation > summary {
+details.explanation > summary, details.desc > summary {
 	font-size: small;
+	text-align: left;
+    font-weight: normal !important;
+    font-style: italic;
 }
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5995,7 +5995,7 @@ No Entry</pre>
 						return <var>true</var>: </p>
 
 					<ol class="algorithm" id="algo-out-of-container">
-						<li> Set the <a>container root URL</a> to <code>https://a.example.org/A/</code>. <details>
+						<li> Set the <a>container root URL</a> to <code>https://a.example.org/A/</code>. <details class="explanation">
 								<summary>Explanation</summary>
 								<p> The goal of the algorithm is to detect whether <var>url</var> could be
 									seen as "leaking" outside the container. To do that, the standard <a
@@ -6011,7 +6011,7 @@ No Entry</pre>
 						<li> Let <var>base</var> be the <a data-cite="url#concept-base-url">base URL</a> that must be
 							used to parse <var>url</var> as defined by the context (document or environment) where
 								<var>url</var> is used, and according to the <a>content URL</a> of the <a>Package
-								Document</a> (see <a href="#sec-parse-package-urls"></a>). <details>
+								Document</a> (see <a href="#sec-parse-package-urls"></a>). <details class="explanation">
 								<summary>Explanation</summary>
 								<p> In the case of a URL in the package document the <var>base</var>
 									variable is set to the <a>content URL</a> of the <a>Package Document</a>. In the
@@ -6033,7 +6033,7 @@ No Entry</pre>
 						<li> Let <var>testURLStringA</var> be the result of applying the <a
 								data-cite="url#concept-url-serializer">URL Serializer</a> to <var>testURLRecord</var>. </li>
 
-						<li> Set the <a>container root URL</a> to <code>https://b.example.org/B/</code>. <details>
+						<li> Set the <a>container root URL</a> to <code>https://b.example.org/B/</code>. <details class="explanation">
 								<summary>Explanation</summary>
 								<p>The reasons to repeat the same steps twice with different, and
 									artificial, settings of the container root URL is to avoid collision which may occur
@@ -6056,7 +6056,7 @@ No Entry</pre>
 
 						<li> If <var>testURLStringA</var> does not start with <code>https://a.example.org/</code> or
 								<var>testURLStringB</var> does not start with <code>https://b.example.org/</code>,
-							return <var>true</var>. <details>
+							return <var>true</var>. <details class="explanation">
 								<summary>Explanation</summary>
 								<p> If any of the result does not share the test URL host, it means that
 										<var>url</var>, or its base URL (for example, in HTML, if it is explicitly set
@@ -6067,7 +6067,7 @@ No Entry</pre>
 
 						<li> If <var>testURLStringA</var> starts with <code>https://a.example.org/A/</code> and
 								<var>testURLStringB</var> starts with <code>https://b.example.org/B/</code>, return
-								<var>true</var>. <details>
+								<var>true</var>. <details class="explanation">
 								<summary>Explanation</summary>
 								<p>The presence of the first test path segments (<code>A</code>,
 									respectively <code>B</code>) indicate that the URL doesn't leak outside the


### PR DESCRIPTION
I got inspired by the way explanations are styled in the LPF spec: making the summary font a bit smaller, and get the background color and left border styled a bit like notes but in gray.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2050.html" title="Last updated on Mar 10, 2022, 8:18 AM UTC (dd7aefd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2050/0e26b2e...dd7aefd.html" title="Last updated on Mar 10, 2022, 8:18 AM UTC (dd7aefd)">Diff</a>