### PR TITLE
Add that title and identifier are repeatable elements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1803,7 +1803,7 @@
 								<dt>Usage</dt>
 								<dd>
 									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
-												><code>metadata</code></a>.</p>
+												><code>metadata</code></a>. Repeatable.</p>
 								</dd>
 
 								<dt>Attributes</dt>
@@ -1904,7 +1904,7 @@
 								<dt>Usage</dt>
 								<dd>
 									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
-												><code>metadata</code></a>.</p>
+												><code>metadata</code></a>. Repeatable.</p>
 								</dd>
 
 								<dt>Attributes</dt>


### PR DESCRIPTION
Repeatable elements are supposed to state "Repeatable" in their usage fields. Noticed that the identifier and title definitions were missing this statement.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Time-out :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 9, 2022, 5:41 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2F7472b4f524e74b624ae7dd16ce3313cf463b660a%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232053.)._
</details>
