### PR TITLE
Controversial copyedit: add dc namespace to element names

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -421,25 +421,25 @@
 								data-cite="epub-33#dfn-value">values</a> [[EPUB-33]] before processing.</p>
 					</dd>
 
-					<dt id="dc-identifier">The <code>identifier</code> element</dt>
+					<dt id="dc-identifier">The <code>dc:identifier</code> element</dt>
 					<dd>
-						<p>To determine whether an <code>identifier</code> conforms to an established system or has been
+						<p>To determine whether a <code>dc:identifier</code> conforms to an established system or has been
 							granted by an issuing authority, Reading Systems SHOULD check for an <a
 								data-cite="epub-33#identifier-type"><code>identifier-type</code> property</a>
 							[[EPUB-33]].</p>
 					</dd>
 
-					<dt id="dc-title">The <code>title</code> element</dt>
+					<dt id="dc-title">The <code>dc:title</code> element</dt>
 					<dd>
 						<p id="title-order" data-tests="#pkg-title-order">Reading Systems MUST recognize the first
-								<code>title</code> element in document order as the main title of the EPUB Publication
+								<code>dc:title</code> element in document order as the main title of the EPUB Publication
 							and present it to users before other title elements.</p>
-						<p>This specification does not define how to process additional <code>title</code> elements.</p>
+						<p>This specification does not define how to process additional <code>dc:title</code> elements.</p>
 					</dd>
 
-					<dt id="sec-opf-dclanguage">The <code>language</code> element</dt>
+					<dt id="sec-opf-dclanguage">The <code>dc:language</code> element</dt>
 					<dd>
-						<p> The language(s) of the <a>EPUB Publication</a> specified in <code>language</code> elements
+						<p> The language(s) of the <a>EPUB Publication</a> specified in <code>dc:language</code> elements
 							are informational. Some uses of this information include: </p>
 						<ul>
 							<li>exposing it to the user through the Reading System user interface</li>
@@ -451,11 +451,11 @@
 								<a>Publication Resource</a>.</p>
 					</dd>
 
-					<dt id="dc-creator">The <code>creator</code> element</dt>
+					<dt id="dc-creator">The <code>dc:creator</code> element</dt>
 					<dd>
 						<p id="confreq-rs-pkg-creator-order" data-tests="#pkg-creator-order">When determining display
-							priority, Reading Systems MUST use the document order of <code>creator</code> elements in
-							the <code>metadata</code> section, where the first <code>creator</code> element encountered
+							priority, Reading Systems MUST use the document order of <code>dc:creator</code> elements in
+							the <code>metadata</code> section, where the first <code>dc:creator</code> element encountered
 							is the primary creator. If a Reading System exposes creator metadata to the user, it SHOULD
 							include all the creators listed in the <code>metadata</code> section whenever possible
 							(e.g., when not constrained by display considerations).</p>


### PR DESCRIPTION
I'm proposing this because "the title element" is ambiguous with the HTML element of that name. I think it's clearer in the core spec, where we use [[DCTERMS]] before each (initial) reference. We could do that too.

Less confusing:
https://w3c.github.io/epub-specs/epub33/core/#sec-opf-dctitle