### PR TITLE
Fix notes

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8412,6 +8412,11 @@ html.my-document-playing * {
 								>author-defined CSS class names</a> to apply to the currently playing EPUB Content
 							Document element.</p>
 
+						<div class="note">
+							<p>The <code>media:</code> prefix is <a href="#sec-metadata-reserved-prefixes">reserved</a>
+								for inclusion of these properties in package metadata.</p>
+						</div>
+
 						<aside class="example" title="Media Overlays metadata in the Package Document">
 							<pre>&lt;package …>
    &lt;metadata …>
@@ -8457,11 +8462,6 @@ html.my-document-playing * {
    &lt;/metadata>
 &lt;/package></pre>
 						</aside>
-						<div class="note">
-							<p>The <code>media:</code> prefix is <a href="#sec-metadata-reserved-prefixes">reserved</a>
-								for inclusion of these properties in package metadata.</p>
-
-						</div>
 					</section>
 				</section>
 			</section>
@@ -8562,7 +8562,6 @@ html.my-document-playing * {
 					<div class="note">
 						<p>Reading System are not required to support for skippability based on <code>epub:type</code>
 							values.</p>
-
 					</div>
 				</section>
 
@@ -8717,6 +8716,11 @@ html.my-document-playing * {
 							<p>figure</p>
 						</li>
 					</ul>
+
+					<div class="note">
+						<p>Reading System are not required to support for escapability based on <code>epub:type</code>
+							values.</p>
+					</div>
 				</section>
 			</section>
 


### PR DESCRIPTION
A couple of minor tweaks:

- moves the note about the media: prefix being predefined before the example so it's not buried at the end of the section
- adds a note that escapability support is not required -- to match the note in the skippability section


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2068.html" title="Last updated on Mar 11, 2022, 2:29 PM UTC (2fde90b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2068/d683a00...2fde90b.html" title="Last updated on Mar 11, 2022, 2:29 PM UTC (2fde90b)">Diff</a>