### PR TITLE
Switch "error" to "no equivalent" for css mapping

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10298,7 +10298,7 @@ html.my-document-playing * {
 							</tr>
 							<tr>
 								<td><code>-epub-text-combine: horizontal &lt;number></code></td>
-								<td>Error</td>
+								<td><em>no equivalent</em></td>
 							</tr>
 						</tbody>
 					</table>


### PR DESCRIPTION
Fixes #2151


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2165.html" title="Last updated on Mar 30, 2022, 3:53 PM UTC (509aa4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2165/fde9119...509aa4b.html" title="Last updated on Mar 30, 2022, 3:53 PM UTC (509aa4b)">Diff</a>