### PR TITLE
Changed the text for the -epub-text-orientation property

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10089,8 +10089,8 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>. User
-						agents MUST interpret these values according to the following table: </p>
+					<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>. 
+						See the table below for how these values translate to unprefixed CSS:</p>
 
 					<table class="data">
 						<thead>


### PR DESCRIPTION
Fix #2074


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2110.html" title="Last updated on Mar 22, 2022, 11:04 AM UTC (1fbceb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2110/d6c4632...1fbceb1.html" title="Last updated on Mar 22, 2022, 11:04 AM UTC (1fbceb1)">Diff</a>