### PR TITLE
Split bullet with two separate requirements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7008,13 +7008,13 @@ No Entry</pre>
 						<li>The <code>mimetype</code> file MUST NOT contain any leading or trailing padding or white
 							space.</li>
 						<li>The <code>mimetype</code> file MUST NOT begin with the Unicode byte order mark U+FEFF.</li>
-						<li>EPUB Creators MUST NOT compress or encrypt the <code>mimetype</code> file, and MUST NOT
-							include an extra field in its ZIP header.</li>
+						<li>EPUB Creators MUST NOT compress or encrypt the <code>mimetype</code> file.</li>
+						<li>EPUB Creators MUST NOT include an extra field in its ZIP header.</li>
 					</ul>
+					
 					<div class="note">
 						<p>Refer to <a href="#app-media-type"></a> for further information about the
 								<code>application/epub+zip</code> media type.</p>
-
 					</div>
 				</section>
 			</section>


### PR DESCRIPTION
In the mimetype requirements, the last bullet had two separate requirements in it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2065.html" title="Last updated on Mar 11, 2022, 1:21 PM UTC (b1492a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2065/52c424b...b1492a5.html" title="Last updated on Mar 11, 2022, 1:21 PM UTC (b1492a5)">Diff</a>