### PR TITLE
Remove vague RS requirement to recognize collection-type values

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11149,6 +11149,9 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>21-Mar-2022: Removed the recommendation that Reading Systems recognize the built-in
+					`collection-type` values and replaced with a note about enabling improved handling of related
+					content. See <a href="https://github.com/w3c/epub-specs/issues/2071">issue 2071</a>.</li>
 				<li>16-Mar-2022: Add new section on conformance checking and definition for EPUB Conformance Checker.
 					See <a href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
 				<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -301,8 +301,8 @@
 						<p>When the <code>collection-type</code> value is drawn from a code list or other formal
 							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
 							be attached to identify its source.</p>
-						<p>When a scheme is not specified, Reading Systems SHOULD recognize the following
-							collection type values:</p>
+						<p>This specification also defines the following collection types when no scheme is
+							specified:</p>
 						<dl>
 							<dt>
 								<code>series</code>
@@ -319,6 +319,10 @@
 									unit, typically issued together and able to be sold as a unit.</p>
 							</dd>
 						</dl>
+						<div class="note">
+							<p>Although Reading Systems are not required to support these values, specifying them
+								provides the option to group related EPUB Publications in more meaningful ways.</p>
+						</div>
 					</td>
 				</tr>
 				<tr>


### PR DESCRIPTION
Rewords to allow the two values when no scheme is present and adds a note explaining that they can be useful for grouping related content.

Fixes #2071


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Time-out :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 22, 2022, 2:25 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fepub-specs%2Fpull%2F2108%2F19418ad.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fepub-specs%2Fpull%2F2108.html)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232108.)._
</details>
