### PR TITLE
Make navigation document overlays section informative

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8720,14 +8720,14 @@ html.my-document-playing * {
 				</section>
 			</section>
 
-			<section id="sec-nav-doc">
+			<section id="sec-nav-doc" class="informative">
 				<h3>Navigation Document Overlays</h3>
 
-				<p>As the <a>EPUB Navigation Document</a> is an <a>XHTML Content Document</a>, <a>EPUB Creators</a> MAY
+				<p>As the <a>EPUB Navigation Document</a> is an <a>XHTML Content Document</a>, <a>EPUB Creators</a> may
 					associate an audio Media Overlay with it. Unlike traditional XHTML Content Documents, however,
 						<a>Reading Systems</a> must present the EPUB Navigation Document to users even when it is not
 					included in the <a>spine</a> (see <a data-cite="epub-rs-33#sec-nav">Navigation Document
-						Processing</a> [[?EPUB-RS-33]]). As a result, the method in which an associated Media Overlay
+						Processing</a> [[EPUB-RS-33]]). As a result, the method in which an associated Media Overlay
 					behaves can change depending on the context:</p>
 
 				<ul>
@@ -8737,7 +8737,7 @@ html.my-document-playing * {
 					</li>
 					<li>
 						<p>When exposed in a presentation context that allows users to access and activate the links,
-							Reading Systems MAY implement additional presentation behaviors to expose audio feedback
+							Reading Systems may implement additional presentation behaviors to expose audio feedback
 							when user access navigation links.</p>
 					</li>
 				</ul>
@@ -8746,7 +8746,6 @@ html.my-document-playing * {
 							href="https://www.daisy.org/guidelines/epub/media-overlays-playback-requirements">DAISY
 							Media Overlays Playback Requirements</a> document describes best practices for EPUB Creators
 						and provides recommendations for Reading System developers.</p>
-
 				</div>
 			</section>
 		</section>


### PR DESCRIPTION
There were only two MAY statements in this section, and neither was technically normative:

- the first about being able to associate media overlays with the navigation document is not something this section is allowing (it's true regardless)
- the second about what reading systems "may" do doesn't provide any detail, and would belong in the RS spec if it did.

I've lowercased both instances and added an informative label to the section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2069.html" title="Last updated on Mar 11, 2022, 2:37 PM UTC (9f89035)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2069/d683a00...9f89035.html" title="Last updated on Mar 11, 2022, 2:37 PM UTC (9f89035)">Diff</a>