### PR TITLE
Fix link to fxl dimensions section

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5266,7 +5266,7 @@ No Entry</pre>
 
 						<p id="fxl-layout-duplication" data-tests="#fxl-layout-duplication">When the property is set to
 								<code>pre-paginated</code> for a spine item, its content dimensions MUST be set as
-							defined in <a href="#sec-fixed-layouts"></a>.</p>
+							defined in <a href="#sec-fxl-content-dimensions"></a>.</p>
 
 						<p>EPUB Creators MUST NOT declare the <code>rendition:layout</code> property more than once.</p>
 


### PR DESCRIPTION
Fixes #2086


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2107.html" title="Last updated on Mar 21, 2022, 5:39 PM UTC (2d76357)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2107/d6c4632...2d76357.html" title="Last updated on Mar 21, 2022, 5:39 PM UTC (2d76357)">Diff</a>