### PR TITLE
Editorials on a11y section in RS

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2157,9 +2157,8 @@
 					and buttons to load features such as the table of contents) are exposed to assistive technologies
 					and that their actions do not rely on specific modalities (e.g., they only operate through touch or a
 					mouse).</li>
-				<li>Search &#8212; Search access to the full text content of all EPUB Content Documents (including
-					alternative text attributes, text in SVG images, etc.) is necessary to ensure users can locate
-					information easily.</li>
+				<li>Search &#8212; Search access to the full text content of all EPUB Content Documents is necessary 
+					to ensure users can locate information easily.</li>
 				<li>Display Control &#8212; Provide methods for users to tailor the styling of the content to their
 					preferences (e.g., to change and increase fonts, increase line and word spacing, and apply alternate
 					contrasts).</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2142,7 +2142,8 @@
 				or seek to avoid in their applications.</p>
 
 			<p>The W3C's User Agent Accessibility Guidelines [[UAAG20]] provides many useful practices developers should
-				apply to improve their Reading Systems as many browser acccessibility issues have parallels in EPUB.</p>
+				apply to improve their Reading Systems as many browser accessibility issues have parallels in EPUB-specific 
+				user agents.</p>
 
 			<p>The following list outlines some additional EPUB-specific areas where a lack of accessibility impacts the
 				reading experience for users:</p>
@@ -2151,10 +2152,10 @@
 				<li>Bookshelf &#8212; Ensure that the process for accessing and opening the user's content is
 					accessible. For example, do not rely on a visual-only display like cover images. Exposing text
 					representations of the title(s) and author(s), including the language they are expressed in, allows
-					assistive technologies to properly announce the options.</li>
+					assistive technologies to properly announce the content.</li>
 				<li>User Interface Controls &#8212; Ensure that all controls (e.g., search boxes, annotation controls,
 					and buttons to load features such as the table of contents) are exposed to assistive technologies
-					and their actions do not rely on specific modalities (e.g., they only operate through touch or a
+					and that their actions do not rely on specific modalities (e.g., they only operate through touch or a
 					mouse).</li>
 				<li>Search &#8212; Search access to the full text content of all EPUB Content Documents (including
 					alternative text attributes, text in SVG images, etc.) is necessary to ensure users can locate
@@ -2171,7 +2172,7 @@
 					properties [[WAI-ARIA-11]], is exposed to the underlying operating system's accessibility API so
 					that users can fully interact with the content when using assistive technologies.</li>
 				<li>Document Object Model (DOM) &#8212; Provide access to the [[DOM]] of EPUB Content Documents so that
-					users can investigate the semantics and structure used in the source.</li>
+					users can investigate the semantics and structure expressed in the source.</li>
 				<li>Table of Contents &#8212; Ensure that users can access the link text, including <a
 						data-cite="epub-33#confreq-nav-a-title">text alternatives for visual content</a>. Activating the
 					table of contents links should be possible using different inputs.</li>


### PR DESCRIPTION
Thanks Ben. Some comments below:

> Search bullet:  
> Does any Reading System allow Search capability to extend to alt attributes, or is this aspirational?

I honestly do not know. I am afraid it is more aspirational (@mattgarrish?) but we can leave it in the text anyway (this is not a normative text)

> Reading Control:  
> Question the phrase "physical interaction" here... is manipulating a keyboard in order to open a new document not allowed?

The text says "does not _depend_ on physical interaction" (emphasis is mine). Ie, using the keyboard is fine, but there should be other alternatives.

> Document Object Model (DOM) bullet:  
> change "used in the source" to "applied in the source content"

I am not sure I agree with what you propose. The issue here is that the semantics expressed in the source (e.g., the choice of an HTML element, possible microdata attributes, aria attributes, etc.) should be available. The DOM contains this information by default, and providing access to the DOM is what is needed for this.

I changed "used in the source" to "expressed in the source", this might be clearer.


cc: @BenSchroeter

Fix #2182