### PR TITLE
Added links to the meta-inf section in the RS spec

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1503,14 +1503,16 @@
 						<dd>
 							<p id="container-default-rendition"
 								data-tests="#ocf-package_arbitrary,#ocf-package_multiple">A Reading System MUST, by
-								default, use the Package Document referenced from first <code>rootfile</code> element to
-								render the EPUB Publication. If the Reading System recognizes a means of selecting from
+								default, use the Package Document referenced from first <code>rootfile</code> element
+								in the <a data-cite="epub-33#sec-container-metainf-container.xml"><code>container.xml</code></a> file [[EPUB-33]]
+								to render the EPUB Publication. If the Reading System recognizes a means of selecting from
 								the other available options, it MAY choose a more appropriate Package Document.</p>
 						</dd>
 
-						<dt id="sec-container-metainf-metadata.xml">Metadata File (<code>metadata.xml</code>)</dt>
+						<dt id="sec-container-metainf-metadata.xml">Metadata File (<code>metadata.xml</code>)</a></dt>
 						<dd>
-							<p>Reading Systems SHOULD ignore <code>metadata.xml</code> files with unrecognized root
+							<p>Reading Systems SHOULD ignore <a
+								data-cite="epub-33#sec-container-metainf-metadata.xml"><code>metadata.xml</code></a> files [[EPUB-33]]  with unrecognized root
 								elements.</p>
 						</dd>
 
@@ -1522,7 +1524,8 @@
 
 						<dt id="sec-container-metainf-manifest.xml">Manifest File (<code>manifest.xml</code>)</dt>
 						<dd>
-							<p>Reading Systems MUST NOT use ancillary manifest information contained in the ZIP archive
+							<p>Reading Systems SHOULD ignore any <a data-cite="epub-33#sec-container-metainf-manifest.xml"><code>manifest.xml</code></a> [[EPUB-33]] file. 
+								Reading Systems MUST NOT use ancillary manifest information contained in the ZIP archive
 								or in the <code>manifest.xml</code> file for processing an EPUB Publication.</p>
 						</dd>
 
@@ -1530,7 +1533,7 @@
 						<dd>
 							<p>Reading Systems MUST NOT fail when encountering configuration files in the <code
 									class="filename">META-INF</code> directory not listed in <a
-									data-cite="epub-33#sec-container-metainf-files">Reserved Files</a> [[EPUB-33]].</p>
+									data-cite="epub-33#sec-container-metainf-files">Reserved Files</a> [[EPUB-33]].</p>
 						</dd>
 					</dl>
 				</section>


### PR DESCRIPTION
This is to fix #2172.

Note that I did not change the text on the ecryption file, because that paragraph is subject to a separate issue. Any additional reference, if necessary, should be added there...