### PR TITLE
Subsection shared attributes

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1216,57 +1216,60 @@
 					<p>This section provides definitions for shared attributes (i.e., attributes allowed on two or more
 						elements).</p>
 
-					<dl class="variablelist">
-						<dt id="attrdef-dir">
-							<code>dir</code>
-						</dt>
-						<dd>
-							<p
-								data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
-								>Specifies the <a data-cite="bidi#BD5">base direction</a> [[BIDI]] of the textual
-								content and attribute values of the carrying element and its descendants</p>
-							<p>Allowed values are:</p>
-							<ul>
-								<li><code>ltr</code> &#8212; left-to-right base direction;</li>
-								<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
-								<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi
-									Algorithm [[BIDI]].</li>
-							</ul>
-							<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will assume
-								the value <code>auto</code> when EPUB Creators omit the attribute or use an invalid
-								value.</p>
-							<div class="note">
-								<p>The base direction specified in the <code>dir</code> attribute does not affect the
-									ordering of characters within directional runs, only the relative ordering of those
-									runs and the placement of weak directional characters such as punctuation.</p>
-							</div>
-							<aside class="example" title="Setting the global base direction for Package Document text">
-								<pre>&lt;package … dir="ltr">
+					<section id="attrdef-dir">
+						<h5>The <code>dir</code> Attribute</h5>
+
+						<p
+							data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
+							>Specifies the <a data-cite="bidi#BD5">base direction</a> [[BIDI]] of the textual content
+							and attribute values of the carrying element and its descendants</p>
+
+						<p>Allowed values are:</p>
+
+						<ul>
+							<li><code>ltr</code> &#8212; left-to-right base direction;</li>
+							<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
+							<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi Algorithm
+								[[BIDI]].</li>
+						</ul>
+
+						<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will assume the
+							value <code>auto</code> when EPUB Creators omit the attribute or use an invalid value.</p>
+
+						<div class="note">
+							<p>The base direction specified in the <code>dir</code> attribute does not affect the
+								ordering of characters within directional runs, only the relative ordering of those runs
+								and the placement of weak directional characters such as punctuation.</p>
+						</div>
+
+						<aside class="example" title="Setting the global base direction for Package Document text">
+							<pre>&lt;package … dir="ltr">
    …
 &lt;/package></pre>
-							</aside>
-							<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-									href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-									href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-									href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
-										><code>dc:title</code></a>, <a href="#sec-meta-elem"><code>meta</code></a> and
-									<a href="#sec-package-elem"><code>package</code></a>.</p>
-						</dd>
+						</aside>
 
-						<dt id="attrdef-href">
-							<code>href</code>
-						</dt>
-						<dd>
-							<p>A <a data-cite="url#valid-url-string">valid URL string</a> [[URL]] that references a
-								resource. If the value is an <a data-cite="url#absolute-url-string">absolute URL</a>, it
-								SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
-							<aside class="example" title="Linking a metadata record">
-								<pre>&lt;package …>
+						<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+								href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+								href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
+								href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
+									><code>dc:title</code></a>, <a href="#sec-meta-elem"><code>meta</code></a> and <a
+								href="#sec-package-elem"><code>package</code></a>.</p>
+					</section>
+
+					<section id="attrdef-href">
+						<h5>The <code>href</code> Attribute</h5>
+
+						<p>A <a data-cite="url#valid-url-string">valid URL string</a> [[URL]] that references a
+							resource. If the value is an <a data-cite="url#absolute-url-string">absolute URL</a>, it
+							SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
+
+						<aside class="example" title="Linking a metadata record">
+							<pre>&lt;package …>
    &lt;metadata …>
       …
       &lt;link
@@ -1277,49 +1280,50 @@
    &lt;/metadata>
    …
 &lt;/package></pre>
-							</aside>
-							<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
-										><code>link</code></a>.</p>
-						</dd>
+						</aside>
 
-						<dt id="attrdef-id">
-							<code>id</code>
-						</dt>
-						<dd>
-							<p>The ID [[XML]] of the element, which MUST be unique within the document scope.</p>
-							<aside class="example" title="Adding an identifier attribute">
-								<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
-							</aside>
-							<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-									href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-									href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:date</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, <a
-									href="#sec-opf-dcidentifier"><code>dc:identifier</code></a>, <a
-									href="#sec-opf-dclanguage"><code>dc:language</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, <a
-									href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
-										><code>dc:title</code></a>, <a href="#sec-opf-dctype"><code>dc:type</code></a>,
-									<a href="#sec-item-elem"><code>item</code></a>, <a href="#sec-itemref-elem"
-										><code>itemref</code></a>, <a href="#sec-link-elem"><code>link</code></a>, <a
-									href="#sec-manifest-elem"><code>manifest</code></a>, <a href="#sec-meta-elem"
-										><code>meta</code></a>, <a href="#sec-package-elem"><code>package</code></a> and
-									<a href="#sec-spine-elem"><code>spine</code></a>.</p>
-						</dd>
+						<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
+									><code>link</code></a>.</p>
+					</section>
 
-						<dt id="attrdef-media-type">
-							<code>media-type</code>
-						</dt>
-						<dd>
-							<p>A media type [[RFC2046]] that specifies the type and format of the referenced
-								resource.</p>
-							<aside class="example" title="Adding the media type for a linked record">
-								<pre>&lt;package …>
+					<section id="attrdef-id">
+						<h5>The <code>id</code> Attribute</h5>
+
+						<p>The ID [[XML]] of the element, which MUST be unique within the document scope.</p>
+
+						<aside class="example" title="Adding an identifier attribute">
+							<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
+						</aside>
+
+						<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+								href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+								href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:date</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, <a
+								href="#sec-opf-dcidentifier"><code>dc:identifier</code></a>, <a
+								href="#sec-opf-dclanguage"><code>dc:language</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, <a
+								href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
+									><code>dc:title</code></a>, <a href="#sec-opf-dctype"><code>dc:type</code></a>, <a
+								href="#sec-item-elem"><code>item</code></a>, <a href="#sec-itemref-elem"
+									><code>itemref</code></a>, <a href="#sec-link-elem"><code>link</code></a>, <a
+								href="#sec-manifest-elem"><code>manifest</code></a>, <a href="#sec-meta-elem"
+									><code>meta</code></a>, <a href="#sec-package-elem"><code>package</code></a> and <a
+								href="#sec-spine-elem"><code>spine</code></a>.</p>
+					</section>
+
+					<section id="attrdef-media-type">
+						<h5>The <code>media-type</code> Attribute</h5>
+
+						<p>A media type [[RFC2046]] that specifies the type and format of the referenced resource.</p>
+
+						<aside class="example" title="Adding the media type for a linked record">
+							<pre>&lt;package …>
    &lt;metadata …>
       …
       &lt;link
@@ -1331,20 +1335,22 @@
    &lt;/metadata>
    …
 &lt;/package></pre>
-							</aside>
-							<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
-										><code>link</code></a>.</p>
-						</dd>
+						</aside>
 
-						<dt id="attrdef-properties">
-							<code>properties</code>
-						</dt>
-						<dd>
-							<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
-							<p>Refer to each element's definition for the <a href="#sec-default-vocab">reserved
-									vocabulary</a> for the attribute.</p>
-							<aside class="example" title="Identifying the EPUB Navigation Document in the manifest">
-								<pre>&lt;package …>
+						<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
+									><code>link</code></a>.</p>
+					</section>
+
+					<section id="attrdef-properties">
+						<h5>The <code>properties</code> Attribute</h5>
+
+						<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
+
+						<p>Refer to each element's definition for the <a href="#sec-default-vocab">reserved
+								vocabulary</a> for the attribute.</p>
+
+						<aside class="example" title="Identifying the EPUB Navigation Document in the manifest">
+							<pre>&lt;package …>
    …
    &lt;manifest>
       …
@@ -1357,24 +1363,24 @@
    &lt;/manifest>
    …
 &lt;/package></pre>
-							</aside>
-							<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a href="#sec-itemref-elem"
-										><code>itemref</code></a> and <a href="#sec-link-elem"
-								><code>link</code></a>.</p>
-						</dd>
+						</aside>
 
-						<dt id="attrdef-refines">
-							<code>refines</code>
-						</dt>
-						<dd>
-							<p>Establishes an association between the current expression and the element or resource
-								identified by its value. EPUB Creators MUST use as the value a <a
-									data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL
-									string</a>, optionally followed by <code>U+0023 (#)</code> and a <a
-									data-cite="url#url-fragment-string">URL-fragment string</a> that references the
-								resource or element they are describing.</p>
-							<aside class="example" title="Specifying that a creator is the illustrator">
-								<pre>&lt;package …>
+						<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a href="#sec-itemref-elem"
+									><code>itemref</code></a> and <a href="#sec-link-elem"><code>link</code></a>.</p>
+					</section>
+
+					<section id="attrdef-refines">
+						<h5>The <code>refines</code> Attribute</h5>
+
+						<p>Establishes an association between the current expression and the element or resource
+							identified by its value. EPUB Creators MUST use as the value a <a
+								data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL
+								string</a>, optionally followed by <code>U+0023 (#)</code> and a <a
+								data-cite="url#url-fragment-string">URL-fragment string</a> that references the resource
+							or element they are describing.</p>
+
+						<aside class="example" title="Specifying that a creator is the illustrator">
+							<pre>&lt;package …>
    &lt;metadata …>
       …
       &lt;dc:creator id="creator02">
@@ -1390,15 +1396,18 @@
    &lt;/metadata>
    …
 &lt;/package></pre>
-							</aside>
-							<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata
-								expressed. When omitted, the element defines a <a href="#primary-expression">primary
-									expression</a>.</p>
-							<p>When creating expressions about a <a>Publication Resource</a>, the <code>refines</code>
-								attribute SHOULD specify a fragment identifier that references the ID of the resource's
-									<a href="#sec-item-elem">manifest entry</a>.</p>
-							<aside class="example" title="Setting the duration of a Media Overlay Document">
-								<pre>&lt;package …>
+						</aside>
+
+						<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata expressed.
+							When omitted, the element defines a <a href="#primary-expression">primary
+							expression</a>.</p>
+
+						<p>When creating expressions about a <a>Publication Resource</a>, the <code>refines</code>
+							attribute SHOULD specify a fragment identifier that references the ID of the resource's <a
+								href="#sec-item-elem">manifest entry</a>.</p>
+
+						<aside class="example" title="Setting the duration of a Media Overlay Document">
+							<pre>&lt;package …>
    &lt;metadata …>
       …
       &lt;meta
@@ -1418,38 +1427,38 @@
    &lt;/manifest>
    …
 &lt;/package></pre>
-							</aside>
-							<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a href="#sec-meta-elem"
-										><code>meta</code></a>.</p>
-						</dd>
+						</aside>
 
-						<dt id="attrdef-xml-lang">
-							<code>xml:lang</code>
-						</dt>
-						<dd>
-							<p>Specifies the language of the textual content and attribute values of the carrying
-								element and its descendants, as defined in section <a data-cite="xml#sec-lang-tag">2.12
-									Language Identification</a> of [[XML]]. The value of each <code>xml:lang</code>
-								attribute MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language tag</a>
-								[[BCP47]].</p>
-							<aside class="example" title="Setting the global language for Package Document text">
-								<pre>&lt;package … xml:lang="ja">
+						<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a href="#sec-meta-elem"
+									><code>meta</code></a>.</p>
+					</section>
+
+					<section id="attrdef-xml-lang">
+						<h5>The <code>xml:lang</code> Attribute</h5>
+						
+						<p>Specifies the language of the textual content and attribute values of the carrying element
+							and its descendants, as defined in section <a data-cite="xml#sec-lang-tag">2.12 Language
+								Identification</a> of [[XML]]. The value of each <code>xml:lang</code> attribute MUST be
+							a <a data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
+						
+						<aside class="example" title="Setting the global language for Package Document text">
+							<pre>&lt;package … xml:lang="ja">
    …
 &lt;/package></pre>
-							</aside>
-							<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-									href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-									href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-									href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-									href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
-										><code>dc:title</code></a>, <a href="#sec-meta-elem"><code>meta</code></a> and
-									<a href="#sec-package-elem"><code>package</code></a>.</p>
-						</dd>
-					</dl>
+						</aside>
+						
+						<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+								href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+								href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+								href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
+								href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
+									><code>dc:title</code></a>, <a href="#sec-meta-elem"><code>meta</code></a> and <a
+								href="#sec-package-elem"><code>package</code></a>.</p>
+					</section>
 				</section>
 
 				<section id="sec-package-elem">
@@ -5997,14 +6006,14 @@ No Entry</pre>
 					<ol class="algorithm" id="algo-out-of-container">
 						<li> Set the <a>container root URL</a> to <code>https://a.example.org/A/</code>. <details>
 								<summary>Explanation</summary>
-								<p> The goal of the algorithm is to detect whether <var>url</var> could be
-									seen as "leaking" outside the container. To do that, the standard <a
+								<p> The goal of the algorithm is to detect whether <var>url</var> could be seen as
+									"leaking" outside the container. To do that, the standard <a
 										data-cite="url#concept-url-parser">URL parsing algorithm</a> is used with an
 									artificial root URL; the detection of the "leak" is done by comparing the result of
 									the parsing with the presence of the first test path segment (<code>A</code>). (Note
 									that the artificial container root URL wilfully violates, for the purpose of this
-									algorithm, the <a href="#sec-root-url-properties">required properties</a> by using that
-									first test path segment.) </p>
+									algorithm, the <a href="#sec-root-url-properties">required properties</a> by using
+									that first test path segment.) </p>
 							</details>
 						</li>
 
@@ -6013,14 +6022,13 @@ No Entry</pre>
 								<var>url</var> is used, and according to the <a>content URL</a> of the <a>Package
 								Document</a> (see <a href="#sec-parse-package-urls"></a>). <details>
 								<summary>Explanation</summary>
-								<p> In the case of a URL in the package document the <var>base</var>
-									variable is set to the <a>content URL</a> of the <a>Package Document</a>. In the
-									case of a document within the <code>META-INF</code> directory, the <var>base</var>
-									variable is set to the <a>container root URL</a> (see <a
-										href="#sec-parsing-urls-metainf"></a>). In the case of a URL in an XHTML Content
-									Document, the base URL used for parsing is defined by the <a
-										data-cite="html#resolving-urls">HTML standard</a>. Typically, it will be the
-										<a>content URL</a> of the content document (unless the <a
+								<p> In the case of a URL in the package document the <var>base</var> variable is set to
+									the <a>content URL</a> of the <a>Package Document</a>. In the case of a document
+									within the <code>META-INF</code> directory, the <var>base</var> variable is set to
+									the <a>container root URL</a> (see <a href="#sec-parsing-urls-metainf"></a>). In the
+									case of a URL in an XHTML Content Document, the base URL used for parsing is defined
+									by the <a data-cite="html#resolving-urls">HTML standard</a>. Typically, it will be
+									the <a>content URL</a> of the content document (unless the <a
 										href="#sec-xhtml-deviations-base">discouraged</a>
 									<code>base</code> element is used). </p>
 							</details>
@@ -6035,10 +6043,10 @@ No Entry</pre>
 
 						<li> Set the <a>container root URL</a> to <code>https://b.example.org/B/</code>. <details>
 								<summary>Explanation</summary>
-								<p>The reasons to repeat the same steps twice with different, and
-									artificial, settings of the container root URL is to avoid collision which may occur
-									if the <var>url</var> string also includes <code>/A/</code>. Consider, for example,
-									the case where <var>url</var> is <code>../../A/doc.xhtml</code>.</p>
+								<p>The reasons to repeat the same steps twice with different, and artificial, settings
+									of the container root URL is to avoid collision which may occur if the
+										<var>url</var> string also includes <code>/A/</code>. Consider, for example, the
+									case where <var>url</var> is <code>../../A/doc.xhtml</code>.</p>
 							</details>
 						</li>
 
@@ -6058,9 +6066,9 @@ No Entry</pre>
 								<var>testURLStringB</var> does not start with <code>https://b.example.org/</code>,
 							return <var>true</var>. <details>
 								<summary>Explanation</summary>
-								<p> If any of the result does not share the test URL host, it means that
-										<var>url</var>, or its base URL (for example, in HTML, if it is explicitly set
-									with the <code>base</code> element), was <em>absolute</em> and points outside the
+								<p> If any of the result does not share the test URL host, it means that <var>url</var>,
+									or its base URL (for example, in HTML, if it is explicitly set with the
+										<code>base</code> element), was <em>absolute</em> and points outside the
 									container. This is acceptable. </p>
 							</details>
 						</li>
@@ -6069,9 +6077,8 @@ No Entry</pre>
 								<var>testURLStringB</var> starts with <code>https://b.example.org/B/</code>, return
 								<var>true</var>. <details>
 								<summary>Explanation</summary>
-								<p>The presence of the first test path segments (<code>A</code>,
-									respectively <code>B</code>) indicate that the URL doesn't leak outside the
-									container.</p>
+								<p>The presence of the first test path segments (<code>A</code>, respectively
+										<code>B</code>) indicate that the URL doesn't leak outside the container.</p>
 							</details>
 						</li>
 


### PR DESCRIPTION
A case of wanting to add some structure instead of removing.

I've been having to go to the shared attribute definitions a lot lately, and it's been a pain to have to link to the top of the section and then scroll through until I find the definition I'm looking for.

Having the attributes appear in the toc by making subsections of them also makes it easier to find out which ones are defined in the section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2051.html" title="Last updated on Mar 10, 2022, 12:12 PM UTC (c6c8e68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2051/2c10389...c6c8e68.html" title="Last updated on Mar 10, 2022, 12:12 PM UTC (c6c8e68)">Diff</a>