### PR TITLE
Example 65: DigestValue should not be empty

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7617,9 +7617,7 @@ No Entry</pre>
                &lt;/Transforms>
                &lt;DigestMethod
                    Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-               &lt;DigestValue>
-	           …
-               &lt;/DigestValue>
+               &lt;DigestValue>…&lt;/DigestValue>
             &lt;/Reference>
             &lt;Reference URI="EPUB/images/cover.jpeg">
                &lt;Transforms>                                                
@@ -7628,9 +7626,7 @@ No Entry</pre>
                &lt;/Transforms>
                &lt;DigestMethod
                    Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-               &lt;DigestValue>
-	           …
-               &lt;/DigestValue>
+               &lt;DigestValue>…&lt;/DigestValue>
             &lt;/Reference>
          &lt;/Manifest>
       &lt;/Object>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7618,6 +7618,7 @@ No Entry</pre>
                &lt;DigestMethod
                    Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
                &lt;DigestValue>
+	           …
                &lt;/DigestValue>
             &lt;/Reference>
             &lt;Reference URI="EPUB/images/cover.jpeg">
@@ -7628,6 +7629,7 @@ No Entry</pre>
                &lt;DigestMethod
                    Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
                &lt;DigestValue>
+	           …
                &lt;/DigestValue>
             &lt;/Reference>
          &lt;/Manifest>


### PR DESCRIPTION
In example 65 the DigestValue element was empty; I do not think it is correct


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2188.html" title="Last updated on Apr 2, 2022, 4:44 AM UTC (a104e39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2188/b532068...a104e39.html" title="Last updated on Apr 2, 2022, 4:44 AM UTC (a104e39)">Diff</a>