### PR TITLE
Update MO fragment reference recommendations

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5775,23 +5775,23 @@ No Entry</pre>
 				<p>Although control over the rendering of <a>EPUB Content Documents</a> to create <a
 						href="#sec-fixed-layouts">fixed layouts</a> is an obvious need not handled by other
 					technologies, there are also considerations for reflowable content that are unique to EPUB
-					Publications (e.g., how to handle the flow of content in the <a>Viewport</a>). This section
-					defines properties that allow <a>EPUB Creators</a> to control presentation aspects of reflowable
+					Publications (e.g., how to handle the flow of content in the <a>Viewport</a>). This section defines
+					properties that allow <a>EPUB Creators</a> to control presentation aspects of reflowable
 					content.</p>
 
 				<section id="flow">
 					<h4>The <code>rendition:flow</code> Property</h4>
 
-					<p>The <code>rendition:flow</code> property specifies the EPUB Creator preference for how
-						Reading Systems should handle content overflow. </p>
+					<p>The <code>rendition:flow</code> property specifies the EPUB Creator preference for how Reading
+						Systems should handle content overflow. </p>
 
-					<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code> property</a>
-						is specified on a <code>meta</code> element, it indicates the EPUB Creator's global
-						preference for overflow content handling (i.e., for all spine items). EPUB Creators MAY
-						indicate a preference for dynamic pagination or scrolling. For scrolled content, it is also
-						possible to specify whether consecutive <a>EPUB Content Documents</a> are to be rendered as
-						a continuous scrolling view or whether each is to be rendered separately (i.e., with a
-						dynamic page break between each).</p>
+					<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code> property</a> is
+						specified on a <code>meta</code> element, it indicates the EPUB Creator's global preference for
+						overflow content handling (i.e., for all spine items). EPUB Creators MAY indicate a preference
+						for dynamic pagination or scrolling. For scrolled content, it is also possible to specify
+						whether consecutive <a>EPUB Content Documents</a> are to be rendered as a continuous scrolling
+						view or whether each is to be rendered separately (i.e., with a dynamic page break between
+						each).</p>
 
 					<p>EPUB Creators MUST use one of the following values with the <code>rendition:flow</code>
 						property:</p>
@@ -5805,11 +5805,11 @@ No Entry</pre>
 						<dt id="scrolled-continuous">scrolled-continuous</dt>
 						<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
 							<p>Render all Content Documents such that overflow content is scrollable, and the EPUB
-								Publication is presented as one continuous scroll from spine item to spine item
-								(except where <a href="#layout-property-flow-overrides">locally overridden</a>).</p>
-							<p>Note that EPUB Creators SHOULD NOT create publications in which different resources
-								have different block flow directions, as continuous scrolled rendition in EPUB
-								Reading Systems would be problematic.</p>
+								Publication is presented as one continuous scroll from spine item to spine item (except
+								where <a href="#layout-property-flow-overrides">locally overridden</a>).</p>
+							<p>Note that EPUB Creators SHOULD NOT create publications in which different resources have
+								different block flow directions, as continuous scrolled rendition in EPUB Reading
+								Systems would be problematic.</p>
 						</dd>
 
 						<dt id="scrolled-doc">scrolled-doc</dt>
@@ -5827,8 +5827,8 @@ No Entry</pre>
 
 					<p id="html-body-page-break-before">Note that when two reflowable EPUB Content Documents occur
 						sequentially in the spine, the default rendering for their [[!HTML]] <a
-							data-cite="html#the-body-element"><code>body</code></a> elements is consistent with the
-							<a href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
+							data-cite="html#the-body-element"><code>body</code></a> elements is consistent with the <a
+							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
 								><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been set to
 							<code>always</code>. In addition to using the <code>rendition:flow</code> property, EPUB
 						Creators MAY override this behavior through an appropriate style sheet declaration, if the
@@ -5836,10 +5836,9 @@ No Entry</pre>
 
 					<p>EPUB Creators MUST NOT delcare the <code>rendition:flow</code> property more than once.</p>
 
-					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
-								><code>refines</code> attribute</a>. Refer to <a
-							href="#layout-property-flow-overrides"></a> for setting the property for individual
-							<a>EPUB Content Documents</a>.</p>
+					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
+							attribute</a>. Refer to <a href="#layout-property-flow-overrides"></a> for setting the
+						property for individual <a>EPUB Content Documents</a>.</p>
 
 					<figure id="fig-flow-paginated-single">
 						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
@@ -5852,8 +5851,8 @@ No Entry</pre>
 					<details id="flow-paginated-single-diagram" class="desc">
 						<summary>Image description</summary>
 						<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective
-							arrows, with a text flowing from one rectangle to the next one. The text is sectioned
-							with headers figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a
+							arrows, with a text flowing from one rectangle to the next one. The text is sectioned with
+							headers figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a
 							schematic view of a tablet.</p>
 					</details>
 
@@ -5869,10 +5868,10 @@ No Entry</pre>
 					<details id="flow-paginated-multiple-diagram" class="desc">
 						<summary>Image description</summary>
 						<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective
-							arrows, with a text flowing from one rectangle to the next one. The text is sectioned
-							with headers figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top
-							of the rightmost rectangle, leaving an empty space at the bottom of the middle
-							rectangle. The leftmost rectangle is enclosed in a schematic view of a tablet.</p>
+							arrows, with a text flowing from one rectangle to the next one. The text is sectioned with
+							headers figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top of the
+							rightmost rectangle, leaving an empty space at the bottom of the middle rectangle. The
+							leftmost rectangle is enclosed in a schematic view of a tablet.</p>
 					</details>
 
 					<figure id="fig-flow-scrolled-continuous">
@@ -5887,8 +5886,8 @@ No Entry</pre>
 					<details id="flow-scrolled-continuous-diagram" class="desc">
 						<summary>Image description</summary>
 						<p>A single, column-like strip (i.e., a rectangle without a bottom edge) with a text flowing
-							down the strip. The text is sectioned with headers figuring 'Chapter 1', '2'. The top
-							part of the strip is enclosed in a schematic view of a tablet.</p>
+							down the strip. The text is sectioned with headers figuring 'Chapter 1', '2'. The top part
+							of the strip is enclosed in a schematic view of a tablet.</p>
 					</details>
 
 					<figure id="fig-flow-scrolled-doc">
@@ -5902,28 +5901,26 @@ No Entry</pre>
 
 					<details id="flow-scrolled-doc-diagram" class="desc">
 						<summary>Image description</summary>
-						<p>Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle
-							and middle-to-right with respective arrows, each containing a text flowing down the
-							strip. The text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip
-							starts with a chapter header and flows down the strip. The top part of the leftmost
-							strip is enclosed in a schematic view of a tablet.</p>
+						<p>Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle and
+							middle-to-right with respective arrows, each containing a text flowing down the strip. The
+							text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip starts with a
+							chapter header and flows down the strip. The top part of the leftmost strip is enclosed in a
+							schematic view of a tablet.</p>
 					</details>
 
 					<section id="layout-property-flow-overrides">
 						<h5>Spine Overrides</h5>
 
-						<p id="layout-property-flow-local">EPUB Creators MAY specify the following properties
-							locally on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
-							override the <a href="#property-flow-global">global value</a> for the given spine
-							item:</p>
+						<p id="layout-property-flow-local">EPUB Creators MAY specify the following properties locally on
+							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+								href="#property-flow-global">global value</a> for the given spine item:</p>
 
 						<dl>
 							<dt id="flow-auto">flow-auto</dt>
 							<dd>Indicates no preference for overflow content handling by the EPUB Creator.</dd>
 
 							<dt id="flow-paginated">flow-paginated</dt>
-							<dd>Indicates the EPUB Creator preference is to dynamically paginate content
-								overflow.</dd>
+							<dd>Indicates the EPUB Creator preference is to dynamically paginate content overflow.</dd>
 
 							<dt id="flow-scrolled-continuous">flow-scrolled-continuous</dt>
 							<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow
@@ -5940,8 +5937,8 @@ No Entry</pre>
 
 						<aside class="example" id="property-flow-ex1"
 							title="Overriding a global paginated flow declaration">
-							<p>In this example, the EPUB Creator's intent is to have a paginated EPUB Publication
-								with a scrollable table of contents.</p>
+							<p>In this example, the EPUB Creator's intent is to have a paginated EPUB Publication with a
+								scrollable table of contents.</p>
 							<pre>&lt;package …>
 &lt;metadata …&gt;
 	…
@@ -5969,8 +5966,8 @@ No Entry</pre>
 				<section id="align-x-center">
 					<h4>The <code>rendition:align-x-center</code> Property</h4>
 
-					<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should
-						be centered horizontally in the viewport or spread.</p>
+					<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should be
+						centered horizontally in the viewport or spread.</p>
 
 					<p>The property MUST NOT be set globally for all EPUB Content Documents (i.e., in a <a
 							href="#sec-meta-elem"><code>meta</code> element</a> without a <a href="#attrdef-refines"
@@ -5979,10 +5976,10 @@ No Entry</pre>
 							element's <code>properties</code> attribute</a>.</p>
 
 					<div class="note">
-						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title
-							pages), in the absence of reliable centering control within the content rendering. As
-							support for paged media evolves in CSS, however, this property is expected to be
-							deprecated. EPUB Creators are encouraged to use CSS solutions when effective.</p>
+						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title pages),
+							in the absence of reliable centering control within the content rendering. As support for
+							paged media evolves in CSS, however, this property is expected to be deprecated. EPUB
+							Creators are encouraged to use CSS solutions when effective.</p>
 					</div>
 				</section>
 			</section>
@@ -6270,19 +6267,22 @@ No Entry</pre>
 							<a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 					<div class="note" id="note-cru-explanation">
-						<p>
-							The <a>container root URL</a> is the URL assigned by the Reading System to the root of the container. It typically depends on how the reading system internally implements the container file system.
-						</p>
-						<p>
-							However, a Reading System cannot arbitrarily use any URL, but one that honors the constraints defined above. These constraints ensure that any relative URL string found in the EPUB will always be parsed to a URL of a resource within the container (which may or may not exist).
-							The primary reason for these constraints is to avoid potential run-time security issues that would be caused by parsed URLs "leaking" outside the container files.
-						</p>						
-						<p>
-							For example, URLs like <code>https://localhost:12345/</code> or <code>https://www.example.org:12345/</code> honor these properties. But URLs like <code>https://localhost:12345/path/to.epub/</code>, 
-							<code>file:///path/to.epub#path=/</code>, or <code>jar:file:/path/to.epub!/EPUB/</code> do not 
-							(parsing the URL string "<code>..</code>" with these three examples as base would return <code>https://localhost:12345/path/</code>, <code>file:///path/</code>, and a parsing error, respectively).
-							It is the responsibility of the Reading System to assign a URL to the root directory that complies with the properties defined above.
-						</p>	
+						<p> The <a>container root URL</a> is the URL assigned by the Reading System to the root of the
+							container. It typically depends on how the reading system internally implements the
+							container file system. </p>
+						<p> However, a Reading System cannot arbitrarily use any URL, but one that honors the
+							constraints defined above. These constraints ensure that any relative URL string found in
+							the EPUB will always be parsed to a URL of a resource within the container (which may or may
+							not exist). The primary reason for these constraints is to avoid potential run-time security
+							issues that would be caused by parsed URLs "leaking" outside the container files. </p>
+						<p> For example, URLs like <code>https://localhost:12345/</code> or
+								<code>https://www.example.org:12345/</code> honor these properties. But URLs like
+								<code>https://localhost:12345/path/to.epub/</code>,
+								<code>file:///path/to.epub#path=/</code>, or <code>jar:file:/path/to.epub!/EPUB/</code>
+							do not (parsing the URL string "<code>..</code>" with these three examples as base would
+							return <code>https://localhost:12345/path/</code>, <code>file:///path/</code>, and a parsing
+							error, respectively). It is the responsibility of the Reading System to assign a URL to the
+							root directory that complies with the properties defined above. </p>
 					</div>
 
 					<div class="note">
@@ -6405,9 +6405,10 @@ No Entry</pre>
 							<li>any other absolute or relative URL string is allowed.</li>
 						</ul>
 
-						<p> 
-							Note that in any case, even the disallowed URL strings described above will not "leak" outside the container after parsing (as explained in the <a href="#note-cru-explanation">first note</a> of this section). They are nevertheless disallowed for better interoperability with non-conforming or legacy Reading Systems and toolchains. 
-						</p>
+						<p> Note that in any case, even the disallowed URL strings described above will not "leak"
+							outside the container after parsing (as explained in the <a href="#note-cru-explanation"
+								>first note</a> of this section). They are nevertheless disallowed for better
+							interoperability with non-conforming or legacy Reading Systems and toolchains. </p>
 					</div>
 
 					<aside class="example" title="Referencing a file in the same directory">
@@ -8251,8 +8252,8 @@ No Entry</pre>
 								Document</a>. While EPUB Creators may use Media Overlays with <a>SVG Content
 								Documents</a>, playback behavior might not be consistent and therefore interoperability
 							is not guaranteed.</p>
-
 					</div>
+
 					<section id="sec-media-overlays-structure">
 						<h5>Overlay Structure</h5>
 
@@ -8440,10 +8441,11 @@ No Entry</pre>
 							fragment (e.g., an element or text string) of the associated <a>EPUB Content
 							Document</a>.</p>
 
-						<p>For XHTML and SVG Content Documents, the fragment SHOULD be a reference to a <a
-								data-cite="html#target-element">target element</a> [[HTML]] or an <a
+						<p>The fragment SHOULD resolve to the <a data-cite="html#the-body-element"><code>body</code>
+								element</a> or an instance of <a data-cite="html#palpable-content">palpable content</a>
+							[[HTML]] for <a>XHTML Content Documents</a>, or be an <a
 								href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
-								Identifier</a> [[SVG]], respectively.</p>
+								Identifier</a> [[SVG]] for <a>SVG Content Documents</a>.</p>
 
 						<p>EPUB Creators MAY use other fragment identifier schemes, but Reading Systems may not support
 							such identifiers.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11150,6 +11150,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>21-Mar-2022: Fixed Media Overlay fragment references to HTML to not use concept of a target element.
+					See <a href="https://github.com/w3c/epub-specs/issues/2096">issue 2096</a>.</li>
 				<li>16-Mar-2022: Add new section on conformance checking and definition for EPUB Conformance Checker.
 					See <a href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
 				<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to


### PR DESCRIPTION
I'm not sure this is right yet, but opening so we can tweak the PR rather than talk about it.

The text right now is:

> The fragment SHOULD resolve to the [body element](https://html.spec.whatwg.org/multipage/#the-body-element) or an instance of [palpable content](https://html.spec.whatwg.org/multipage/#palpable-content) [[HTML](http://localhost:120/core/#bib-html)] for [XHTML Content Documents](http://localhost:120/core/#dfn-xhtml-content-document), or be an [SVG Fragment Identifier](https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers) [[SVG](http://localhost:120/core/#bib-svg)] for [SVG Content Documents](http://localhost:120/core/#dfn-svg-content-document).

My one concern is calling out the specific allowed html elements. Will this be a source of ongoing headaches for epubcheck, given that the list changes over time?

Fixes #2096


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2105.html" title="Last updated on Mar 21, 2022, 4:49 PM UTC (f38c2d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2105/d6c4632...f38c2d3.html" title="Last updated on Mar 21, 2022, 4:49 PM UTC (f38c2d3)">Diff</a>