### PR TITLE
Remove normative keyword from date element definition

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2265,7 +2265,7 @@
 &lt;/metadata></pre>
 							</aside>
 
-							<p>EPUB Creators SHOULD express additional dates using the specialized date properties
+							<p>EPUB Creators should express additional dates using the specialized date properties
 								available in the [[DCTERMS]] vocabulary, or similar.</p>
 
 							<p>EPUB Publications MUST NOT contain more than one <code>date</code> element.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2185,7 +2185,7 @@
 &lt;/metadata></pre>
 							</aside>
 
-							<p>The <code>creator</code> element SHOULD contain the name of the creator as EPUB Creators
+							<p>The <code>creator</code> element should contain the name of the creator as EPUB Creators
 								intend Reading Systems to display it to users.</p>
 
 							<p>EPUB Creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
@@ -2215,7 +2215,7 @@
 &lt;/metadata></pre>
 							</aside>
 
-							<p>If an EPUB Publication has more than one creator, EPUB Creators SHOULD specify each in a
+							<p>If an EPUB Publication has more than one creator, EPUB Creators should specify each in a
 								separate <code>creator</code> element.</p>
 
 							<p>The document order of <code>creator</code> elements in the <code>metadata</code> section
@@ -2239,7 +2239,7 @@
 &lt;/metadata></pre>
 							</aside>
 
-							<p>EPUB Creators SHOULD represent secondary contributors using the <a
+							<p>EPUB Creators should represent secondary contributors using the <a
 									href="#sec-opf-dccontributor"><code>contributor</code> element</a>.</p>
 						</section>
 
@@ -2275,8 +2275,8 @@
 							<h6>The <code>subject</code> Element</h6>
 
 							<p>The [[DCTERMS]] <code>subject</code> element identifies the subject of the EPUB
-								Publication. EPUB Creators SHOULD set the <a>value</a> of the element to the
-								human-readable heading or label, but MAY use a code value if the subject taxonomy does
+								Publication. EPUB Creators should set the <a>value</a> of the element to the
+								human-readable heading or label, but may use a code value if the subject taxonomy does
 								not provide a separate descriptive label.</p>
 
 							<p>EPUB Creators MAY identify the system or scheme they drew the element's <a>value</a> from

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2246,11 +2246,11 @@
 						<section id="sec-opf-dcdate">
 							<h6>The <code>date</code> Element</h6>
 
-							<p>The [[DCTERMS]] <code>date</code> element MUST only be used to define the publication
-								date of the <a>EPUB Publication</a>. The publication date is not the same as the <a
+							<p>The [[DCTERMS]] <code>date</code> element defines the publication date of the <a>EPUB
+								Publication</a>. The publication date is not the same as the <a
 									href="#last-modified-date">last modified date</a> (the last time the EPUB Creator
 								changed the EPUB Publication).</p>
-
+							
 							<p>It is RECOMMENDED that the date string conform to [[ISO8601]], particularly the subset
 								expressed in W3C Date and Time Formats [[DateTime]], as such strings are both human and
 								machine readable.</p>


### PR DESCRIPTION
This statement doesn't need to be expressed as a requirement on authors, since it's impossible to verify intent:

> The [DCTERMS] date element MUST only be used to define the publication date of the EPUB Publication.

It only needs to state how the element is interpreted:

> The [DCTERMS] date element defines the publication date of the EPUB Publication.

Fixes #2054


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2055.html" title="Last updated on Mar 9, 2022, 8:09 PM UTC (e785e5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2055/0e26b2e...e785e5c.html" title="Last updated on Mar 9, 2022, 8:09 PM UTC (e785e5c)">Diff</a>