### PR TITLE
Copyedit: clarify foreign resource fallback

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -223,9 +223,9 @@
 
 				<p id="confreq-rs-foreign"
 					data-tests="#pub-foreign_image,#pub-foreign_xml-spine,#pub-foreign_xml-suffix-spine,#pub-foreign_bad-fallback,#pub-foreign_json-spine"
-					>Reading Systems MAY support an arbitrary set of <a>Foreign Resource</a> types, and MUST process
-					fallbacks for unsupported Foreign Resources as defined in <a
-						data-cite="epub-33#sec-foreign-restrictions">Foreign Resources</a> [[EPUB-33]] if not.</p>
+					>Reading Systems MAY support an arbitrary set of <a>Foreign Resource</a> types, and if a Foreign Resource
+					is not supported, MUST process fallbacks as defined in <a
+						data-cite="epub-33#sec-foreign-restrictions">Foreign Resources</a> [[EPUB-33]].</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-remote-res">


### PR DESCRIPTION
This is because the "if not" was dangling at the end, easy to miss.