### PR TITLE
Added a note to the URL constraints

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5968,13 +5968,13 @@ No Entry</pre>
 							The <a>container root URL</a> is the URL assigned by the Reading System to the root of the container. It typically depends on how the reading system internally implements the container file system.
 						</p>
 						<p>
-							However, a Reading System cannot arbitrarily use any URL, but one that honor the constraints defined above. These constraints ensure that any relative URL string found in the EPUB will always be parsed to a URL of a resource within the container (which may or may not exist).
+							However, a Reading System cannot arbitrarily use any URL, but one that honors the constraints defined above. These constraints ensure that any relative URL string found in the EPUB will always be parsed to a URL of a resource within the container (which may or may not exist).
 							The primary reason for these constraints is to avoid potential run-time security issues that would be caused by parsed URLs "leaking" outside the container files.
 						</p>						
 						<p>
 							For example, URLs like <code>https://localhost:12345/</code> or <code>https://www.example.org:12345/</code> honor these properties. But URLs like <code>https://localhost:12345/path/to.epub/</code>, 
 							<code>file:///path/to.epub#path=/</code>, or <code>jar:file:/path/to.epub!/EPUB/</code> do not 
-							(for example, parsing the URL string "<code>..</code>" with these three examples as base would return <code>https://localhost:12345/path/</code>, <code>file:///path/</code>, and a parsing error, respectively).
+							(parsing the URL string "<code>..</code>" with these three examples as base would return <code>https://localhost:12345/path/</code>, <code>file:///path/</code>, and a parsing error, respectively).
 							It is the responsibility of the Reading System to assign a URL to the root directory that complies with the properties defined above.
 						</p>	
 					</div>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5963,13 +5963,20 @@ No Entry</pre>
 						of <a data-cite="url#concept-url-parser">parsing</a> the file's <a>File Path</a> with the
 							<a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
-					<div class="note">
-						The constraints on a <a>container root URL</a> are automatically honored for URLs like,
-						for example,  <code>https://localhost:12345/</code> or <code>https://www.example.org:12345/</code>; however,
-						a Reading System may choose a different strategy to identify the files of an EPUB container like, for example,
-						<code>file://path/to.epub#path=/EPUB/content.opf</code> or <code>jar:file:/path/to.epub!/EPUB/content.opf</code>.
-						In such a case, the Reading System has to implement its own version of URL parsing to conform to the conceptual
-						model of a <a>container root URL</a> as defined in this specification.
+					<div class="note" id="note-cru-explanation">
+						<p>
+							The <a>container root URL</a> is the URL assigned by the Reading System to the root of the container. It typically depends on how the reading system internally implements the container file system.
+						</p>
+						<p>
+							However, a Reading System cannot arbitrarily use any URL, but one that honor the constraints defined above. These constraints ensure that any relative URL string found in the EPUB will always be parsed to a URL of a resource within the container (which may or may not exist).
+							The primary reason for these constraints is to avoid potential run-time security issues that would be caused by parsed URLs "leaking" outside the container files.
+						</p>						
+						<p>
+							For example, URLs like <code>https://localhost:12345/</code> or <code>https://www.example.org:12345/</code> honor these properties. But URLs like <code>https://localhost:12345/path/to.epub/</code>, 
+							<code>file:///path/to.epub#path=/</code>, or <code>jar:file:/path/to.epub!/EPUB/</code> do not 
+							(for example, parsing the URL string "<code>..</code>" with these three examples as base would return <code>https://localhost:12345/path/</code>, <code>file:///path/</code>, and a parsing error, respectively).
+							It is the responsibility of the Reading System to assign a URL to the root directory that complies with the properties defined above.
+						</p>	
 					</div>
 
 					<div class="note">
@@ -6092,11 +6099,9 @@ No Entry</pre>
 							<li>any other absolute or relative URL string is allowed.</li>
 						</ul>
 
-						<p> Note that in any case, to avoid potential run-time security issues, the properties of the
-								<a>container root URL</a> are such that a conforming Reading System will parse any
-							relative URL string to a <a>content URL</a>. In other words, even the disallowed URL strings
-							described above will not "leak" outside the container. They are still disallowed for better
-							interoperability with non-conforming or legacy Reading Systems and toolchains. </p>
+						<p> 
+							Note that in any case, even the disallowed URL strings described above will not "leak" outside the container after parsing (as explained in the <a href="#note-cru-explanation">first note</a> of this section). They are nevertheless disallowed for better interoperability with non-conforming or legacy Reading Systems and toolchains. 
+						</p>
 					</div>
 
 					<aside class="example" title="Referencing a file in the same directory">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5964,7 +5964,7 @@ No Entry</pre>
 							<a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 					<div class="note">
-						The constraints on a <a>container root URL</a> are automatically honored for "usual" URLs like,
+						The constraints on a <a>container root URL</a> are automatically honored for URLs like,
 						for example,  <code>https://localhost:12345/</code> or <code>https://www.example.org:12345/</code>; however,
 						a Reading System may choose a different strategy to identify the files of an EPUB container like, for example,
 						<code>file://path/to.epub#path=/EPUB/content.opf</code> or <code>jar:file:/path/to.epub!/EPUB/content.opf</code>.

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5964,6 +5964,15 @@ No Entry</pre>
 							<a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 					<div class="note">
+						The constraints on a <a>container root URL</a> are automatically honored for "usual" URLs like,
+						for example,  <code>https://localhost:12345/</code> or <code>https://www.example.org:12345/</code>. However,
+						a Reading System may chose a different strategy to identify the files of an EPUB container like, for example,
+						<code>file://path/to.epub#path=/EPUB/content.opf</code> or <code>jar:file:/path/to.epub!/EPUB/content.opf</code>;
+						in such a case the Reading System have to implement its own version of URL parsing to be conform to the conceptual
+						model of a <a>container root URL</a> as defined in this specification.
+					</div>
+
+					<div class="note">
 						<p>
 							<a data-cite="url#concept-url-parser">Parsing</a> may replace some characters in the File
 							Path by their <a data-cite="url#percent-encode">percent encoded</a> alternative. For

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5965,10 +5965,10 @@ No Entry</pre>
 
 					<div class="note">
 						The constraints on a <a>container root URL</a> are automatically honored for "usual" URLs like,
-						for example,  <code>https://localhost:12345/</code> or <code>https://www.example.org:12345/</code>. However,
-						a Reading System may chose a different strategy to identify the files of an EPUB container like, for example,
-						<code>file://path/to.epub#path=/EPUB/content.opf</code> or <code>jar:file:/path/to.epub!/EPUB/content.opf</code>;
-						in such a case the Reading System have to implement its own version of URL parsing to be conform to the conceptual
+						for example,  <code>https://localhost:12345/</code> or <code>https://www.example.org:12345/</code>; however,
+						a Reading System may choose a different strategy to identify the files of an EPUB container like, for example,
+						<code>file://path/to.epub#path=/EPUB/content.opf</code> or <code>jar:file:/path/to.epub!/EPUB/content.opf</code>.
+						In such a case, the Reading System has to implement its own version of URL parsing to conform to the conceptual
 						model of a <a>container root URL</a> as defined in this specification.
 					</div>
 


### PR DESCRIPTION
Added a note in §6.1.5 on the background of the constraints on URLs

Fix #2075


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2082.html" title="Last updated on Mar 17, 2022, 12:25 PM UTC (d5ecbd9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2082/c601d10...d5ecbd9.html" title="Last updated on Mar 17, 2022, 12:25 PM UTC (d5ecbd9)">Diff</a>