### PR TITLE
Note that refines is not available in epub 2 to make a11y expressions

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -228,6 +228,13 @@
 				<p>Creators of such EPUB Publications should create content in conformance with the accessibility and
 					discoverability requirements of this specification. EPUB Creators should also upgrade to the latest
 					version of EPUB to get access to the most advanced accessibility features and techniques.</p>
+
+				<p>Note that not all metadata expressions defined in this specification are supported in older version
+					of EPUB. EPUB 2, in particular, does not support the <a
+						href="https://www.w3.org/TR/epub-33/#attrdef-refines"><code>refines</code> attribute</a>
+					[[EPUB-33]]. If EPUB Creators cannot avoid expressions that require this attribute, they will have
+					to accept a certain amount of ambiguity in their statements (i.e., relationships between expression
+					may only be apparent by their placement in the Package Document metadata).</p>
 			</section>
 
 			<section id="sec-terminology">
@@ -285,10 +292,10 @@
 					metadata.</p>
 
 				<p>Ensuring that any interested party can discover the accessible qualities of an EPUB Publication is
-					therefore a primary concern. An EPUB Publication can have more than one set of sufficient
-					<a href="#confreq-schema-accessMode">access modes</a> depending on the alternatives
-					provided to enable reading in another mode. For example, if alternative text and descriptions are provided
-					for all the images in a publication, it would have both its default textual and visual sufficient access
+					therefore a primary concern. An EPUB Publication can have more than one set of sufficient <a
+						href="#confreq-schema-accessMode">access modes</a> depending on the alternatives provided to
+					enable reading in another mode. For example, if alternative text and descriptions are provided for
+					all the images in a publication, it would have both its default textual and visual sufficient access
 					mode <em>and</em> a purely textual sufficient access mode.</p>
 
 				<p>Similarly, content that does not meet the accessibility requirements of this specification does not
@@ -1692,6 +1699,9 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>21-Mar-2022: Note that not all metadata expressions can be achieved in EPUB 2 due to the absence of
+					the <code>refines</code> attribute. See <a href="https://github.com/w3c/epub-specs/issues/2042"
+						>issue 2042</a>.</li>
 				<li>28-Sep-2021: The section on optimized publication has been made informative and rewritten to
 					highlight best practices for identifying conformance to such standards. See <a
 						href="https://github.com/w3c/epub-specs/pulls/1833">pull request 1833</a>.</li>


### PR DESCRIPTION
I've added the following paragraph to the "Application to Older Versions" section:

> Note that not all metadata expressions defined in this specification are supported in older version of EPUB. EPUB 2, in particular, does not support the [refines attribute](https://www.w3.org/TR/epub-33/#attrdef-refines) [EPUB-33]. If EPUB Creators cannot avoid expressions that require this attribute, they will have to accept a certain amount of ambiguity in their statements (i.e., relationships between expression may only be apparent by their placement in the Package Document metadata).

Fixes #2042 