### PR TITLE
Change epub:type note to a caution and elaborate on applications

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9533,17 +9533,22 @@ html.my-document-playing * {
 				<div class="caution">
 					<p>Although the <code>epub:type</code> attribute is similar in nature to the <a
 							data-cite="html#attr-aria-role"><code>role</code> attribute</a> [[HTML]], the attributes
-						serve different purposes. The values of the <code>epub:type</code> attribute do not enhance the
-						accessibility of EPUB Publications, for example, as they do not map to the accessibility <abbr
-							title="Application Programming Interfaces">APIs</abbr> used by assistive technologies. This
-						means that adding <code>epub:type</code> values to semantically neutral elements like [[HTML]]
-							<a data-cite="html#the-div-element"><code>div</code></a> and <a
+						serve different purposes. The values of the <code>epub:type</code> attribute do not enhance
+						access through assistive technologies like screen readers as they do not map to the
+						accessibility <abbr title="Application Programming Interfaces">APIs</abbr> used by these
+						technologies. This means that adding <code>epub:type</code> values to semantically neutral
+						elements like [[HTML]] <a data-cite="html#the-div-element"><code>div</code></a> and <a
 							data-cite="html#the-span-element"><code>span</code></a> does not make them any more
-						accessible. Only ARIA roles influence how assistive technologies understand such elements.</p>
+						accessible to assistive technologies. Only ARIA roles influence how assistive technologies
+						understand such elements.</p>
 
 					<p>The <code>epub:type</code> attribute is consequently only intended for publishing semantics and
-						Reading System enhancements. Refer to <a data-cite="dpub-aria-1.0#">Digital Publishing WAI-ARIA
-							Module 1.0</a> [[DPUB-ARIA-1.0]] for more information about accessible publishing roles.</p>
+						Reading System enhancements. Reading Systems may use <code>epub:type</code> values to provide
+						accessibility enhancements like built-in read aloud or Media Overlays functionality where
+						interaction with assistive technologies is not essential.</p>
+
+					<p>Refer to <a data-cite="dpub-aria-1.0#">Digital Publishing WAI-ARIA Module 1.0</a>
+						[[DPUB-ARIA-1.0]] for more information about accessible publishing roles.</p>
 				</div>
 
 				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9536,8 +9536,8 @@ html.my-document-playing * {
 						serve different purposes. The values of the <code>epub:type</code> attribute do not enhance the
 						accessibility of EPUB Publications, for example, as they do not map to the accessibility <abbr
 							title="Application Programming Interfaces">APIs</abbr> used by assistive technologies. This
-						means that adding <code>epub:type</code> values to semantically elements like [[HTML]] <a
-							data-cite="html#the-div-element"><code>div</code></a> and <a
+						means that adding <code>epub:type</code> values to semantically neutral elements like [[HTML]]
+							<a data-cite="html#the-div-element"><code>div</code></a> and <a
 							data-cite="html#the-span-element"><code>span</code></a> does not make them any more
 						accessible. Only ARIA roles influence how assistive technologies understand such elements.</p>
 
@@ -11132,6 +11132,9 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>17-Mar-2022: Removed dated requirements on the use of <code>epub:type</code> that suggest
+					equivalence with ARIA roles. See <a href="https://github.com/w3c/epub-specs/pull/2070">issue
+						2070</a>.</li>
 				<li>16-Mar-2022: Add new section on conformance checking and definition for EPUB Conformance Checker.
 					See <a href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
 				<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9530,27 +9530,25 @@ html.my-document-playing * {
 					</dd>
 				</dl>
 
-				<div class="note">
+				<div class="caution">
 					<p>Although the <code>epub:type</code> attribute is similar in nature to the <a
 							data-cite="html#attr-aria-role"><code>role</code> attribute</a> [[HTML]], the attributes
 						serve different purposes. The values of the <code>epub:type</code> attribute do not enhance the
-						accessibility of EPUB Publications, for example, they do not map to accessibility <abbr
-							title="Application Programming Interfaces">APIs</abbr> used by assistive technologies. The
-							<code>epub:type</code> attribute is only intended for publishing semantics and Reading
-						System enhancements. Refer to <a data-cite="dpub-aria-1.0#">Digital Publishing WAI-ARIA Module
-							1.0</a> [[DPUB-ARIA-1.0]] for more information about accessible publishing roles.</p>
+						accessibility of EPUB Publications, for example, as they do not map to the accessibility <abbr
+							title="Application Programming Interfaces">APIs</abbr> used by assistive technologies. This
+						means that adding <code>epub:type</code> values to semantically elements like [[HTML]] <a
+							data-cite="html#the-div-element"><code>div</code></a> and <a
+							data-cite="html#the-span-element"><code>span</code></a> does not make them any more
+						accessible. Only ARIA roles influence how assistive technologies understand such elements.</p>
 
+					<p>The <code>epub:type</code> attribute is consequently only intended for publishing semantics and
+						Reading System enhancements. Refer to <a data-cite="dpub-aria-1.0#">Digital Publishing WAI-ARIA
+							Module 1.0</a> [[DPUB-ARIA-1.0]] for more information about accessible publishing roles.</p>
 				</div>
 
 				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
 					is one or more white space-separated terms stemming from external vocabularies associated with the
 					document instance.</p>
-
-				<p>The inflected semantic MUST express a subclass of the semantic of the carrying element. In the case
-					of semantically neutral elements, such as the [[HTML]] <a data-cite="html#the-div-element"
-							><code>div</code></a> and <a data-cite="html#the-span-element"><code>span</code></a>
-					elements, the inflected semantic MUST NOT attach a meaning that is already conveyed by an existing
-					element (e.g., that a <code>div</code> represents a paragraph or section).</p>
 
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
 					the EPUB 3 Structural Semantics Vocabulary [[?EPUB-SSV-11]]. EPUB Creators MAY include unprefixed


### PR DESCRIPTION
For this PR, I've changed the note in the `epub:type` section to a caution in removing the unchecked restrictions on its use. I believe it's worth extra emphasis that `epub:type` is not at all like ARIA `role`.

I've also tried to explain the differences better, so the caution now reads:

> Although the epub:type attribute is similar in nature to the [role attribute](https://html.spec.whatwg.org/multipage/#attr-aria-role) [HTML], the attributes serve different purposes. The values of the epub:type attribute do not enhance the accessibility of EPUB Publications, for example, as they do not map to the accessibility APIs used by assistive technologies. This means that adding epub:type values to semantically neutral elements like [HTML] [div](https://html.spec.whatwg.org/multipage/#the-div-element) and [span](https://html.spec.whatwg.org/multipage/#the-span-element) does not make them any more accessible. Only ARIA roles influence how assistive technologies understand such elements.
> 
> The epub:type attribute is consequently only intended for publishing semantics and Reading System enhancements. Refer to [Digital Publishing WAI-ARIA Module 1.0](https://www.w3.org/TR/dpub-aria-1.0/#) [DPUB-ARIA-1.0] for more information about accessible publishing roles.

Fixes #2070


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2090.html" title="Last updated on Mar 20, 2022, 11:51 AM UTC (17f21b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2090/8d4a9d6...17f21b4.html" title="Last updated on Mar 20, 2022, 11:51 AM UTC (17f21b4)">Diff</a>