### PR TITLE
Add rendition: prefix back to spine override property definitions

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5252,10 +5252,10 @@ No Entry</pre>
 									<a href="#property-layout-global">global value</a> for the given spine item:</p>
 
 							<dl>
-								<dt id="layout-pre-paginated">layout-pre-paginated</dt>
+								<dt id="layout-pre-paginated">rendition:layout-pre-paginated</dt>
 								<dd>Specifies that the given spine item is pre-paginated.</dd>
 
-								<dt id="layout-reflowable">layout-reflowable</dt>
+								<dt id="layout-reflowable">rendition:layout-reflowable</dt>
 								<dd>Specifies that the given spine item is reflowable.</dd>
 							</dl>
 
@@ -5330,15 +5330,15 @@ No Entry</pre>
 								item:</p>
 
 							<dl>
-								<dt id="orientation-auto">orientation-auto</dt>
+								<dt id="orientation-auto">rendition:orientation-auto</dt>
 								<dd>Specifies that the Reading System determines the orientation to render the spine
 									item in.</dd>
 
-								<dt id="orientation-landscape">orientation-landscape</dt>
+								<dt id="orientation-landscape">rendition:orientation-landscape</dt>
 								<dd>Specifies that Reading Systems should render the given spine item in landscape
 									orientation.</dd>
 
-								<dt id="orientation-portrait">orientation-portrait</dt>
+								<dt id="orientation-portrait">rendition:orientation-portrait</dt>
 								<dd>Specifies that Reading Systems should render the given spine item in portrait
 									orientation.</dd>
 							</dl>
@@ -5473,26 +5473,26 @@ No Entry</pre>
 									<a href="#property-spread-global">global value</a> for the given spine item:</p>
 
 							<dl>
-								<dt id="spread-auto">spread-auto</dt>
+								<dt id="spread-auto">rendition:spread-auto</dt>
 								<dd>Specifies the Reading System determines when to render a synthetic spread for the
 									spine item. </dd>
 
-								<dt id="spread-both">spread-both</dt>
+								<dt id="spread-both">rendition:spread-both</dt>
 								<dd>Specifies the Reading System should render a synthetic spread for the spine item in
 									both portrait and landscape orientations. </dd>
 
-								<dt id="spread-landscape">spread-landscape</dt>
+								<dt id="spread-landscape">rendition:spread-landscape</dt>
 								<dd>Specifies the Reading System should render a synthetic spread for the spine item
 									only when in landscape orientation.</dd>
 
-								<dt id="spread-none">spread-none</dt>
+								<dt id="spread-none">rendition:spread-none</dt>
 								<dd>Specifies the Reading System should not render a synthetic spread for the spine
 									item.</dd>
 
-								<dt id="spread-portrait">spread-portrait</dt>
+								<dt id="spread-portrait">rendition:spread-portrait</dt>
 								<dd>
-									<p>The <code>spread-portrait</code> property is <a href="#deprecated"
-										>deprecated</a>.</p>
+									<p>The <code>rendition:spread-portrait</code> property is <a href="#deprecated"
+											>deprecated</a>.</p>
 									<p></p>Refer to the <a
 										href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
 											><code>spread-portrait</code> property definition</a>
@@ -5830,18 +5830,18 @@ No Entry</pre>
 								href="#property-flow-global">global value</a> for the given spine item:</p>
 
 						<dl>
-							<dt id="flow-auto">flow-auto</dt>
+							<dt id="flow-auto">rendition:flow-auto</dt>
 							<dd>Indicates no preference for overflow content handling by the EPUB Creator.</dd>
 
-							<dt id="flow-paginated">flow-paginated</dt>
+							<dt id="flow-paginated">rendition:flow-paginated</dt>
 							<dd>Indicates the EPUB Creator preference is to dynamically paginate content overflow.</dd>
 
-							<dt id="flow-scrolled-continuous">flow-scrolled-continuous</dt>
+							<dt id="flow-scrolled-continuous">rendition:flow-scrolled-continuous</dt>
 							<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow
 								content, and that consecutive spine items with this property are to be rendered as a
 								continuous scroll.</dd>
 
-							<dt id="flow-scrolled-doc">flow-scrolled-doc</dt>
+							<dt id="flow-scrolled-doc">rendition:flow-scrolled-doc</dt>
 							<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow
 								content, and each spine item with this property is to be rendered as a separate
 								scrollable document.</dd>
@@ -9012,9 +9012,9 @@ html.my-document-playing * {
 				to <a>EPUB Publications</a>. It also adds EPUB-specific requirements and recommendations for metadata,
 				pagination, and media overlays.</p>
 
-			<p>This specification recommends that EPUB Publications <a href="#confreq-a11y">conform to the 
-				accessibility requirements</a> defined in [[EPUB-A11Y-11]]. A benefit of following this recommendation is 
-				that it helps to ensure that EPUB Publications meet the accessibility requirements legislated in jurisdictions 
+			<p>This specification recommends that EPUB Publications <a href="#confreq-a11y">conform to the accessibility
+					requirements</a> defined in [[EPUB-A11Y-11]]. A benefit of following this recommendation is that it
+				helps to ensure that EPUB Publications meet the accessibility requirements legislated in jurisdictions
 				around the world.</p>
 
 			<p><a>EPUB Creators</a>, however, should look beyond legal imperatives and treat accessibility as a
@@ -10005,8 +10005,8 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>. 
-						See the table below for how these values translate to unprefixed CSS:</p>
+					<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>. See
+						the table below for how these values translate to unprefixed CSS:</p>
 
 					<table class="data">
 						<thead>
@@ -11076,10 +11076,11 @@ EPUB/images/cover.png</pre>
 				<li>22-Mar-2022: Removed the recommendation that Reading Systems recognize the built-in
 					`collection-type` values and replaced with a note about enabling improved handling of related
 					content. See <a href="https://github.com/w3c/epub-specs/issues/2071">issue 2071</a>.</li>
-      	<li>17-Mar-2022: Deprecate the creation of new collection types. See <a
+				<li>17-Mar-2022: Deprecate the creation of new collection types. See <a
 						href="https://github.com/w3c/epub-specs/pull/2060">issue 2060</a>.</li>
 				<li>17-Mar-2022: Removed dated requirements on the use of <code>epub:type</code> that suggest
 					equivalence with ARIA roles. See <a href="https://github.com/w3c/epub-specs/pull/2070">issue
+						2070</a>.</li>
 				<li>16-Mar-2022: Add new section on conformance checking and definition for EPUB Conformance Checker.
 					See <a href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
 				<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5318,7 +5318,7 @@ No Entry</pre>
       &lt;/meta>
    &lt;/metadata>
    …
-&lt;/package</pre>
+&lt;/package></pre>
 						</aside>
 
 						<section id="orientation-overrides">


### PR DESCRIPTION
Fixes #2128


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2129.html" title="Last updated on Mar 26, 2022, 3:25 PM UTC (d7cc588)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2129/7b781f1...d7cc588.html" title="Last updated on Mar 26, 2022, 3:25 PM UTC (d7cc588)">Diff</a>