### PR TITLE
Editorial changes, issue 2183

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -133,18 +133,17 @@
 					while this specification details the rendering requirements for them in EPUB Reading Systems.</p>
 
 				<p>An EPUB Reading System can take many forms. It might have a visual display area for rendering the
-					content to users, for example, or it might only provide audio playback of the content. As a result,
-					there is no single set of rules that all Reading Systems must follow. Rather, this specification
-					breaks down the rendering requirements based on a Reading System's capabilities and the features its
+					content to users, for example, or it might only provide audio playback of the content. 
+					Therefore, there is no single set of rules that applies to all Reading Systems. Rather, this specification
+					breaks down the rendering requirements based on a Reading System's capabilities and the features it
 					supports.</p>
 
-				<p>Moreover, this specification provides a great deal of flexibility to developers to create unique user
-					interfaces, such as in their bookshelves. As a result, metadata processing requirements are often
-					quite minimal, for example.</p>
+				<p>Moreover, this specification allows for a great deal of flexibility for developers to create unique user interfaces, 
+				   and requirements for things like metadata processing are intentionally minimal to allow for such flexibility.</p>
 
 				<p>So, although this specification identifies the formal requirements for Reading Systems, it is not
-					possible to read this document in isolation. Developers should also familiarize themselves with the
-					full content structure of an EPUB Publication to understand the complete range of information that
+					possible to understand this document in isolation. Developers should also familiarize themselves with the
+					full content structure of an EPUB Publication in order to understand the complete range of information that
 					is available.</p>
 
 				<div class="note">
@@ -157,7 +156,7 @@
 				<h3>Terminology</h3>
 
 				<p>This specification uses <a data-cite="epub-33#sec-terminology">terminology defined in EPUB 3.3</a>
-					[[EPUB-33]] as well as the terms defined in this section. Terms appear capitalized wherever
+					[[EPUB-33]] as well as the term defined in this section. Terms appear capitalized wherever
 					used.</p>
 
 				<p>Only the first instance of a term in a section links to its definition.</p>
@@ -193,7 +192,7 @@
 					<p>This specification does not require EPUB Reading Systems to support scripting, HTML forms or the
 						HTML DOM. Reading Systems conformant with this specification are only expected to be able to
 						process a conforming <a>EPUB Content Document</a>. As <a href="#sec-scripted-content">support
-							for scripting and HTML forms</a> is not compulsory, a conformant Reading System may not be a
+							for scripting and HTML forms</a> is not compulsory, a conformant Reading System might not be a
 						fully-conformant HTML user agent.</p>
 				</section>
 
@@ -206,7 +205,7 @@
 						specification is the authoritative reference.</p>
 
 					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. Reading
-						System developers must keep track of changes to the SVG standard to ensure they keep their
+						System developers must keep track of changes to the SVG standard to ensure that they keep their
 						systems up to date.</p>
 				</section>
 			</section>


### PR DESCRIPTION
Thanks Ben,

answers to some comments (others are taken over)

> 
> Section 1.2
> "as well as the terms defined in this section"... Did we intend to include more than one term (Content Display Area) in this section? 
> Should we change to singular "term"?

I presume the original intention was that there would be more... and we ended up having only one.

I have changed it to "term" but we have to be careful if ever we add a new term.

> 
> Section 1.3

The text for this section is a W3C boilerplate, which is added to the final spec by the tool we use (respec). Let us not touch it...


> 
> Para 3
> "may" s/b "might"

(I presume this was for section 1.4.1)


Fix #2183

cc @BenSchroeter
