### PR TITLE
Improved a sentence on linear itemref elements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3577,10 +3577,12 @@ No Entry</pre>
 
 						</div>
 
-						<p id="linear-itemrefs">The <a>spine</a> MUST contain at least one linear <code>itemref</code>
-							element &#8212; whose <code>linear</code> attribute value is either explicitly or implicitly
-							set to "<code>yes</code>". Reading Systems will assume the value "<code>yes</code>" for
-								<code>itemref</code> elements without a <code>linear</code> attribute.</p>
+						<p id="linear-itemrefs">
+							A linear <code>itemref</code> element is one whose <code>linear</code> attribute value is explicitly
+							set to "<code>yes</code>"" or that omits the attribute — Reading Systems will assume the value
+							 "<code>yes</code>" for <code>itemref</code> elements without the attribute.
+							 The spine MUST contain at least one linear <code>itemref</code> element.
+						</p>
 
 						<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide a
 							means of accessing all non-linear content (e.g., hyperlinks in the content or from the <a


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2059.html" title="Last updated on Mar 10, 2022, 2:15 PM UTC (c30a775)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2059/59d5821...c30a775.html" title="Last updated on Mar 10, 2022, 2:15 PM UTC (c30a775)">Diff</a>