### PR TITLE
Fix requirements on authoring semantics in MO documents

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7278,10 +7278,6 @@ No Entry</pre>
 								more than one Media Overlay Document MUST NOT reference the same EPUB Content
 								Document.</p>
 						</li>
-						<li>
-							<p id="confreq-mo-docprops-semantics">SHOULD use <a href="#sec-docs-structural-semantic"
-									>semantic markup</a> where appropriate.</p>
-						</li>
 					</ul>
 				</section>
 
@@ -8488,6 +8484,29 @@ html.my-document-playing * {
 							<a href="#sec-docs-structural-semantic"><code>epub:type</code></a> attribute to determine
 						when to offer users the option of skippable features.</p>
 
+					<p>EPUB Creators MAY use the following semantics to enable skippability:</p>
+
+					<ul>
+						<li>
+							<p>footnote</p>
+						</li>
+						<li>
+							<p>endnote</p>
+						</li>
+						<li>
+							<p>pagebreak</p>
+						</li>
+					</ul>
+
+					<p>This list is non-exhaustive, however. It represents terms from the Structural Semantics
+						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems are most likely to offer the option of
+						skippability.</p>
+
+					<div class="note">
+						<p>Reading System are not required to support for skippability based on <code>epub:type</code>
+							values.</p>
+					</div>
+
 					<aside class="example" title="Media Overlay with a page break">
 						<p>In this example, a Reading System could offer the user the option of turning on and off the
 							page break/page number announcements, which are often cumbersome to listen to.</p>
@@ -8554,25 +8573,6 @@ html.my-document-playing * {
    &lt;/body>
 &lt;/html></pre>
 					</aside>
-
-					<p>The following non-exhaustive list represents terms from the Structural Semantics
-						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems may offer the option of skippability:</p>
-
-					<ul>
-						<li>
-							<p>footnote</p>
-						</li>
-						<li>
-							<p>endnote</p>
-						</li>
-						<li>
-							<p>pagebreak</p>
-						</li>
-					</ul>
-					<div class="note">
-						<p>Reading System are not required to support for skippability based on <code>epub:type</code>
-							values.</p>
-					</div>
 				</section>
 
 				<section id="sec-escapability">
@@ -8583,6 +8583,38 @@ html.my-document-playing * {
 						feature differs from the skippability feature in that it does not enable or disable entire types
 						of items, but provides an exit from them (e.g., a user can listen to some of the content before
 						choosing to escape).</p>
+
+					<p>EPUB Creators MAY use the following semantics to enable escapability:</p>
+					
+					<ul>
+						<li>
+							<p>table</p>
+						</li>
+						<li>
+							<p>table-row</p>
+						</li>
+						<li>
+							<p>table-cell</p>
+						</li>
+						<li>
+							<p>list</p>
+						</li>
+						<li>
+							<p>list-item</p>
+						</li>
+						<li>
+							<p>figure</p>
+						</li>
+					</ul>
+
+					<p>This list is non-exhaustive list, however. It represents terms from the Structural Semantics
+						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems are most likely to offer the option of
+						escapability.</p>
+
+					<div class="note">
+						<p>Reading System are not required to support for escapability based on <code>epub:type</code>
+							values.</p>
+					</div>
 
 					<aside class="example" title="Escapable structures">
 						<p>In this example, the Media Overlay Document for an EPUB Content Document contains a
@@ -8702,35 +8734,6 @@ html.my-document-playing * {
    &lt;/body>
 &lt;/smil></pre>
 					</aside>
-
-					<p>The following non-exhaustive list represents terms from the Structural Semantics
-						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems may offer the option of escapability:</p>
-
-					<ul>
-						<li>
-							<p>table</p>
-						</li>
-						<li>
-							<p>table-row</p>
-						</li>
-						<li>
-							<p>table-cell</p>
-						</li>
-						<li>
-							<p>list</p>
-						</li>
-						<li>
-							<p>list-item</p>
-						</li>
-						<li>
-							<p>figure</p>
-						</li>
-					</ul>
-
-					<div class="note">
-						<p>Reading System are not required to support for escapability based on <code>epub:type</code>
-							values.</p>
-					</div>
 				</section>
 			</section>
 
@@ -10767,8 +10770,8 @@ EPUB/images/cover.png</pre>
 
 			<ul>
 				<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to
-					"valid-relative-ocf-URL-with-fragment string". See <a href="https://github.com/w3c/epub-specs/issues/2076"
-						>issue 2076</a>.</li>
+					"valid-relative-ocf-URL-with-fragment string". See <a
+						href="https://github.com/w3c/epub-specs/issues/2076">issue 2076</a>.</li>
 				<li>09-Mar-2022: Restore requirement that valid-relative-container-URL-with-fragment strings resolve to
 					resources in the OCF Abstract Container. See <a href="https://github.com/w3c/epub-specs/issues/2024"
 						>issue 2024</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8585,7 +8585,7 @@ html.my-document-playing * {
 						choosing to escape).</p>
 
 					<p>EPUB Creators MAY use the following semantics to enable escapability:</p>
-					
+
 					<ul>
 						<li>
 							<p>table</p>
@@ -10769,6 +10769,9 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>17-Mar-2022: Fixed conflicting statements about the requirement for semantics in Media Overlay
+					Documents and clarified requirements for skippability and escapability. See <a
+						href="https://github.com/w3c/epub-specs/issues/2066">issue 2066</a>.</li>
 				<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to
 					"valid-relative-ocf-URL-with-fragment string". See <a
 						href="https://github.com/w3c/epub-specs/issues/2076">issue 2076</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8502,11 +8502,6 @@ html.my-document-playing * {
 						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems are most likely to offer the option of
 						skippability.</p>
 
-					<div class="note">
-						<p>Reading System are not required to support for skippability based on <code>epub:type</code>
-							values.</p>
-					</div>
-
 					<aside class="example" title="Media Overlay with a page break">
 						<p>In this example, a Reading System could offer the user the option of turning on and off the
 							page break/page number announcements, which are often cumbersome to listen to.</p>
@@ -8610,11 +8605,6 @@ html.my-document-playing * {
 					<p>This list is non-exhaustive list, however. It represents terms from the Structural Semantics
 						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems are most likely to offer the option of
 						escapability.</p>
-
-					<div class="note">
-						<p>Reading System are not required to support for escapability based on <code>epub:type</code>
-							values.</p>
-					</div>
 
 					<aside class="example" title="Escapable structures">
 						<p>In this example, the Media Overlay Document for an EPUB Content Document contains a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -361,8 +361,9 @@
 			<section id="sec-epub-rs-external-links">
 				<h3>External Links</h3>
 
-				<p data-tests="#pub-external-links">Reading Systems SHOULD open links that resolve outside the <a>EPUB Publication</a> in a new browser
-					instance to ensure that the security and privacy controls of the browser are available to users.</p>
+				<p data-tests="#pub-external-links">Reading Systems SHOULD open links that resolve outside the <a>EPUB
+						Publication</a> in a new browser instance to ensure that the security and privacy controls of
+					the browser are available to users.</p>
 
 				<p>Although links to external web sites and resources are commonly found in <a>EPUB Content
 						Documents</a>, these are not the only sources. If a Reading System provides access to <a
@@ -379,8 +380,8 @@
 		<section id="sec-package-doc">
 			<h2>Package Document Processing</h2>
 
-			<p id="confreq-rs-epub-pub" class="support">Reading Systems
-				MUST process the <a data-cite="epub-33#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
+			<p id="confreq-rs-epub-pub" class="support">Reading Systems MUST process the <a
+					data-cite="epub-33#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
 
 			<section id="sec-pkg-doc-base-dir">
 				<h4>Base Direction</h4>
@@ -923,17 +924,14 @@
 					</li>
 
 					<li>
-						<p id="confreq-rs-scripted-origin"> 
-							<span id="confreq-rs-scripted-origin-shared"  data-tests="#scr-support_origin">
-								It MUST assign a unique <a data-cite="url#origin"
-								>origin</a> [[URL]], shared by all <a data-cite="epub-33#sec-scripted-spine">spine-level
-									scripts</a> of the EPUB Publication. 	
-							</span>
-							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin">
-								That <a data-cite="url#origin">origin</a> [[URL]]
-								MUST be <em>unique</em> for each user-specific instance of an EPUB Publication in a Reading
-								System.	
-							</span>
+						<p id="confreq-rs-scripted-origin">
+							<span id="confreq-rs-scripted-origin-shared" data-tests="#scr-support_origin"> It MUST
+								assign a unique <a data-cite="url#origin">origin</a> [[URL]], shared by all <a
+									data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> of the EPUB
+								Publication. </span>
+							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin"> That <a
+									data-cite="url#origin">origin</a> [[URL]] MUST be <em>unique</em> for each
+								user-specific instance of an EPUB Publication in a Reading System. </span>
 						</p>
 					</li>
 
@@ -1333,23 +1331,27 @@
 				<section id="sec-container-iri">
 					<h4>URL of the Root Directory</h4>
 
-					<p id="sec-container-iri-root" data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">
-						Reading Systems MUST assign a URL [[URL]] to the <a>Root Directory</a> of the 
-						<a>OCF Abstract Container</a>.</span> 
-							This URL is called the <a data-cite="epub-33#dfn-container-root-url"
-							>container root URL</a>. It is implementation specific, but the implementation MUST have the
-						following properties:</p>
+					<p id="sec-container-iri-root"
+						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative"> Reading Systems MUST
+						assign a URL [[URL]] to the <a>Root Directory</a> of the <a>OCF Abstract Container</a>. This URL
+						is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a>. It is
+						implementation specific, but the implementation MUST have the following properties:</p>
 
 					<ul>
-						<li id="sec-container-iri-root-parse" data-tests="#ocf-url_link-path-absolute,#ocf-url_parse-path-absolute">The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>/</code>"
-							with the <a>container root URL</a> as <a data-cite="url#concept-base-url"
-								><var>base</var></a> is the <a>container root URL</a>.</li>
-						<li  id="sec-container-iri-step-parse" data-tests="#ocf-url_link-leaking-relative,#ocf-url_parse-leaking-relative">The result of <a data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>..</code>"
-							with the <a>container root URL</a> as <a data-cite="url#concept-base-url"
-								><var>base</var></a> is the <a>container root URL</a>.</li>
+						<li id="sec-container-iri-root-parse"
+							data-tests="#ocf-url_link-path-absolute,#ocf-url_parse-path-absolute">The result of <a
+								data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>/</code>" with the
+								<a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is
+							the <a>container root URL</a>.</li>
+						<li id="sec-container-iri-step-parse"
+							data-tests="#ocf-url_link-leaking-relative,#ocf-url_parse-leaking-relative">The result of <a
+								data-cite="url#concept-url-parser">parsing</a> [[URL]] "<code>..</code>" with the
+								<a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is
+							the <a>container root URL</a>.</li>
 
-						<li id="sec-container-iri-origin" data-tests="#ocf-url_origin">The <a data-cite="url#origin">origin</a> of the <a>container root URL</a> is unique for each
-							user-specific instance of an EPUB Publication in a Reading System.</li>				
+						<li id="sec-container-iri-origin" data-tests="#ocf-url_origin">The <a data-cite="url#origin"
+								>origin</a> of the <a>container root URL</a> is unique for each user-specific instance
+							of an EPUB Publication in a Reading System.</li>
 					</ul>
 
 					<p class="note">The unicity of the <a data-cite="url#origin">origin</a> per each user-specific
@@ -1358,11 +1360,9 @@
 						copies even if the same Reading System is used.</p>
 
 					<div class="note">
-						<p>
-							The properties of the <a>container root URL</a> are such that a conforming Reading System will parse any relative URL
-							string to a <a>content URL</a>. In other words, relative links do not "leak" outside the container content, which is an important
-							feature for security.
-						</p>
+						<p> The properties of the <a>container root URL</a> are such that a conforming Reading System
+							will parse any relative URL string to a <a>content URL</a>. In other words, relative links
+							do not "leak" outside the container content, which is an important feature for security. </p>
 
 						<p>In practice, the container root URL behaves similarly to a URL defined as follows:</p>
 
@@ -1433,7 +1433,8 @@
 						<table class="zebra">
 							<thead>
 								<tr>
-									<td style="font-weight: bold; text-align: center;">URL string<br/>(found for example in the package document)</td>
+									<td style="font-weight: bold; text-align: center;">URL string<br />(found for
+										example in the package document)</td>
 									<td style="font-weight: bold; text-align: center;">Content URL</td>
 								</tr>
 							</thead>
@@ -1464,10 +1465,9 @@
 								</tr>
 							</tbody>
 						</table>
-						<p>
-							Note that the last two links are <a data-cite="epub-33#urls-in-ocf-constraints">disallowed</a> in an 
-							EPUB Publications to ensure better interoperability with non-conforming or legacy Reading Systems and toolchains.
-						</p>
+						<p> Note that the last two links are <a data-cite="epub-33#urls-in-ocf-constraints"
+								>disallowed</a> in an EPUB Publications to ensure better interoperability with
+							non-conforming or legacy Reading Systems and toolchains. </p>
 					</div>
 
 					<div class="note">
@@ -1888,9 +1888,9 @@
 						associated speech synthesis. The implicit duration of the <code>text</code> element (and by
 						inference, of the parent <code>par</code> element) is therefore determined by the execution of
 						the Text-to-Speech engine, and cannot be known at authoring time (factors like speech rate,
-						pauses and other prosody parameters influence the audio output).
-						This also means that Reading Systems should treat the data-cite="epub-33#duration"><code>duration</code></a> property values set in the Package Document as approximative when making use of them.
-					</p>
+						pauses and other prosody parameters influence the audio output). This also means that Reading
+						Systems should treat the <a data-cite="epub-33#duration"><code>duration</code></a> property
+						values set in the Package Document as approximative when making use of them. </p>
 				</section>
 			</section>
 
@@ -1901,8 +1901,12 @@
 					<h5>Skippability</h5>
 
 					<p>Reading Systems SHOULD use the semantic information provided by Media Overlay elements' <a
-							href="#sec-structural-semantics"><code>epub:type</code> attribute</a> to determine when to
-						offer users the option of skippable features.</p>
+							href="#sec-structural-semantics"><code>epub:type</code> attribute</a> to offer users the
+						option of skipping content.</p>
+
+					<p>When skipping of content is enabled, Reading Systems MUST suppress playback of any
+							<code>par</code> and <code>seq</code> elements whose <code>epub:type</code> attribute
+						contains a semantic that matches a skippable structure.</p>
 				</section>
 
 				<section id="sec-escapability">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2523,6 +2523,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>17-Mar-2022: Added requirement to suppress playback of skippable elements in Media Overlays
+					Documents. See <a href="https://github.com/w3c/epub-specs/issues/2066">issue 2066</a>.</li>
 				<li>11-Feb-2022: Fix the contradictory support statements for Media Overlays. Support is recommended
 					when rendering of prerecorded audio is supported, as in previous versions of EPUB 3. See <a
 						href="https://github.com/w3c/epub-specs/issues/1991">issue 1991</a>.</li>


### PR DESCRIPTION
This is my best attempt to solve #2066 as minimally as possible. The PR:

- removes the bullet about adding semantics from the requirements section because the first bullet already allows semantics to be added since the method of adding them is part of the schema definition (specifying things twice is how these mismatches always arise). Section 7.3.3 also already covers adding semantics with the correct normative requirements.
- adds "MAY" statements for using the lists of semantics we previously called out for skippability and escapability. This improves our eventually raising support of skippability and escapability to recommendations in the accessibility specification
- moves the lists of semantics up above the examples in the skippability and escapability sections. It's odd to reach an example of implementing the features before knowing what the semantics to use are.
- adds a paragraph to the RS specification for skippability to require that reading systems suppress playback of par/seq elements with matching semantics. All we were requiring was that reading systems should look and see if there are semantics to determine whether to enable skippability. I'm not sure if I have the best wording for this, though, so feedback welcome.

<strike>I also had to make some fixes to the markup of the RS spec, as I was getting errors. There was a missing end tag and part of an opening tag was missing, so we were getting an attribute in the source.</strike> (Fixed these in main.)

Anyway, let me know if I've got this right or if there's more that needs fixing.

Fixes #2066 

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-2066/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-2066/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2089.html" title="Last updated on Mar 25, 2022, 9:45 AM UTC (e525a8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2089/55d5466...e525a8b.html" title="Last updated on Mar 25, 2022, 9:45 AM UTC (e525a8b)">Diff</a>