### PR TITLE
Fix up deprecated prefixed properties

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10280,9 +10280,10 @@ html.my-document-playing * {
 					<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>
 						Properties</h6>
 
-					<p>These properties are prefixed versions of <a data-cite="css-writing-modes-3#text-combine-upright"
-								><code>text-combine-upright</code> property</a> [[CSS-Writing-Modes-3]], although
-							<code>-epub-text-combine</code> is deprecated.</p>
+					<p>These properties are prefixed versions of the <a
+							data-cite="css-writing-modes-3#text-combine-upright"><code>text-combine-upright</code>
+							property</a> [[CSS-Writing-Modes-3]], although <code>-epub-text-combine</code> is
+						deprecated.</p>
 
 					<table class="def propdef">
 						<tbody>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10209,7 +10209,9 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-writing-modes-text-orientation" data-tests="#css-epub-text-orientation">
 					<h6>The <code>-epub-text-orientation</code> Property</h6>
 
-					<p>This is a prefixed version of the CSS <code>text-orientation</code> property.</p>
+					<p>This property is a prefixed version of the <a
+							data-cite="css-writing-modes-3#propdef-text-orientation"><code>text-orientation</code>
+							property</a> [[CSS-Writing-Modes-3]].</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10224,8 +10226,10 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>Previous versions of EPUB 3 used additional values of <code>-epub-text-orientation</code>. See
-						the table below for how these values translate to unprefixed CSS:</p>
+					<p>For compatibility with legacy content, the <code>-epub-text-orientation</code> property also
+						supports the deprecated <code>vertical-right</code>, <code>rotate-right</code>, and
+							<code>rotate-normal</code> keywords. The following table specifies the effect these have
+						when specified.</p>
 
 					<table class="data">
 						<thead>
@@ -10254,8 +10258,9 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-writing-modes-writing-mode" data-tests="#css-epub-writing-mode">
 					<h6>The <code>-epub-writing-mode</code> Property</h6>
 
-					<p>This is a prefixed version of the CSS <code>writing-mode</code> property, with the same syntax
-						and behavior.</p>
+					<p>This property is a prefixed version of the <a
+							data-cite="css-writing-modes-3#propdef-writing-mode"><code>writing-mode</code> property</a>
+						[[CSS-Writing-Modes-3]], with the same syntax and behavior.</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10275,9 +10280,9 @@ html.my-document-playing * {
 					<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>
 						Properties</h6>
 
-					<p>These are prefixed versions of <code>text-combine-upright</code>, although
-							<code>-epub-text-combine</code> is deprecated. See the table below for how values of both
-						properties translate to unprefixed CSS.</p>
+					<p>These properties are prefixed versions of <a data-cite="css-writing-modes-3#text-combine-upright"
+								><code>text-combine-upright</code> property</a> [[CSS-Writing-Modes-3]], although
+							<code>-epub-text-combine</code> is deprecated.</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10305,7 +10310,9 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>The following table shows how to map from the prefixed versions to the current CSS versions.</p>
+					<p>For compatibility with legacy content, the <code>-epub-text-combine-horizontal</code> and
+							<code>-epub-text-combine</code> properties also support a number of deprecated keywords. The
+						following table specifies the effect these have when specified.</p>
 
 					<table class="data">
 						<thead>
@@ -10349,7 +10356,8 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-hyphens" data-tests="#css-epub-hyphens">
 					<h6>The <code>-epub-hyphens</code> Property</h6>
 
-					<p>This is a prefixed version of the <code>hyphens</code> property.</p>
+					<p>This property is a prefixed version of the <a data-cite="css-text-3#hyphens-property"
+								><code>hyphens</code> property</a> [[CSS-Text-3]].</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10364,13 +10372,16 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p class="note">The <code>all</code> value is no longer supported in CSS.</p>
+					<p>For compatibility with legacy content, the <code>-epub-hyphens</code> property also supports the
+						deprecated <code>all</code> keyword. The value is no longer supported in CSS and there is no
+						equivalent to use in its place.</p>
 				</section>
 
 				<section id="sec-css-prefixed-text-epub-line-break" data-tests="#css-epub-line-break">
 					<h6>The <code>-epub-line-break</code> Property</h6>
 
-					<p>This is a prefixed version of the <code>line-break</code> property.</p>
+					<p>This property is a prefixed version of the <a data-cite="css-text-3#line-break-property"
+								><code>line-break</code> property</a> [[CSS-Text-3]].</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10389,7 +10400,8 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-text-align-last" data-tests="#css-epub-text-align-last">
 					<h6>The <code>-epub-text-align-last</code> Property</h6>
 
-					<p>This is a prefixed version of the <code>text-align-last</code> property.</p>
+					<p>This property is a prefixed version of the <a data-cite="css-text-3#text-align-last-property"
+								><code>text-align-last</code> property</a> [[CSS-Text-3]].</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10408,7 +10420,8 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-word-break" data-tests="#css-epub-word-break">
 					<h6>The <code>-epub-word-break</code> Property</h6>
 
-					<p>This is a prefixed version of the <code>word-break</code> property.</p>
+					<p>This property is a prefixed version of the <a data-cite="css-text-3#word-break-property"
+								><code>word-break</code> property</a> [[CSS-Text-3]].</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10427,7 +10440,8 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-text-transform" data-tests="#css-epub-text-transform">
 					<h6>The <code>text-transform</code> Property</h6>
 
-					<p>This is a prefixed value for the <code>text-transform</code> property.</p>
+					<p>This property is a prefixed value for the <a data-cite="css-text-3#text-transform-property"
+								><code>text-transform</code> property</a> [[CSS-Text-3]].</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10442,22 +10456,9 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>The following table describes the equivalent value in CSS.</p>
-
-					<table class="data">
-						<thead>
-							<tr>
-								<th>EPUB version</th>
-								<th>CSS equivalent</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td><code>text-transform: -epub-fullwidth</code></td>
-								<td><code>text-transform: full-width</code></td>
-							</tr>
-						</tbody>
-					</table>
+					<p>For compatibility with legacy content, the <code>text-transform</code> property also supports the
+						deprecated <code>-epub-fullwidth</code> keyword. When specified, this has the same effect as
+							<code>text-transform: full-width</code>.</p>
 				</section>
 			</section>
 
@@ -10469,7 +10470,9 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-text-emphasis-color" data-tests="#css-epub-text-emphasis">
 					<h6>The <code>-epub-text-emphasis-color</code> Property</h6>
 
-					<p>This is a prefixed version of the <code>text-emphasis-color</code> property.</p>
+					<p>This property is a prefixed version of the <a
+							data-cite="css-text-decor-3#text-emphasis-color-property"><code>text-emphasis-color</code>
+							property</a> [[CSS-Text-Decor-3]].</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10488,7 +10491,9 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-text-emphasis-position" data-tests="#css-epub-text-emphasis">
 					<h6>The <code>-epub-text-emphasis-position</code> Property</h6>
 
-					<p>This is a prefixed version of the <code>text-emphasis-position</code> property.</p>
+					<p>This property is a prefixed version of the <a
+							data-cite="css-text-decor-3#text-emphasis-position-property"
+								><code>text-emphasis-position</code> property</a> [[CSS-Text-Decor-3]].</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10507,7 +10512,9 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-text-emphasis-style" data-tests="#css-epub-text-emphasis">
 					<h6>The <code>-epub-text-emphasis-style</code> Property</h6>
 
-					<p>This is a prefixed version of the <code>text-emphasis-style</code> property.</p>
+					<p>This property is a prefixed version of the <a
+							data-cite="css-text-decor-3#text-emphasis-style-property"><code>text-emphasis-style</code>
+							property</a> [[CSS-Text-Decor-3]].</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10528,8 +10535,9 @@ html.my-document-playing * {
 					data-tests="#css-epub-text-underline-position">
 					<h6>The <code>-epub-text-underline-position</code> Property</h6>
 
-					<p>This is a prefixed version of the <code>text-underline-position</code> property. One value is no
-						longer supported by CSS.</p>
+					<p>This property is a prefixed version of the <a
+							data-cite="css-text-decor-3#text-underline-position-property"
+								><code>text-underline-position</code> property</a> [[CSS-Text-Decor-3]].</p>
 
 					<table class="def propdef">
 						<tbody>
@@ -10544,22 +10552,9 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>The following table describes the equivalent value in CSS.</p>
-
-					<table class="data">
-						<thead>
-							<tr>
-								<th>EPUB version</th>
-								<th>CSS equivalent</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<td><code>-epub-text-underline-position: alphabetic</code></td>
-								<td><code>text-underline-position: auto</code></td>
-							</tr>
-						</tbody>
-					</table>
+					<p>For compatibility with legacy content, the value <code>-epub-text-underline-position</code>
+						property also supports the deprecated <code>alphabetic</code> keyword. When specified, this has
+						the same effect as <code>text-underline-position: auto</code>.</p>
 				</section>
 			</section>
 		</section>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10226,7 +10226,7 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>For compatibility with legacy content, the <code>-epub-text-orientation</code> property also
+					<p>For compatibility with existing content, the <code>-epub-text-orientation</code> property also
 						supports the deprecated <code>vertical-right</code>, <code>rotate-right</code>, and
 							<code>rotate-normal</code> keywords. The following table specifies the effect these have
 						when specified.</p>
@@ -10310,7 +10310,7 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>For compatibility with legacy content, the <code>-epub-text-combine-horizontal</code> and
+					<p>For compatibility with existing content, the <code>-epub-text-combine-horizontal</code> and
 							<code>-epub-text-combine</code> properties also support a number of deprecated keywords. The
 						following table specifies the effect these have when specified.</p>
 
@@ -10372,8 +10372,8 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>For compatibility with legacy content, the <code>-epub-hyphens</code> property also supports the
-						deprecated <code>all</code> keyword. The value is no longer supported in CSS and there is no
+					<p>For compatibility with existing content, the <code>-epub-hyphens</code> property also supports
+						the deprecated <code>all</code> keyword. The value is no longer supported in CSS and there is no
 						equivalent to use in its place.</p>
 				</section>
 
@@ -10456,8 +10456,8 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>For compatibility with legacy content, the <code>text-transform</code> property also supports the
-						deprecated <code>-epub-fullwidth</code> keyword. When specified, this has the same effect as
+					<p>For compatibility with existing content, the <code>text-transform</code> property also supports
+						the deprecated <code>-epub-fullwidth</code> keyword. When specified, this has the same effect as
 							<code>text-transform: full-width</code>.</p>
 				</section>
 			</section>
@@ -10552,7 +10552,7 @@ html.my-document-playing * {
 						</tbody>
 					</table>
 
-					<p>For compatibility with legacy content, the value <code>-epub-text-underline-position</code>
+					<p>For compatibility with existing content, the value <code>-epub-text-underline-position</code>
 						property also supports the deprecated <code>alphabetic</code> keyword. When specified, this has
 						the same effect as <code>text-underline-position: auto</code>.</p>
 				</section>


### PR DESCRIPTION
This PR fixes #2152 but not exactly as suggested in the issue.

I went looking for a deprecated CSS value to see how they're done in those specs and ended up copying similar phrasing into ours. I kept the tables where there are multiple values, but for single values I compacted the explanation down to a single paragraph.

I also added links to the individual CSS properties to each section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2178.html" title="Last updated on Mar 31, 2022, 4:03 PM UTC (9c94d2a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2178/017a47c...9c94d2a.html" title="Last updated on Mar 31, 2022, 4:03 PM UTC (9c94d2a)">Diff</a>