### PR TITLE
s/Web/web/ except where part of proper nouns

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -637,7 +637,7 @@
 						href="https://www.w3.org/WAI/WCAG21/Techniques/">Techniques for WCAG</a>. This document does not
 					repeat those techniques.</p>
 
-				<p>In general, the differences between the application of WCAG techniques to Web pages and their
+				<p>In general, the differences between the application of WCAG techniques to web pages and their
 					application to EPUB Content Documents is minimal, but the following sections outline some key
 					differences.</p>
 
@@ -709,7 +709,7 @@
 					<h4>Ensure meaningful order of content across spreads</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#meaningful-sequence">Success Criterion 1.3.2</a>
-						specifies that each Web page have a meaningful order (i.e., that the visual presentation of the
+						specifies that each web page have a meaningful order (i.e., that the visual presentation of the
 						content match the underlying markup).</p>
 
 					<p>As EPUB allows two documents to be rendered together in a <a
@@ -731,7 +731,7 @@
 					<h4>Provide multiple ways to access the content</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#multiple-ways">Success Criterion
-						2.4.5</a> requires there be more than one way to locate a Web page within a set of Web pages. By
+						2.4.5</a> requires there be more than one way to locate a web page within a set of web pages. By
 						default, EPUB Publications meet this WCAG requirement so long as EPUB Creators follow the EPUB
 						requirements to <a href="https://www.w3.org/TR/epub/#sec-spine-elem">include all EPUB Content
 							Documents in the spine</a> and <a href="https://www.w3.org/TR/epub/#sec-itemref-elem">ensure
@@ -1099,7 +1099,7 @@
 					<h4>Include publication and document titles</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#page-titled">Success Criterion 2.4.2</a> requires
-						that each Web page include a title. EPUB has a similar requirement for EPUB Publications:
+						that each web page include a title. EPUB has a similar requirement for EPUB Publications:
 						publications require a [[DCTERMS]] <code>title</code> element in the Package Document metadata.
 						The [[WCAG2]] requirement is not satisfied by the EPUB requirement, however.</p>
 

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -167,8 +167,8 @@
 				<p>This specification does not target a single version of EPUB. It is applicable to EPUB Publications
 					that conform to any version or profile, including future versions of the standard.</p>
 
-				<p>Ideally, these guidelines help evaluate any digital publication built on Open Web technologies,
-					although ensuring such application is outside the scope of this specification.</p>
+				<p>Ideally, these guidelines help evaluate any digital publication built on Open Web Platform
+					technologies, although ensuring such application is outside the scope of this specification.</p>
 
 				<div class="note">
 					<p>For additional background on the decisions that went into this specification, refer to <a
@@ -215,7 +215,7 @@
 					<p>As a consequence, there may be language- or culture-specific practices for meeting accessibility
 						requirements. Whether these practices are defined within this specification and its techniques
 						or elsewhere (e.g., in WCAG techniques or language-specific best practice recommendations) will
-						depend on whether the issues are specific to EPUB or broadly affect all Web content.</p>
+						depend on whether the issues are specific to EPUB or broadly affect all web content.</p>
 				</section>
 			</section>
 
@@ -455,9 +455,9 @@
 						</li>
 
 						<li>
-							<p id="confreq-wcag-a">MUST, for whichever version of WCAG 2 selected, meet the
-								requirements of Level A, but it is strongly recommended that it meet the requirements of
-								Level AA.</p>
+							<p id="confreq-wcag-a">MUST, for whichever version of WCAG 2 selected, meet the requirements
+								of Level A, but it is strongly recommended that it meet the requirements of Level
+								AA.</p>
 						</li>
 					</ul>
 
@@ -516,7 +516,7 @@
 							[[WCAG2]] focus on the evaluation of individual web pages, but an EPUB Publication more
 							closely resembles what WCAG refers to as a <a
 								href="https://www.w3.org/TR/WCAG2/#dfn-set-of-web-pages">set of web pages</a>: "[a]
-							collection of Web pages that share a common purpose" [[WCAG2]].</p>
+							collection of web pages that share a common purpose" [[WCAG2]].</p>
 
 						<p>Consequently, when evaluating the accessibility of an EPUB Publication, EPUB Creators cannot
 							review individual pages — or Content Documents, as they are known in EPUB 3 — in isolation.
@@ -1699,7 +1699,7 @@
 
 			<ul>
 				<li>23-Mar-2021: Clarified linking for WCAG conformance versions and levels. See <a
-					href="https://github.com/w3c/epub-specs/issues/2099">issue 2099</a>.</li>
+						href="https://github.com/w3c/epub-specs/issues/2099">issue 2099</a>.</li>
 				<li>21-Mar-2022: Note that not all metadata expressions can be achieved in EPUB 2 due to the absence of
 					the <code>refines</code> attribute. See <a href="https://github.com/w3c/epub-specs/issues/2042"
 						>issue 2042</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -83,7 +83,7 @@
 		<section id="abstract">
 			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
-				Web content — including HTML, CSS, SVG, and other resources — for distribution in a single-file
+				web content — including HTML, CSS, SVG, and other resources — for distribution in a single-file
 				container.</p>
 			<p>This specification defines the authoring requirements for EPUB Publications and represents the third
 				major revision of the standard.</p>
@@ -204,7 +204,7 @@
 						MathML, SVG, CSS, and JavaScript.</p>
 
 					<p>The benefit of this approach for EPUB is that <a>EPUB Publications</a> always keep pace with
-						changes to the Web without the need for new revisions. <a>EPUB Creators</a>, however, must keep
+						changes to the web without the need for new revisions. <a>EPUB Creators</a>, however, must keep
 						track of the various changes to HTML and the technologies it references to ensure they keep
 						their processes up to date.</p>
 
@@ -259,7 +259,7 @@
 					<h4>Relationship to URL</h4>
 
 					<p>This specification refers to the [[URL]] standard for terminology and processing related to URLs
-						expressed in EPUB Publications. It is anticipated that new and revised Web formats will adopt
+						expressed in EPUB Publications. It is anticipated that new and revised web formats will adopt
 						this standard, but until then this may put this specification in conflict with the internal
 						requirements for some formats (e.g., valid relative paths), specifically with respect to the use
 						of internationalized URLs. If a format does not allow internationalized URLs (i.e., URLs must
@@ -3504,7 +3504,7 @@ No Entry</pre>
 
 						<div class="note">
 							<p>As <a>Remote Resources</a> referenced from hyperlinks are not Publication Resources, they
-								are not subject to the requirement to include in the spine (e.g., Web pages and
+								are not subject to the requirement to include in the spine (e.g., web pages and
 								resources).</p>
 
 							<p>Publication Resources used in the rendering of spine items (e.g., referenced from
@@ -4073,7 +4073,7 @@ No Entry</pre>
 									Resources</a>, i.e., resources that are outside the <a>EPUB Container</a>. Using the
 									<code>base</code> element in an <a>EPUB Publication</a> may cause Reading Systems to
 								misinterpret the location of resources (e.g., relative links to other documents in the
-								publication might appear as links to a Web site if the <code>base</code> element
+								publication might appear as links to a web site if the <code>base</code> element
 								specifies an absolute URL). To avoid significant interoperability issues, EPUB Creators
 								should not use the <code>base</code> element. </p>
 						</section>

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -90,7 +90,7 @@
 				standardized method for referencing arbitrary content within an EPUB® Publication through the use of
 				fragment identifiers. </p>
 
-			<p>The Web has proven that the concept of hyperlinking is tremendously powerful, but EPUB Publications have
+			<p>The web has proven that the concept of hyperlinking is tremendously powerful, but EPUB Publications have
 				been denied much of the benefit that hyperlinking makes possible because of the lack of a standardized
 				scheme to link into them. Although proprietary schemes have been developed and implemented for
 				individual Reading Systems, without a commonly-understood syntax there has been no way to achieve
@@ -110,7 +110,7 @@
 				</li>
 				<li>
 					<p>Document references to EPUB content should be enabled in the same way that existing hyperlinks
-						enable references throughout the Web.</p>
+						enable references throughout the web.</p>
 				</li>
 				<li>
 					<p>Each location in an EPUB file should be able to be identified without the need to modify the

--- a/epub33/explainers/EPUB-33-security-privacy.md
+++ b/epub33/explainers/EPUB-33-security-privacy.md
@@ -22,7 +22,7 @@ It’s hard to even reason about how HTML’s security issues affect EPUB. If I 
 
 ## Questionnaire
 
-### 1. What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary?
+### 1. What information might this feature expose to web sites or other parties, and for what purposes is that exposure necessary?
 
 EPUB Reading Systems typically collect information on the reading habits of their users. In some cases this information is necessary to provide a good user experience; in other cases the information is collected for other users—the reading system company or the publisher of the book. 
 
@@ -59,7 +59,7 @@ Many EPUB reading systems do not support scripting at all. For those that do, sc
 
 EPUB does have requirements for user agents to respond to device orientation (`portrait | landscape`) for fixed-layout EPUBs. 
 
-There has been talk about scripted EPUBs using geolocation information; I don’t know if this has happened in the wild yet, or if any reading systems would allow access to this information. This would happen through existing Web APIs; EPUB does not specify new APIs to interact with sensors. 
+There has been talk about scripted EPUBs using geolocation information; I don’t know if this has happened in the wild yet, or if any reading systems would allow access to this information. This would happen through existing web APIs; EPUB does not specify new APIs to interact with sensors. 
 
 ### 8. What data does this specification expose to an origin? Please also document what data is identical to data exposed by other features, in the same or different contexts.
 

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -152,11 +152,11 @@
 					defines a reading order for linear consumption, and associates metadata and navigation
 					information.</p>
 
-				<p>The Package Document defines a layer on top of the traditional structuring of a typical Web site to
-					facilitate the authoring of digital publications. A Web site, for example, embeds references to its
+				<p>The Package Document defines a layer on top of the traditional structuring of a typical web site to
+					facilitate the authoring of digital publications. A web site, for example, embeds references to its
 					resources within its content, which, while a simple and flexible means of identifying resources,
 					makes it difficult to enumerate all the resources required to render it. In addition, there is no
-					standard way for a Web site to define that a sequence of pages make up a larger publication, which
+					standard way for a web site to define that a sequence of pages make up a larger publication, which
 					is precisely what EPUB's <a data-cite="epub-33#sec-spine-elem"><code>spine</code> element</a>
 					[[EPUB-33]] does (i.e., it provides an external declarative means to explicitly specify navigation
 					through a collection of documents). Finally, the Package Document defines a standard way to
@@ -201,7 +201,7 @@
 						simplifying their discovery and use.</p>
 
 					<p>EPUB Publications are not limited to the linear ordering of their contents, nor do they preclude
-						linking in arbitrary ways — just like the Web, EPUB Publications are built on hypertext — but
+						linking in arbitrary ways — just like the web, EPUB Publications are built on hypertext — but
 						the basic consumption and navigation can be reliably accomplished in a way that is not true for
 						a set of HTML pages.</p>
 				</section>
@@ -300,8 +300,8 @@
 
 				<p>A key concept of EPUB is that content presentation adapts to the user, rather than the user having to
 					adapt to a particular presentation of content. HTML was originally designed to support dynamic
-					rendering of structured content, but over time HTML as supported in Web browsers has become focused
-					on the needs of Web applications, and many popular Web sites now have layouts with less
+					rendering of structured content, but over time HTML as supported in web browsers has become focused
+					on the needs of web applications, and many popular web sites now have layouts with less
 					flexibility.</p>
 
 				<p>EPUB Publications, however, are designed to maximize accessibility for the visually impaired, and
@@ -344,17 +344,17 @@
 				<h2>Fonts</h2>
 
 				<p>EPUB 3 supports two closely related font formats — OpenType [[OpenType]] and WOFF [[WOFF]]
-					[[WOFF2]] — to accommodate both traditional publishing workflows and emerging Web-based workflows.
+					[[WOFF2]] — to accommodate both traditional publishing workflows and emerging web-based workflows.
 					Word processing programs used to create EPUB Publications are likely to have access only to a
-					collection of installed OpenType fonts, for example, whereas Web-archival EPUB generators will
+					collection of installed OpenType fonts, for example, whereas web-archival EPUB generators will
 					likely only have access to WOFF resources (which cannot be converted to OpenType without
 					undesirable, and potentially unlicensed, stripping of WOFF metadata).</p>
 
 				<p>EPUB 3 also supports both obfuscated and regular font resources for both OpenType and WOFF font
 					formats. Support for obfuscated font resources is required to accommodate font licensing
 					restrictions for many commercially available fonts. See the dedicated <a
-						data-cite="epub-33#sec-font-obfuscation">section on Font Obfuscation</a> in [[EPUB-33]]
-					for more details.</p>
+						data-cite="epub-33#sec-font-obfuscation">section on Font Obfuscation</a> in [[EPUB-33]] for more
+					details.</p>
 
 			</section>
 
@@ -370,7 +370,7 @@
 					and scripting might be disabled for security reasons.</p>
 
 				<p>EPUB Creators need to be aware that scripting in an EPUB Publication can create security
-					considerations that are different from scripting within a Web browser. For example, typical
+					considerations that are different from scripting within a web browser. For example, typical
 					same-origin policies are not applicable to content that has been downloaded to a user's local
 					system. Therefore, it is strongly encouraged that scripting be limited to container constrained
 					contexts, as further described in the section on <a
@@ -470,7 +470,7 @@
 				<h2>Fonts</h2>
 
 				<p>EPUB 3 does not require that Reading Systems come with a set of built-in system fonts. As occurs in
-					Web contexts, users in a particular locale might have installed fonts that omit characters required
+					web contexts, users in a particular locale might have installed fonts that omit characters required
 					for other locales and Reading Systems might utilize intrinsic fonts or font engines that do not
 					utilize operating system installed fonts. As a result, the text content of an EPUB Publication might
 					not natively render as intended on all Reading Systems.</p>
@@ -513,7 +513,7 @@
 				ensuring that EPUB Publications are accessible where applicable.</p>
 
 			<p>EPUB 3 also includes an Accessibility specification [[EPUB-A11Y-11]] that leverages the extensive work
-				done to make Web content accessible in [[WCAG21]]. The specification defines requirements to produce
+				done to make web content accessible in [[WCAG21]]. The specification defines requirements to produce
 				EPUB Publications that can be accessed by a wide range of users. It is accompanied by a techniques
 				document [[EPUB-A11Y-TECH-11]] that outlines best practices for meeting these requirements.</p>
 
@@ -550,7 +550,7 @@
 						data-cite="html#the-section-element"><code>section</code></a>, <a
 						data-cite="html#the-nav-element"><code>nav</code></a>, and <a data-cite="html#the-aside-element"
 							><code>aside</code></a>). EPUB Creators are encouraged to use these elements, in conjunction
-					with best practices for authoring well-structured Web content, when creating EPUB XHTML Content
+					with best practices for authoring well-structured web content, when creating EPUB XHTML Content
 					Documents. These additions allow content to be better grouped and defined, both for representing the
 					structure of documents and to facilitate their logical navigation. XHTML Content Documents also
 					natively support the inclusion of ARIA role and state attributes and events, including the dedicated
@@ -631,7 +631,7 @@
 						data-cite="epub-33#sec-scripted-content">can provide fallbacks</a> [[EPUB-33]] to further
 					facilitate access to their contents, the documents have to be accessible without them.</p>
 
-				<p>EPUB Creators should always implement best practices for accessible scripting in Web documents, such
+				<p>EPUB Creators should always implement best practices for accessible scripting in web documents, such
 					as provided in [[WAI-ARIA]], and reserve the use of scripting for situations in which interactivity
 					is critical to the user experience.</p>
 			</section>
@@ -683,7 +683,7 @@
 			<section id="epub31">
 				<h3>EPUB 3.1: 2017</h3>
 				<p>EPUB 3.1 was the first minor revision of EPUB 3. The goal of this revision was to better align EPUB 3
-					with current Web standards. References to important standards were made undated, meaning that
+					with current web standards. References to important standards were made undated, meaning that
 					whenever they are updated they are legal to use in EPUB 3 content (e.g., the latest version of HTML
 					is always valid to use; a revision of EPUB is not needed). The use of CSS was also clarified, and
 					the use of EPUB-specific properties reduced.</p>
@@ -722,8 +722,8 @@
 					they may have some authoring uptakes, still lack support in Reading Systems; as a result, these
 					technologies should not yet be considered stable and interoperable.</p>
 
-				<p>The separate <a data-cite="epub-33#change-log">section</a> in [[EPUB-33]] provides a more
-					detailed overview of the changes.</p>
+				<p>The separate <a data-cite="epub-33#change-log">section</a> in [[EPUB-33]] provides a more detailed
+					overview of the changes.</p>
 			</section>
 		</section>
 	</body>

--- a/epub33/reports/exit_criteria.html
+++ b/epub33/reports/exit_criteria.html
@@ -57,7 +57,7 @@
         </p>
 
         <ul>
-            <li>interpret and render these standard formats, much like Web browsers do; and</li>
+            <li>interpret and render these standard formats, much like web browsers do; and</li>
             <li>provide some additional features <em>“on top”</em> of that renderer.</li>
         </ul>
 
@@ -91,7 +91,7 @@
             <h2 id="epub-3.3-reading-systems">EPUB 3.3 Reading Systems</h2>
 
             <p>
-              Interested implementers for the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> are provided with a <a href="https://github.com/w3c/epub-tests">test suite</a> that follows the examples of the Web Platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for all <em>MUST</em> statements, as well as for many <em>SHOULD</em> and for some <em>MAY</em> statements, that appear in the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> specification.
+              Interested implementers for the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> are provided with a <a href="https://github.com/w3c/epub-tests">test suite</a> that follows the examples of the web platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for all <em>MUST</em> statements, as well as for many <em>SHOULD</em> and for some <em>MAY</em> statements, that appear in the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> specification.
             </p>
 
             <p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -117,7 +117,7 @@
 		<section id="abstract">
 			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
-				Web content — including HTML, CSS, SVG and other resources — for distribution in a single-file
+				web content — including HTML, CSS, SVG and other resources — for distribution in a single-file
 				container.</p>
 			<p>This specification defines the conformance requirements for EPUB 3 Reading Systems — the user agents that
 				render EPUB Publications.</p>
@@ -998,7 +998,7 @@
 					<p>Reading System developers who also support scripting must be aware of the security issues that
 						arise when Reading Systems execute scripted content. As the underlying scripting model employed
 						by Reading Systems and browsers is the same, developers must take into consideration the same
-						kinds of issues encountered in Web contexts.</p>
+						kinds of issues encountered in web contexts.</p>
 
 					<p>Each Reading System must establish if it can trust the scripts in a particular document. Reading
 						Systems should treat all scripts as untrusted (and potentially malicious), and developers should
@@ -1035,7 +1035,7 @@
 						[[EPUB-33]] are isolated from other EPUB Publications, and limits access to cookies, DOM
 						storage, etc.</p>
 
-					<p>Examples of Web APIs that are tied to the concept of "origin" include Web Storage [[WEBSTORAGE]]
+					<p>Examples of web APIs that are tied to the concept of "origin" include Web Storage [[WEBSTORAGE]]
 						and IndexedDB [[INDEXEDDB]], which EPUB Content Documents can interact with via scripting.
 						Reading Systems that allow users to add/remove publications from a managed library (their
 						"bookshelf") may maintain the publication's unique origin when the publication is removed and
@@ -2288,7 +2288,7 @@
 
 			<p class="note">Reading Systems act as the core rendering engines of EPUB Publications and provide a
 				scripting environment based on the [[DOM]] specification. So, although this interface definition uses
-				the [[WEBIDL]] notation for implementation by Reading Systems, Web browsers generally do not have to
+				the [[WEBIDL]] notation for implementation by Reading Systems, web browsers generally do not have to
 				implement these objects. </p>
 
 			<section id="app-ers-idl">


### PR DESCRIPTION
Consistency cleanup for new W3C style.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2131.html" title="Last updated on Mar 28, 2022, 11:13 AM UTC (891ee64)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2131/09e1788...891ee64.html" title="Last updated on Mar 28, 2022, 11:13 AM UTC (891ee64)">Diff</a>