### PR TITLE
Add a tolerance of one second to MO duration sums equalling the total

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8736,7 +8736,13 @@ html.my-document-playing * {
 							<a href="#elemdef-package-item"><code>item</code></a>.</p>
 
 						<p>The sum of the durations for each Media Overlay Document SHOULD equal the <a
-								href="#total-duration">total duration</a>.</p>
+								href="#total-duration">total duration</a> plus or minus one second.</p>
+
+						<div class="note">
+							<p>Although the sum of indivudal durations may not exactly match the total due to rounding
+								the times to nearest fraction of a second, a difference of greater than one second
+								indicates a mismatch arising from other issues.</p>
+						</div>
 
 						<p><a>EPUB Creators</a> MAY also specify <a href="#narrator"><code>narrator</code></a>
 							information in the Package Document, as well as <a href="#sec-docs-assoc-style"
@@ -11149,6 +11155,9 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>21-Mar-2022: Add a tolerance of one second for the sum of the individual Media Overlay Docuemnts
+					matching the total duration. See <a href="https://github.com/w3c/epub-specs/issues/2093">issue
+						2093</a>.</li>
 				<li>16-Mar-2022: Add new section on conformance checking and definition for EPUB Conformance Checker.
 					See <a href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
 				<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to


### PR DESCRIPTION
I've added a tolerance to the recommendation per the discussion in #2093. I've also added a note to explain why we have this tolerance.

This is probably another to take to the WG to discuss before merging, though, since it changes the recommendation.

Fixes #2093


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2106.html" title="Last updated on Mar 25, 2022, 3:19 PM UTC (46c5a38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2106/e841576...46c5a38.html" title="Last updated on Mar 25, 2022, 3:19 PM UTC (46c5a38)">Diff</a>