### PR TITLE
Remove redundant requirement for a publication to define a title

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1943,9 +1943,9 @@
 								</dd>
 							</dl>
 
-							<p>The <code>metadata</code> section MUST contain at least one <code>title</code> element
-								containing the title for the EPUB Publication.</p>
-
+							<p id="title-order">The first <code>title</code> element in document order is the main title
+								of the EPUB Publication (i.e., the primary one Reading Systems present to users).</p>
+							
 							<aside class="example" title="A basic title element">
 								<pre>&lt;metadata …>
    &lt;dc:title>
@@ -1955,9 +1955,6 @@
 &lt;/metadata>
 </pre>
 							</aside>
-
-							<p id="title-order">The first <code>title</code> element in document order is the main title
-								of the EPUB Publication (i.e., the primary one Reading Systems present to users).</p>
 
 							<p>EPUB Creators should use only a single <code>title</code> element to ensure consistent
 								rendering of the title in Reading Systems.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2042,8 +2042,7 @@
 								</dd>
 							</dl>
 
-							<p>The <code>metadata</code> section MUST contain at least one <code>language</code>
-								element. The <a>value</a> of each <code>language</code> element MUST be a <a
+							<p>The <a>value</a> of each <code>language</code> element MUST be a <a
 									data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
 
 							<aside class="example"


### PR DESCRIPTION
In the title element definition, this sentence isn't saying anything new:

> The metadata section MUST contain at least one title element containing the title for the EPUB Publication.

The metadata element already defines the required minimal metadata, and the definition box for the title element also specifies it's a required element. It's not until you get to the paragraph after the example that we tell people the first title element in document order specifies the title.

This PR deletes the requirement and moves the paragraph about how the title is determined into its place.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2052.html" title="Last updated on Mar 9, 2022, 5:54 PM UTC (b0888b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2052/0e26b2e...b0888b2.html" title="Last updated on Mar 9, 2022, 5:54 PM UTC (b0888b2)">Diff</a>