### PR TITLE
Clarify wcag conformance requirements and fix linking

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -285,10 +285,10 @@
 					metadata.</p>
 
 				<p>Ensuring that any interested party can discover the accessible qualities of an EPUB Publication is
-					therefore a primary concern. An EPUB Publication can have more than one set of sufficient
-					<a href="#confreq-schema-accessMode">access modes</a> depending on the alternatives
-					provided to enable reading in another mode. For example, if alternative text and descriptions are provided
-					for all the images in a publication, it would have both its default textual and visual sufficient access
+					therefore a primary concern. An EPUB Publication can have more than one set of sufficient <a
+						href="#confreq-schema-accessMode">access modes</a> depending on the alternatives provided to
+					enable reading in another mode. For example, if alternative text and descriptions are provided for
+					all the images in a publication, it would have both its default textual and visual sufficient access
 					mode <em>and</em> a purely textual sufficient access mode.</p>
 
 				<p>Similarly, content that does not meet the accessibility requirements of this specification does not
@@ -442,16 +442,15 @@
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-wcag-20">MUST meet the requirements of WCAG 2.0 [[WCAG20]], but it is
-								strongly RECOMMENDED that it meet the requirements of the <a
+							<p id="confreq-wcag-20">MUST, at the minimum, meet the requirements of WCAG 2.0 [[WCAG20]],
+								but it is strongly recommended that it meet the requirements of the <a
 									href="https://www.w3.org/TR/WCAG2/">latest recommended version of WCAG 2</a>.</p>
 						</li>
 
 						<li>
-							<p id="confreq-wcag-a">MUST meet the requirements of <a
-									href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a>, but it is strongly RECOMMENDED
-								that it meet the requirements of <a href="https://www.w3.org/TR/WCAG2/#cc1">Level AA</a>
-								[[WCAG2]].</p>
+							<p id="confreq-wcag-a">MUST, for whichever version of [[WCAG2]] selected, meet the
+								requirements of Level A, but it is strongly recommended that it meet the requirements of
+								Level AA.</p>
 						</li>
 					</ul>
 
@@ -1322,11 +1321,11 @@
 						release, the EPUB Creator may only need to evaluate the new modifications to re-confirm
 						conformance.</p>
 
-					<p>If an updated version of this specification or [[WCAG]] has been published since the last release
-						of the EPUB Publication, however, this specification also recommends performing a new evaluation
-						to ensure conformance to the latest standards. EPUB Creators may not have to perform a full
-						re-evaluation even in this case (i.e., they may only need to check new or modified success
-						criteria unless the standards undergo major changes to methodology or conformance).</p>
+					<p>If an updated version of this specification or [[WCAG2]] has been published since the last
+						release of the EPUB Publication, however, this specification also recommends performing a new
+						evaluation to ensure conformance to the latest standards. EPUB Creators may not have to perform
+						a full re-evaluation even in this case (i.e., they may only need to check new or modified
+						success criteria unless the standards undergo major changes to methodology or conformance).</p>
 
 					<p>Conversely, EPUB Creators do not need to perform a re-evaluation when making non-substantive
 						changes, such as:</p>
@@ -1692,6 +1691,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>21-Mar-2021: Clarified linking for WCAG conformance versions and levels. See <a
+					href="https://github.com/w3c/epub-specs/issues/2099">issue 2099</a>.</li>
 				<li>28-Sep-2021: The section on optimized publication has been made informative and rewritten to
 					highlight best practices for identifying conformance to such standards. See <a
 						href="https://github.com/w3c/epub-specs/pulls/1833">pull request 1833</a>.</li>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -448,7 +448,7 @@
 						</li>
 
 						<li>
-							<p id="confreq-wcag-a">MUST, for whichever version of [[WCAG2]] selected, meet the
+							<p id="confreq-wcag-a">MUST, for whichever version of WCAG 2 selected, meet the
 								requirements of Level A, but it is strongly recommended that it meet the requirements of
 								Level AA.</p>
 						</li>


### PR DESCRIPTION
This PR fixes the WCAG conformance bullets as discussed in #2099.

It switches the normative "recommended" to informative for conforming to the latest version/level of WCAG, otherwise if you validly meet 2.0/A you'll also get warnings that you should be meeting 2.X/AA. I don't believe this was what we intended, at least not yet.

It also removes links from the levels, as what level you meet is first dependent on what version you conform to.

The bullets now read:

> - MUST, at the minimum, meet the requirements of WCAG 2.0 [WCAG20], but it is strongly recommended that it meet the requirements of the [latest recommended version of WCAG 2](https://www.w3.org/TR/WCAG2/).

> - MUST, for whichever version of WCAG 2 selected, meet the requirements of Level A, but it is strongly recommended that it meet the requirements of Level AA.

Fixes #2099 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-2099/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-2099/epub33/a11y/index.html)
