### PR TITLE
Renamed the valid-relative-container-URL-with-fragment term

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5973,7 +5973,7 @@ No Entry</pre>
 					</div>
 
 					<p> A string <var>url</var> is a <dfn id="dfn-valid-relative-container-url-with-fragment-string"
-							>valid-relative-container-URL-with-fragment string</dfn> if it is a <a
+							>valid-relative-ocf-URL-with-fragment string</dfn> if it is a <a
 							data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL
 							string</a>, optionally followed by <code>U+0023 (#)</code> and a <a
 							data-cite="url#url-fragment-string">URL-fragment string</a>, and if the following steps
@@ -6065,7 +6065,7 @@ No Entry</pre>
 
 					<p id="urls-in-ocf-constraints"> In the <a>OCF Abstract Container</a>, any URL string MUST be an <a
 							data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment-string</a> or a
-							<a>valid-relative-container-URL-with-fragment string</a>.</p>
+							<a>valid-relative-ocf-URL-with-fragment string</a>.</p>
 
 					<p>In addition, all <a data-cite="url#relative-url-with-fragment-string">relative-URL-with-fragment
 							strings</a> [[URL]] MUST, after <a data-cite="url#concept-url-parser">parsing</a>, be equal
@@ -10766,6 +10766,9 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to
+					"valid-relative-ocf-URL-with-fragment string". See <a href="https://github.com/w3c/epub-specs/issues/2076"
+						>issue 2076</a>.</li>
 				<li>09-Mar-2022: Restore requirement that valid-relative-container-URL-with-fragment strings resolve to
 					resources in the OCF Abstract Container. See <a href="https://github.com/w3c/epub-specs/issues/2024"
 						>issue 2024</a>.</li>


### PR DESCRIPTION
As proposed in https://github.com/w3c/epub-specs/issues/2076#issuecomment-1065857512 the term was replaced by "valid-relative-ocf-URL-with-fragment string".

Fix #2076


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2081.html" title="Last updated on Mar 14, 2022, 8:15 AM UTC (3298f3f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2081/c601d10...3298f3f.html" title="Last updated on Mar 14, 2022, 8:15 AM UTC (3298f3f)">Diff</a>