### PR TITLE
Separate collection authoring from specialization requirements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3702,39 +3702,11 @@ No Entry</pre>
 							or collecting together resources that present additional information about the <a>EPUB
 								Publication</a>.</p>
 
-						<p>The <code>collection</code> element, as defined in this section, represents a generic
-							framework from which specializations are intended to be derived (e.g., through EPUB
-							sub-specifications). Such specializations MUST define the purpose of the
-								<code>collection</code> element, as well as all requirements for its valid production
-							and use (specifically any requirements that differ from the general framework presented
-							below).</p>
-
-						<p id="attrdef-collection-role">Each specialization MUST define a role value that uniquely
-							identifies all conformant <code>collection</code> elements. EPUB Creators MUST identify the
-							role of each <code>collection</code> element in its <code>role</code> attribute, whose value
-							MUST be one or more NMTOKENs [[XMLSCHEMA-2]] and/or <a
+						<p id="attrdef-collection-role">EPUB Creators MUST identify the role of each
+								<code>collection</code> element in its <code>role</code> attribute, whose value MUST be
+							one or more NMTOKENs [[XMLSCHEMA-2]] and/or <a
 								data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment strings</a>
 							[[URL]].</p>
-
-						<p>This specification reserves the use of NMTOKEN values for roles defined in EPUB
-							specifications. NMTOKEN values not defined by a recognized specification are not valid. This
-							section does not define any roles.</p>
-
-						<p>Third parties MAY define custom roles for the <code>collection</code> element, but they MUST
-							identify such roles using <a data-cite="url#absolute-url-with-fragment-string"
-								>absolute-URL-with-fragment strings</a> [[URL]]. Custom roles MUST NOT incorporate the
-							string "<code>idpf.org</code>" in the <a data-cite="url#concept-host">host component</a>
-							[[URL]] of their identifying URL.</p>
-
-						<div class="note">
-							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
-								Working Group maintained both a <a href="http://www.idpf.org/epub/registries/roles"
-									>registry of role extensions</a> and a list of <a
-									href="http://www.idpf.org/epub/extensions/roles">custom extension roles</a>. This
-								Working Group no longer maintains these registries and does not anticipate defining new
-								types of collections.</p>
-
-						</div>
 
 						<p id="elemdef-collection-metadata">The OPTIONAL <code>metadata</code> element child of
 								<code>collection</code> is an adaptation of the package <a href="#elemdef-opf-metadata"
@@ -3758,8 +3730,6 @@ No Entry</pre>
 											<code>meta</code> elements</a>.</p>
 							</li>
 						</ul>
-						<p>EPUB specifications that implement collections MAY override package-level restrictions on the
-							use of metadata elements.</p>
 
 						<p>A <code>collection</code> MAY define sub-collections through the inclusion of one or more
 							child <code>collection</code> elements.</p>
@@ -3782,18 +3752,9 @@ No Entry</pre>
 								<p>EPUB Creators MUST NOT specify the <code>refines</code> attribute.</p>
 							</li>
 						</ul>
+
 						<p>Each <code>link</code> element MUST reference a resource that is a member of the group. The
 							order of <code>link</code> elements is not significant.</p>
-
-						<p>Specializations of the <code>collection</code> element MAY tailor the requirements defined
-							above to better reflect their needs (e.g., requiring metadata, imposing further restrictions
-							on the use of elements and attributes, or making the order of <code>link</code> elements
-							significant). However, the resulting content model MUST represent a valid subset of the one
-							defined in this section (e.g., specializations cannot introduce new elements or attributes,
-							or re-introduce those expressly forbidden above). Specializations MUST NOT define
-							collections in a way that overrides the requirements of the <a href="#elemdef-opf-manifest"
-									><code>manifest</code></a> and <a href="#elemdef-opf-spine"
-							><code>spine</code></a>.</p>
 
 						<p>The rendering of an EPUB Publication MUST NOT be dependent on the recognition of
 								<code>collection</code> elements. The content MUST remain consumable by a user without
@@ -3820,6 +3781,50 @@ No Entry</pre>
    …
 &lt;/package></pre>
 						</aside>
+
+						<section id="sec-collections-defining-types">
+							<h6>Defining Collection Types</h6>
+
+							<div class="note">
+								<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
+									Working Group maintained both a <a href="http://www.idpf.org/epub/registries/roles"
+										>registry of role extensions</a> and a list of <a
+										href="http://www.idpf.org/epub/extensions/roles">custom extension roles</a>.
+									This Working Group no longer maintains these registries and does not anticipate
+									defining new types of collections.</p>
+							</div>
+
+							<p>The <code>collection</code> element, as defined in this specification, represents a
+								generic framework from which specializations are intended to be derived (e.g., through
+								EPUB sub-specifications). Such specializations define the purpose of the
+									<code>collection</code> element, as well as all requirements for its valid
+								production and use (specifically any requirements that differ from the general framework
+								presented below).</p>
+
+							<p>Each specialization MUST define a role value that uniquely identifies all conformant
+									<code>collection</code> elements. This specification reserves the use of NMTOKEN
+								values for roles defined in EPUB specifications. NMTOKEN values not defined by a
+								recognized specification are not valid. This section does not define any roles.</p>
+
+							<p>Third parties MAY define custom roles for the <code>collection</code> element, but they
+								MUST identify such roles using <a data-cite="url#absolute-url-with-fragment-string"
+									>absolute-URL-with-fragment strings</a> [[URL]]. Custom roles MUST NOT incorporate
+								the strings "<code>idpf.org</code>" or "w3.org" in the <a data-cite="url#concept-host"
+									>host component</a> [[URL]] of their identifying URL.</p>
+
+							<p>EPUB specifications that implement collections MAY override package-level restrictions on
+								the use of metadata elements.</p>
+
+							<p>Specializations of the <code>collection</code> element MAY tailor the requirements
+								defined above to better reflect their needs (e.g., requiring metadata, imposing further
+								restrictions on the use of elements and attributes, or making the order of
+									<code>link</code> elements significant). However, the resulting content model MUST
+								represent a valid subset of the one defined in this section (e.g., specializations
+								cannot introduce new elements or attributes, or re-introduce those expressly forbidden
+								above). Specializations must not define collections in a way that overrides the
+								requirements of the <a href="#elemdef-opf-manifest"><code>manifest</code></a> and <a
+									href="#elemdef-opf-spine"><code>spine</code></a>.</p>
+						</section>
 					</section>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3809,8 +3809,8 @@ No Entry</pre>
 						<p>Third parties MAY define custom roles for the <code>collection</code> element, but they MUST
 							identify such roles using <a data-cite="url#absolute-url-with-fragment-string"
 								>absolute-URL-with-fragment strings</a> [[URL]]. Custom roles MUST NOT incorporate the
-							strings "<code>idpf.org</code>" or "w3.org" in the <a data-cite="url#concept-host">host
-								component</a> [[URL]] of their identifying URL.</p>
+							strings "<code>idpf.org</code>" or "<code>w3.org</code>" in the <a
+								data-cite="url#concept-host">host component</a> [[URL]] of their identifying URL.</p>
 
 						<p>EPUB specifications that implement collections MAY override package-level restrictions on the
 							use of metadata elements.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3706,7 +3706,7 @@ No Entry</pre>
 								<code>collection</code> element in its <code>role</code> attribute, whose value MUST be
 							one or more NMTOKENs [[XMLSCHEMA-2]] and/or <a
 								data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment strings</a>
-							[[URL]].</p>
+							[[URL]]. (Refer to <a href="#sec-defining-collection-types"></a> for more information.)</p>
 
 						<p id="elemdef-collection-metadata">The OPTIONAL <code>metadata</code> element child of
 								<code>collection</code> is an adaptation of the package <a href="#elemdef-opf-metadata"

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3756,10 +3756,6 @@ No Entry</pre>
 						<p>Each <code>link</code> element MUST reference a resource that is a member of the group. The
 							order of <code>link</code> elements is not significant.</p>
 
-						<p>The rendering of an EPUB Publication MUST NOT be dependent on the recognition of
-								<code>collection</code> elements. The content MUST remain consumable by a user without
-							any information loss or other significant deterioration.</p>
-
 						<aside class="example" id="example-collection" title="A basic collection">
 							<p>In this example, the two linked <a>XHTML Content Documents</a> represent a single
 								unit.</p>
@@ -3824,6 +3820,10 @@ No Entry</pre>
 							collections in a way that overrides the requirements of the <a href="#elemdef-opf-manifest"
 									><code>manifest</code></a> and <a href="#elemdef-opf-spine"
 							><code>spine</code></a>.</p>
+
+						<p>The rendering of an EPUB Publication MUST NOT be dependent on the recognition of
+								<code>collection</code> elements. The content MUST remain consumable by a user without
+							any information loss or other significant deterioration.</p>
 					</section>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10752,6 +10752,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>10-Mar-2022: Created a new section for the requirements on defining new collection types. See <a
+						href="https://github.com/w3c/epub-specs/pull/2060">issue 2060</a>.</li>
 				<li>09-Mar-2022: Restore requirement that valid-relative-container-URL-with-fragment strings resolve to
 					resources in the OCF Abstract Container. See <a href="https://github.com/w3c/epub-specs/issues/2024"
 						>issue 2024</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3686,11 +3686,11 @@ No Entry</pre>
 
 							<dt>Content Model</dt>
 							<dd>
-								<p>In this order: <a href="#elemdef-collection-metadata"><code>metadata</code></a>
+								<p>In this order: <code>metadata</code>
 									<code>[0 or 1]</code>, ( <a href="#elemdef-collection"><code>collection</code></a>
 									<code>[1 or more]</code> or ( <a href="#elemdef-collection"
 										><code>collection</code></a>
-									<code>[0 or more]</code>, <a href="#elemdef-collection-link"><code>link</code></a>
+									<code>[0 or more]</code>, <code>link</code>
 									<code>[1 or more]</code> ))</p>
 							</dd>
 						</dl>
@@ -3724,10 +3724,11 @@ No Entry</pre>
 					<section id="sec-defining-collection-types">
 						<h5>Defining Collection Types (Deprecated)</h5>
 
-						<p>The creation of new <code>collection</code> element roles is now <a>deprecated</a>.</p>
+						<p>The creation of new <code>collection</code> element roles is now <a href="#deprecated"
+								>deprecated</a>.</p>
 
-						<p>Refer to [[EPUB32]] for more information about their creation, including the requirements and
-							restrictions on their use.</p>
+						<p>Refer to [[EPUBPackages-32]] for more information about their creation, including the
+							requirements and restrictions on their use.</p>
 					</section>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3708,7 +3708,7 @@ No Entry</pre>
 								data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment strings</a>
 							[[URL]].</p>
 
-						<p>The requirements for the authoring of specialized collections are defined by their respective
+						<p>The requirements for authoring specialized collections are defined by their respective
 							specifications.</p>
 
 						<div class="note">
@@ -3716,9 +3716,16 @@ No Entry</pre>
 								Working Group maintained both a <a href="http://www.idpf.org/epub/registries/roles"
 									>registry of role extensions</a> and a list of <a
 									href="http://www.idpf.org/epub/extensions/roles">custom extension roles</a>. This
-								Working Group no longer maintains these registries and does not anticipate defining new
-								types of collections.</p>
+								Working Group no longer maintains these registries.</p>
 						</div>
+
+						<aside class="example" title="A multi-document index">
+							<pre>&lt;collection role="index">
+   &lt;link href="subjectIndex01.xhtml"/>
+   &lt;link href="subjectIndex02.xhtml"/>
+   &lt;link href="subjectIndex03.xhtml"/>
+&lt;/collection></pre>
+						</aside>
 					</section>
 
 					<section id="sec-defining-collection-types">
@@ -3727,8 +3734,11 @@ No Entry</pre>
 						<p>The creation of new <code>collection</code> element roles is now <a href="#deprecated"
 								>deprecated</a>.</p>
 
-						<p>Refer to [[EPUBPackages-32]] for more information about their creation, including the
-							requirements and restrictions on their use.</p>
+						<p>Refer to the <a
+								href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
+									><code>collection</code> element definition</a> in [[EPUBPackages-32]] for more
+							information about the creation of specialized collections, including the requirements and
+							restrictions on their use.</p>
 					</section>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3706,81 +3706,10 @@ No Entry</pre>
 								<code>collection</code> element in its <code>role</code> attribute, whose value MUST be
 							one or more NMTOKENs [[XMLSCHEMA-2]] and/or <a
 								data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment strings</a>
-							[[URL]]. (Refer to <a href="#sec-defining-collection-types"></a> for more information.)</p>
+							[[URL]].</p>
 
-						<p id="elemdef-collection-metadata">The OPTIONAL <code>metadata</code> element child of
-								<code>collection</code> is an adaptation of the package <a href="#elemdef-opf-metadata"
-									><code>metadata</code> element</a>, with the following differences in syntax and
-							semantics:</p>
-
-						<ul>
-							<li>
-								<p>No metadata is mandatory by default.</p>
-							</li>
-							<li>
-								<p>All <a href="#primary-expression">primary metadata expressions</a> apply to the
-										<code>collection</code>.</p>
-							</li>
-							<li>
-								<p>The <a href="#attrdef-refines"><code>refines</code> attribute</a> MUST NOT reference
-									elements outside the containing <code>collection</code>.</p>
-							</li>
-							<li>
-								<p>The <code>metadata</code> element MUST NOT contain <a href="#sec-opf2-meta">OPF2
-											<code>meta</code> elements</a>.</p>
-							</li>
-						</ul>
-
-						<p>A <code>collection</code> MAY define sub-collections through the inclusion of one or more
-							child <code>collection</code> elements.</p>
-
-						<p id="elemdef-collection-link">The <code>link</code> element child of <code>collection</code>
-							is an adaptation of the metadata <a href="#elemdef-opf-link"><code>link</code> element</a>,
-							with the following differences in syntax and semantics:</p>
-
-						<ul>
-							<li>
-								<p>The <code>rel</code> attribute is OPTIONAL.</p>
-							</li>
-							<li>
-								<p>The <code>properties</code> attribute also accepts <a
-										href="#app-item-properties-vocab">manifest <code>item</code> properties</a>
-									without a prefix (e.g., so that a collection can declare its own Navigation Document
-									or cover image).</p>
-							</li>
-							<li>
-								<p>EPUB Creators MUST NOT specify the <code>refines</code> attribute.</p>
-							</li>
-						</ul>
-
-						<p>Each <code>link</code> element MUST reference a resource that is a member of the group. The
-							order of <code>link</code> elements is not significant.</p>
-
-						<aside class="example" id="example-collection" title="A basic collection">
-							<p>In this example, the two linked <a>XHTML Content Documents</a> represent a single
-								unit.</p>
-
-							<pre>&lt;package …>
-   …
-   &lt;collection
-       role="http://example.org/roles/unit">
-      &lt;metadata …>
-         &lt;dc:title>
-            Foo Bar
-         &lt;/dc:title>
-      &lt;/metadata>
-       &lt;link
-           href="EPUB/xhtml/foo-1.xhtml"/>
-       &lt;link
-           href="EPUB/xhtml/foo-2.xhtml"/>
-   &lt;/collection>
-   …
-&lt;/package></pre>
-						</aside>
-					</section>
-
-					<section id="sec-defining-collection-types">
-						<h5>Defining Collection Types</h5>
+						<p>The requirements for the authoring of specialized collections are defined by their respective
+							specifications.</p>
 
 						<div class="note">
 							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
@@ -3790,40 +3719,15 @@ No Entry</pre>
 								Working Group no longer maintains these registries and does not anticipate defining new
 								types of collections.</p>
 						</div>
+					</section>
 
-						<p>The <code>collection</code> element, as defined in this specification, represents a generic
-							framework from which specializations are intended to be derived (e.g., through EPUB
-							sub-specifications). Such specializations define the purpose of the <code>collection</code>
-							element, as well as all requirements for its valid production and use (specifically any
-							requirements that differ from the general framework presented below).</p>
+					<section id="sec-defining-collection-types">
+						<h5>Defining Collection Types (Deprecated)</h5>
 
-						<p>Each specialization MUST define a role value that uniquely identifies all conformant
-								<code>collection</code> elements. This specification reserves the use of NMTOKEN values
-							for roles defined in EPUB specifications. NMTOKEN values not defined by a recognized
-							specification are not valid. This section does not define any roles.</p>
+						<p>The creation of new <code>collection</code> element roles is now <a>deprecated</a>.</p>
 
-						<p>Third parties MAY define custom roles for the <code>collection</code> element, but they MUST
-							identify such roles using <a data-cite="url#absolute-url-with-fragment-string"
-								>absolute-URL-with-fragment strings</a> [[URL]]. Custom roles MUST NOT incorporate the
-							strings "<code>idpf.org</code>" or "<code>w3.org</code>" in the <a
-								data-cite="url#concept-host">host component</a> [[URL]] of their identifying URL.</p>
-
-						<p>EPUB specifications that implement collections MAY override package-level restrictions on the
-							use of metadata elements.</p>
-
-						<p>Specializations of the <code>collection</code> element MAY tailor the requirements defined
-							above to better reflect their needs (e.g., requiring metadata, imposing further restrictions
-							on the use of elements and attributes, or making the order of <code>link</code> elements
-							significant). However, the resulting content model MUST represent a valid subset of the one
-							defined in this section (e.g., specializations cannot introduce new elements or attributes,
-							or re-introduce those expressly forbidden above). Specializations MUST NOT define
-							collections in a way that overrides the requirements of the <a href="#elemdef-opf-manifest"
-									><code>manifest</code></a> and <a href="#elemdef-opf-spine"
-							><code>spine</code></a>.</p>
-
-						<p>The rendering of an EPUB Publication MUST NOT be dependent on the recognition of
-								<code>collection</code> elements. The content MUST remain consumable by a user without
-							any information loss or other significant deterioration.</p>
+						<p>Refer to [[EPUB32]] for more information about their creation, including the requirements and
+							restrictions on their use.</p>
 					</section>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3781,50 +3781,49 @@ No Entry</pre>
    …
 &lt;/package></pre>
 						</aside>
+					</section>
 
-						<section id="sec-collections-defining-types">
-							<h6>Defining Collection Types</h6>
+					<section id="sec-defining-collection-types">
+						<h5>Defining Collection Types</h5>
 
-							<div class="note">
-								<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
-									Working Group maintained both a <a href="http://www.idpf.org/epub/registries/roles"
-										>registry of role extensions</a> and a list of <a
-										href="http://www.idpf.org/epub/extensions/roles">custom extension roles</a>.
-									This Working Group no longer maintains these registries and does not anticipate
-									defining new types of collections.</p>
-							</div>
+						<div class="note">
+							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
+								Working Group maintained both a <a href="http://www.idpf.org/epub/registries/roles"
+									>registry of role extensions</a> and a list of <a
+									href="http://www.idpf.org/epub/extensions/roles">custom extension roles</a>. This
+								Working Group no longer maintains these registries and does not anticipate defining new
+								types of collections.</p>
+						</div>
 
-							<p>The <code>collection</code> element, as defined in this specification, represents a
-								generic framework from which specializations are intended to be derived (e.g., through
-								EPUB sub-specifications). Such specializations define the purpose of the
-									<code>collection</code> element, as well as all requirements for its valid
-								production and use (specifically any requirements that differ from the general framework
-								presented below).</p>
+						<p>The <code>collection</code> element, as defined in this specification, represents a generic
+							framework from which specializations are intended to be derived (e.g., through EPUB
+							sub-specifications). Such specializations define the purpose of the <code>collection</code>
+							element, as well as all requirements for its valid production and use (specifically any
+							requirements that differ from the general framework presented below).</p>
 
-							<p>Each specialization MUST define a role value that uniquely identifies all conformant
-									<code>collection</code> elements. This specification reserves the use of NMTOKEN
-								values for roles defined in EPUB specifications. NMTOKEN values not defined by a
-								recognized specification are not valid. This section does not define any roles.</p>
+						<p>Each specialization MUST define a role value that uniquely identifies all conformant
+								<code>collection</code> elements. This specification reserves the use of NMTOKEN values
+							for roles defined in EPUB specifications. NMTOKEN values not defined by a recognized
+							specification are not valid. This section does not define any roles.</p>
 
-							<p>Third parties MAY define custom roles for the <code>collection</code> element, but they
-								MUST identify such roles using <a data-cite="url#absolute-url-with-fragment-string"
-									>absolute-URL-with-fragment strings</a> [[URL]]. Custom roles MUST NOT incorporate
-								the strings "<code>idpf.org</code>" or "w3.org" in the <a data-cite="url#concept-host"
-									>host component</a> [[URL]] of their identifying URL.</p>
+						<p>Third parties MAY define custom roles for the <code>collection</code> element, but they MUST
+							identify such roles using <a data-cite="url#absolute-url-with-fragment-string"
+								>absolute-URL-with-fragment strings</a> [[URL]]. Custom roles MUST NOT incorporate the
+							strings "<code>idpf.org</code>" or "w3.org" in the <a data-cite="url#concept-host">host
+								component</a> [[URL]] of their identifying URL.</p>
 
-							<p>EPUB specifications that implement collections MAY override package-level restrictions on
-								the use of metadata elements.</p>
+						<p>EPUB specifications that implement collections MAY override package-level restrictions on the
+							use of metadata elements.</p>
 
-							<p>Specializations of the <code>collection</code> element MAY tailor the requirements
-								defined above to better reflect their needs (e.g., requiring metadata, imposing further
-								restrictions on the use of elements and attributes, or making the order of
-									<code>link</code> elements significant). However, the resulting content model MUST
-								represent a valid subset of the one defined in this section (e.g., specializations
-								cannot introduce new elements or attributes, or re-introduce those expressly forbidden
-								above). Specializations must not define collections in a way that overrides the
-								requirements of the <a href="#elemdef-opf-manifest"><code>manifest</code></a> and <a
-									href="#elemdef-opf-spine"><code>spine</code></a>.</p>
-						</section>
+						<p>Specializations of the <code>collection</code> element MAY tailor the requirements defined
+							above to better reflect their needs (e.g., requiring metadata, imposing further restrictions
+							on the use of elements and attributes, or making the order of <code>link</code> elements
+							significant). However, the resulting content model MUST represent a valid subset of the one
+							defined in this section (e.g., specializations cannot introduce new elements or attributes,
+							or re-introduce those expressly forbidden above). Specializations must not define
+							collections in a way that overrides the requirements of the <a href="#elemdef-opf-manifest"
+									><code>manifest</code></a> and <a href="#elemdef-opf-spine"
+							><code>spine</code></a>.</p>
 					</section>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3820,7 +3820,7 @@ No Entry</pre>
 							on the use of elements and attributes, or making the order of <code>link</code> elements
 							significant). However, the resulting content model MUST represent a valid subset of the one
 							defined in this section (e.g., specializations cannot introduce new elements or attributes,
-							or re-introduce those expressly forbidden above). Specializations must not define
+							or re-introduce those expressly forbidden above). Specializations MUST NOT define
 							collections in a way that overrides the requirements of the <a href="#elemdef-opf-manifest"
 									><code>manifest</code></a> and <a href="#elemdef-opf-spine"
 							><code>spine</code></a>.</p>


### PR DESCRIPTION
The collection element definition is hard to read because it mixes authoring requirements with requirements on how to write types of collections (which are largely all untestable by a validator).

This PR splits out the requirements on defining new types into a separate section so it's less of a jumble.

It's kind of weird to define so many requirements on how to write specializations in the core spec, as these have nothing to do with authoring, but short of a note on how to write specializations to move these out of the core, I don't what else to do with this prose.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2060.html" title="Last updated on Mar 17, 2022, 4:40 PM UTC (ec770fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2060/8d4a9d6...ec770fc.html" title="Last updated on Mar 17, 2022, 4:40 PM UTC (ec770fc)">Diff</a>