### PR TITLE
Added deep links for deprecated entries

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3367,9 +3367,14 @@ No Entry</pre>
 						<h6>The <code>bindings</code> Element (Deprecated)</h6>
 
 						<p>The <code>bindings</code> element defines a set of custom handlers for media types not
-							supported by this specification. Its use is <a href="#deprecated">deprecated</a>.</p>
+							supported by this specification.</p>
 
-						<p>Refer to its <a href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem">definition</a> in [[EPUBPublications-301]] for more information about this element.</p>
+						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
+
+						<p>Refer to the <a
+								href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
+									><code>bindings</code> element definition</a> in [[EPUBPublications-301]] for more
+							information.</p>
 					</section>
 				</section>
 
@@ -3846,7 +3851,8 @@ No Entry</pre>
 								href="#sec-meta-elem"><code>meta</code> element</a>, which uses different attributes and
 							requires text content, replaces this element.</p>
 
-						<p>For more information about the <code>meta</code> element, refer to its <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2">definition</a> in [[OPF-201]].</p>
+						<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
+									><code>meta</code> element definition</a> in [[OPF-201]] for more information.</p>
 
 						<div class="note">
 							<p>The [[OPF-201]] <code>meta</code> element is retained in EPUB 3 primarily so that EPUB
@@ -3867,7 +3873,8 @@ No Entry</pre>
 								href="#sec-nav-landmarks">landmarks nav</a> in the <a>EPUB Navigation Document</a>
 							replaces this element.</p>
 
-						<p>For more information about the <code>guide</code> element, refer to its <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6">definition</a> in [[OPF-201]].</p>
+						<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
+									><code>guide</code> elementdefinition</a> in [[OPF-201]] for more information.</p>
 					</section>
 
 					<section id="sec-opf2-ncx">
@@ -3877,7 +3884,8 @@ No Entry</pre>
 							[[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table of
 							contents. The <a href="#sec-nav">EPUB Navigation Document</a> replaces this document.</p>
 
-						<p>For more information about the NCX, refer to its <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">definition</a> in [[OPF-201]].</p>
+						<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
+								definition</a> in [[OPF-201]] for more information.</p>
 					</section>
 				</section>
 			</section>
@@ -3979,9 +3987,12 @@ No Entry</pre>
 								Creators</a> can tailor the content displayed to users, one that is not dependent on the
 							scripting capabilities of the <a>EPUB Reading System</a>.</p>
 
-						<p>Use of the <code>switch</code> element is <a href="#deprecated">deprecated</a>. Refer to its
-							<a href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch">definition</a>
-							in [[EPUBContentDocs-301]] for usage information.</p>
+						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
+
+						<p>Refer to the <a
+								href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
+									><code>switch</code> element definition</a> in [[EPUBContentDocs-301]] for more
+							information.</p>
 					</section>
 
 					<section id="sec-xhtml-epub-trigger">
@@ -3991,9 +4002,12 @@ No Entry</pre>
 							controlling multimedia objects, such as audio and video playback, in both scripted and
 							non-scripted contexts.</p>
 
-						<p>Use of the <code>trigger</code> element is <a href="#deprecated">deprecated</a>. Refer to 
-							its <a href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger">definition</a> 
-							in [[EPUBContentDocs-301]] for usage information.</p>
+						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
+
+						<p>Refer to the <a
+								href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
+									><code>epub:trigger</code> element definition</a> in [[EPUBContentDocs-301]] for
+							more information.</p>
 					</section>
 
 					<section id="sec-xhtml-custom-attributes">
@@ -5503,9 +5517,12 @@ No Entry</pre>
 								item.</dd>
 
 							<dt id="spread-portrait">spread-portrait</dt>
-							<dd>The <code>spread-portrait</code> property is <a href="#deprecated">deprecated</a>. Refer
-								to its
-								<a href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait">definition</a> 
+							<dd>
+								<p>The <code>spread-portrait</code> property is <a href="#deprecated"
+									>deprecated</a>.</p>
+								<p></p>Refer to the <a
+									href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
+										><code>spread-portrait</code> property definition</a>
 								in [[EPUBPublications-301]] for more information.</dd>
 						</dl>
 
@@ -5627,9 +5644,12 @@ No Entry</pre>
 						initial containing block (ICB) [[CSS2]] for XHTML and SVG Content Documents whose
 							<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
 
-					<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its 
-						<a href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport">definition</a>
-						in [[EPUBPublications-301]] for more information.</p>
+					<p>Use of the property is <a href="#deprecated">deprecated</a>.</p>
+
+					<p>Refer to the <a
+							href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
+								><code>rendition:viewport</code> property definition</a> in [[EPUBPublications-301]] for
+						more information.</p>
 				</section>
 			</section>
 
@@ -10770,8 +10790,8 @@ EPUB/images/cover.png</pre>
 
 			<ul>
 				<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to
-					"valid-relative-ocf-URL-with-fragment string". See <a href="https://github.com/w3c/epub-specs/issues/2076"
-						>issue 2076</a>.</li>
+					"valid-relative-ocf-URL-with-fragment string". See <a
+						href="https://github.com/w3c/epub-specs/issues/2076">issue 2076</a>.</li>
 				<li>09-Mar-2022: Restore requirement that valid-relative-container-URL-with-fragment strings resolve to
 					resources in the OCF Abstract Container. See <a href="https://github.com/w3c/epub-specs/issues/2024"
 						>issue 2024</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3369,7 +3369,7 @@ No Entry</pre>
 						<p>The <code>bindings</code> element defines a set of custom handlers for media types not
 							supported by this specification. Its use is <a href="#deprecated">deprecated</a>.</p>
 
-						<p>Refer to [[EPUBPublications-301]] for more information about this element.</p>
+						<p>Refer to its <a href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem">definition</a> in [[EPUBPublications-301]] for more information about this element.</p>
 					</section>
 				</section>
 
@@ -3846,8 +3846,7 @@ No Entry</pre>
 								href="#sec-meta-elem"><code>meta</code> element</a>, which uses different attributes and
 							requires text content, replaces this element.</p>
 
-						<p>For more information about the <code>meta</code> element, refer to its definition in
-							[[OPF-201]].</p>
+						<p>For more information about the <code>meta</code> element, refer to its <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2">definition</a> in [[OPF-201]].</p>
 
 						<div class="note">
 							<p>The [[OPF-201]] <code>meta</code> element is retained in EPUB 3 primarily so that EPUB
@@ -3863,13 +3862,12 @@ No Entry</pre>
 						<h5>The <code>guide</code> Element</h5>
 
 						<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
-									><code>guide</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a>
+									><code>guide</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a>
 							feature that previously provided machine-processable navigation to key structures. The <a
 								href="#sec-nav-landmarks">landmarks nav</a> in the <a>EPUB Navigation Document</a>
 							replaces this element.</p>
 
-						<p>For more information about the <code>guide</code> element, refer to its definition in
-							[[OPF-201]].</p>
+						<p>For more information about the <code>guide</code> element, refer to its <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6">definition</a> in [[OPF-201]].</p>
 					</section>
 
 					<section id="sec-opf2-ncx">
@@ -3879,7 +3877,7 @@ No Entry</pre>
 							[[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table of
 							contents. The <a href="#sec-nav">EPUB Navigation Document</a> replaces this document.</p>
 
-						<p>For more information about the NCX, refer to its definition in [[OPF-201]].</p>
+						<p>For more information about the NCX, refer to its <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">definition</a> in [[OPF-201]].</p>
 					</section>
 				</section>
 			</section>
@@ -3982,7 +3980,8 @@ No Entry</pre>
 							scripting capabilities of the <a>EPUB Reading System</a>.</p>
 
 						<p>Use of the <code>switch</code> element is <a href="#deprecated">deprecated</a>. Refer to its
-							definition in [[EPUBContentDocs-301]] for usage information.</p>
+							<a href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch">definition</a>
+							in [[EPUBContentDocs-301]] for usage information.</p>
 					</section>
 
 					<section id="sec-xhtml-epub-trigger">
@@ -3992,8 +3991,9 @@ No Entry</pre>
 							controlling multimedia objects, such as audio and video playback, in both scripted and
 							non-scripted contexts.</p>
 
-						<p>Use of the <code>trigger</code> element is <a href="#deprecated">deprecated</a>. Refer to its
-							definition in [[EPUBContentDocs-301]] for usage information.</p>
+						<p>Use of the <code>trigger</code> element is <a href="#deprecated">deprecated</a>. Refer to 
+							its <a href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger">definition</a> 
+							in [[EPUBContentDocs-301]] for usage information.</p>
 					</section>
 
 					<section id="sec-xhtml-custom-attributes">
@@ -5504,7 +5504,9 @@ No Entry</pre>
 
 							<dt id="spread-portrait">spread-portrait</dt>
 							<dd>The <code>spread-portrait</code> property is <a href="#deprecated">deprecated</a>. Refer
-								to its definition in [[EPUBPublications-301]] for more information.</dd>
+								to its
+								<a href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait">definition</a> 
+								in [[EPUBPublications-301]] for more information.</dd>
 						</dl>
 
 						<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
@@ -5625,8 +5627,9 @@ No Entry</pre>
 						initial containing block (ICB) [[CSS2]] for XHTML and SVG Content Documents whose
 							<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
 
-					<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its definition in
-						[[EPUBPublications-301]] for more information.</p>
+					<p>Use of the property is <a href="#deprecated">deprecated</a>. Refer to its 
+						<a href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport">definition</a>
+						in [[EPUBPublications-301]] for more information.</p>
 				</section>
 			</section>
 

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -111,7 +111,9 @@
 					href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
 				"<code>application/marcxml+xml</code>".</p>
 			
-			<p>For more information about this property, refer its <a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record">definition</a> in [[!EPUBPublications-30]].</p>
+			<p>Refer to the <a 
+				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"><code>marc21xml-record</code>
+				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
 		</section>
 		<section id="sec-mods-record">
 			<h5>mods-record (Deprecated)</h5>
@@ -121,7 +123,9 @@
 					href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
 				"<code>application/mods+xml</code>".</p>
 			
-			<p>For more information about this property, refer its <a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record">definition</a> in [[!EPUBPublications-30]].</p>
+			<p>Refer to the <a 
+				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"><code>mods-record</code>
+				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
 		</section>
 		<section id="sec-onix-record">
 			<h5>onix-record (Deprecated)</h5>
@@ -131,9 +135,9 @@
 					href="#attrdef-properties">properties attribute</a> value <a href="#onix"
 						><code>onix</code></a>.</p>
 			
-			<p>For more information about this property, refer its 
-				<a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record">definition</a>
-				in [[!EPUBPublications-30]].</p>
+			<p>Refer to the <a 
+				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"><code>onix-record</code>
+				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
 		</section>
 		<section id="sec-record">
 			<h5>record</h5>
@@ -229,10 +233,10 @@
 			<p id="xml-signature">Use of the <code>xml-signature</code> keyword is <a href="#deprecated">deprecated</a>.
 				It is not replaced by another linking method. Identification of XML signatures will be addressed in a
 				future version of EPUB.</p>
-				
-			<p>For more information about this property, refer its 
-				<a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature">definition</a> 
-				in [[!EPUBPublications-30]].</p>
+			
+			<p>Refer to the <a 
+				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"><code>xml-signature</code>
+				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
 		</section>
 		<section id="sec-xmp-record">
 			<h5>xmp-record (Deprecated)</h5>
@@ -242,9 +246,9 @@
 					href="#attrdef-properties">properties attribute</a> value <a href="#xmp"
 						><code>xmp</code></a>.</p>
 			
-			<p>For more information about this property, refer its 
-				<a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record">definition</a> 
-				in [[!EPUBPublications-30]].</p>
+			<p>Refer to the <a 
+				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"><code>xmp-record</code>
+				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
 		</section>
 	</section>
 	<section id="sec-link-properties">

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -111,7 +111,7 @@
 					href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
 				"<code>application/marcxml+xml</code>".</p>
 			
-			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
+			<p>For more information about this property, refer its <a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record">definition</a> in [[!EPUBPublications-30]].</p>
 		</section>
 		<section id="sec-mods-record">
 			<h5>mods-record (Deprecated)</h5>
@@ -121,7 +121,7 @@
 					href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
 				"<code>application/mods+xml</code>".</p>
 			
-			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
+			<p>For more information about this property, refer its <a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record">definition</a> in [[!EPUBPublications-30]].</p>
 		</section>
 		<section id="sec-onix-record">
 			<h5>onix-record (Deprecated)</h5>
@@ -131,7 +131,9 @@
 					href="#attrdef-properties">properties attribute</a> value <a href="#onix"
 						><code>onix</code></a>.</p>
 			
-			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
+			<p>For more information about this property, refer its 
+				<a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record">definition</a>
+				in [[!EPUBPublications-30]].</p>
 		</section>
 		<section id="sec-record">
 			<h5>record</h5>
@@ -228,7 +230,9 @@
 				It is not replaced by another linking method. Identification of XML signatures will be addressed in a
 				future version of EPUB.</p>
 				
-			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
+			<p>For more information about this property, refer its 
+				<a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature">definition</a> 
+				in [[!EPUBPublications-30]].</p>
 		</section>
 		<section id="sec-xmp-record">
 			<h5>xmp-record (Deprecated)</h5>
@@ -238,7 +242,9 @@
 					href="#attrdef-properties">properties attribute</a> value <a href="#xmp"
 						><code>xmp</code></a>.</p>
 			
-			<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
+			<p>For more information about this property, refer its 
+				<a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record">definition</a> 
+				in [[!EPUBPublications-30]].</p>
 		</section>
 	</section>
 	<section id="sec-link-properties">

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -604,7 +604,9 @@
 		<h5>meta-auth (Deprecated)</h5>
 		<p id="meta-auth">Use of the <code>meta-auth</code> property is <a href="#deprecated"
 			>deprecated</a>.</p>
-		<p>For more information about this property, refer its definition in [[!EPUBPublications-30]].</p>
+		<p>For more information about this property, refer its 
+			<a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth">definition</a> 
+			in [[!EPUBPublications-30]].</p>
 	</section>
 	<section id="sec-role">
 		<h5>role</h5>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -602,11 +602,11 @@
 	</section>
 	<section id="sec-meta-auth">
 		<h5>meta-auth (Deprecated)</h5>
-		<p id="meta-auth">Use of the <code>meta-auth</code> property is <a href="#deprecated"
-			>deprecated</a>.</p>
-		<p>For more information about this property, refer its 
-			<a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth">definition</a> 
-			in [[!EPUBPublications-30]].</p>
+		<p id="meta-auth">Use of this property is <a href="#deprecated">deprecated</a>.</p>
+		
+		<p>Refer to the <a 
+			href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"><code>meta-auth</code>
+			property definition</a> in [[!EPUBPublications-30]] for more information.</p>
 	</section>
 	<section id="sec-role">
 		<h5>role</h5>


### PR DESCRIPTION
I hope to have found all of them...

Fix #2079

See also [full preview](https://raw.githack.com/w3c/epub-specs/editorial/deep-links-issue-2079/epub33/core/index.html) (including the vocabularies).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2085.html" title="Last updated on Mar 15, 2022, 3:23 PM UTC (d8dc2c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2085/01db0f2...d8dc2c1.html" title="Last updated on Mar 15, 2022, 3:23 PM UTC (d8dc2c1)">Diff</a>