### PR TITLE
Copyedit: remove excess spaces in RS spec

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -384,7 +384,7 @@
 
 				<p id="confreq-rs-pkg-dir"
 					data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
-					> If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
+					>If the <code>dir</code> attribute is set and indicates a base direction of <code>ltr</code> or
 						<code>rtl</code>, Reading Systems MUST override the bidi algorithm per <a
 						data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a> defined in [[BIDI]],
 					setting the paragraph embedding level to 0 if the base direction is <code>ltr</code>, or 1 if the
@@ -437,8 +437,8 @@
 
 					<dt id="sec-opf-dclanguage">The <code>language</code> element</dt>
 					<dd>
-						<p> The language(s) of the <a>EPUB Publication</a> specified in <code>language</code> elements
-							are informational. Some uses of this information include: </p>
+						<p>The language(s) of the <a>EPUB Publication</a> specified in <code>language</code> elements
+							are informational. Some uses of this information include:</p>
 						<ul>
 							<li>exposing it to the user through the Reading System user interface</li>
 							<li>using it to enhance functionality in a bookshelf (e.g., sorting by language)</li>
@@ -475,10 +475,10 @@
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
 					<dd>
 						<p>Retrieval and support of linked resources is OPTIONAL.</p>
-						<p> The language identified in an <code>hreflang</code> is purely advisory. Upon fetching the
+						<p>The language identified in an <code>hreflang</code> is purely advisory. Upon fetching the
 							resource, a Reading System must only use the language information associated with the
 							resource to determine its language, not the metadata included in the link to the resource.</p>
-						<p id="sec-linked-records" data-tests="#pkg-linked-records"> In the case of a <a
+						<p id="sec-linked-records" data-tests="#pkg-linked-records">In the case of a <a
 								data-cite="epub-33#record">linked metadata record</a> [[EPUB-33]], Reading Systems MUST
 							NOT skip processing the metadata expressed in the Package Document (i.e., use only the
 							information expressed in the record). Reading Systems MAY compile metadata from multiple
@@ -750,7 +750,7 @@
 						</ul>
 
 						<p class="note">Reading Systems may choose to use third-party libraries such as MathJax to
-							provide MathML rendering. </p>
+							provide MathML rendering.</p>
 					</section>
 
 					<section id="sec-xhtml-svg">
@@ -922,13 +922,13 @@
 
 					<li>
 						<p id="confreq-rs-scripted-origin">
-							<span id="confreq-rs-scripted-origin-shared" data-tests="#scr-support_origin"> It MUST
+							<span id="confreq-rs-scripted-origin-shared" data-tests="#scr-support_origin">It MUST
 								assign a unique <a data-cite="url#origin">origin</a> [[URL]], shared by all <a
 									data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> of the EPUB
-								Publication. </span>
-							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin"> That <a
+								Publication.</span>
+							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin">That <a
 									data-cite="url#origin">origin</a> [[URL]] MUST be <em>unique</em> for each
-								user-specific instance of an EPUB Publication in a Reading System. </span>
+								user-specific instance of an EPUB Publication in a Reading System.</span>
 						</p>
 					</li>
 
@@ -1108,10 +1108,10 @@
 				<section id="layout">
 					<h4>The <code>rendition:layout</code> Property</h4>
 
-					<p> The default value <code>reflowable</code> MUST be assumed by EPUB Reading Systems as the global
+					<p>The default value <code>reflowable</code> MUST be assumed by EPUB Reading Systems as the global
 						value if no meta element carrying this property occurs in the <a
 							data-cite="epub-33#elemdef-opf-metadata"><code>metadata</code> section</a> section
-						[[EPUB-33]]. </p>
+						[[EPUB-33]].</p>
 
 					<p id="layout-pre-paginated" data-tests="#fxl-layout-pre-paginated-spreads">When the
 							<code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading Systems
@@ -1326,7 +1326,7 @@
 					<h4>URL of the Root Directory</h4>
 
 					<p id="sec-container-iri-root"
-						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative"> Reading Systems MUST
+						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">Reading Systems MUST
 						assign a URL [[URL]] to the <a>Root Directory</a> of the <a>OCF Abstract Container</a>. This URL
 						is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a>. It is
 						implementation specific, but the implementation MUST have the following properties:</p>
@@ -1354,17 +1354,17 @@
 						copies even if the same Reading System is used.</p>
 
 					<div class="note">
-						<p> The properties of the <a>container root URL</a> are such that a conforming Reading System
+						<p>The properties of the <a>container root URL</a> are such that a conforming Reading System
 							will parse any relative URL string to a <a>content URL</a>. In other words, relative links
-							do not "leak" outside the container content, which is an important feature for security. </p>
+							do not "leak" outside the container content, which is an important feature for security.</p>
 
 						<p>In practice, the container root URL behaves similarly to a URL defined as follows:</p>
 
 						<table class="zebra">
 							<thead>
 								<tr>
-									<td style="font-weight: bold; text-align: center;"> URL component </td>
-									<td style="font-weight: bold; text-align: center;"> Values </td>
+									<td style="font-weight: bold; text-align: center;">URL component</td>
+									<td style="font-weight: bold; text-align: center;">Values</td>
 								</tr>
 							</thead>
 							<tbody>
@@ -1395,7 +1395,7 @@
 							</thead>
 							<tbody>
 								<tr>
-									<td> Root Directory </td>
+									<td>Root Directory</td>
 									<td>
 										<var>empty string</var>
 									</td>
@@ -1459,9 +1459,9 @@
 								</tr>
 							</tbody>
 						</table>
-						<p> Note that the last two links are <a data-cite="epub-33#urls-in-ocf-constraints"
+						<p>Note that the last two links are <a data-cite="epub-33#urls-in-ocf-constraints"
 								>disallowed</a> in an EPUB Publications to ensure better interoperability with
-							non-conforming or legacy Reading Systems and toolchains. </p>
+							non-conforming or legacy Reading Systems and toolchains.</p>
 					</div>
 
 					<div class="note">
@@ -1474,7 +1474,7 @@
 							URL</a> as the <a data-cite="url#concept-base-url">base URL</a> [[URL]] for all files within
 						the <code>META-INF</code> directory. See also the section on <a
 							data-cite="epub-33#sec-parsing-urls-metainf">Parsing URLs in the <code>META-INF</code>
-							Directory</a> in [[!EPUB-33]]. </p>
+							Directory</a> in [[!EPUB-33]].</p>
 
 				</section>
 
@@ -1885,7 +1885,7 @@
 						the Text-to-Speech engine, and cannot be known at authoring time (factors like speech rate,
 						pauses and other prosody parameters influence the audio output). This also means that Reading
 						Systems should treat the <a data-cite="epub-33#duration"><code>duration</code></a> property
-						values set in the Package Document as approximative when making use of them. </p>
+						values set in the Package Document as approximative when making use of them.</p>
 				</section>
 			</section>
 
@@ -2239,7 +2239,7 @@
 					Consideration" sections of the Media Type registrations for the <a
 						data-cite="epub-33#app-media-type-app-oebps-package"
 						><code>application/oebps-package+xml</code></a> and the <a data-cite="epub-33#app-media-type"
-							><code>application/epub+zip</code></a> formats for further details. </p>
+							><code>application/epub+zip</code></a> formats for further details.</p>
 			</section>
 
 			<section id="security-privacy-recommendations">
@@ -2283,7 +2283,7 @@
 			<p class="note">Reading Systems act as the core rendering engines of EPUB Publications and provide a
 				scripting environment based on the [[DOM]] specification. So, although this interface definition uses
 				the [[WEBIDL]] notation for implementation by Reading Systems, web browsers generally do not have to
-				implement these objects. </p>
+				implement these objects.</p>
 
 			<section id="app-ers-idl">
 				<h3>Interface Definition</h3>
@@ -2378,9 +2378,9 @@ partial interface Navigator {
 					</tbody>
 				</table>
 
-				<p> This specification used to define a <code>layoutStyle</code> property, but it is now <a
+				<p>This specification used to define a <code>layoutStyle</code> property, but it is now <a
 						data-cite="epub-33#deprecated">deprecated</a> [[EPUB-33]]. Refer to its definition in
-					[[EPUBContentDocs-301]] for more information. </p>
+					[[EPUBContentDocs-301]] for more information.</p>
 			</section>
 
 			<section id="app-ers-methods">
@@ -2419,11 +2419,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						<h5>Features</h5>
 
 
-						<p id="scripting-req-readingsystem-features" data-tests="#scr-readingsystem-features"> The
+						<p id="scripting-req-readingsystem-features" data-tests="#scr-readingsystem-features">The
 							following table lists the set of features that Reading Systems that support the
 								<code>epubReadingSystem</code> object MUST recognize. When the features are queried from
 							the <code>hasFeature</code> method, Reading Systems MUST return a boolean value indicating
-							their support. </p>
+							their support.</p>
 
 
 						<table>
@@ -2572,13 +2572,13 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						>Working Group Resolution</a>.</li>
 				<li>12-Apr-2021: The section <a href="#app-epubReadingSystem"></a> has been marked as "at-risk". See <a
 						href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-09-epub#resolution1"
-						>Working Group resolution</a>. </li>
+						>Working Group resolution</a>.</li>
 				<li>09-Apr-2021: Added a new section dedicated to accessibility and removed the outdated reference to
 					the defunct appendix in the Accessibility specification. See <a
 						href="https://github.com/w3c/epub-specs/issues/1608">issue 1608</a>.</li>
 				<li>09-Apr-2021: Added section clarifying all the conformance requirements on establishing the primary
 					language and base direction of Publication Resources. See <a
-						href="https://github.com/w3c/epub-specs/pull/1613">pull request 1613</a>. </li>
+						href="https://github.com/w3c/epub-specs/pull/1613">pull request 1613</a>.</li>
 				<li>01-Apr-2021: Added section clarifying how absolute URLs are created from relative in the Package
 					Document. See <a href="https://github.com/w3c/epub-specs/pull/1468">pull request 1468</a>.</li>
 				<li>30-Mar-2021: Restructured the document to remove the rendundant conformance sections and
@@ -2597,7 +2597,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					discussion and <a
 						href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-12-18-epub#resolution2"
 						>Working Group resolution</a>. See <a href="https://github.com/w3c/epub-specs/issues/1310">issue
-						1310</a>. </li>
+						1310</a>.</li>
 				<li>08-Mar-2021: Remove unnecessary requirement to assume default value for rendering metadata. See <a
 						href="https://github.com/w3c/epub-specs/issues/1313">issue 1313</a>.</li>
 				<li>05-Mar-2021: Added requirement for reading systems to collapse whitespace in DCMES and meta elements


### PR DESCRIPTION
If you like this, I can do the same to the core spec (much larger).