### PR TITLE
Minor updates/changes on the exit criteria description

### DIFF
--- a/epub33/reports/exit_criteria.html
+++ b/epub33/reports/exit_criteria.html
@@ -12,11 +12,9 @@
 
     </style>
     <script class="remove">
-        // All config options at https://respec.org/docs/
         var respecConfig = {
-            group: "epub",
-            wgPublicList: "public-epub-wg",
             specStatus: "base",
+            "latestVersion": "https://w3c.github.io/epub-specs/epub33/reports/exit_criteria.html",
             noRecTrack: true,
             editors: [{
                 name: "Ivan Herman",
@@ -44,7 +42,7 @@
         <ol>
             <li><a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB Reading Systems 3.3</a></li>
             <li><a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a></li>
-            <li><a href="https://w3c.github.io/epub-specs/epub33/a11y/"></a>EPUB Accessibility 1.1</li>
+            <li><a href="https://w3c.github.io/epub-specs/epub33/a11y/">EPUB Accessibility 1.1</a></li>
         </ol>
     </section>
     <section id="sotd">
@@ -66,7 +64,7 @@
         </p>
 
         <p>
-          Comprehensive testing would require to include the union of all HTML, SVG, or CSS tests both on the content side as well as the implementation side <em>as well as</em> testing the unique, EPUB 3.3 specific features. The industry standard checking tools, like <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> or <a href="https://daisy.github.io/ace/">ACE, by Daisy</a> indeed <em>include</em> standard, and externally developed, HTML, CSS, or accessibility checkers, which would check the validity or conformance of the Publication Resources. Similarly, today’s Reading Systems do not develop an HTML renderer themselves; they, rather, rely on external tools (typically a webview implementation) that can be assumed to conform to the relevant W3C specifications.
+          Comprehensive testing would require to include the union of all HTML, SVG, or CSS tests both on the content side as well as the implementation side <em>as well as</em> testing the unique, EPUB 3.3 specific features. The industry standard checking tools, like <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> or <a href="https://daisy.github.io/ace/">ACE, by Daisy</a> indeed include standard, and externally developed, HTML, CSS, or accessibility checkers, which would check the validity or conformance of the Publication Resources. Similarly, today’s Reading Systems do not develop an HTML renderer themselves; they, rather, rely on external tools (typically a webview implementation) that can be assumed to conform to the relevant W3C specifications.
         </p>
 
         <p>
@@ -91,11 +89,11 @@
             <h2 id="epub-3.3-reading-systems">EPUB 3.3 Reading Systems</h2>
 
             <p>
-              Interested implementers for the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> are provided with a <a href="https://github.com/w3c/epub-tests">test suite</a> that follows the examples of the web platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for all <em>MUST</em> statements, as well as for many <em>SHOULD</em> and for some <em>MAY</em> statements, that appear in the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> specification.
+              Interested implementers for the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> are provided with a <a href="https://w3c.github.io/epub-tests/">test suite</a> that follows the examples of the web platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for all <em>MUST</em> statements, as well as for many <em>SHOULD</em> and for some <em>MAY</em> statements, that appear in the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> specification.
             </p>
 
             <p>
-              The <a href="https://w3c.github.io/epub-tests/">test suite documentation</a> describes the individual tests, linking them to the relevant section(s) of the specifications. The <em>editors’ draft</em> (as opposed to the official, published version) also has a pull-down menu attached to each <em>MUST</em> statement providing the references to the relevant tests.
+              The <a href="https://w3c.github.io/epub-tests/">test suite documentation</a> describes the individual tests, linking them to the relevant section(s) of the specifications. The <a href="https://w3c.github.io/epub-specs/epub33/rs/"><em>editors’ draft</em></a> (as opposed to the official, published version) also has a pull-down menu attached to each <em>MUST</em> statement providing the references to the relevant tests.
             </p>
             <section>
                 <h3 id="exit-criteria-rs">Exit criteria</h3>
@@ -125,7 +123,7 @@
                 </li>
                 <li>
                     <p>
-                      Extra restrictions concerning content documents such as the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xhtml-deviations">restrictions on HTML</a>, the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-nav">format of an XHTML navigation document</a>, or the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xml-constraints">requirements on XML conformance</a>.
+                      Extra restrictions concerning content documents such as the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xhtml-deviations">restrictions on XHTML</a>, the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-nav">format of an XHTML navigation document</a>, or the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xml-constraints">requirements on XML conformance</a>.
                     </p>
                 </li>
                 <li>
@@ -145,12 +143,13 @@
                     </li>
                     <li>
                         <p>
-                          Testing the features in categories 2 and 3 concentrates on whether these restrictions are <em>feasible</em> in practice, i.e., whether they are enforceable when checking validity. The main tool to check this is <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>, which is being upgraded for EPUB 3.3, and whose earlier versions for EPUB 3.2 have been extensively used throughout the industry for several years now; EPUBCheck <em>must</em> be able to validate a valid EPUB 3.3 Publication as well as report an error or warning for invalid publications. The relevant tests themselves are part of the <a href="https://github.com/w3c/epub-tests">test suite</a> and reporting should be part of the <a href="https://w3c.github.io/epub-tests/results">implementation report</a>.
+                          Testing the features in categories 2 and 3 concentrates on whether these restrictions are <em>feasible</em> in practice, i.e., whether they are enforceable when checking validity. The main tool to check this is <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>, which is being upgraded for EPUB 3.3, and whose earlier versions for EPUB 3.2 have been extensively used throughout the industry for several years now; EPUBCheck <em>must</em> be able to validate a valid EPUB 3.3 Publication as well as report an error or warning for invalid publications. The relevant tests themselves are either part of the <a href="https://github.com/w3c/epub-tests">test suite</a> or will be provided in another, similar test suite documentation, with a
+                          corresponding implementation report.                          
                         </p>
                     </li>
                     <li>
                         <p>
-                          Testing the features in category 4 concentrates on vocabulary term <em>usage</em>, i.e., whether real-world publishers use those terms. Each term must have at least two independent publishers using those terms in production. The results of testing are available in a separate <span class="todo">implementation report to be done</span>.
+                          Testing the features in category 4 concentrates on vocabulary term <em>usage</em>, i.e., whether real-world publishers use those terms. Each term must have at least two independent publishers using those terms in production. The results of testing are available in a separate <a href="https://w3c.github.io/epub-specs/epub33/reports/epub-properties-use">implementation report</a>.
                         </p>
                     </li>
                 </ol>

--- a/epub33/reports/exit_criteria.html
+++ b/epub33/reports/exit_criteria.html
@@ -89,17 +89,17 @@
             <h2 id="epub-3.3-reading-systems">EPUB 3.3 Reading Systems</h2>
 
             <p>
-              Interested implementers for the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> are provided with a <a href="https://w3c.github.io/epub-tests/">test suite</a> that follows the examples of the web platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for all <em>MUST</em> statements, as well as for many <em>SHOULD</em> and for some <em>MAY</em> statements, that appear in the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> specification.
+              Interested implementers for the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> are provided with a <a href="https://w3c.github.io/epub-tests/">test suite</a> that follows the examples of the web platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for all <em style="font-variant: small-caps;">must</em> statements, as well as for many <em style="font-variant: small-caps;">should</em> and for some <em style="font-variant: small-caps;">may</em> statements, that appear in the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> specification.
             </p>
 
             <p>
-              The <a href="https://w3c.github.io/epub-tests/">test suite documentation</a> describes the individual tests, linking them to the relevant section(s) of the specifications. The <a href="https://w3c.github.io/epub-specs/epub33/rs/"><em>editors’ draft</em></a> (as opposed to the official, published version) also has a pull-down menu attached to each <em>MUST</em> statement providing the references to the relevant tests.
+              The <a href="https://w3c.github.io/epub-tests/">test suite documentation</a> describes the individual tests, linking them to the relevant section(s) of the specifications. The <a href="https://w3c.github.io/epub-specs/epub33/rs/"><em>editors’ draft</em></a> (as opposed to the official, published version) also has a pull-down menu attached to each <em style="font-variant: small-caps;">must</em> statement providing the references to the relevant tests.
             </p>
             <section>
                 <h3 id="exit-criteria-rs">Exit criteria</h3>
 
                 <p>
-                  The <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading System</a> document must have at least two passing, independent implementations for <a href="https://w3c.github.io/epub-tests/">each test</a> linked to a <em>MUST</em> statement in the specification. The results of testing are available in a separate <a href="https://w3c.github.io/epub-tests/results">implementation report</a>.
+                  The <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading System</a> document must have at least two passing, independent implementations for <a href="https://w3c.github.io/epub-tests/">each test</a> linked to a <em style="font-variant: small-caps;">must</em> statement in the specification. The results of testing are available in a separate <a href="https://w3c.github.io/epub-tests/results">implementation report</a>.
                 </p>
             </section>
         </section>

--- a/epub33/reports/exit_criteria.html
+++ b/epub33/reports/exit_criteria.html
@@ -177,11 +177,11 @@
                 <ol>
                     <li>
                         <p>
-                          Testing the features in category 1 tests whether these restrictions are <em>feasible</em> and <em>used</em> in practice. This is achieved by the requirement that at least 5 publishers will produce at least 1 EPUB each that conform to <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting-pub">EPUB-A11Y-11_WCAG-21-AA</a>.
+                          Testing the features in category 1 tests whether these restrictions are <em>feasible</em> and <em>used</em> in practice. This is achieved by the requirement that at least 5 publishers will produce at least 1 EPUB each that conform to <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting-pub">EPUB-A11Y-11_WCAG-20-AA</a>.
                         </p> 
                           
                         <p>
-                          Note that these conformance levels rely on each Publication Resource to be conform to WCAG 2.1 AA, when applicable; there are only a few EPUB specific features like page numbering. An EPUB Accessibility 1.1 Usage Report <span class="todo">to be done!!</span> shows that conformance table.
+                          Note that these conformance levels rely on each Publication Resource to be conform to WCAG 2.0 AA, when applicable; there are only a few EPUB specific features like page numbering. An EPUB Accessibility 1.1 Usage Report <span class="todo">to be done!!</span> shows that conformance table.
                         </p>
                     </li>
                     <li>


### PR DESCRIPTION
Only minor things, but a review of the text in general would be good

- See [preview](https://raw.githack.com/w3c/epub-specs/admin/exit-criteria-march-22/epub33/reports/exit_criteria.html)
- See [diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fepub-specs%2Fepub33%2Freports%2Fexit_criteria.html&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fepub-specs%2Fadmin%2Fexit-criteria-march-22%2Fepub33%2Freports%2Fexit_criteria.html)