### PR TITLE
Clean up def boxes (try 2)

### DIFF
--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -33,6 +33,15 @@ dl.conformance-list > dd {
     margin-top: 0.7em;
 }
 
+dl.elemdef > dt,
+table.propdef th {
+	font-weight: normal;
+	font-style: italic;
+}
+
+dl.elemdef > dt {
+	margin-bottom: 0.5em;
+}
 
 /* styles for conformance list links */
 
@@ -205,14 +214,14 @@ td[headers="tbl-cmt-appl"] {
 /****************************************************/
 
 /* ensure confomity of width for property tables */
-section.vocab table {
+table.propdef {
 	border-spacing: 0px;
 	border: none;
 	font-size: 1em;
 	width: 100%
 }
 
-section.vocab table td, table th {
+table.propdef td, table.propdef th {
 	border: none;
 	background-color: rgb(236,246,255);
 	color: rgb(0,0,0);
@@ -220,22 +229,22 @@ section.vocab table td, table th {
 	vertical-align: top;
 }
 
-section.vocab table th {
+table.propdef th {
     text-align: left;
 	vertical-align: top;
     width: 8em;
     border-right: 1px solid rgb(145,200,255);
 }
 
-section.vocab table th {
+table.propdef th {
     border-left: 5px solid rgb(145,200,255);
 }
 
-section.vocab td {
+table.propdef td {
     padding: 3px 3px 3px 10px;
 }
 
-section.vocab td > p:first-child {
+table.propdef td > p:first-child {
 	padding: 0em;
 	margin: 0em
 }

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1485,19 +1485,19 @@
 					<p>The <code>package</code> element is the root element of the <a>Package Document</a>.</p>
 
 					<dl id="elemdef-opf-package" class="elemdef">
-						<dt>Element Name</dt>
+						<dt>Element Name:</dt>
 						<dd>
 							<p>
 								<code>package</code>
 							</p>
 						</dd>
 
-						<dt>Usage</dt>
+						<dt>Usage:</dt>
 						<dd>
 							<p>The <code>package</code> element is the root element of the Package Document.</p>
 						</dd>
 
-						<dt>Attributes</dt>
+						<dt>Attributes:</dt>
 						<dd>
 							<ul class="nomark">
 								<li>
@@ -1551,7 +1551,7 @@
 							</ul>
 						</dd>
 
-						<dt>Content Model</dt>
+						<dt>Content Model:</dt>
 						<dd>
 							<p>In this order:</p>
 							<ul class="nomark">
@@ -1639,24 +1639,24 @@
 						<p>The <code>metadata</code> element encapsulates meta information.</p>
 
 						<dl id="elemdef-opf-metadata" class="elemdef">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>metadata</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>REQUIRED first child of <a href="#elemdef-opf-package"><code>package</code></a>.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<p>None</p>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>In any order:</p>
 								<ul class="nomark">
@@ -1813,27 +1813,27 @@
 									title="International Standard Book Number">ISBN</abbr>.</p>
 
 							<dl id="elemdef-opf-dcidentifier" class="elemdef">
-								<dt>Element Name</dt>
+								<dt>Element Name:</dt>
 								<dd>
 									<p>
 										<code>dc:identifier</code>
 									</p>
 								</dd>
 
-								<dt>Namespace</dt>
+								<dt>Namespace:</dt>
 								<dd>
 									<p>
 										<code>http://purl.org/dc/elements/1.1/</code>
 									</p>
 								</dd>
 
-								<dt>Usage</dt>
+								<dt>Usage:</dt>
 								<dd>
 									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
 												><code>metadata</code></a>. Repeatable.</p>
 								</dd>
 
-								<dt>Attributes</dt>
+								<dt>Attributes:</dt>
 								<dd>
 									<ul class="nomark">
 										<li>
@@ -1847,7 +1847,7 @@
 									</ul>
 								</dd>
 
-								<dt>Content Model</dt>
+								<dt>Content Model:</dt>
 								<dd>
 									<p>Text</p>
 								</dd>
@@ -1914,27 +1914,27 @@
 									<a>EPUB Publication</a>.</p>
 
 							<dl id="elemdef-opf-dctitle" class="elemdef">
-								<dt>Element Name</dt>
+								<dt>Element Name:</dt>
 								<dd>
 									<p>
 										<code>dc:title</code>
 									</p>
 								</dd>
 
-								<dt>Namespace</dt>
+								<dt>Namespace:</dt>
 								<dd>
 									<p>
 										<code>http://purl.org/dc/elements/1.1/</code>
 									</p>
 								</dd>
 
-								<dt>Usage</dt>
+								<dt>Usage:</dt>
 								<dd>
 									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
 												><code>metadata</code></a>. Repeatable.</p>
 								</dd>
 
-								<dt>Attributes</dt>
+								<dt>Attributes:</dt>
 								<dd>
 									<ul class="nomark">
 										<li>
@@ -1964,7 +1964,7 @@
 									</ul>
 								</dd>
 
-								<dt>Content Model</dt>
+								<dt>Content Model:</dt>
 								<dd>
 									<p>Text</p>
 								</dd>
@@ -2033,27 +2033,27 @@
 								the <a>EPUB Publication</a>.</p>
 
 							<dl id="elemdef-opf-dclanguage" class="elemdef">
-								<dt>Element Name</dt>
+								<dt>Element Name:</dt>
 								<dd>
 									<p>
 										<code>dc:language</code>
 									</p>
 								</dd>
 
-								<dt>Namespace</dt>
+								<dt>Namespace:</dt>
 								<dd>
 									<p>
 										<code>http://purl.org/dc/elements/1.1/</code>
 									</p>
 								</dd>
 
-								<dt>Usage</dt>
+								<dt>Usage:</dt>
 								<dd>
 									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
 												><code>metadata</code></a>. Repeatable.</p>
 								</dd>
 
-								<dt>Attributes</dt>
+								<dt>Attributes:</dt>
 								<dd>
 									<p>
 										<a href="#attrdef-id">
@@ -2063,7 +2063,7 @@
 									</p>
 								</dd>
 
-								<dt>Content Model</dt>
+								<dt>Content Model:</dt>
 								<dd>
 									<p>Text</p>
 								</dd>
@@ -2108,7 +2108,7 @@
 								following generalized definition:</p>
 
 							<dl class="elemdef">
-								<dt>Element Name</dt>
+								<dt>Element Name:</dt>
 								<dd>
 									<p>
 										<code>contributor</code> | <code>coverage</code> | <code>creator</code> |
@@ -2117,20 +2117,20 @@
 											<code>source</code> | <code>subject</code> | <code>type</code></p>
 								</dd>
 
-								<dt>Namespace</dt>
+								<dt>Namespace:</dt>
 								<dd>
 									<p>
 										<code>http://purl.org/dc/elements/1.1/</code>
 									</p>
 								</dd>
 
-								<dt>Usage</dt>
+								<dt>Usage:</dt>
 								<dd>
 									<p>OPTIONAL child of <a class="codelink" href="#elemdef-opf-metadata"
 												><code>metadata</code></a>. Repeatable.</p>
 								</dd>
 
-								<dt>Attributes</dt>
+								<dt>Attributes:</dt>
 								<dd>
 									<ul class="nomark">
 										<li>
@@ -2156,7 +2156,7 @@
 									</ul>
 								</dd>
 
-								<dt>Content Model</dt>
+								<dt>Content Model:</dt>
 								<dd>
 									<p>Text</p>
 								</dd>
@@ -2376,20 +2376,20 @@
 						<p>The <code>meta</code> element provides a generic means of including package metadata.</p>
 
 						<dl id="elemdef-meta" class="elemdef">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>meta</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>As child of the <a class="codelink" href="#elemdef-opf-metadata"
 											><code>metadata</code></a> element. Repeatable.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<ul class="nomark">
 									<li>
@@ -2443,7 +2443,7 @@
 								</ul>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>Text</p>
 							</dd>
@@ -2571,20 +2571,20 @@
 							metadata records.</p>
 
 						<dl id="elemdef-opf-link" class="elemdef">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>link</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>As a child of <a class="codelink" href="#elemdef-opf-metadata"
 										><code>metadata</code></a>. Repeatable.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<ul class="nomark">
 									<li>
@@ -2646,7 +2646,7 @@
 								</ul>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>Empty</p>
 							</dd>
@@ -2853,21 +2853,21 @@ XHTML:
 							used in the rendering of the content.</p>
 
 						<dl id="elemdef-opf-manifest" class="elemdef">
-							<dt>Element name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>manifest</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>REQUIRED second child of <a class="codelink" href="#elemdef-opf-package"
 											><code>package</code></a>, following <a class="codelink"
 										href="#elemdef-opf-metadata"><code>metadata</code></a>.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<p>
 									<a href="#attrdef-id">
@@ -2877,7 +2877,7 @@ XHTML:
 								</p>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>
 									<a class="codelink" href="#elemdef-package-item">
@@ -2909,20 +2909,20 @@ XHTML:
 						<p>The <code>item</code> element represents a <a>Publication Resource</a>.</p>
 
 						<dl id="elemdef-package-item" class="elemdef">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>item</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>As a child of <a class="codelink" href="#elemdef-opf-manifest"
 										><code>manifest</code></a>. Repeatable.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<ul class="nomark">
 									<li>
@@ -2975,7 +2975,7 @@ XHTML:
 									</li>
 								</ul>
 							</dd>
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>Empty</p>
 							</dd>
@@ -3428,21 +3428,21 @@ No Entry</pre>
 								>manifest <code>item</code> references</a> that represent the default reading order.</p>
 
 						<dl id="elemdef-opf-spine" class="elemdef">
-							<dt>Element name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>spine</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>REQUIRED third child of <a class="codelink" href="#elemdef-opf-package"
 											><code>package</code></a>, following <a class="codelink"
 										href="#elemdef-opf-manifest"><code>manifest</code></a>.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<ul class="nomark">
 									<li>
@@ -3473,7 +3473,7 @@ No Entry</pre>
 								</ul>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>
 									<a class="codelink" href="#elemdef-spine-itemref">
@@ -3535,20 +3535,20 @@ No Entry</pre>
 							reading order.</p>
 
 						<dl id="elemdef-spine-itemref" class="elemdef">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>itemref</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>As a child of <a class="codelink" href="#elemdef-opf-spine"><code>spine</code></a>.
 									Repeatable.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<ul class="nomark">
 									<li>
@@ -3586,7 +3586,7 @@ No Entry</pre>
 								</ul>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>Empty</p>
 							</dd>
@@ -3690,19 +3690,19 @@ No Entry</pre>
 						<p>The <code>collection</code> element defines a related group of resources.</p>
 
 						<dl id="elemdef-collection" class="elemdef">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>collection</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>OPTIONAL sixth element of <code>package</code>. Repeatable.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<ul class="nomark">
 									<li>
@@ -3740,7 +3740,7 @@ No Entry</pre>
 								</ul>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>In this order: <code>metadata</code>
 									<code>[0 or 1]</code>, ( <a href="#elemdef-collection"><code>collection</code></a>
@@ -4612,7 +4612,7 @@ No Entry</pre>
 					model of the element and its descendants as follows:</p>
 
 				<dl class="elemdef">
-					<dt>Content Model</dt>
+					<dt>Content Model:</dt>
 					<dd>
 						<dl class="variablelist">
 							<dt>
@@ -6615,19 +6615,19 @@ No Entry</pre>
 										<code>container.xml</code> file.</p>
 
 								<dl id="elemdef-container" class="elemdef">
-									<dt>Element Name</dt>
+									<dt>Element Name:</dt>
 									<dd>
 										<p>
 											<code>container</code>
 										</p>
 									</dd>
 
-									<dt>Usage</dt>
+									<dt>Usage:</dt>
 									<dd>
 										<p>Root element of the <code>container.xml</code> file.</p>
 									</dd>
 
-									<dt>Attributes</dt>
+									<dt>Attributes:</dt>
 									<dd>
 										<dl>
 											<dt>
@@ -6639,7 +6639,7 @@ No Entry</pre>
 										</dl>
 									</dd>
 
-									<dt>Content Model</dt>
+									<dt>Content Model:</dt>
 									<dd>
 										<p>In this order:</p>
 										<ul class="nomark">
@@ -6658,25 +6658,25 @@ No Entry</pre>
 									available in the <a>EPUB Container</a>.</p>
 
 								<dl id="elemdef-rootfiles" class="elemdef">
-									<dt>Element Name</dt>
+									<dt>Element Name:</dt>
 									<dd>
 										<p>
 											<code>rootfiles</code>
 										</p>
 									</dd>
 
-									<dt>Usage</dt>
+									<dt>Usage:</dt>
 									<dd>
 										<p>REQUIRED first child of <a href="#elemdef-container"
 												><code>container</code></a>.</p>
 									</dd>
 
-									<dt>Attributes</dt>
+									<dt>Attributes:</dt>
 									<dd>
 										<p>None</p>
 									</dd>
 
-									<dt>Content Model</dt>
+									<dt>Content Model:</dt>
 									<dd>
 										<ul class="nomark">
 											<li><a href="#elemdef-rootfile"><code>rootfile</code></a> [1 or more]</li>
@@ -6692,20 +6692,20 @@ No Entry</pre>
 										Document</a> in the <a>EPUB Container</a>.</p>
 
 								<dl id="elemdef-rootfile" class="elemdef">
-									<dt>Element Name</dt>
+									<dt>Element Name:</dt>
 									<dd>
 										<p>
 											<code>rootfile</code>
 										</p>
 									</dd>
 
-									<dt>Usage</dt>
+									<dt>Usage:</dt>
 									<dd>
 										<p>As child of the <a href="#elemdef-rootfiles"><code>rootfiles</code></a>
 											element. Repeatable.</p>
 									</dd>
 
-									<dt>Attributes</dt>
+									<dt>Attributes:</dt>
 									<dd>
 										<dl>
 											<dt>
@@ -6732,7 +6732,7 @@ No Entry</pre>
 										</dl>
 									</dd>
 
-									<dt>Content Model</dt>
+									<dt>Content Model:</dt>
 									<dd>
 										<p>Empty</p>
 									</dd>
@@ -6758,25 +6758,25 @@ No Entry</pre>
 									necessary for the processing of the <a>OCF ZIP Container</a>.</p>
 
 								<dl id="elemdef-links" class="elemdef">
-									<dt>Element Name</dt>
+									<dt>Element Name:</dt>
 									<dd>
 										<p>
 											<code>links</code>
 										</p>
 									</dd>
 
-									<dt>Usage</dt>
+									<dt>Usage:</dt>
 									<dd>
 										<p>OPTIONAL second child of <a href="#elemdef-container"
 												><code>container</code></a>. Repeatable.</p>
 									</dd>
 
-									<dt>Attributes</dt>
+									<dt>Attributes:</dt>
 									<dd>
 										<p>None</p>
 									</dd>
 
-									<dt>Content Model</dt>
+									<dt>Content Model:</dt>
 									<dd>
 										<ul class="nomark">
 											<li><a href="#elemdef-link"><code>link</code></a> [1 or more]</li>
@@ -6795,20 +6795,20 @@ No Entry</pre>
 								<h6>The <code>link</code> Element</h6>
 
 								<dl id="elemdef-link" class="elemdef">
-									<dt>Element Name</dt>
+									<dt>Element Name:</dt>
 									<dd>
 										<p>
 											<code>link</code>
 										</p>
 									</dd>
 
-									<dt>Usage</dt>
+									<dt>Usage:</dt>
 									<dd>
 										<p>As child of the <a href="#elemdef-links"><code>links</code></a> element.
 											Repeatable.</p>
 									</dd>
 
-									<dt>Attributes</dt>
+									<dt>Attributes:</dt>
 									<dd>
 										<dl>
 											<dt>
@@ -6845,7 +6845,7 @@ No Entry</pre>
 										</dl>
 									</dd>
 
-									<dt>Content Model</dt>
+									<dt>Content Model:</dt>
 									<dd>
 										<p>Empty</p>
 									</dd>
@@ -6881,29 +6881,29 @@ No Entry</pre>
 								<h6>The <code>encryption</code> element</h6>
 
 								<dl class="elemdef" id="elemdef-encryption">
-									<dt>Element Name</dt>
+									<dt>Element Name:</dt>
 									<dd>
 										<p>
 											<code>encryption</code>
 										</p>
 									</dd>
 
-									<dt>Namespace</dt>
+									<dt>Namespace:</dt>
 									<dd>
 										<p><code>urn:oasis:names:tc:opendocument:xmlns:container</code></p>
 									</dd>
 
-									<dt>Usage</dt>
+									<dt>Usage:</dt>
 									<dd>
 										<p>Root element of the <code>encryption.xml</code> file.</p>
 									</dd>
 
-									<dt>Attributes</dt>
+									<dt>Attributes:</dt>
 									<dd>
 										<p>None</p>
 									</dd>
 
-									<dt>Content Model</dt>
+									<dt>Content Model:</dt>
 									<dd>
 										<p>In any order:</p>
 										<ul class="nomark">
@@ -7055,26 +7055,26 @@ No Entry</pre>
 									resource (i.e., before encryption).</p>
 
 								<dl class="elemdef" id="elemdef-enc-Compression">
-									<dt>Element Name</dt>
+									<dt>Element Name:</dt>
 									<dd>
 										<p>
 											<code>Compression</code>
 										</p>
 									</dd>
 
-									<dt>Namespace</dt>
+									<dt>Namespace:</dt>
 									<dd>
 										<p>
 											<code>http://www.idpf.org/2016/encryption#compression</code>
 										</p>
 									</dd>
 
-									<dt>Usage</dt>
+									<dt>Usage:</dt>
 									<dd>
 										<p>OPTIONAL child of <code>EncryptionProperty</code>.</p>
 									</dd>
 
-									<dt>Attributes</dt>
+									<dt>Attributes:</dt>
 									<dd>
 										<dl class="variablelist">
 											<dt>Method <code>[required]</code></dt>
@@ -7092,7 +7092,7 @@ No Entry</pre>
 										</dl>
 									</dd>
 
-									<dt>Content Model</dt>
+									<dt>Content Model:</dt>
 									<dd>
 										<p>Empty</p>
 									</dd>
@@ -7189,29 +7189,29 @@ No Entry</pre>
 								<h6>The <code>signatures</code> element</h6>
 
 								<dl class="elemdef" id="elemdef-signatures">
-									<dt>Element Name</dt>
+									<dt>Element Name:</dt>
 									<dd>
 										<p>
 											<code>signatures</code>
 										</p>
 									</dd>
 
-									<dt>Namespace</dt>
+									<dt>Namespace:</dt>
 									<dd>
 										<p><code>urn:oasis:names:tc:opendocument:xmlns:container</code></p>
 									</dd>
 
-									<dt>Usage</dt>
+									<dt>Usage:</dt>
 									<dd>
 										<p>Root element of the <code>signature.xml</code> file.</p>
 									</dd>
 
-									<dt>Attributes</dt>
+									<dt>Attributes:</dt>
 									<dd>
 										<p>None</p>
 									</dd>
 
-									<dt>Content Model</dt>
+									<dt>Content Model:</dt>
 									<dd>
 										<ul class="nomark">
 											<li><code>Signature</code> [1 or more]</li>
@@ -7715,19 +7715,19 @@ No Entry</pre>
 						<p>The <code>smil</code> element is the root element of all Media Overlay Documents.</p>
 
 						<dl class="elemdef" id="elemdef-smil">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>smil</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>The <code>smil</code> element is the root element of the Media Overlay Document.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<dl>
 									<dt>
@@ -7761,7 +7761,7 @@ No Entry</pre>
 								</dl>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>In this order:</p>
 								<ul class="nomark">
@@ -7793,25 +7793,25 @@ No Entry</pre>
 							Document.</p>
 
 						<dl class="elemdef" id="elemdef-smil-head">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>head</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>The <code>head</code> element is the OPTIONAL first child of the <a
 										href="#elemdef-smil"><code>smil</code></a> element.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<p>None</p>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>
 									<a href="#elemdef-smil-metadata">
@@ -7834,24 +7834,24 @@ No Entry</pre>
 							metadata from any metainformation structuring language.</p>
 
 						<dl class="elemdef" id="elemdef-smil-metadata">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>metadata</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>As a child of the <a href="#elemdef-smil-head"><code>head</code></a> element.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<p>None</p>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p><code>[0 or more]</code> elements from any namespace</p>
 							</dd>
@@ -7869,21 +7869,21 @@ No Entry</pre>
 								<code>seq</code> elements.</p>
 
 						<dl class="elemdef" id="elemdef-smil-body">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>body</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>The <code>body</code> element is a REQUIRED child of the <a href="#elemdef-smil"
 											><code>smil</code></a> element. It follows the <a href="#elemdef-smil-head"
 											><code>head</code></a> element, when that element is present.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<dl>
 									<dt id="addrdef-smil-body-type">
@@ -7922,7 +7922,7 @@ No Entry</pre>
 								</dl>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>In any order:</p>
 								<ul class="nomark">
@@ -7955,21 +7955,21 @@ No Entry</pre>
 							time containers.</p>
 
 						<dl class="elemdef" id="elemdef-smil-seq">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>seq</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>One or more <code>seq</code> elements MAY occur as children of the <a
 										href="#elemdef-smil-body"><code>body</code> element</a> and of the <a
 										href="#elemdef-smil-seq"><code>seq</code> element</a>.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<dl>
 									<dt>
@@ -8010,7 +8010,7 @@ No Entry</pre>
 								</dl>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>In any order:</p>
 								<ul class="nomark">
@@ -8041,21 +8041,21 @@ No Entry</pre>
 						<p>The <code>par</code> element is a parallel time container for media objects.</p>
 
 						<dl class="elemdef" id="elemdef-smil-par">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>par</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>One or more <code>par</code> elements MAY occur as children of the <a
 										href="#elemdef-smil-body"><code>body</code></a> and <a href="#elemdef-smil-seq"
 											><code>seq</code></a> elements.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<dl>
 									<dt>
@@ -8081,7 +8081,7 @@ No Entry</pre>
 								</dl>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>In any order:</p>
 								<ul class="nomark">
@@ -8116,20 +8116,20 @@ No Entry</pre>
 							may be rendered via <a href="#sec-tts">text-to-speech</a>. </p>
 
 						<dl class="elemdef" id="elemdef-smil-text">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>text</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>As a REQUIRED child of the <a href="#elemdef-smil-par"><code>par</code></a>
 									element.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<dl>
 									<dt>
@@ -8156,7 +8156,7 @@ No Entry</pre>
 								</dl>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>Empty</p>
 							</dd>
@@ -8178,20 +8178,20 @@ No Entry</pre>
 						<p>The <code>audio</code> element represents a clip of audio media.</p>
 
 						<dl class="elemdef" id="elemdef-smil-audio">
-							<dt>Element Name</dt>
+							<dt>Element Name:</dt>
 							<dd>
 								<p>
 									<code>audio</code>
 								</p>
 							</dd>
 
-							<dt>Usage</dt>
+							<dt>Usage:</dt>
 							<dd>
 								<p>An OPTIONAL child of the <a href="#elemdef-smil-par"><code>par</code>
 									element</a>.</p>
 							</dd>
 
-							<dt>Attributes</dt>
+							<dt>Attributes:</dt>
 							<dd>
 								<dl>
 									<dt>
@@ -8243,7 +8243,7 @@ No Entry</pre>
 								</dl>
 							</dd>
 
-							<dt>Content Model</dt>
+							<dt>Content Model:</dt>
 							<dd>
 								<p>Empty</p>
 							</dd>
@@ -9620,27 +9620,27 @@ html.my-document-playing * {
 				<h3>The <code>epub:type</code> Attribute</h3>
 
 				<dl class="elemdef" id="attrdef-epub-type">
-					<dt>Attribute Name</dt>
+					<dt>Attribute Name:</dt>
 					<dd>
 						<p>
 							<code>type</code>
 						</p>
 					</dd>
 
-					<dt>Namespace</dt>
+					<dt>Namespace:</dt>
 					<dd>
 						<p>
 							<code>http://www.idpf.org/2007/ops</code>
 						</p>
 					</dd>
 
-					<dt>Usage</dt>
+					<dt>Usage:</dt>
 					<dd>
 						<p><a data-cite="html#global-attributes">Global attribute</a>. EPUB Creators MAY specify on all
 							elements.</p>
 					</dd>
 
-					<dt>Value</dt>
+					<dt>Value:</dt>
 					<dd>
 						<p>A white space-separated list of <a href="#sec-property-datatype">property</a> values, with
 							restrictions as defined in <a href="#sec-vocab-assoc"></a>.</p>
@@ -10180,7 +10180,7 @@ html.my-document-playing * {
 
 					<p>This is a prefixed version of the CSS <code>text-orientation</code> property.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10226,7 +10226,7 @@ html.my-document-playing * {
 					<p>This is a prefixed version of the CSS <code>writing-mode</code> property, with the same syntax
 						and behavior.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10248,7 +10248,7 @@ html.my-document-playing * {
 							<code>-epub-text-combine</code> is deprecated. See the table below for how values of both
 						properties translate to unprefixed CSS.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10261,7 +10261,7 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10320,7 +10320,7 @@ html.my-document-playing * {
 
 					<p>This is a prefixed version of the <code>hyphens</code> property.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10341,7 +10341,7 @@ html.my-document-playing * {
 
 					<p>This is a prefixed version of the <code>line-break</code> property.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10360,7 +10360,7 @@ html.my-document-playing * {
 
 					<p>This is a prefixed version of the <code>text-align-last</code> property.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10379,7 +10379,7 @@ html.my-document-playing * {
 
 					<p>This is a prefixed version of the <code>word-break</code> property.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10398,7 +10398,7 @@ html.my-document-playing * {
 
 					<p>This is a prefixed value for the <code>text-transform</code> property.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10440,7 +10440,7 @@ html.my-document-playing * {
 
 					<p>This is a prefixed version of the <code>text-emphasis-color</code> property.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10459,7 +10459,7 @@ html.my-document-playing * {
 
 					<p>This is a prefixed version of the <code>text-emphasis-position</code> property.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10478,7 +10478,7 @@ html.my-document-playing * {
 
 					<p>This is a prefixed version of the <code>text-emphasis-style</code> property.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>
@@ -10500,7 +10500,7 @@ html.my-document-playing * {
 					<p>This is a prefixed version of the <code>text-underline-position</code> property. One value is no
 						longer supported by CSS.</p>
 
-					<table class="def propdef">
+					<table class="propdef">
 						<tbody>
 							<tr>
 								<th>Name: </th>

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -10,7 +10,7 @@
 	
 	<section id="sec-cover-image">
 		<h4>cover-image</h4>
-		<table id="cover-image">
+		<table class="propdef" id="cover-image">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -38,7 +38,7 @@
 	</section>
 	<section id="sec-mathml">
 		<h4>mathml</h4>
-		<table id="mathml">
+		<table class="propdef" id="mathml">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -68,7 +68,7 @@
 	</section>
 	<section id="sec-nav-prop">
 		<h4>nav</h4>
-		<table id="nav">
+		<table class="propdef" id="nav">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -97,7 +97,7 @@
 	</section>
 	<section id="sec-remote-resources">
 		<h4>remote-resources</h4>
-		<table id="remote-resources">
+		<table class="propdef" id="remote-resources">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -131,7 +131,7 @@
 	</section>
 	<section id="sec-scripted">
 		<h4>scripted</h4>
-		<table id="scripted">
+		<table class="propdef" id="scripted">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -162,7 +162,7 @@
 	</section>
 	<section id="sec-svg-prop">
 		<h4>svg</h4>
-		<table id="svg">
+		<table class="propdef" id="svg">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -196,7 +196,7 @@
 	</section>
 	<section id="sec-switch">
 		<h4>switch</h4>
-		<table id="switch">
+		<table class="propdef" id="switch">
 			<tbody>
 				<tr>
 					<th>Name:</th>

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -11,7 +11,7 @@
 
 	<section id="sec-page-spread-left">
 		<h4>page-spread-left</h4>
-		<table id="page-spread-left">
+		<table class="propdef" id="page-spread-left">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -30,7 +30,7 @@
 	</section>
 	<section id="sec-page-spread-right">
 		<h4>page-spread-right</h4>
-		<table id="page-spread-right">
+		<table class="propdef" id="page-spread-right">
 			<tbody>
 				<tr>
 					<th>Name:</th>

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -18,7 +18,7 @@
 		
 		<section id="sec-acquire">
 			<h5>acquire</h5>
-			<table id="acquire">
+			<table class="propdef" id="acquire">
 				<tbody>
 					<tr>
 						<th>Name:</th>
@@ -55,7 +55,7 @@
 		</section>
 		<section id="sec-alternate">
 			<h5>alternate</h5>
-			<table id="alternate">
+			<table class="propdef" id="alternate">
 				<tbody>
 					<tr>
 						<th>Name:</th>
@@ -141,7 +141,7 @@
 		</section>
 		<section id="sec-record">
 			<h5>record</h5>
-			<table id="record">
+			<table class="propdef" id="record">
 				<tbody>
 					<tr>
 						<th>Name:</th>
@@ -187,7 +187,7 @@
 		</section>
 		<section id="sec-voicing">
 			<h5>voicing</h5>
-			<table id="voicing">
+			<table class="propdef" id="voicing">
 				<tbody>
 					<tr>
 						<th>Name:</th>
@@ -259,7 +259,7 @@
 			type.</p>
 		<section id="sec-onix">
 			<h5>onix</h5>
-			<table id="onix">
+			<table class="propdef" id="onix">
 				<tbody>
 					<tr>
 						<th>Name:</th>
@@ -284,7 +284,7 @@
 		</section>
 		<section id="sec-xmp">
 			<h5>xmp</h5>
-			<table id="xmp">
+			<table class="propdef" id="xmp">
 				<tbody>
 					<tr>
 						<th>Name:</th>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -16,7 +16,7 @@
 	
 	<section id="sec-alternate-script">
 		<h5>alternate-script</h5>
-		<table id="alternate-script">
+		<table class="propdef" id="alternate-script">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -70,7 +70,7 @@
 	</section>
 	<section id="sec-authority">
 		<h5>authority</h5>
-		<table id="authority">
+		<table class="propdef" id="authority">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -219,7 +219,7 @@
 	</section>
 	<section id="sec-belongs-to-collection">
 		<h5>belongs-to-collection</h5>
-		<table id="belongs-to-collection">
+		<table class="propdef" id="belongs-to-collection">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -285,7 +285,7 @@
 	</section>
 	<section id="sec-collection-type">
 		<h5>collection-type</h5>
-		<table id="collection-type">
+		<table class="propdef" id="collection-type">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -368,7 +368,7 @@
 	</section>
 	<section id="sec-display-seq">
 		<h5>display-seq</h5>
-		<table id="display-seq">
+		<table class="propdef" id="display-seq">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -407,7 +407,7 @@
 	</section>
 	<section id="sec-file-as">
 		<h5>file-as</h5>
-		<table id="file-as">
+		<table class="propdef" id="file-as">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -457,7 +457,7 @@
 	</section>
 	<section id="sec-group-position">
 		<h5>group-position</h5>
-		<table id="group-position">
+		<table class="propdef" id="group-position">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -542,7 +542,7 @@
 	</section>
 	<section id="sec-identifier-type">
 		<h5>identifier-type</h5>
-		<table id="identifier-type">
+		<table class="propdef" id="identifier-type">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -609,7 +609,7 @@
 	</section>
 	<section id="sec-role">
 		<h5>role</h5>
-		<table id="role">
+		<table class="propdef" id="role">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -709,7 +709,7 @@
 	</section>
 	<section id="sec-source-of">
 		<h5>source-of</h5>
-		<table id="source-of">
+		<table class="propdef" id="source-of">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -786,7 +786,7 @@
 	</section>
 	<section id="sec-term">
 		<h5>term</h5>
-		<table id="term">
+		<table class="propdef" id="term">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -846,7 +846,7 @@
 	</section>
 	<section id="sec-title-type">
 		<h5>title-type</h5>
-		<table id="title-type">
+		<table class="propdef" id="title-type">
 			<tbody>
 				<tr>
 					<th>Name:</th>

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -13,7 +13,7 @@
 	
 	<section id="sec-active-class">
 		<h4>active-class</h4>
-		<table id="active-class">
+		<table class="propdef" id="active-class">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -51,7 +51,7 @@
 	
 	<section id="sec-duration">
 		<h4>duration</h4>
-		<table id="duration">
+		<table class="propdef" id="duration">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -88,7 +88,7 @@
 	
 	<section id="sec-narrator">
 		<h4>narrator</h4>
-		<table id="narrator">
+		<table class="propdef" id="narrator">
 			<tbody>
 				<tr>
 					<th>Name:</th>
@@ -124,7 +124,7 @@
 
 	<section id="sec-playback-active-class">
 		<h4>playback-active-class</h4>
-		<table id="playback-active-class">
+		<table class="propdef" id="playback-active-class">
 			<tbody>
 				<tr>
 					<th>Name:</th>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -17,7 +17,7 @@
 			The following table provides a map to the properties, overrides, and where they are defined.</p>
 	</div>
 		
-	<table class="zebra">
+	<table class="propdef" class="zebra">
 		<thead>
 			<tr>
 				<th>Property</th>


### PR DESCRIPTION
I don't know what triggered me about the definition boxes this morning, but the bolded field names are jarring to read, especially when you hit all the ones in the vocabularies.

I looked at the boxes the CSS specs use and their field names are italicized, which I find less conflicting with headings, too.

I also fixed some other inconsistencies, like not always having colons after the names and some names using different cases. (If we don't keep the bolding change, we should still keep these.)

I don't know if the auto-previews will show the style changes, so here's an alternative: https://cdn.statically.io/gh/w3c/epub-specs/style/def-box-fixes/epub33/core/index.html


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2167.html" title="Last updated on Mar 30, 2022, 5:10 PM UTC (5d2c2c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2167/e8241a8...5d2c2c0.html" title="Last updated on Mar 30, 2022, 5:10 PM UTC (5d2c2c0)">Diff</a>