### PR TITLE
Change in the example on landscape orientation

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5383,7 +5383,7 @@ No Entry</pre>
 							for setting the property for individual <a>EPUB Content Documents</a>.</p>
 
 						<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
-							<p>In this example, the content should also render without synthetic spreads.</p>
+							<p>In this example, items in the spine are to be rendered in landscape mode.</p>
 
 							<pre>&lt;package …>
    &lt;metadata …>
@@ -5392,12 +5392,7 @@ No Entry</pre>
           property="rendition:layout">
          pre-paginated
       &lt;/meta>
-      
-      &lt;meta
-          property="rendition:spread">
-         none
-      &lt;/meta>
-   
+
       &lt;meta
           property="rendition:orientation">
          landscape


### PR DESCRIPTION
Fix #2115

The synthetic spread term has been removed from the example. It is defined later, and does not add to the example in terms of the section it is in.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2117.html" title="Last updated on Mar 24, 2022, 2:45 PM UTC (210f2fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2117/55d5466...210f2fa.html" title="Last updated on Mar 24, 2022, 2:45 PM UTC (210f2fa)">Diff</a>