### PR TITLE
Changed the reference to a11y spec

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9099,10 +9099,10 @@ html.my-document-playing * {
 				to <a>EPUB Publications</a>. It also adds EPUB-specific requirements and recommendations for metadata,
 				pagination, and media overlays.</p>
 
-			<p>This specification recommends that EPUB Publications <a href="#confreq-a11y">conform to the EPUB
-					Accessibility standard</a>. A benefit of following this recommendation is that it helps ensure that
-				EPUB Publications meet the accessibility requirements legislated in jurisdictions around the world,
-				ensuring EPUB Creators are not locked out of potential markets.</p>
+			<p>This specification <a href="#confreq-a11y">recommends</a> that EPUB Publications conform to the 
+				accessibility requirements defined in [[EPUB-A11Y-11]]. A benefit of following this recommendation is 
+				that it helps to ensure that EPUB Publications meet the accessibility requirements legislated in jurisdictions 
+				around the world, and that EPUB Creators are not locked out of potential markets.</p>
 
 			<p><a>EPUB Creators</a>, however, should look beyond legal imperatives and treat accessibility as a
 				requirement for all their content. The more accessible that EPUB Publications are, the greater the

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9099,10 +9099,10 @@ html.my-document-playing * {
 				to <a>EPUB Publications</a>. It also adds EPUB-specific requirements and recommendations for metadata,
 				pagination, and media overlays.</p>
 
-			<p>This specification <a href="#confreq-a11y">recommends</a> that EPUB Publications conform to the 
-				accessibility requirements defined in [[EPUB-A11Y-11]]. A benefit of following this recommendation is 
+			<p>This specification recommends that EPUB Publications <a href="#confreq-a11y">conform to the 
+				accessibility requirements</a> defined in [[EPUB-A11Y-11]]. A benefit of following this recommendation is 
 				that it helps to ensure that EPUB Publications meet the accessibility requirements legislated in jurisdictions 
-				around the world, and that EPUB Creators are not locked out of potential markets.</p>
+				around the world.</p>
 
 			<p><a>EPUB Creators</a>, however, should look beyond legal imperatives and treat accessibility as a
 				requirement for all their content. The more accessible that EPUB Publications are, the greater the


### PR DESCRIPTION
This is to fix #2113


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Time-out :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 24, 2022, 2:17 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fepub-specs%2Fpull%2F2114%2F6b55cbb.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fepub-specs%2Fpull%2F2114.html)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232114.)._
</details>
