### PR TITLE
Add xrefs and missing citations to RS spec;

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -610,6 +610,10 @@
 				<p>In <a>Package Document</a> metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
 						prefixes</a> are used without declaration.</p>
 
+				<p>References to Dublin Core elements [[DCTERMS]] use the <code>dc:</code> prefix. This prefix must be
+					declared in the <a>Package Document</a> for their use to be valid
+						(<code>xmlns:dc="http://purl.org/dc/elements/1.1/"</code>)</p>
+
 				<p>The <code>epub</code> namespace prefix [[XML-NAMES]] is also used on elements and attributes without
 					always having an explicit declaration (<code>xmlns:epub="http://www.idpf.org/2007/ops"</code>).</p>
 			</section>
@@ -1743,11 +1747,11 @@
 
 						<p id="core-metadata-reqs">In keeping with this philosophy, the Package Document only has the
 							following minimal metadata requirements: it MUST contain the [[DCTERMS]] <a
-								href="#sec-opf-dcidentifier"><code>title</code></a>, <a href="#elemdef-opf-dcidentifier"
-									><code>identifier</code></a>, and <a href="#elemdef-opf-dclanguage"
-									><code>language</code></a> elements together with the [[DCTERMS]] <a
-								href="#last-modified-date"><code>modified</code> property</a>. All other metadata is
-							OPTIONAL.</p>
+								href="#sec-opf-dcidentifier"><code>dc:title</code></a>, <a
+								href="#elemdef-opf-dcidentifier"><code>dc:identifier</code></a>, and <a
+								href="#elemdef-opf-dclanguage"><code>dc:language</code></a> elements together with the
+							[[DCTERMS]] <a href="#last-modified-date"><code>dcterms:modified</code> property</a>. All
+							other metadata is OPTIONAL.</p>
 
 						<aside class="example" title="The minimal set of metadata required in the Package Document">
 							<pre>&lt;package … unique-identifier="pub-id">
@@ -1805,10 +1809,12 @@
 						<h5>DCMES Required Elements</h5>
 
 						<section id="sec-opf-dcidentifier">
-							<h6>The <code>identifier</code> Element</h6>
+							<h6>The <code>dc:identifier</code> Element</h6>
 
-							<p>The [[DCTERMS]] <code>identifier</code> element contains an identifier such as a <abbr
-									title="Universally Unique Identifier">UUID</abbr>, <abbr
+							<p>The <a
+									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
+										><code>dc:identifier</code> element</a> [[DCTERMS]] contains an identifier such
+								as a <abbr title="Universally Unique Identifier">UUID</abbr>, <abbr
 									title="Digital Object Identfier">DOI</abbr> or <abbr
 									title="International Standard Book Number">ISBN</abbr>.</p>
 
@@ -1855,8 +1861,8 @@
 
 							<p>The <a>EPUB Creator</a> MUST provide an identifier that is unique to one and only one
 									<a>EPUB Publication</a> &#8212; its <a>Unique Identifier</a> &#8212; in an
-									<code>identifier</code> element. This <code>identifier</code> element MUST specify
-								an <code>id</code> attribute whose value is referenced from the <a
+									<code>dc:identifier</code> element. This <code>dc:identifier</code> element MUST
+								specify an <code>id</code> attribute whose value is referenced from the <a
 									href="#elemdef-opf-package"><code>package</code> element's</a>
 								<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
 									attribute</a>.</p>
@@ -1882,8 +1888,8 @@
 								qualified URIs.</p>
 
 							<p>EPUB Creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
-									property</a> to indicate that an <code>identifier</code> conforms to an established
-								system or an issuing authority granted it.</p>
+									property</a> to indicate that the value of a <code>dc:identifier</code> element
+								conforms to an established system or an issuing authority granted it.</p>
 
 							<aside class="example" title="Specifying the type of the identifier">
 								<p>In this example, the <code>identifier-type</code> property is used with the <a
@@ -1908,10 +1914,12 @@
 						</section>
 
 						<section id="sec-opf-dctitle">
-							<h6>The <code>title</code> Element</h6>
+							<h6>The <code>dc:title</code> Element</h6>
 
-							<p>The [[DCTERMS]] <code>title</code> element represents an instance of a name for the
-									<a>EPUB Publication</a>.</p>
+							<p>The <a
+									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
+										><code>dc:title</code> element</a> [[DCTERMS]] represents an instance of a name
+								for the <a>EPUB Publication</a>.</p>
 
 							<dl id="elemdef-opf-dctitle" class="elemdef">
 								<dt>Element Name</dt>
@@ -1970,8 +1978,9 @@
 								</dd>
 							</dl>
 
-							<p id="title-order">The first <code>title</code> element in document order is the main title
-								of the EPUB Publication (i.e., the primary one Reading Systems present to users).</p>
+							<p id="title-order">The first <code>dc:title</code> element in document order is the main
+								title of the EPUB Publication (i.e., the primary one Reading Systems present to
+								users).</p>
 
 							<aside class="example" title="A basic title element">
 								<pre>&lt;metadata …>
@@ -1983,14 +1992,14 @@
 </pre>
 							</aside>
 
-							<p>EPUB Creators should use only a single <code>title</code> element to ensure consistent
+							<p>EPUB Creators should use only a single <code>dc:title</code> element to ensure consistent
 								rendering of the title in Reading Systems.</p>
 
 							<div class="note">
-								<p>Although it is possible to include more than one <code>title</code> element for
-									multipart titles, Reading System support for additional <code>title</code> elements
-									is inconsistent. Reading Systems may ignore the additional segments or combine them
-									in unexpected ways.</p>
+								<p>Although it is possible to include more than one <code>dc:title</code> element for
+									multipart titles, Reading System support for additional <code>dc:title</code>
+									elements is inconsistent. Reading Systems may ignore the additional segments or
+									combine them in unexpected ways.</p>
 
 								<p>For example, the following example shows a basic multipart title:</p>
 
@@ -2027,10 +2036,12 @@
 						</section>
 
 						<section id="sec-opf-dclanguage">
-							<h6>The <code>language</code> Element</h6>
+							<h6>The <code>dc:language</code> Element</h6>
 
-							<p>The [[DCTERMS]] <code>language</code> element specifies the language of the content of
-								the <a>EPUB Publication</a>.</p>
+							<p>The <a
+									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/language"
+										><code>dc:language</code> element</a> [[DCTERMS]] specifies the language of the
+								content of the <a>EPUB Publication</a>.</p>
 
 							<dl id="elemdef-opf-dclanguage" class="elemdef">
 								<dt>Element Name</dt>
@@ -2069,7 +2080,7 @@
 								</dd>
 							</dl>
 
-							<p>The <a>value</a> of each <code>language</code> element MUST be a <a
+							<p>The <a>value</a> of each <code>dc:language</code> element MUST be a <a
 									data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
 
 							<aside class="example"
@@ -2083,8 +2094,8 @@
 &lt;/metadata></pre>
 							</aside>
 
-							<p>Although EPUB Creators MAY specify additional <code>language</code> elements for
-								multilingual Publications, Reading Systems will treat the first <code>language</code>
+							<p>Although EPUB Creators MAY specify additional <code>dc:language</code> elements for
+								multilingual Publications, Reading Systems will treat the first <code>dc:language</code>
 								element in document order as the primary language of the EPUB Publication.</p>
 
 							<div class="note">
@@ -2102,19 +2113,20 @@
 							<h6>General Definition</h6>
 
 							<p>All [[DCTERMS]] elements except for <a href="#sec-opf-dcidentifier"
-										><code>identifier</code></a>, <a href="#sec-opf-dclanguage"
-										><code>language</code></a>, and <a href="#sec-opf-dctitle"
-									><code>title</code></a> are designated as OPTIONAL. These elements conform to the
-								following generalized definition:</p>
+										><code>dc:identifier</code></a>, <a href="#sec-opf-dclanguage"
+										><code>dc:language</code></a>, and <a href="#sec-opf-dctitle"
+										><code>dc:title</code></a> are designated as OPTIONAL. These elements conform to
+								the following generalized definition:</p>
 
 							<dl class="elemdef">
 								<dt>Element Name</dt>
 								<dd>
 									<p>
-										<code>contributor</code> | <code>coverage</code> | <code>creator</code> |
-											<code>date</code> | <code>description</code> | <code>format</code> |
-											<code>publisher</code> | <code>relation</code> | <code>rights</code> |
-											<code>source</code> | <code>subject</code> | <code>type</code></p>
+										<code>dc:contributor</code> | <code>dc:coverage</code> | <code>dc:creator</code>
+										| <code>dc:date</code> | <code>dc:description</code> | <code>dc:format</code> |
+											<code>dc:publisher</code> | <code>dc:relation</code> |
+											<code>dc:rights</code> | <code>dc:source</code> | <code>dc:subject</code> |
+											<code>dc:type</code></p>
 								</dd>
 
 								<dt>Namespace</dt>
@@ -2135,11 +2147,11 @@
 									<ul class="nomark">
 										<li>
 											<p><a href="#attrdef-dir"><code>dir</code></a>
-												<code>[optional]</code> – only allowed on <code>contributor</code>,
-													<code>coverage</code>, <code>creator</code>,
-													<code>description</code>, <code>publisher</code>,
-													<code>relation</code>, <code>rights</code>, and
-												<code>subject</code>.</p>
+												<code>[optional]</code> – only allowed on <code>dc:contributor</code>,
+													<code>dc:coverage</code>, <code>dc:creator</code>,
+													<code>dc:description</code>, <code>dc:publisher</code>,
+													<code>dc:relation</code>, <code>dc:rights</code>, and
+													<code>dc:subject</code>.</p>
 										</li>
 										<li>
 											<p><a href="#attrdef-id"><code>id</code></a>
@@ -2147,11 +2159,11 @@
 										</li>
 										<li>
 											<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-												<code>[optional]</code> – only allowed on <code>contributor</code>,
-													<code>coverage</code>, <code>creator</code>,
-													<code>description</code>, <code>publisher</code>,
-													<code>relation</code>, <code>rights</code>, and
-												<code>subject</code>.</p>
+												<code>[optional]</code> – only allowed on <code>dc:contributor</code>,
+													<code>dc:coverage</code>, <code>dc:creator</code>,
+													<code>dc:description</code>, <code>dc:publisher</code>,
+													<code>dc:relation</code>, <code>dc:rights</code>, and
+													<code>dc:subject</code>.</p>
 										</li>
 									</ul>
 								</dd>
@@ -2167,24 +2179,28 @@
 						</section>
 
 						<section id="sec-opf-dccontributor">
-							<h6>The <code>contributor</code> Element</h6>
+							<h6>The <code>dc:contributor</code> Element</h6>
 
-							<p>The [[DCTERMS]] <code>contributor</code> element is used to represent the name of a
-								person, organization, etc. that played a secondary role in the creation of the
+							<p>The <a
+									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/contributor"
+										><code>dc:contributor</code> element</a> [[DCTERMS]] is used to represent the
+								name of a person, organization, etc. that played a secondary role in the creation of the
 								content.</p>
 
-							<p>The requirements for the <code>contributor</code> element are identical to those for the
-									<a href="#sec-opf-dccreator"><code>creator</code> element</a> in all other
+							<p>The requirements for the <code>dc:contributor</code> element are identical to those for
+								the <a href="#sec-opf-dccreator"><code>dc:creator</code> element</a> in all other
 								respects.</p>
 						</section>
 
 						<section id="sec-opf-dccreator">
-							<h6>The <code>creator</code> Element</h6>
+							<h6>The <code>dc:creator</code> Element</h6>
 
-							<p>The [[DCTERMS]] <code>creator</code> element represents the name of a person,
-								organization, etc. responsible for the creation of the content. EPUB Creators MAY <a
-									href="#subexpression">associate</a> a <a href="#role"><code>role</code> property</a>
-								with the element to indicate the function the creator played.</p>
+							<p>The <a
+									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/creator"
+										><code>dc:creator</code> element</a> [[DCTERMS]] represents the name of a
+								person, organization, etc. responsible for the creation of the content. EPUB Creators
+								MAY <a href="#subexpression">associate</a> a <a href="#role"><code>role</code>
+									property</a> with the element to indicate the function the creator played.</p>
 
 							<aside class="example" title="Specifying that a creator is an author">
 								<p>In this example, the <a href="https://id.loc.gov/vocabulary/relators.html">MARC
@@ -2208,8 +2224,8 @@
 &lt;/metadata></pre>
 							</aside>
 
-							<p>The <code>creator</code> element should contain the name of the creator as EPUB Creators
-								intend Reading Systems to display it to users.</p>
+							<p>The <code>dc:creator</code> element should contain the name of the creator as EPUB
+								Creators intend Reading Systems to display it to users.</p>
 
 							<p>EPUB Creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
 								<a href="#subexpression">to associate</a> a normalized form of the creator's name, and
@@ -2239,10 +2255,10 @@
 							</aside>
 
 							<p>If an EPUB Publication has more than one creator, EPUB Creators should specify each in a
-								separate <code>creator</code> element.</p>
+								separate <code>dc:creator</code> element.</p>
 
-							<p>The document order of <code>creator</code> elements in the <code>metadata</code> section
-								determines the display priority, where the first <code>creator</code> element
+							<p>The document order of <code>dc:creator</code> elements in the <code>metadata</code>
+								section determines the display priority, where the first <code>dc:creator</code> element
 								encountered is the primary creator.</p>
 
 							<aside class="example" title="Expressing the primary creator">
@@ -2263,14 +2279,16 @@
 							</aside>
 
 							<p>EPUB Creators should represent secondary contributors using the <a
-									href="#sec-opf-dccontributor"><code>contributor</code> element</a>.</p>
+									href="#sec-opf-dccontributor"><code>dc:contributor</code> element</a>.</p>
 						</section>
 
 						<section id="sec-opf-dcdate">
-							<h6>The <code>date</code> Element</h6>
+							<h6>The <code>dc:date</code> Element</h6>
 
-							<p>The [[DCTERMS]] <code>date</code> element defines the publication date of the <a>EPUB
-									Publication</a>. The publication date is not the same as the <a
+							<p>The <a
+									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/date"
+										><code>dc:date</code> element</a> [[DCTERMS]] defines the publication date of
+								the <a>EPUB Publication</a>. The publication date is not the same as the <a
 									href="#last-modified-date">last modified date</a> (the last time the EPUB Creator
 								changed the EPUB Publication).</p>
 
@@ -2291,14 +2309,16 @@
 							<p>EPUB Creators should express additional dates using the specialized date properties
 								available in the [[DCTERMS]] vocabulary, or similar.</p>
 
-							<p>EPUB Publications MUST NOT contain more than one <code>date</code> element.</p>
+							<p>EPUB Publications MUST NOT contain more than one <code>dc:date</code> element.</p>
 						</section>
 
 						<section id="sec-opf-dcsubject">
-							<h6>The <code>subject</code> Element</h6>
+							<h6>The <code>dc:subject</code> Element</h6>
 
-							<p>The [[DCTERMS]] <code>subject</code> element identifies the subject of the EPUB
-								Publication. EPUB Creators should set the <a>value</a> of the element to the
+							<p>The <a
+									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/subject"
+										><code>dc:subject</code> element</a> [[DCTERMS]] identifies the subject of the
+								EPUB Publication. EPUB Creators should set the <a>value</a> of the element to the
 								human-readable heading or label, but may use a code value if the subject taxonomy does
 								not provide a separate descriptive label.</p>
 
@@ -2345,17 +2365,19 @@
 							</aside>
 
 							<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
-										<code>subject</code> element</a> that does not specify a scheme.</p>
+										<code>dc:subject</code> element</a> that does not specify a scheme.</p>
 
-							<p>The <a>values</a> of the <code>subject</code> element and <code>term</code> property are
-								case sensitive only when the designated scheme requires.</p>
+							<p>The <a>values</a> of the <code>dc:subject</code> element and <code>term</code> property
+								are case sensitive only when the designated scheme requires.</p>
 						</section>
 
 						<section id="sec-opf-dctype">
-							<h6>The <code>type</code> Element</h6>
+							<h6>The <code>dc:type</code> Element</h6>
 
-							<p>The [[DCTERMS]] <code>type</code> element is used to indicate that the EPUB Publication
-								is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
+							<p>The <a
+									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/type"
+										><code>dc:type</code> element</a> [[DCTERMS]] is used to indicate that the EPUB
+								Publication is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
 								format).</p>
 
 							<p>EPUB Creators MAY use any text string as a <a>value</a>.</p>
@@ -11218,8 +11240,8 @@ EPUB/images/cover.png</pre>
 						href="https://github.com/w3c/epub-specs/issues/1087">issue 1087</a>.</li>
 				<li>26-Mar-2021: Removed requirement for page list ordering to reflect the order of page breaks in the
 					content. See <a href="https://github.com/w3c/epub-specs/issues/1500">issue 1500</a>.</li>
-				<li>26-Mar-2021: Allowed <code>creator</code> and <code>contributor</code> elements to have multiple
-					roles and allowed roles for <code>publisher</code>. See <a
+				<li>26-Mar-2021: Allowed <code>dc:creator</code> and <code>dc:contributor</code> elements to have
+					multiple roles and allowed roles for <code>publisher</code>. See <a
 						href="https://github.com/w3c/epub-specs/issues/1129">issue 1129</a> and <a
 						href="https://github.com/w3c/epub-specs/issues/1583">issue 1583</a></li>
 				<li>23-Mar-2021: Clarified the requirements for the use of data URLs in EPUB Publications. See <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1555,20 +1555,22 @@
 								elements.</p>
 						</dd>
 
-						<dt id="sec-container-metainf-encryption.xml">Encryption File (<code>encryption.xml</code>)</dt>
-						<dd>
-							<p>Before computing the digest used to validate the signature in the <a
-									data-cite="epub-33#sec-container-metainf-encryption.xml"><code>encryption.xml</code>
-									file</a> [[EPUB-33]], Reading Systems MUST decrypt any data encrypted after signing
-								&#8212; data encrypted before signing MUST NOT be decrypted.</p>
-						</dd>
-
 						<dt id="sec-container-metainf-manifest.xml">Manifest File (<code>manifest.xml</code>)</dt>
 						<dd>
 							<p>Reading Systems MUST NOT use ancillary manifest information contained in the ZIP archive
 								or in the <a data-cite="epub-33#sec-container-metainf-manifest.xml"
 										><code>manifest.xml</code> file</a> [[EPUB-33]] for processing an <a>EPUB
 									Publication</a>.</p>
+						</dd>
+
+						<dt id="sec-container-metainf-signature.xml">Signature File (<code>signature.xml</code>)</dt>
+						<dd>
+							<p>Before computing the digest used to validate the signature in the <a
+									data-cite="epub-33#sec-container-metainf-signature.xml"><code>signature.xml</code>
+									file</a> [[EPUB-33]], Reading Systems MUST decrypt any data encrypted after signing
+								&#8212; data encrypted before signing MUST NOT be decrypted.</p>
+							<p>Refer to Decryption Transform for XML Signature [XMLENC-DECRYPT] for more information
+								about identifying data encrypted after signing.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-inc">Other Files</dt>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -260,9 +260,9 @@
 
 				<p class="note" id="note-video-codecs">It is recommended that Reading Systems support at least one of
 					the H.264 [[H264]] and VP8 [[RFC6386]] video codecs, but this is not a conformance requirement
-					&#8212; a Reading System may support any video codec, or none at all. Reading System developers should
-					take into consideration factors such as breadth of adoption, playback quality, and technology royalties
-					when deciding which video formats to support.</p>
+					&#8212; a Reading System may support any video codec, or none at all. Reading System developers
+					should take into consideration factors such as breadth of adoption, playback quality, and technology
+					royalties when deciding which video formats to support.</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-xml">
@@ -296,45 +296,47 @@
 					applicable. This includes:</p>
 
 				<ul>
-					<li>the <code>xml:lang</code> attribute for all XML documents like the <a
-							data-cite="epub-33#attrdef-xml-lang">Package Document</a> or the <a
-							data-cite="epub-33#sec-overlay-docs">Media Overlay Document</a> [[EPUB-33]].</li>
+					<li>the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a> [[XML]] for all XML
+						documents (e.g., the <a>Package Document</a> and <a>Media Overlay
+						Documents</a> [[EPUB-33]]).</li>
 
-					<li>the <code>xml:lang</code> and <code>lang</code> attributes for <a
-							data-cite="html#the-lang-and-xml:lang-attributes">XHTML</a> [[HTML]] or <a
-							href="https://www.w3.org/TR/SVG/struct.html#LangSpaceAttrs">SVG</a> [[SVG]].</li>
+					<li>the [[HTML]] <a data-cite="html#the-lang-and-xml:lang-attributes"><code>lang</code>
+							attribute</a> for <a>XHTML Content Documents</a> and <a>SVG Content Documents</a>.</li>
 				</ul>
 
 				<p>Similarly, a Reading System MUST process, for all <a data-cite="epub-33#dfn-publication-resource"
-						>Publication Resources</a>, the attributes that set the base direction for the documents'
-					contents, when applicable. This includes:</p>
+						>Publication Resources</a> [[EPUB-33]], the attributes that set the base direction for the
+					documents' contents, when applicable. This includes:</p>
 
 				<ul>
 					<li id="confreq-rs-pkg-dir-intro"
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
-						>the <code>dir</code> attribute for the <a data-cite="epub-33#attrdef-dir">Package
-						Document</a> [[EPUB-33]]. (See also <a href="#sec-pkg-doc-base-dir"></a> for further
+						>the <a data-cite="epub-33#attrdef-dir"><code>dir</code> attribute</a> [[EPUB-33]] for the
+							<a>Package Document</a>. (See also <a href="#sec-pkg-doc-base-dir"></a> for further
 						details.)</li>
-					<li>the <code>dir</code> attribute for <a data-cite="html#the-dir-attribute"
-						>XHTML</a> [[HTML]].</li>
-					<li>the <code>direction</code> attribute for <a
-							href="https://www.w3.org/TR/SVG/text.html#DirectionProperty">SVG</a> [[SVG]].</li>
+					<li>the [[HTML]] <a data-cite="html#the-dir-attribute"><code>dir</code> attribute</a> for XHTML
+						Content Documents.</li>
+					<li>the [[SVG]] <a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
+								><code>direction</code> attribute</a> for SVG Content Documents.</li>
 				</ul>
 
 				<p id="confreq-rs-pkg-lang-no-content"
 					data-tests="#pgk-lang_pkg_non_content_dir,#pgk-lang_pkg_non_content">In the absence of this
 					information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume either the language or
-					the base direction of that resource from information expressed in the Package Document (i.e., in
-						<code>xml:lang</code> and <code>dir</code> attributes, in <code>hreflang</code> attributes on
-					link elements, or from <code>dc:language</code> elements). Refer to a resource's formal
-					specification for more information about to handle the absence of explicit language or direction
-					information.</p>
+					the base direction of that resource from information expressed in the Package Document (i.e., in <a
+						data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
+						data-cite="epub-33#attrdef-dir"><code>dir</code></a> attributes, in <a
+						data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attributes</a> on <a
+						data-cite="epub-33#sec-link-elem"><code>link</code> elements</a>, or from <a
+						data-cite="epub-33#sec-opf-dclanguage"><code>dc:language</code> elements</a> [[EPUB-33]]). Refer
+					to a resource's formal specification for more information about to handle the absence of explicit
+					language or direction information.</p>
 			</section>
 
 			<section id="sec-epub-rs-network-access">
 				<h3>Network Access</h3>
 
-				<p>Reading Systems may support network access to <a href="#sec-epub-rs-conf-remote-res">retrieve remote
+				<p>Reading Systems MAY support network access to <a href="#sec-epub-rs-conf-remote-res">retrieve remote
 						resources</a> and to allow <a>Scripted Content Documents</a> to <a
 						href="#confreq-rs-scripted-limit">communicate with web-hosted APIs and retrieve
 					resources</a>.</p>
@@ -348,6 +350,7 @@
 						href="#sec-security-privacy"></a>.</p>
 
 				<p>If Reading System developers allow network access, it is strongly RECOMMENDED both that they:</p>
+
 				<ul>
 					<li>notify users when network activity occurs; and</li>
 					<li>let users block access to the network (e.g., disable network access for the Reading System
@@ -384,11 +387,11 @@
 
 				<p id="confreq-rs-pkg-dir"
 					data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
-					> If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
-						<code>rtl</code>, Reading Systems MUST override the bidi algorithm per <a
-						data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]],
-					setting the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the
-					base direction is <code>rtl</code>.</p>
+					> If the <a data-cite="epub-33#attrdef-dir"><code>dir</code> attribute</a> [[EPUB-33]] is set and
+					indicates a base direction of <code>ltr</code> or <code>rtl</code>, Reading Systems MUST override
+					the bidi algorithm per <a data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a>
+					defined in [[BIDI]], setting the paragraph embedding level to 0 if the base direction is
+						<code>ltr</code>, or 1 if the base direction is <code>rtl</code>.</p>
 
 				<p id="confreq-rs-pkg-dir-auto" data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Otherwise
 					the base direction is <code>auto</code>, in which case Reading Systems MUST determine the text's
@@ -414,31 +417,35 @@
 					<dd>
 						<p id="confreq-rs-pkg-whitespace" data-tests="#pkg-meta-whitespace">Reading Systems MUST <a
 								data-cite="infra#strip-and-collapse-ascii-whitespace">strip and collapse ASCII
-								whitespace</a> [[Infra]] from Dublin Core [[DC11]] and <a
+								whitespace</a> [[Infra]] from Dublin Core [[DCTERMS]] and <a
 								data-cite="epub-33#sec-meta-elem"><code>meta</code></a> element <a
 								data-cite="epub-33#dfn-value">values</a> [[EPUB-33]] before processing.</p>
 					</dd>
 
-					<dt id="dc-identifier">The <code>identifier</code> element</dt>
+					<dt id="dc-identifier">The <code>dc:identifier</code> element</dt>
 					<dd>
-						<p>To determine whether an <code>identifier</code> conforms to an established system or has been
-							granted by an issuing authority, Reading Systems SHOULD check for an <a
+						<p>To determine whether the value of a <a data-cite="epub-33#sec-opf-dcidentifier"
+									><code>dc:identifier</code> element</a> [[EPUB-33]] conforms to an established
+							system or has been granted by an issuing authority, Reading Systems SHOULD check for an <a
 								data-cite="epub-33#identifier-type"><code>identifier-type</code> property</a>
 							[[EPUB-33]].</p>
 					</dd>
 
-					<dt id="dc-title">The <code>title</code> element</dt>
+					<dt id="dc-title">The <code>dc:title</code> element</dt>
 					<dd>
-						<p id="title-order" data-tests="#pkg-title-order">Reading Systems MUST recognize the first
-								<code>title</code> element in document order as the main title of the EPUB Publication
-							and present it to users before other title elements.</p>
-						<p>This specification does not define how to process additional <code>title</code> elements.</p>
+						<p id="title-order" data-tests="#pkg-title-order">Reading Systems MUST recognize the first <a
+								data-cite="epub-33#sec-opf-dctitle"><code>dc:title</code> element</a> [[EPUB-33]] in
+							document order as the main title of the EPUB Publication and present it to users before
+							other title elements.</p>
+						<p>This specification does not define how to process additional <code>dc:title</code>
+							elements.</p>
 					</dd>
 
-					<dt id="sec-opf-dclanguage">The <code>language</code> element</dt>
+					<dt id="sec-opf-dclanguage">The <code>dc:language</code> element</dt>
 					<dd>
-						<p> The language(s) of the <a>EPUB Publication</a> specified in <code>language</code> elements
-							are informational. Some uses of this information include: </p>
+						<p> The language(s) of the <a>EPUB Publication</a> specified in <a
+								data-cite="epub-33#sec-opf-dclanguage"><code>dc:language</code> elements</a> are
+							informational. Some uses of this information include: </p>
 						<ul>
 							<li>exposing it to the user through the Reading System user interface</li>
 							<li>using it to enhance functionality in a bookshelf (e.g., sorting by language)</li>
@@ -449,50 +456,58 @@
 								<a>Publication Resource</a>.</p>
 					</dd>
 
-					<dt id="dc-creator">The <code>creator</code> element</dt>
+					<dt id="dc-creator">The <code>dc:creator</code> element</dt>
 					<dd>
 						<p id="confreq-rs-pkg-creator-order" data-tests="#pkg-creator-order">When determining display
-							priority, Reading Systems MUST use the document order of <code>creator</code> elements in
-							the <code>metadata</code> section, where the first <code>creator</code> element encountered
-							is the primary creator. If a Reading System exposes creator metadata to the user, it SHOULD
-							include all the creators listed in the <code>metadata</code> section whenever possible
-							(e.g., when not constrained by display considerations).</p>
+							priority, Reading Systems MUST use the document order of <a
+								data-cite="epub-33#sec-opf-dccreator"><code>dc:creator</code> elements</a> [[EPUB-33]]
+							in the <code>metadata</code> section, where the first <code>creator</code> element
+							encountered is the primary creator. If a Reading System exposes creator metadata to the
+							user, it SHOULD include all the creators listed in the <code>metadata</code> section
+							whenever possible (e.g., when not constrained by display considerations).</p>
 					</dd>
 
 					<dt id="meta">The <code>meta</code> element</dt>
 					<dd>
-						<p>If a Reading System does not recognize the <code>scheme</code> attribute value, it SHOULD
-							treat the value of the element as a string.</p>
-						<p>Reading Systems SHOULD ignore all <code>meta</code> elements whose <code>property</code>
-							attributes define expressions they do not recognize. <span id="confreq-rs-pkg-meta-unknown"
-								data-tests="#pkg-meta-unknown">A Reading System MUST NOT fail when encountering unknown
-								expressions.</span></p>
-						<p>If the <code>property</code> attribute's value does not include a prefix, Reading Systems
-							MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to <a
+						<p>Reading Systems SHOULD ignore all <a data-cite="epub-33#sec-meta-elem"><code>meta</code>
+								elements</a> whose <a data-cite="epub-33#attrdef-meta-property"><code>property</code>
+								attributes</a> [[EPUB-33]] define expressions they do not recognize. <span
+								id="confreq-rs-pkg-meta-unknown" data-tests="#pkg-meta-unknown">A Reading System MUST
+								NOT fail when encountering unknown expressions.</span></p>
+						<p>If the <code>property</code> attribute's value does not include a <a
+								data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], Reading Systems MUST
+							use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to <a
 								href="#sec-property-datatype">expand the value</a>.</p>
+						<p>If a Reading System does not recognize the <a data-cite="epub-33#attrdef-scheme"
+									><code>scheme</code> attribute</a> [[EPUB-33]] value, it SHOULD treat the value of
+							the element as a string.</p>
 					</dd>
 
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
 					<dd>
 						<p>Retrieval and support of linked resources is OPTIONAL.</p>
-						<p> The language identified in an <code>hreflang</code> is purely advisory. Upon fetching the
-							resource, a Reading System must only use the language information associated with the
-							resource to determine its language, not the metadata included in the link to the resource.</p>
+						<p> The language identified in an <a data-cite="epub-33#attrdef-hreflang"><code>hreflang</code>
+								attribute</a> is purely advisory. Upon fetching the resource, a Reading System MUST use
+							the language information associated with the resource to determine its language, not the
+							metadata included in the link to the resource.</p>
 						<p id="sec-linked-records" data-tests="#pkg-linked-records"> In the case of a <a
 								data-cite="epub-33#record">linked metadata record</a> [[EPUB-33]], Reading Systems MUST
 							NOT skip processing the metadata expressed in the Package Document (i.e., use only the
 							information expressed in the record). Reading Systems MAY compile metadata from multiple
 							linked records.</p>
 						<p>When resolving discrepancies and conflicts between metadata expressed in the Package Document
-							and in linked metadata records, Reading Systems MUST use the document order of
-							<code>link</code> elements in the Package Document to establish precedence (i.e., metadata
-							in the first linked record has the highest precedence and metadata in the Package Document
-							the lowest, regardless of whether the <code>link</code> elements occur before, within, or
-							after the package metadata elements).</p>
+							and in linked metadata records, Reading Systems MUST use the document order of <a
+								data-cite="epub-33#sec-link-elem"><code>link</code> elements</a> [[EPUB-33]] in the
+							Package Document to establish precedence (i.e., metadata in the first linked record has the
+							highest precedence and metadata in the Package Document the lowest, regardless of whether
+							the <code>link</code> elements occur before, within, or after the package metadata
+							elements).</p>
 						<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
 							layout and rendering of the EPUB Publication.</p>
-						<p>If any of the <code>rel</code> or <code>properties</code> attributes' values do not include a
-							prefix, Reading Systems MUST use the prefix URL
+						<p>If any of the <a data-cite="epub-33#attrdef-link-rel"><code>rel</code></a> or <a
+								data-cite="epub-33#attrdef-properties"><code>properties</code></a> [[EPUB-33]]
+							attributes' values do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a>,
+							Reading Systems MUST use the prefix URL
 								"<code>http://idpf.org/epub/vocab/package/link/#</code>" to <a
 								href="#sec-property-datatype">expand the values</a>.</p>
 					</dd>
@@ -509,9 +524,9 @@
 			<section id="sec-pkg-doc-manifest">
 				<h3>Manifest</h3>
 
-
-				<p>Reading Systems MAY optimize the rendering depending on the properties set in the
-						<code>properties</code> attribute (e.g., disable a rendering process or use a fallback). <span
+				<p>Reading Systems MAY optimize the rendering depending on the properties set in the <a
+						data-cite="epub-33#sec-item-resource-properties"><code>properties</code> attribute</a>
+					[[EPUB-33]] (e.g., disable a rendering process or use a fallback). <span
 						id="confreq-rs-pkg-manifest-unknown" data-tests="#pkg-manifest-unknown">Reading Systems MUST
 						ignore values of the <code>properties</code> attribute they do not recognize.</span></p>
 
@@ -520,25 +535,26 @@
 					inherent limitations and risks involved (e.g., lack of information about the resource and how to
 					process it, security risks from remotely-hosted sources, lack of fallbacks, etc.).</p>
 
-				<p>A Reading System that does not support the Media Type of a given Publication Resource MUST traverse
-					the fallback chain until it identifies a supported Publication Resource to use in place of the
-					unsupported resource. If the Reading System supports multiple Publication Resources in the fallback
-					chain, it MAY select the resource to use based on specific <a
-						data-cite="epub-33#attrdef-item-properties">properties</a> [[EPUB-33]] of that resource,
-					otherwise it SHOULD honor the EPUB Creator's preferred fallback order. If a Reading System does not
-					support any resource in the fallback chain, it MUST alert the reader that it could not display the
-					content.</p>
+				<p>A Reading System that does not support the MIME media type [[RFC2046]] of a given Publication
+					Resource MUST traverse the <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a>
+					[[EPUB-33]] until it identifies a supported Publication Resource to use in place of the unsupported
+					resource. If the Reading System supports multiple Publication Resources in the fallback chain, it
+					MAY select the resource to use based on the resource's <a
+						data-cite="epub-33#attrdef-item-properties"><code>properties</code> attribute</a> [[EPUB-33]]
+					values, otherwise it SHOULD honor the EPUB Creator's preferred fallback order. If a Reading System
+					does not support any resource in the fallback chain, it MUST alert the reader that it could not
+					display the content.</p>
 
-				<p>When <a data-cite="epub-33#sec-foreign-restrictions-manifest">manifest fallbacks</a> [[EPUB-33]] are
-					provided for <a>Top-level Content Documents</a>, Reading Systems MAY choose from the available
-					options to find the optimal version to render in a given context (e.g., by inspecting the
-					<code>properties</code> attribute for each).</p>
+				<p>When manifest fallbacks are provided for <a>Top-level Content Documents</a>, Reading Systems MAY
+					choose from the available options to find the optimal version to render in a given context (e.g., by
+					inspecting the <code>properties</code> attribute for each).</p>
 
 				<p>A Reading System MUST terminate the fallback chain at the first reference to a manifest item it has
 					already encountered.</p>
 
-				<p>If any of the <code>properties</code> attribute's values do not include a prefix, Reading Systems
-					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/item/#</code>" to <a
+				<p>If any of the <code>properties</code> attribute's values do not include a <a
+						data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], Reading Systems MUST use the
+					prefix URL "<code>http://idpf.org/epub/vocab/package/item/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 			</section>
 
@@ -546,33 +562,38 @@
 				<h3>Spine</h3>
 
 				<p id="confreq-rs-spine-order" data-tests="#pkg-spine-order">Reading Systems MUST provide a means of
-					rendering the EPUB Publication in the order defined in the <code>spine</code>, which includes:</p>
+					rendering the EPUB Publication in the order defined in the <a data-cite="epub-33#sec-spine-elem"
+							><code>spine</code> element</a> [[EPUB-33]], which includes:</p>
 				<ul>
-					<li>recognizing the first primary (linear) <code>itemref</code> as the beginning of the default
-						reading order; and,</li>
+					<li>recognizing the first <a data-cite="epub-33#attrdef-itemref-linear">primary (linear)
+								<code>itemref</code></a> [[EPUB-33]] as the beginning of the default reading order;
+						and,</li>
 					<li>rendering successive primary items in the order given in the <code>spine</code>.</li>
 				</ul>
 
 				<p id="confreq-rendition-rs-spine-nonlinear">When a user traverses the default reading order defined in
-					the <a data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]], a Reading System MAY automatically
-					skip <code>itemref</code> elements marked as non-linear. <span
-						id="confreq-rs-spine-nonlinear-activation" data-tests="#pkg-spine-nonlinear-activation">When a
-						user activates a hyperlink to a non-linear resource, however, Reading Systems MUST render the
-						referenced resource or a designated fallback.</span> Reading Systems MAY also provide the option
-					for users to skip non-linear content by default or not.</p>
+					the <code>spine</code> element, a Reading System MAY automatically skip <a
+						data-cite="epub-33#attrdef-itemref-linear">non-linear <code>itemref</code> elements</a>
+					[[EPUB-33]]. <span id="confreq-rs-spine-nonlinear-activation"
+						data-tests="#pkg-spine-nonlinear-activation">When a user activates a hyperlink to a non-linear
+						resource, however, Reading Systems MUST render the referenced resource or a designated
+						fallback.</span> Reading Systems MAY also provide the option for users to skip non-linear
+					content by default or not.</p>
 
 				<p id="confreq-rs-spine-progression-default" data-tests="#pkg-spine-progression-default">If the EPUB
-					Creator has not specified the <code>page-progression-direction</code>, the Reading System MUST
-					assume the value of <code>default</code>. When <code>page-progression-direction</code> is
-					<code>default</code>, the Reading System can choose the rendering
-					direction.</p>
+					Creator has not specified the <a data-cite="epub-33#attrdef-spine-page-progression-direction"
+							><code>page-progression-direction</code> attribute</a> [[EPUB-33]], the Reading System MUST
+					assume the value of <code>default</code>. When <code>page-progression-direction</code> value is
+						<code>default</code>, the Reading System can choose the rendering direction.</p>
 
 				<p id="confreq-rs-spine-progression-pre-paginated" data-tests="#pkg-spine-progression-pre-paginated">If
-					<code>page-progression-direction</code> has a value other than <code>default</code>, the Reading
-					System MUST ignore any directionality computed from <a href="#layout"><code>pre-paginated</code></a>
-					XHTML Content Documents.</p>
+					the <code>page-progression-direction</code> attribute has a value other than <code>default</code>,
+					the Reading System MUST ignore any directionality computed from <a href="#layout"
+							><code>pre-paginated</code></a>
+					<a>XHTML Content Documents</a>.</p>
 
-				<p>If any of the <code>properties</code> attribute's values do not include a prefix, Reading Systems
+				<p>If any values of the <a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a>
+					do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], Reading Systems
 					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 
@@ -585,8 +606,8 @@
 						Reading Systems MUST NOT skip spine references to duplicate manifest items when rendering the
 						linear reading order.</span>
 					<span id="confreq-rs-pkg-duplicate-item-ui" data-tests="#pkg-spine-duplicate-item-ui">The Reading
-						System MUST treat these as distinct items for UI purposes (for example, each occurrence could be
-						independently bookmarked or annotated).</span>
+						System MUST treat these as distinct items for user interface (UI) purposes (for example, each
+						occurrence could be independently bookmarked or annotated).</span>
 					<span id="confreq-rs-pkg-duplicate-item-hyperlink" data-tests="#pkg-spine-duplicate-item-hyperlink"
 						>When a Reading System follows a hyperlink to a resource referenced multiple times in the spine,
 						the Reading System MUST navigate to the first occurrence of the document in the linear reading
@@ -596,15 +617,16 @@
 				<section id="spine-overrides">
 					<h4>Spine Overrides</h4>
 
-					<p>When a spine <code>itemref</code> element's <code>properties</code> attribute overrides a
-						<a data-cite="epub-33#app-rendering-vocab">global rendering property</a>
-						[[EPUB-33]], Reading Systems MUST follow the requirements for the override's global value to
-						display that spine item.</p>
+					<p>When a spine <a data-cite="epub-33#sec-itemref-elem"><code>itemref</code> element's</a>
+						<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a <a
+							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[EPUB-33]], Reading
+						Systems MUST follow the requirements for the override's global value to display that spine
+						item.</p>
 
-					<p>For example, a spine item that contains the <a
-						data-cite="epub-33#layout-overrides"><code>layout-pre-paginated</code>
-						override</a> [[EPUB-33]] is rendered following the requirements of the global <a
-						href="#def-layout-pre-paginated"><code>pre-paginated</code> value</a>.</p>
+					<p>For example, a spine item that contains the <a data-cite="epub-33#layout-overrides"
+								><code>layout-pre-paginated</code> override</a> [[EPUB-33]] is rendered following the
+						requirements of the global <a href="#def-layout-pre-paginated"><code>pre-paginated</code>
+							value</a>.</p>
 
 					<p>If more than one override for the same property is specified in a <code>properties</code>
 						attribute, Reading Systems MUST use only the first value.</p>
@@ -614,7 +636,8 @@
 			<section id="sec-pkg-doc-collections">
 				<h3>Collections</h3>
 
-				<p>In the context of this specification, support for collections in Reading Systems is OPTIONAL. <span
+				<p>In the context of this specification, support for <a data-cite="epub-33#sec-collection-elem"
+						>collections</a> [[EPUB-33]] in Reading Systems is OPTIONAL. <span
 						id="confreq-rs-pkg-collections-unknown" data-tests="#pkg-collections-unknown">Reading Systems
 						MUST ignore <code>collection</code> elements that define unrecognized roles.</span></p>
 			</section>
@@ -729,7 +752,8 @@
 					<section id="sec-xhtml-mathml">
 						<h3>MathML</h3>
 
-						<p>To support MathML embedded in XHTML Content Documents, a Reading System:</p>
+						<p>To support MathML [[MathML3]] embedded in <a>XHTML Content Documents</a>, a Reading
+							System:</p>
 
 						<ul class="conformance-list">
 							<li>
@@ -744,28 +768,29 @@
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
-										data-cite="mathml3/chapter4.html#">Content MathML</a> found in
-										<code>annotation-xml</code> elements.</p>
+										data-cite="mathml3/chapter4.html#">Content MathML</a> found in <a
+										data-cite="mathml3/chapter5.html#mixing.elements.annotation.xml"
+											><code>annotation-xml</code> elements</a> [[MathML3]].</p>
 							</li>
 						</ul>
 
-						<p class="note">Reading Systems may choose to use third-party libraries such as MathJax to
-							provide MathML rendering. </p>
+						<p class="note">Reading Systems may choose to use third-party libraries such as <a
+								href="https://www.mathjax.org/">MathJax</a> to provide MathML rendering. </p>
 					</section>
 
 					<section id="sec-xhtml-svg">
 						<h5>Embedded SVG</h5>
 
 						<p id="confreq-svg-rs-embed" data-tests="#cnt-svg-embedded">Reading Systems MUST process SVG
-							embedded in XHTML Content Documents as defined in <a href="#sec-svg"></a>.</p>
+							embedded in <a>XHTML Content Documents</a> as defined in <a href="#sec-svg"></a>.</p>
 
 						<section id="sec-xhtml-svg-css">
 							<h6>Embedded SVG and CSS</h6>
 
 							<p id="confreq-svg-rs-css-embed-ref" data-tests="#cnt-svg-css-reference">For the purposes of
-								styling SVG embedded in XHTML Content Documents <em>by reference</em>, Reading Systems
-								MUST NOT apply CSS style rules of the containing document to the referenced SVG
-								document.</p>
+								styling SVG embedded in <a>XHTML Content Documents</a>
+								<em>by reference</em>, Reading Systems MUST NOT apply CSS style rules of the containing
+								document to the referenced SVG document.</p>
 
 							<p id="confreq-svg-rs-css-embed-inc" data-tests="#cnt-svg-css-inclusion">For the purposes of
 								styling SVG embedded in XHTML Content Documents <em>by inclusion</em>, Reading Systems
@@ -776,7 +801,7 @@
 								<p>SVG included <em>by reference</em> is processed as a separate document, and can
 									include its own CSS style rules just like an <a>SVG Content Document</a> would. Note
 									that this is consistent with situations where an [[HTML]] <a
-										data-cite="html#the-object-element"><code>object</code></a> element references
+										data-cite="html#the-object-element"><code>object</code> element</a> references
 									an external [[HTML]] element.</p>
 							</div>
 						</section>
@@ -842,7 +867,8 @@
 					</li>
 					<li>
 						<p id="confreq-css-rs-fonts">MUST support [[TrueType]], [[OpenType]], [[WOFF]] and [[WOFF2]]
-							font resources referenced from <code>@font-face</code> rules.</p>
+							font resources referenced from <a data-cite="css-fonts-4#font-face-rule"
+									><code>@font-face</code> rules</a> [[CSS-FONTS-4]].</p>
 					</li>
 					<li>
 						<p id="confreq-css-rs-prefixed"
@@ -934,10 +960,11 @@
 
 					<li>
 						<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to modify
-							the DOM of the host EPUB Content Document or other contents in the EPUB Publication and MUST
-							NOT allow it to manipulate the size of its containing rectangle. (Note: Even if a script is
-							not container-constrained, the Reading System MAY impose restrictions on modifications (see
-							also the <a href="#feature-dom-manipulation">dom-manipulation feature</a>).)</p>
+							the [[DOM]] of the host EPUB Content Document or other contents in the EPUB Publication and
+							MUST NOT allow it to manipulate the size of its containing rectangle. (Note: Even if a
+							script is not container-constrained, the Reading System MAY impose restrictions on
+							modifications (see also the <a href="#feature-dom-manipulation">dom-manipulation
+							feature</a>).)</p>
 					</li>
 					<li>
 						<p id="confreq-rs-scripted-limit">It MAY place additional limitations on the capabilities
@@ -966,14 +993,15 @@
 				<section id="sec-local-storage">
 					<h4>Local Storage</h4>
 
-					<p>Scripts may save persistent data through cookies and DOM storage, but Reading Systems MAY block
-						such attempts. Reading Systems that allow users to store data MUST ensure they do not make that
-						data available to other unrelated documents (e.g., ones that could be spoofed). In particular,
+					<p>Scripts may save persistent data through <a data-cite="html#dom-document-cookie">cookies</a> and
+							<a data-cite="html#webstorage">web storage</a> [[HTML]], but Reading Systems MAY block such
+						attempts. Reading Systems that allow users to store data MUST ensure they do not make that data
+						available to other unrelated documents (e.g., ones that could be spoofed). In particular,
 						checking for a matching document identifier (or similar metadata) is not a valid method to
 						control access to persistent data.</p>
 
-					<p>Reading Systems that allow local storage SHOULD provide methods for users to inspect or delete
-						that data.</p>
+					<p>Reading Systems that allow <a data-cite="html#dom-localstorage">local storage</a> [[HTML]] SHOULD
+						provide methods for users to inspect or delete that data.</p>
 				</section>
 
 				<section id="sec-scripted-content-events">
@@ -1029,14 +1057,16 @@
 						Systems establish a unique <a data-cite="url#origin">origin</a> [[URL]] allocated to each
 							<a>EPUB Publication</a> (see <a href="#sec-container-iri"></a>). Assigning a unique origin
 						ensures that <a data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> [[EPUB-33]] are
-						isolated from other EPUB Publications, and limits access to cookies, DOM storage, etc.</p>
+						isolated from other EPUB Publications, and limits access to <a
+							data-cite="html#dom-document-cookie">cookies</a> [[HTML]], <a data-cite="html#webstorage"
+							>web storage</a> [[HTML]], etc.</p>
 
-					<p>Examples of web APIs that are tied to the concept of "origin" include Web Storage [[WEBSTORAGE]]
-						and IndexedDB [[INDEXEDDB]], which EPUB Content Documents can interact with via scripting.
-						Reading Systems that allow users to add/remove publications from a managed library (their
-						"bookshelf") may maintain the publication's unique origin when the publication is removed and
-						subsequently re-imported into the content library. Conversely, Reading Systems may create a new
-						unique origin for every newly added publication.</p>
+					<p>Examples of web APIs that are tied to the concept of "origin" include web storage [[HTML]] and
+						IndexedDB [[INDEXEDDB]], which EPUB Content Documents can interact with via scripting. Reading
+						Systems that allow users to add/remove publications from a managed library (their "bookshelf")
+						may maintain the publication's unique origin when the publication is removed and subsequently
+						re-imported into the content library. Conversely, Reading Systems may create a new unique origin
+						for every newly added publication.</p>
 
 					<p>This specification also recommends that <a data-cite="epub-33#sec-scripted-container-constrained"
 							>container-constrained scripts</a> [[EPUB-33]] not be allowed to modify the DOM of the host
@@ -1109,9 +1139,9 @@
 					<h4>The <code>rendition:layout</code> Property</h4>
 
 					<p> The default value <code>reflowable</code> MUST be assumed by EPUB Reading Systems as the global
-						value if no meta element carrying this property occurs in the <a
-							data-cite="epub-33#elemdef-opf-metadata"><code>metadata</code> section</a> section
-						[[EPUB-33]]. </p>
+						value if no <a data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
+							data-cite="epub-33#layout"><code>rendition:layout</code> property</a> occurs in the <a
+							data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a> [[EPUB-33]]. </p>
 
 					<p id="layout-pre-paginated" data-tests="#fxl-layout-pre-paginated-spreads">When the
 							<code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading Systems
@@ -1128,12 +1158,13 @@
 						<dt id="def-layout-pre-paginated" data-tests="#fxl-layout-pre-paginated">pre-paginated</dt>
 						<dd>
 							<p>Reading Systems MUST produce exactly one page per spine <a
-									data-cite="epub-33#elemdef-spine-itemref"><code>itemref</code></a> [[EPUB-33]] when
-								rendering.</p>
+									data-cite="epub-33#elemdef-spine-itemref"><code>itemref</code> element</a>
+								[[EPUB-33]] when rendering.</p>
 						</dd>
 					</dl>
 
-					<p>When a spine <code>itemref</code> element's <code>properties</code> attribute contains an <a
+					<p>When a spine <code>itemref</code> element's <a data-cite="epub-33#attrdef-properties"
+								><code>properties</code> attribute</a> contains an <a
 							data-cite="epub-33#layout-overrides">override of the global rendition:layout property</a>
 						[[EPUB-33]], Reading Systems MUST follow the requirements for the override's global value when
 						displaying that spine item (e.g., a spine item that specifies <code>layout-prepaginated</code>
@@ -1144,9 +1175,10 @@
 					<h4>The <code>rendition:orientation</code> Property</h4>
 
 					<p id="fxl-orientation-default" data-tests="#fxl-orientation-default">The default value
-							<code>auto</code> MUST be assumed by EPUB Reading Systems as the global value if no
-							<code>meta</code> element carrying this property occurs in the <code>metadata</code>
-						section.</p>
+							<code>auto</code> MUST be assumed by EPUB Reading Systems as the global value if no <a
+							data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
+							data-cite="epub-33#orientation"><code>rendition:orientation</code> property</a> occurs in
+						the <a data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a> [[EPUB-33]].</p>
 
 					<p>The <code>rendition:orientation</code> property values have the following processing
 						requirements:</p>
@@ -1177,16 +1209,19 @@
 					<h4>The <code>rendition:spread</code> Property</h4>
 
 					<p id="fxl-spread-default" data-tests="#fxl-spread-default">The default value <code>auto</code> MUST
-						be assumed by EPUB Reading Systems as the global value if no <code>meta</code> element carrying
-						this property occurs in the <code>metadata</code> section.</p>
+						be assumed by EPUB Reading Systems as the global value if no <a
+							data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
+							data-cite="epub-33#spread"><code>rendition:spread</code> property</a> occurs in the <a
+							data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a> [[EPUB-33]].</p>
 
 					<p>The <code>rendition:spread</code> property values have the following processing requirements:</p>
 
 					<dl class="variablelist">
 						<dt id="def-spread-none" data-tests="#fxl-spread-none">none</dt>
 						<dd>
-							<p>Reading Systems MUST NOT incorporate spine items in a Synthetic Spread. Reading Systems
-								SHOULD create a single viewport positioned at the center of the screen.</p>
+							<p>Reading Systems MUST NOT incorporate spine items in a <a>Synthetic Spread</a>. Reading
+								Systems SHOULD create a single <a>Viewport</a> positioned at the center of the
+								screen.</p>
 						</dd>
 						<dt id="def-spread-landscape" data-tests="#fxl-spread-landscape">landscape</dt>
 						<dd>
@@ -1213,16 +1248,17 @@
 				<section id="page-spread">
 					<h4>The <code>rendition:page-spread-*</code> Properties</h4>
 
-					<p>The <span id="page-spread-left" data-tests="#fxl-page-spread-left"
-								><code>rendition:page-spread-left</code></span> property indicates that the given spine
-						item SHOULD be rendered in the left-hand slot in the spread, and <span id="page-spread-right"
-								><code>rendition:page-spread-right</code></span> that it SHOULD be rendered in the
-						right-hand slot.</p>
+					<p>The <a data-cite="epub-33#fxl-page-spread-left"><span id="page-spread-left"
+								data-tests="#fxl-page-spread-left"><code>rendition:page-spread-left</code></span>
+							property</a> [[EPUB-33]] indicates that the given spine item SHOULD be rendered in the
+						left-hand slot in the spread, and <a data-cite="epub-33#fxl-page-spread-right"><span
+								id="page-spread-right"><code>rendition:page-spread-right</code></span> property</a>
+						[[EPUB-33]] that it SHOULD be rendered in the right-hand slot.</p>
 
 					<p>Reading Systems that support the <a href="#def-spread-none"><code>spread-none</code> property</a>
-						MUST recognize the <span id="page-spread-center"
-							><code>rendition:page-spread-center</code></span> as an alias for it, otherwise they MUST
-						ignore the <code>rendition:page-spread-center</code> property.</p>
+						MUST recognize the <a data-cite="epub-33#fxl-page-spread-center"><span id="page-spread-center"
+									><code>rendition:page-spread-center</code></span> property</a> as an alias for it,
+						otherwise they MUST ignore the <code>rendition:page-spread-center</code> property.</p>
 
 					<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 						properties apply to both pre-paginated and reflowable content, and they only apply when the
@@ -1238,18 +1274,18 @@
 							>reflowable</a> spine item follows a <a href="#def-layout-pre-paginated">pre-paginated</a>
 						one, the reflowable one SHOULD start on the next page &#8212; as defined by the <a
 							data-cite="epub-33#attrdef-spine-page-progression-direction"
-								><code>page-progression-direction</code></a> [[EPUB-33]] &#8212; when it lacks a
-							<code>rendition:page-spread-*</code> property value.</p>
+								><code>page-progression-direction</code> attribute</a> [[EPUB-33]] &#8212; when it lacks
+						a <code>rendition:page-spread-*</code> property value.</p>
 
 					<p id="page-spread-flow" data-tests="#page-layout-both-flow">If the reflowable spine item has a
 							<code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by inserting a
 						blank page).</p>
 
 					<p>Similarly, when a pre-paginated spine item follows a reflowable one, the pre-paginated one SHOULD
-						start on the next page (as defined by the <code>page-progression-direction</code>) when it lacks
-						a <code>rendition:page-spread-*</code> property value. If the pre-paginated spine item has a
-							<code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by inserting a
-						blank page).</p>
+						start on the next page (as defined by the <code>page-progression-direction</code> attribute)
+						when it lacks a <code>rendition:page-spread-*</code> property value. If the pre-paginated spine
+						item has a <code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by
+						inserting a blank page).</p>
 
 					<p id="fxl-page-spread-combined" data-tests="#fxl-page-spread-combined">When a Reading System
 						encounters two spine items that represent a true spread (i.e., two adjacent spine items with the
@@ -1313,10 +1349,10 @@
 				process the <a data-cite="epub-33#sec-ocf">EPUB Container</a> [[EPUB-33]].</p>
 
 			<div class="note">
-				<p>An application that processes OCF Containers does not have to be a full-fledged Reading System (e.g.,
-					an application might only extract the content of a container or check the validity of the packaged
-					content). In these cases, developers of such applications can ignore the rendering requirements for
-					Reading Systems defined in this section.</p>
+				<p>An application that processes EPUB Containers does not have to be a full-fledged Reading System
+					(e.g., an application might only extract the content of a container or check the validity of the
+					packaged content). In these cases, developers of such applications can ignore the rendering
+					requirements for Reading Systems defined in this section.</p>
 			</div>
 
 			<section id="sec-container-abstract">
@@ -1326,10 +1362,10 @@
 					<h4>URL of the Root Directory</h4>
 
 					<p id="sec-container-iri-root"
-						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative"> Reading Systems MUST
+						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">Reading Systems MUST
 						assign a URL [[URL]] to the <a>Root Directory</a> of the <a>OCF Abstract Container</a>. This URL
-						is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a>. It is
-						implementation specific, but the implementation MUST have the following properties:</p>
+						is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a> [[EPUB-33]].
+						It is implementation specific, but the implementation MUST have the following properties:</p>
 
 					<ul>
 						<li id="sec-container-iri-root-parse"
@@ -1345,7 +1381,7 @@
 
 						<li id="sec-container-iri-origin" data-tests="#ocf-url_origin">The <a data-cite="url#origin"
 								>origin</a> of the <a>container root URL</a> is unique for each user-specific instance
-							of an EPUB Publication in a Reading System.</li>
+							of an <a>EPUB Publication</a> in a Reading System.</li>
 					</ul>
 
 					<p class="note">The unicity of the <a data-cite="url#origin">origin</a> per each user-specific
@@ -1459,9 +1495,10 @@
 								</tr>
 							</tbody>
 						</table>
-						<p> Note that the last two links are <a data-cite="epub-33#urls-in-ocf-constraints"
+
+						<p>Note that the last two links are <a data-cite="epub-33#urls-in-ocf-constraints"
 								>disallowed</a> in an EPUB Publications to ensure better interoperability with
-							non-conforming or legacy Reading Systems and toolchains. </p>
+							non-conforming or legacy Reading Systems and toolchains.</p>
 					</div>
 
 					<div class="note">
@@ -1470,12 +1507,13 @@
 							for content in that particular language.</p>
 					</div>
 
-					<p class="note">Unlike most language specifications, Reading Systems must use the <a>container root
-							URL</a> as the <a data-cite="url#concept-base-url">base URL</a> [[URL]] for all files within
-						the <code>META-INF</code> directory. See also the section on <a
-							data-cite="epub-33#sec-parsing-urls-metainf">Parsing URLs in the <code>META-INF</code>
-							Directory</a> in [[!EPUB-33]]. </p>
-
+					<div class="note">
+						<p>Unlike most language specifications, Reading Systems must use the <a>container root URL</a>
+							as the <a data-cite="url#concept-base-url">base URL</a> [[URL]] for all files within the
+								<code>META-INF</code> directory. See also the section on <a
+								data-cite="epub-33#sec-parsing-urls-metainf">Parsing URLs in the <code>META-INF</code>
+								Directory</a> in [[!EPUB-33]]. </p>
+					</div>
 				</section>
 
 				<section id="sec-container-filenames">
@@ -1483,7 +1521,7 @@
 
 					<p>Although EPUB Creators are required to follow various <a
 							data-cite="epub-33#sec-container-filenames">File Name and File Path restrictions</a>
-						[[!EPUB-33]] for maximum interoperability, Reading Systems SHOULD attempt to process File Names
+						[[EPUB-33]] for maximum interoperability, Reading Systems SHOULD attempt to process File Names
 						and Paths that are not valid to these requirements. Invalid File Names and Paths may only be
 						problematic on some operating systems.</p>
 
@@ -1503,27 +1541,34 @@
 						<dd>
 							<p id="container-default-rendition"
 								data-tests="#ocf-package_arbitrary,#ocf-package_multiple">A Reading System MUST, by
-								default, use the Package Document referenced from first <code>rootfile</code> element to
-								render the EPUB Publication. If the Reading System recognizes a means of selecting from
-								the other available options, it MAY choose a more appropriate Package Document.</p>
+								default, use the <a>Package Document</a> referenced from first <a
+									data-cite="epub-33#sec-container.xml-rootfile-elem"><code>rootfile</code>
+									element</a> [[EPUB-33]] to render the <a>EPUB Publication</a>. If the Reading System
+								recognizes a means of selecting from the other available options, it MAY choose a more
+								appropriate Package Document.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-metadata.xml">Metadata File (<code>metadata.xml</code>)</dt>
 						<dd>
-							<p>Reading Systems SHOULD ignore <code>metadata.xml</code> files with unrecognized root
+							<p>Reading Systems SHOULD ignore <a data-cite="epub-33#sec-container-metainf-metadata.xml"
+										><code>metadata.xml</code> files</a> [[EPUB-33]] with unrecognized root
 								elements.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-encryption.xml">Encryption File (<code>encryption.xml</code>)</dt>
 						<dd>
-							<p>Reading Systems MUST only decrypt data encrypted after signing before computing the
-								digest used to validate the signature.</p>
+							<p>Before computing the digest used to validate the signature in the <a
+									data-cite="epub-33#sec-container-metainf-encryption.xml"><code>encryption.xml</code>
+									file</a> [[EPUB-33]], Reading Systems MUST decrypt any data encrypted after signing
+								&#8212; data encrypted before signing MUST NOT be decrypted.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-manifest.xml">Manifest File (<code>manifest.xml</code>)</dt>
 						<dd>
 							<p>Reading Systems MUST NOT use ancillary manifest information contained in the ZIP archive
-								or in the <code>manifest.xml</code> file for processing an EPUB Publication.</p>
+								or in the <a data-cite="epub-33#sec-container-metainf-manifest.xml"
+										><code>manifest.xml</code> file</a> [[EPUB-33]] for processing an <a>EPUB
+									Publication</a>.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-inc">Other Files</dt>
@@ -1543,18 +1588,18 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-zip-mult">MUST treat any OCF Containers that specify the ZIP file is split across
-							multiple storage media as in error.</p>
+						<p id="confreq-zip-mult">MUST treat any OCF Containers that specify the [[ZIP]] file is split
+							across multiple storage media as in error.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-comp">MUST treat any OCF Containers that use compression techniques other
-							than Deflate as in error.</p>
+							than Deflate [[RFC1951]] as in error.</p>
 					</li>
 					<li>
-						<p id="confreq-zip-64">MUST support the ZIP64 extensions defined as "Version 1".</p>
+						<p id="confreq-zip-64">MUST support the ZIP64 extensions defined as "Version 1" [[ZIP]].</p>
 					</li>
 					<li>
-						<p id="confreq-zip-enc">MUST treat OCF ZIP Containers that use ZIP encryption features as in
+						<p id="confreq-zip-enc">MUST treat OCF ZIP Containers that use [[ZIP]] encryption features as in
 							error.</p>
 					</li>
 					<li>
@@ -1577,15 +1622,17 @@
 					<li>
 						<p id="confreq-zip-fld-version">MUST treat <code>version needed to extract</code> field values
 							other than <code>10</code>, <code>20</code> or <code>45</code> in the local file header
-							table as being in error.</p>
+							table [[ZIP]] as being in error.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-fld-comp">MUST treat <code>compression</code> method field values other than
-								<code>0</code> or <code>8</code> in the local file header table as being in error.</p>
+								<code>0</code> or <code>8</code> in the local file header table [[ZIP]] as being in
+							error.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-fld-er">MUST treat OCF ZIP Containers with an <code>Archive decryption
-								header</code> or an <code>Archive extra data record</code> as being in error.</p>
+								header</code> or an <code>Archive extra data record</code> [[ZIP]] as being in
+							error.</p>
 					</li>
 				</ul>
 			</section>
@@ -1594,7 +1641,7 @@
 				<h3>Font Obfuscation</h3>
 
 				<p id="confreq-ocf-fobfus">Reading Systems SHOULD support deobfuscation of fonts as defined in <a
-						data-cite="epub-33#sec-font-obfuscation"><em>Font Obfuscation</em></a> [[EPUB-33]].</p>
+						data-cite="epub-33#sec-font-obfuscation">Font Obfuscation</a> [[EPUB-33]].</p>
 
 				<p>For Reading Systems to get the original obfuscated data back, simply reverse the process: the source
 					file becomes the obfuscated data, and the destination file contains the raw data.</p>
@@ -1614,16 +1661,20 @@
 			<p id="confreq-rs-epub3-mo" class="support">Reading Systems with the capability to render prerecorded audio
 				SHOULD support <a data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[EPUB-33]].</p>
 
-			<p>If a Reading System does not support Media Overlays, it MUST ignore both the <code>media-overlay</code>
-				attribute on <a>Manifest</a>
-				<a data-cite="epub-33#elemdef-package-item"><code>item</code> elements</a> [[EPUB-33]] and the manifest
-					<code>item</code> elements where the <code>media-type</code> attribute value equals
-					<code>application/smil+xml</code>.</p>
+			<p>If a Reading System does not support Media Overlays, it MUST ignore both:</p>
+
+			<ul>
+				<li>the <a data-cite="epub-33#attrdef-item-media-overlay"><code>media-overlay</code> attribute</a> on
+						<a>manifest</a>
+					<a data-cite="epub-33#elemdef-package-item"><code>item</code> elements</a> [[EPUB-33]]; and</li>
+				<li><code>item</code> elements where the <code>media-type</code> attribute value equals
+						<code>application/smil+xml</code>.</li>
+			</ul>
 
 			<section id="sec-behaviors-loading">
 				<h4>Loading the Media Overlay</h4>
 
-				<p>When a Reading System loads a <a>Package Document</a>, it MUST refer to the <a>Manifest</a>
+				<p>When a Reading System loads a <a>Package Document</a>, it MUST refer to the <a>manifest</a>
 					<a data-cite="epub-33#elemdef-package-item"><code>item</code> elements'</a> [[EPUB-33]]
 						<code>media-overlay</code> attributes to discover the corresponding Media Overlays for <a>EPUB
 						Content Documents</a>.</p>
@@ -1661,26 +1712,26 @@
 					<h5>Rendering Audio</h5>
 
 					<p>When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
-							element</a> [[EPUB-33]], Reading Systems MUST play the audio resource referenced by the
-							<code>src</code> attribute, starting at the clip offset time given by the <a
-							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> [[EPUB-33]]
-						and ending at the clip offset time given by the <a data-cite="epub-33#attrdef-smil-clipEnd"
+							element</a>, Reading Systems MUST play the audio resource referenced by the <code>src</code>
+						attribute, starting at the clip offset time given by the <a
+							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> and ending
+						at the clip offset time given by the <a data-cite="epub-33#attrdef-smil-clipEnd"
 								><code>clipEnd</code> attribute</a> [[EPUB-33]].</p>
 
 					<p>In addition:</p>
 
 					<ul>
 						<li id="mol-audio-no-clipbegin" data-tests="#mol-audio-no-clipbegin">
-							<p>If the EPUB Creator has not specified a <code>clipBegin</code>, Reading Systems MUST
-								assume the value "<code>0</code>".</p>
+							<p>If the EPUB Creator has not specified a <code>clipBegin</code> attribute, Reading Systems
+								MUST assume the value "<code>0</code>".</p>
 						</li>
 						<li id="mol-audio-no-clipend" data-tests="#mol-audio-no-clipend">
-							<p>If the EPUB Creator has not specified a <code>clipEnd</code>, Reading Systems MUST assume
-								the value to be the full duration of the physical media.</p>
+							<p>If the EPUB Creator has not specified a <code>clipEnd</code> attribute, Reading Systems
+								MUST assume the value to be the full duration of the physical media.</p>
 						</li>
 						<li id="mol-audio-exceeding-clipend" data-tests="#mol-audio-exceeding-clipend">
-							<p>If <code>clipEnd</code> exceeds the full duration of the physical media, Reading Systems
-								MUST assume its value to be the full duration of the physical media.</p>
+							<p>If the value of <code>clipEnd</code> exceeds the full duration of the physical media,
+								Reading Systems MUST assume its value to be the full duration of the physical media.</p>
 						</li>
 					</ul>
 
@@ -1694,7 +1745,7 @@
 					<h5>Rendering EPUB Content Document Elements</h5>
 
 					<p>When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-text"><code>text</code>
-							element</a> [[!EPUB-33]] whose <code>src</code> attribute contains a <a
+							element</a> [[EPUB-33]] whose <code>src</code> attribute contains a <a
 							data-cite="url#url-fragment-string">URL-fragment string</a> referencing a specific part of
 						an EPUB Content Document, Reading Systems SHOULD ensure the referenced portion is visible in the
 							<a>Viewport</a>. In addition to [[HTML]] element ID references and <a
@@ -1734,15 +1785,15 @@
 
 					<p>This same approach allows for synchronizing the Media Overlay playback with user selection of a
 						navigation point in the <a>EPUB Navigation Document</a>. The Reading System loads the Media
-						Overlay for that file and finds the correct point for starting playback based on the ID [[XML]]
-						of the navigation point target.</p>
+						Overlay for that file and finds the correct point for starting playback based on the ID of the
+						navigation point target.</p>
 
 					<div class="note">
-						<p>EPUB Creators may associate a Media Overlay Document directly with a Navigation Document in
-							order to provide synchronized playback of its contents, regardless of whether the <a>XHTML
-								Content Document</a> in which it resides is included in the <a>spine</a>. See <a
-								data-cite="epub-33#sec-nav-doc"><em>EPUB Navigation Document</em></a> [[EPUB-33]] for
-							more information.</p>
+						<p>EPUB Creators may associate a Media Overlay Document directly with an <a>EPUB Navigation
+								Document</a> in order to provide synchronized playback of its contents, regardless of
+							whether the <a>XHTML Content Document</a> in which it resides is included in the
+								<a>spine</a>. See <a data-cite="epub-33#sec-nav-doc">EPUB Navigation Document</a>
+							[[EPUB-33]] for more information.</p>
 					</div>
 
 					<div class="note" id="note-table-reading-mode">
@@ -1859,7 +1910,6 @@
 								stream (possibly displaying the poster image specified using the [[HTML]] markup).</p>
 						</li>
 					</ul>
-
 				</section>
 
 				<section id="sec-text-to-speech">
@@ -1953,10 +2003,11 @@
 			<dl class="conformance-list">
 				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
 				<dd>
-					<p>Reading Systems MUST resolve all reserved prefixes used in Package Documents using their
-						predefined URLs unless the EPUB Creator declares a local <a href="#sec-prefix-attr">prefix</a>.
-						Reading Systems MUST use the URLs defined for locally overridden prefixes (using the
-							<code>prefix</code> attribute) when encountered.</p>
+					<p>Reading Systems MUST resolve all <a data-cite="epub-33#sec-reserved-prefixes">reserved
+							prefixes</a> [[EPUB-33]] used in Package Documents using their predefined URLs unless the
+						EPUB Creator declares a local <a href="#sec-prefix-attr">prefix</a>. Reading Systems MUST use
+						the URLs defined for locally overridden prefixes (using the <code>prefix</code> attribute) when
+						encountered.</p>
 					<p>As changes to the reserved prefixes and updates to Reading Systems are not always going happen in
 						synchrony, Reading Systems MUST NOT fail when encountering unrecognized prefixes (i.e., not
 						reserved and not declared using the <code>prefix</code> attribute).</p>
@@ -1972,7 +2023,8 @@
 
 				<dt id="sec-property-datatype">Expanding <code>property</code> Data Types</dt>
 				<dd>
-					<p>Reading Systems MUST expand <code>property</code> values as follows:</p>
+					<p>Reading Systems MUST expand <a data-cite="epub-33#sec-property-datatype"><code>property</code>
+							values</a> [[EPUB-33]] as follows:</p>
 					<ul>
 						<li>
 							<p>If the property consists only of a reference, concatenate the prefix URL associated with
@@ -2006,12 +2058,14 @@
 			<section id="flow">
 				<h5>The <code>rendition:flow</code> Property</h5>
 
-				<p>If a Reading System supports the specified rendering, it SHOULD use that method to handle overflow
-					content, but MAY provide the option for users to override the requested rendering.</p>
+				<p>If a Reading System supports the rendering defined in a <a data-cite="epub-33#flow"
+							><code>rendition:flow</code> property</a> [[EPUB-33]], it SHOULD use that method to handle
+					overflow content but MAY provide the option for users to override the requested rendering.</p>
 
-				<p>The default global value is <code>auto</code> if no <code>meta</code> element carrying this property
-					occurs in the <a data-cite="epub-33#elemdef-opf-metadata"><code>metadata</code> section</a>
-					[[EPUB-33]]. Reading Systems MAY support only this default value.</p>
+				<p>The default global value is <code>auto</code> if no <a data-cite="epub-33#sec-meta-elem"
+							><code>meta</code> element</a> carrying this property occurs in the <a
+						data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a> [[EPUB-33]]. Reading
+					Systems MAY support only this default value.</p>
 
 				<p>The <code>rendition:flow</code> property values have the following processing requirements:</p>
 
@@ -2022,15 +2076,15 @@
 					</dd>
 					<dt id="scrolled-continuous">scrolled-continuous</dt>
 					<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
-						<p>The Reading System SHOULD render all Content Documents such that overflow content is
+						<p>The Reading System SHOULD render all EPUB Content Documents such that overflow content is
 							scrollable, and SHOULD present the EPUB Publication as one continuous scroll from spine item
 							to spine item (except where <a data-cite="epub-33#layout-property-flow-overrides">locally
 								overridden</a> [[EPUB-33]]).</p>
 					</dd>
 					<dt id="scrolled-doc">scrolled-doc</dt>
 					<dd id="scrolled-doc-dd" data-tests="#pkg-flow-scrolled-doc">
-						<p>The Reading System SHOULD render all Content Documents such that users can scroll overflow
-							content, and SHOULD present each spine item as a separate scrollable document.</p>
+						<p>The Reading System SHOULD render all EPUB Content Documents such that users can scroll
+							overflow content, and SHOULD present each spine item as a separate scrollable document.</p>
 					</dd>
 					<dt id="auto">auto</dt>
 					<dd>
@@ -2039,12 +2093,13 @@
 					</dd>
 				</dl>
 
-				<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction MUST be
-					defined relative to the block flow direction of the root element of the XHTML Content Document
-					referenced by the <a data-cite="epub-33#elemdef-spine-itemref"><code>itemref</code> element</a>
-					[[EPUB-33]]. The scroll direction MUST be vertical if the block flow direction is downward
-					(top-to-bottom). It MUST be horizontal if the block flow direction of the root element is rightward
-					(left-to-right) or leftward (right-to-left).</p>
+				<p>For the <a data-cite="epub-33#flow-scrolled-continuous"
+							><code>rendition:flow-scrolled-continuous</code> override property</a>, the scroll direction
+					MUST be defined relative to the block flow direction of the root element of the XHTML Content
+					Document referenced by the <a data-cite="epub-33#elemdef-spine-itemref"><code>itemref</code>
+						element</a> [[EPUB-33]]. The scroll direction MUST be vertical if the block flow direction is
+					downward (top-to-bottom). It MUST be horizontal if the block flow direction of the root element is
+					rightward (left-to-right) or leftward (right-to-left).</p>
 
 				<p>Reading Systems MUST ignore the <code>rendition:flow</code> property and its overrides when
 					processing <a data-cite="epub-33#def-layout-pre-paginated">pre-paginated spine items</a>
@@ -2054,10 +2109,10 @@
 			<section id="align-x-center">
 				<h5>The <code>rendition:align-x-center</code> Property</h5>
 
-				<p>When the <a href="#align-x-center"><code>rendition:align-x-center</code> property</a> is set on a
-					spine item, Reading Systems SHOULD render the content centered horizontally within the
-						<a>Viewport</a> or spread, as applicable. This property does not affect the rendering of the
-					spine item, only the placement of the resulting content box.</p>
+				<p>When the <a data-cite="epub-33#align-x-center"><code>rendition:align-x-center</code> property</a>
+					[[EPUB-33]] is set on a <a>spine</a> item, Reading Systems SHOULD render the content centered
+					horizontally within the <a>Viewport</a> or spread, as applicable. This property does not affect the
+					rendering of the spine item, only the placement of the resulting content box.</p>
 
 				<p>For reflowable content, Reading Systems that support this property MUST center each virtual page.</p>
 
@@ -2070,8 +2125,9 @@
 			<h3>Backward Compatibility</h3>
 
 			<p id="confreq-rs-backward-epub" data-tests="#pkg-version-backward">Reading Systems MUST attempt to process
-				an EPUB Publication whose Package Document <code>version</code> attribute is less than
-				"<code>3.0</code>".</p>
+				an <a>EPUB Publication</a> whose <a>Package Document</a>
+				<a data-cite="epub-33#attrdef-package-version"><code>version</code> attribute</a> [[EPUB-33]] is less
+				than "<code>3.0</code>".</p>
 
 			<p id="confreq-rs-backward-conf">EPUB Publications with older version numbers will not always render exactly
 				as intended unless processed according to their respective specifications. Reading Systems SHOULD
@@ -2080,8 +2136,10 @@
 		<section id="sec-epub-rs-conf-forward">
 			<h3>Forward Compatibility</h3>
 
-			<p id="confreq-rs-forward-epubn">Reading Systems SHOULD attempt to process an EPUB Publication whose Package
-				Document <code>version</code> attribute is greater than "<code>3.0</code>".</p>
+			<p id="confreq-rs-forward-epubn">Reading Systems SHOULD attempt to process an <a>EPUB Publication</a> whose
+					<a>Package Document</a>
+				<a data-cite="epub-33#attrdef-package-version"><code>version</code> attribute</a> [[EPUB-33]] is greater
+				than "<code>3.0</code>".</p>
 		</section>
 		<section id="sec-accessibility" class="informative">
 			<h2>Accessibility</h2>
@@ -2233,8 +2291,8 @@
 					</dd>
 				</dl>
 
-				<p>Additionally, the security considerations that apply to XML [[XML]] and ZIP [[ZIP]] files also apply
-					to the <a data-cite="epub-33#sec-package-doc">Package Document</a> and the <a
+				<p>Additionally, the security considerations that apply to [[XML]] and [[ZIP]] files also apply to the
+						<a data-cite="epub-33#sec-package-doc">Package Document</a> and the <a
 						data-cite="epub-33#sec-ocf">Open Container Format</a>, respectively. See the "Security
 					Consideration" sections of the Media Type registrations for the <a
 						data-cite="epub-33#app-media-type-app-oebps-package"
@@ -2245,10 +2303,9 @@
 			<section id="security-privacy-recommendations">
 				<h3>Recommendations</h3>
 
-				<p>Arguably the strongest measure that Reading System developers can take for privacy is to specify the
-					data they intend to collect and use about the user and/or their reading behaviour and seek the
-					consent of users to obtain it. They should also allow personalization and control over this
-					information.</p>
+				<p>The strongest measure that Reading System developers can take for privacy is to specify the data they
+					intend to collect and use about the user and/or their reading behaviour and seek the consent of
+					users to obtain it. They should also allow personalization and control over this information.</p>
 
 				<p>If a Reading System allows users to store persistent data, especially personally identifiable
 					information, it must treat that data as sensitive.</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -297,11 +297,12 @@
 
 				<ul>
 					<li>the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a> [[XML]] for all XML
-						documents (e.g., the <a>Package Document</a> and <a>Media Overlay
-						Documents</a> [[EPUB-33]]).</li>
+						documents (e.g., the <a>Package Document</a>, <a>XHTML Content Documents</a>, <a>SVG Content
+							Documents</a>, and <a>Media Overlay Documents</a>).</li>
 
-					<li>the [[HTML]] <a data-cite="html#the-lang-and-xml:lang-attributes"><code>lang</code>
-							attribute</a> for <a>XHTML Content Documents</a> and <a>SVG Content Documents</a>.</li>
+					<li>the <code>lang</code> attribute for XHTML Content Documents and SVG Content Documents. (Refer to
+						respective "The 'lang' and 'xml:lang' attributes" sections in [[HTML]] and [[SVG]] for more
+						information.)</li>
 				</ul>
 
 				<p>Similarly, a Reading System MUST process, for all <a data-cite="epub-33#dfn-publication-resource"


### PR DESCRIPTION
The bulk of this PR is just adding linking across to the core spec, but I also added some other missing citations and links.

I also added the dc: prefix to all DC elements -- we had the prefix in the definition box names, oddly enough. I mention this in the existing authoring shorthands section in the core spec only. Since the RS spec references across, I don't see there's a need to add the same to that document. (This PR means we don't need to merge #2156.)

I also spotted a couple of normative-looking statements that weren't capitalized:
> a Reading System MUST use the language information associated with the resource to determine its language, not the metadata included in the link to the resource.
> 
> Reading Systems MAY support network access to `<a href="#sec-epub-rs-conf-remote-res">`retrieve remote resources`</a>` and to allow `<a>Scripted Content Documents</a>` to `<a href="#confreq-rs-scripted-limit">communicate with web-hosted APIs and retrieve resources</a>`.

- Reading Systems [preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/rs-refs-links/epub33/rs/index.html)
- Reading Systems [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/rs-refs-links/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2163.html" title="Last updated on Mar 31, 2022, 10:19 AM UTC (c1a191d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2163/c23ce7b...c1a191d.html" title="Last updated on Mar 31, 2022, 10:19 AM UTC (c1a191d)">Diff</a>