### PR TITLE
Add normative requirement disallowing align-x-center globally

### DIFF
--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -203,7 +203,9 @@
 			<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should
 				be centered horizontally in the viewport or spread. </p>
 			
-			<p>The property cannot be set globally for all EPUB Content Documents. It is only available as a spine
+			<p>The property MUST NOT be set globally for all EPUB Content Documents (i.e., in a <a 
+				href="#sec-meta-elem"><code>meta</code> element</a> without a <a
+					href="#attrdef-refines"><code>refines</code> attribute</a>). It is only available as a spine
 				override for individual EPUB Content Documents via the <a
 					href="#sec-itemref-elem"><code>itemref</code> element's <code>properties</code>
 					attribute</a>.</p>


### PR DESCRIPTION
This sentence:

> The property cannot be set globally for all EPUB Content Documents.

https://w3c.github.io/epub-specs/epub33/core/#align-x-center

Is only true if we s/cannot/MUST NOT/.