### PR TITLE
s/may/must/ for using refines for individual durations

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8400,7 +8400,7 @@ html.my-document-playing * {
 								property</a>.</p>
 
 						<p>In addition, EPUB Creators MUST provide the duration of each Media Overlay Document. EPUB
-							Creators may use the <a href="#attrdef-refines"><code>refines</code> attribute</a> to
+							Creators MUST use the <a href="#attrdef-refines"><code>refines</code> attribute</a> to
 							associate each duration declaration to the corresponding <a>manifest</a>
 							<a href="#elemdef-package-item"><code>item</code></a>.</p>
 


### PR DESCRIPTION
Changes may to MUST in this sentence:

> EPUB Creators may use the refines attribute to associate each duration declaration to the corresponding manifest item.

https://w3c.github.io/epub-specs/epub33/core/#sec-mo-package-metadata

There's no other way to do it, and without refines they'd be global declarations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2067.html" title="Last updated on Mar 11, 2022, 2:14 PM UTC (ee3eced)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2067/52c424b...ee3eced.html" title="Last updated on Mar 11, 2022, 2:14 PM UTC (ee3eced)">Diff</a>