### PR TITLE
Make hidden attribute nav section informative

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5029,7 +5029,7 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-nav-doc-use-spine" class="informative">
-				<h3>Using the Navigation Document in the Spine</h3>
+				<h3>Using in the Spine</h3>
 
 				<p>Although it is possible to reuse the EPUB Navigation Document in the <a>spine</a>, it is often the
 					case that not all of the navigation structures, or branches within them, are needed. <a>EPUB

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5039,9 +5039,9 @@ No Entry</pre>
 
 				<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
 						property</a> [[CSSSnapshot]] controls the visual rendering of EPUB Navigation Documents in
-					Reading Systems with <a>Viewports</a>, not all Reading Systems provide such an interface. To control
-					rendering across all Reading Systems, EPUB Creators should use the [[HTML]] <a
-						data-cite="html#the-hidden-attribute"><code>hidden</code></a> attribute to indicate which (if
+					Reading Systems with <a>Viewports</a>, Reading Systems without Viewports may not support CSS. To
+					better ensure the proper rendering in these Reading Systems, EPUB Creators should use the [[HTML]]
+						<a data-cite="html#the-hidden-attribute"><code>hidden</code></a> attribute to indicate which (if
 					any) portions of the navigation data are excluded from rendering in the content flow.</p>
 
 				<p>The <code>hidden</code> attribute has no effect on how Reading Systems render the navigation data

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4615,166 +4615,163 @@ No Entry</pre>
 					content will retain its integrity when rendered in a non-browser context.</p>
 			</section>
 
-			<section id="sec-nav-def">
-				<h3>EPUB Navigation Document Definition</h3>
+			<section id="sec-nav-def-model">
+				<h3>The <code>nav</code> Element: Restrictions</h3>
 
-				<section id="sec-nav-def-model">
-					<h4>The <code>nav</code> Element: Restrictions</h4>
+				<p>When a <code>nav</code> element carries the <a href="#sec-epub-type-attribute"><code>epub:type</code>
+						attribute</a> in an <a>EPUB Navigation Document</a>, this specification restricts the content
+					model of the element and its descendants as follows:</p>
 
-					<p>When a <code>nav</code> element carries the <a href="#sec-epub-type-attribute"
-								><code>epub:type</code> attribute</a> in an <a>EPUB Navigation Document</a>, this
-						specification restricts the content model of the element and its descendants as follows:</p>
+				<dl class="elemdef">
+					<dt>Content Model</dt>
+					<dd>
+						<dl class="variablelist">
+							<dt>
+								<a data-cite="html#the-nav-element">
+									<code>nav</code>
+								</a>
+							</dt>
+							<dd>
+								<p>In this order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a data-cite="html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">
+												<code>h1-h6</code>
+											</a>
+											<code>[0 or 1]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<code>ol</code>
+											<code>[exactly 1]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
 
-					<dl class="elemdef">
-						<dt>Content Model</dt>
-						<dd>
-							<dl class="variablelist">
-								<dt>
-									<a data-cite="html#the-nav-element">
-										<code>nav</code>
-									</a>
-								</dt>
-								<dd>
-									<p>In this order:</p>
-									<ul class="nomark">
-										<li>
-											<p>
-												<a data-cite="html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">
-													<code>h1-h6</code>
-												</a>
-												<code>[0 or 1]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<code>ol</code>
-												<code>[exactly 1]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
+							<dt>
+								<a data-cite="html#the-ol-element">
+									<code>ol</code>
+								</a>
+							</dt>
+							<dd>
+								<p>In this order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<code>li</code>
+											<code>[1 or more]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
 
-								<dt>
-									<a data-cite="html#the-ol-element">
-										<code>ol</code>
-									</a>
-								</dt>
-								<dd>
-									<p>In this order:</p>
-									<ul class="nomark">
-										<li>
-											<p>
-												<code>li</code>
-												<code>[1 or more]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
+							<dt>
+								<a data-cite="html#the-li-element">
+									<code>li</code>
+								</a>
+							</dt>
+							<dd>
+								<p>In this order:</p>
+								<ul class="nomark">
+									<li>
+										<p> (<code>span</code> or <code>a</code>) <code>[exactly 1]</code></p>
+									</li>
+									<li>
+										<p>
+											<code>ol</code>
+											<code>[conditionally required]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
 
-								<dt>
-									<a data-cite="html#the-li-element">
-										<code>li</code>
-									</a>
-								</dt>
-								<dd>
-									<p>In this order:</p>
-									<ul class="nomark">
-										<li>
-											<p> (<code>span</code> or <code>a</code>) <code>[exactly 1]</code></p>
-										</li>
-										<li>
-											<p>
-												<code>ol</code>
-												<code>[conditionally required]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
+							<dt><a data-cite="html#the-span-element"><code>span</code></a> and <a
+									data-cite="html#the-a-element"><code>a</code></a></dt>
+							<dd>
+								<p>In any order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a data-cite="html#phrasing-content">
+												<code>HTML Phrasing content</code>
+											</a>
+											<code>[1 or more]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
+						</dl>
+						<p>Note that there are no restrictions on the attributes allowed on these elements.</p>
+						<p>Refer the definition below for additional requirements.</p>
+					</dd>
+				</dl>
 
-								<dt><a data-cite="html#the-span-element"><code>span</code></a> and <a
-										data-cite="html#the-a-element"><code>a</code></a></dt>
-								<dd>
-									<p>In any order:</p>
-									<ul class="nomark">
-										<li>
-											<p>
-												<a data-cite="html#phrasing-content">
-													<code>HTML Phrasing content</code>
-												</a>
-												<code>[1 or more]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
-							</dl>
-							<p>Note that there are no restrictions on the attributes allowed on these elements.</p>
-							<p>Refer the definition below for additional requirements.</p>
-						</dd>
-					</dl>
+				<p>The following elaboration of the content model of the <code>nav</code> element explains the purpose
+					and restrictions of the various elements:</p>
 
-					<p>The following elaboration of the content model of the <code>nav</code> element explains the
-						purpose and restrictions of the various elements:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-nav-ol">The <code>ol</code> child of the <code>nav</code> element represents
-								the primary level of content navigation.</p>
-						</li>
-						<li>
-							<p id="confreq-nav-a">Each list item of the ordered list represents a heading, structure, or
-								other item of interest. A child <code>a</code> element describes the target that the
-								link points to, while a <code>span</code> element serves as a heading for breaking down
-								lists into distinct groups (for example, an EPUB Creator could segment a large list of
-								illustrations into several lists, one for each chapter).</p>
-						</li>
-						<li>
-							<p id="confreq-nav-a-cnt">The child <code>a</code> or <code>span</code> element MUST provide
-								a non-zero-length text label after concatenation of all child content and application of
-								white space normalization rules. When determining compliance with this requirement, the
-								concatenated label MUST include text content contained in <code>title</code> or
-									<code>alt</code> attributes for non-textual descendant elements.</p>
-						</li>
-						<li>
-							<p id="confreq-nav-a-title">If an <code>a</code> or <code>span</code> element contains
-								instances of <a data-cite="html#embedded-content">HTML embedded content</a> that do not
-								provide intrinsic text alternatives, the element MUST also contain a <code>title</code>
-								attribute with an alternate text rendering of the link label.</p>
-						</li>
-						<li>
-							<p id="confreq-nav-a-href">The URL [[URL]] reference provided in the <code>href</code>
-								attribute of the <code>a</code> element:</p>
-							<ul class="conformance-list">
-								<li>
-									<p id="confreq-nav-a-href-default">MUST, in the case of the <a href="#sec-nav-toc"
-												><code>toc nav</code></a>, <a href="#sec-nav-landmarks"><code>landmarks
-												nav</code></a> and <a href="#sec-nav-pagelist"><code>page-list
-												nav</code></a>, resolve to a <a>Top-level Content Document</a> or
-										fragment therein.</p>
-								</li>
-								<li>
-									<p id="confreq-nav-a-href-other">MAY, for all other <code>nav</code> types, also
-										reference <a>Remote Resources</a>.</p>
-								</li>
-							</ul>
-						</li>
-						<li>
-							<p id="confreq-nav-a-nest">An <code>ol</code> (ordered list) element representing a
-								subsidiary content level (e.g., all the subsection headings of a section) MAY follow an
-									<code>a</code> element.</p>
-						</li>
-						<li>
-							<p id="confreq-nav-span-nest">An <code>ol</code> (ordered list) element MUST follow a
-									<code>span</code> element (<code>span</code> elements cannot occur in "leaf"
-									<code>li</code> elements).</p>
-						</li>
-						<li>
-							<p id="confreq-nav-sublist">Regardless of whether an <code>a</code> or <code>span</code>
-								element precedes it, every sublist MUST adhere to the content requirements defined in
-								this section for constructing the primary navigation list.</p>
-						</li>
-					</ul>
-					<aside class="example" title="Basic patterns of a navigation element">
-						<pre>&lt;nav epub:type="…">
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-nav-ol">The <code>ol</code> child of the <code>nav</code> element represents the
+							primary level of content navigation.</p>
+					</li>
+					<li>
+						<p id="confreq-nav-a">Each list item of the ordered list represents a heading, structure, or
+							other item of interest. A child <code>a</code> element describes the target that the link
+							points to, while a <code>span</code> element serves as a heading for breaking down lists
+							into distinct groups (for example, an EPUB Creator could segment a large list of
+							illustrations into several lists, one for each chapter).</p>
+					</li>
+					<li>
+						<p id="confreq-nav-a-cnt">The child <code>a</code> or <code>span</code> element MUST provide a
+							non-zero-length text label after concatenation of all child content and application of white
+							space normalization rules. When determining compliance with this requirement, the
+							concatenated label MUST include text content contained in <code>title</code> or
+								<code>alt</code> attributes for non-textual descendant elements.</p>
+					</li>
+					<li>
+						<p id="confreq-nav-a-title">If an <code>a</code> or <code>span</code> element contains instances
+							of <a data-cite="html#embedded-content">HTML embedded content</a> that do not provide
+							intrinsic text alternatives, the element MUST also contain a <code>title</code> attribute
+							with an alternate text rendering of the link label.</p>
+					</li>
+					<li>
+						<p id="confreq-nav-a-href">The URL [[URL]] reference provided in the <code>href</code> attribute
+							of the <code>a</code> element:</p>
+						<ul class="conformance-list">
+							<li>
+								<p id="confreq-nav-a-href-default">MUST, in the case of the <a href="#sec-nav-toc"
+											><code>toc nav</code></a>, <a href="#sec-nav-landmarks"><code>landmarks
+											nav</code></a> and <a href="#sec-nav-pagelist"><code>page-list
+										nav</code></a>, resolve to a <a>Top-level Content Document</a> or fragment
+									therein.</p>
+							</li>
+							<li>
+								<p id="confreq-nav-a-href-other">MAY, for all other <code>nav</code> types, also
+									reference <a>Remote Resources</a>.</p>
+							</li>
+						</ul>
+					</li>
+					<li>
+						<p id="confreq-nav-a-nest">An <code>ol</code> (ordered list) element representing a subsidiary
+							content level (e.g., all the subsection headings of a section) MAY follow an <code>a</code>
+							element.</p>
+					</li>
+					<li>
+						<p id="confreq-nav-span-nest">An <code>ol</code> (ordered list) element MUST follow a
+								<code>span</code> element (<code>span</code> elements cannot occur in "leaf"
+								<code>li</code> elements).</p>
+					</li>
+					<li>
+						<p id="confreq-nav-sublist">Regardless of whether an <code>a</code> or <code>span</code> element
+							precedes it, every sublist MUST adhere to the content requirements defined in this section
+							for constructing the primary navigation list.</p>
+					</li>
+				</ul>
+				<aside class="example" title="Basic patterns of a navigation element">
+					<pre>&lt;nav epub:type="…">
    &lt;h1>…&lt;/h1>
    &lt;ol>
       &lt;li>
@@ -4798,145 +4795,142 @@ No Entry</pre>
       &lt;/li>
    &lt;/ol>
 &lt;/nav></pre>
-					</aside>
+				</aside>
 
-					<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, EPUB Creators MAY
-						include the EPUB Navigation Document in the <a href="#sec-spine-elem">spine</a>.</p>
+				<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, EPUB Creators MAY include
+					the EPUB Navigation Document in the <a href="#sec-spine-elem">spine</a>.</p>
 
-					<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
-						items within <code>nav</code> elements is equivalent to the <a
-							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:</code>
-							<code>none</code> property</a> [[CSSSnapshot]]. <a>EPUB Creators</a> MAY specify alternative
-						list styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
-								><code>spine</code></a>.</p>
+				<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
+					items within <code>nav</code> elements is equivalent to the <a
+						href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:</code>
+						<code>none</code> property</a> [[CSSSnapshot]]. <a>EPUB Creators</a> MAY specify alternative
+					list styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
+							><code>spine</code></a>.</p>
+			</section>
+
+			<section id="sec-nav-def-types">
+				<h3>The <code>nav</code> Element: Types</h3>
+
+				<section id="sec-nav-def-types-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>The <code>nav</code> elements defined in an EPUB Navigation Document are distinguished
+						semantically by the value of their <a href="#sec-epub-type-attribute"><code>epub:type</code>
+							attribute</a>.</p>
+
+					<p>This specification defines three types of navigation aid:</p>
+
+					<dl class="variablelist">
+						<dt>
+							<a href="#sec-nav-toc">
+								<code>toc</code>
+							</a>
+						</dt>
+						<dd>
+							<p>Identifies the <code>nav</code> element that contains the table of contents. The
+									<code>toc</code>
+								<code>nav</code> is the only navigation aid that EPUB Creators must include in the EPUB
+								Navigation Document.</p>
+						</dd>
+
+						<dt>
+							<a href="#sec-nav-pagelist">
+								<code>page-list</code>
+							</a>
+						</dt>
+						<dd>
+							<p>Identifies the <code>nav</code> element that contains a list of pages for a print or
+								other statically paginated source.</p>
+						</dd>
+
+						<dt>
+							<a href="#sec-nav-landmarks">
+								<code>landmarks</code>
+							</a>
+						</dt>
+						<dd>
+							<p>Identifies the <code>nav</code> element that contains a list of points of interest.</p>
+						</dd>
+					</dl>
+
+					<p>An EPUB Navigation Document may contain at most one navigation aid for each of these types.</p>
+
+					<p>The EPUB Navigation Document may include additional navigation types. See <a
+							href="#sec-nav-def-types-other"></a> for more information.</p>
 				</section>
 
-				<section id="sec-nav-def-types">
-					<h4>The <code>nav</code> Element: Types</h4>
+				<section id="sec-nav-toc">
+					<h4>The <code>toc nav</code> Element </h4>
 
-					<section id="sec-nav-def-types-intro" class="informative">
-						<h5>Introduction</h5>
+					<p>The <code>toc</code>
+						<code>nav</code> element defines the primary navigational hierarchy. It conceptually corresponds
+						to a table of contents in a printed work (i.e., it provides navigation to the major structural
+						sections of the publication).</p>
 
-						<p>The <code>nav</code> elements defined in an EPUB Navigation Document are distinguished
-							semantically by the value of their <a href="#sec-epub-type-attribute"><code>epub:type</code>
-								attribute</a>.</p>
+					<p>The <code>toc</code>
+						<code>nav</code> element MUST occur exactly once in an EPUB Navigation Document.</p>
 
-						<p>This specification defines three types of navigation aid:</p>
+					<p>EPUB Creators SHOULD order the references in the <code>toc</code>
+						<code>nav</code> element such that they reflect both:</p>
 
-						<dl class="variablelist">
-							<dt>
-								<a href="#sec-nav-toc">
-									<code>toc</code>
-								</a>
-							</dt>
-							<dd>
-								<p>Identifies the <code>nav</code> element that contains the table of contents. The
-										<code>toc</code>
-									<code>nav</code> is the only navigation aid that EPUB Creators must include in the
-									EPUB Navigation Document.</p>
-							</dd>
+					<ul>
+						<li>
+							<p>the order of the <a href="#confreq-nav-a-href">referenced EPUB Content Documents</a> in
+								the <a>spine</a>; and</p>
+						</li>
+						<li>
+							<p>the order of the targeted elements within their respective EPUB Content Documents.</p>
+						</li>
+					</ul>
+				</section>
 
-							<dt>
-								<a href="#sec-nav-pagelist">
-									<code>page-list</code>
-								</a>
-							</dt>
-							<dd>
-								<p>Identifies the <code>nav</code> element that contains a list of pages for a print or
-									other statically paginated source.</p>
-							</dd>
+				<section id="sec-nav-pagelist">
+					<h4>The <code>page-list nav</code> Element </h4>
 
-							<dt>
-								<a href="#sec-nav-landmarks">
-									<code>landmarks</code>
-								</a>
-							</dt>
-							<dd>
-								<p>Identifies the <code>nav</code> element that contains a list of points of
-									interest.</p>
-							</dd>
-						</dl>
+					<p>The <code>page-list</code>
+						<code>nav</code> element provides navigation to positions in the content that correspond to the
+						locations of page boundaries present in a print source.</p>
 
-						<p>An EPUB Navigation Document may contain at most one navigation aid for each of these
-							types.</p>
+					<p>The <code>page-list</code>
+						<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more than
+						once.</p>
 
-						<p>The EPUB Navigation Document may include additional navigation types. See <a
-								href="#sec-nav-def-types-other"></a> for more information.</p>
-					</section>
+					<p>The <code>page-list</code>
+						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
+						nested sublists).</p>
 
-					<section id="sec-nav-toc">
-						<h5>The <code>toc nav</code> Element </h5>
+					<p>EPUB Creators MAY identify the destinations of the <code>page-list</code> references in their
+						respective EPUB Content Documents using the <a data-cite="epub-ssv-11/#pagebreak"
+								><code>pagebreak</code> term</a> [[EPUB-SSV-11]].</p>
+				</section>
 
-						<p>The <code>toc</code>
-							<code>nav</code> element defines the primary navigational hierarchy. It conceptually
-							corresponds to a table of contents in a printed work (i.e., it provides navigation to the
-							major structural sections of the publication).</p>
+				<section id="sec-nav-landmarks">
+					<h4>The <code>landmarks nav</code> Element</h4>
 
-						<p>The <code>toc</code>
-							<code>nav</code> element MUST occur exactly once in an EPUB Navigation Document.</p>
+					<p>The <code>landmarks</code>
+						<code>nav</code> element identifies fundamental structural components in the content to enable
+						Reading Systems to provide the user efficient access to them (e.g., through a dedicated button
+						in the user interface).</p>
 
-						<p>EPUB Creators SHOULD order the references in the <code>toc</code>
-							<code>nav</code> element such that they reflect both:</p>
+					<p>The <code>landmarks</code>
+						<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more than
+						once.</p>
 
-						<ul>
-							<li>
-								<p>the order of the <a href="#confreq-nav-a-href">referenced EPUB Content Documents</a>
-									in the <a>spine</a>; and</p>
-							</li>
-							<li>
-								<p>the order of the targeted elements within their respective EPUB Content
-									Documents.</p>
-							</li>
-						</ul>
-					</section>
+					<p>The <code>landmarks</code>
+						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
+						nested sublists).</p>
 
-					<section id="sec-nav-pagelist">
-						<h5>The <code>page-list nav</code> Element </h5>
+					<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is REQUIRED on
+							<code>a</code> element descendants of the <code>landmarks</code>
+						<code>nav</code> element. The structural semantics of each link target within the
+							<code>landmarks</code>
+						<code>nav</code> element is determined by the value of this attribute.</p>
 
-						<p>The <code>page-list</code>
-							<code>nav</code> element provides navigation to positions in the content that correspond to
-							the locations of page boundaries present in a print source.</p>
+					<aside class="example" title="A basic landmarks nav">
+						<p>In this example, the <code>epub:type</code> attribute value are drawn from structural
+							semantics drawn from [[EPUB-SSV-11]].</p>
 
-						<p>The <code>page-list</code>
-							<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more
-							than once.</p>
-
-						<p>The <code>page-list</code>
-							<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
-							nested sublists).</p>
-
-						<p>EPUB Creators MAY identify the destinations of the <code>page-list</code> references in their
-							respective EPUB Content Documents using the <a data-cite="epub-ssv-11/#pagebreak"
-									><code>pagebreak</code> term</a> [[EPUB-SSV-11]].</p>
-					</section>
-
-					<section id="sec-nav-landmarks">
-						<h5>The <code>landmarks nav</code> Element </h5>
-
-						<p>The <code>landmarks</code>
-							<code>nav</code> element identifies fundamental structural components in the content to
-							enable Reading Systems to provide the user efficient access to them (e.g., through a
-							dedicated button in the user interface).</p>
-
-						<p>The <code>landmarks</code>
-							<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more
-							than once.</p>
-
-						<p>The <code>landmarks</code>
-							<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
-							nested sublists).</p>
-
-						<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is REQUIRED on
-								<code>a</code> element descendants of the <code>landmarks</code>
-							<code>nav</code> element. The structural semantics of each link target within the
-								<code>landmarks</code>
-							<code>nav</code> element is determined by the value of this attribute.</p>
-
-						<aside class="example" title="A basic landmarks nav">
-							<p>In this example, the <code>epub:type</code> attribute value are drawn from structural
-								semantics drawn from [[EPUB-SSV-11]].</p>
-
-							<pre>&lt;nav epub:type="landmarks">
+						<pre>&lt;nav epub:type="landmarks">
    &lt;h2>Guide&lt;/h2>
    &lt;ol>
        &lt;li>
@@ -4959,56 +4953,55 @@ No Entry</pre>
        &lt;/li>
    &lt;/ol>
 &lt;/nav></pre>
-						</aside>
+					</aside>
 
-						<p>The <code>landmarks</code>
-							<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code>
-							value that reference the same resource, or fragment thereof.</p>
+					<p>The <code>landmarks</code>
+						<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code> value
+						that reference the same resource, or fragment thereof.</p>
 
-						<p>EPUB Creators should limit the number of items they define in the <code>landmarks</code>
-							<code>nav</code> to only items that a Reading System is likely to use in its user interface.
-							The element is not meant to repeat the table of contents.</p>
+					<p>EPUB Creators should limit the number of items they define in the <code>landmarks</code>
+						<code>nav</code> to only items that a Reading System is likely to use in its user interface. The
+						element is not meant to repeat the table of contents.</p>
 
-						<p>The following landmarks are recommended to include when available:</p>
+					<p>The following landmarks are recommended to include when available:</p>
 
-						<ul>
-							<li><a data-cite="epub-ssv-11#bodymatter"><code>bodymatter</code></a> [[?EPUB-SSV-11]]
-								&#8212; Reading Systems often use this landmark to automatically jump users past the
-								front matter when they begin reading.</li>
-							<li><a data-cite="epub-ssv-11#toc-1"><code>toc</code></a> [[?EPUB-SSV-11]] &#8212; If the
-								table of contents is available in the spine, Reading Systems may use this landmark to
-								take users to the document containing it.</li>
-						</ul>
+					<ul>
+						<li><a data-cite="epub-ssv-11#bodymatter"><code>bodymatter</code></a> [[?EPUB-SSV-11]] &#8212;
+							Reading Systems often use this landmark to automatically jump users past the front matter
+							when they begin reading.</li>
+						<li><a data-cite="epub-ssv-11#toc-1"><code>toc</code></a> [[?EPUB-SSV-11]] &#8212; If the table
+							of contents is available in the spine, Reading Systems may use this landmark to take users
+							to the document containing it.</li>
+					</ul>
 
-						<p>Other possibilities for inclusion in the <code>landmarks</code>
-							<code>nav</code> are key reference sections such as indexes and glossaries.</p>
+					<p>Other possibilities for inclusion in the <code>landmarks</code>
+						<code>nav</code> are key reference sections such as indexes and glossaries.</p>
 
-						<p>Although the <code>landmarks</code>
-							<code>nav</code> is intended for Reading System use, EPUB Creators should still ensure that
-							the labels for the <code>landmarks</code>
-							<code>nav</code> are human readable. Reading Systems may expose the links directly to
-							users.</p>
-					</section>
+					<p>Although the <code>landmarks</code>
+						<code>nav</code> is intended for Reading System use, EPUB Creators should still ensure that the
+						labels for the <code>landmarks</code>
+						<code>nav</code> are human readable. Reading Systems may expose the links directly to users.</p>
+				</section>
 
-					<section id="sec-nav-def-types-other">
-						<h5>Other <code>nav</code> Elements</h5>
+				<section id="sec-nav-def-types-other">
+					<h4>Other <code>nav</code> Elements</h4>
 
-						<p>EPUB Navigation Documents MAY contain one or more <code>nav</code> elements in addition to
-							the <code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
-							<code>nav</code> elements defined in the preceding sections. If these <code>nav</code>
-							elements are intended for Reading System processing, they MUST have an <a
-								href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> and are subject to
-							the content model restrictions defined in <a href="#sec-nav-def-model"></a>.</p>
+					<p>EPUB Navigation Documents MAY contain one or more <code>nav</code> elements in addition to the
+							<code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
+						<code>nav</code> elements defined in the preceding sections. If these <code>nav</code> elements
+						are intended for Reading System processing, they MUST have an <a href="#sec-epub-type-attribute"
+								><code>epub:type</code> attribute</a> and are subject to the content model restrictions
+						defined in <a href="#sec-nav-def-model"></a>.</p>
 
-						<p>This specification imposes no restrictions on the semantics of any additional
-								<code>nav</code> elements: they MAY represent navigational semantics for any information
-							domain, and they MAY contain link targets with homogeneous or heterogeneous semantics.</p>
+					<p>This specification imposes no restrictions on the semantics of any additional <code>nav</code>
+						elements: they MAY represent navigational semantics for any information domain, and they MAY
+						contain link targets with homogeneous or heterogeneous semantics.</p>
 
-						<aside class="example" title="Adding a custom navigation element">
-							<p>In this example, the <code>lot</code> semantic indicates that the EPUB Creator is adding
-								a "list of tables" navigation element.</p>
+					<aside class="example" title="Adding a custom navigation element">
+						<p>In this example, the <code>lot</code> semantic indicates that the EPUB Creator is adding a
+							"list of tables" navigation element.</p>
 
-							<pre>&lt;nav
+						<pre>&lt;nav
     epub:type="lot"
     aria-labelledby="lot">
    &lt;h2 id="lot">List of tables&lt;/h2>
@@ -5031,34 +5024,41 @@ No Entry</pre>
       …
    &lt;/ol>
 &lt;/nav></pre>
-						</aside>
-					</section>
+					</aside>
 				</section>
+			</section>
 
-				<section id="sec-nav-def-hidden">
-					<h4>The <code>hidden</code> attribute</h4>
+			<section id="sec-nav-doc-use-spine" class="informative">
+				<h3>Using the Navigation Document in the Spine</h3>
 
-					<p>In some cases, <a>EPUB Creators</a> might wish to hide parts of the navigation data within the
-						content flow (i.e., the Reading System's principal rendering of the <a>spine</a> contents). A
-						typical example is the <a href="#sec-nav-pagelist">list of page breaks</a>, which EPUB Creators
-						do not want Reading Systems to render as part of the content flow.</p>
+				<p>Although it is possible to reuse the EPUB Navigation Document in the <a>spine</a>, it is often the
+					case that not all of the navigation structures, or branches within them, are needed. <a>EPUB
+						Creators</a> will often want to hide the <a href="sec-nav-pagelist">page list</a> and <a
+						href="sec-nav-landmarks">landmarks</a> navigation elements, or trim the branches of the table of
+					contents for books that have many levels of subsections.</p>
 
-					<p> While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
-							property</a> [[CSSSnapshot]] controls the visual rendering of EPUB Navigation Documents in
-						Reading Systems with <a>Viewports</a>, not all Reading Systems provide such an interface. To
-						control rendering across all Reading Systems, EPUB Creators MUST use the [[HTML]] <a
-							data-cite="html#the-hidden-attribute"><code>hidden</code></a> attribute to indicate which
-						(if any) portions of the navigation data are excluded from rendering in the content flow. The
-							<code>hidden</code> attribute has no effect on how Reading Systems render the navigation
-						data outside of the content flow (such as in dedicated navigation user interfaces provided by
-						Reading Systems).</p>
+				<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
+						property</a> [[CSSSnapshot]] controls the visual rendering of EPUB Navigation Documents in
+					Reading Systems with <a>Viewports</a>, not all Reading Systems provide such an interface. To control
+					rendering across all Reading Systems, EPUB Creators should consider using the [[HTML]] <a
+						data-cite="html#the-hidden-attribute"><code>hidden</code></a> attribute to indicate which (if
+					any) portions of the navigation data are excluded from rendering in the content flow.</p>
 
-					<aside class="example" title="Hiding a nav element in spine">
-						<p>In this example, the presence of the <code>hidden</code> attribute on the <code>nav</code>
-							element indicates the page list will be excluded from rendering in the content flow when the
-							document is rendered in the spine.</p>
+				<div class="note">
+					<p>The <code>hidden</code> attribute can be used together with the <code>display</code> property to
+						maximize interoperability across all Reading Systems.</p>
+				</div>
 
-						<pre>&lt;nav
+				<p>The <code>hidden</code> attribute has no effect on how Reading Systems render the navigation data
+					outside of the content flow (such as in dedicated navigation user interfaces provided by Reading
+					Systems).</p>
+
+				<aside class="example" title="Hiding a nav element in spine">
+					<p>In this example, the presence of the <code>hidden</code> attribute on the <code>nav</code>
+						element indicates the page list will be excluded from rendering in the content flow when the
+						document is rendered in the spine.</p>
+
+					<pre>&lt;nav
     epub:type="page-list"
     hidden="">
    &lt;h2>Pagebreaks of the print version, third edition&lt;/h2>
@@ -5072,14 +5072,14 @@ No Entry</pre>
    &lt;/ol>
 &lt;/nav>
 </pre>
-					</aside>
+				</aside>
 
-					<aside class="example" title="Hiding branches of a nav element">
-						<p>In this example, the branch (<code>ol</code> element) not wanted for rendering in the spine
-							has the <code>hidden</code> attribute on it. When rendered, this limits the table of content
-							to the two top-most hierarchical levels.</p>
+				<aside class="example" title="Hiding branches of a nav element">
+					<p>In this example, the branch (<code>ol</code> element) not wanted for rendering in the spine has
+						the <code>hidden</code> attribute on it. When rendered, this limits the table of content to the
+						two top-most hierarchical levels.</p>
 
-						<pre>&lt;nav
+					<pre>&lt;nav
     epub:type="toc"
     id="toc">
    &lt;h1>Table of contents&lt;/h1>
@@ -5108,8 +5108,7 @@ No Entry</pre>
       …
    &lt;/ol>
 &lt;/nav></pre>
-					</aside>
-				</section>
+				</aside>
 			</section>
 		</section>
 		<section id="sec-fixed-layouts">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5040,18 +5040,18 @@ No Entry</pre>
 				<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
 						property</a> [[CSSSnapshot]] controls the visual rendering of EPUB Navigation Documents in
 					Reading Systems with <a>Viewports</a>, not all Reading Systems provide such an interface. To control
-					rendering across all Reading Systems, EPUB Creators should consider using the [[HTML]] <a
+					rendering across all Reading Systems, EPUB Creators should use the [[HTML]] <a
 						data-cite="html#the-hidden-attribute"><code>hidden</code></a> attribute to indicate which (if
 					any) portions of the navigation data are excluded from rendering in the content flow.</p>
+
+				<p>The <code>hidden</code> attribute has no effect on how Reading Systems render the navigation data
+					outside of the content flow (such as in dedicated navigation user interfaces provided by Reading
+					Systems).</p>
 
 				<div class="note">
 					<p>The <code>hidden</code> attribute can be used together with the <code>display</code> property to
 						maximize interoperability across all Reading Systems.</p>
 				</div>
-
-				<p>The <code>hidden</code> attribute has no effect on how Reading Systems render the navigation data
-					outside of the content flow (such as in dedicated navigation user interfaces provided by Reading
-					Systems).</p>
 
 				<aside class="example" title="Hiding a nav element in spine">
 					<p>In this example, the presence of the <code>hidden</code> attribute on the <code>nav</code>


### PR DESCRIPTION
I've changed the hidden attribute section to informative and renamed it "Using in the Spine". I also rewrote the first paragraph a bit so it doesn't jump straight into hiding content.

I kept the guidance about using the `hidden` attribute for RSes without viewports as-is, but added a note that also recommends pairing with the CSS property for maximum interoperability.

Hopefully, that's enough to cover the issue.

(I also took advantage of the moment to strip another unnecessary "XXX Definition" wrapper section that nothing even links to.)

Fixes #2061


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2062.html" title="Last updated on Mar 14, 2022, 12:58 PM UTC (c05d8d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2062/52c424b...c05d8d2.html" title="Last updated on Mar 14, 2022, 12:58 PM UTC (c05d8d2)">Diff</a>