### PR TITLE
Add note about other scripting contexts

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3343,8 +3343,8 @@ Package Document:
 								<p>The following example shows a reference to a remote audio file. Because the
 										<code>audio</code> element embeds the audio in its EPUB Content Document, the
 									file is considered a Publication Resource. EPUB Creators therefore must list the
-									audio file in the manifest and indicate that its parent EPUB Content Document
-									contains a remote resource.</p>
+									audio file in the manifest and indicate that its host EPUB Content Document contains
+									a remote resource.</p>
 
 								<pre>XHTML:
 &lt;html …>
@@ -4479,7 +4479,7 @@ No Entry</pre>
 								<li>
 									<p>An instance of the [[HTML]] <a data-cite="html#the-script-element"
 												><code>script</code></a> element contained in an <a>XHTML Content
-											Document</a> that is embedded in a parent XHTML Content Document using the
+											Document</a> that is embedded in an XHTML Content Document using the
 										[[HTML]] <a data-cite="html#the-iframe-element"><code>iframe</code></a>
 										element.</p>
 								</li>
@@ -4487,9 +4487,8 @@ No Entry</pre>
 									<p>An instance of the [[SVG]] <a
 											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
 												><code>script</code></a> element contained in an <a>SVG Content
-											Document</a> that is embedded in a parent XHTML Content Document using the
-										[[HTML]] <a data-cite="html#the-iframe-element"><code>iframe</code></a>
-										element.</p>
+											Document</a> that is embedded in a XHTML Content Document using the [[HTML]]
+											<a data-cite="html#the-iframe-element"><code>iframe</code></a> element.</p>
 								</li>
 							</ul>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4418,7 +4418,6 @@ No Entry</pre>
 						<div class="note">
 							<p>[[SVG]] does not define data blocks as of publication, but the same exclusion would apply
 								if a future update adds the concept.</p>
-
 						</div>
 
 						<p>EPUB Creators should note that Reading Systems are required to behave as though a unique <a
@@ -4435,7 +4434,6 @@ No Entry</pre>
 							<p>Reading Systems may render Scripted Content Documents in a manner that disables other
 								EPUB capabilities and/or provides a different rendering and user experience (e.g., by
 								disabling pagination).</p>
-
 						</div>
 					</section>
 
@@ -4450,6 +4448,15 @@ No Entry</pre>
 							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a script
 								occurs directly within a <a>Top-level Content Document</a>.</li>
 						</ul>
+
+						<div class="note">
+							<p>Scripts may execute in other contexts, but Reading System support for these contexts is
+								optional. For example, a scripted SVG document may be referenced from an [[HTML]] <a
+									data-cite="html#the-object-element"><code>object</code> tag</a>.</p>
+							<p>Refer to the <a href="https://www.w3.org/TR/epub-rs-33#sec-scripted-content">processing
+									of scripts</a> [[EPUB-RS-33]] for more information.</p>
+						</div>
+
 						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference
 							it via the element's <code>src</code> attribute makes no difference to its executing
 							context.</p>
@@ -4461,8 +4468,8 @@ No Entry</pre>
 						<div class="note">
 							<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference
 								between the two contexts.</p>
-
 						</div>
+
 						<section id="sec-scripted-container-constrained">
 							<h5>Container-Constrained Scripts</h5>
 
@@ -5194,11 +5201,11 @@ No Entry</pre>
 							setting the property for individual <a>EPUB Content Documents</a>.</p>
 
 						<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
-							<p>In this example, the document's layout is set to <code>pre-paginated</code>, i.e., 
-								it is defined to be a fixed layout document. Furthermore, media queries [[CSS3-MediaQueries]] are used to 
-								apply different style sheets for three different device categories. Note that the media queries only affect
-								the style sheet applied to the document; the size of the content area set in the
-									<code>viewport</code>
+							<p>In this example, the document's layout is set to <code>pre-paginated</code>, i.e., it is
+								defined to be a fixed layout document. Furthermore, media queries [[CSS3-MediaQueries]]
+								are used to apply different style sheets for three different device categories. Note
+								that the media queries only affect the style sheet applied to the document; the size of
+								the content area set in the <code>viewport</code>
 								<code>meta</code> tag is static.</p>
 
 							<p>Package Document</p>
@@ -7726,7 +7733,8 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>Refers to the associated EPUB Content Document and, optionally, identifies a specific part of it.</p>
+										<p>Refers to the associated EPUB Content Document and, optionally, identifies a
+											specific part of it.</p>
 										<p>The value MUST be a <a data-cite="url#path-relative-scheme-less-url-string"
 												>path-relative-scheme-less-URL string</a>, optionally followed by
 												<code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string"
@@ -7764,9 +7772,9 @@ No Entry</pre>
 					<section id="sec-smil-seq-elem">
 						<h5>The <code>seq</code> Element</h5>
 
-						<p>The <code>seq</code> element is a sequential time container for media objects 
-							and/or child time containers.</p>
-						
+						<p>The <code>seq</code> element is a sequential time container for media objects and/or child
+							time containers.</p>
+
 						<dl class="elemdef" id="elemdef-smil-seq">
 							<dt>Element Name</dt>
 							<dd>
@@ -7811,7 +7819,8 @@ No Entry</pre>
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>Refers to the associated EPUB Content Document and, optionally, identifies a specific part of it.</p>
+										<p>Refers to the associated EPUB Content Document and, optionally, identifies a
+											specific part of it.</p>
 										<p>The value MUST be a <a data-cite="url#path-relative-scheme-less-url-string"
 												>path-relative-scheme-less-URL string</a>, optionally followed by
 												<code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string"
@@ -7949,7 +7958,8 @@ No Entry</pre>
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>Refers to the associated EPUB Content Document and, optionally, identifies a specific part of it.</p>
+										<p>Refers to the associated EPUB Content Document and, optionally, identifies a
+											specific part of it.</p>
 										<p>The value MUST be a <a data-cite="url#path-relative-scheme-less-url-string"
 												>path-relative-scheme-less-URL string</a>, optionally followed by
 												<code>U+0023 (#)</code> and a <a data-cite="url#url-fragment-string"
@@ -8089,10 +8099,9 @@ No Entry</pre>
 						pointer to the associated EPUB Content Document fragment. The <code>par</code> element uses two
 						media element children to represent this information: an <a href="#elemdef-smil-audio"
 								><code>audio</code></a> element and a <a href="#elemdef-smil-text"><code>text</code></a>
-						element. Because <code>par</code> elements' media object children are timed in parallel, 
-						Reading Systems render
-						the audio clip and EPUB Content Document fragment at the same time, resulting in a synchronized
-						presentation.</p>
+						element. Because <code>par</code> elements' media object children are timed in parallel, Reading
+						Systems render the audio clip and EPUB Content Document fragment at the same time, resulting in
+						a synchronized presentation.</p>
 
 					<p>The <code>text</code> element <code>src</code> attribute references the associated phrase,
 						sentence, or other segment of the EPUB Content Document by its URL [[URL]] reference. The
@@ -8175,9 +8184,9 @@ No Entry</pre>
 							represents how Reading Systems render the content in the corresponding EPUB Content
 							Documents during playback.</p>
 
-						<p>The <code>par</code> element represents a segment of content, such as a word,
-							phrase, sentence, table cell, list item, image, or other identifiable piece of content in
-							the markup. Each element identifies both the content to display (in the <a
+						<p>The <code>par</code> element represents a segment of content, such as a word, phrase,
+							sentence, table cell, list item, image, or other identifiable piece of content in the
+							markup. Each element identifies both the content to display (in the <a
 								href="#elemdef-smil-text"><code>text</code> element</a>) and audio to synchronize (in
 							the <a href="#elemdef-smil-audio"><code>audio</code> element</a>) during playback.</p>
 
@@ -8349,13 +8358,12 @@ No Entry</pre>
 
 						<p>Both the <code>epub:textref</code> attribute and the <a href="#elemdef-smil-text"
 									><code>text</code> element's</a>
-							<code>src</code> attribute may contain a <a
-							data-cite="url#url-fragment-string">URL-fragment string</a> that references a specific
-							part (e.g., an element via its ID) of the associated <a>EPUB Content
-							Document</a>.</p>
+							<code>src</code> attribute may contain a <a data-cite="url#url-fragment-string">URL-fragment
+								string</a> that references a specific part (e.g., an element via its ID) of the
+							associated <a>EPUB Content Document</a>.</p>
 
-						<p>For XHTML and SVG Content Documents, the URL-fragment string SHOULD be a reference to 
-							a specific element via its ID, or an <a
+						<p>For XHTML and SVG Content Documents, the URL-fragment string SHOULD be a reference to a
+							specific element via its ID, or an <a
 								href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
 								Identifier</a> [[SVG]], respectively.</p>
 
@@ -8369,17 +8377,16 @@ No Entry</pre>
 						<p>The granularity level of the Media Overlay depends on how EPUB Creators mark up the EPUB
 							Content Document and the type of fragment identifier they use in the <a
 								href="#elemdef-smil-text"><code>text</code> elements'</a>
-							<code>src</code> attributes and the <a href="#elemdef-smil-seq"><code>seq</code></a> 
-							elements' <code>epub:textref</code> attrbutes. For example, when referencing [[HTML]] 
-							elements, if the finest level of
-							markup is at the paragraph level, then that is the finest possible level for Media Overlay
-							synchronization. Likewise, if sub-paragraph markup is available, such as [[HTML]] <a
-								data-cite="html#the-span-element"><code>span</code></a> elements representing phrases or
-							sentences, then finer granularity is possible in the Media Overlay. Finer granularity gives
-							users more precise results for synchronized playback when navigating by word or phrase and
-							when searching the text but increases the file size of the Media Overlay Documents. Fragment
-							identifier schemes that do not rely on the presence of elements could provide even finer
-							granularity, where supported.</p>
+							<code>src</code> attributes and the <a href="#elemdef-smil-seq"><code>seq</code></a>
+							elements' <code>epub:textref</code> attrbutes. For example, when referencing [[HTML]]
+							elements, if the finest level of markup is at the paragraph level, then that is the finest
+							possible level for Media Overlay synchronization. Likewise, if sub-paragraph markup is
+							available, such as [[HTML]] <a data-cite="html#the-span-element"><code>span</code></a>
+							elements representing phrases or sentences, then finer granularity is possible in the Media
+							Overlay. Finer granularity gives users more precise results for synchronized playback when
+							navigating by word or phrase and when searching the text but increases the file size of the
+							Media Overlay Documents. Fragment identifier schemes that do not rely on the presence of
+							elements could provide even finer granularity, where supported.</p>
 					</section>
 
 					<section id="sec-embedded-media">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -937,7 +937,7 @@
 
 					<li>
 						<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to modify
-							the DOM of the parent Content Document or other contents in the EPUB Publication and MUST
+							the DOM of the host EPUB Content Document or other contents in the EPUB Publication and MUST
 							NOT allow it to manipulate the size of its containing rectangle. (Note: Even if a script is
 							not container-constrained, the Reading System MAY impose restrictions on modifications (see
 							also the <a href="#feature-dom-manipulation">dom-manipulation feature</a>).)</p>
@@ -1044,8 +1044,8 @@
 
 					<p>This specification also recommends that <a
 							href="https://www.w3.org/TR/epub-33/#sec-scripted-container-constrained"
-							>container-constrained scripts</a> [[EPUB-33]] not be allowed to modify the DOM of the
-						parent EPUB Content Document and/or manipulate the containing rectangle (see <a
+							>container-constrained scripts</a> [[EPUB-33]] not be allowed to modify the DOM of the host
+						EPUB Content Document and/or manipulate the containing rectangle (see <a
 							href="#sec-scripted-content"></a>).</p>
 
 					<p>Note that compliance with these recommendations does not guarantee protection from the possible
@@ -1702,10 +1702,10 @@
 					<p>When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-text"><code>text</code>
 							element</a> [[!EPUB-33]] whose <code>src</code> attribute contains a <a
 							data-cite="url#url-fragment-string">URL-fragment string</a> referencing a specific part of
-							an EPUB Content Document, Reading Systems SHOULD ensure the referenced portion is visible in
-						the <a>Viewport</a>. In addition to [[HTML]] element ID references and <a
-						href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
-						Identifiers</a> [[SVG]], Reading Systems MAY support other fragment identifier schemes.</p>
+						an EPUB Content Document, Reading Systems SHOULD ensure the referenced portion is visible in the
+							<a>Viewport</a>. In addition to [[HTML]] element ID references and <a
+							href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
+							Identifiers</a> [[SVG]], Reading Systems MAY support other fragment identifier schemes.</p>
 
 					<p id="mol-rendering-with-styling"
 						data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">During


### PR DESCRIPTION
Best place I could find for the note is right after we first define the top-level and container-constrained scripting contexts.

Fixes #2098


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2136.html" title="Last updated on Mar 30, 2022, 9:25 AM UTC (1709136)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2136/7e81268...1709136.html" title="Last updated on Mar 30, 2022, 9:25 AM UTC (1709136)">Diff</a>