### PR TITLE
Remove authoring requirement from file description

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6711,8 +6711,8 @@ No Entry</pre>
 						<section id="sec-container-metainf-metadata.xml">
 							<h6>Metadata File (<code>metadata.xml</code>)</h6>
 
-							<p>EPUB Creators MUST use the OPTIONAL <code>metadata.xml</code> file in the
-									<code>META-INF</code> directory only for container-level metadata.</p>
+							<p>The OPTIONAL <code>metadata.xml</code> file in the <code>META-INF</code> directory is
+								only for container-level metadata.</p>
 
 							<p>If EPUB Creators include a <code>metadata.xml</code> file, they SHOULD use only
 								namespace-qualified elements [[XML-NAMES]] in it. The file SHOULD contain the root


### PR DESCRIPTION
The first sentence of the metadata.xml file tries to enforce its purpose as an authoring requirement:

> EPUB Creators MUST use the OPTIONAL metadata.xml file in the META-INF directory only for container-level metadata.

We only need to describe the purpose of the file, so the PR changes this to:

> The OPTIONAL metadata.xml file in the META-INF directory is only for container-level metadata.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2064.html" title="Last updated on Mar 11, 2022, 1:10 PM UTC (226d642)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2064/52c424b...226d642.html" title="Last updated on Mar 11, 2022, 1:10 PM UTC (226d642)">Diff</a>