### PR TITLE
Restructure of section 2 and ocf

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -679,765 +679,745 @@
 					always having an explicit declaration (<code>xmlns:epub="http://www.idpf.org/2007/ops"</code>).</p>
 			</section>
 		</section>
-		<section id="sec-publications">
-			<h2>EPUB Publications</h2>
+		<section id="sec-epub-conf">
+			<h2>EPUB Publication Conformance</h2>
 
-			<section id="sec-epub-conf">
-				<h3>Conformance Criteria</h3>
+			<p>An EPUB Publication:</p>
 
-				<p>An EPUB Publication:</p>
+			<ul class="conformance-list">
+				<li>
+					<p id="confreq-package">MUST define at least one rendering of its content as follows:</p>
+					<ul class="conformance-list">
+						<li>
+							<p id="confreq-package-doc">MUST contain a <a>Package Document</a> that conforms to <a
+									href="#sec-package-doc"></a> and meet all <a>Publication Resource</a> requirements
+								for the Package Document.</p>
+						</li>
+						<li>
+							<p id="confreq-nav">MUST contain an <a>EPUB Navigation Document</a> that conforms to <a
+									href="#sec-nav"></a>.</p>
+						</li>
+					</ul>
+				</li>
+				<li>
+					<p id="confreq-a11y">SHOULD conform to the accessibility requirements defined in
+						[[EPUB-A11Y-11]].</p>
+				</li>
+				<li>
+					<p id="confreq-ocf">MUST be packaged in an <a>EPUB Container</a> as defined in <a href="#sec-ocf"
+						></a>.</p>
+				</li>
+			</ul>
 
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-package">MUST define at least one rendering of its content as follows:</p>
-						<ul class="conformance-list">
-							<li>
-								<p id="confreq-package-doc">MUST contain a <a>Package Document</a> that conforms to <a
-										href="#sec-package-doc"></a> and meet all <a>Publication Resource</a>
-									requirements for the Package Document.</p>
-							</li>
-							<li>
-								<p id="confreq-nav">MUST contain an <a>EPUB Navigation Document</a> that conforms to <a
-										href="#sec-nav"></a>.</p>
-							</li>
-						</ul>
-					</li>
-					<li>
-						<p id="confreq-a11y">SHOULD conform to the accessibility requirements defined in
-							[[EPUB-A11Y-11]].</p>
-					</li>
-					<li>
-						<p id="confreq-ocf">MUST be packaged in an <a>EPUB Container</a> as defined in <a
-								href="#sec-ocf"></a>.</p>
-					</li>
+			<p id="confreq-res-location">In addition, all Publication Resources MUST adhere to the requirements in <a
+					href="#sec-publication-resources"></a>.</p>
+
+			<p>The rest of this specification covers specific conformance details.</p>
+
+			<section id="sec-conformance-checking" class="informative">
+				<h3>Conformance Checking</h3>
+
+				<p>Due to the complexity of this specification and number of technologies used in <a>EPUB
+						Publications</a>, <a>EPUB Creators</a> are advised to use an <a>EPUB Conformance Checker</a> to
+					verify the conformance of their content.</p>
+
+				<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto EPUB Conformance
+					Checker used by the publishing industry and has been updated with each new version of EPUB. It is
+					integrated into a number of authoring tools and also available in alternative interfaces and other
+					languages (for more information, refer to its <a
+						href="https://www.w3.org/publishing/epubcheck/docs/apps-and-tools/">Apps and Tools
+					page</a>).</p>
+
+				<p>When verifying their EPUB Publications, EPUB Creators should ensure they do not violate the
+					requirements of this specification (practices identified by the keywords "MUST", "MUST NOT", and
+					"REQUIRED"). These types of issues will often result in EPUB Publications not rendering or rendering
+					in inconsistent ways. These issues are typically reported as errors or critical errors.</p>
+
+				<p>EPUB Creators should also ensure that their EPUB Publications do not violate the recommendations of
+					this specification (practices identified by the keywords "SHOULD", "SHOULD NOT", and "RECOMMENDED").
+					Failure to follow these practices does not result in an invalid EPUB Publication but may lead to
+					interoperability problems and other issues that impact the user reading experience. These issues are
+					typically reported as warnings.</p>
+
+				<div class="note">
+					<p>Vendors, distributors, and other retailers of EPUB Publications should consider the importance of
+						recommended practices before basing their acceptance or rejection on a zero-issue outcome from
+						an EPUB Conformance Checker. There will be legitimate reasons why EPUB Creators cannot follow
+						recommended practices in all cases.</p>
+				</div>
+			</section>
+		</section>
+		<section id="sec-publication-resources">
+			<h2>Publication Resources</h2>
+
+			<section id="sec-pub-res-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>An <a>EPUB Publication</a> is made up of many different categories of resources, not all of which are
+					mutually exclusive. Some resources are <a>Publication Resources</a>, some are not. Some Publication
+					Resources are allowed in the <a>spine</a> by default, while all others require fallbacks. Some
+					resources can be used in rendering <a>EPUB Content Documents</a>, while others can only be used with
+					fallbacks.</p>
+
+				<p>Trying to understand these differences by reading the technical definitions of each category of
+					resource can be complex. To make the categorizations easier to understand, this introduction uses
+					the concept of different planes to explain how resources are grouped and referred to.</p>
+
+				<p>The three planes are:</p>
+
+				<ul>
+					<li>The <a>manifest plane</a> &#8212; The manifest plane holds all the resources of the EPUB
+						Publication (namely, <a>Publication Resources</a> and <a>Linked Resources</a>).</li>
+					<li>The <a>spine plane</a> &#8212; The spine plane holds only the resources used in rendering the
+							<a>spine</a> (namely, <a>EPUB Content Documents</a> and <a>Foreign Content
+						Documents</a>).</li>
+					<li>The <a>content plane</a> &#8212; The content plane holds only the resources used in the
+						rendering of EPUB and Foreign Content Documents (namely, <a>Core Media Type Resources</a>,
+							<a>Foreign Resources</a> and <a>Exempt Resources</a>).</li>
 				</ul>
 
-				<p id="confreq-res-location">In addition, all Publication Resources MUST adhere to the requirements in
-						<a href="#sec-publication-resources"></a>.</p>
+				<p>The same resource may exist on more than one plane and will be referred to differently in this
+					specification depending on which plane is being discussed. For example, a Core Media Type Resource
+					used in the rendering of an EPUB Content Document (on the content plane) may also be a Foreign
+					Content Document if it is also listed in the spine (the spine plane).</p>
 
-				<p>The rest of this specification covers specific conformance details.</p>
+				<p>The following sections describe these planes in more detail.</p>
 
-				<section id="sec-conformance-checking" class="informative">
-					<h4>Conformance Checking</h4>
+				<div class="note">
+					<p>Refer to <a href="#publication-resources-example"></a> for a detailed example showing how
+						resources fit into the different planes.</p>
+				</div>
 
-					<p>Due to the complexity of this specification and number of technologies used in <a>EPUB
-							Publications</a>, <a>EPUB Creators</a> are advised to use an <a>EPUB Conformance Checker</a>
-						to verify the conformance of their content.</p>
+				<section id="sec-manifest-plane">
+					<h4>The Manifest Plane</h4>
 
-					<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto EPUB Conformance
-						Checker used by the publishing industry and has been updated with each new version of EPUB. It
-						is integrated into a number of authoring tools and also available in alternative interfaces and
-						other languages (for more information, refer to its <a
-							href="https://www.w3.org/publishing/epubcheck/docs/apps-and-tools/">Apps and Tools
-						page</a>).</p>
+					<p>To <dfn>manifest plane</dfn> defines all the resources of an <a>EPUB Publication</a>. It is
+						analogous to the <a>Package Document</a>
+						<a>manifest</a>, but includes resources not present in that list.</p>
 
-					<p>When verifying their EPUB Publications, EPUB Creators should ensure they do not violate the
-						requirements of this specification (practices identified by the keywords "MUST", "MUST NOT", and
-						"REQUIRED"). These types of issues will often result in EPUB Publications not rendering or
-						rendering in inconsistent ways. These issues are typically reported as errors or critical
-						errors.</p>
+					<p>The primary resources in this group are designated <a>Publication Resources</a>, which are all
+						the resources used in rendering an EPUB Publication to the user. <a>EPUB Creators</a> always
+						have to list these resources in the <a href="#sec-manifest-elem"><code>manifest</code>
+							element</a> but they do not have to locate them all in the <a>EPUB Container</a>. EPUB 3
+						allows <a href="#sec-resource-locations">audio, video, font and script data resources</a> to be
+						hosted outside the Container.</p>
 
-					<p>EPUB Creators should also ensure that their EPUB Publications do not violate the recommendations
-						of this specification (practices identified by the keywords "SHOULD", "SHOULD NOT", and
-						"RECOMMENDED"). Failure to follow these practices does not result in an invalid EPUB Publication
-						but may lead to interoperability problems and other issues that impact the user reading
-						experience. These issues are typically reported as warnings.</p>
+					<p>Publication Resources are further classified by their use(s) in the <a>spine plane</a> and
+							<a>content plane</a>.</p>
+
+					<p>The manifest plane also contains a set of <a>Linked Resources</a>. These resources are tangential
+						to the direct rendering. They include, for example, metadata records and links to external
+						content (e.g., where to purchase an EPUB Publication).</p>
+
+					<p>Unlike Publication Resources, they are not listed in the Package Document manifest (i.e., because
+						they are not essential to rendering the EPUB Publication). They are instead defined in <a
+							href="#sec-link-elem"><code>link</code> elements</a> in the Package Document metadata. These
+						elements define their nature and purpose similar to how manifest <a href="#sec-item-elem"
+								><code>item</code> elements</a> define Publication Reousrce. (In this way, they are like
+						an extension of the manifest.)</p>
+
+					<p>Refer to <a href="#sec-link-elem"></a> for more information about Linked Resources.</p>
+				</section>
+
+				<section id="sec-spine-plane">
+					<h4>The Spine Plane</h4>
+
+					<p>The <dfn>spine plane</dfn> defines resources used in the default reading order established by the
+							<a>spine</a>, which includes both <a href="#attrdef-itemref-linear">linear and non-linear
+							content</a>. The spine instructs <a>Reading Systems</a> on how to load these resources as
+						the user progresses through the <a>EPUB Publication</a>. Although many resources may be bundled
+						in an <a>EPUB Container</a>, they are not all allowed by default in the spine.</p>
+
+					<p>EPUB 3 defines a special class of resources called <a>EPUB Content Documents</a> that <a>EPUB
+							Creators</a> can use in the spine without any restrictions. EPUB Content Documents encompass
+						both <a>XHTML Content Documents</a> and <a>SVG Content Documents</a>.</p>
+
+					<p>To use any other type of resource in the spine, called a <a>Foreign Content Document</a>,
+						requires including a fallback to an EPUB Content Document. This extensibility model allows EPUB
+						Creators to experiment with formats while ensuring that Reading Systems are always able to
+						render something for the user to read, as there is no guarantee of support for Foreign Content
+						Documents.</p>
+
+					<p>A mechanism called <a href="#sec-manifest-fallbacks">manifest fallbacks</a> allows EPUB Creators
+						to provide fallbacks for Foreign Content Documents. In this model, the <a>manifest</a> entry for
+						the Foreign Content Document must include a <a href="#attrdef-item-fallback"
+								><code>fallback</code> attribute</a> that points to the next possible resource for
+						Reading Systems to try when they do not support its format. Although not common, a fallback
+						resource can specify another fallback, thereby making chains many resources deep. The one
+						requirement is that there must be at least one EPUB Content Document in a fallback chain.</p>
+
+					<p>Although they are not directly listed in the spine, all of the resources in the fallback chain
+						are considered part of the spine, and by extension part of the spine plane, since any may be
+						used by a Reading System.</p>
+
+					<p>Refer to <a href="#sec-manifest-fallbacks"></a> for more information.</p>
+
+					<div class="caution" id="caution-fallbacks">
+						<p>Although manifest fallbacks fulfill the technical requirements of EPUB, there is little
+							practical support for them in Reading Systems. Their use is strongly discouraged as it can
+							lead to unreadable publications.</p>
+					</div>
 
 					<div class="note">
-						<p>Vendors, distributors, and other retailers of EPUB Publications should consider the
-							importance of recommended practices before basing their acceptance or rejection on a
-							zero-issue outcome from an EPUB Conformance Checker. There will be legitimate reasons why
-							EPUB Creators cannot follow recommended practices in all cases.</p>
+						<p>It is possible to provide manifest fallbacks for EPUB Content Documents, but this is not
+							required or common. For example, a <a>Scripted Content Document</a> could have a fallback to
+							an unscripted alternative for Reading Systems that do not support scripting.</p>
+					</div>
+				</section>
+
+				<section id="sec-content-plane">
+					<h4>The Content Plane</h4>
+
+					<p>The <dfn>content plane</dfn> classifies resources based on their use in rendering <a>EPUB Content
+							Documents</a> and <a>Foreign Content Documents</a>. These resources fall into three
+						categories: <a>Core Media Type Resources</a>, <a>Foreign Resources</a>, and <a>Exempt
+							Resources</a>.</p>
+
+					<p>A Core Media Type Resource is one that <a>Reading Systems</a> have to support, so it can be used
+						without restriction in EPUB or Foreign Content Documents. For more information about Core Media
+						Type Resources, refer to <a href="#sec-core-media-types"></a>.</p>
+
+					<div class="note">
+						<p>Being a Core Media Type Resource does not mean that Reading Systems will always render the
+							resource, as not all Reading Systems support all features of EPUB 3. A Reading System
+							without a <a>Viewport</a>, for example, will not render visual content such as images.</p>
+					</div>
+
+					<p>The opposite of Core Media Type Resources are Foreign Resources. These are resources that Reading
+						Systems are not guaranteed to support the rendering of. As a result, similar to how using
+						Foreign Content Documents in the spine requires fallbacks to ensure their rendering, using
+						Foreign Resources in content documents also requires fallbacks. These fallbacks are provided in
+						one of two ways: using the capabilities of the host format or via manifest fallbacks.</p>
+
+					<p>The preferred method is to use the fallback capabilities of the host format. Many HTML elements,
+						for example, have intrinsic fallback capabilities. One example is the <a
+							href="html#the-picture-element"><code>picture</code> element</a> [[HTML]], which allows EPUB
+						Creators to specify multiple alternative image formats.</p>
+
+					<p>If an intrinsic fallback method is not available, it is also possible to use manifest fallbacks,
+						but this method, as <a href="#caution-fallbacks">cautioned against</a> in the previous section,
+						is discouraged. For more information about Foreign Resources, refer to <a
+							href="#sec-foreign-resources"></a>.</p>
+
+					<p>Falling between Core Media Type Resources and Foreign Resources are Exempt Resources. These are
+						most closely associated with Foreign Resources, as there is no guarantee that Reading Systems
+						will render them. But like Core Media Types, they do not require fallbacks.</p>
+
+					<p>Exempt Resources tend to address specific cases for which there are no Core Media Types defined,
+						but for which providing a fallback would prove cumbersome or unnecessary. These include
+						embedding video, adding accessibility tracks, and linking to resources from the [[HTML]] <a
+							data-cite="html#the-link-element"><code>link</code> element</a>.</p>
+
+					<p>Refer to <a href="#sec-exempt-resources"></a> for more information about these exceptions.</p>
+
+					<div class="note">
+						<p>A common point of confusion arising from Core Media Type Resources is the listing of XHTML
+							and SVG as Core Media Type Resources with the requirement the markup conform to their
+							respective <a>EPUB Content Document</a> definitions. This allows EPUB Creators to embed both
+							XHTML and SVG documents in EPUB Content Documents while keeping consistent requirements for
+							authoring and Reading System support.</p>
+
+						<p>In practice, it means that EPUB Creators can put XHTML and SVG Core Media Type Resources in
+							the spine without any modification or fallback (they are also conforming XHTML and SVG
+							Content Documents), but this is a unique case. All other Core Media Type Resources become
+							Foreign Content Documents when used in the spine (i.e., Foreign Content Documents include
+							all Foreign Resources and all Core Media Type Resources except for XHTML and SVG).</p>
 					</div>
 				</section>
 			</section>
 
-			<section id="sec-publication-resources">
-				<h3>Publication Resources</h3>
+			<section id="sec-core-media-types">
+				<h3>Core Media Types</h3>
 
-				<section id="sec-pub-res-intro" class="informative">
-					<h4>Introduction</h4>
+				<p><a>EPUB Creators</a> MAY include <a>Publication Resources</a> that conform to the MIME media type
+					[[RFC2046]] specifications defined in the following table without fallbacks when they are used in
+						<a>EPUB Content Documents</a> and <a>Foreign Content Documents</a>. These resources are
+					classified as <a>Core Media Type Resources</a>.</p>
 
-					<p>An <a>EPUB Publication</a> is made up of many different categories of resources, not all of which
-						are mutually exclusive. Some resources are <a>Publication Resources</a>, some are not. Some
-						Publication Resources are allowed in the <a>spine</a> by default, while all others require
-						fallbacks. Some resources can be used in rendering <a>EPUB Content Documents</a>, while others
-						can only be used with fallbacks.</p>
+				<p>With the exception of XHTML Content Documents and SVG Content Documents, EPUB Creators MUST provide
+						<a href="#sec-manifest-fallbacks">manifest fallbacks</a> for Core Media Type Resources
+					referenced directly from the <a>spine</a>. In this case, they are <a>Foreign Content
+					Documents</a>.</p>
 
-					<p>Trying to understand these differences by reading the technical definitions of each category of
-						resource can be complex. To make the categorizations easier to understand, this introduction
-						uses the concept of different planes to explain how resources are grouped and referred to.</p>
+				<p>The columns in the table represent the following information:</p>
 
-					<p>The three planes are:</p>
+				<ul>
+					<li>
+						<p><strong>Media Type</strong>—The MIME media type [[RFC2046]] used to represent the given
+							Publication Resource in the <a href="#sec-manifest-elem">manifest</a>.</p>
+						<p>If the table lists more than one media type, the first one is the preferred media type. EPUB
+							Creators should use the preferred media type for all new EPUB Publications.</p>
+					</li>
+					<li><strong>Content Type Definition</strong>—The specification to which the given Core Media Type
+						Resource must conform.</li>
+					<li><strong>Applies to</strong>—The Publication Resource type(s) that the Media Type and Content
+						Type Definition applies to.</li>
+				</ul>
 
-					<ul>
-						<li>The <a>manifest plane</a> &#8212; The manifest plane holds all the resources of the EPUB
-							Publication (namely, <a>Publication Resources</a> and <a>Linked Resources</a>).</li>
-						<li>The <a>spine plane</a> &#8212; The spine plane holds only the resources used in rendering
-							the <a>spine</a> (namely, <a>EPUB Content Documents</a> and <a>Foreign Content
-							Documents</a>).</li>
-						<li>The <a>content plane</a> &#8212; The content plane holds only the resources used in the
-							rendering of EPUB and Foreign Content Documents (namely, <a>Core Media Type Resources</a>,
-								<a>Foreign Resources</a> and <a>Exempt Resources</a>).</li>
-					</ul>
+				<table id="tbl-core-media-types">
+					<thead>
+						<tr>
+							<th id="tbl-cmt-string">Media Type</th>
+							<th id="tbl-cmt-def">Content Type Definition</th>
+							<th id="tbl-cmt-appl">Applies to</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
+						</tr>
+						<tr>
+							<td id="cmt-gif" data-tests="#pub-cmt-gif">
+								<code>image/gif</code>
+							</td>
+							<td> [[GIF]] </td>
+							<td>GIF Images</td>
+						</tr>
+						<tr>
+							<td id="cmt-jpeg" data-tests="#pub-cmt-jpeg">
+								<code>image/jpeg</code>
+							</td>
+							<td> [[JPEG]] </td>
+							<td>JPEG Images</td>
+						</tr>
+						<tr>
+							<td id="cmt-png" data-tests="#pub-cmt-png">
+								<code>image/png</code>
+							</td>
+							<td> [[PNG]] </td>
+							<td>PNG Images</td>
+						</tr>
+						<tr>
+							<td id="cmt-svg" data-tests="#pub-cmt-svg,#cnt-svg-support">
+								<code>image/svg+xml</code>
+							</td>
+							<td>
+								<a href="#sec-svg">SVG Content Documents</a>
+							</td>
+							<td>SVG documents</td>
+						</tr>
+						<tr>
+							<td id="cmt-webp" data-tests="#pub-cmt-webp">
+								<code>image/webp</code>
+							</td>
+							<td> [[WebP-Container]], [[WebP-LB]] </td>
+							<td>WebP Images</td>
+						</tr>
+						<tr>
+							<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>
+						</tr>
+						<tr>
+							<td id="cmt-mp3" data-tests="#pub-cmt-mp3">
+								<code>audio/mpeg</code>
+							</td>
+							<td> [[MP3]] </td>
+							<td>MP3 audio</td>
+						</tr>
+						<tr>
+							<td id="cmt-mp4-aac" data-tests="#pub-cmt-mp4">
+								<code>audio/mp4</code>
+							</td>
+							<td> [[MPEG4-Audio]], [[MP4]] </td>
+							<td>AAC LC audio using MP4 container</td>
+						</tr>
+						<tr>
+							<td id="cmt-ogg-opus" data-tests="#pub-cmt-opus">
+								<code>audio/opus</code>
+							</td>
+							<td> [[RFC7845]] </td>
+							<td>OPUS audio using OGG container</td>
+						</tr>
+						<tr>
+							<th colspan="3" id="cmt-grp-text" class="tbl-group">Style</th>
+						</tr>
+						<tr>
+							<td id="cmt-css">
+								<code>text/css</code>
+							</td>
+							<td>
+								<a href="#sec-css">CSS Style Sheets</a>
+							</td>
+							<td>CSS Style Sheets.</td>
+						</tr>
+						<tr>
+							<th colspan="3" id="cmt-grp-font" class="tbl-group">Fonts</th>
+						</tr>
+						<tr>
+							<td id="cmt-sfnt">
+								<ol class="cmt">
+									<li><code>font/ttf</code></li>
+									<li><code>application/font-sfnt</code></li>
+								</ol>
+							</td>
+							<td>[[TrueType]] </td>
+							<td>TrueType fonts</td>
+						</tr>
+						<tr>
+							<td id="cmt-otf">
+								<ol class="cmt">
+									<li><code>font/otf</code></li>
+									<li><code>application/font-sfnt</code></li>
+									<li><code>application/vnd.ms-opentype</code></li>
+								</ol>
+							</td>
+							<td>[[OpenType]]</td>
+							<td>OpenType fonts</td>
+						</tr>
+						<tr>
+							<td id="cmt-woff">
+								<ol class="cmt">
+									<li><code>font/woff</code></li>
+									<li><code>application/font-woff</code></li>
+								</ol>
+							</td>
+							<td> [[WOFF]] </td>
+							<td>WOFF fonts</td>
+						</tr>
+						<tr>
+							<td id="cmt-woff2">
+								<code>font/woff2</code>
+							</td>
+							<td> [[WOFF2]] </td>
+							<td>WOFF2 fonts</td>
+						</tr>
+						<tr>
+							<th colspan="3" id="cmt-grp-other" class="tbl-group">Other</th>
+						</tr>
+						<tr>
+							<td id="cmt-xhtml">
+								<code>application/xhtml+xml</code>
+							</td>
+							<td>
+								<a href="#sec-xhtml">XHTML Content Documents</a>
+							</td>
+							<td>HTML documents that use the <a data-cite="html#the-xhtml-syntax">XML syntax</a>
+								[[HTML]].</td>
+						</tr>
+						<tr>
+							<td id="cmt-js">
+								<ol class="cmt">
+									<li><code>application/javascript</code></li>
+									<li><code>application/ecmascript</code></li>
+									<li><code>text/javascript</code></li>
+								</ol>
+							</td>
+							<td> [[RFC4329]] </td>
+							<td>Scripts.</td>
+						</tr>
+						<tr>
+							<td id="cmt-ncx">
+								<code>application/x-dtbncx+xml</code>
+							</td>
+							<td> [[OPF-201]] </td>
+							<td>The <a href="#legacy">legacy</a> NCX.</td>
+						</tr>
+						<tr>
+							<td id="cmt-smil">
+								<code>application/smil+xml</code>
+							</td>
+							<td>
+								<a href="#sec-media-overlays">Media Overlays</a>
+							</td>
+							<td>EPUB Media Overlay documents</td>
+						</tr>
+					</tbody>
+				</table>
 
-					<p>The same resource may exist on more than one plane and will be referred to differently in this
-						specification depending on which plane is being discussed. For example, a Core Media Type
-						Resource used in the rendering of an EPUB Content Document (on the content plane) may also be a
-						Foreign Content Document if it is also listed in the spine (the spine plane).</p>
+				<div class="note">
+					<p>Inclusion as a Core Media Type Resource does not mean that all Reading Systems will support the
+						rendering of a resource. Reading System support also depends on the capabilities of the
+						application (e.g., a Reading System with a <a>Viewport</a> must support image Core Media Type
+						Resources, but a Reading System without a Viewport does not). Refer to <a
+							data-cite="epub-rs-33#sec-epub-rs-conf-cmt">Core Media Types</a> [[EPUB-RS-33]] for more
+						information about which Reading Systems rendering capabilities require support for which Core
+						Media Type Resources.</p>
 
-					<p>The following sections describe these planes in more detail.</p>
+					<p>The Working Group typically only includes formats as Core Media Type Resources when they have
+						broad support in web browser cores &#8212; the rendering engines that EPUB 3 Reading Systems
+						build upon. They are an agreement between Reading System developers and EPUB Creators to ensure
+						the predictability of rendering of EPUB Publications.</p>
+				</div>
+			</section>
 
-					<div class="note">
-						<p>Refer to <a href="#publication-resources-example"></a> for a detailed example showing how
-							resources fit into the different planes.</p>
-					</div>
+			<section id="sec-foreign-resources">
+				<h3>Foreign Resources</h3>
 
-					<section id="sec-manifest-plane">
-						<h5>The Manifest Plane</h5>
+				<p>A <a>Foreign Resource</a>, unlike a <a href="#sec-core-media-types">Core Media Type Resource</a> is
+					one which is not guaranteed <a>Reading System</a> support when used in an <a>EPUB Content
+						Document</a> or <a>Foreign Content Document</a>.</p>
 
-						<p>To <dfn>manifest plane</dfn> defines all the resources of an <a>EPUB Publication</a>. It is
-							analogous to the <a>Package Document</a>
-							<a>manifest</a>, but includes resources not present in that list.</p>
+				<p id="confreq-cmt">EPUB Creators MUST provide fallbacks for Foreign Resources, where fallbacks take one
+					of the following forms:</p>
 
-						<p>The primary resources in this group are designated <a>Publication Resources</a>, which are
-							all the resources used in rendering an EPUB Publication to the user. <a>EPUB Creators</a>
-							always have to list these resources in the <a href="#sec-manifest-elem"
-									><code>manifest</code> element</a> but they do not have to locate them all in the
-								<a>EPUB Container</a>. EPUB 3 allows <a href="#sec-resource-locations">audio, video,
-								font and script data resources</a> to be hosted outside the Container.</p>
+				<ul>
+					<li>
+						<p>intrinsic fallback mechanisms provided by the host format (e.g., [[?HTML]] elements often
+							provide the ability to reference more than one media type or to display an alternate
+							embedded message when a media type cannot be rendered); or</p>
+					</li>
+					<li>
+						<p><a href="#sec-manifest-fallbacks">manifest fallback</a> chains defined on <a
+								href="#sec-item-elem"><code>item</code> elements</a> in the <a>Package Document</a>.</p>
+					</li>
+				</ul>
 
-						<p>Publication Resources are further classified by their use(s) in the <a>spine plane</a> and
-								<a>content plane</a>.</p>
+				<div class="note">
+					<p>Refer to the [[HTML]] and [[SVG]] specifications for the intrinsic fallback capabilities their
+						elements provide.</p>
+				</div>
 
-						<p>The manifest plane also contains a set of <a>Linked Resources</a>. These resources are
-							tangential to the direct rendering. They include, for example, metadata records and links to
-							external content (e.g., where to purchase an EPUB Publication).</p>
+				<p>The following sections provide additional clarifications about the intrinsic fallback requirements of
+					specific elements.</p>
 
-						<p>Unlike Publication Resources, they are not listed in the Package Document manifest (i.e.,
-							because they are not essential to rendering the EPUB Publication). They are instead defined
-							in <a href="#sec-link-elem"><code>link</code> elements</a> in the Package Document metadata.
-							These elements define their nature and purpose similar to how manifest <a
-								href="#sec-item-elem"><code>item</code> elements</a> define Publication Reousrce. (In
-							this way, they are like an extension of the manifest.)</p>
+				<section id="sec-fallbacks-audio">
+					<h4>HTML <code>audio</code> Fallbacks</h4>
 
-						<p>Refer to <a href="#sec-link-elem"></a> for more information about Linked Resources.</p>
-					</section>
+					<p id="confreq-resources-cd-fallback-media">EPUB Creators MUST NOT use embedded [[HTML]] <a
+							data-cite="html#flow-content">flow content</a> within the <a
+							data-cite="html#the-audio-element"><code>audio</code></a> element as an intrinsic fallback
+						for Foreign Resources. Only child <a data-cite="html#the-source-element"><code>source</code>
+							elements</a> [[HTML]] provide intrinsic fallback capabilities.</p>
 
-					<section id="sec-spine-plane">
-						<h5>The Spine Plane</h5>
-
-						<p>The <dfn>spine plane</dfn> defines resources used in the default reading order established by
-							the <a>spine</a>, which includes both <a href="#attrdef-itemref-linear">linear and
-								non-linear content</a>. The spine instructs <a>Reading Systems</a> on how to load these
-							resources as the user progresses through the <a>EPUB Publication</a>. Although many
-							resources may be bundled in an <a>EPUB Container</a>, they are not all allowed by default in
-							the spine.</p>
-
-						<p>EPUB 3 defines a special class of resources called <a>EPUB Content Documents</a> that <a>EPUB
-								Creators</a> can use in the spine without any restrictions. EPUB Content Documents
-							encompass both <a>XHTML Content Documents</a> and <a>SVG Content Documents</a>.</p>
-
-						<p>To use any other type of resource in the spine, called a <a>Foreign Content Document</a>,
-							requires including a fallback to an EPUB Content Document. This extensibility model allows
-							EPUB Creators to experiment with formats while ensuring that Reading Systems are always able
-							to render something for the user to read, as there is no guarantee of support for Foreign
-							Content Documents.</p>
-
-						<p>A mechanism called <a href="#sec-manifest-fallbacks">manifest fallbacks</a> allows EPUB
-							Creators to provide fallbacks for Foreign Content Documents. In this model, the
-								<a>manifest</a> entry for the Foreign Content Document must include a <a
-								href="#attrdef-item-fallback"><code>fallback</code> attribute</a> that points to the
-							next possible resource for Reading Systems to try when they do not support its format.
-							Although not common, a fallback resource can specify another fallback, thereby making chains
-							many resources deep. The one requirement is that there must be at least one EPUB Content
-							Document in a fallback chain.</p>
-
-						<p>Although they are not directly listed in the spine, all of the resources in the fallback
-							chain are considered part of the spine, and by extension part of the spine plane, since any
-							may be used by a Reading System.</p>
-
-						<p>Refer to <a href="#sec-manifest-fallbacks"></a> for more information.</p>
-
-						<div class="caution" id="caution-fallbacks">
-							<p>Although manifest fallbacks fulfill the technical requirements of EPUB, there is little
-								practical support for them in Reading Systems. Their use is strongly discouraged as it
-								can lead to unreadable publications.</p>
-						</div>
-
-						<div class="note">
-							<p>It is possible to provide manifest fallbacks for EPUB Content Documents, but this is not
-								required or common. For example, a <a>Scripted Content Document</a> could have a
-								fallback to an unscripted alternative for Reading Systems that do not support
-								scripting.</p>
-						</div>
-					</section>
-
-					<section id="sec-content-plane">
-						<h5>The Content Plane</h5>
-
-						<p>The <dfn>content plane</dfn> classifies resources based on their use in rendering <a>EPUB
-								Content Documents</a> and <a>Foreign Content Documents</a>. These resources fall into
-							three categories: <a>Core Media Type Resources</a>, <a>Foreign Resources</a>, and <a>Exempt
-								Resources</a>.</p>
-
-						<p>A Core Media Type Resource is one that <a>Reading Systems</a> have to support, so it can be
-							used without restriction in EPUB or Foreign Content Documents. For more information about
-							Core Media Type Resources, refer to <a href="#sec-core-media-types"></a>.</p>
-
-						<div class="note">
-							<p>Being a Core Media Type Resource does not mean that Reading Systems will always render
-								the resource, as not all Reading Systems support all features of EPUB 3. A Reading
-								System without a <a>Viewport</a>, for example, will not render visual content such as
-								images.</p>
-						</div>
-
-						<p>The opposite of Core Media Type Resources are Foreign Resources. These are resources that
-							Reading Systems are not guaranteed to support the rendering of. As a result, similar to how
-							using Foreign Content Documents in the spine requires fallbacks to ensure their rendering,
-							using Foreign Resources in content documents also requires fallbacks. These fallbacks are
-							provided in one of two ways: using the capabilities of the host format or via manifest
-							fallbacks.</p>
-
-						<p>The preferred method is to use the fallback capabilities of the host format. Many HTML
-							elements, for example, have intrinsic fallback capabilities. One example is the <a
-								href="html#the-picture-element"><code>picture</code> element</a> [[HTML]], which allows
-							EPUB Creators to specify multiple alternative image formats.</p>
-
-						<p>If an intrinsic fallback method is not available, it is also possible to use manifest
-							fallbacks, but this method, as <a href="#caution-fallbacks">cautioned against</a> in the
-							previous section, is discouraged. For more information about Foreign Resources, refer to <a
-								href="#sec-foreign-resources"></a>.</p>
-
-						<p>Falling between Core Media Type Resources and Foreign Resources are Exempt Resources. These
-							are most closely associated with Foreign Resources, as there is no guarantee that Reading
-							Systems will render them. But like Core Media Types, they do not require fallbacks.</p>
-
-						<p>Exempt Resources tend to address specific cases for which there are no Core Media Types
-							defined, but for which providing a fallback would prove cumbersome or unnecessary. These
-							include embedding video, adding accessibility tracks, and linking to resources from the
-							[[HTML]] <a data-cite="html#the-link-element"><code>link</code> element</a>.</p>
-
-						<p>Refer to <a href="#sec-exempt-resources"></a> for more information about these
-							exceptions.</p>
-
-						<div class="note">
-							<p>A common point of confusion arising from Core Media Type Resources is the listing of
-								XHTML and SVG as Core Media Type Resources with the requirement the markup conform to
-								their respective <a>EPUB Content Document</a> definitions. This allows EPUB Creators to
-								embed both XHTML and SVG documents in EPUB Content Documents while keeping consistent
-								requirements for authoring and Reading System support.</p>
-
-							<p>In practice, it means that EPUB Creators can put XHTML and SVG Core Media Type Resources
-								in the spine without any modification or fallback (they are also conforming XHTML and
-								SVG Content Documents), but this is a unique case. All other Core Media Type Resources
-								become Foreign Content Documents when used in the spine (i.e., Foreign Content Documents
-								include all Foreign Resources and all Core Media Type Resources except for XHTML and
-								SVG).</p>
-						</div>
-					</section>
-				</section>
-
-				<section id="sec-core-media-types">
-					<h4>Core Media Types</h4>
-
-					<p><a>EPUB Creators</a> MAY include <a>Publication Resources</a> that conform to the MIME media type
-						[[RFC2046]] specifications defined in the following table without fallbacks when they are used
-						in <a>EPUB Content Documents</a> and <a>Foreign Content Documents</a>. These resources are
-						classified as <a>Core Media Type Resources</a>.</p>
-
-					<p>With the exception of XHTML Content Documents and SVG Content Documents, EPUB Creators MUST
-						provide <a href="#sec-manifest-fallbacks">manifest fallbacks</a> for Core Media Type Resources
-						referenced directly from the <a>spine</a>. In this case, they are <a>Foreign Content
-							Documents</a>.</p>
-
-					<p>The columns in the table represent the following information:</p>
-
-					<ul>
-						<li>
-							<p><strong>Media Type</strong>—The MIME media type [[RFC2046]] used to represent the given
-								Publication Resource in the <a href="#sec-manifest-elem">manifest</a>.</p>
-							<p>If the table lists more than one media type, the first one is the preferred media type.
-								EPUB Creators should use the preferred media type for all new EPUB Publications.</p>
-						</li>
-						<li><strong>Content Type Definition</strong>—The specification to which the given Core Media
-							Type Resource must conform.</li>
-						<li><strong>Applies to</strong>—The Publication Resource type(s) that the Media Type and Content
-							Type Definition applies to.</li>
-					</ul>
-
-					<table id="tbl-core-media-types">
-						<thead>
-							<tr>
-								<th id="tbl-cmt-string">Media Type</th>
-								<th id="tbl-cmt-def">Content Type Definition</th>
-								<th id="tbl-cmt-appl">Applies to</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr>
-								<th colspan="3" id="cmt-grp-image" class="tbl-group">Images</th>
-							</tr>
-							<tr>
-								<td id="cmt-gif" data-tests="#pub-cmt-gif">
-									<code>image/gif</code>
-								</td>
-								<td> [[GIF]] </td>
-								<td>GIF Images</td>
-							</tr>
-							<tr>
-								<td id="cmt-jpeg" data-tests="#pub-cmt-jpeg">
-									<code>image/jpeg</code>
-								</td>
-								<td> [[JPEG]] </td>
-								<td>JPEG Images</td>
-							</tr>
-							<tr>
-								<td id="cmt-png" data-tests="#pub-cmt-png">
-									<code>image/png</code>
-								</td>
-								<td> [[PNG]] </td>
-								<td>PNG Images</td>
-							</tr>
-							<tr>
-								<td id="cmt-svg" data-tests="#pub-cmt-svg,#cnt-svg-support">
-									<code>image/svg+xml</code>
-								</td>
-								<td>
-									<a href="#sec-svg">SVG Content Documents</a>
-								</td>
-								<td>SVG documents</td>
-							</tr>
-							<tr>
-								<td id="cmt-webp" data-tests="#pub-cmt-webp">
-									<code>image/webp</code>
-								</td>
-								<td> [[WebP-Container]], [[WebP-LB]] </td>
-								<td>WebP Images</td>
-							</tr>
-							<tr>
-								<th colspan="3" id="cmt-grp-audio" class="tbl-group">Audio</th>
-							</tr>
-							<tr>
-								<td id="cmt-mp3" data-tests="#pub-cmt-mp3">
-									<code>audio/mpeg</code>
-								</td>
-								<td> [[MP3]] </td>
-								<td>MP3 audio</td>
-							</tr>
-							<tr>
-								<td id="cmt-mp4-aac" data-tests="#pub-cmt-mp4">
-									<code>audio/mp4</code>
-								</td>
-								<td> [[MPEG4-Audio]], [[MP4]] </td>
-								<td>AAC LC audio using MP4 container</td>
-							</tr>
-							<tr>
-								<td id="cmt-ogg-opus" data-tests="#pub-cmt-opus">
-									<code>audio/opus</code>
-								</td>
-								<td> [[RFC7845]] </td>
-								<td>OPUS audio using OGG container</td>
-							</tr>
-							<tr>
-								<th colspan="3" id="cmt-grp-text" class="tbl-group">Style</th>
-							</tr>
-							<tr>
-								<td id="cmt-css">
-									<code>text/css</code>
-								</td>
-								<td>
-									<a href="#sec-css">CSS Style Sheets</a>
-								</td>
-								<td>CSS Style Sheets.</td>
-							</tr>
-							<tr>
-								<th colspan="3" id="cmt-grp-font" class="tbl-group">Fonts</th>
-							</tr>
-							<tr>
-								<td id="cmt-sfnt">
-									<ol class="cmt">
-										<li><code>font/ttf</code></li>
-										<li><code>application/font-sfnt</code></li>
-									</ol>
-								</td>
-								<td>[[TrueType]] </td>
-								<td>TrueType fonts</td>
-							</tr>
-							<tr>
-								<td id="cmt-otf">
-									<ol class="cmt">
-										<li><code>font/otf</code></li>
-										<li><code>application/font-sfnt</code></li>
-										<li><code>application/vnd.ms-opentype</code></li>
-									</ol>
-								</td>
-								<td>[[OpenType]]</td>
-								<td>OpenType fonts</td>
-							</tr>
-							<tr>
-								<td id="cmt-woff">
-									<ol class="cmt">
-										<li><code>font/woff</code></li>
-										<li><code>application/font-woff</code></li>
-									</ol>
-								</td>
-								<td> [[WOFF]] </td>
-								<td>WOFF fonts</td>
-							</tr>
-							<tr>
-								<td id="cmt-woff2">
-									<code>font/woff2</code>
-								</td>
-								<td> [[WOFF2]] </td>
-								<td>WOFF2 fonts</td>
-							</tr>
-							<tr>
-								<th colspan="3" id="cmt-grp-other" class="tbl-group">Other</th>
-							</tr>
-							<tr>
-								<td id="cmt-xhtml">
-									<code>application/xhtml+xml</code>
-								</td>
-								<td>
-									<a href="#sec-xhtml">XHTML Content Documents</a>
-								</td>
-								<td>HTML documents that use the <a data-cite="html#the-xhtml-syntax">XML syntax</a>
-									[[HTML]].</td>
-							</tr>
-							<tr>
-								<td id="cmt-js">
-									<ol class="cmt">
-										<li><code>application/javascript</code></li>
-										<li><code>application/ecmascript</code></li>
-										<li><code>text/javascript</code></li>
-									</ol>
-								</td>
-								<td> [[RFC4329]] </td>
-								<td>Scripts.</td>
-							</tr>
-							<tr>
-								<td id="cmt-ncx">
-									<code>application/x-dtbncx+xml</code>
-								</td>
-								<td> [[OPF-201]] </td>
-								<td>The <a href="#legacy">legacy</a> NCX.</td>
-							</tr>
-							<tr>
-								<td id="cmt-smil">
-									<code>application/smil+xml</code>
-								</td>
-								<td>
-									<a href="#sec-media-overlays">Media Overlays</a>
-								</td>
-								<td>EPUB Media Overlay documents</td>
-							</tr>
-						</tbody>
-					</table>
+					<p>Only older Reading Systems that do not recognize the <code>audio</code> element (e.g., EPUB 2
+						Reading Systems) will render the embedded content. When Reading Systems support the
+							<code>audio</code> element but not the available audio formats, they do not render the
+						embedded content for the user.</p>
 
 					<div class="note">
-						<p>Inclusion as a Core Media Type Resource does not mean that all Reading Systems will support
-							the rendering of a resource. Reading System support also depends on the capabilities of the
-							application (e.g., a Reading System with a <a>Viewport</a> must support image Core Media
-							Type Resources, but a Reading System without a Viewport does not). Refer to <a
-								data-cite="epub-rs-33#sec-epub-rs-conf-cmt">Core Media Types</a> [[EPUB-RS-33]] for more
-							information about which Reading Systems rendering capabilities require support for which
-							Core Media Type Resources.</p>
-
-						<p>The Working Group typically only includes formats as Core Media Type Resources when they have
-							broad support in web browser cores &#8212; the rendering engines that EPUB 3 Reading Systems
-							build upon. They are an agreement between Reading System developers and EPUB Creators to
-							ensure the predictability of rendering of EPUB Publications.</p>
+						<p>As video resources are <a>Exempt Resources</a>, this requirement does not apply to the
+								<code>video</code> element. EPUB Creators may also include flow content in the
+								<code>video</code> element for Reading Systems that do not support the element,
+							however.</p>
 					</div>
 				</section>
 
-				<section id="sec-foreign-resources">
-					<h4>Foreign Resources</h4>
+				<section id="sec-fallbacks-img">
+					<h4>HTML <code>img</code> Fallbacks</h4>
 
-					<p>A <a>Foreign Resource</a>, unlike a <a href="#sec-core-media-types">Core Media Type Resource</a>
-						is one which is not guaranteed <a>Reading System</a> support when used in an <a>EPUB Content
-							Document</a> or <a>Foreign Content Document</a>.</p>
-
-					<p id="confreq-cmt">EPUB Creators MUST provide fallbacks for Foreign Resources, where fallbacks take
-						one of the following forms:</p>
+					<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that EPUB Creators can
+						specify in the [[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>, the
+						following fallback conditions apply to its use:</p>
 
 					<ul>
 						<li>
-							<p>intrinsic fallback mechanisms provided by the host format (e.g., [[?HTML]] elements often
-								provide the ability to reference more than one media type or to display an alternate
-								embedded message when a media type cannot be rendered); or</p>
+							<p>If it is the child of a <a data-cite="html#the-picture-element"><code>picture</code>
+									element</a>:</p>
+							<ul>
+								<li>it MUST reference Core Media Type Resources from its <code>src</code> and
+										<code>srcset</code> attributes, when EPUB Creators specify those attributes;
+									and</li>
+								<li>each sibling <a data-cite="html#the-source-element"><code>source</code> element</a>
+									MUST reference a Core Media Type Resource from its <code>src</code> and
+										<code>srcset</code> attributes unless it specifies the MIME media type
+									[[RFC2046]] of a Foreign Resource in its <code>type</code> attribute.</li>
+							</ul>
 						</li>
-						<li>
-							<p><a href="#sec-manifest-fallbacks">manifest fallback</a> chains defined on <a
-									href="#sec-item-elem"><code>item</code> elements</a> in the <a>Package
+
+						<li>Otherwise, it MAY reference Foreign Resources in its <code>src</code> and
+								<code>srcset</code> attributes provided EPUB Creators define a <a
+								href="#sec-manifest-fallbacks">manifest fallback</a>.</li>
+					</ul>
+				</section>
+			</section>
+
+			<section id="sec-exempt-resources">
+				<h3>Exempt Resources</h3>
+
+				<p>An <a>Exempt Resource</a> shares properties with both <a>Foreign Resources</a> and <a>Core Media Type
+						Resources</a>. It is most similar to a <a>Foreign Resource</a> in that it is not guaranteed
+						<a>Reading System</a> support, but, like a Core Media Type Resource, does not require a
+					fallback.</p>
+
+				<p>There are only a small set of special cases for Exempt Resources. Video, for example, are exempt from
+					fallbacks because there is no consensus on a Core Media Type video format at this time (i.e., there
+					is no format to fallback to). Similarly, audio and video tracks are exempt to allow EPUB Creators to
+					meet accessibility requirements using whatever format Reading Systems support best.</p>
+
+				<p>The following list details cases of content-specific Exempt Resources, including any restrictions on
+					where EPUB Creators can use them.</p>
+
+				<dl>
+					<dt id="exempt-fonts">Fonts</dt>
+					<dd id="confreq-resources-cd-fonts">
+						<p>All font resources not already covered as <a href="#cmt-grp-font">font Core Media Types</a>
+							are Exempt Resources.</p>
+						<p>This exemption allows EPUB Creators to use any font format without a fallback, regardless of
+							Reading System support expectations, as CSS rules will ensure a fallback font in case of no
+							support.</p>
+						<p>Refer to the <a data-cite="epub-rs-33#confreq-css-rs-fonts">Reading System support
+								requirements for fonts</a> [[EPUB-RS-33]] for more information.</p>
+					</dd>
+
+					<dt id="exempt-links">Linked resources</dt>
+					<dd id="confreq-resources-cd-fallback-link">
+						<p>Any resource referenced from the [[HTML]] <a data-cite="html#the-link-element"
+									><code>link</code> element</a> that is not already a Core Media Type Resource (e.g.,
+							CSS style sheets) is an Exempt Resource.</p>
+					</dd>
+
+					<dt id="exempt-track" class="tbl-group">Tracks</dt>
+					<dd id="confreq-resources-cd-fallback-track">
+						<p>All audio and video tracks (e.g., [[?WebVTT]] captions, subtitles and descriptions)
+							referenced from the [[HTML]] <a data-cite="html#the-track-element"><code>track</code></a>
+							element are Exempt Resources.</p>
+					</dd>
+
+					<dt id="exempt-video" class="tbl-group">Video</dt>
+					<dd id="confreq-resources-cd-fallback-video">
+						<p>All video codecs referenced from the [[HTML]] <a data-cite="html#the-video-element"
+									><code>video</code></a> — including any child <a data-cite="html#the-source-element"
+									><code>source</code></a> elements — are Exempt Resources.</p>
+						<div class="note">
+							<p>Although Reading Systems are encouraged to support at least one of the H.264 [[?H264]]
+								and VP8 [[?RFC6386]] video codecs, support for video codecs is not a conformance
+								requirement. EPUB Creators must consider factors such as breadth of adoption, playback
+								quality, and technology royalties when deciding which video formats to include.</p>
+						</div>
+					</dd>
+				</dl>
+
+				<div class="note">
+					<p>The exemptions made above do not apply to the spine. If an Exempt Resource is used in the spine,
+						and it is not also an EPUB Content Document, it will require a fallback in that context.</p>
+				</div>
+
+				<p id="confreq-foreign-no-fallback">In addition to the content-specific exemptions, a resource is
+					classified as an Exempt Resource if:</p>
+
+				<ul>
+					<li>
+						<p>it is not referenced from a <a href="#sec-itemref-elem">spine <code>itemref</code>
+								element</a> (i.e., used as a <a>Foreign Content Document</a>);
+								<strong><em>and</em></strong></p>
+					</li>
+					<li>
+						<p>it is not embedded directly in EPUB Content Documents (e.g., via [[?HTML]] <a
+								data-cite="html#embedded-content">embedded content</a> and [[?SVG]] <a
+								href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"><code>image</code></a> and
+								<a href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
+									><code>foreignObject</code></a> elements).</p>
+					</li>
+				</ul>
+
+				<p>This exemption allows EPUB Creators to include resources in the <a>EPUB Container</a> that are not
+					for use by EPUB Reading Systems. The primary case for this exemption is to allow data files to
+					travel with an EPUB Publication, whether for scripts to use in their constituent EPUB Content
+					Documents or for external applications to use (e.g., a scientific journal might include a data set
+					with instructions on how to extract it from the EPUB Container).</p>
+
+				<p>It also allows EPUB Creators to use Foreign Resources in Foreign Content Documents without Reading
+					Systems or <a>EPUB Conformance Checkers</a> having to understand the fallback capabilities of those
+					resources (i.e., the requirement for a fallback for the Foreign Content Document covers any
+					rendering issues within it). As the resource is not referenced from an EPUB Content Document, it
+					automatically becomes exempt from fallbacks.</p>
+			</section>
+
+			<section id="sec-manifest-fallbacks">
+				<h3>Manifest Fallbacks</h3>
+
+				<div class="caution">
+					<p>Reading System support for manifest fallbacks is poor and should not be relied upon to create
+						interoperable content. In most cases, if a Reading System does not support a format, it will not
+						use its fallback. This can lead to unexpected failures.</p>
+
+					<p>EPUB Creators should use the intrinsic fallback capabilities of HTML and SVG to provide fallback
+						content whenever possible, and avoid using <a>Foreign Content Documents</a> in the spine.</p>
+				</div>
+
+				<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback chains, allowing
+					Reading Systems to select an alternative format they can render.</p>
+
+				<p>There are two primary use cases for manifest fallbacks:</p>
+
+				<ol>
+					<li>To specify fallbacks when <a>Foreign Content Documents</a> are referenced from the <a
+							href="#sec-spine-elem">spine</a>.</li>
+					<li>To provide fallbacks when intrinsic fallback are not available for elements in EPUB Content
+						Documents (e.g., for the [[HTML]] <a data-cite="html#the-img-element"><code>img</code></a>
+						element) in order to satisfy the requirements in <a href="#sec-foreign-resources"></a>.</li>
+				</ol>
+
+				<p>The <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> on the <a>manifest</a>
+					<a href="#elemdef-package-item"><code>item</code></a> element specifies the fallback for the
+					referenced Publication Resource. The <code>fallback</code> attribute's IDREF [[XML]] value MUST
+					resolve to another <code>item</code> in the <code>manifest</code>. This fallback <code>item</code>
+					MAY itself specify another fallback <code>item</code>, and so on.</p>
+
+				<p>The ordered list of all the ID references that a Reading System can reach, starting from a given
+					item's <code>fallback</code> attribute, represents the <em>fallback chain</em> for that item. The
+					order of the resources in the fallback chain represents the EPUB Creator's preferred fallback
+					order.</p>
+
+				<p>Fallback chains MUST conform to one of the following requirements, as appropriate:</p>
+
+				<ul>
+					<li>
+						<p>For Foreign Content Documents, the chain MUST contain at least one <a>EPUB Content
 								Document</a>.</p>
-						</li>
-					</ul>
+					</li>
+					<li>
+						<p>For Foreign Resources for which an EPUB Creator cannot provide an intrinsic fallback, the
+							chain MUST contain at least one <a>Core Media Type Resource</a>.</p>
+					</li>
+				</ul>
 
-					<div class="note">
-						<p>Refer to the [[HTML]] and [[SVG]] specifications for the intrinsic fallback capabilities
-							their elements provide.</p>
-					</div>
+				<p>Fallback chains MUST NOT contain circular or self-references to <code>item</code> elements in the
+					chain.</p>
 
-					<p>The following sections provide additional clarifications about the intrinsic fallback
-						requirements of specific elements.</p>
+				<p>EPUB Creators MAY provide fallbacks for <a>Top-Level Content Documents</a> that are EPUB Content
+					Documents (e.g., to provide <a href="#confreq-cd-scripted-flbk">fallbacks for scripted
+					content</a>).</p>
 
-					<section id="sec-fallbacks-audio">
-						<h5>HTML <code>audio</code> Fallbacks</h5>
+				<p>EPUB Creators MAY also provide manifest fallbacks for <a>Core Media Type Resources</a> (e.g., to
+					allow Reading Systems to select from more than one image format).</p>
 
-						<p id="confreq-resources-cd-fallback-media">EPUB Creators MUST NOT use embedded [[HTML]] <a
-								data-cite="html#flow-content">flow content</a> within the <a
-								data-cite="html#the-audio-element"><code>audio</code></a> element as an intrinsic
-							fallback for Foreign Resources. Only child <a data-cite="html#the-source-element"
-									><code>source</code> elements</a> [[HTML]] provide intrinsic fallback
-							capabilities.</p>
+				<div class="note">
+					<p>As it is not possible to use manifest fallbacks for resources represented in <a
+							href="#sec-data-urls">data URLs</a>, EPUB Creators can only represent Foreign Resources as
+						data URLs where an intrinsic fallback mechanism is available.</p>
+				</div>
+			</section>
 
-						<p>Only older Reading Systems that do not recognize the <code>audio</code> element (e.g., EPUB 2
-							Reading Systems) will render the embedded content. When Reading Systems support the
-								<code>audio</code> element but not the available audio formats, they do not render the
-							embedded content for the user.</p>
+			<section id="sec-resource-locations">
+				<h3>Resource Locations</h3>
 
-						<div class="note">
-							<p>As video resources are <a>Exempt Resources</a>, this requirement does not apply to the
-									<code>video</code> element. EPUB Creators may also include flow content in the
-									<code>video</code> element for Reading Systems that do not support the element,
-								however.</p>
-						</div>
-					</section>
+				<p>EPUB Creators MAY host the following types of Publication Resources outside the EPUB Container:</p>
 
-					<section id="sec-fallbacks-img">
-						<h5>HTML <code>img</code> Fallbacks</h5>
+				<ul class="conformance-list">
+					<li>
+						<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a>.</p>
+					</li>
+					<li>
+						<p id="sec-resource-locations-video"><a href="#exempt-video">Video resources</a>.</p>
+					</li>
+					<li>
+						<p id="sec-resource-locations-script">Resources retrieved via scripting APIs (e.g.,
+							XmlHttpRequest [[?XHR]] and Fetch [[?FETCH]]).</p>
+					</li>
+					<li>
+						<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a>.</p>
+					</li>
+				</ul>
 
-						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that EPUB Creators can
-							specify in the [[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>,
-							the following fallback conditions apply to its use:</p>
+				<p>EPUB Creators MUST store all other resources within the EPUB Container.</p>
 
-						<ul>
-							<li>
-								<p>If it is the child of a <a data-cite="html#the-picture-element"><code>picture</code>
-										element</a>:</p>
-								<ul>
-									<li>it MUST reference Core Media Type Resources from its <code>src</code> and
-											<code>srcset</code> attributes, when EPUB Creators specify those attributes;
-										and</li>
-									<li>each sibling <a data-cite="html#the-source-element"><code>source</code>
-											element</a> MUST reference a Core Media Type Resource from its
-											<code>src</code> and <code>srcset</code> attributes unless it specifies the
-										MIME media type [[RFC2046]] of a Foreign Resource in its <code>type</code>
-										attribute.</li>
-								</ul>
-							</li>
+				<p>Storing all resources inside the EPUB Container is strongly encouraged whenever possible as it allows
+					users access to the entire presentation regardless of connectivity status.</p>
 
-							<li>Otherwise, it MAY reference Foreign Resources in its <code>src</code> and
-									<code>srcset</code> attributes provided EPUB Creators define a <a
-									href="#sec-manifest-fallbacks">manifest fallback</a>.</li>
-						</ul>
-					</section>
-				</section>
+				<p>These rules for locating Publication Resource apply regardless of whether the given resource is a
+						<a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
 
-				<section id="sec-exempt-resources">
-					<h4>Exempt Resources</h4>
+				<div class="note">
+					<p>Refer to the <a href="#remote-resources"><code>remote-resources</code> property</a> for more
+						information on how to indicate that a <a>manifest</a>
+						<a href="#sec-item-elem"><code>item</code></a> references a <a>Remote Resource</a>.</p>
+				</div>
 
-					<p>An <a>Exempt Resource</a> shares properties with both <a>Foreign Resources</a> and <a>Core Media
-							Type Resources</a>. It is most similar to a <a>Foreign Resource</a> in that it is not
-						guaranteed <a>Reading System</a> support, but, like a Core Media Type Resource, does not require
-						a fallback.</p>
-
-					<p>There are only a small set of special cases for Exempt Resources. Video, for example, are exempt
-						from fallbacks because there is no consensus on a Core Media Type video format at this time
-						(i.e., there is no format to fallback to). Similarly, audio and video tracks are exempt to allow
-						EPUB Creators to meet accessibility requirements using whatever format Reading Systems support
-						best.</p>
-
-					<p>The following list details cases of content-specific Exempt Resources, including any restrictions
-						on where EPUB Creators can use them.</p>
-
-					<dl>
-						<dt id="exempt-fonts">Fonts</dt>
-						<dd id="confreq-resources-cd-fonts">
-							<p>All font resources not already covered as <a href="#cmt-grp-font">font Core Media
-									Types</a> are Exempt Resources.</p>
-							<p>This exemption allows EPUB Creators to use any font format without a fallback, regardless
-								of Reading System support expectations, as CSS rules will ensure a fallback font in case
-								of no support.</p>
-							<p>Refer to the <a data-cite="epub-rs-33#confreq-css-rs-fonts">Reading System support
-									requirements for fonts</a> [[EPUB-RS-33]] for more information.</p>
-						</dd>
-
-						<dt id="exempt-links">Linked resources</dt>
-						<dd id="confreq-resources-cd-fallback-link">
-							<p>Any resource referenced from the [[HTML]] <a data-cite="html#the-link-element"
-										><code>link</code> element</a> that is not already a Core Media Type Resource
-								(e.g., CSS style sheets) is an Exempt Resource.</p>
-						</dd>
-
-						<dt id="exempt-track" class="tbl-group">Tracks</dt>
-						<dd id="confreq-resources-cd-fallback-track">
-							<p>All audio and video tracks (e.g., [[?WebVTT]] captions, subtitles and descriptions)
-								referenced from the [[HTML]] <a data-cite="html#the-track-element"
-									><code>track</code></a> element are Exempt Resources.</p>
-						</dd>
-
-						<dt id="exempt-video" class="tbl-group">Video</dt>
-						<dd id="confreq-resources-cd-fallback-video">
-							<p>All video codecs referenced from the [[HTML]] <a data-cite="html#the-video-element"
-										><code>video</code></a> — including any child <a
-									data-cite="html#the-source-element"><code>source</code></a> elements — are Exempt
-								Resources.</p>
-              <div class="note">
-							  <p>Although Reading Systems are encouraged to support at least one of the H.264 [[?H264]]
-                  and VP8 [[?RFC6386]] video codecs, support for video codecs is not a conformance
-                  requirement. EPUB Creators must consider factors such as breadth of adoption, playback
-                  quality, and technology royalties when deciding which video formats to include.</p>
-              </div>
-						</dd>
-					</dl>
-
-					<div class="note">
-						<p>The exemptions made above do not apply to the spine. If an Exempt Resource is used in the
-							spine, and it is not also an EPUB Content Document, it will require a fallback in that
-							context.</p>
-					</div>
-
-					<p id="confreq-foreign-no-fallback">In addition to the content-specific exemptions, a resource is
-						classified as an Exempt Resource if:</p>
-
-					<ul>
-						<li>
-							<p>it is not referenced from a <a href="#sec-itemref-elem">spine <code>itemref</code>
-									element</a> (i.e., used as a <a>Foreign Content Document</a>);
-									<strong><em>and</em></strong></p>
-						</li>
-						<li>
-							<p>it is not embedded directly in EPUB Content Documents (e.g., via [[?HTML]] <a
-									data-cite="html#embedded-content">embedded content</a> and [[?SVG]] <a
-									href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"><code>image</code></a>
-								and <a href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
-										><code>foreignObject</code></a> elements).</p>
-						</li>
-					</ul>
-
-					<p>This exemption allows EPUB Creators to include resources in the <a>EPUB Container</a> that are
-						not for use by EPUB Reading Systems. The primary case for this exemption is to allow data files
-						to travel with an EPUB Publication, whether for scripts to use in their constituent EPUB Content
-						Documents or for external applications to use (e.g., a scientific journal might include a data
-						set with instructions on how to extract it from the EPUB Container).</p>
-
-					<p>It also allows EPUB Creators to use Foreign Resources in Foreign Content Documents without
-						Reading Systems or <a>EPUB Conformance Checkers</a> having to understand the fallback
-						capabilities of those resources (i.e., the requirement for a fallback for the Foreign Content
-						Document covers any rendering issues within it). As the resource is not referenced from an EPUB
-						Content Document, it automatically becomes exempt from fallbacks.</p>
-				</section>
-
-				<section id="sec-manifest-fallbacks">
-					<h5>Manifest Fallbacks</h5>
-
-					<div class="caution">
-						<p>Reading System support for manifest fallbacks is poor and should not be relied upon to create
-							interoperable content. In most cases, if a Reading System does not support a format, it will
-							not use its fallback. This can lead to unexpected failures.</p>
-
-						<p>EPUB Creators should use the intrinsic fallback capabilities of HTML and SVG to provide
-							fallback content whenever possible, and avoid using <a>Foreign Content Documents</a> in the
-							spine.</p>
-					</div>
-
-					<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create fallback chains,
-						allowing Reading Systems to select an alternative format they can render.</p>
-
-					<p>There are two primary use cases for manifest fallbacks:</p>
-
-					<ol>
-						<li>To specify fallbacks when <a>Foreign Content Documents</a> are referenced from the <a
-								href="#sec-spine-elem">spine</a>.</li>
-						<li>To provide fallbacks when intrinsic fallback are not available for elements in EPUB Content
-							Documents (e.g., for the [[HTML]] <a data-cite="html#the-img-element"><code>img</code></a>
-							element) in order to satisfy the requirements in <a href="#sec-foreign-resources"></a>.</li>
-					</ol>
-
-					<p>The <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> on the <a>manifest</a>
-						<a href="#elemdef-package-item"><code>item</code></a> element specifies the fallback for the
-						referenced Publication Resource. The <code>fallback</code> attribute's IDREF [[XML]] value MUST
-						resolve to another <code>item</code> in the <code>manifest</code>. This fallback
-							<code>item</code> MAY itself specify another fallback <code>item</code>, and so on.</p>
-
-					<p>The ordered list of all the ID references that a Reading System can reach, starting from a given
-						item's <code>fallback</code> attribute, represents the <em>fallback chain</em> for that item.
-						The order of the resources in the fallback chain represents the EPUB Creator's preferred
-						fallback order.</p>
-
-					<p>Fallback chains MUST conform to one of the following requirements, as appropriate:</p>
-
-					<ul>
-						<li>
-							<p>For Foreign Content Documents, the chain MUST contain at least one <a>EPUB Content
-									Document</a>.</p>
-						</li>
-						<li>
-							<p>For Foreign Resources for which an EPUB Creator cannot provide an intrinsic fallback, the
-								chain MUST contain at least one <a>Core Media Type Resource</a>.</p>
-						</li>
-					</ul>
-
-					<p>Fallback chains MUST NOT contain circular or self-references to <code>item</code> elements in the
-						chain.</p>
-
-					<p>EPUB Creators MAY provide fallbacks for <a>Top-Level Content Documents</a> that are EPUB Content
-						Documents (e.g., to provide <a href="#confreq-cd-scripted-flbk">fallbacks for scripted
-							content</a>).</p>
-
-					<p>EPUB Creators MAY also provide manifest fallbacks for <a>Core Media Type Resources</a> (e.g., to
-						allow Reading Systems to select from more than one image format).</p>
-
-					<div class="note">
-						<p>As it is not possible to use manifest fallbacks for resources represented in <a
-								href="#sec-data-urls">data URLs</a>, EPUB Creators can only represent Foreign Resources
-							as data URLs where an intrinsic fallback mechanism is available.</p>
-					</div>
-				</section>
-
-				<section id="sec-resource-locations">
-					<h4>Resource Locations</h4>
-
-					<p>EPUB Creators MAY host the following types of Publication Resources outside the EPUB
-						Container:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="sec-resource-locations-audio"><a href="#cmt-grp-audio">Audio resources</a>.</p>
-						</li>
-						<li>
-							<p id="sec-resource-locations-video"><a href="#exempt-video">Video resources</a>.</p>
-						</li>
-						<li>
-							<p id="sec-resource-locations-script">Resources retrieved via scripting APIs (e.g.,
-								XmlHttpRequest [[?XHR]] and Fetch [[?FETCH]]).</p>
-						</li>
-						<li>
-							<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a>.</p>
-						</li>
-					</ul>
-
-					<p>EPUB Creators MUST store all other resources within the EPUB Container.</p>
-
-					<p>Storing all resources inside the EPUB Container is strongly encouraged whenever possible as it
-						allows users access to the entire presentation regardless of connectivity status.</p>
-
-					<p>These rules for locating Publication Resource apply regardless of whether the given resource is a
-							<a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
-
-					<div class="note">
-						<p>Refer to the <a href="#remote-resources"><code>remote-resources</code> property</a> for more
-							information on how to indicate that a <a>manifest</a>
-							<a href="#sec-item-elem"><code>item</code></a> references a <a>Remote Resource</a>.</p>
-					</div>
-
-					<aside class="example" title="Referencing a local resource">
-						<p>In this example, the audio file referenced from the [[HTML]] <a
-								data-cite="html#the-audio-element"><code>audio</code> element</a> is located inside the
-								<a>EPUB Container</a>.</p>
-						<pre>&lt;html …>
+				<aside class="example" title="Referencing a local resource">
+					<p>In this example, the audio file referenced from the [[HTML]] <a
+							data-cite="html#the-audio-element"><code>audio</code> element</a> is located inside the
+							<a>EPUB Container</a>.</p>
+					<pre>&lt;html …>
    …
    &lt;body>
       …
@@ -1447,13 +1427,12 @@
       …
    &lt;/body>
 &lt;/html></pre>
-					</aside>
+				</aside>
 
-					<aside class="example" title="Referencing a remote resource">
-						<p>In this example, the audio file referenced from the [[HTML]] <a
-								data-cite="html#the-audio-element"><code>audio</code> element</a> is hosted on the
-							web.</p>
-						<pre>&lt;html …>
+				<aside class="example" title="Referencing a remote resource">
+					<p>In this example, the audio file referenced from the [[HTML]] <a
+							data-cite="html#the-audio-element"><code>audio</code> element</a> is hosted on the web.</p>
+					<pre>&lt;html …>
    …
    &lt;body>
       …
@@ -1463,4915 +1442,94 @@
       …
    &lt;/body>
 &lt;/html></pre>
-					</aside>
-				</section>
-
-				<section id="sec-data-urls">
-					<h4>Data URLs</h4>
-
-					<p>The <a data-cite="rfc2397#"><code>data:</code> URL scheme</a> [[RFC2397]] is used to encode
-						resources directly into a URL string. The advantage of this scheme is that it allows EPUB
-						Creators to embed a resource within another, avoiding the need for an external file.</p>
-
-					<p><a>EPUB Creators</a> MAY use data URLs in EPUB Publications provided their use does not result in
-						a <a>Top-level Content Document</a> or <a data-cite="html#top-level-browsing-context">top-level
-							browsing context</a> [[HTML]]. This restriction applies to data URLs used in the following
-						scenarios:</p>
-
-					<ul>
-						<li>
-							<p>in manifest <a href="#sec-item-elem"><code>item</code> elements</a> referenced from the
-									<a>spine</a>;</p>
-						</li>
-						<li>
-							<p>in the <code>href</code> attribute on [[HTML]] or [[SVG]] <code>a</code> elements (except
-								when inside an <a data-cite="html#the-iframe-element"><code>iframe</code> element</a>
-								[[HTML]]);</p>
-						</li>
-						<li>
-							<p>in the <code>href</code> attribute on [[HTML]] <code>area</code> elements (except when
-								inside an <code>iframe</code> element);</p>
-						</li>
-						<li>
-							<p>in calls to [[ECMASCRIPT]] <code>window.open</code> or <code>document.open</code>.</p>
-						</li>
-					</ul>
-
-					<div class="note">
-						<p>The list of prohibited uses for data URLs is subject to change as the respective standards
-							that allow their use evolve.</p>
-					</div>
-
-					<p>This restriction on their use is to prevent security issues and also to ensure that <a>Reading
-							Systems</a> can determine where to take a user next (i.e., because these resources are not
-						be listed in the spine).</p>
-
-					<p>Resources represented as data URLs are not Publication Resources so are exempt from the
-						requirement for EPUB Creators to list them in the <a>manifest</a>.</p>
-
-					<p>EPUB Creators MUST encode Data URLs as Core Media Type Resources or use them where they can
-						provide a fallback (i.e., Data URLs are subject to the <a href="#sec-foreign-resources">Foreign
-							Resource restrictions</a>).</p>
-				</section>
-
-				<section id="sec-xml-constraints">
-					<h4>XML Conformance</h4>
-
-					<p>Any <a>Publication Resource</a> that is an XML-Based Media Type:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-xml-wellformed">MUST be a conformant XML 1.0 Document as defined in <a
-									data-cite="xml-names#Conformance">Conformance of Documents</a> [[XML-NAMES]].</p>
-						</li>
-						<li>
-							<p id="confreq-xml-identifiers">MAY only specify a <a data-cite="xml#dt-doctype">document
-									type declaration</a> that references an <a data-cite="xml#NT-ExternalID">external
-									identifier</a> appropriate for its media type &#8212; as defined in <a
-									href="#app-identifiers-allowed"></a> &#8212; or that omits external identifiers
-								[[XML]].</p>
-						</li>
-						<li>
-							<p id="confreq-xml-entities">MUST NOT contain <a data-cite="xml#dt-extent">external
-									entity</a> declarations in the internal DTD subset [[XML]].</p>
-						</li>
-						<li>
-							<p id="confreq-xml-xinc">MUST NOT make use of XInclude [[XInclude]].</p>
-						</li>
-						<li>
-							<p id="confreq-xml-enc">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8 as the
-								RECOMMENDED encoding.</p>
-						</li>
-					</ul>
-
-					<p>The above constraints apply regardless of whether the given Publication Resource is a <a>Core
-							Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
-
-					<div class="note">
-						<p>[[HTML]] and [[SVG]] are removing support for the XML `base` attribute [[XMLBase]]. EPUB
-							Creators should avoid using this feature.</p>
-					</div>
-				</section>
+				</aside>
 			</section>
 
-			<section id="sec-package-doc">
-				<h3>Package Document</h3>
-
-				<p>All [[XML]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
-					namespace [[XML-NAMES]] unless otherwise specified.</p>
-
-				<section id="sec-package-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>The <a>Package Document</a> is an XML document that consists of a set of elements that each
-						encapsulate information about a particular aspect of an <a>EPUB Publication</a>. These elements
-						serve to centralize metadata, detail the individual resources, and provide the reading order and
-						other information necessary for its rendering.</p>
-
-					<p>The following list summarizes the information found in the Package Document:</p>
-
-					<ul>
-						<li>
-							<p><a href="#sec-pkg-metadata">Metadata</a> — mechanisms to include and/or reference
-								information about the EPUB Publication.</p>
-						</li>
-						<li>
-							<p>A <a href="#sec-manifest-elem">manifest</a> — identifies via URL [[URL]], and describes
-								via MIME media type [[RFC4839]], the set of <a>Publication Resources</a>.</p>
-						</li>
-						<li>
-							<p>A <a href="#sec-spine-elem">spine</a> — an ordered sequence of ID references to top-level
-								resources in the manifest from which Reading Systems can reach or utilize all other
-								resources in the set. The spine defines the default reading order.</p>
-						</li>
-						<li>
-							<p><a href="#sec-collection-elem">Collections</a> — a method of encapsulating and
-								identifying subcomponents within the Package.</p>
-						</li>
-						<li>
-							<p><a href="#sec-manifest-fallbacks">Manifest fallback chains</a> — a mechanism that defines
-								an ordered list of top-level resources as content equivalents. A Reading System can then
-								choose between the resources based on which it is capable of rendering.</p>
-						</li>
-					</ul>
-
-					<div class="note">
-						<p>An EPUB Publication can reference more than one Package Document, allowing for alternative
-							representations of the content. For more information, refer to <a
-								href="#sec-container-metainf-container.xml"></a></p>
-					</div>
-
-					<div class="note">
-						<p>Refer to <a href="#app-media-type-app-oebps-package"></a> for information about the file
-							properties of Package Documents.</p>
-					</div>
-				</section>
-
-				<section id="sec-parse-package-urls">
-					<h4>Parsing URLs in the Package Document</h4>
-
-					<p id="pkg-parse-package-url" data-tests="#ocf-url_link-relative,#ocf-url_relative"> To parse a URL
-						string <var>url</var> used in the Package Document, the <a data-cite="url#concept-url-parser"
-							>URL Parser</a> [[URL]] MUST be applied to <var>url</var>, with the <a>content URL</a> of
-						the Package Document as <var>base</var>.</p>
-				</section>
-
-				<section id="sec-shared-attrs">
-					<h4>Shared Attributes</h4>
-
-					<p>This section provides definitions for shared attributes (i.e., attributes allowed on two or more
-						elements).</p>
-
-					<section id="attrdef-dir">
-						<h5>The <code>dir</code> Attribute</h5>
-
-						<p
-							data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
-							>Specifies the <a data-cite="bidi#BD5">base direction</a> [[BIDI]] of the textual content
-							and attribute values of the carrying element and its descendants</p>
-
-						<p>Allowed values are:</p>
-
-						<ul>
-							<li><code>ltr</code> &#8212; left-to-right base direction;</li>
-							<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
-							<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi Algorithm
-								[[BIDI]].</li>
-						</ul>
-
-						<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will assume the
-							value <code>auto</code> when EPUB Creators omit the attribute or use an invalid value.</p>
-
-						<div class="note">
-							<p>The base direction specified in the <code>dir</code> attribute does not affect the
-								ordering of characters within directional runs, only the relative ordering of those runs
-								and the placement of weak directional characters such as punctuation.</p>
-						</div>
-
-						<aside class="example" title="Setting the global base direction for Package Document text">
-							<pre>&lt;package … dir="ltr">
-   …
-&lt;/package></pre>
-						</aside>
-
-						<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-								href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-								href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-								href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
-									><code>dc:title</code></a>, <a href="#sec-meta-elem"><code>meta</code></a> and <a
-								href="#sec-package-elem"><code>package</code></a>.</p>
-					</section>
-
-					<section id="attrdef-href">
-						<h5>The <code>href</code> Attribute</h5>
-
-						<p>A <a data-cite="url#valid-url-string">valid URL string</a> [[URL]] that references a
-							resource. If the value is an <a data-cite="url#absolute-url-string">absolute URL</a>, it
-							SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
-
-						<aside class="example" title="Linking a metadata record">
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;link
-          rel="record"
-          href="meta/9780000000001.xml" 
-          media-type="application/marc"/>
-      …
-   &lt;/metadata>
-   …
-&lt;/package></pre>
-						</aside>
-
-						<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
-									><code>link</code></a>.</p>
-					</section>
-
-					<section id="attrdef-id">
-						<h5>The <code>id</code> Attribute</h5>
-
-						<p>The ID [[XML]] of the element, which MUST be unique within the document scope.</p>
-
-						<aside class="example" title="Adding an identifier attribute">
-							<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
-						</aside>
-
-						<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-								href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-								href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:date</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, <a
-								href="#sec-opf-dcidentifier"><code>dc:identifier</code></a>, <a
-								href="#sec-opf-dclanguage"><code>dc:language</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, <a
-								href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
-									><code>dc:title</code></a>, <a href="#sec-opf-dctype"><code>dc:type</code></a>, <a
-								href="#sec-item-elem"><code>item</code></a>, <a href="#sec-itemref-elem"
-									><code>itemref</code></a>, <a href="#sec-link-elem"><code>link</code></a>, <a
-								href="#sec-manifest-elem"><code>manifest</code></a>, <a href="#sec-meta-elem"
-									><code>meta</code></a>, <a href="#sec-package-elem"><code>package</code></a> and <a
-								href="#sec-spine-elem"><code>spine</code></a>.</p>
-					</section>
-
-					<section id="attrdef-media-type">
-						<h5>The <code>media-type</code> Attribute</h5>
-
-						<p>A media type [[RFC2046]] that specifies the type and format of the referenced resource.</p>
-
-						<aside class="example" title="Adding the media type for a linked record">
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;link
-          rel="record"
-          href="http://example.org/meta/12389347?format=xmp"
-          media-type="application/xml"
-          properties="xmp"/>
-      …
-   &lt;/metadata>
-   …
-&lt;/package></pre>
-						</aside>
-
-						<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
-									><code>link</code></a>.</p>
-					</section>
-
-					<section id="attrdef-properties">
-						<h5>The <code>properties</code> Attribute</h5>
-
-						<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
-
-						<p>Refer to each element's definition for the <a href="#sec-default-vocab">reserved
-								vocabulary</a> for the attribute.</p>
-
-						<aside class="example" title="Identifying the EPUB Navigation Document in the manifest">
-							<pre>&lt;package …>
-   …
-   &lt;manifest>
-      …
-      &lt;item
-          id="nav" 
-          href="nav.xhtml"
-          properties="nav"
-          media-type="application/xhtml+xml"/>
-      …
-   &lt;/manifest>
-   …
-&lt;/package></pre>
-						</aside>
-
-						<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a href="#sec-itemref-elem"
-									><code>itemref</code></a> and <a href="#sec-link-elem"><code>link</code></a>.</p>
-					</section>
-
-					<section id="attrdef-refines">
-						<h5>The <code>refines</code> Attribute</h5>
-
-						<p>Establishes an association between the current expression and the element or resource
-							identified by its value. EPUB Creators MUST use as the value a <a
-								data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL
-								string</a>, optionally followed by <code>U+0023 (#)</code> and a <a
-								data-cite="url#url-fragment-string">URL-fragment string</a> that references the resource
-							or element they are describing.</p>
-
-						<aside class="example" title="Specifying that a creator is the illustrator">
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;dc:creator id="creator02">
-         E.H. Shepard
-      &lt;/dc:creator>
-      &lt;meta
-          refines="#creator02"
-          property="role"
-          scheme="marc:relators">
-         ill
-      &lt;/meta>
-      …
-   &lt;/metadata>
-   …
-&lt;/package></pre>
-						</aside>
-
-						<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata expressed.
-							When omitted, the element defines a <a href="#primary-expression">primary
-							expression</a>.</p>
-
-						<p>When creating expressions about a <a>Publication Resource</a>, the <code>refines</code>
-							attribute SHOULD specify a fragment identifier that references the ID of the resource's <a
-								href="#sec-item-elem">manifest entry</a>.</p>
-
-						<p>Refinement chains MUST NOT contain circular references or self-references.</p>
-
-						<aside class="example" title="Setting the duration of a Media Overlay Document">
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;meta
-          property="media:duration" 
-          refines="#c01_overlay">
-         0:32:29
-      &lt;/meta>
-      …
-   &lt;/metadata>
-   &lt;manifest>
-      …
-      &lt;item
-          id="c01_overlay"
-          href="overlays/chapter01.smil"
-          media-type="application/smil+xml"/>
-      …
-   &lt;/manifest>
-   …
-&lt;/package></pre>
-						</aside>
-
-						<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a href="#sec-meta-elem"
-									><code>meta</code></a>.</p>
-					</section>
-
-					<section id="attrdef-xml-lang">
-						<h5>The <code>xml:lang</code> Attribute</h5>
-
-						<p>Specifies the language of the textual content and attribute values of the carrying element
-							and its descendants, as defined in section <a data-cite="xml#sec-lang-tag">2.12 Language
-								Identification</a> of [[XML]]. The value of each <code>xml:lang</code> attribute MUST be
-							a <a data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
-
-						<aside class="example" title="Setting the global language for Package Document text">
-							<pre>&lt;package … xml:lang="ja">
-   …
-&lt;/package></pre>
-						</aside>
-
-						<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
-								href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
-								href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-								href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-								href="#sec-opf-dcsubject"><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"
-									><code>dc:title</code></a>, <a href="#sec-meta-elem"><code>meta</code></a> and <a
-								href="#sec-package-elem"><code>package</code></a>.</p>
-					</section>
-				</section>
-
-				<section id="sec-package-elem">
-					<h4>The <code>package</code> Element</h4>
-
-					<p>The <code>package</code> element is the root element of the <a>Package Document</a>.</p>
-
-					<dl id="elemdef-opf-package" class="elemdef">
-						<dt>Element Name:</dt>
-						<dd>
-							<p>
-								<code>package</code>
-							</p>
-						</dd>
-
-						<dt>Usage:</dt>
-						<dd>
-							<p>The <code>package</code> element is the root element of the Package Document.</p>
-						</dd>
-
-						<dt>Attributes:</dt>
-						<dd>
-							<ul class="nomark">
-								<li>
-									<p>
-										<a href="#attrdef-dir">
-											<code>dir</code>
-										</a>
-										<code>[optional]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#attrdef-id">
-											<code>id</code>
-										</a>
-										<code>[optional]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#attrdef-package-prefix">
-											<code>prefix</code>
-										</a>
-										<code>[optional]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#attrdef-xml-lang">
-											<code>xml:lang</code>
-										</a>
-										<code>[optional]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#attrdef-package-unique-identifier">
-											<code>unique-identifier</code>
-										</a>
-										<code>[required]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#attrdef-package-version">
-											<code>version</code>
-										</a>
-										<code>[required]</code>
-									</p>
-								</li>
-							</ul>
-						</dd>
-
-						<dt>Content Model:</dt>
-						<dd>
-							<p>In this order:</p>
-							<ul class="nomark">
-								<li>
-									<p>
-										<a class="codelink" href="#elemdef-opf-metadata">
-											<code>metadata</code>
-										</a>
-										<code>[exactly 1]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#elemdef-opf-manifest">
-											<code>manifest</code>
-										</a>
-										<code>[exactly 1]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#elemdef-opf-spine">
-											<code>spine</code>
-										</a>
-										<code>[exactly 1]</code>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#sec-opf2-guide">
-											<code>guide</code>
-										</a>
-										<code>[0 or 1]</code>
-										<a href="#legacy" class="legacy">(legacy)</a>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#sec-opf-bindings">
-											<code>bindings</code>
-										</a>
-										<code>[0 or 1]</code>
-										<a href="#deprecated" class="deprecated">(deprecated)</a>
-									</p>
-								</li>
-								<li>
-									<p>
-										<a href="#elemdef-collection">
-											<code>collection</code>
-										</a>
-										<code>[0 or more]</code>
-									</p>
-								</li>
-							</ul>
-						</dd>
-					</dl>
-
-					<p id="attrdef-package-version">The <code>version</code> attribute specifies the EPUB specification
-						version to which the given EPUB Publication conforms. The attribute MUST have the value
-							"<code>3.0</code>" to indicate conformance with EPUB 3.</p>
-
-					<div class="note">
-						<p>Updates to this specification do not represent new versions of EPUB 3 (i.e., each new 3.X
-							specification is a continuation of the EPUB 3 format). The Working Group is committed to
-							minimizing any changes that would invalidate existing content, allowing the
-								<code>version</code> attribute value to remain unchanged.</p>
-					</div>
-
-					<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an
-						IDREF [[XML]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"
-								><code>dc:identifier</code></a> element that provides the preferred, or primary,
-						identifier.</p>
-
-					<p id="attrdef-package-prefix">The <code>prefix</code> attribute provides a declaration mechanism
-						for prefixes not <a href="#sec-metadata-reserved-prefixes">reserved by this specification</a>.
-						Refer to <a href="#sec-prefix-attr"></a> for more information.</p>
-				</section>
-
-				<section id="sec-pkg-metadata">
-					<h4>Metadata Section</h4>
-
-					<section id="sec-metadata-elem">
-						<h5>The <code>metadata</code> Element</h5>
-
-						<p>The <code>metadata</code> element encapsulates meta information.</p>
-
-						<dl id="elemdef-opf-metadata" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<code>metadata</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>REQUIRED first child of <a href="#elemdef-opf-package"><code>package</code></a>.</p>
-							</dd>
-
-							<dt>Attributes:</dt>
-							<dd>
-								<p>None</p>
-							</dd>
-
-							<dt>Content Model:</dt>
-							<dd>
-								<p>In any order:</p>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a class="codelink" href="#elemdef-opf-dcidentifier">
-												<code>dc:identifier</code>
-											</a>
-											<code>[1 or more]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#elemdef-opf-dctitle">
-												<code>dc:title</code>
-											</a>
-											<code>[1 or more]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#elemdef-opf-dclanguage">
-												<code>dc:language</code>
-											</a>
-											<code>[1 or more]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#sec-opf-dcmes-optional">
-												<code>Dublin Core Optional Elements</code>
-											</a>
-											<code>[0 or more]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#elemdef-meta">
-												<code>meta</code>
-											</a>
-											<code>[1 or more]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#sec-opf2-meta">OPF2 <code>meta</code></a>
-											<code>[0 or more]</code>
-											<a href="#legacy" class="legacy">(legacy)</a>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#elemdef-opf-link">
-												<code>link</code>
-											</a>
-											<code>[0 or more]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-						</dl>
-
-						<p>The Package Document <code>metadata</code> element has two primary functions:</p>
-
-						<ol>
-							<li>
-								<p>to provide a minimal set of meta information for Reading Systems to use to internally
-									catalogue an <a>EPUB Publication</a> and make it available to a user (e.g., to
-									present in a bookshelf).</p>
-							</li>
-							<li>
-								<p>to provide access to all rendering metadata needed to control the layout and display
-									of the content (e.g., <a href="#sec-fxl-package">fixed-layout properties</a>).</p>
-							</li>
-						</ol>
-
-						<p>The Package Document does not provide complex metadata encoding capabilities. If EPUB
-							Creators need to provide more detailed information, they can associate metadata records
-							(e.g., that conform to an international standard such as [[ONIX]] or are created for custom
-							purposes) using the <a href="#sec-link-elem"><code>link</code></a> element. This approach
-							allows Reading Systems to process the metadata in its native form, avoiding the potential
-							problems and information loss caused by translating to use the minimal Package Document
-							structure.</p>
-
-						<p id="core-metadata-reqs">In keeping with this philosophy, the Package Document only has the
-							following minimal metadata requirements: it MUST contain the [[DCTERMS]] <a
-								href="#sec-opf-dcidentifier"><code>dc:title</code></a>, <a
-								href="#elemdef-opf-dcidentifier"><code>dc:identifier</code></a>, and <a
-								href="#elemdef-opf-dclanguage"><code>dc:language</code></a> elements together with the
-							[[DCTERMS]] <a href="#last-modified-date"><code>dcterms:modified</code> property</a>. All
-							other metadata is OPTIONAL.</p>
-
-						<aside class="example" title="The minimal set of metadata required in the Package Document">
-							<pre>&lt;package … unique-identifier="pub-id">
-    …
-    &lt;metadata …>
-       &lt;dc:identifier
-           id="pub-id">
-          urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
-       &lt;/dc:identifier>
-       &lt;dc:title>
-          Norwegian Wood
-       &lt;/dc:title>
-       &lt;dc:language>
-          en
-       &lt;/dc:language>
-       &lt;meta
-           property="dcterms:modified">
-          2011-01-01T12:00:00Z
-       &lt;/meta>
-    &lt;/metadata>
-    …
-&lt;/package>
-</pre>
-						</aside>
-
-						<p>The <a href="#sec-meta-elem"><code>meta</code> element</a> provides a generic mechanism for
-							including <a href="#sec-vocab-assoc">metadata properties from any vocabulary</a>. Although
-							EPUB Creators MAY use this mechanism for any metadata purposes, they will typically use it
-							to include rendering metadata defined in EPUB specifications.</p>
-
-						<div class="note">
-							<p>See [[EPUB-A11Y-11]] for accessibility metadata recommendations.</p>
-						</div>
-					</section>
-
-					<section id="sec-metadata-values">
-						<h5>Metadata Values</h5>
-
-						<p>The Dublin Core elements [[DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code>
-								element</a> have mandatory <a data-cite="dom#concept-child-text-content">child text
-								content</a> [[DOM]]. This specification refers to this content as the <dfn>value</dfn>
-							of the element in their descriptions.</p>
-
-						<p>These elements MUST have non-empty values after <a
-								data-cite="infra#strip-leading-and-trailing-ascii-whitespace">leading and trailing ASCII
-								whitespace</a> [[Infra]] is stripped (i.e., they must consist of at least one
-							non-whitespace character).</p>
-
-						<p>Whitespace within these element values is not significant. Sequences of one or more
-							whitespace characters are <a data-cite="infra#strip-and-collapse-ascii-whitespace">collapsed
-								to a single space</a> [[Infra]] during processing .</p>
-					</section>
-
-					<section id="sec-opf-dcmes-required">
-						<h5>Dublin Core Required Elements</h5>
-
-						<section id="sec-opf-dcidentifier">
-							<h6>The <code>dc:identifier</code> Element</h6>
-
-							<p>The <a
-									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
-										><code>dc:identifier</code> element</a> [[DCTERMS]] contains an identifier such
-								as a <abbr title="Universally Unique Identifier">UUID</abbr>, <abbr
-									title="Digital Object Identfier">DOI</abbr> or <abbr
-									title="International Standard Book Number">ISBN</abbr>.</p>
-
-							<dl id="elemdef-opf-dcidentifier" class="elemdef">
-								<dt>Element Name:</dt>
-								<dd>
-									<p>
-										<code>dc:identifier</code>
-									</p>
-								</dd>
-
-								<dt>Namespace:</dt>
-								<dd>
-									<p>
-										<code>http://purl.org/dc/elements/1.1/</code>
-									</p>
-								</dd>
-
-								<dt>Usage:</dt>
-								<dd>
-									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
-												><code>metadata</code></a>. Repeatable.</p>
-								</dd>
-
-								<dt>Attributes:</dt>
-								<dd>
-									<ul class="nomark">
-										<li>
-											<p>
-												<a href="#attrdef-id">
-													<code>id</code>
-												</a>
-												<code>[conditionally required]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
-
-								<dt>Content Model:</dt>
-								<dd>
-									<p>Text</p>
-								</dd>
-							</dl>
-
-							<p>The <a>EPUB Creator</a> MUST provide an identifier that is unique to one and only one
-									<a>EPUB Publication</a> &#8212; its <a>Unique Identifier</a> &#8212; in an
-									<code>dc:identifier</code> element. This <code>dc:identifier</code> element MUST
-								specify an <code>id</code> attribute whose value is referenced from the <a
-									href="#elemdef-opf-package"><code>package</code> element's</a>
-								<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
-									attribute</a>.</p>
-
-							<aside class="example" title="Specifying the element with the unique identifier">
-								<pre>&lt;package … unique-identifier="pub-id">
-    &lt;metadata …>
-       &lt;dc:identifier id="pub-id">
-           urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
-       &lt;/dc:identifier>
-       …
-    &lt;/metadata>
-&lt;/package></pre>
-							</aside>
-
-							<p>Although not static, EPUB Creators should make changes to the Unique Identifier for an
-								EPUB Publication as infrequently as possible. Unique Identifiers should have maximal
-								persistence both for referencing and distribution purposes. EPUB Creators should not
-								issue new identifiers when making minor revisions such as updating metadata, fixing
-								errata, or making similar minor changes.</p>
-
-							<p>EPUB Creators MAY specify additional identifiers. The identifiers should be fully
-								qualified URIs.</p>
-
-							<p>EPUB Creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
-									property</a> to indicate that the value of a <code>dc:identifier</code> element
-								conforms to an established system or an issuing authority granted it.</p>
-
-							<aside class="example" title="Specifying the type of the identifier">
-								<p>In this example, the <code>identifier-type</code> property is used with the <a
-										href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> scheme to indicate
-									the product identifier type is a <a href="https://doi.org">DOI</a> (i.e., the value
-										<code>06</code> in codelist 5 is for DOIs).</p>
-
-								<pre>&lt;metadata …>
-   &lt;dc:identifier
-       id="pub-id">
-      urn:doi:10.1016/j.iheduc.2008.03.001
-   &lt;/dc:identifier>
-   &lt;meta
-       refines="#pub-id"
-       property="identifier-type"
-       scheme="onix:codelist5">
-      06
-   &lt;/meta>
-   …
-&lt;/metadata></pre>
-							</aside>
-						</section>
-
-						<section id="sec-opf-dctitle">
-							<h6>The <code>dc:title</code> Element</h6>
-
-							<p>The <a
-									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
-										><code>dc:title</code> element</a> [[DCTERMS]] represents an instance of a name
-								for the <a>EPUB Publication</a>.</p>
-
-							<dl id="elemdef-opf-dctitle" class="elemdef">
-								<dt>Element Name:</dt>
-								<dd>
-									<p>
-										<code>dc:title</code>
-									</p>
-								</dd>
-
-								<dt>Namespace:</dt>
-								<dd>
-									<p>
-										<code>http://purl.org/dc/elements/1.1/</code>
-									</p>
-								</dd>
-
-								<dt>Usage:</dt>
-								<dd>
-									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
-												><code>metadata</code></a>. Repeatable.</p>
-								</dd>
-
-								<dt>Attributes:</dt>
-								<dd>
-									<ul class="nomark">
-										<li>
-											<p>
-												<a href="#attrdef-dir">
-													<code>dir</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-id">
-													<code>id</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-										<li>
-											<p>
-												<a href="#attrdef-xml-lang">
-													<code>xml:lang</code>
-												</a>
-												<code>[optional]</code>
-											</p>
-										</li>
-									</ul>
-								</dd>
-
-								<dt>Content Model:</dt>
-								<dd>
-									<p>Text</p>
-								</dd>
-							</dl>
-
-							<p id="title-order">The first <code>dc:title</code> element in document order is the main
-								title of the EPUB Publication (i.e., the primary one Reading Systems present to
-								users).</p>
-
-							<aside class="example" title="A basic title element">
-								<pre>&lt;metadata …>
-   &lt;dc:title>
-      Norwegian Wood
-   &lt;/dc:title>
-   …
-&lt;/metadata>
-</pre>
-							</aside>
-
-							<p>EPUB Creators should use only a single <code>dc:title</code> element to ensure consistent
-								rendering of the title in Reading Systems.</p>
-
-							<div class="note">
-								<p>Although it is possible to include more than one <code>dc:title</code> element for
-									multipart titles, Reading System support for additional <code>dc:title</code>
-									elements is inconsistent. Reading Systems may ignore the additional segments or
-									combine them in unexpected ways.</p>
-
-								<p>For example, the following example shows a basic multipart title:</p>
-
-								<pre>&lt;metadata …>
-   &lt;dc:title>
-      THE LORD OF THE RINGS
-   &lt;/dc:title>
-   &lt;dc:title>
-      Part One: The Fellowship of the Ring
-   &lt;/dc:title>
-   …
-&lt;/metadata>
-</pre>
-
-								<p>The same title could instead be expressed using a single <code>dc:title</code>
-									element as follows:</p>
-
-								<pre>&lt;metadata …>
-   &lt;dc:title>
-       THE LORD OF THE RINGS, Part One:
-       The Fellowship of the Ring
-   &lt;/dc:title>
-   …
-&lt;/metadata>
-</pre>
-
-								<p>Previous versions of this specification recommended using the <a
-										href="#sec-title-type"><code>title-type</code></a> and <a
-										href="#sec-display-seq"><code>display-seq</code></a> properties to identify and
-									format the segments of multipart titles (see the <a href="#cookbook-ex">Great
-										Cookbooks example</a>). It is still possible to add these semantics, but they
-									are also not well supported.</p>
-							</div>
-						</section>
-
-						<section id="sec-opf-dclanguage">
-							<h6>The <code>dc:language</code> Element</h6>
-
-							<p>The <a
-									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/language"
-										><code>dc:language</code> element</a> [[DCTERMS]] specifies the language of the
-								content of the <a>EPUB Publication</a>.</p>
-
-							<dl id="elemdef-opf-dclanguage" class="elemdef">
-								<dt>Element Name:</dt>
-								<dd>
-									<p>
-										<code>dc:language</code>
-									</p>
-								</dd>
-
-								<dt>Namespace:</dt>
-								<dd>
-									<p>
-										<code>http://purl.org/dc/elements/1.1/</code>
-									</p>
-								</dd>
-
-								<dt>Usage:</dt>
-								<dd>
-									<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
-												><code>metadata</code></a>. Repeatable.</p>
-								</dd>
-
-								<dt>Attributes:</dt>
-								<dd>
-									<p>
-										<a href="#attrdef-id">
-											<code>id</code>
-										</a>
-										<code>[optional]</code>
-									</p>
-								</dd>
-
-								<dt>Content Model:</dt>
-								<dd>
-									<p>Text</p>
-								</dd>
-							</dl>
-
-							<p>The <a>value</a> of each <code>dc:language</code> element MUST be a <a
-									data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
-
-							<aside class="example"
-								title="Specifying U.S. English as the language of the EPUB Publication">
-								<pre>&lt;metadata …>
-   …
-   &lt;dc:language>
-      en-US
-   &lt;/dc:language>
-   …
-&lt;/metadata></pre>
-							</aside>
-
-							<p>Although EPUB Creators MAY specify additional <code>dc:language</code> elements for
-								multilingual Publications, Reading Systems will treat the first <code>dc:language</code>
-								element in document order as the primary language of the EPUB Publication.</p>
-
-							<div class="note">
-								<p><a>Publication Resources</a> do not inherit their language from the
-										<code>dc:language</code> element(s). EPUB Creators must set the language of a
-									resource using the intrinsic methods of the format.</p>
-							</div>
-						</section>
-					</section>
-
-					<section id="sec-opf-dcmes-optional">
-						<h5>Dublin Core Optional Elements</h5>
-
-						<section id="sec-opf-dcmes-optional-def">
-							<h6>General Definition</h6>
-
-							<p>All [[DCTERMS]] elements except for <a href="#sec-opf-dcidentifier"
-										><code>dc:identifier</code></a>, <a href="#sec-opf-dclanguage"
-										><code>dc:language</code></a>, and <a href="#sec-opf-dctitle"
-										><code>dc:title</code></a> are designated as OPTIONAL. These elements conform to
-								the following generalized definition:</p>
-
-							<dl class="elemdef">
-								<dt>Element Name:</dt>
-								<dd>
-									<p>
-										<code>dc:contributor</code> | <code>dc:coverage</code> | <code>dc:creator</code>
-										| <code>dc:date</code> | <code>dc:description</code> | <code>dc:format</code> |
-											<code>dc:publisher</code> | <code>dc:relation</code> |
-											<code>dc:rights</code> | <code>dc:source</code> | <code>dc:subject</code> |
-											<code>dc:type</code></p>
-								</dd>
-
-								<dt>Namespace:</dt>
-								<dd>
-									<p>
-										<code>http://purl.org/dc/elements/1.1/</code>
-									</p>
-								</dd>
-
-								<dt>Usage:</dt>
-								<dd>
-									<p>OPTIONAL child of <a class="codelink" href="#elemdef-opf-metadata"
-												><code>metadata</code></a>. Repeatable.</p>
-								</dd>
-
-								<dt>Attributes:</dt>
-								<dd>
-									<ul class="nomark">
-										<li>
-											<p><a href="#attrdef-dir"><code>dir</code></a>
-												<code>[optional]</code> – only allowed on <code>dc:contributor</code>,
-													<code>dc:coverage</code>, <code>dc:creator</code>,
-													<code>dc:description</code>, <code>dc:publisher</code>,
-													<code>dc:relation</code>, <code>dc:rights</code>, and
-													<code>dc:subject</code>.</p>
-										</li>
-										<li>
-											<p><a href="#attrdef-id"><code>id</code></a>
-												<code>[optional]</code> – allowed on any element.</p>
-										</li>
-										<li>
-											<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
-												<code>[optional]</code> – only allowed on <code>dc:contributor</code>,
-													<code>dc:coverage</code>, <code>dc:creator</code>,
-													<code>dc:description</code>, <code>dc:publisher</code>,
-													<code>dc:relation</code>, <code>dc:rights</code>, and
-													<code>dc:subject</code>.</p>
-										</li>
-									</ul>
-								</dd>
-
-								<dt>Content Model:</dt>
-								<dd>
-									<p>Text</p>
-								</dd>
-							</dl>
-
-							<p>This specification does not modify the [[DCTERMS]] element definitions except as noted in
-								the following sections.</p>
-						</section>
-
-						<section id="sec-opf-dccontributor">
-							<h6>The <code>dc:contributor</code> Element</h6>
-
-							<p>The <a
-									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/contributor"
-										><code>dc:contributor</code> element</a> [[DCTERMS]] is used to represent the
-								name of a person, organization, etc. that played a secondary role in the creation of the
-								content.</p>
-
-							<p>The requirements for the <code>dc:contributor</code> element are identical to those for
-								the <a href="#sec-opf-dccreator"><code>dc:creator</code> element</a> in all other
-								respects.</p>
-						</section>
-
-						<section id="sec-opf-dccreator">
-							<h6>The <code>dc:creator</code> Element</h6>
-
-							<p>The <a
-									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/creator"
-										><code>dc:creator</code> element</a> [[DCTERMS]] represents the name of a
-								person, organization, etc. responsible for the creation of the content. EPUB Creators
-								MAY <a href="#subexpression">associate</a> a <a href="#role"><code>role</code>
-									property</a> with the element to indicate the function the creator played.</p>
-
-							<aside class="example" title="Specifying that a creator is an author">
-								<p>In this example, the <a href="https://id.loc.gov/vocabulary/relators.html">MARC
-										relators</a> scheme is used to indicate the role (i.e., the value
-										<code>aut</code> indicates an author in MARC).</p>
-
-								<pre>&lt;metadata …>
-   …
-   &lt;dc:creator
-       id="creator">
-      Haruki Murakami
-   &lt;/dc:creator>
-   &lt;meta
-       refines="#creator"
-       property="role"
-       scheme="marc:relators"
-       id="role">
-      aut
-   &lt;/meta>
-   …
-&lt;/metadata></pre>
-							</aside>
-
-							<p>The <code>dc:creator</code> element should contain the name of the creator as EPUB
-								Creators intend Reading Systems to display it to users.</p>
-
-							<p>EPUB Creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
-								<a href="#subexpression">to associate</a> a normalized form of the creator's name, and
-								the <a href="#alternate-script"><code>alternate-script</code> property</a> to represent
-								the creator's name in another language or script.</p>
-
-							<aside class="example" title="Expressing sorting and rendering information for a creator">
-								<pre>&lt;metadata …>
-   …
-   &lt;dc:creator
-       id="creator">
-      Haruki Murakami
-   &lt;/dc:creator>
-   &lt;meta
-       refines="#creator"
-       property="alternate-script"
-       xml:lang="ja">
-      村上 春樹
-   &lt;/meta>
-   &lt;meta
-       refines="#creator"
-       property="file-as">
-      Murakami, Haruki
-   &lt;/meta>
-   …
-&lt;/metadata></pre>
-							</aside>
-
-							<p>If an EPUB Publication has more than one creator, EPUB Creators should specify each in a
-								separate <code>dc:creator</code> element.</p>
-
-							<p>The document order of <code>dc:creator</code> elements in the <code>metadata</code>
-								section determines the display priority, where the first <code>dc:creator</code> element
-								encountered is the primary creator.</p>
-
-							<aside class="example" title="Expressing the primary creator">
-								<p>In this example, Lewis Carroll is the primary creator because he is listed first.</p>
-
-								<pre>&lt;metadata …>
-   …
-   &lt;dc:creator
-       id="creator01">
-      Lewis Carroll
-   &lt;/dc:creator>
-   &lt;dc:creator
-       id="creator02">
-      John Tenniel
-   &lt;/dc:creator>
-   …
-&lt;/metadata></pre>
-							</aside>
-
-							<p>EPUB Creators should represent secondary contributors using the <a
-									href="#sec-opf-dccontributor"><code>dc:contributor</code> element</a>.</p>
-						</section>
-
-						<section id="sec-opf-dcdate">
-							<h6>The <code>dc:date</code> Element</h6>
-
-							<p>The <a
-									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/date"
-										><code>dc:date</code> element</a> [[DCTERMS]] defines the publication date of
-								the <a>EPUB Publication</a>. The publication date is not the same as the <a
-									href="#last-modified-date">last modified date</a> (the last time the EPUB Creator
-								changed the EPUB Publication).</p>
-
-							<p>It is RECOMMENDED that the date string conform to [[ISO8601]], particularly the subset
-								expressed in W3C Date and Time Formats [[DateTime]], as such strings are both human and
-								machine readable.</p>
-
-							<aside class="example" title="Expressing the publication date">
-								<pre>&lt;metadata …>
-   …
-   &lt;dc:date>
-      2000-01-01T00:00:00Z
-   &lt;/dc:date>
-   …
-&lt;/metadata></pre>
-							</aside>
-
-							<p>EPUB Creators should express additional dates using the specialized date properties
-								available in the [[DCTERMS]] vocabulary, or similar.</p>
-
-							<p>EPUB Publications MUST NOT contain more than one <code>dc:date</code> element.</p>
-						</section>
-
-						<section id="sec-opf-dcsubject">
-							<h6>The <code>dc:subject</code> Element</h6>
-
-							<p>The <a
-									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/subject"
-										><code>dc:subject</code> element</a> [[DCTERMS]] identifies the subject of the
-								EPUB Publication. EPUB Creators should set the <a>value</a> of the element to the
-								human-readable heading or label, but may use a code value if the subject taxonomy does
-								not provide a separate descriptive label.</p>
-
-							<p>EPUB Creators MAY identify the system or scheme they drew the element's <a>value</a> from
-								using the <a href="#authority"><code>authority</code> property</a>.</p>
-
-							<p>When a scheme is identified, EPUB Creators MUST <a href="#subexpression">associate</a> a
-								subject code using the <a href="#term"><code>term</code> property</a>.</p>
-
-							<aside class="example" title="Specifying a BISAC code and heading">
-								<pre>&lt;metadata …>
-   &lt;dc:subject id="subject01">
-      FICTION / Occult &amp;amp; Supernatural
-   &lt;/dc:subject>
-   &lt;meta
-       refines="#subject01"
-       property="authority">
-      BISAC
-   &lt;/meta>
-   &lt;meta
-       refines="#subject01"
-       property="term">
-      FIC024000
-   &lt;/meta>
-&lt;/metadata</pre>
-							</aside>
-
-							<aside class="example" title="Specifying a URL for the scheme">
-								<pre>&lt;metadata …>
-   &lt;dc:subject id="sbj01">
-      Number Theory
-   &lt;/dc:subject>
-   &lt;meta
-       refines="#sbj01"
-       property="authority">
-      http://www.ams.org/msc/msc2010.html
-   &lt;/meta>
-   &lt;meta
-      refines="#sbj01"
-      property="term">
-     11
-  &lt;/meta>
-&lt;/metadata></pre>
-							</aside>
-
-							<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
-										<code>dc:subject</code> element</a> that does not specify a scheme.</p>
-
-							<p>The <a>values</a> of the <code>dc:subject</code> element and <code>term</code> property
-								are case sensitive only when the designated scheme requires.</p>
-						</section>
-
-						<section id="sec-opf-dctype">
-							<h6>The <code>dc:type</code> Element</h6>
-
-							<p>The <a
-									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/type"
-										><code>dc:type</code> element</a> [[DCTERMS]] is used to indicate that the EPUB
-								Publication is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
-								format).</p>
-
-							<p>EPUB Creators MAY use any text string as a <a>value</a>.</p>
-
-							<div class="note">
-								<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
-									Working Group maintained an <a href="http://www.idpf.org/epub/vocab/package/types"
-										>informative registry of specialized EPUB Publication types</a> for use with
-									this element. This Working Group no longer maintains this registry and does not
-									anticipate developing new specialized publication types.</p>
-							</div>
-						</section>
-					</section>
-
-					<section id="sec-meta-elem">
-						<h5>The <code>meta</code> Element</h5>
-
-						<p>The <code>meta</code> element provides a generic means of including package metadata.</p>
-
-						<dl id="elemdef-meta" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<code>meta</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>As child of the <a class="codelink" href="#elemdef-opf-metadata"
-											><code>metadata</code></a> element. Repeatable.</p>
-							</dd>
-
-							<dt>Attributes:</dt>
-							<dd>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#attrdef-dir">
-												<code>dir</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-id">
-												<code>id</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-meta-property">
-												<code>property</code>
-											</a>
-											<code>[required]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-refines">
-												<code>refines</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-scheme">
-												<code>scheme</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-xml-lang">
-												<code>xml:lang</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-
-							<dt>Content Model:</dt>
-							<dd>
-								<p>Text</p>
-							</dd>
-						</dl>
-
-						<p id="attrdef-meta-property">Each <code>meta</code> element defines a metadata expression. The
-								<code>property</code> attribute takes a <a href="#sec-property-datatype"
-									><var>property</var> data type value</a> that defines the statement made in the
-							expression, and the text content of the element represents the assertion. (Refer to <a
-								href="#sec-vocab-assoc"></a> for more information.)</p>
-
-						<p id="meta-expr-types">This specification defines two types of metadata expressions that EPUB
-							Creators can define using the <code>meta</code> element:</p>
-
-						<ul>
-							<li id="primary-expression">A <em>primary expression</em> is one in which the expression
-								defined in the <code>meta</code> element establishes some aspect of the <a>EPUB
-									Publication</a>. A <code>meta</code> element that omits a refines attribute defines
-								a primary expression.</li>
-							<li id="subexpression">A <em>subexpression</em> is one in which the expression defined in
-								the <code>meta</code> element is associated with another expression or resource using
-								the <code>refines</code> attribute to enhance its meaning. A subexpression might refine
-								a media clip, for example, by expressing its duration, or refine a creator or
-								contributor expression by defining the role of the person.</li>
-						</ul>
-
-						<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions, thereby
-							creating chains of information.</p>
-
-						<p class="note">All the [[DCTERMS]] elements represent primary expressions, and permit
-							refinement by meta element subexpressions.</p>
-
-						<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a
-								href="#sec-default-vocab">default vocabulary</a> for use with the <code>property</code>
-							attribute.</p>
-
-						<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-							></a>.</p>
-
-						<aside class="example" title="Using properties with reserved prefixes">
-							<p>For the full list of reserved prefixes, refer to <a href="#sec-reserved-prefixes"
-								></a>.</p>
-
-							<pre>&lt;metadata …>
-   …
-   &lt;meta
-       property="dcterms:modified">
-      2016-02-29T12:34:56Z
-   &lt;/meta>
-   &lt;meta
-       property="rendition:layout">
-      pre-paginated
-   &lt;/meta>
-   &lt;meta
-       property="media:active-class">
-      my-active-item
-   &lt;/meta>
-   …
-&lt;/metadata></pre>
-						</aside>
-
-						<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme the
-							EPUB Creator obtained the element's <a>value</a> from. The value of the attribute MUST be a
-								<a href="#sec-property-datatype"><var>property</var> data type value</a> that resolves
-							to the resource that defines the scheme.</p>
-
-						<aside class="example" title="Using values from a scheme">
-							<p>In this example, the <code>scheme</code> attribute indicates that the <a>value</a> of the
-								tag is from [[ONIX]] code list 5 (i.e., the value <code>15</code> indicates a 13 digit
-								ISBN).</p>
-							<pre>&lt;metadata &#8230;>
-   &#8230;
-   &lt;meta
-       refines="#isbn-id"
-       property="identifier-type"
-       scheme="onix:codelist5">
-      15
-   &lt;/meta>
-   &#8230;
-&lt;/metadata></pre>
-						</aside>
-					</section>
-
-					<section id="sec-metadata-last-modified">
-						<h5>Last Modified Date</h5>
-
-						<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one
-							[[DCTERMS]] <code>modified</code> property containing the last modification date. The
-								<a>value</a> of this property MUST be an [[XMLSCHEMA-2]] dateTime conformant date of the
-							form: <code>CCYY-MM-DDThh:mm:ssZ</code></p>
-
-						<p>EPUB Creators MUST express the last modification date in Coordinated Universal Time (UTC) and
-							MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>
-
-						<aside class="example" title="Expressing a last modification date">
-							<pre>&lt;metadata …>
-   …
-   &lt;meta
-       property="dcterms:modified">
-      2016-01-01T00:00:01Z
-   &lt;/meta>
-   …
-&lt;/metadata></pre>
-						</aside>
-
-						<p>EPUB Creators should update the last modified date whenever they make changes to the EPUB
-							Publication.</p>
-
-						<p>EPUB Creators MAY specify additional modified properties in the Package Document metadata,
-							but they MUST have a different subject (i.e., they require a <code>refines</code> attribute
-							that references an element or resource).</p>
-
-						<div class="note">
-							<p>The requirements for the last modification date are to ensure compatibility with earlier
-								versions of EPUB 3 that defined a <a
-									href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
-									>release identifier</a> [[EPUBPackages-32]] for EPUB Publications.</p>
-						</div>
-					</section>
-
-					<section id="sec-link-elem">
-						<h5>The <code>link</code> Element</h5>
-
-						<p>The <code>link</code> element associates resources with an <a>EPUB Publication</a>, such as
-							metadata records.</p>
-
-						<dl id="elemdef-opf-link" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<code>link</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>As a child of <a class="codelink" href="#elemdef-opf-metadata"
-										><code>metadata</code></a>. Repeatable.</p>
-							</dd>
-
-							<dt>Attributes:</dt>
-							<dd>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#attrdef-href">
-												<code>href</code>
-											</a>
-											<code>[required]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-hreflang">
-												<code>hreflang</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-id">
-												<code>id</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-link-media-type">
-												<code>media-type</code>
-											</a>
-											<code>[conditionally required]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-properties">
-												<code>properties</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-refines">
-												<code>refines</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-link-rel">
-												<code>rel</code>
-											</a>
-											<code>[required]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-
-							<dt>Content Model:</dt>
-							<dd>
-								<p>Empty</p>
-							</dd>
-						</dl>
-
-						<p>The <a href="#sec-metadata-elem"><code>metadata</code> element</a> MAY contain zero or more
-								<code>link</code> elements, each of which identifies the location of a <a>Linked
-								Resource</a> in its REQUIRED <code>href</code> attribute</p>
-
-						<p id="linked-res-manifest">Linked Resources are <a>Publication Resources</a> only when they
-							are:</p>
-
-						<ul>
-							<li>
-								<p>referenced from the <a href="#sec-spine-elem">spine</a>; or</p>
-							</li>
-							<li>
-								<p>included or embedded in an EPUB Content Document (e.g., a metadata record serialized
-									as RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]] embedded in an [[HTML]] <a
-										data-cite="html#the-script-element"><code>script</code> element</a>).</p>
-							</li>
-						</ul>
-
-						<p>In all other cases (e.g., when linking to standalone [[?ONIX]] or [[?XMP]] records), the
-							Linked Resources are not Publication Resources (i.e., are not subject to <a
-								href="#sec-core-media-types">Core Media Type requirements</a>) and EPUB Creators MUST
-							NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
-
-						<aside class="example" title="Reference to a record embedded in an XHTML Content Document">
-							<p>In this example, the metadata record is embedded in a <code>script</code> element. Note
-								that the media type of the embedded record (i.e., <code>application/ld+json</code>) is
-								obtained from the <code>type</code> attribute on the <code>script</code> element; it is
-								not specified in the <code>link</code> element.</p>
-
-							<pre>Package Document:
-
-&lt;package …>
-   &lt;metadata …>
-      … 
-      &lt;link rel="record"
-          href="front.xhtml#meta-json"
-          media-type="application/xhtml+xml"
-          hreflang="en"/>
-      …
-   &lt;/metadata>
-   …
-&lt;/package>
-
-XHTML:
-
-&lt;html …>
-   &lt;head>
-      …
-      &lt;script id="meta-json" type="application/ld+json">
-          "@context" : "http://schema.org",
-          "name" : "…",
-         …
-      &lt;/script>
-      …
-   &lt;/head>
-   &lt;body>
-      …
-   &lt;/body>
-&lt;/html></pre>
-						</aside>
-
-						<p id="linked-res-location">EPUB Creators MAY locate Linked Resources <a
-								data-lt="Local Resource">locally</a> or <a data-lt="Remote Resource">remotely</a>, but
-							should consider that <a>Reading Systems</a> are not required to retrieve Remote Resources
-							(i.e., Reading Systems might not make Remote Resources available).</p>
-
-						<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
-								attribute</a> is OPTIONAL when a Linked Resource is located outside the EPUB Container,
-							as more than one media type could be served from the same URL [[URL]]. EPUB Creators MUST
-							specify the attribute for all <a>Local Resources</a>.</p>
-
-						<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of
-							the Linked Resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed
-								language tag</a> [[BCP47]].</p>
-
-						<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated list of
-								<a href="#sec-property-datatype">property</a> values that establish the relationship the
-							Linked Resource has with the EPUB Publication.</p>
-
-						<aside class="example" title="Linking to a MARC XML record">
-							<pre>&lt;metadata …>
-   …
-   &lt;link
-       rel="record"
-       href="meta/9780000000001.xml" 
-       media-type="application/marc"/>
-   …
-&lt;/metadata></pre>
-						</aside>
-
-						<p>The value of the <code>media-type</code> attribute is not always sufficient to identify the
-							type of Linked Resource (e.g., many XML-based record formats use the media type
-								"<code>application/xml</code>"). To aid Reading Systems in the identification of such
-							generic resources, EPUB Creators MAY specify a semantic identifier in the
-								<code>properties</code> attribute.</p>
-
-						<aside class="example" title="Identifying a record type via a property">
-							<p>In this example, the <code>properties</code> attribute identifies the link is to a XMP
-								record.</p>
-
-							<pre>&lt;metadata …>
-   …
-   &lt;link rel="record"
-       href="http://example.org/meta/12389347?format=xmp"
-       media-type="application/xml"
-       properties="xmp"/>
-   …
-&lt;/metadata></pre>
-						</aside>
-
-						<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a
-								href="#sec-default-vocab">default vocabulary</a> for the <code>rel</code> and
-								<code>properties</code> attributes.</p>
-
-						<p><a>EPUB Creators</a> MAY add relationships and properties from other vocabularies as defined
-							in <a href="#sec-vocab-assoc"></a>.</p>
-
-						<aside class="example" title="Declaring a new link relationship">
-							<p>In this example, the <code>link</code> element is used to associate an author's home page
-								using the FOAF vocabulary. Note that as <code>foaf</code> is not a <a
-									href="#sec-metadata-reserved-prefixes">predefined prefix</a>, it must be declared in
-								the <a href="#attrdef-package-prefix">prefix attribute</a>.</p>
-
-							<pre>&lt;package
-    …
-    prefix="foaf: http://xmlns.com/foaf/spec/">
-   &lt;metadata …>
-      … 
-      &lt;link
-          refines="#creator01"
-          rel="foaf:homepage"
-          href="http://example.org/book-info/12389347" />
-      …
-   &lt;/metadata> 
-   …
-&lt;/package>
-</pre>
-						</aside>
-
-						<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB Creators MAY provide one or
-							more <a href="#record">linked metadata records</a> to enhance the information available to
-							Reading Systems, but Reading Systems may ignore these records.</p>
-
-						<p>When a Reading System <a data-cite="epub-rs-33#sec-linked-records">processes linked
-								records</a> [[EPUB-RS-33]], the document order of <code>link</code> elements is used to
-							determine which has the highest priority in the case of conflicts (i.e., first in document
-							order has the highest priority).</p>
-
-						<aside class="example" title="Specifying metadata precedence">
-							<p>In this example, the first remote record has the highest precedence, the local record has
-								the next highest, and the metadata in the <code>metadata</code> element the lowest.</p>
-
-							<pre>&lt;metadata …>
-   &lt;link rel="record"
-       href="http://example.org/onix/12389347"
-       media-type="application/xml"
-       properties="onix" />
-    
-   &lt;link rel="record"
-       href="meta/meta.jsonld"
-       media-type="application/ld+json" />
-    
-    &lt;dc:title>The Sound and The Fury&lt;/dc:title>
-    &lt;dc:identifier>urn:isbn:9780101010101&lt;/dc:identifier>
-    &lt;dc:language>en-us&lt;/dc:language>
-    …
-&lt;/metadata></pre>
-						</aside>
-
-						<div class="note">
-							<p>Due to the variety of metadata record formats and serializations that an EPUB Creator can
-								link to an EPUB Publication, and the complexity of comparing metadata properties between
-								them, this specification does not require Reading Systems to process linked records.</p>
-						</div>
-
-						<p>In addition to full records, EPUB Creators MAY also use the <code>link</code> element to
-							identify individual metadata properties available in an alternative format.</p>
-
-						<aside class="example" title="Link to a description">
-							<p>In this example, the description of the EPUB Publication is contained in an HTML
-								document.</p>
-
-							<pre>&lt;metadata …>
-   …
-   &lt;link
-       rel="dcterms:description"
-       href="description.html"
-       media-type="text/html"/>
-   …
-&lt;/metadata></pre>
-						</aside>
-					</section>
-				</section>
-
-				<section id="sec-pkg-manifest">
-					<h4>Manifest Section</h4>
-
-					<section id="sec-manifest-elem">
-						<h5>The <code>manifest</code> Element</h5>
-
-						<p>The <code>manifest</code> element provides an exhaustive list of <a>Publication Resources</a>
-							used in the rendering of the content.</p>
-
-						<dl id="elemdef-opf-manifest" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<code>manifest</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>REQUIRED second child of <a class="codelink" href="#elemdef-opf-package"
-											><code>package</code></a>, following <a class="codelink"
-										href="#elemdef-opf-metadata"><code>metadata</code></a>.</p>
-							</dd>
-
-							<dt>Attributes:</dt>
-							<dd>
-								<p>
-									<a href="#attrdef-id">
-										<code>id</code>
-									</a>
-									<code>[optional]</code>
-								</p>
-							</dd>
-
-							<dt>Content Model:</dt>
-							<dd>
-								<p>
-									<a class="codelink" href="#elemdef-package-item">
-										<code>item</code>
-									</a>
-									<code>[1 or more]</code>
-								</p>
-							</dd>
-						</dl>
-
-						<p id="confreq-rendition-manifest">EPUB Creators MUST list all <a>Publication Resources</a> in
-							the <code>manifest</code>, regardless of whether they are <a data-lt="Local Resource"
-								>Local</a> or <a>Remote Resources</a>, using <a class="codelink" href="#sec-item-elem"
-									><code>item</code> elements</a>.</p>
-
-						<p>Note that the <code>manifest</code> is not self-referencing: EPUB Creators MUST NOT specify
-							an <code>item</code> element that refers to the Package Document itself.</p>
-
-						<div class="note">
-							<p>Failure to provide a complete manifest of resources may lead to rendering issues. Reading
-								Systems might not unzip such resources or could prevent access to them for security
-								reasons.</p>
-						</div>
-					</section>
-
-					<section id="sec-item-elem">
-						<h5>The <code>item</code> Element</h5>
-
-						<p>The <code>item</code> element represents a <a>Publication Resource</a>.</p>
-
-						<dl id="elemdef-package-item" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<code>item</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>As a child of <a class="codelink" href="#elemdef-opf-manifest"
-										><code>manifest</code></a>. Repeatable.</p>
-							</dd>
-
-							<dt>Attributes:</dt>
-							<dd>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#attrdef-item-fallback">
-												<code>fallback</code>
-											</a>
-											<code>[conditionally required]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-href">
-												<code>href</code>
-											</a>
-											<code>[required]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-id">
-												<code>id</code>
-											</a>
-											<code>[required]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-item-media-overlay">
-												<code>media-overlay</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-item-media-type">
-												<code>media-type</code>
-											</a>
-											<code>[required]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#sec-item-resource-properties">
-												<code>properties</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-							<dt>Content Model:</dt>
-							<dd>
-								<p>Empty</p>
-							</dd>
-						</dl>
-
-						<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL [[URL]] in
-							its <code>href</code> attribute. The value MUST be an <a data-cite="url#absolute-url-string"
-								>absolute-</a> or <a data-cite="url#path-relative-scheme-less-url-string"
-								>path-relative-scheme-less-URL</a> string [[URL]]. EPUB Creators MUST ensure each URL is
-							unique within the <code>manifest</code> scope after <a href="#sec-parse-package-urls"
-								>parsing</a>.</p>
-
-						<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code>
-							element MUST conform to the applicable specification(s) as inferred from the MIME media type
-							provided in the <a href="#attrdef-media-type"><code>media-type</code> attribute</a>. For
-								<a>Core Media Type Resources</a>, EPUB Creators MUST use the media type designated in <a
-								href="#sec-core-media-types"></a>.</p>
-
-						<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[XML]] that
-							identifies a fallback for the Publication Resource referenced from the <code>item</code>
-							element, as defined in <a href="#sec-manifest-fallbacks"></a>.</p>
-
-						<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF
-							[[XML]] that identifies the <a>Media Overlay Document</a> for the resource described by this
-								<code>item</code>. Refer to <a href="#sec-docs-package"></a> for more information.</p>
-
-						<div class="note">
-							<p>The order of <code>item</code> elements in the <code>manifest</code> is not significant.
-								The <a class="codelink" href="#sec-spine-elem"><code>spine</code> element</a> provides
-								the presentation sequence of content documents.</p>
-						</div>
-
-						<section id="sec-item-resource-properties">
-							<h6>Resource Properties</h6>
-
-							<p>The <a href="#attrdef-properties"><code>properties</code> attribute</a> provides
-								information to <a>Reading Systems</a> about the content of a resource. This information
-								enables discovery of key resources, such as the cover image and <a>EPUB Navigation
-									Document</a>. It also allows Reading Systems to optimize rendering by indicating,
-								for example, whether the resource contains embedded scripting, MathML, or SVG.</p>
-
-							<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
-									Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
-									<code>properties</code> attribute.</p>
-
-							<p>EPUB Creators MUST set the following properties whenever a resource referenced by an
-									<code>item</code> element matches their respective definitions:</p>
-
-							<ul>
-								<li><a href="#sec-mathml">mathml</a></li>
-								<li><a href="#sec-remote-resources">remote-resources</a></li>
-								<li><a href="#sec-scripted">scripted</a></li>
-								<li><a href="#sec-svg">svg</a></li>
-								<li><a href="#sec-switch">switch</a></li>
-							</ul>
-
-							<aside class="example" id="example-item-properties-scripted-mathml"
-								title="Identifying a Scripted Content Document with embedded MathML">
-								<pre class="synopsis">&lt;item
-    properties="scripted mathml"
-    id="c2"
-    href="c2.xhtml"
-    media-type="application/xhtml+xml" /&gt;
-</pre>
-							</aside>
-
-							<p>These properties do not apply recursively to content included into a resource (e.g., via
-								the HTML <code>iframe</code> element). For example, if a non-scripted XHTML Content
-								Document embeds a scripted Content Document, only the embedded document's manifest
-									<code>item</code>
-								<code>properties</code> attribute will have the <code>scripted</code> value.</p>
-
-							<p>EPUB Creators MUST declare exactly one <code>item</code> as the EPUB Navigation Document
-								using the <a href="#sec-nav-prop"><code>nav</code> property</a>.</p>
-
-							<aside class="example" id="example-item-properties-nav"
-								title="Identifying the EPUB Navigation Document">
-								<pre class="synopsis">&lt;item
-    properties="nav"
-    id="c1"
-    href="c1.xhtml"
-    media-type="application/xhtml+xml" /&gt;</pre>
-							</aside>
-
-							<p>If an EPUB Publication contains a cover image, it is recommended to set the <a
-									href="#sec-cover-image"><code>cover-image</code> property</a>, but setting this
-								property is OPTIONAL.</p>
-
-							<aside class="example" id="example-item-properties-cover-image"
-								title="Identifying the cover image">
-								<pre class="synopsis">&lt;item
-    properties="cover-image"
-    id="ci"
-    href="cover.svg"
-    media-type="image/svg+xml" /&gt;</pre>
-							</aside>
-
-							<p>EPUB Creators MAY add terms from other vocabularies as defined in <a
-									href="#sec-vocab-assoc"></a>.</p>
-						</section>
-
-						<section id="sec-item-elem-examples">
-							<h6>Examples</h6>
-
-							<aside class="example" id="example-manifest-cmt"
-								title="A manifest with only Core Media Type Resources">
-								<pre>&lt;package …>
-   …
-   &lt;manifest>
-      &lt;item
-          id="nav" 
-          href="nav.xhtml" 
-          properties="nav"
-          media-type="application/xhtml+xml"/>
-      &lt;item
-          id="intro" 
-          href="intro.xhtml" 
-          media-type="application/xhtml+xml"/>
-      &lt;item
-          id="c1" 
-          href="chap1.xhtml" 
-          media-type="application/xhtml+xml"/>
-      &lt;item
-          id="c1-answerkey" 
-          href="chap1-answerkey.xhtml" 
-          media-type="application/xhtml+xml"/>
-      &lt;item
-          id="c2" 
-          href="chap2.xhtml" 
-          media-type="application/xhtml+xml"/>
-      &lt;item
-          id="c2-answerkey" 
-          href="chap2-answerkey.xhtml" 
-          media-type="application/xhtml+xml"/>
-      &lt;item
-          id="c3" 
-          href="chap3.xhtml" 
-          media-type="application/xhtml+xml"/>
-      &lt;item
-          id="c3-answerkey" 
-          href="chap3-answerkey.xhtml" 
-          media-type="application/xhtml+xml"/>    
-      &lt;item
-          id="notes" 
-          href="notes.xhtml" 
-          media-type="application/xhtml+xml"/>
-      &lt;item
-          id="cover" 
-          href="./images/cover.svg" 
-          properties="cover-image"
-          media-type="image/svg+xml"/>
-      &lt;item
-          id="f1" 
-          href="./images/fig1.jpg" 
-          media-type="image/jpeg"/>
-      &lt;item
-          id="f2" 
-          href="./images/fig2.jpg" 
-          media-type="image/jpeg"/>
-      &lt;item
-          id="css" 
-          href="./style/book.css" 
-          media-type="text/css"/>   
-   &lt;/manifest>
-   …
-&lt;/package></pre>
-							</aside>
-
-							<aside class="example" id="example-manifest-flbk"
-								title="Foreign Content Document in Spine with Fallback">
-								<p>The following example shows the <a href="#sec-manifest-fallbacks">fallback chain
-										mechanism</a> allowing a <a>Foreign Content Document</a> (JPEG) to be listed in
-									the spine with fallback to an SVG Content Document.</p>
-
-								<pre>&lt;package …>
-   …
-   &lt;manifest>
-      …
-      &lt;item
-          id="page-001"
-          href="images/page-001.jpg"
-          media-type="image/jpeg"
-          fallback="#page-001-svg"/>
-
-      &lt;item
-          id="page-001-svg"
-          href="images/page-001.svg"
-          media-type="image/svg+xml"/>
-      … 
-      …
-   &lt;/manifest>
-   &lt;spine>
-      …
-      &lt;itemref idref="page-001"/>
-      …
-   &lt;/spine>
-&lt;/package></pre>
-							</aside>
-
-							<aside class="example"
-								title="Embedded Core Media Type Resource with Link to View as Top-Level Content Document">
-								<p>The following example shows a JPEG embedded in an EPUB Content Document (via the
-										<code>img</code> tag) with a hyperlink that allows it to open as a separate page
-									(e.g., for easier zooming). Although embedding the image using the <code>img</code>
-									tag does not require it to be listed in the <a href="#sec-spine-elem">spine</a> or
-									have a fallback, adding the hyperlink causes the document to open as a <a>Top-Level
-										Content Document</a>. As its use in the spine makes it a <a>Foreign Content
-										Document</a>, the EPUB Creator must include a fallback to an EPUB Content
-									Document.</p>
-
-								<pre>XHTML:
-&lt;html …>
-   …
-   &lt;body>
-      …
-      &lt;img
-          src="images/infographic.jpg"
-          alt="…"/>
-      &lt;a
-          href="images/infographic.jpg">
-         Expand Image
-      &lt;/a>
-      …
-   &lt;/body>
-&lt;/html>
-
-Package Document:
-&lt;package …>
-   …
-   &lt;manifest>
-      …
-      &lt;item
-          id="img01"
-          href="images/infographic.jpg"
-          media-type="image/jpeg"
-          fallback="#infographic-svg"/>
-
-      &lt;item
-          id="infographic-svg"
-          href="images/infographic.svg"
-          media-type="image/svg+xml"/>
-      …
-   &lt;/manifest>
-   &lt;spine>
-      …
-      &lt;itemref
-          idref="img01"
-          properties="layout-pre-paginated"
-          linear="no"/>
-      …
-   &lt;/spine>
-&lt;/package></pre>
-							</aside>
-
-							<aside class="example" title="Link to View Foreign Resource as Top-Level Content Document">
-								<p>The following example shows a link to the raw CSV data file. The data will open in
-									the Reading System as a <a>Top-Level Content Document</a> the EPUB Creator must list
-									it in the spine. As its use in the spine makes it a <a>Foreign Content Document</a>,
-									the EPUB Creator must also provide a fallback to an <a>EPUB Content Document</a>.
-									Because there is no guarantee users will be able to access the data in its raw form,
-									instructions on how to extract the file from the <a>EPUB Container</a> are also
-									provided.</p>
-
-								<pre>XHTML:
-&lt;html …>
-   …
-   &lt;body>
-      …
-      &lt;p>
-         &lt;a href="../data/raw.csv">
-            [Open the raw CSV data for this project.]
-         &lt;/a>
-      &lt;/p>
-      &lt;p class="small">To extract the data file
-         from this publication, unzip the EPUB file.
-         The data is located in the
-      	&lt;code>/EPUB/data/raw.csv&lt;/code> file.
-      &lt;/p>
-      …
-   &lt;/body>
-&lt;/html>
-
-Package Document:
-&lt;package …>
-   …
-   &lt;manifest>
-      …
-      &lt;item
-          id="data01"
-          href="data/raw.csv"
-          media-type="text/csv"
-          fallback="#data-html"/>
-
-      &lt;item
-          id="data-html"
-          href="xhtml/data-table.html"
-          media-type="application/xhtml+xml"/>
-      …
-   &lt;/manifest>
-   &lt;spine>
-      …
-      &lt;itemref
-          idref="data01"
-          linear="no"/>
-      …
-   &lt;/spine>
-&lt;/package></pre>
-							</aside>
-
-							<aside class="example" title="Remote Resources that are Publication Resources">
-								<p>The following example shows a reference to a remote audio file. Because the
-										<code>audio</code> element embeds the audio in its EPUB Content Document, the
-									file is considered a Publication Resource. The EPUB Creator therefore must list the
-									audio file in the manifest and indicate that its parent EPUB Content Document
-									contains a remote resource.</p>
-
-								<pre>XHTML:
-&lt;html …>
-   …
-   &lt;body>
-      …
-      &lt;audio
-          src="http://www.example.com/book/audio/ch01.mp4"
-          controls="controls"/>
-      …
-   &lt;/body>
-&lt;/html>
-
-Package Document:
-&lt;package …>
-   …
-   &lt;manifest>
-      …
-      &lt;item
-          id="audio01"
-          href="http://www.example.com/book/audio/ch01.mp4"
-          media-type="audio/mp4"/>
-   
-      &lt;item
-          id="c01"
-          href="XHTML/chapter001.xhtml"
-          media-type="application/xhtml+xml"
-          properties="remote-resources"/>
-      …
-   &lt;/manifest>
-   …
-&lt;/package></pre>
-							</aside>
-
-							<aside class="example" title="External Resources that are not Publication Resources">
-								<p>The following example shows a hyperlink to an audio file hosted on the web. Reading
-									Systems will open such external content in a new browser window; it is not rendered
-									within the publication. In this case, the EPUB Creator does not list the file in the
-									manifest because it is not a Publication Resource.</p>
-
-								<pre>XHTML:
-&lt;html …>
-   …
-   &lt;body>
-      …
-      &lt;a
-          href="http://www.example.com/book/audio/ch01.mp4">
-         Listen to audio
-      &lt;/a>
-      …
-   &lt;/body>
-&lt;/html>
-
-Manifest:
-No Entry</pre>
-							</aside>
-						</section>
-					</section>
-
-					<section id="sec-opf-bindings">
-						<h6>The <code>bindings</code> Element (Deprecated)</h6>
-
-						<p>The <code>bindings</code> element defines a set of custom handlers for media types not
-							supported by this specification.</p>
-
-						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
-
-						<p>Refer to the <a
-								href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
-									><code>bindings</code> element definition</a> in [[EPUBPublications-301]] for more
-							information.</p>
-					</section>
-				</section>
-
-				<section id="sec-pkg-spine">
-					<h4>Spine Section</h4>
-
-					<section id="sec-spine-elem">
-						<h5>The <code>spine</code> Element</h5>
-
-						<p>The <code>spine</code> element defines an ordered list of <a href="#sec-itemref-elem"
-								>manifest <code>item</code> references</a> that represent the default reading order.</p>
-
-						<dl id="elemdef-opf-spine" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<code>spine</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>REQUIRED third child of <a class="codelink" href="#elemdef-opf-package"
-											><code>package</code></a>, following <a class="codelink"
-										href="#elemdef-opf-manifest"><code>manifest</code></a>.</p>
-							</dd>
-
-							<dt>Attributes:</dt>
-							<dd>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#attrdef-id">
-												<code>id</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-spine-page-progression-direction">
-												<code>page-progression-direction</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#sec-opf2-ncx">
-												<code>toc</code>
-											</a>
-											<code>[optional]</code>
-											<a href="#legacy" class="legacy">(legacy)</a>
-										</p>
-									</li>
-								</ul>
-							</dd>
-
-							<dt>Content Model:</dt>
-							<dd>
-								<p>
-									<a class="codelink" href="#elemdef-spine-itemref">
-										<code>itemref</code>
-									</a>
-									<code>[1 or more]</code>
-								</p>
-							</dd>
-						</dl>
-
-						<p id="confreq-pub-resource">The <code>spine</code> MUST specify at least one <a>EPUB Content
-								Document</a> or <a>Foreign Content Document</a>.</p>
-
-						<p id="spine-inclusion-req">EPUB Creators MUST list in the <code>spine</code> all EPUB and
-							Foreign Content Documents that are hyperlinked to from Publication Resources in the
-								<code>spine</code>, where hyperlinking encompasses any linking mechanism that requires
-							the user to navigate away from the current resource. Common hyperlinking mechanisms include
-							the <code>href</code> attribute of the [[HTML]] <a data-cite="html#the-a-element"
-									><code>a</code></a> and <a data-cite="html#the-area-element"><code>area</code></a>
-							elements and scripted links (e.g., using DOM Events and/or form elements). The requirement
-							to list hyperlinked resources applies recursively (i.e., EPUB Creators must list all EPUB
-							and Foreign Content Documents hyperlinked to from hyperlinked documents, and so on.).</p>
-
-						<p>EPUB Creators also MUST list in the <code>spine</code> all EPUB and Foreign Content Documents
-							hyperlinked to from the <a>EPUB Navigation Document</a>, regardless of whether EPUB Creators
-							include the Navigation Document in the <code>spine</code>.</p>
-
-						<div class="note">
-							<p>As hyperlinks to resources outside the EPUB Container are not Publication Resources, they
-								are not subject to the requirement to include in the spine (e.g., web pages and
-								web-hosted resources).</p>
-
-							<p>Publication Resources used in the rendering of spine items (e.g., referenced from
-								[[HTML]] <a data-cite="html#embedded-content-2">embedded content</a>) similarly do not
-								have to be included in the spine.</p>
-						</div>
-
-						<p id="attrdef-spine-page-progression-direction">The <code>page-progression-direction</code>
-							attribute sets the global direction in which the content flows. Allowed values are
-								<code>ltr</code> (left-to-right), <code>rtl</code> (right-to-left) and
-								<code>default</code>. When EPUB Creators specify the <code>default</code> value, they
-							are expressing no preference and the Reading System can choose the rendering direction.</p>
-
-						<p>Although the <code>page-progression-direction</code> attribute sets the global flow
-							direction, individual Content Documents and parts of Content Documents MAY override this
-							setting (e.g., via the <code>writing-mode</code> CSS property). Reading Systems may also
-							provide mechanisms to override the default direction (e.g., buttons or settings that allow
-							the application of alternate style sheets).</p>
-
-						<p>The <a href="#legacy">legacy</a>
-							<code>toc</code> attribute takes an IDREF [[XML]] that identifies the manifest item that
-							represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
-					</section>
-
-					<section id="sec-itemref-elem">
-						<h5>The <code>itemref</code> Element</h5>
-
-						<p>The <code>itemref</code> element identifies an <a>EPUB Content Document</a> or <a>Foreign
-								Content Document</a> in the default reading order.</p>
-
-						<dl id="elemdef-spine-itemref" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<code>itemref</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>As a child of <a class="codelink" href="#elemdef-opf-spine"><code>spine</code></a>.
-									Repeatable.</p>
-							</dd>
-
-							<dt>Attributes:</dt>
-							<dd>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#attrdef-id">
-												<code>id</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-itemref-idref">
-												<code>idref</code>
-											</a>
-											<code>[required]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-itemref-linear">
-												<code>linear</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-properties">
-												<code>properties</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-
-							<dt>Content Model:</dt>
-							<dd>
-								<p>Empty</p>
-							</dd>
-						</dl>
-
-						<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an <a
-								href="#elemdef-package-item"><code>item</code></a> in the <a>manifest</a> via the
-							IDREF [[XML]] in its <code>idref</code> attribute, and item IDs MUST NOT be referenced more
-							than once. </p>
-
-						<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a) an
-								<a>EPUB Content Document</a> or b) a <a>Foreign Content Document</a> which,
-								<em>regardless of whether it is a <a>Core Media Type Resource</a> or a <a>Foreign
-									Resource</a></em>, MUST include an EPUB Content Document in its <a
-								href="#sec-manifest-fallbacks">fallback chain</a>.</p>
-
-						<div class="note">
-							<p>Although EPUB Publications <a href="#confreq-nav">require an EPUB Navigation
-								Document</a>, it is not mandatory to include it in the <code>spine</code>.</p>
-
-						</div>
-
-						<p id="attrdef-itemref-linear">The <code>linear</code> attribute indicates whether the
-							referenced <code>item</code> contains content that contributes to the primary reading order
-							and that Reading Systems must read sequentially ("<code>yes</code>"), or auxiliary content
-							that enhances or augments the primary content that Reading Systems can access out of
-							sequence ("<code>no</code>"). Examples of auxiliary content include notes, descriptions, and
-							answer keys.</p>
-
-						<p>The <code>linear</code> attribute allows Reading Systems to distinguish content that a user
-							should access as part of the default reading order from supplementary content which a
-							Reading System might, for example, present in a popup window or omit from an aural
-							rendering.</p>
-
-						<p>Specifying that content is non-linear does not require Reading Systems to present it in a
-							specific way, however; it is only a hint to the purpose. Reading Systems may present
-							non-linear content where it occurs in the spine, for example, or may skip it until users
-							reach the end of the spine.</p>
-
-						<div class="note">
-							<p>EPUB Creators should list non-linear content at the end of the spine except when it makes
-								sense for users to encounter it between linear spine items.</p>
-
-						</div>
-
-						<p id="linear-itemrefs"> A linear <code>itemref</code> element is one whose <code>linear</code>
-							attribute value is explicitly set to "<code>yes</code>" or that omits the
-							attribute — Reading Systems will assume the value "<code>yes</code>" for
-								<code>itemref</code> elements without the attribute. The spine MUST contain at least one
-							linear <code>itemref</code> element. </p>
-
-						<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide a
-							means of accessing all non-linear content (e.g., hyperlinks in the content or from the <a
-								href="#sec-nav">EPUB Navigation Document</a>).</p>
-
-						<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine Properties
-								Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
-								<code>properties</code> attribute.</p>
-
-						<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-							></a>.</p>
-
-						<aside class="example" title="A basic spine">
-							<p>In this example, the spine entries correspond to <a href="#example-manifest-cmt">the
-									manifest example above</a>.</p>
-
-							<pre>&lt;spine
-    page-progression-direction="ltr">
-   &lt;itemref
-       idref="intro"/>
-   &lt;itemref
-       idref="c1"/>
-   &lt;itemref
-       idref="c1-answerkey"
-       linear="no"/>
-   &lt;itemref
-       idref="c2"/>
-   &lt;itemref
-       idref="c2-answerkey"
-       linear="no"/>
-   &lt;itemref
-       idref="c3"/>
-   &lt;itemref
-       idref="c3-answerkey"
-       linear="no"/>
-   &lt;itemref
-       idref="notes"
-       linear="no"/>
-&lt;/spine>
-</pre>
-						</aside>
-					</section>
-				</section>
-
-				<section id="sec-pkg-collections">
-					<h4>Collections</h4>
-
-					<section id="sec-collection-elem">
-						<h5>The <code>collection</code> Element</h5>
-
-						<p>The <code>collection</code> element defines a related group of resources.</p>
-
-						<dl id="elemdef-collection" class="elemdef">
-							<dt>Element Name:</dt>
-							<dd>
-								<p>
-									<code>collection</code>
-								</p>
-							</dd>
-
-							<dt>Usage:</dt>
-							<dd>
-								<p>OPTIONAL sixth element of <code>package</code>. Repeatable.</p>
-							</dd>
-
-							<dt>Attributes:</dt>
-							<dd>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a href="#attrdef-dir">
-												<code>dir</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-id">
-												<code>id</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-collection-role">
-												<code>role</code>
-											</a>
-											<code>[required]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<a href="#attrdef-xml-lang">
-												<code>xml:lang</code>
-											</a>
-											<code>[optional]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-
-							<dt>Content Model:</dt>
-							<dd>
-								<p>In this order: <code>metadata</code>
-									<code>[0 or 1]</code>, ( <a href="#elemdef-collection"><code>collection</code></a>
-									<code>[1 or more]</code> or ( <a href="#elemdef-collection"
-										><code>collection</code></a>
-									<code>[0 or more]</code>, <code>link</code>
-									<code>[1 or more]</code> ))</p>
-							</dd>
-						</dl>
-
-						<p>The <code>collection</code> element allows EPUB Creators to assemble resources into logical
-							groups for a variety of potential uses: enabling reassembly into a meaningful unit of
-							content split across multiple <a>EPUB Content Documents</a> (e.g., an index split across
-							multiple documents), identifying resources for specialized purposes (e.g., preview content),
-							or collecting together resources that present additional information about the <a>EPUB
-								Publication</a>.</p>
-
-						<p id="attrdef-collection-role">EPUB Creators MUST identify the role of each
-								<code>collection</code> element in its <code>role</code> attribute, whose value MUST be
-							one or more NMTOKENs [[XMLSCHEMA-2]] and/or <a
-								data-cite="url#absolute-url-with-fragment-string">absolute-URL-with-fragment strings</a>
-							[[URL]].</p>
-
-						<p>The requirements for authoring specialized collections are defined by their respective
-							specifications.</p>
-
-						<div class="note">
-							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
-								Working Group maintained both a <a href="http://www.idpf.org/epub/registries/roles"
-									>registry of role extensions</a> and a list of <a
-									href="http://www.idpf.org/epub/extensions/roles">custom extension roles</a>. This
-								Working Group no longer maintains these registries.</p>
-						</div>
-
-						<aside class="example" title="A multi-document index">
-							<pre>&lt;collection role="index">
-   &lt;link href="subjectIndex01.xhtml"/>
-   &lt;link href="subjectIndex02.xhtml"/>
-   &lt;link href="subjectIndex03.xhtml"/>
-&lt;/collection></pre>
-						</aside>
-					</section>
-
-					<section id="sec-defining-collection-types">
-						<h5>Defining Collection Types (Deprecated)</h5>
-
-						<p>The creation of new <code>collection</code> element roles is now <a href="#deprecated"
-								>deprecated</a>.</p>
-
-						<p>Refer to the <a
-								href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
-									><code>collection</code> element definition</a> in [[EPUBPackages-32]] for more
-							information about the creation of specialized collections, including the requirements and
-							restrictions on their use.</p>
-					</section>
-				</section>
-
-				<section id="sec-pkg-legacy">
-					<h4>Legacy Content</h4>
-
-					<section id="sec-opf2-meta">
-						<h5>The <code>meta</code> Element</h5>
-
-						<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
-									><code>meta</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a> feature
-							that previously provided a means of including generic metadata. The EPUB 3 <a
-								href="#sec-meta-elem"><code>meta</code> element</a>, which uses different attributes and
-							requires text content, replaces this element.</p>
-
-						<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
-									><code>meta</code> element definition</a> in [[OPF-201]] for more information.</p>
-
-						<div class="note">
-							<p>The [[OPF-201]] <code>meta</code> element is retained in EPUB 3 primarily so that EPUB
-								Creators can identify the cover image for compatibility with EPUB 2 Reading Systems. In
-								EPUB 3, the cover image must be identified using the <a href="#sec-cover-image"
-										><code>cover-image</code> property</a> on the <a href="#sec-item-elem">manifest
-										<code>item</code></a> for the image.</p>
-
-						</div>
-					</section>
-
-					<section id="sec-opf2-guide">
-						<h5>The <code>guide</code> Element</h5>
-
-						<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
-									><code>guide</code> element</a> [[OPF-201]] is a <a href="#legacy">legacy</a>
-							feature that previously provided machine-processable navigation to key structures. The <a
-								href="#sec-nav-landmarks">landmarks nav</a> in the <a>EPUB Navigation Document</a>
-							replaces this element.</p>
-
-						<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
-									><code>guide</code> element definition</a> in [[OPF-201]] for more information.</p>
-					</section>
-
-					<section id="sec-opf2-ncx">
-						<h5>NCX</h5>
-
-						<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a>
-							[[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table of
-							contents. The <a href="#sec-nav">EPUB Navigation Document</a> replaces this document.</p>
-
-						<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
-								definition</a> in [[OPF-201]] for more information.</p>
-					</section>
-				</section>
-			</section>
-		</section>
-		<section id="sec-contentdocs">
-			<h2>EPUB Content Documents</h2>
-
-			<section id="sec-xhtml">
-				<h3>XHTML Content Documents</h3>
-
-				<section id="sec-xhtml-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>This section defines a profile of [[HTML]] for creating XHTML Content Documents. An instance of
-						an XML document that conforms to this profile is a <a>Core Media Type Resource</a> and is
-						referred to in this specification as an <a>XHTML Content Document</a>.</p>
-				</section>
-
-				<section id="sec-xhtml-req">
-					<h4>XHTML Requirements</h4>
-
-					<p>An XHTML Content Document:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-cd-html-docprops-syntax">MUST be an [[HTML]] document that conforms to the <a
-									data-cite="html#the-xhtml-syntax">XML</a> syntax.</p>
-						</li>
-						<li>
-							<p id="confreq-cd-html-docprops-html">MUST conform to the conformance criteria for all
-								document constructs defined by [[HTML]] unless explicitly overridden in <a
-									href="#sec-xhtml-deviations"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-cd-html-docprops-schema">MAY include extensions to the [[HTML]] grammar as
-								defined in <a href="#sec-xhtml-extensions"></a>, and MUST conform to all content
-								conformance constraints defined therein.</p>
-						</li>
-					</ul>
-					<p>Unless specified otherwise, XHTML Content Documents inherit all definitions of semantics,
-						structure, and processing behaviors from the [[HTML]] specification.</p>
-
-					<div class="note">
-						<p>The recommendation that EPUB Publications follow the accessibility requirements in
-							[[EPUB-A11Y-11]] applies to XHTML Content Documents. See <a href="#confreq-a11y"
-								>Accessibility</a>.</p>
-
-					</div>
-				</section>
-
-				<section id="sec-xhtml-extensions">
-					<h4>HTML Extensions</h4>
-
-					<p>This section defines EPUB 3 <a>XHTML Content Document</a> extensions to the underlying [[HTML]]
-						document model.</p>
-
-					<div class="note">
-						<p>Although [[HTML]] allows user agents to support <a data-cite="html#extensibility-2"
-								>vendor-neutral extensions</a>, unless such extensions are listed in this section, they
-							are not supported features of EPUB 3.</p>
-
-					</div>
-					<section id="sec-xhtml-structural-semantics">
-						<h5>Structural Semantics</h5>
-
-						<p>EPUB Creators MAY use the <a href="#sec-epub-type-attribute"><code>epub:type</code>
-								attribute</a> in <a>XHTML Content Documents</a> to express <a
-								href="#sec-structural-semantics-intro">structural semantics</a>.</p>
-
-						<p>As the [[HTML]] <a data-cite="html#the-head-element"><code>head</code> element</a> contains
-							metadata for the document, structural semantics expressed on this element or any descendant
-							of it have no meaning.</p>
-					</section>
-
-					<section id="sec-xhtml-rdfa">
-						<h5>RDFa</h5>
-
-						<p>The [[HTML-RDFA]] specification defines a set of attributes that EPUB Creators MAY use in
-								<a>XHTML Content Documents</a> to semantically enrich the content. The use of these
-							attributes MUST conform to the requirements defined in [[HTML-RDFA]].</p>
-
-						<p>The [[HTML-RDFA]] specification defines changes to the [[HTML]] content model when authors
-							use RDFa attributes. This modified content model is valid in XHTML Content Documents.</p>
-
-						<div class="note">
-							<p>The listing of RDFa does not express a preference on the part of the Working Group, only
-								that these attributes represent an extension of the HTML grammar. EPUB Creators can also
-								specify <a data-cite="html#microdata">microdata attributes</a> [[HTML]] and <a
-									data-cite="json-ld11#">linked data</a> [[JSON-LD11]] in XHTML Content Documents as
-								both are natively supported.</p>
-
-						</div>
-					</section>
-
-					<section id="sec-xhtml-content-switch">
-						<h5>Content Switching (Deprecated)</h5>
-
-						<p>The <code>switch</code> element provides a simple mechanism through which <a>EPUB
-								Creators</a> can tailor the content displayed to users, one that is not dependent on the
-							scripting capabilities of the <a>EPUB Reading System</a>.</p>
-
-						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
-
-						<p>Refer to the <a
-								href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
-									><code>switch</code> element definition</a> in [[EPUBContentDocs-301]] for more
-							information.</p>
-					</section>
-
-					<section id="sec-xhtml-epub-trigger">
-						<h5>The <code>epub:trigger</code> Element (Deprecated)</h5>
-
-						<p>The <code>trigger</code> element enables the creation of markup-defined user interfaces for
-							controlling multimedia objects, such as audio and video playback, in both scripted and
-							non-scripted contexts.</p>
-
-						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
-
-						<p>Refer to the <a
-								href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
-									><code>epub:trigger</code> element definition</a> in [[EPUBContentDocs-301]] for
-							more information.</p>
-					</section>
-
-					<section id="sec-xhtml-custom-attributes">
-						<h5>Custom Attributes</h5>
-
-						<p><a>XHTML Content Documents</a> MAY contain custom attributes, which are <a
-								data-cite="xml-names#NT-Prefix">prefixed</a> [[XML-NAMES]] attributes whose namespace
-							URL does not include either of the following strings in its <a
-								data-cite="url#concept-domain">domain</a> [[URL]]:</p>
-
-						<ul>
-							<li><code>w3.org</code></li>
-							<li><code>idpf.org</code></li>
-						</ul>
-						<p>When using custom attributes, the content MUST remain consumable by a user without any
-							information loss or other significant deterioration, regardless of the Reading System it is
-							rendered on.</p>
-
-						<div class="note">
-							<p>Custom attributes are usually defined in a Reading System-specific manner and are not
-								intended for use by other Reading Systems. This specification should be extended to
-								provide extensions that multiple independent Reading Systems can use.</p>
-						</div>
-					</section>
-				</section>
-
-				<section id="sec-xhtml-deviations">
-					<h4>HTML Deviations and Constraints</h4>
-
-					<p>This section defines deviations from, and constraints on, the underlying [[HTML]] document model
-						applicable to EPUB 3 <a>XHTML Content Documents</a>.</p>
-
-					<section id="sec-xhtml-mathml">
-						<h5>Embedded MathML</h5>
-
-						<p>XHTML Content Documents support embedded [[MATHML3]]. Occurrences of MathML markup MUST
-							conform to the constraints expressed in the MathML specification [[MATHML3]], with the
-							following additional restrictions:</p>
-
-						<dl class="conformance-list">
-							<dt id="math-pres">Presentation MathML</dt>
-							<dd>
-								<p id="confreq-mathml-pres">The <code>math</code> element MUST contain only <a
-										data-cite="mathml3/chapter3.html#">Presentation MathML</a>, except within the
-										<code>annotation-xml</code> element.</p>
-							</dd>
-
-							<dt id="math-cont">Content MathML</dt>
-							<dd>
-								<p id="confreq-mathml-annot-cont">EPUB Creators MAY include <a
-										data-cite="mathml3/chapter4.html#">Content MathML</a> within MathML markup in
-									XHTML Content Documents, and, when present, MUST include it within an
-										<code>annotation-xml</code> child element of a <code>semantics</code>
-									element.</p>
-								<p id="confreq-mathml-annot-cont-attrs">When EPUB Creators include Content MathML per
-									the previous condition, they MUST set the given <code>annotation-xml</code>
-									element's <code>encoding</code> attribute to either of the functionally-equivalent
-									values <code>MathML-Content</code> or <code>application/mathml-content+xml</code>,
-									and the <code>name</code> attribute to <code>contentequiv</code>.</p>
-							</dd>
-						</dl>
-
-						<p>This subset eases the implementation burden on Reading Systems and promotes accessibility,
-							while retaining compatibility with [[HTML]] user agents.</p>
-
-						<div class="note">
-							<p>The <a href="#mathml"><code>mathml</code> property</a> of the <a>manifest</a>
-								<code>item</code> element indicates that an XHTML Content Document contains embedded
-								MathML.</p>
-
-						</div>
-					</section>
-
-					<section id="sec-xhtml-svg">
-						<h5>Embedded SVG</h5>
-
-						<p><a>XHTML Content Documents</a> support the embedding of <a
-								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
-								fragments</a> [[SVG]] <em>by reference</em> (embedding via reference, for example, from
-							an <code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
-							direct inclusion of the <code>svg</code> element in the XHTML Content Document).</p>
-
-						<p>The content conformance constraints for SVG embedded in XHTML Content Documents are the same
-							as defined for <a>SVG Content Documents</a> in <a href="#sec-svg-restrictions"></a>.</p>
-
-						<div class="note">
-							<p>The <a href="#svg"><code>svg</code> property</a> of the <a>manifest</a>
-								<a href="#sec-item-elem"><code>item</code> element</a> indicates that an XHTML Content
-								Document contains embedded SVG.</p>
-
-						</div>
-					</section>
-
-					<section id="sec-xhtml-deviations-discouraged" class="informative">
-						<h5>Discouraged Constructs</h5>
-
-						<section id="sec-xhtml-deviations-base">
-							<h6>The <code>base</code> Element</h6>
-
-							<p id="confreq-html-vocab-base"> The [[HTML]] <a data-cite="html#the-base-element"
-										><code>base</code></a> element can be used to specify the <a
-									data-cite="html#document-base-url">document base URL</a> for the purposes of parsing
-								URLs. When using it in an <a>EPUB Publication</a>, the interpretation of the
-									<code>base</code> elements may inadvertently result in references to <a>Remote
-									Resources</a>, i.e., resources that are outside the <a>EPUB Container</a>. Using the
-									<code>base</code> element in an <a>EPUB Publication</a> may cause Reading Systems to
-								misinterpret the location of resources (e.g., relative links to other documents in the
-								publication might appear as links to a web site if the <code>base</code> element
-								specifies an absolute URL). To avoid significant interoperability issues, EPUB Creators
-								should not use the <code>base</code> element. </p>
-						</section>
-
-						<section id="sec-xhtml-deviations-rp">
-							<h6>The <code>rp</code> Element</h6>
-
-							<p id="confreq-html-vocab-rp">The [[HTML]] <a data-cite="html#the-rp-element"
-										><code>rp</code></a> element is intended to provide a fallback for older
-									<a>Reading Systems</a> that do not recognize ruby markup (i.e., a parenthesis
-								display around <code>ruby</code> markup). As EPUB 3 Reading Systems are ruby-aware, and
-								can provide fallbacks, EPUB Creators should not use <code>rp</code> elements.</p>
-						</section>
-
-						<section id="sec-xhtml-deviations-embed">
-							<h6>The <code>embed</code> Element</h6>
-
-							<p id="confreq-html-vocab-embed">Since the [[HTML]] <a data-cite="html#the-embed-element"
-										><code>embed</code></a> element does not include intrinsic facilities to provide
-								fallback content for Reading Systems that do not support scripting, <a>EPUB Creators</a>
-								are discouraged from using the element when the referenced resource includes scripting.
-								The [[HTML]] <a data-cite="html#the-object-element"><code>object</code> element</a> is a
-								better alternative, as it includes intrinsic fallback capabilities.</p>
-						</section>
-					</section>
-				</section>
-			</section>
-
-			<section id="sec-svg">
-				<h3>SVG Content Documents</h3>
-
-				<div class="caution">
-					<p><a>Reading Systems</a> may not support all the features of [[SVG]] or supported them across all
-						platforms that Reading Systems run on. When utilizing such features, <a>EPUB Creators</a> should
-						consider the inherent risks on interoperability and document longevity.</p>
-
+			<section id="sec-data-urls">
+				<h3>Data URLs</h3>
+
+				<p>The <a data-cite="rfc2397#"><code>data:</code> URL scheme</a> [[RFC2397]] is used to encode resources
+					directly into a URL string. The advantage of this scheme is that it allows EPUB Creators to embed a
+					resource within another, avoiding the need for an external file.</p>
+
+				<p><a>EPUB Creators</a> MAY use data URLs in EPUB Publications provided their use does not result in a
+						<a>Top-level Content Document</a> or <a data-cite="html#top-level-browsing-context">top-level
+						browsing context</a> [[HTML]]. This restriction applies to data URLs used in the following
+					scenarios:</p>
+
+				<ul>
+					<li>
+						<p>in manifest <a href="#sec-item-elem"><code>item</code> elements</a> referenced from the
+								<a>spine</a>;</p>
+					</li>
+					<li>
+						<p>in the <code>href</code> attribute on [[HTML]] or [[SVG]] <code>a</code> elements (except
+							when inside an <a data-cite="html#the-iframe-element"><code>iframe</code> element</a>
+							[[HTML]]);</p>
+					</li>
+					<li>
+						<p>in the <code>href</code> attribute on [[HTML]] <code>area</code> elements (except when inside
+							an <code>iframe</code> element);</p>
+					</li>
+					<li>
+						<p>in calls to [[ECMASCRIPT]] <code>window.open</code> or <code>document.open</code>.</p>
+					</li>
+				</ul>
+
+				<div class="note">
+					<p>The list of prohibited uses for data URLs is subject to change as the respective standards that
+						allow their use evolve.</p>
 				</div>
 
-				<section id="sec-svg-intro" class="informative">
-					<h4>Introduction</h4>
+				<p>This restriction on their use is to prevent security issues and also to ensure that <a>Reading
+						Systems</a> can determine where to take a user next (i.e., because these resources are not be
+					listed in the spine).</p>
 
-					<p>The Scalable Vector Graphics (SVG) specification [[SVG]] defines a format for representing
-						final-form vector graphics and text.</p>
+				<p>Resources represented as data URLs are not Publication Resources so are exempt from the requirement
+					for EPUB Creators to list them in the <a>manifest</a>.</p>
 
-					<p>Although <a>EPUB Creators</a> typically use <a href="#sec-xhtml">XHTML Content Documents</a> as
-						the <a data-lt="Top-level Content Document">top-level</a> document type, the use of <a>SVG
-							Content Documents</a> is also permitted. EPUB Creators will typically only need SVGs for
-						certain special cases, such as when final-form page images are the only suitable representation
-						of the content (e.g., for cover art or in the context of manga or comic books).</p>
-
-					<p>This section defines a profile for [[SVG]] documents. An instance of an XML document that
-						conforms to this profile is a <a>Core Media Type Resource</a> and is referred to in this
-						specification as an <a>SVG Content Document</a>.</p>
-
-					<div class="note">
-						<p>This section defines conformance requirements for <a>SVG Content Documents</a>. Refer to <a
-								href="#sec-xhtml-svg"></a> for the conformance requirements for SVG embedded in XHTML
-							Content Documents.</p>
-
-					</div>
-				</section>
-
-				<section id="sec-svg-req">
-					<h4>SVG Requirements</h4>
-
-					<p>An SVG Content Document:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-cd-svg-docprops-schema">MUST be a <a
-									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles"
-									>conforming SVG stand-alone file</a> [[SVG]] and conform to all content conformance
-								constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-svg-structural-semantics">MAY specify the <a href="#attrdef-epub-type"
-										><code>epub:type</code></a> attribute for expressing <a
-									href="#app-structural-semantics">structural semantics</a> and use all applicable <a
-									href="#sec-vocab-assoc">vocabulary association mechanisms</a>.</p>
-						</li>
-					</ul>
-					<div class="note">
-						<p>The recommendation that EPUB Publications follow the accessibility requirements in
-							[[EPUB-A11Y-11]] applies to SVG Content Documents. See <a href="#confreq-a11y"
-								>Accessibility</a>.</p>
-
-					</div>
-				</section>
-
-				<section id="sec-svg-restrictions">
-					<h4>Restrictions on SVG</h4>
-
-					<p>This specification restricts the content model of <a>SVG Content Documents</a> and <a
-							href="#sec-xhtml-svg">SVG embedded in XHTML Content Documents</a> as follows:</p>
-
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-svg-foreignObject">The [[SVG]] <a
-									href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
-										><code>foreignObject</code></a> element:</p>
-							<ul class="conformance-list">
-								<li>
-									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[HTML]] <a
-											data-cite="html#flow-content">flow content</a> or exactly one [[HTML]] <a
-											data-cite="html#the-body-element"><code>body</code> element</a>.</p>
-									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
-											<code>body</code> element is not permitted per the <a data-cite="html#svg-0"
-											>restrictions on SVG</a> defined in [[HTML]].</p>
-								</li>
-								<li>
-									<p id="confreq-svg-foreignObject-xhtml-frag">MUST contain a valid document fragment
-										that conforms to the XHTML Content Document model defined in <a
-											href="#sec-xhtml-req"></a>.</p>
-								</li>
-							</ul>
-						</li>
-						<li>
-							<p id="confreq-svg-title">The [[SVG]] <a
-									href="https://www.w3.org/TR/SVG/struct.html#TitleElement"><code>title</code></a>
-								element MUST contain only valid <a href="#sec-xhtml-req">XHTML Content Document Phrasing
-									content</a>.</p>
-						</li>
-					</ul>
-				</section>
+				<p>EPUB Creators MUST encode Data URLs as Core Media Type Resources or use them where they can provide a
+					fallback (i.e., Data URLs are subject to the <a href="#sec-foreign-resources">Foreign Resource
+						restrictions</a>).</p>
 			</section>
 
-			<section id="sec-common-resource-req">
-				<h3>Common Resource Requirements</h3>
+			<section id="sec-xml-constraints">
+				<h3>XML Conformance</h3>
 
-				<p>This section defines requirements for technologies usable in both XHTML and SVG Content
-					Documents.</p>
-
-				<section id="sec-css">
-					<h3>Cascading Style Sheets (CSS)</h3>
-
-					<section id="sec-css-intro" class="informative">
-						<h4>Introduction</h4>
-
-						<p>CSS is an integral part of the Open Web Platform. Readers, publishers, and document authors
-							expect CSS to "just work," as they expect HTML to just work.</p>
-
-						<p>In the past, EPUB defined a profile of CSS that mandated support for certain properties and
-							provided prefixed versions of numerous other properties. Although the CSS Working Group no
-							longer recommends the use of prefixed properties, this specification maintains some prefixed
-							properties to avoid breaking existing content. But with the minor exceptions defined in this
-							section, EPUB defers to the W3C to define CSS.</p>
-
-						<div class="note">
-							<p>Keep in mind that some <a>Reading Systems</a> will not support all desired features of
-								CSS. The following are known to be particularly problematic:</p>
-
-							<ul>
-								<li>
-									<p>Reading System-induced pagination can interact poorly with style sheets as
-										Reading Systems sometimes paginate using columns. This may result in incorrect
-										values for viewport sizes. Fixed and absolute positioning are particularly
-										problematic.</p>
-								</li>
-								<li>
-									<p>Some types of screens will render animations and transitions poorly (e.g., those
-										with high latency).</p>
-								</li>
-							</ul>
-						</div>
-					</section>
-
-					<section id="sec-css-req">
-						<h4>CSS Requirements</h4>
-
-						<p>A CSS style sheet:</p>
-
-						<ul class="conformance-list">
-							<li>
-								<p id="confreq-css-props">MAY include any CSS properties, with the following
-									exceptions:</p>
-								<ul class="conformance-list">
-									<li>
-										<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
-												data-cite="css-writing-modes-3#direction"><code>direction</code>
-												property</a> [[CSS-Writing-Modes-3]].</p>
-									</li>
-									<li>
-										<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT include the <a
-												data-cite="css-writing-modes-3#unicode-bidi"><code>unicode-bidi</code>
-												property</a> [[CSS-Writing-Modes-3]].</p>
-									</li>
-								</ul>
-							</li>
-							<li>
-								<p id="confreq-css-prefixed">MAY include the prefixed properties defined in <a
-										href="#sec-css-prefixed"></a>.</p>
-							</li>
-							<li>
-								<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8
-									as the RECOMMENDED encoding.</p>
-							</li>
-						</ul>
-						<div class="note">
-							<p>This specification restricts the use of the <code>direction</code> and
-									<code>unicode-bidi</code> properties because Reading Systems may not implement, or
-								may switch off, CSS processing. EPUB Creators must use the following format-specific
-								methods when they need control over these aspects of the rendering:</p>
-
-							<ul>
-								<li>
-									<p>the <a data-cite="html#the-dir-attribute"><code>dir</code> attribute</a> [[HTML]]
-										and <a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
-												><code>direction</code> attribute</a> [[SVG]] for inline base
-										directionality.</p>
-								</li>
-								<li>
-									<p>the <a data-cite="html#the-bdo-element"><code>bdo</code> element</a> with the <a
-											data-cite="html#the-dir-attribute"><code>dir</code> attribute</a> [[HTML]]
-										and the <a href="https://www.w3.org/TR/SVG/styling.html#PresentationAttributes"
-											>presentation attribute alternative</a> for <code>unicode-bidi</code>
-										[[SVG]] for bidirectionality.</p>
-								</li>
-							</ul>
-						</div>
-					</section>
-
-					<section id="sec-css-prefixed">
-						<h4>Prefixed Properties</h4>
-
-						<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to
-							world languages were not yet mature. To ensure backwards compatibility for content authored
-							using these prefixes, they have been retained in this specification. Unless otherwise noted,
-							prefixed properties and values behave exactly as their unprefixed equivalents as described
-							in the appropriate CSS specification. The prefixed properties are documented in <a
-								href="#css-prefixes"></a>. </p>
-
-						<div class="caution">
-							<p><a>EPUB Creators</a> should use unprefixed properties and <a>Reading Systems</a> should
-								support current CSS specifications. This specification retains the widely used prefixed
-								properties from [[EPUBContentDocs-301]] but removes support for the less-used ones. EPUB
-								Creators should use CSS-native solutions for the removed properties whenever
-								available.</p>
-
-							<p>The Working Group recommends that EPUB Creators currently using these prefixed properties
-								move to unprefixed versions as soon as support allows, as the Working Group does not
-								anticipate supporting them in the next major version of EPUB.</p>
-
-						</div>
-
-						<p class="note">In some cases, the unprefixed versions of these properties now support
-							additional values. Reading Systems may support these values even with the prefixed
-							property.</p>
-					</section>
-				</section>
-
-				<section id="sec-scripted-content">
-					<h3>Scripting</h3>
-
-					<section id="sec-scripted-support">
-						<h4>Script Inclusion</h4>
-
-						<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in
-							the respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB Content
-							Document contains scripting, this specification refers to it as a <a>Scripted Content
-								Document</a>. This label also applies to <a>XHTML Content Documents</a> when they
-							contain instances of [[HTML]] <a data-cite="html#forms">forms</a>.</p>
-
-						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
-							<code>item</code> element is used to indicate that an EPUB Content Document is a <a>Scripted
-								Content Document</a>.</p>
-
-						<p>When an [[HTML]] <code>script</code> element contains a <a data-cite="html#data-block">data
-								block</a> [[HTML]], it does not represent scripted content.</p>
-
-						<div class="note">
-							<p>[[SVG]] does not define data blocks as of publication, but the same exclusion would apply
-								if a future update adds the concept.</p>
-						</div>
-
-						<p>EPUB Creators should note that Reading Systems are required to behave as though a unique <a
-								data-cite="url#origin">origin</a> [[URL]] has been assigned to each EPUB Publication. In
-							practice, this means that it is not possible for scripts to share data between EPUB
-							Publications.</p>
-
-						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
-							rights and restrictions that a Reading System places on it (refer to <a
-								data-cite="epub-rs-33#sec-scripted-content">Scripting Conformance</a> [[?EPUB-RS-33]]
-							for more information).</p>
-
-						<div class="note">
-							<p>Reading Systems may render Scripted Content Documents in a manner that disables other
-								EPUB capabilities and/or provides a different rendering and user experience (e.g., by
-								disabling pagination).</p>
-						</div>
-					</section>
-
-					<section id="sec-scripted-context">
-						<h4>Scripting Contexts</h4>
-
-						<p>EPUB 3 defines two contexts for script execution:</p>
-
-						<ul>
-							<li><a href="#sec-scripted-container-constrained">container constrained</a> &#8212; when the
-								execution of a script occurs within an <code>iframe</code>; and</li>
-							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a script
-								occurs directly within a <a>Top-level Content Document</a>.</li>
-						</ul>
-
-						<div class="note">
-							<p>Scripts may execute in other contexts, but Reading System support for these contexts is
-								optional. For example, a scripted SVG document may be referenced from an [[HTML]] <a
-									data-cite="html#the-object-element"><code>object</code> tag</a>.</p>
-							<p>Refer to the <a href="https://www.w3.org/TR/epub-rs-33#sec-scripted-content">processing
-									of scripts</a> [[EPUB-RS-33]] for more information.</p>
-						</div>
-
-						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference
-							it via the element's <code>src</code> attribute makes no difference to its executing
-							context.</p>
-
-						<p>Which context EPUB Creators use for their scripts affects both what actions the scripts can
-							perform and the likelihood of support in Reading Systems, as described in the following
-							subsections.</p>
-
-						<div class="note">
-							<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference
-								between the two contexts.</p>
-						</div>
-
-						<section id="sec-scripted-container-constrained">
-							<h5>Container-Constrained Scripts</h5>
-
-							<p>A <em>container-constrained script</em> is either of the following:</p>
-
-							<ul>
-								<li>
-									<p>An instance of the [[HTML]] <a data-cite="html#the-script-element"
-												><code>script</code></a> element contained in an <a>XHTML Content
-											Document</a> that is embedded in an XHTML Content Document using the
-										[[HTML]] <a data-cite="html#the-iframe-element"><code>iframe</code></a>
-										element.</p>
-								</li>
-								<li>
-									<p>An instance of the [[SVG]] <a
-											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
-												><code>script</code></a> element contained in an <a>SVG Content
-											Document</a> that is embedded in a XHTML Content Document using the [[HTML]]
-											<a data-cite="html#the-iframe-element"><code>iframe</code></a> element.</p>
-								</li>
-							</ul>
-
-							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
-								instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e.,
-								the one that contains the <code>iframe</code> element). It also MUST NOT contain
-								instructions for manipulating the size of its containing rectangle.</p>
-
-							<p>EPUB Creators should note that <a data-cite="epub-rs-33#sec-scripted-content">support for
-									container-constrained scripting in Reading Systems</a> is only recommended in
-								reflowable documents [[EPUB-RS-33]]. Furthermore, Reading System support in
-								fixed-layouts EPUBs is optional.</p>
-
-							<p>EPUB Creators should ensure container-constrained scripts degrade gracefully in Reading
-								Systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
-
-							<div class="note">
-								<p>EPUB Creators choosing to restrict the usage of scripting to the
-									container-constrained model will ensure a more consistent user experience between
-									scripted and non-scripted content (e.g., consistent pagination behavior).</p>
-
-							</div>
-						</section>
-
-						<section id="sec-scripted-spine">
-							<h5>Spine-Level Scripts</h5>
-
-							<p>A <em>spine-level script</em> is an instance of the [[HTML]] <a
-									data-cite="html#the-script-element"><code>script</code></a> or [[SVG]] <a
-									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
-								element contained in a <a>Top-level Content Document</a>.</p>
-
-							<p>EPUB Creators should note that support for spine-level scripting in Reading Systems is
-								only recommended in <a data-cite="epub-rs-33#confreq-rs-scripted-fxl-support"
-									>fixed-layout documents</a> and <a
-									data-cite="epub-rs-33#confreq-rs-scripted-scrolled">reflowable documents set to
-									scroll</a> [[EPUB-RS-33]]. Furthermore, Reading System support in all other contexts
-								is optional.</p>
-
-							<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include
-								spine-level scripting SHOULD remain consumable by the user without any information loss
-								or other significant deterioration when scripting is disabled or not available (e.g., by
-								employing progressive enhancement techniques or <a href="#sec-scripted-fallbacks"
-									>fallbacks</a>). Failing to account for non-scripted environments in Top-level
-								Content Documents can result in EPUB Publications being unreadable.</p>
-						</section>
-					</section>
-
-					<section id="sec-scripted-content-events" class="informative">
-						<h4>Event Model</h4>
-
-						<p><a>EPUB Creators</a> should consider the wide variety of possible Reading System
-							implementations when adding scripting functionality to their EPUB Publications (e.g., not
-							all devices have physical keyboards, and in many cases a soft keyboard is activated only for
-							text input elements). Consequently, EPUB Creators should not rely on keyboard events alone;
-							they should always provide alternative ways to trigger a desired action.</p>
-					</section>
-
-					<section id="sec-scripted-a11y">
-						<h4>Scripting Accessibility</h4>
-
-						<p id="confreq-cd-scripted-a11y">EPUB Content Documents that contain scripting SHOULD employ
-							relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable
-							by all users.</p>
-					</section>
-
-					<section id="sec-scripted-fallbacks">
-						<h4 id="confreq-cd-scripted-flbk">Scripting Fallbacks</h4>
-
-						<p id="confreq-cd-scripted-fallback">EPUB Content Documents that contain scripting MAY provide
-							fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
-							available for the [[HTML]] <a data-cite="html#the-object-element"><code>object</code></a>
-							and <a data-cite="html#the-canvas-element"><code>canvas</code></a> elements) or, when an
-							intrinsic fallback is not applicable, by using a <a href="#sec-manifest-fallbacks"
-								>manifest-level fallback</a>.</p>
-
-						<p id="confreq-cd-scripted-foreign-resources">EPUB Creators MUST ensure that scripts only
-							generate <a href="#sec-core-media-types">Core Media Type Resources</a> or fragments
-							thereof.</p>
-					</section>
-				</section>
-			</section>
-		</section>
-		<section id="sec-nav">
-			<h2>EPUB Navigation Document</h2>
-
-			<section id="sec-nav-intro" class="informative">
-				<h3>Introduction</h3>
-
-				<p>The EPUB Navigation Document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
-						Publication</a>. It allows <a>EPUB Creators</a> to include a human- and machine-readable global
-					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
-
-				<p>The EPUB Navigation Document is a special type of <a>XHTML Content Document</a> that defines the <a
-						href="#sec-nav-toc">table of contents</a> for <a>Reading Systems</a>. It may also include other
-					specialized navigation elements, such as a <a href="#sec-nav-pagelist">page list</a> and a list of
-					key <a href="#sec-nav-landmarks">landmarks</a>. These navigation elements have <a
-						href="#sec-nav-def-model">additional restrictions</a> on their content to facilitate their
-					processing.</p>
-
-				<p>The EPUB Navigation Document is not exclusively for machine processing, however. There are no
-					restrictions on the structure or content of the EPUB Navigation Document outside of the specialized
-					navigation elements (i.e., EPUB Creators can mark the rest of the document up like any other XHTML
-					Content Document). As a result, it can also be part of the linear reading order, avoiding the need
-					for duplicate tables of contents. EPUB Creators can hide navigation elements that are only for
-					machine processing (e.g., the page list) with the <a href="#sec-nav-doc-use-spine"
-							><code>hidden</code> attribute</a>.</p>
-
-				<p>Note that Reading Systems may strip scripting, styling, and HTML formatting as they generate
-					navigational interfaces from information found in the EPUB Navigation Document, and this may make
-					the result difficult to read. If EPUB Creators require such formatting and functionality, then they
-					should also include the EPUB Navigation Document in the <a>spine</a>. The use of progressive
-					enhancement techniques for scripting and styling of the navigation document will help ensure the
-					content will retain its integrity when rendered in a non-browser context.</p>
-			</section>
-
-			<section id="sec-nav-def-model">
-				<h3>The <code>nav</code> Element: Restrictions</h3>
-
-				<p>When a <code>nav</code> element carries the <a href="#sec-epub-type-attribute"><code>epub:type</code>
-						attribute</a> in an <a>EPUB Navigation Document</a>, this specification restricts the content
-					model of the element and its descendants as follows:</p>
-
-				<dl class="elemdef">
-					<dt>Content Model:</dt>
-					<dd>
-						<dl class="variablelist">
-							<dt>
-								<a data-cite="html#the-nav-element">
-									<code>nav</code>
-								</a>
-							</dt>
-							<dd>
-								<p>In this order:</p>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a data-cite="html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">
-												<code>h1-h6</code>
-											</a>
-											<code>[0 or 1]</code>
-										</p>
-									</li>
-									<li>
-										<p>
-											<code>ol</code>
-											<code>[exactly 1]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-
-							<dt>
-								<a data-cite="html#the-ol-element">
-									<code>ol</code>
-								</a>
-							</dt>
-							<dd>
-								<p>In this order:</p>
-								<ul class="nomark">
-									<li>
-										<p>
-											<code>li</code>
-											<code>[1 or more]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-
-							<dt>
-								<a data-cite="html#the-li-element">
-									<code>li</code>
-								</a>
-							</dt>
-							<dd>
-								<p>In this order:</p>
-								<ul class="nomark">
-									<li>
-										<p> (<code>span</code> or <code>a</code>) <code>[exactly 1]</code></p>
-									</li>
-									<li>
-										<p>
-											<code>ol</code>
-											<code>[conditionally required]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-
-							<dt><a data-cite="html#the-span-element"><code>span</code></a> and <a
-									data-cite="html#the-a-element"><code>a</code></a></dt>
-							<dd>
-								<p>In any order:</p>
-								<ul class="nomark">
-									<li>
-										<p>
-											<a data-cite="html#phrasing-content">
-												<code>HTML Phrasing content</code>
-											</a>
-											<code>[1 or more]</code>
-										</p>
-									</li>
-								</ul>
-							</dd>
-						</dl>
-						<p>Note that there are no restrictions on the attributes allowed on these elements.</p>
-						<p>Refer the definition below for additional requirements.</p>
-					</dd>
-				</dl>
-
-				<p>The following elaboration of the content model of the <code>nav</code> element explains the purpose
-					and restrictions of the various elements:</p>
+				<p>Any <a>Publication Resource</a> that is an XML-Based Media Type:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-nav-ol">The <code>ol</code> child of the <code>nav</code> element represents the
-							primary level of content navigation.</p>
+						<p id="confreq-xml-wellformed">MUST be a conformant XML 1.0 Document as defined in <a
+								data-cite="xml-names#Conformance">Conformance of Documents</a> [[XML-NAMES]].</p>
 					</li>
 					<li>
-						<p id="confreq-nav-a">Each list item of the ordered list represents a heading, structure, or
-							other item of interest. A child <code>a</code> element describes the target that the link
-							points to, while a <code>span</code> element serves as a heading for breaking down lists
-							into distinct groups (for example, an EPUB Creator could segment a large list of
-							illustrations into several lists, one for each chapter).</p>
+						<p id="confreq-xml-identifiers">MAY only specify a <a data-cite="xml#dt-doctype">document type
+								declaration</a> that references an <a data-cite="xml#NT-ExternalID">external
+								identifier</a> appropriate for its media type &#8212; as defined in <a
+								href="#app-identifiers-allowed"></a> &#8212; or that omits external identifiers
+							[[XML]].</p>
 					</li>
 					<li>
-						<p id="confreq-nav-a-cnt">The child <code>a</code> or <code>span</code> element MUST provide a
-							non-zero-length text label after concatenation of all child content and application of white
-							space normalization rules. When determining compliance with this requirement, the
-							concatenated label MUST include text content contained in <code>title</code> or
-								<code>alt</code> attributes for non-textual descendant elements.</p>
+						<p id="confreq-xml-entities">MUST NOT contain <a data-cite="xml#dt-extent">external entity</a>
+							declarations in the internal DTD subset [[XML]].</p>
 					</li>
 					<li>
-						<p id="confreq-nav-a-title">If an <code>a</code> or <code>span</code> element contains instances
-							of <a data-cite="html#embedded-content">HTML embedded content</a> that do not provide
-							intrinsic text alternatives, the element MUST also contain a <code>title</code> attribute
-							with an alternate text rendering of the link label.</p>
+						<p id="confreq-xml-xinc">MUST NOT make use of XInclude [[XInclude]].</p>
 					</li>
 					<li>
-						<p id="confreq-nav-a-href">The URL [[URL]] reference provided in the <code>href</code> attribute
-							of the <code>a</code> element:</p>
-						<ul class="conformance-list">
-							<li>
-								<p id="confreq-nav-a-href-default">MUST, in the case of the <a href="#sec-nav-toc"
-											><code>toc nav</code></a>, <a href="#sec-nav-landmarks"><code>landmarks
-											nav</code></a> and <a href="#sec-nav-pagelist"><code>page-list
-										nav</code></a>, resolve to a <a>Top-level Content Document</a> or fragment
-									therein.</p>
-							</li>
-							<li>
-								<p id="confreq-nav-a-href-other">MAY, for all other <code>nav</code> types, also
-									reference <a>Remote Resources</a>.</p>
-							</li>
-						</ul>
-					</li>
-					<li>
-						<p id="confreq-nav-a-nest">An <code>ol</code> (ordered list) element representing a subsidiary
-							content level (e.g., all the subsection headings of a section) MAY follow an <code>a</code>
-							element.</p>
-					</li>
-					<li>
-						<p id="confreq-nav-span-nest">An <code>ol</code> (ordered list) element MUST follow a
-								<code>span</code> element (<code>span</code> elements cannot occur in "leaf"
-								<code>li</code> elements).</p>
-					</li>
-					<li>
-						<p id="confreq-nav-sublist">Regardless of whether an <code>a</code> or <code>span</code> element
-							precedes it, every sublist MUST adhere to the content requirements defined in this section
-							for constructing the primary navigation list.</p>
+						<p id="confreq-xml-enc">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8 as the
+							RECOMMENDED encoding.</p>
 					</li>
 				</ul>
-				<aside class="example" title="Basic patterns of a navigation element">
-					<pre>&lt;nav epub:type="…">
-   &lt;h1>…&lt;/h1>
-   &lt;ol>
-      &lt;li>
-         &lt;a href="chap1.xhtml">
-            A basic leaf node
-         &lt;/a>
-      &lt;/li>
-      &lt;li>
-         &lt;a href="chap2.xhtml">
-            A linked heading
-         &lt;/a>
-         &lt;ol>
-            …
-         &lt;/ol>
-      &lt;/li>
-      &lt;li>
-         &lt;span>An unlinked heading&lt;/span>
-         &lt;ol>
-            …
-         &lt;/ol>
-      &lt;/li>
-   &lt;/ol>
-&lt;/nav></pre>
-				</aside>
 
-				<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, EPUB Creators MAY include
-					the EPUB Navigation Document in the <a href="#sec-spine-elem">spine</a>.</p>
-
-				<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
-					items within <code>nav</code> elements is equivalent to the <a
-						href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:</code>
-						<code>none</code> property</a> [[CSSSnapshot]]. <a>EPUB Creators</a> MAY specify alternative
-					list styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
-							><code>spine</code></a>.</p>
-			</section>
-
-			<section id="sec-nav-def-types">
-				<h3>The <code>nav</code> Element: Types</h3>
-
-				<section id="sec-nav-def-types-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>The <code>nav</code> elements defined in an EPUB Navigation Document are distinguished
-						semantically by the value of their <a href="#sec-epub-type-attribute"><code>epub:type</code>
-							attribute</a>.</p>
-
-					<p>This specification defines three types of navigation aid:</p>
-
-					<dl class="variablelist">
-						<dt>
-							<a href="#sec-nav-toc">
-								<code>toc</code>
-							</a>
-						</dt>
-						<dd>
-							<p>Identifies the <code>nav</code> element that contains the table of contents. The
-									<code>toc</code>
-								<code>nav</code> is the only navigation aid that EPUB Creators must include in the EPUB
-								Navigation Document.</p>
-						</dd>
-
-						<dt>
-							<a href="#sec-nav-pagelist">
-								<code>page-list</code>
-							</a>
-						</dt>
-						<dd>
-							<p>Identifies the <code>nav</code> element that contains a list of pages for a print or
-								other statically paginated source.</p>
-						</dd>
-
-						<dt>
-							<a href="#sec-nav-landmarks">
-								<code>landmarks</code>
-							</a>
-						</dt>
-						<dd>
-							<p>Identifies the <code>nav</code> element that contains a list of points of interest.</p>
-						</dd>
-					</dl>
-
-					<p>An EPUB Navigation Document may contain at most one navigation aid for each of these types.</p>
-
-					<p>The EPUB Navigation Document may include additional navigation types. See <a
-							href="#sec-nav-def-types-other"></a> for more information.</p>
-				</section>
-
-				<section id="sec-nav-toc">
-					<h4>The <code>toc nav</code> Element </h4>
-
-					<p>The <code>toc</code>
-						<code>nav</code> element defines the primary navigational hierarchy. It conceptually corresponds
-						to a table of contents in a printed work (i.e., it provides navigation to the major structural
-						sections of the publication).</p>
-
-					<p>The <code>toc</code>
-						<code>nav</code> element MUST occur exactly once in an EPUB Navigation Document.</p>
-
-					<p>EPUB Creators SHOULD order the references in the <code>toc</code>
-						<code>nav</code> element such that they reflect both:</p>
-
-					<ul>
-						<li>
-							<p>the order of the <a href="#confreq-nav-a-href">referenced EPUB Content Documents</a> in
-								the <a>spine</a>; and</p>
-						</li>
-						<li>
-							<p>the order of the targeted elements within their respective EPUB Content Documents.</p>
-						</li>
-					</ul>
-				</section>
-
-				<section id="sec-nav-pagelist">
-					<h4>The <code>page-list nav</code> Element </h4>
-
-					<p>The <code>page-list</code> element provides navigation to static page boundaries in the content.
-						These boundaries may correspond to a statically paginated source such as print or may be defined exclusively 
-						for the <a>EPUB Publication</a>.</p>
-
-
-					<p>The <code>page-list</code>
-						<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more than
-						once.</p>
-
-					<p>The <code>page-list</code>
-						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
-						nested sublists).</p>
-
-					<p>EPUB Creators MAY identify the destinations of the <code>page-list</code> references in their
-						respective EPUB Content Documents using the <a data-cite="epub-ssv-11/#pagebreak"
-								><code>pagebreak</code> term</a> [[EPUB-SSV-11]].</p>
-				</section>
-
-				<section id="sec-nav-landmarks">
-					<h4>The <code>landmarks nav</code> Element</h4>
-
-					<p>The <code>landmarks</code>
-						<code>nav</code> element identifies fundamental structural components in the content to enable
-						Reading Systems to provide the user efficient access to them (e.g., through a dedicated button
-						in the user interface).</p>
-
-					<p>The <code>landmarks</code>
-						<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more than
-						once.</p>
-
-					<p>The <code>landmarks</code>
-						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
-						nested sublists).</p>
-
-					<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is REQUIRED on
-							<code>a</code> element descendants of the <code>landmarks</code>
-						<code>nav</code> element. The structural semantics of each link target within the
-							<code>landmarks</code>
-						<code>nav</code> element is determined by the value of this attribute.</p>
-
-					<aside class="example" title="A basic landmarks nav">
-						<p>In this example, the <code>epub:type</code> attribute value are drawn from structural
-							semantics drawn from [[EPUB-SSV-11]].</p>
-
-						<pre>&lt;nav epub:type="landmarks">
-   &lt;h2>Guide&lt;/h2>
-   &lt;ol>
-       &lt;li>
-          &lt;a epub:type="toc"
-             href="#toc">
-            Table of Contents
-          &lt;/a>
-       &lt;/li>
-       &lt;li>
-          &lt;a epub:type="loi"
-             href="content.html#loi">
-            List of Illustrations
-          &lt;/a>
-       &lt;/li>
-       &lt;li>
-          &lt;a epub:type="bodymatter"
-             href="content.html#bodymatter">
-            Start of Content
-          &lt;/a>
-       &lt;/li>
-   &lt;/ol>
-&lt;/nav></pre>
-					</aside>
-
-					<p>The <code>landmarks</code>
-						<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code> value
-						that reference the same resource, or fragment thereof.</p>
-
-					<p>EPUB Creators should limit the number of items they define in the <code>landmarks</code>
-						<code>nav</code> to only items that a Reading System is likely to use in its user interface. The
-						element is not meant to repeat the table of contents.</p>
-
-					<p>The following landmarks are recommended to include when available:</p>
-
-					<ul>
-						<li><a data-cite="epub-ssv-11#bodymatter"><code>bodymatter</code></a> [[?EPUB-SSV-11]] &#8212;
-							Reading Systems often use this landmark to automatically jump users past the front matter
-							when they begin reading.</li>
-						<li><a data-cite="epub-ssv-11#toc-1"><code>toc</code></a> [[?EPUB-SSV-11]] &#8212; If the table
-							of contents is available in the spine, Reading Systems may use this landmark to take users
-							to the document containing it.</li>
-					</ul>
-
-					<p>Other possibilities for inclusion in the <code>landmarks</code>
-						<code>nav</code> are key reference sections such as indexes and glossaries.</p>
-
-					<p>Although the <code>landmarks</code>
-						<code>nav</code> is intended for Reading System use, EPUB Creators should still ensure that the
-						labels for the <code>landmarks</code>
-						<code>nav</code> are human readable. Reading Systems may expose the links directly to users.</p>
-				</section>
-
-				<section id="sec-nav-def-types-other">
-					<h4>Other <code>nav</code> Elements</h4>
-
-					<p>EPUB Navigation Documents MAY contain one or more <code>nav</code> elements in addition to the
-							<code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
-						<code>nav</code> elements defined in the preceding sections. If these <code>nav</code> elements
-						are intended for Reading System processing, they MUST have an <a href="#sec-epub-type-attribute"
-								><code>epub:type</code> attribute</a> and are subject to the content model restrictions
-						defined in <a href="#sec-nav-def-model"></a>.</p>
-
-					<p>This specification imposes no restrictions on the semantics of any additional <code>nav</code>
-						elements: they MAY represent navigational semantics for any information domain, and they MAY
-						contain link targets with homogeneous or heterogeneous semantics.</p>
-
-					<aside class="example" title="Adding a custom navigation element">
-						<p>In this example, the <code>lot</code> semantic indicates that the EPUB Creator is adding a
-							"list of tables" navigation element.</p>
-
-						<pre>&lt;nav
-    epub:type="lot"
-    aria-labelledby="lot">
-   &lt;h2 id="lot">List of tables&lt;/h2>
-   &lt;ol>
-      &lt;li>
-         &lt;span>Tables in Chapter 1&lt;/span>
-         &lt;ol>
-            &lt;li>
-               &lt;a href="chap1.xhtml#table-1.1">
-                  Table 1.1
-               &lt;/a>
-            &lt;/li>
-            &lt;li>
-               &lt;a href="chap1.xhtml#table-1.2">
-                  Table 1.2
-               &lt;/a>
-            &lt;/li>
-         &lt;/ol>
-      &lt;/li>
-      …
-   &lt;/ol>
-&lt;/nav></pre>
-					</aside>
-				</section>
-			</section>
-
-			<section id="sec-nav-doc-use-spine" class="informative">
-				<h3>Using in the Spine</h3>
-
-				<p>Although it is possible to reuse the EPUB Navigation Document in the <a>spine</a>, it is often the
-					case that not all of the navigation structures, or branches within them, are needed. <a>EPUB
-						Creators</a> will often want to hide the <a href="#sec-nav-pagelist">page list</a> and <a
-						href="#sec-nav-landmarks">landmarks</a> navigation elements or trim the branches of the table of
-					contents for books that have many levels of subsections.</p>
-
-				<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
-						property</a> [[CSSSnapshot]] controls the visual rendering of EPUB Navigation Documents in
-					Reading Systems with <a>Viewports</a>, Reading Systems without Viewports may not support CSS. To
-					better ensure the proper rendering in these Reading Systems, EPUB Creators should use the [[HTML]]
-						<a data-cite="html#the-hidden-attribute"><code>hidden</code></a> attribute to indicate which (if
-					any) portions of the navigation data are excluded from rendering in the content flow.</p>
-
-				<p>The <code>hidden</code> attribute has no effect on how Reading Systems render the navigation data
-					outside of the content flow (such as in dedicated navigation user interfaces provided by Reading
-					Systems).</p>
+				<p>The above constraints apply regardless of whether the given Publication Resource is a <a>Core Media
+						Type Resource</a> or a <a>Foreign Resource</a>.</p>
 
 				<div class="note">
-					<p>The <code>hidden</code> attribute can be used together with the <code>display</code> property to
-						maximize interoperability across all Reading Systems.</p>
+					<p>[[HTML]] and [[SVG]] are removing support for the XML `base` attribute [[XMLBase]]. EPUB Creators
+						should avoid using this feature.</p>
 				</div>
-
-				<aside class="example" title="Hiding a nav element in spine">
-					<p>In this example, the presence of the <code>hidden</code> attribute on the <code>nav</code>
-						element indicates the page list will be excluded from rendering in the content flow when the
-						document is rendered in the spine.</p>
-
-					<pre>&lt;nav
-    epub:type="page-list"
-    hidden="">
-   &lt;h2>Pagebreaks of the print version, third edition&lt;/h2>
-   &lt;ol>
-      &lt;li>
-         &lt;a href="frontmatter.xhtml#pi">
-            I
-         &lt;/a>
-      &lt;/li>
-      …
-   &lt;/ol>
-&lt;/nav>
-</pre>
-				</aside>
-
-				<aside class="example" title="Hiding branches of a nav element">
-					<p>In this example, the branch (<code>ol</code> element) not wanted for rendering in the spine has
-						the <code>hidden</code> attribute on it. When rendered, this limits the table of content to the
-						two top-most hierarchical levels.</p>
-
-					<pre>&lt;nav
-    epub:type="toc"
-    id="toc">
-   &lt;h1>Table of contents&lt;/h1>
-   &lt;ol>
-      &lt;li>
-         &lt;a href="chap1.xhtml">
-            Chapter 1
-         &lt;/a>
-         &lt;ol>
-            &lt;li>
-               &lt;a href="chap1.xhtml#sec-1.1">
-                  Chapter 1.1
-               &lt;/a>
-               &lt;ol hidden="">
-                  &lt;li>
-                     &lt;a href="chap1.xhtml#sec-1.1.1">
-                        Section 1.1.1
-                     &lt;/a>
-                  &lt;/li>
-                  …
-               &lt;/ol>
-            &lt;/li>
-            …
-         &lt;/ol>
-      &lt;/li>
-      …
-   &lt;/ol>
-&lt;/nav></pre>
-				</aside>
-			</section>
-		</section>
-		<section id="sec-rendering-control">
-			<h2>Layout Rendering Control</h2>
-
-			<section id="sec-general-rendering-intro" class="informative">
-				<h3>Introduction</h3>
-
-				<p>Not all rendering information can be expressed through the underlying technologies that EPUB is built
-					upon. For example, although HTML with CSS provides powerful layout capabilities, those capabilities
-					are limited to the scope of the document being rendered.</p>
-
-				<p>This section defines properties that allow EPUB Creators to express package-level rendering
-					intentions (i.e., functionality that can only be implemented by the <a>EPUB Reading System</a>). If
-					a Reading System supports the desired rendering, these properties enable the user to be presented
-					the content as the EPUB Creator optimally designed it.</p>
-			</section>
-
-			<section id="sec-fixed-layouts">
-				<h3>Fixed Layouts</h3>
-
-				<section id="fxl-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>EPUB documents, unlike print books or PDF files, are designed to change. The content flows, or
-						reflows, to fit the screen and to fit the needs of the user. As noted in <a
-							data-cite="epub-overview-33#sec-rendering">Rendering and CSS</a> "content presentation
-						adapts to the user, rather than the user having to adapt to a particular presentation of
-						content." [[EPUB-OVERVIEW-33]]</p>
-
-					<p>But this principle does not work for all types of documents. Sometimes content and design are so
-						intertwined it is not possible to separate them. Any change in appearance risks changing the
-						meaning or losing all meaning. <a>Fixed-Layout Documents</a> give <a>EPUB Creators</a> greater
-						control over presentation when a reflowable EPUB is not suitable for the content.</p>
-
-					<p>EPUB Creators define fixed layouts using a <a href="#sec-fxl-package">set of Package Document
-							properties</a> to control the rendering in <a>Reading Systems</a>. In addition, they set <a
-							href="#sec-fxl-package">the dimensions of each Fixed-Layout Document</a> in its respective
-						EPUB Content Document.</p>
-
-					<div class="note" id="note-mechanisms">
-						<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
-							content is necessary, the EPUB Creator's choice of mechanism will depend on many factors
-							including desired degree of precision, file size, accessibility, etc. This section does not
-							attempt to dictate the EPUB Creator's choice of mechanism.</p>
-
-					</div>
-				</section>
-
-				<section id="sec-fxl-package">
-					<h4>Fixed-Layout Package Settings</h4>
-
-					<section id="layout">
-						<h5>Layout</h5>
-
-						<p>The <code>rendition:layout</code> property specifies whether the content is reflowable or
-							pre-paginated.</p>
-
-						<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code>
-								property</a> is specified on a <code>meta</code> element, it indicates that the
-							paginated or reflowable layout style applies globally (i.e., for all spine items).</p>
-
-						<p>EPUB Creators MUST use one of the following values with the <code>rendition:layout</code>
-							property:</p>
-
-						<dl class="variablelist">
-							<dt id="def-layout-reflowable">reflowable</dt>
-							<dd>
-								<p>The content is not pre-paginated (i.e., Reading Systems apply dynamic pagination when
-									rendering). Default value.</p>
-							</dd>
-
-							<dt id="def-layout-pre-paginated">pre-paginated</dt>
-							<dd>
-								<p>The content is pre-paginated (i.e., Reading Systems produce exactly one page per
-									spine <a href="#elemdef-spine-itemref"><code>itemref</code></a> when rendering).</p>
-							</dd>
-						</dl>
-
-						<div class="note" id="uaag">
-							<p>Reading Systems typically restrict or deny the application of user or user agent style
-								sheets to pre-paginated documents because dynamic style changes are likely to have
-								unintended consequence on the intrinsic properties of such documents. EPUB Creators
-								should consider the negative impact on usability and accessibility that these
-								restrictions have when choosing to use pre-paginated instead of reflowable content.
-								Refer to <a data-cite="UAAG20#gl-text-config">Guideline 1.4 - Provide text
-									configuration</a> [[UAAG20]] for related information.</p>
-
-						</div>
-
-						<p id="fxl-layout-duplication" data-tests="#fxl-layout-duplication">When the property is set to
-								<code>pre-paginated</code> for a spine item, its content dimensions MUST be set as
-							defined in <a href="#sec-fxl-content-dimensions"></a>.</p>
-
-						<p>EPUB Creators MUST NOT declare the <code>rendition:layout</code> property more than once.</p>
-
-						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
-									><code>refines</code> attribute</a>. Refer to <a href="#layout-overrides"></a> for
-							setting the property for individual <a>EPUB Content Documents</a>.</p>
-
-						<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
-							<p>In this example, the document's layout is set to <code>pre-paginated</code>, i.e., it is
-								defined to be a fixed layout document. Furthermore, media queries [[CSS3-MediaQueries]]
-								are used to apply different style sheets for three different device categories. Note
-								that the media queries only affect the style sheet applied to the document; the size of
-								the content area set in the <code>viewport</code>
-								<code>meta</code> tag is static.</p>
-
-							<p>Package Document</p>
-
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;meta
-          property="rendition:layout">
-         pre-paginated
-      &lt;/meta>
-      …
-   &lt;/metadata>
-   …
-&lt;/package></pre>
-
-							<p>XHTML</p>
-
-							<pre>&lt;html …>
-   &lt;head>
-      &lt;meta
-          name="viewport"
-          content="width=1200,
-          height=900"/>
-      
-      &lt;link
-          rel="stylesheet"
-          href="eink-style.css"
-          media="(max-monochrome: 3)"/>
-         
-      &lt;link
-          rel="stylesheet"
-          href="skinnytablet-style.css"
-          media="((color) and (max-height:600px) and (orientation:landscape),
-                  (color) and (max-width:600px) and (orientation:portrait))"/>
-      
-      &lt;link
-          rel="stylesheet"
-          href="fattablet-style.css"
-          media="((color) and (min-height:601px) and (orientation:landscape),
-                  (color) and (min-width:601px) and (orientation:portrait))"/>	
-   &lt;/head>
-   …
-&lt;/html></pre>
-						</aside>
-
-						<section id="layout-overrides">
-							<h6>Layout Overrides</h6>
-
-							<p id="property-layout-local">EPUB Creators MAY specify the following properties locally on
-								spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
-									<a href="#property-layout-global">global value</a> for the given spine item:</p>
-
-							<dl>
-								<dt id="layout-pre-paginated">rendition:layout-pre-paginated</dt>
-								<dd>Specifies that the given spine item is pre-paginated.</dd>
-
-								<dt id="layout-reflowable">rendition:layout-reflowable</dt>
-								<dd>Specifies that the given spine item is reflowable.</dd>
-							</dl>
-
-							<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
-						</section>
-					</section>
-
-					<section id="orientation">
-						<h5>Orientation</h5>
-
-						<p>The <code>rendition:orientation</code> property specifies which orientation the EPUB Creator
-							intends the content to be rendered in. </p>
-
-						<p id="property-orientation-global">When the <a href="#orientation"
-									><code>rendition:orientation</code> property</a> is specified on a <code>meta</code>
-							element, it indicates that the intended orientation applies globally (i.e., for all spine
-							items).</p>
-
-						<p>EPUB Creators MUST use one of the following values with the
-								<code>rendition:orientation</code> property:</p>
-
-						<dl class="variablelist">
-							<dt>landscape</dt>
-							<dd>
-								<p>Reading Systems should render the content in landscape orientation.</p>
-							</dd>
-
-							<dt>portrait</dt>
-							<dd>
-								<p>Reading Systems should render the content in portrait orientation.</p>
-							</dd>
-
-							<dt>auto</dt>
-							<dd>
-								<p>The content is not orientation constrained. Default value.</p>
-							</dd>
-						</dl>
-
-						<p id="fxl-orientation-duplication" data-tests="#fxl-orientation-duplication">EPUB Creators MUST
-							NOT declare the <code>rendition:orientation</code> property more than once.</p>
-
-						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
-									><code>refines</code> attribute</a>. Refer to <a href="#orientation-overrides"></a>
-							for setting the property for individual <a>EPUB Content Documents</a>.</p>
-
-						<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
-							<p>In this example, items in the spine are to be rendered in landscape mode.</p>
-
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;meta
-          property="rendition:layout">
-         pre-paginated
-      &lt;/meta>
-
-      &lt;meta
-          property="rendition:orientation">
-         landscape
-      &lt;/meta>
-   &lt;/metadata>
-   …
-&lt;/package></pre>
-						</aside>
-
-						<section id="orientation-overrides">
-							<h6>Orientation Overrides</h6>
-
-							<p id="property-orientation-local">EPUB Creators MAY specify the following properties
-								locally on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
-								override the <a href="#property-orientation-global">global value</a> for the given spine
-								item:</p>
-
-							<dl>
-								<dt id="orientation-auto">rendition:orientation-auto</dt>
-								<dd>Specifies that the Reading System determines the orientation to render the spine
-									item in.</dd>
-
-								<dt id="orientation-landscape">rendition:orientation-landscape</dt>
-								<dd>Specifies that Reading Systems should render the given spine item in landscape
-									orientation.</dd>
-
-								<dt id="orientation-portrait">rendition:orientation-portrait</dt>
-								<dd>Specifies that Reading Systems should render the given spine item in portrait
-									orientation.</dd>
-							</dl>
-
-							<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
-						</section>
-					</section>
-
-					<section id="spread">
-						<h5>Synthetic Spreads</h5>
-
-						<p>The <code>rendition:spread</code> property specifies the intended Reading System synthetic
-							spread behavior.</p>
-
-						<p id="property-spread-global">When the <code>rendition:spread</code> property is specified on a
-								<code>meta</code> element, it indicates that the intended <a>Synthetic Spread</a>
-							behavior applies globally (i.e., for all spine items).</p>
-
-						<p>EPUB Creators MUST use one of the following values with the <code>rendition:spread</code>
-							property:</p>
-
-						<dl class="variablelist">
-							<dt>none</dt>
-							<dd>
-								<p>Do not incorporate spine items in a Synthetic Spread. Reading Systems should display
-									the items in a single viewport positioned at the center of the screen.</p>
-							</dd>
-
-							<dt>landscape</dt>
-							<dd>
-								<p>Render a Synthetic Spread for spine items only when the device is in landscape
-									orientation.</p>
-							</dd>
-
-							<dt>portrait (deprecated)</dt>
-							<dd>
-								<p>The use of spreads only in portrait orientation is <a href="#deprecated"
-										>deprecated</a>.</p>
-								<p>EPUB Creators should use the value "<code>both</code>" instead, as spreads that are
-									readable in portrait orientation are also readable in landscape.</p>
-							</dd>
-
-							<dt>both</dt>
-							<dd>
-								<p>Render a Synthetic Spread regardless of device orientation.</p>
-							</dd>
-
-							<dt>auto</dt>
-							<dd>
-								<p>The EPUB Creator is not defining an explicit Synthetic Spread behavior. Default
-									value.</p>
-							</dd>
-						</dl>
-
-						<p>EPUB Creators MUST NOT declare the <code>rendition:spread</code> property more than once.</p>
-
-						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
-									><code>refines</code> attribute</a>. Refer to <a href="#spread-overrides"></a> for
-							setting the property for individual <a>EPUB Content Documents</a>.</p>
-
-						<div class="note">
-							<p>When Synthetic Spreads are used in the context of HTML and SVG Content Documents, the
-								dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
-									<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"><code>viewBox</code>
-									attribute</a> represents the size of one page in the spread, respectively.</p>
-						</div>
-
-						<div class="note">
-							<p>Refer to <a href="#sec-spine-elem">spine</a> for information about declaration of global
-								flow directionality using the <code>page-progression-direction</code> attribute and that
-								of local page-progression-direction within content documents.</p>
-						</div>
-
-						<aside class="example" id="spread-none-example"
-							title="A fixed-layout EPUB Publication without synthetic spread">
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;meta
-          property="rendition:layout">
-         pre-paginated
-      &lt;/meta>
-      
-      &lt;meta
-          property="rendition:spread">
-         none
-      &lt;/meta>
-   &lt;/metadata>
-   …
-&lt;/package></pre>
-
-							<figure id="spread-none-figure">
-								<figcaption> Rendering of three fixed-layout documents without synthetic spread.
-										<br /><span class="attribution">(Comics courtesy of <a
-											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-										2.5</a>.)</span>
-								</figcaption>
-								<img src="images/example_spread_none.svg" width="600" aria-details="spread-none-diagram"
-									alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time everywhere"
-								 />
-							</figure>
-
-							<details id="spread-none-diagram" class="desc">
-								<summary>Image description</summary>
-								<p> Two rows of schematic views of tablets (three in each row). The tablets in the top
-									row are in portrait mode, and in landscape mode in the bottom one. The schematic
-									views of the tablets within a row are linked with left-to-right arrows. </p>
-								<p> In the tablets of each row the consecutive panels of a comics are displayed; the
-									panels are centered in their respective tablets. </p>
-							</details>
-						</aside>
-
-
-						<aside class="example" id="spread-landscape-example"
-							title="Specifying the usage of syntetic spreads in landscape orientation only">
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;meta
-          property="rendition:layout">
-         pre-paginated
-      &lt;/meta>
-      
-      &lt;meta
-          property="rendition:spread">
-         landscape
-      &lt;/meta>
-   &lt;/metadata>
-   …
-&lt;/package></pre>
-
-
-							<figure id="spread-landscape-figure">
-								<figcaption> Rendering of three fixed-Layout Documents, with synthetic spread in
-									landscape orientation only. <br /><span class="attribution">(Comics courtesy of <a
-											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-										2.5</a>.)</span>
-								</figcaption>
-								<img src="images/example_spread_landscape.svg" width="600"
-									aria-details="spread-landscape-diagram"
-									alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time in portrait and using synthetic spread in landscape."
-								 />
-							</figure>
-
-							<details id="spread-landscape-diagram" class="desc">
-								<summary>Image description</summary>
-								<p> Two rows of schematic views of tablets (three in top row, and two in the bottom).
-									The tablets in the top row are in portrait mode, and in landscape mode in the bottom
-									one. The schematic views of the tablets within a row are linked with left-to-right
-									arrows. </p>
-								<p> In both rows three panels of a comics are displayed. In the top row the panels are
-									centered in their respective tablets. In the bottom row, the first tablet contains
-									the first and second panels of the comics side by side; the second tablet contains
-									the second and third panels of the comics side-by-side. </p>
-							</details>
-						</aside>
-
-
-						<aside class="example" id="spread-both-example"
-							title="Specifying to use syntetic spreads both in portrait and in landscape orientations">
-							<p>See also <a href="#spread-both-figure"></a>.</p>
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;meta
-          property="rendition:layout">
-         pre-paginated
-      &lt;/meta>
-      
-      &lt;meta
-          property="rendition:spread">
-         both
-      &lt;/meta>
-   &lt;/metadata>
-   …
-&lt;/package></pre>
-
-							<figure id="spread-both-figure">
-								<figcaption> Rendering of three fixed-layout documents, with synthetic spread in both
-									portrait and landscape orientations. <br /><span class="attribution">(Comics
-										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-										2.5</a>.)</span>
-								</figcaption>
-								<img src="images/example_spread_both.svg" width="600" aria-details="spread-both-diagram"
-									alt="Progression of FXL pages both in portrait and in landscape modes, using synthetic spread in both cases."
-								 />
-							</figure>
-
-							<details id="spread-both-diagram" class="desc">
-								<summary>Image description</summary>
-								<p> Two rows of schematic views of tablets (two in each row). The tablets in the top row
-									are in portrait mode, and in landscape mode in the bottom one. The schematic views
-									of the tablets within a row are linked with left-to-right arrows. </p>
-								<p> In both rows three panels of a comics are displayed. The first tablet in a row
-									contains the first and second panels of the comics side by side; the second tablet
-									contains the second and third panels of the comics side-by-side. </p>
-							</details>
-						</aside>
-
-
-						<aside class="example" id="spread-both-with-intro-example"
-							title="Overriding the global spread behavior">
-							<p>In this example, the EPUB Creator overrides the global reflowable setting in the spine
-								for the introductory page. The intention is for Reading Systems to render it as a
-								reflowable document.</p>
-
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;meta
-          property="rendition:layout">
-         pre-paginated
-      &lt;/meta>
-      &lt;meta
-          property="rendition:spread">
-         both
-      &lt;/meta>
-   &lt;/metadata>
-   
-   &lt;spine>
-      &lt;itemref
-          idref="introduction"
-          properties="rendition:layout-reflowable"/>
-      …
-   &lt;/spine>
-   …
-&lt;/package></pre>
-
-							<figure id="spread-both-with-intro-figure">
-								<figcaption> Rendering of an introduction document in reflowable layout, followed by
-									three fixed-layout documents with synthetic spread in portrait orientation.
-										<br /><span class="attribution">(Comics courtesy of <a
-											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-										2.5</a>.)</span>
-								</figcaption>
-								<img src="images/example_spread_both_with_reflowable_intro.svg" width="600"
-									aria-details="spread-both-with-intro-diagram"
-									alt="Progression of FXL pages both in portrait using synthetic spread in both cases, preceded by an introduction with reflowable contnt."
-								 />
-							</figure>
-
-							<details id="spread-both-with-intro-diagram" class="desc">
-								<summary>Image description</summary>
-								<p> A row of schematic views of three tablets in portrait mode, and linked with
-									left-to-right arrows. </p>
-								<p> The first tablet views includes a single, column-like strip (i.e., a rectangle
-									without a bottom edge following beyond the bottom of the tablet) with a text flowing
-									down the strip, and starting with the word "Introduction". This is followed by two
-									schematic tablets with three panels of comics displayed. The first tablet in the row
-									contains the first and second panels of the comics side by side; the second tablet
-									contains the second and third panels of the comics side-by-side. </p>
-							</details>
-						</aside>
-
-						<section id="spread-overrides">
-							<h6>Synthetic Spread Overrides</h6>
-
-							<p id="property-spread-local">EPUB Creators MAY specify the following properties locally on
-								spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
-									<a href="#property-spread-global">global value</a> for the given spine item:</p>
-
-							<dl>
-								<dt id="spread-auto">rendition:spread-auto</dt>
-								<dd>Specifies the Reading System determines when to render a synthetic spread for the
-									spine item. </dd>
-
-								<dt id="spread-both">rendition:spread-both</dt>
-								<dd>Specifies the Reading System should render a synthetic spread for the spine item in
-									both portrait and landscape orientations. </dd>
-
-								<dt id="spread-landscape">rendition:spread-landscape</dt>
-								<dd>Specifies the Reading System should render a synthetic spread for the spine item
-									only when in landscape orientation.</dd>
-
-								<dt id="spread-none">rendition:spread-none</dt>
-								<dd>Specifies the Reading System should not render a synthetic spread for the spine
-									item.</dd>
-
-								<dt id="spread-portrait">rendition:spread-portrait</dt>
-								<dd>
-									<p>The <code>rendition:spread-portrait</code> property is <a href="#deprecated"
-											>deprecated</a>.</p>
-									<p></p>Refer to the <a
-										href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
-											><code>spread-portrait</code> property definition</a>
-									in [[EPUBPublications-301]] for more information.</dd>
-							</dl>
-
-							<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
-						</section>
-					</section>
-
-					<section id="page-spread">
-						<h5>Spread Placement</h5>
-
-						<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to populate
-							the spread by rendering the next <a>EPUB Content Document</a> in the next available
-							unpopulated viewport, where the next available viewport is determined by the given <a
-								href="#sec-spine-elem">page progression direction</a> or by local declarations within
-							Content Documents. An EPUB Creator MAY override this automatic population behavior and force
-							Reading Systems to place a document in a particular viewport by specifying one of the
-							following properties on its spine <code>itemref</code> element:</p>
-
-						<dl>
-							<dt id="page-spread-center">
-								<code>rendition:page-spread-center</code></dt>
-							<dd>The <code>rendition:page-spread-center</code> property is an alias of the <a
-									href="#spread-none"><code>spread-none</code> property</a> for centering a spine
-								item.</dd>
-
-							<dt id="fxl-page-spread-left">
-								<code>rendition:page-spread-left</code>
-							</dt>
-							<dd>The <code>rendition:page-spread-left</code> property is an alias of the <code><a
-										href="#page-spread-left">page-spread-left</a></code> property for placing a
-								spine item in the left-hand slot of a two-page spread.</dd>
-
-							<dt id="fxl-page-spread-right">
-								<code>rendition:page-spread-right</code>
-							</dt>
-							<dd>The <code>rendition:page-spread-right</code> property is an alias of the <code><a
-										href="#page-spread-right">page-spread-right</a></code> property for placing a
-								spine item in the right-hand slot of a two-page spread.</dd>
-						</dl>
-
-						<p>The <code>rendition:page-spread-center</code>, <code>rendition:page-spread-left</code>, and
-								<code>rendition:page-spread-right</code> properties apply to both pre-paginated and
-							reflowable content. They only apply when the Reading System is creating Synthetic
-							Spreads.</p>
-
-						<p>Although EPUB Creators often indicate to use a spread in certain device orientations, the
-							content itself does not represent true spreads (i.e., two consecutive pages that Reading
-							Systems must render side-by-side for readability, such as a two-page map). To indicate that
-							two consecutive pages represent a true spread, EPUB Creators SHOULD use the
-								<code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-							properties on the spine items for the two adjacent EPUB Content Documents, and omit the
-							properties on spine items where one-up or two-up presentation is equally acceptable.</p>
-
-						<p>EPUB Creators MUST NOT declare more than one <code>page-spread-*</code> property on any given
-							spine item.</p>
-
-						<div class="note" id="note-page-spread-aliases">
-							<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-								properties were created to allow the use of a single vocabulary for all fixed-layout
-								properties. EPUB Creators can use either property set, but older Reading Systems might
-								only recognize the unprefixed versions.</p>
-
-							<p>The <code>rendition:page-spread-center</code> was created to make it easier for EPUB
-								Creators to understand the process of switching between two-page spreads and single
-								centered pages. EPUB Creators can use either <code>rendition:page-spread-center</code>
-								or <code>spread-none</code> to disable spread behavior in Reading Systems.</p>
-						</div>
-
-						<aside class="example" id="spread-page-spread-right-example"
-							title="Starting the first document on the right">
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;meta
-          property="rendition:layout">
-          reflowable
-      &lt;/meta>
-	  
-      &lt;meta
-          property="rendition:spread">
-          landscape
-      &lt;/meta>
-      …
-   &lt;/metadata>
-   &lt;spine page-progression-direction="ltr">
-      …
-      &lt;itemref
-          idref="first-panel"
-          properties="rendition:page-spread-right"/>
-      …
-   &lt;/spine>
-&lt;/package></pre>
-
-							<figure id="spread-page-spread-right-figure">
-								<figcaption> Rendering of three fixed-layout documents, with synthetic spread in
-									landscape orientation starting on the right. <br /><span class="attribution">(Comics
-										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
-										2.5</a>.)</span>
-								</figcaption>
-								<img src="images/example_spread_page_spread_right.svg" width="600"
-									aria-details="spread-page-spread-right-diagram"
-									alt="Progression of FXL pages in landscape modes, showing synthetic spread in both cases but with the first page appearing on the right side of the first page."
-								 />
-							</figure>
-
-							<details id="spread-page-spread-right-diagram" class="desc">
-								<summary>Image description</summary>
-								<p> A row of schematic views of two tablets in landscape mode, and linked with a
-									left-to-right arrow. </p>
-								<p> Three panels of a comics are displayed in the tablets. The first tablet in the row
-									contains the first panels of the comics on the right hand of the tablet, with the
-									left side empty; the second tablet contains the second and third panels of the
-									comics side-by-side. </p>
-							</details>
-						</aside>
-
-						<aside class="example" id="fxl-ex5" title="Placing individual spine items in a spread">
-							<p>In this example, the EPUB Creator intends the Reading System to create a two-page
-								fixed-layout center plate using synthetic spreads in any device orientation. Note that
-								the EPUB Creator has left spread behavior for the other (reflowable) parts undefined,
-								since the global value of <code>rendition:spread</code> initializes to <code>auto</code>
-								by default.</p>
-
-							<pre>&lt;package …>
-   …
-   &lt;spine page-progression-direction="ltr">
-      …
-      &lt;itemref
-          idref="center-plate-left"
-          properties="rendition:spread-both rendition:page-spread-left"/>
-      &lt;itemref
-          idref="center-plate-right"
-          properties="rendition:spread-both rendition:page-spread-right"/>
-      …
-   &lt;/spine>
-&lt;/package></pre>
-						</aside>
-
-						<aside class="example" id="fxl-ex6" title="Creating a centered layout">
-							<pre>&lt;package …>
-   &lt;metadata …>
-      …
-      &lt;meta
-          property="rendition:layout">
-         pre-paginated
-      &lt;/meta>
-      &lt;meta
-          property="rendition:spread">
-         auto
-      &lt;/meta>
-   &lt;/metadata>
-   &lt;spine>
-      …
-      &lt;itemref
-          idref="center-plate"
-          properties="rendition:page-spread-center"/>
-      …
-   &lt;/spine>
-   …
-&lt;/package></pre>
-						</aside>
-					</section>
-
-					<section id="viewport">
-						<h5>Viewport Dimensions (Deprecated)</h5>
-
-						<p>The <code>rendition:viewport</code> property allows <a>EPUB Creators</a> to express the CSS
-							initial containing block (ICB) [[CSS2]] for XHTML and SVG Content Documents whose
-								<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
-
-						<p>Use of the property is <a href="#deprecated">deprecated</a>.</p>
-
-						<p>Refer to the <a
-								href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
-									><code>rendition:viewport</code> property definition</a> in [[EPUBPublications-301]]
-							for more information.</p>
-					</section>
-
-					<section id="sec-fxl-content-dimensions">
-						<h4>Content Document Dimensions</h4>
-
-						<p>This section defines rules for the expression and interpretation of dimensional properties of
-								<a>Fixed-Layout Documents</a>.</p>
-
-						<p id="confreg-fxl-icb">Fixed-Layout Documents specify their <a
-								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-								containing block</a> [[CSS2]] in the manner applicable to their format:</p>
-
-						<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
-							<dt id="sec-fxl-icb-html" data-tests="#fxl-xhtml-icb">Expressing in XHTML</dt>
-							<dd>
-								<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
-										href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-										containing block</a> [[CSS2]] dimensions MUST be expressed in a
-										<code>viewport</code>
-									<code>meta</code> tag using the syntax defined in [[CSS-Device-Adapt-1]].</p>
-								<aside class="example"
-									title="Specifying the initial containing block in a viewport meta tag">
-									<pre>&lt;html …>
-   &lt;head>
-      …
-      &lt;meta
-          name="viewport"
-          content="width=1200, height=600"/>
-      …
-   &lt;/head>
-   …
-&lt;/html></pre>
-								</aside>
-							</dd>
-
-							<dt id="sec-fxl-icb-svg">Expressing in SVG</dt>
-							<dd>
-								<p>For SVG <a>Fixed-Layout Documents</a>, the initial containing block [[CSS2]]
-									dimensions MUST be expressed using the <a
-										href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
-											><code>viewBox</code> attribute</a> [[SVG]].</p>
-								<aside class="example"
-									title="Specifying the initial containing block in the viewBox attribute">
-									<p>In this example, the <code>viewBox</code> attribute sets the ICB to an aspect
-										ratio of 844 pixels wide by 1200 pixels high.</p>
-
-									<pre>
-&lt;svg xmlns="http://www.w3.org/2000/svg"
-     version="1.1" 
-     viewBox="0 0 844 1200">
-   …
-&lt;/svg></pre>
-								</aside>
-							</dd>
-						</dl>
-					</section>
-				</section>
-			</section>
-
-			<section id="sec-reflowable-layouts">
-				<h3>Reflowable Layouts</h3>
-
-				<p>Although control over the rendering of <a>EPUB Content Documents</a> to create <a
-						href="#sec-fixed-layouts">fixed layouts</a> is an obvious need not handled by other
-					technologies, there are also considerations for reflowable content that are unique to EPUB
-					Publications (e.g., how to handle the flow of content in the <a>Viewport</a>). This section defines
-					properties that allow <a>EPUB Creators</a> to control presentation aspects of reflowable
-					content.</p>
-
-				<section id="flow">
-					<h4>The <code>rendition:flow</code> Property</h4>
-
-					<p>The <code>rendition:flow</code> property specifies the EPUB Creator preference for how Reading
-						Systems should handle content overflow. </p>
-
-					<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code> property</a> is
-						specified on a <code>meta</code> element, it indicates the EPUB Creator's global preference for
-						overflow content handling (i.e., for all spine items). EPUB Creators MAY indicate a preference
-						for dynamic pagination or scrolling. For scrolled content, it is also possible to specify
-						whether consecutive <a>EPUB Content Documents</a> are to be rendered as a continuous scrolling
-						view or whether each is to be rendered separately (i.e., with a dynamic page break between
-						each).</p>
-
-					<p>EPUB Creators MUST use one of the following values with the <code>rendition:flow</code>
-						property:</p>
-
-					<dl class="variablelist">
-						<dt id="paginated">paginated</dt>
-						<dd id="paginated-dd" data-tests="#pkg-flow-paginated">
-							<p>Dynamically paginate all overflow content.</p>
-						</dd>
-
-						<dt id="scrolled-continuous">scrolled-continuous</dt>
-						<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
-							<p>Render all Content Documents such that overflow content is scrollable, and the EPUB
-								Publication is presented as one continuous scroll from spine item to spine item (except
-								where <a href="#layout-property-flow-overrides">locally overridden</a>).</p>
-							<p>Note that EPUB Creators SHOULD NOT create publications in which different resources have
-								different block flow directions, as continuous scrolled rendition in EPUB Reading
-								Systems would be problematic.</p>
-						</dd>
-
-						<dt id="scrolled-doc">scrolled-doc</dt>
-						<dd id="scrolled-doc-dd" data-tests="#pkg-flow-scrolled-doc">
-							<p>Render all Content Documents such that overflow content is scrollable, and each spine
-								item is presented as a separate scrollable document.</p>
-						</dd>
-
-						<dt id="auto">auto</dt>
-						<dd>
-							<p>Render overflow content using the Reading System default method or a user preference,
-								whichever is applicable. Default value.</p>
-						</dd>
-					</dl>
-
-					<p id="html-body-page-break-before">Note that when two reflowable EPUB Content Documents occur
-						sequentially in the spine, the default rendering for their [[!HTML]] <a
-							data-cite="html#the-body-element"><code>body</code></a> elements is consistent with the <a
-							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-								><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been set to
-							<code>always</code>. In addition to using the <code>rendition:flow</code> property, EPUB
-						Creators MAY override this behavior through an appropriate style sheet declaration, if the
-						Reading System supports such overrides.</p>
-
-					<p>EPUB Creators MUST NOT declare the <code>rendition:flow</code> property more than once.</p>
-
-					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
-							attribute</a>. Refer to <a href="#layout-property-flow-overrides"></a> for setting the
-						property for individual <a>EPUB Content Documents</a>.</p>
-
-					<figure id="fig-flow-paginated-single">
-						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
-								<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
-						<img src="images/example_rendering_paginated_single_spine.svg" width="600"
-							aria-details="flow-paginated-single-diagram"
-							alt="The continuous progression of paginated content produced for a single document." />
-					</figure>
-
-					<details id="flow-paginated-single-diagram" class="desc">
-						<summary>Image description</summary>
-						<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective
-							arrows, with a text flowing from one rectangle to the next one. The text is sectioned with
-							headers figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a
-							schematic view of a tablet.</p>
-					</details>
-
-					<figure id="fig-flow-paginated-multiple">
-						<figcaption>Rendering of an EPUB publication with multiple spine items, and with the
-								<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
-						<img src="images/example_rendering_paginated_multiple_spine.svg" width="600"
-							aria-details="flow-paginated-multiple-diagram"
-							alt="The continuous progression of paginated content produced for each document with transitions to
-					new pages between documents." />
-					</figure>
-
-					<details id="flow-paginated-multiple-diagram" class="desc">
-						<summary>Image description</summary>
-						<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective
-							arrows, with a text flowing from one rectangle to the next one. The text is sectioned with
-							headers figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top of the
-							rightmost rectangle, leaving an empty space at the bottom of the middle rectangle. The
-							leftmost rectangle is enclosed in a schematic view of a tablet.</p>
-					</details>
-
-					<figure id="fig-flow-scrolled-continuous">
-						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
-								<code>rendition:flow</code> set to <code>scrolled-continuous</code>.</figcaption>
-						<img src="images/example_rendering_scrolled_continuous.svg" width="220"
-							aria-details="flow-scrolled-continuous-diagram"
-							alt="The progression of a continuous scroll of content extends vertically off the user's screen,
-					with new documents added to the bottom as encountered." />
-					</figure>
-
-					<details id="flow-scrolled-continuous-diagram" class="desc">
-						<summary>Image description</summary>
-						<p>A single, column-like strip (i.e., a rectangle without a bottom edge) with a text flowing
-							down the strip. The text is sectioned with headers figuring 'Chapter 1', '2'. The top part
-							of the strip is enclosed in a schematic view of a tablet.</p>
-					</details>
-
-					<figure id="fig-flow-scrolled-doc">
-						<figcaption>Rendering of an EPUB publication with multiple spine items, and with the
-								<code>rendition:flow</code> set to <code>scrolled-doc</code>.</figcaption>
-						<img src="images/example_rendering_scrolled_doc.svg" width="600"
-							aria-details="flow-scrolled-doc-diagram"
-							alt="The progression of scrollable documents depicting how only the content within each document
-					is scrollable." />
-					</figure>
-
-					<details id="flow-scrolled-doc-diagram" class="desc">
-						<summary>Image description</summary>
-						<p>Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle and
-							middle-to-right with respective arrows, each containing a text flowing down the strip. The
-							text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip starts with a
-							chapter header and flows down the strip. The top part of the leftmost strip is enclosed in a
-							schematic view of a tablet.</p>
-					</details>
-
-					<section id="layout-property-flow-overrides">
-						<h5>Spine Overrides</h5>
-
-						<p id="layout-property-flow-local">EPUB Creators MAY specify the following properties locally on
-							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
-								href="#property-flow-global">global value</a> for the given spine item:</p>
-
-						<dl>
-							<dt id="flow-auto">rendition:flow-auto</dt>
-							<dd>Indicates no preference for overflow content handling by the EPUB Creator.</dd>
-
-							<dt id="flow-paginated">rendition:flow-paginated</dt>
-							<dd>Indicates the EPUB Creator preference is to dynamically paginate content overflow.</dd>
-
-							<dt id="flow-scrolled-continuous">rendition:flow-scrolled-continuous</dt>
-							<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow
-								content, and that consecutive spine items with this property are to be rendered as a
-								continuous scroll.</dd>
-
-							<dt id="flow-scrolled-doc">rendition:flow-scrolled-doc</dt>
-							<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow
-								content, and each spine item with this property is to be rendered as a separate
-								scrollable document.</dd>
-						</dl>
-
-						<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
-
-						<aside class="example" id="property-flow-ex1"
-							title="Overriding a global paginated flow declaration">
-							<p>In this example, the EPUB Creator's intent is to have a paginated EPUB Publication with a
-								scrollable table of contents.</p>
-							<pre>&lt;package …>
-&lt;metadata …&gt;
-	…
-	&lt;meta
-		property="rendition:flow"&gt;
-		paginated
-	&lt;/meta&gt;
-	…
-&lt;/metadata&gt;
-
-…
-
-&lt;spine&gt;
-	&lt;itemref
-		idref="toc"
-		properties="rendition:flow-scrolled-doc"/&gt;
-	&lt;itemref
-		idref="c01"/&gt;
-&lt;/spine&gt;
-&lt;/package></pre>
-						</aside>
-					</section>
-				</section>
-
-				<section id="align-x-center">
-					<h4>The <code>rendition:align-x-center</code> Property</h4>
-
-					<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should be
-						centered horizontally in the viewport or spread.</p>
-
-					<p>The property MUST NOT be set globally for all EPUB Content Documents (i.e., in a <a
-							href="#sec-meta-elem"><code>meta</code> element</a> without a <a href="#attrdef-refines"
-								><code>refines</code> attribute</a>). It is only available as a spine override for
-						individual EPUB Content Documents via the <a href="#sec-itemref-elem"><code>itemref</code>
-							element's <code>properties</code> attribute</a>.</p>
-
-					<div class="note">
-						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title pages),
-							in the absence of reliable centering control within the content rendering. As support for
-							paged media evolves in CSS, however, this property is expected to be deprecated. EPUB
-							Creators are encouraged to use CSS solutions when effective.</p>
-					</div>
-				</section>
 			</section>
 		</section>
 		<section id="sec-ocf">
@@ -7934,6 +3092,4805 @@ No Entry</pre>
 					<p>To prevent trivial copying of the embedded font to other EPUB Publications, EPUB Creators MUST
 						NOT provide the <a href="#obfus-keygen">obfuscation key</a> in the <code>encryption.xml</code>
 						file.</p>
+				</section>
+			</section>
+		</section>
+		<section id="sec-package-doc">
+			<h2>Package Document</h2>
+
+			<p>All [[XML]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
+				namespace [[XML-NAMES]] unless otherwise specified.</p>
+
+			<section id="sec-package-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>The <a>Package Document</a> is an XML document that consists of a set of elements that each
+					encapsulate information about a particular aspect of an <a>EPUB Publication</a>. These elements
+					serve to centralize metadata, detail the individual resources, and provide the reading order and
+					other information necessary for its rendering.</p>
+
+				<p>The following list summarizes the information found in the Package Document:</p>
+
+				<ul>
+					<li>
+						<p><a href="#sec-pkg-metadata">Metadata</a> — mechanisms to include and/or reference information
+							about the EPUB Publication.</p>
+					</li>
+					<li>
+						<p>A <a href="#sec-manifest-elem">manifest</a> — identifies via URL [[URL]], and describes via
+							MIME media type [[RFC4839]], the set of <a>Publication Resources</a>.</p>
+					</li>
+					<li>
+						<p>A <a href="#sec-spine-elem">spine</a> — an ordered sequence of ID references to top-level
+							resources in the manifest from which Reading Systems can reach or utilize all other
+							resources in the set. The spine defines the default reading order.</p>
+					</li>
+					<li>
+						<p><a href="#sec-collection-elem">Collections</a> — a method of encapsulating and identifying
+							subcomponents within the Package.</p>
+					</li>
+					<li>
+						<p><a href="#sec-manifest-fallbacks">Manifest fallback chains</a> — a mechanism that defines an
+							ordered list of top-level resources as content equivalents. A Reading System can then choose
+							between the resources based on which it is capable of rendering.</p>
+					</li>
+				</ul>
+
+				<div class="note">
+					<p>An EPUB Publication can reference more than one Package Document, allowing for alternative
+						representations of the content. For more information, refer to <a
+							href="#sec-container-metainf-container.xml"></a></p>
+				</div>
+
+				<div class="note">
+					<p>Refer to <a href="#app-media-type-app-oebps-package"></a> for information about the file
+						properties of Package Documents.</p>
+				</div>
+			</section>
+
+			<section id="sec-parse-package-urls">
+				<h3>Parsing URLs in the Package Document</h3>
+
+				<p id="pkg-parse-package-url" data-tests="#ocf-url_link-relative,#ocf-url_relative"> To parse a URL
+					string <var>url</var> used in the Package Document, the <a data-cite="url#concept-url-parser">URL
+						Parser</a> [[URL]] MUST be applied to <var>url</var>, with the <a>content URL</a> of the Package
+					Document as <var>base</var>.</p>
+			</section>
+
+			<section id="sec-shared-attrs">
+				<h3>Shared Attributes</h3>
+
+				<p>This section provides definitions for shared attributes (i.e., attributes allowed on two or more
+					elements).</p>
+
+				<section id="attrdef-dir">
+					<h4>The <code>dir</code> Attribute</h4>
+
+					<p
+						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
+						>Specifies the <a data-cite="bidi#BD5">base direction</a> [[BIDI]] of the textual content and
+						attribute values of the carrying element and its descendants</p>
+
+					<p>Allowed values are:</p>
+
+					<ul>
+						<li><code>ltr</code> &#8212; left-to-right base direction;</li>
+						<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
+						<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi Algorithm
+							[[BIDI]].</li>
+					</ul>
+
+					<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will assume the
+						value <code>auto</code> when EPUB Creators omit the attribute or use an invalid value.</p>
+
+					<div class="note">
+						<p>The base direction specified in the <code>dir</code> attribute does not affect the ordering
+							of characters within directional runs, only the relative ordering of those runs and the
+							placement of weak directional characters such as punctuation.</p>
+					</div>
+
+					<aside class="example" title="Setting the global base direction for Package Document text">
+						<pre>&lt;package … dir="ltr">
+   …
+&lt;/package></pre>
+					</aside>
+
+					<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+							href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+							href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:rights</code></a>, <a href="#sec-opf-dcsubject"><code>dc:subject</code></a>,
+							<a href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-meta-elem"
+								><code>meta</code></a> and <a href="#sec-package-elem"><code>package</code></a>.</p>
+				</section>
+
+				<section id="attrdef-href">
+					<h4>The <code>href</code> Attribute</h4>
+
+					<p>A <a data-cite="url#valid-url-string">valid URL string</a> [[URL]] that references a resource. If
+						the value is an <a data-cite="url#absolute-url-string">absolute URL</a>, it SHOULD NOT use the
+						"file" URI scheme [[rfc8089]].</p>
+
+					<aside class="example" title="Linking a metadata record">
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;link
+          rel="record"
+          href="meta/9780000000001.xml" 
+          media-type="application/marc"/>
+      …
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+					</aside>
+
+					<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
+								><code>link</code></a>.</p>
+				</section>
+
+				<section id="attrdef-id">
+					<h4>The <code>id</code> Attribute</h4>
+
+					<p>The ID [[XML]] of the element, which MUST be unique within the document scope.</p>
+
+					<aside class="example" title="Adding an identifier attribute">
+						<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
+					</aside>
+
+					<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+							href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+							href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:date</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:format</code></a>, <a href="#sec-opf-dcidentifier"
+							><code>dc:identifier</code></a>, <a href="#sec-opf-dclanguage"><code>dc:language</code></a>,
+							<a href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, <a href="#sec-opf-dcsubject"
+								><code>dc:subject</code></a>, <a href="#sec-opf-dctitle"><code>dc:title</code></a>, <a
+							href="#sec-opf-dctype"><code>dc:type</code></a>, <a href="#sec-item-elem"
+							><code>item</code></a>, <a href="#sec-itemref-elem"><code>itemref</code></a>, <a
+							href="#sec-link-elem"><code>link</code></a>, <a href="#sec-manifest-elem"
+								><code>manifest</code></a>, <a href="#sec-meta-elem"><code>meta</code></a>, <a
+							href="#sec-package-elem"><code>package</code></a> and <a href="#sec-spine-elem"
+								><code>spine</code></a>.</p>
+				</section>
+
+				<section id="attrdef-media-type">
+					<h4>The <code>media-type</code> Attribute</h4>
+
+					<p>A media type [[RFC2046]] that specifies the type and format of the referenced resource.</p>
+
+					<aside class="example" title="Adding the media type for a linked record">
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;link
+          rel="record"
+          href="http://example.org/meta/12389347?format=xmp"
+          media-type="application/xml"
+          properties="xmp"/>
+      …
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+					</aside>
+
+					<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a> and <a href="#sec-link-elem"
+								><code>link</code></a>.</p>
+				</section>
+
+				<section id="attrdef-properties">
+					<h4>The <code>properties</code> Attribute</h4>
+
+					<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
+
+					<p>Refer to each element's definition for the <a href="#sec-default-vocab">reserved vocabulary</a>
+						for the attribute.</p>
+
+					<aside class="example" title="Identifying the EPUB Navigation Document in the manifest">
+						<pre>&lt;package …>
+   …
+   &lt;manifest>
+      …
+      &lt;item
+          id="nav" 
+          href="nav.xhtml"
+          properties="nav"
+          media-type="application/xhtml+xml"/>
+      …
+   &lt;/manifest>
+   …
+&lt;/package></pre>
+					</aside>
+
+					<p>Allowed on: <a href="#sec-item-elem"><code>item</code></a>, <a href="#sec-itemref-elem"
+								><code>itemref</code></a> and <a href="#sec-link-elem"><code>link</code></a>.</p>
+				</section>
+
+				<section id="attrdef-refines">
+					<h4>The <code>refines</code> Attribute</h4>
+
+					<p>Establishes an association between the current expression and the element or resource identified
+						by its value. EPUB Creators MUST use as the value a <a
+							data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL
+							string</a>, optionally followed by <code>U+0023 (#)</code> and a <a
+							data-cite="url#url-fragment-string">URL-fragment string</a> that references the resource or
+						element they are describing.</p>
+
+					<aside class="example" title="Specifying that a creator is the illustrator">
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;dc:creator id="creator02">
+         E.H. Shepard
+      &lt;/dc:creator>
+      &lt;meta
+          refines="#creator02"
+          property="role"
+          scheme="marc:relators">
+         ill
+      &lt;/meta>
+      …
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+					</aside>
+
+					<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata expressed. When
+						omitted, the element defines a <a href="#primary-expression">primary expression</a>.</p>
+
+					<p>When creating expressions about a <a>Publication Resource</a>, the <code>refines</code> attribute
+						SHOULD specify a fragment identifier that references the ID of the resource's <a
+							href="#sec-item-elem">manifest entry</a>.</p>
+
+					<p>Refinement chains MUST NOT contain circular references or self-references.</p>
+
+					<aside class="example" title="Setting the duration of a Media Overlay Document">
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="media:duration" 
+          refines="#c01_overlay">
+         0:32:29
+      &lt;/meta>
+      …
+   &lt;/metadata>
+   &lt;manifest>
+      …
+      &lt;item
+          id="c01_overlay"
+          href="overlays/chapter01.smil"
+          media-type="application/smil+xml"/>
+      …
+   &lt;/manifest>
+   …
+&lt;/package></pre>
+					</aside>
+
+					<p>Allowed on: <a href="#sec-link-elem"><code>link</code></a> and <a href="#sec-meta-elem"
+								><code>meta</code></a>.</p>
+				</section>
+
+				<section id="attrdef-xml-lang">
+					<h4>The <code>xml:lang</code> Attribute</h4>
+
+					<p>Specifies the language of the textual content and attribute values of the carrying element and
+						its descendants, as defined in section <a data-cite="xml#sec-lang-tag">2.12 Language
+							Identification</a> of [[XML]]. The value of each <code>xml:lang</code> attribute MUST be a
+							<a data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
+
+					<aside class="example" title="Setting the global language for Package Document text">
+						<pre>&lt;package … xml:lang="ja">
+   …
+&lt;/package></pre>
+					</aside>
+
+					<p>Allowed on: <a href="#sec-collection-elem"><code>collection</code></a>, <a
+							href="#sec-opf-dccontributor"><code>dc:contributor</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, <a
+							href="#sec-opf-dccreator"><code>dc:creator</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"
+								><code>dc:rights</code></a>, <a href="#sec-opf-dcsubject"><code>dc:subject</code></a>,
+							<a href="#sec-opf-dctitle"><code>dc:title</code></a>, <a href="#sec-meta-elem"
+								><code>meta</code></a> and <a href="#sec-package-elem"><code>package</code></a>.</p>
+				</section>
+			</section>
+
+			<section id="sec-package-elem">
+				<h3>The <code>package</code> Element</h3>
+
+				<p>The <code>package</code> element is the root element of the <a>Package Document</a>.</p>
+
+				<dl id="elemdef-opf-package" class="elemdef">
+					<dt>Element Name:</dt>
+					<dd>
+						<p>
+							<code>package</code>
+						</p>
+					</dd>
+
+					<dt>Usage:</dt>
+					<dd>
+						<p>The <code>package</code> element is the root element of the Package Document.</p>
+					</dd>
+
+					<dt>Attributes:</dt>
+					<dd>
+						<ul class="nomark">
+							<li>
+								<p>
+									<a href="#attrdef-dir">
+										<code>dir</code>
+									</a>
+									<code>[optional]</code>
+								</p>
+							</li>
+							<li>
+								<p>
+									<a href="#attrdef-id">
+										<code>id</code>
+									</a>
+									<code>[optional]</code>
+								</p>
+							</li>
+							<li>
+								<p>
+									<a href="#attrdef-package-prefix">
+										<code>prefix</code>
+									</a>
+									<code>[optional]</code>
+								</p>
+							</li>
+							<li>
+								<p>
+									<a href="#attrdef-xml-lang">
+										<code>xml:lang</code>
+									</a>
+									<code>[optional]</code>
+								</p>
+							</li>
+							<li>
+								<p>
+									<a href="#attrdef-package-unique-identifier">
+										<code>unique-identifier</code>
+									</a>
+									<code>[required]</code>
+								</p>
+							</li>
+							<li>
+								<p>
+									<a href="#attrdef-package-version">
+										<code>version</code>
+									</a>
+									<code>[required]</code>
+								</p>
+							</li>
+						</ul>
+					</dd>
+
+					<dt>Content Model:</dt>
+					<dd>
+						<p>In this order:</p>
+						<ul class="nomark">
+							<li>
+								<p>
+									<a class="codelink" href="#elemdef-opf-metadata">
+										<code>metadata</code>
+									</a>
+									<code>[exactly 1]</code>
+								</p>
+							</li>
+							<li>
+								<p>
+									<a href="#elemdef-opf-manifest">
+										<code>manifest</code>
+									</a>
+									<code>[exactly 1]</code>
+								</p>
+							</li>
+							<li>
+								<p>
+									<a href="#elemdef-opf-spine">
+										<code>spine</code>
+									</a>
+									<code>[exactly 1]</code>
+								</p>
+							</li>
+							<li>
+								<p>
+									<a href="#sec-opf2-guide">
+										<code>guide</code>
+									</a>
+									<code>[0 or 1]</code>
+									<a href="#legacy" class="legacy">(legacy)</a>
+								</p>
+							</li>
+							<li>
+								<p>
+									<a href="#sec-opf-bindings">
+										<code>bindings</code>
+									</a>
+									<code>[0 or 1]</code>
+									<a href="#deprecated" class="deprecated">(deprecated)</a>
+								</p>
+							</li>
+							<li>
+								<p>
+									<a href="#elemdef-collection">
+										<code>collection</code>
+									</a>
+									<code>[0 or more]</code>
+								</p>
+							</li>
+						</ul>
+					</dd>
+				</dl>
+
+				<p id="attrdef-package-version">The <code>version</code> attribute specifies the EPUB specification
+					version to which the given EPUB Publication conforms. The attribute MUST have the value
+						"<code>3.0</code>" to indicate conformance with EPUB 3.</p>
+
+				<div class="note">
+					<p>Updates to this specification do not represent new versions of EPUB 3 (i.e., each new 3.X
+						specification is a continuation of the EPUB 3 format). The Working Group is committed to
+						minimizing any changes that would invalidate existing content, allowing the <code>version</code>
+						attribute value to remain unchanged.</p>
+				</div>
+
+				<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an IDREF
+					[[XML]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"
+							><code>dc:identifier</code></a> element that provides the preferred, or primary,
+					identifier.</p>
+
+				<p id="attrdef-package-prefix">The <code>prefix</code> attribute provides a declaration mechanism for
+					prefixes not <a href="#sec-metadata-reserved-prefixes">reserved by this specification</a>. Refer to
+						<a href="#sec-prefix-attr"></a> for more information.</p>
+			</section>
+
+			<section id="sec-pkg-metadata">
+				<h3>Metadata Section</h3>
+
+				<section id="sec-metadata-elem">
+					<h4>The <code>metadata</code> Element</h4>
+
+					<p>The <code>metadata</code> element encapsulates meta information.</p>
+
+					<dl id="elemdef-opf-metadata" class="elemdef">
+						<dt>Element Name:</dt>
+						<dd>
+							<p>
+								<code>metadata</code>
+							</p>
+						</dd>
+
+						<dt>Usage:</dt>
+						<dd>
+							<p>REQUIRED first child of <a href="#elemdef-opf-package"><code>package</code></a>.</p>
+						</dd>
+
+						<dt>Attributes:</dt>
+						<dd>
+							<p>None</p>
+						</dd>
+
+						<dt>Content Model:</dt>
+						<dd>
+							<p>In any order:</p>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a class="codelink" href="#elemdef-opf-dcidentifier">
+											<code>dc:identifier</code>
+										</a>
+										<code>[1 or more]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-opf-dctitle">
+											<code>dc:title</code>
+										</a>
+										<code>[1 or more]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-opf-dclanguage">
+											<code>dc:language</code>
+										</a>
+										<code>[1 or more]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#sec-opf-dcmes-optional">
+											<code>Dublin Core Optional Elements</code>
+										</a>
+										<code>[0 or more]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-meta">
+											<code>meta</code>
+										</a>
+										<code>[1 or more]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#sec-opf2-meta">OPF2 <code>meta</code></a>
+										<code>[0 or more]</code>
+										<a href="#legacy" class="legacy">(legacy)</a>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#elemdef-opf-link">
+											<code>link</code>
+										</a>
+										<code>[0 or more]</code>
+									</p>
+								</li>
+							</ul>
+						</dd>
+					</dl>
+
+					<p>The Package Document <code>metadata</code> element has two primary functions:</p>
+
+					<ol>
+						<li>
+							<p>to provide a minimal set of meta information for Reading Systems to use to internally
+								catalogue an <a>EPUB Publication</a> and make it available to a user (e.g., to present
+								in a bookshelf).</p>
+						</li>
+						<li>
+							<p>to provide access to all rendering metadata needed to control the layout and display of
+								the content (e.g., <a href="#sec-fxl-package">fixed-layout properties</a>).</p>
+						</li>
+					</ol>
+
+					<p>The Package Document does not provide complex metadata encoding capabilities. If EPUB Creators
+						need to provide more detailed information, they can associate metadata records (e.g., that
+						conform to an international standard such as [[ONIX]] or are created for custom purposes) using
+						the <a href="#sec-link-elem"><code>link</code></a> element. This approach allows Reading Systems
+						to process the metadata in its native form, avoiding the potential problems and information loss
+						caused by translating to use the minimal Package Document structure.</p>
+
+					<p id="core-metadata-reqs">In keeping with this philosophy, the Package Document only has the
+						following minimal metadata requirements: it MUST contain the [[DCTERMS]] <a
+							href="#sec-opf-dcidentifier"><code>dc:title</code></a>, <a href="#elemdef-opf-dcidentifier"
+								><code>dc:identifier</code></a>, and <a href="#elemdef-opf-dclanguage"
+								><code>dc:language</code></a> elements together with the [[DCTERMS]] <a
+							href="#last-modified-date"><code>dcterms:modified</code> property</a>. All other metadata is
+						OPTIONAL.</p>
+
+					<aside class="example" title="The minimal set of metadata required in the Package Document">
+						<pre>&lt;package … unique-identifier="pub-id">
+    …
+    &lt;metadata …>
+       &lt;dc:identifier
+           id="pub-id">
+          urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
+       &lt;/dc:identifier>
+       &lt;dc:title>
+          Norwegian Wood
+       &lt;/dc:title>
+       &lt;dc:language>
+          en
+       &lt;/dc:language>
+       &lt;meta
+           property="dcterms:modified">
+          2011-01-01T12:00:00Z
+       &lt;/meta>
+    &lt;/metadata>
+    …
+&lt;/package>
+</pre>
+					</aside>
+
+					<p>The <a href="#sec-meta-elem"><code>meta</code> element</a> provides a generic mechanism for
+						including <a href="#sec-vocab-assoc">metadata properties from any vocabulary</a>. Although EPUB
+						Creators MAY use this mechanism for any metadata purposes, they will typically use it to include
+						rendering metadata defined in EPUB specifications.</p>
+
+					<div class="note">
+						<p>See [[EPUB-A11Y-11]] for accessibility metadata recommendations.</p>
+					</div>
+				</section>
+
+				<section id="sec-metadata-values">
+					<h4>Metadata Values</h4>
+
+					<p>The Dublin Core elements [[DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code> element</a>
+						have mandatory <a data-cite="dom#concept-child-text-content">child text content</a> [[DOM]].
+						This specification refers to this content as the <dfn>value</dfn> of the element in their
+						descriptions.</p>
+
+					<p>These elements MUST have non-empty values after <a
+							data-cite="infra#strip-leading-and-trailing-ascii-whitespace">leading and trailing ASCII
+							whitespace</a> [[Infra]] is stripped (i.e., they must consist of at least one non-whitespace
+						character).</p>
+
+					<p>Whitespace within these element values is not significant. Sequences of one or more whitespace
+						characters are <a data-cite="infra#strip-and-collapse-ascii-whitespace">collapsed to a single
+							space</a> [[Infra]] during processing .</p>
+				</section>
+
+				<section id="sec-opf-dcmes-required">
+					<h4>Dublin Core Required Elements</h4>
+
+					<section id="sec-opf-dcidentifier">
+						<h5>The <code>dc:identifier</code> Element</h5>
+
+						<p>The <a
+								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
+									><code>dc:identifier</code> element</a> [[DCTERMS]] contains an identifier such as a
+								<abbr title="Universally Unique Identifier">UUID</abbr>, <abbr
+								title="Digital Object Identfier">DOI</abbr> or <abbr
+								title="International Standard Book Number">ISBN</abbr>.</p>
+
+						<dl id="elemdef-opf-dcidentifier" class="elemdef">
+							<dt>Element Name:</dt>
+							<dd>
+								<p>
+									<code>dc:identifier</code>
+								</p>
+							</dd>
+
+							<dt>Namespace:</dt>
+							<dd>
+								<p>
+									<code>http://purl.org/dc/elements/1.1/</code>
+								</p>
+							</dd>
+
+							<dt>Usage:</dt>
+							<dd>
+								<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
+											><code>metadata</code></a>. Repeatable.</p>
+							</dd>
+
+							<dt>Attributes:</dt>
+							<dd>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#attrdef-id">
+												<code>id</code>
+											</a>
+											<code>[conditionally required]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
+
+							<dt>Content Model:</dt>
+							<dd>
+								<p>Text</p>
+							</dd>
+						</dl>
+
+						<p>The <a>EPUB Creator</a> MUST provide an identifier that is unique to one and only one <a>EPUB
+								Publication</a> &#8212; its <a>Unique Identifier</a> &#8212; in an
+								<code>dc:identifier</code> element. This <code>dc:identifier</code> element MUST specify
+							an <code>id</code> attribute whose value is referenced from the <a
+								href="#elemdef-opf-package"><code>package</code> element's</a>
+							<a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
+							attribute</a>.</p>
+
+						<aside class="example" title="Specifying the element with the unique identifier">
+							<pre>&lt;package … unique-identifier="pub-id">
+    &lt;metadata …>
+       &lt;dc:identifier id="pub-id">
+           urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
+       &lt;/dc:identifier>
+       …
+    &lt;/metadata>
+&lt;/package></pre>
+						</aside>
+
+						<p>Although not static, EPUB Creators should make changes to the Unique Identifier for an EPUB
+							Publication as infrequently as possible. Unique Identifiers should have maximal persistence
+							both for referencing and distribution purposes. EPUB Creators should not issue new
+							identifiers when making minor revisions such as updating metadata, fixing errata, or making
+							similar minor changes.</p>
+
+						<p>EPUB Creators MAY specify additional identifiers. The identifiers should be fully qualified
+							URIs.</p>
+
+						<p>EPUB Creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
+								property</a> to indicate that the value of a <code>dc:identifier</code> element conforms
+							to an established system or an issuing authority granted it.</p>
+
+						<aside class="example" title="Specifying the type of the identifier">
+							<p>In this example, the <code>identifier-type</code> property is used with the <a
+									href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> scheme to indicate the
+								product identifier type is a <a href="https://doi.org">DOI</a> (i.e., the value
+									<code>06</code> in codelist 5 is for DOIs).</p>
+
+							<pre>&lt;metadata …>
+   &lt;dc:identifier
+       id="pub-id">
+      urn:doi:10.1016/j.iheduc.2008.03.001
+   &lt;/dc:identifier>
+   &lt;meta
+       refines="#pub-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      06
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
+						</aside>
+					</section>
+
+					<section id="sec-opf-dctitle">
+						<h5>The <code>dc:title</code> Element</h5>
+
+						<p>The <a
+								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
+									><code>dc:title</code> element</a> [[DCTERMS]] represents an instance of a name for
+							the <a>EPUB Publication</a>.</p>
+
+						<dl id="elemdef-opf-dctitle" class="elemdef">
+							<dt>Element Name:</dt>
+							<dd>
+								<p>
+									<code>dc:title</code>
+								</p>
+							</dd>
+
+							<dt>Namespace:</dt>
+							<dd>
+								<p>
+									<code>http://purl.org/dc/elements/1.1/</code>
+								</p>
+							</dd>
+
+							<dt>Usage:</dt>
+							<dd>
+								<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
+											><code>metadata</code></a>. Repeatable.</p>
+							</dd>
+
+							<dt>Attributes:</dt>
+							<dd>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a href="#attrdef-dir">
+												<code>dir</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-id">
+												<code>id</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<a href="#attrdef-xml-lang">
+												<code>xml:lang</code>
+											</a>
+											<code>[optional]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
+
+							<dt>Content Model:</dt>
+							<dd>
+								<p>Text</p>
+							</dd>
+						</dl>
+
+						<p id="title-order">The first <code>dc:title</code> element in document order is the main title
+							of the EPUB Publication (i.e., the primary one Reading Systems present to users).</p>
+
+						<aside class="example" title="A basic title element">
+							<pre>&lt;metadata …>
+   &lt;dc:title>
+      Norwegian Wood
+   &lt;/dc:title>
+   …
+&lt;/metadata>
+</pre>
+						</aside>
+
+						<p>EPUB Creators should use only a single <code>dc:title</code> element to ensure consistent
+							rendering of the title in Reading Systems.</p>
+
+						<div class="note">
+							<p>Although it is possible to include more than one <code>dc:title</code> element for
+								multipart titles, Reading System support for additional <code>dc:title</code> elements
+								is inconsistent. Reading Systems may ignore the additional segments or combine them in
+								unexpected ways.</p>
+
+							<p>For example, the following example shows a basic multipart title:</p>
+
+							<pre>&lt;metadata …>
+   &lt;dc:title>
+      THE LORD OF THE RINGS
+   &lt;/dc:title>
+   &lt;dc:title>
+      Part One: The Fellowship of the Ring
+   &lt;/dc:title>
+   …
+&lt;/metadata>
+</pre>
+
+							<p>The same title could instead be expressed using a single <code>dc:title</code> element as
+								follows:</p>
+
+							<pre>&lt;metadata …>
+   &lt;dc:title>
+       THE LORD OF THE RINGS, Part One:
+       The Fellowship of the Ring
+   &lt;/dc:title>
+   …
+&lt;/metadata>
+</pre>
+
+							<p>Previous versions of this specification recommended using the <a href="#sec-title-type"
+										><code>title-type</code></a> and <a href="#sec-display-seq"
+										><code>display-seq</code></a> properties to identify and format the segments of
+								multipart titles (see the <a href="#cookbook-ex">Great Cookbooks example</a>). It is
+								still possible to add these semantics, but they are also not well supported.</p>
+						</div>
+					</section>
+
+					<section id="sec-opf-dclanguage">
+						<h5>The <code>dc:language</code> Element</h5>
+
+						<p>The <a
+								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/language"
+									><code>dc:language</code> element</a> [[DCTERMS]] specifies the language of the
+							content of the <a>EPUB Publication</a>.</p>
+
+						<dl id="elemdef-opf-dclanguage" class="elemdef">
+							<dt>Element Name:</dt>
+							<dd>
+								<p>
+									<code>dc:language</code>
+								</p>
+							</dd>
+
+							<dt>Namespace:</dt>
+							<dd>
+								<p>
+									<code>http://purl.org/dc/elements/1.1/</code>
+								</p>
+							</dd>
+
+							<dt>Usage:</dt>
+							<dd>
+								<p>REQUIRED child of <a class="codelink" href="#elemdef-opf-metadata"
+											><code>metadata</code></a>. Repeatable.</p>
+							</dd>
+
+							<dt>Attributes:</dt>
+							<dd>
+								<p>
+									<a href="#attrdef-id">
+										<code>id</code>
+									</a>
+									<code>[optional]</code>
+								</p>
+							</dd>
+
+							<dt>Content Model:</dt>
+							<dd>
+								<p>Text</p>
+							</dd>
+						</dl>
+
+						<p>The <a>value</a> of each <code>dc:language</code> element MUST be a <a
+								data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
+
+						<aside class="example" title="Specifying U.S. English as the language of the EPUB Publication">
+							<pre>&lt;metadata …>
+   …
+   &lt;dc:language>
+      en-US
+   &lt;/dc:language>
+   …
+&lt;/metadata></pre>
+						</aside>
+
+						<p>Although EPUB Creators MAY specify additional <code>dc:language</code> elements for
+							multilingual Publications, Reading Systems will treat the first <code>dc:language</code>
+							element in document order as the primary language of the EPUB Publication.</p>
+
+						<div class="note">
+							<p><a>Publication Resources</a> do not inherit their language from the
+									<code>dc:language</code> element(s). EPUB Creators must set the language of a
+								resource using the intrinsic methods of the format.</p>
+						</div>
+					</section>
+				</section>
+
+				<section id="sec-opf-dcmes-optional">
+					<h4>Dublin Core Optional Elements</h4>
+
+					<section id="sec-opf-dcmes-optional-def">
+						<h5>General Definition</h5>
+
+						<p>All [[DCTERMS]] elements except for <a href="#sec-opf-dcidentifier"
+									><code>dc:identifier</code></a>, <a href="#sec-opf-dclanguage"
+									><code>dc:language</code></a>, and <a href="#sec-opf-dctitle"
+								><code>dc:title</code></a> are designated as OPTIONAL. These elements conform to the
+							following generalized definition:</p>
+
+						<dl class="elemdef">
+							<dt>Element Name:</dt>
+							<dd>
+								<p>
+									<code>dc:contributor</code> | <code>dc:coverage</code> | <code>dc:creator</code> |
+										<code>dc:date</code> | <code>dc:description</code> | <code>dc:format</code> |
+										<code>dc:publisher</code> | <code>dc:relation</code> | <code>dc:rights</code> |
+										<code>dc:source</code> | <code>dc:subject</code> | <code>dc:type</code></p>
+							</dd>
+
+							<dt>Namespace:</dt>
+							<dd>
+								<p>
+									<code>http://purl.org/dc/elements/1.1/</code>
+								</p>
+							</dd>
+
+							<dt>Usage:</dt>
+							<dd>
+								<p>OPTIONAL child of <a class="codelink" href="#elemdef-opf-metadata"
+											><code>metadata</code></a>. Repeatable.</p>
+							</dd>
+
+							<dt>Attributes:</dt>
+							<dd>
+								<ul class="nomark">
+									<li>
+										<p><a href="#attrdef-dir"><code>dir</code></a>
+											<code>[optional]</code> – only allowed on <code>dc:contributor</code>,
+												<code>dc:coverage</code>, <code>dc:creator</code>,
+												<code>dc:description</code>, <code>dc:publisher</code>,
+												<code>dc:relation</code>, <code>dc:rights</code>, and
+												<code>dc:subject</code>.</p>
+									</li>
+									<li>
+										<p><a href="#attrdef-id"><code>id</code></a>
+											<code>[optional]</code> – allowed on any element.</p>
+									</li>
+									<li>
+										<p><a href="#attrdef-xml-lang"><code>xml:lang</code></a>
+											<code>[optional]</code> – only allowed on <code>dc:contributor</code>,
+												<code>dc:coverage</code>, <code>dc:creator</code>,
+												<code>dc:description</code>, <code>dc:publisher</code>,
+												<code>dc:relation</code>, <code>dc:rights</code>, and
+												<code>dc:subject</code>.</p>
+									</li>
+								</ul>
+							</dd>
+
+							<dt>Content Model:</dt>
+							<dd>
+								<p>Text</p>
+							</dd>
+						</dl>
+
+						<p>This specification does not modify the [[DCTERMS]] element definitions except as noted in the
+							following sections.</p>
+					</section>
+
+					<section id="sec-opf-dccontributor">
+						<h5>The <code>dc:contributor</code> Element</h5>
+
+						<p>The <a
+								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/contributor"
+									><code>dc:contributor</code> element</a> [[DCTERMS]] is used to represent the name
+							of a person, organization, etc. that played a secondary role in the creation of the
+							content.</p>
+
+						<p>The requirements for the <code>dc:contributor</code> element are identical to those for the
+								<a href="#sec-opf-dccreator"><code>dc:creator</code> element</a> in all other
+							respects.</p>
+					</section>
+
+					<section id="sec-opf-dccreator">
+						<h5>The <code>dc:creator</code> Element</h5>
+
+						<p>The <a
+								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/creator"
+									><code>dc:creator</code> element</a> [[DCTERMS]] represents the name of a person,
+							organization, etc. responsible for the creation of the content. EPUB Creators MAY <a
+								href="#subexpression">associate</a> a <a href="#role"><code>role</code> property</a>
+							with the element to indicate the function the creator played.</p>
+
+						<aside class="example" title="Specifying that a creator is an author">
+							<p>In this example, the <a href="https://id.loc.gov/vocabulary/relators.html">MARC
+									relators</a> scheme is used to indicate the role (i.e., the value <code>aut</code>
+								indicates an author in MARC).</p>
+
+							<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator">
+      Haruki Murakami
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator"
+       property="role"
+       scheme="marc:relators"
+       id="role">
+      aut
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
+						</aside>
+
+						<p>The <code>dc:creator</code> element should contain the name of the creator as EPUB Creators
+							intend Reading Systems to display it to users.</p>
+
+						<p>EPUB Creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
+							<a href="#subexpression">to associate</a> a normalized form of the creator's name, and the
+								<a href="#alternate-script"><code>alternate-script</code> property</a> to represent the
+							creator's name in another language or script.</p>
+
+						<aside class="example" title="Expressing sorting and rendering information for a creator">
+							<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator">
+      Haruki Murakami
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator"
+       property="alternate-script"
+       xml:lang="ja">
+      村上 春樹
+   &lt;/meta>
+   &lt;meta
+       refines="#creator"
+       property="file-as">
+      Murakami, Haruki
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
+						</aside>
+
+						<p>If an EPUB Publication has more than one creator, EPUB Creators should specify each in a
+							separate <code>dc:creator</code> element.</p>
+
+						<p>The document order of <code>dc:creator</code> elements in the <code>metadata</code> section
+							determines the display priority, where the first <code>dc:creator</code> element encountered
+							is the primary creator.</p>
+
+						<aside class="example" title="Expressing the primary creator">
+							<p>In this example, Lewis Carroll is the primary creator because he is listed first.</p>
+
+							<pre>&lt;metadata …>
+   …
+   &lt;dc:creator
+       id="creator01">
+      Lewis Carroll
+   &lt;/dc:creator>
+   &lt;dc:creator
+       id="creator02">
+      John Tenniel
+   &lt;/dc:creator>
+   …
+&lt;/metadata></pre>
+						</aside>
+
+						<p>EPUB Creators should represent secondary contributors using the <a
+								href="#sec-opf-dccontributor"><code>dc:contributor</code> element</a>.</p>
+					</section>
+
+					<section id="sec-opf-dcdate">
+						<h5>The <code>dc:date</code> Element</h5>
+
+						<p>The <a
+								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/date"
+									><code>dc:date</code> element</a> [[DCTERMS]] defines the publication date of the
+								<a>EPUB Publication</a>. The publication date is not the same as the <a
+								href="#last-modified-date">last modified date</a> (the last time the EPUB Creator
+							changed the EPUB Publication).</p>
+
+						<p>It is RECOMMENDED that the date string conform to [[ISO8601]], particularly the subset
+							expressed in W3C Date and Time Formats [[DateTime]], as such strings are both human and
+							machine readable.</p>
+
+						<aside class="example" title="Expressing the publication date">
+							<pre>&lt;metadata …>
+   …
+   &lt;dc:date>
+      2000-01-01T00:00:00Z
+   &lt;/dc:date>
+   …
+&lt;/metadata></pre>
+						</aside>
+
+						<p>EPUB Creators should express additional dates using the specialized date properties available
+							in the [[DCTERMS]] vocabulary, or similar.</p>
+
+						<p>EPUB Publications MUST NOT contain more than one <code>dc:date</code> element.</p>
+					</section>
+
+					<section id="sec-opf-dcsubject">
+						<h5>The <code>dc:subject</code> Element</h5>
+
+						<p>The <a
+								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/subject"
+									><code>dc:subject</code> element</a> [[DCTERMS]] identifies the subject of the EPUB
+							Publication. EPUB Creators should set the <a>value</a> of the element to the human-readable
+							heading or label, but may use a code value if the subject taxonomy does not provide a
+							separate descriptive label.</p>
+
+						<p>EPUB Creators MAY identify the system or scheme they drew the element's <a>value</a> from
+							using the <a href="#authority"><code>authority</code> property</a>.</p>
+
+						<p>When a scheme is identified, EPUB Creators MUST <a href="#subexpression">associate</a> a
+							subject code using the <a href="#term"><code>term</code> property</a>.</p>
+
+						<aside class="example" title="Specifying a BISAC code and heading">
+							<pre>&lt;metadata …>
+   &lt;dc:subject id="subject01">
+      FICTION / Occult &amp;amp; Supernatural
+   &lt;/dc:subject>
+   &lt;meta
+       refines="#subject01"
+       property="authority">
+      BISAC
+   &lt;/meta>
+   &lt;meta
+       refines="#subject01"
+       property="term">
+      FIC024000
+   &lt;/meta>
+&lt;/metadata</pre>
+						</aside>
+
+						<aside class="example" title="Specifying a URL for the scheme">
+							<pre>&lt;metadata …>
+   &lt;dc:subject id="sbj01">
+      Number Theory
+   &lt;/dc:subject>
+   &lt;meta
+       refines="#sbj01"
+       property="authority">
+      http://www.ams.org/msc/msc2010.html
+   &lt;/meta>
+   &lt;meta
+      refines="#sbj01"
+      property="term">
+     11
+  &lt;/meta>
+&lt;/metadata></pre>
+						</aside>
+
+						<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
+									<code>dc:subject</code> element</a> that does not specify a scheme.</p>
+
+						<p>The <a>values</a> of the <code>dc:subject</code> element and <code>term</code> property are
+							case sensitive only when the designated scheme requires.</p>
+					</section>
+
+					<section id="sec-opf-dctype">
+						<h5>The <code>dc:type</code> Element</h5>
+
+						<p>The <a
+								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/type"
+									><code>dc:type</code> element</a> [[DCTERMS]] is used to indicate that the EPUB
+							Publication is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
+							format).</p>
+
+						<p>EPUB Creators MAY use any text string as a <a>value</a>.</p>
+
+						<div class="note">
+							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
+								Working Group maintained an <a href="http://www.idpf.org/epub/vocab/package/types"
+									>informative registry of specialized EPUB Publication types</a> for use with this
+								element. This Working Group no longer maintains this registry and does not anticipate
+								developing new specialized publication types.</p>
+						</div>
+					</section>
+				</section>
+
+				<section id="sec-meta-elem">
+					<h4>The <code>meta</code> Element</h4>
+
+					<p>The <code>meta</code> element provides a generic means of including package metadata.</p>
+
+					<dl id="elemdef-meta" class="elemdef">
+						<dt>Element Name:</dt>
+						<dd>
+							<p>
+								<code>meta</code>
+							</p>
+						</dd>
+
+						<dt>Usage:</dt>
+						<dd>
+							<p>As child of the <a class="codelink" href="#elemdef-opf-metadata"
+									><code>metadata</code></a> element. Repeatable.</p>
+						</dd>
+
+						<dt>Attributes:</dt>
+						<dd>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#attrdef-dir">
+											<code>dir</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-id">
+											<code>id</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-meta-property">
+											<code>property</code>
+										</a>
+										<code>[required]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-refines">
+											<code>refines</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-scheme">
+											<code>scheme</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-xml-lang">
+											<code>xml:lang</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+							</ul>
+						</dd>
+
+						<dt>Content Model:</dt>
+						<dd>
+							<p>Text</p>
+						</dd>
+					</dl>
+
+					<p id="attrdef-meta-property">Each <code>meta</code> element defines a metadata expression. The
+							<code>property</code> attribute takes a <a href="#sec-property-datatype"><var>property</var>
+							data type value</a> that defines the statement made in the expression, and the text content
+						of the element represents the assertion. (Refer to <a href="#sec-vocab-assoc"></a> for more
+						information.)</p>
+
+					<p id="meta-expr-types">This specification defines two types of metadata expressions that EPUB
+						Creators can define using the <code>meta</code> element:</p>
+
+					<ul>
+						<li id="primary-expression">A <em>primary expression</em> is one in which the expression defined
+							in the <code>meta</code> element establishes some aspect of the <a>EPUB Publication</a>. A
+								<code>meta</code> element that omits a refines attribute defines a primary
+							expression.</li>
+						<li id="subexpression">A <em>subexpression</em> is one in which the expression defined in the
+								<code>meta</code> element is associated with another expression or resource using the
+								<code>refines</code> attribute to enhance its meaning. A subexpression might refine a
+							media clip, for example, by expressing its duration, or refine a creator or contributor
+							expression by defining the role of the person.</li>
+					</ul>
+
+					<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions, thereby
+						creating chains of information.</p>
+
+					<p class="note">All the [[DCTERMS]] elements represent primary expressions, and permit refinement by
+						meta element subexpressions.</p>
+
+					<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a
+							href="#sec-default-vocab">default vocabulary</a> for use with the <code>property</code>
+						attribute.</p>
+
+					<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+						></a>.</p>
+
+					<aside class="example" title="Using properties with reserved prefixes">
+						<p>For the full list of reserved prefixes, refer to <a href="#sec-reserved-prefixes"></a>.</p>
+
+						<pre>&lt;metadata …>
+   …
+   &lt;meta
+       property="dcterms:modified">
+      2016-02-29T12:34:56Z
+   &lt;/meta>
+   &lt;meta
+       property="rendition:layout">
+      pre-paginated
+   &lt;/meta>
+   &lt;meta
+       property="media:active-class">
+      my-active-item
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
+					</aside>
+
+					<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme the EPUB
+						Creator obtained the element's <a>value</a> from. The value of the attribute MUST be a <a
+							href="#sec-property-datatype"><var>property</var> data type value</a> that resolves to the
+						resource that defines the scheme.</p>
+
+					<aside class="example" title="Using values from a scheme">
+						<p>In this example, the <code>scheme</code> attribute indicates that the <a>value</a> of the tag
+							is from [[ONIX]] code list 5 (i.e., the value <code>15</code> indicates a 13 digit
+							ISBN).</p>
+						<pre>&lt;metadata &#8230;>
+   &#8230;
+   &lt;meta
+       refines="#isbn-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      15
+   &lt;/meta>
+   &#8230;
+&lt;/metadata></pre>
+					</aside>
+				</section>
+
+				<section id="sec-metadata-last-modified">
+					<h4>Last Modified Date</h4>
+
+					<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one [[DCTERMS]]
+							<code>modified</code> property containing the last modification date. The <a>value</a> of
+						this property MUST be an [[XMLSCHEMA-2]] dateTime conformant date of the form:
+							<code>CCYY-MM-DDThh:mm:ssZ</code></p>
+
+					<p>EPUB Creators MUST express the last modification date in Coordinated Universal Time (UTC) and
+						MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>
+
+					<aside class="example" title="Expressing a last modification date">
+						<pre>&lt;metadata …>
+   …
+   &lt;meta
+       property="dcterms:modified">
+      2016-01-01T00:00:01Z
+   &lt;/meta>
+   …
+&lt;/metadata></pre>
+					</aside>
+
+					<p>EPUB Creators should update the last modified date whenever they make changes to the EPUB
+						Publication.</p>
+
+					<p>EPUB Creators MAY specify additional modified properties in the Package Document metadata, but
+						they MUST have a different subject (i.e., they require a <code>refines</code> attribute that
+						references an element or resource).</p>
+
+					<div class="note">
+						<p>The requirements for the last modification date are to ensure compatibility with earlier
+							versions of EPUB 3 that defined a <a
+								href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
+								>release identifier</a> [[EPUBPackages-32]] for EPUB Publications.</p>
+					</div>
+				</section>
+
+				<section id="sec-link-elem">
+					<h4>The <code>link</code> Element</h4>
+
+					<p>The <code>link</code> element associates resources with an <a>EPUB Publication</a>, such as
+						metadata records.</p>
+
+					<dl id="elemdef-opf-link" class="elemdef">
+						<dt>Element Name:</dt>
+						<dd>
+							<p>
+								<code>link</code>
+							</p>
+						</dd>
+
+						<dt>Usage:</dt>
+						<dd>
+							<p>As a child of <a class="codelink" href="#elemdef-opf-metadata"><code>metadata</code></a>.
+								Repeatable.</p>
+						</dd>
+
+						<dt>Attributes:</dt>
+						<dd>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#attrdef-href">
+											<code>href</code>
+										</a>
+										<code>[required]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-hreflang">
+											<code>hreflang</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-id">
+											<code>id</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-link-media-type">
+											<code>media-type</code>
+										</a>
+										<code>[conditionally required]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-properties">
+											<code>properties</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-refines">
+											<code>refines</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-link-rel">
+											<code>rel</code>
+										</a>
+										<code>[required]</code>
+									</p>
+								</li>
+							</ul>
+						</dd>
+
+						<dt>Content Model:</dt>
+						<dd>
+							<p>Empty</p>
+						</dd>
+					</dl>
+
+					<p>The <a href="#sec-metadata-elem"><code>metadata</code> element</a> MAY contain zero or more
+							<code>link</code> elements, each of which identifies the location of a <a>Linked
+							Resource</a> in its REQUIRED <code>href</code> attribute</p>
+
+					<p id="linked-res-manifest">Linked Resources are <a>Publication Resources</a> only when they
+						are:</p>
+
+					<ul>
+						<li>
+							<p>referenced from the <a href="#sec-spine-elem">spine</a>; or</p>
+						</li>
+						<li>
+							<p>included or embedded in an EPUB Content Document (e.g., a metadata record serialized as
+								RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]] embedded in an [[HTML]] <a
+									data-cite="html#the-script-element"><code>script</code> element</a>).</p>
+						</li>
+					</ul>
+
+					<p>In all other cases (e.g., when linking to standalone [[?ONIX]] or [[?XMP]] records), the Linked
+						Resources are not Publication Resources (i.e., are not subject to <a
+							href="#sec-core-media-types">Core Media Type requirements</a>) and EPUB Creators MUST NOT
+						list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
+
+					<aside class="example" title="Reference to a record embedded in an XHTML Content Document">
+						<p>In this example, the metadata record is embedded in a <code>script</code> element. Note that
+							the media type of the embedded record (i.e., <code>application/ld+json</code>) is obtained
+							from the <code>type</code> attribute on the <code>script</code> element; it is not specified
+							in the <code>link</code> element.</p>
+
+						<pre>Package Document:
+
+&lt;package …>
+   &lt;metadata …>
+      … 
+      &lt;link rel="record"
+          href="front.xhtml#meta-json"
+          media-type="application/xhtml+xml"
+          hreflang="en"/>
+      …
+   &lt;/metadata>
+   …
+&lt;/package>
+
+XHTML:
+
+&lt;html …>
+   &lt;head>
+      …
+      &lt;script id="meta-json" type="application/ld+json">
+          "@context" : "http://schema.org",
+          "name" : "…",
+         …
+      &lt;/script>
+      …
+   &lt;/head>
+   &lt;body>
+      …
+   &lt;/body>
+&lt;/html></pre>
+					</aside>
+
+					<p id="linked-res-location">EPUB Creators MAY locate Linked Resources <a data-lt="Local Resource"
+							>locally</a> or <a data-lt="Remote Resource">remotely</a>, but should consider that
+							<a>Reading Systems</a> are not required to retrieve Remote Resources (i.e., Reading Systems
+						might not make Remote Resources available).</p>
+
+					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
+							attribute</a> is OPTIONAL when a Linked Resource is located outside the EPUB Container, as
+						more than one media type could be served from the same URL [[URL]]. EPUB Creators MUST specify
+						the attribute for all <a>Local Resources</a>.</p>
+
+					<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of the
+						Linked Resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language
+							tag</a> [[BCP47]].</p>
+
+					<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated list of <a
+							href="#sec-property-datatype">property</a> values that establish the relationship the Linked
+						Resource has with the EPUB Publication.</p>
+
+					<aside class="example" title="Linking to a MARC XML record">
+						<pre>&lt;metadata …>
+   …
+   &lt;link
+       rel="record"
+       href="meta/9780000000001.xml" 
+       media-type="application/marc"/>
+   …
+&lt;/metadata></pre>
+					</aside>
+
+					<p>The value of the <code>media-type</code> attribute is not always sufficient to identify the type
+						of Linked Resource (e.g., many XML-based record formats use the media type
+							"<code>application/xml</code>"). To aid Reading Systems in the identification of such
+						generic resources, EPUB Creators MAY specify a semantic identifier in the
+							<code>properties</code> attribute.</p>
+
+					<aside class="example" title="Identifying a record type via a property">
+						<p>In this example, the <code>properties</code> attribute identifies the link is to a XMP
+							record.</p>
+
+						<pre>&lt;metadata …>
+   …
+   &lt;link rel="record"
+       href="http://example.org/meta/12389347?format=xmp"
+       media-type="application/xml"
+       properties="xmp"/>
+   …
+&lt;/metadata></pre>
+					</aside>
+
+					<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a href="#sec-default-vocab"
+							>default vocabulary</a> for the <code>rel</code> and <code>properties</code> attributes.</p>
+
+					<p><a>EPUB Creators</a> MAY add relationships and properties from other vocabularies as defined in
+							<a href="#sec-vocab-assoc"></a>.</p>
+
+					<aside class="example" title="Declaring a new link relationship">
+						<p>In this example, the <code>link</code> element is used to associate an author's home page
+							using the FOAF vocabulary. Note that as <code>foaf</code> is not a <a
+								href="#sec-metadata-reserved-prefixes">predefined prefix</a>, it must be declared in the
+								<a href="#attrdef-package-prefix">prefix attribute</a>.</p>
+
+						<pre>&lt;package
+    …
+    prefix="foaf: http://xmlns.com/foaf/spec/">
+   &lt;metadata …>
+      … 
+      &lt;link
+          refines="#creator01"
+          rel="foaf:homepage"
+          href="http://example.org/book-info/12389347" />
+      …
+   &lt;/metadata> 
+   …
+&lt;/package>
+</pre>
+					</aside>
+
+					<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB Creators MAY provide one or more <a
+							href="#record">linked metadata records</a> to enhance the information available to Reading
+						Systems, but Reading Systems may ignore these records.</p>
+
+					<p>When a Reading System <a data-cite="epub-rs-33#sec-linked-records">processes linked records</a>
+						[[EPUB-RS-33]], the document order of <code>link</code> elements is used to determine which has
+						the highest priority in the case of conflicts (i.e., first in document order has the highest
+						priority).</p>
+
+					<aside class="example" title="Specifying metadata precedence">
+						<p>In this example, the first remote record has the highest precedence, the local record has the
+							next highest, and the metadata in the <code>metadata</code> element the lowest.</p>
+
+						<pre>&lt;metadata …>
+   &lt;link rel="record"
+       href="http://example.org/onix/12389347"
+       media-type="application/xml"
+       properties="onix" />
+    
+   &lt;link rel="record"
+       href="meta/meta.jsonld"
+       media-type="application/ld+json" />
+    
+    &lt;dc:title>The Sound and The Fury&lt;/dc:title>
+    &lt;dc:identifier>urn:isbn:9780101010101&lt;/dc:identifier>
+    &lt;dc:language>en-us&lt;/dc:language>
+    …
+&lt;/metadata></pre>
+					</aside>
+
+					<div class="note">
+						<p>Due to the variety of metadata record formats and serializations that an EPUB Creator can
+							link to an EPUB Publication, and the complexity of comparing metadata properties between
+							them, this specification does not require Reading Systems to process linked records.</p>
+					</div>
+
+					<p>In addition to full records, EPUB Creators MAY also use the <code>link</code> element to identify
+						individual metadata properties available in an alternative format.</p>
+
+					<aside class="example" title="Link to a description">
+						<p>In this example, the description of the EPUB Publication is contained in an HTML
+							document.</p>
+
+						<pre>&lt;metadata …>
+   …
+   &lt;link
+       rel="dcterms:description"
+       href="description.html"
+       media-type="text/html"/>
+   …
+&lt;/metadata></pre>
+					</aside>
+				</section>
+			</section>
+
+			<section id="sec-pkg-manifest">
+				<h3>Manifest Section</h3>
+
+				<section id="sec-manifest-elem">
+					<h4>The <code>manifest</code> Element</h4>
+
+					<p>The <code>manifest</code> element provides an exhaustive list of <a>Publication Resources</a>
+						used in the rendering of the content.</p>
+
+					<dl id="elemdef-opf-manifest" class="elemdef">
+						<dt>Element Name:</dt>
+						<dd>
+							<p>
+								<code>manifest</code>
+							</p>
+						</dd>
+
+						<dt>Usage:</dt>
+						<dd>
+							<p>REQUIRED second child of <a class="codelink" href="#elemdef-opf-package"
+										><code>package</code></a>, following <a class="codelink"
+									href="#elemdef-opf-metadata"><code>metadata</code></a>.</p>
+						</dd>
+
+						<dt>Attributes:</dt>
+						<dd>
+							<p>
+								<a href="#attrdef-id">
+									<code>id</code>
+								</a>
+								<code>[optional]</code>
+							</p>
+						</dd>
+
+						<dt>Content Model:</dt>
+						<dd>
+							<p>
+								<a class="codelink" href="#elemdef-package-item">
+									<code>item</code>
+								</a>
+								<code>[1 or more]</code>
+							</p>
+						</dd>
+					</dl>
+
+					<p id="confreq-rendition-manifest">EPUB Creators MUST list all <a>Publication Resources</a> in the
+							<code>manifest</code>, regardless of whether they are <a data-lt="Local Resource">Local</a>
+						or <a>Remote Resources</a>, using <a class="codelink" href="#sec-item-elem"><code>item</code>
+							elements</a>.</p>
+
+					<p>Note that the <code>manifest</code> is not self-referencing: EPUB Creators MUST NOT specify an
+							<code>item</code> element that refers to the Package Document itself.</p>
+
+					<div class="note">
+						<p>Failure to provide a complete manifest of resources may lead to rendering issues. Reading
+							Systems might not unzip such resources or could prevent access to them for security
+							reasons.</p>
+					</div>
+				</section>
+
+				<section id="sec-item-elem">
+					<h4>The <code>item</code> Element</h4>
+
+					<p>The <code>item</code> element represents a <a>Publication Resource</a>.</p>
+
+					<dl id="elemdef-package-item" class="elemdef">
+						<dt>Element Name:</dt>
+						<dd>
+							<p>
+								<code>item</code>
+							</p>
+						</dd>
+
+						<dt>Usage:</dt>
+						<dd>
+							<p>As a child of <a class="codelink" href="#elemdef-opf-manifest"><code>manifest</code></a>.
+								Repeatable.</p>
+						</dd>
+
+						<dt>Attributes:</dt>
+						<dd>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#attrdef-item-fallback">
+											<code>fallback</code>
+										</a>
+										<code>[conditionally required]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-href">
+											<code>href</code>
+										</a>
+										<code>[required]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-id">
+											<code>id</code>
+										</a>
+										<code>[required]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-item-media-overlay">
+											<code>media-overlay</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-item-media-type">
+											<code>media-type</code>
+										</a>
+										<code>[required]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#sec-item-resource-properties">
+											<code>properties</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+							</ul>
+						</dd>
+						<dt>Content Model:</dt>
+						<dd>
+							<p>Empty</p>
+						</dd>
+					</dl>
+
+					<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL [[URL]] in its
+							<code>href</code> attribute. The value MUST be an <a data-cite="url#absolute-url-string"
+							>absolute-</a> or <a data-cite="url#path-relative-scheme-less-url-string"
+							>path-relative-scheme-less-URL</a> string [[URL]]. EPUB Creators MUST ensure each URL is
+						unique within the <code>manifest</code> scope after <a href="#sec-parse-package-urls"
+							>parsing</a>.</p>
+
+					<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code> element
+						MUST conform to the applicable specification(s) as inferred from the MIME media type provided in
+						the <a href="#attrdef-media-type"><code>media-type</code> attribute</a>. For <a>Core Media Type
+							Resources</a>, EPUB Creators MUST use the media type designated in <a
+							href="#sec-core-media-types"></a>.</p>
+
+					<p id="attrdef-item-fallback">The <code>fallback</code> attribute takes an IDREF [[XML]] that
+						identifies a fallback for the Publication Resource referenced from the <code>item</code>
+						element, as defined in <a href="#sec-manifest-fallbacks"></a>.</p>
+
+					<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF [[XML]]
+						that identifies the <a>Media Overlay Document</a> for the resource described by this
+							<code>item</code>. Refer to <a href="#sec-docs-package"></a> for more information.</p>
+
+					<div class="note">
+						<p>The order of <code>item</code> elements in the <code>manifest</code> is not significant. The
+								<a class="codelink" href="#sec-spine-elem"><code>spine</code> element</a> provides the
+							presentation sequence of content documents.</p>
+					</div>
+
+					<section id="sec-item-resource-properties">
+						<h6>Resource Properties</h6>
+
+						<p>The <a href="#attrdef-properties"><code>properties</code> attribute</a> provides information
+							to <a>Reading Systems</a> about the content of a resource. This information enables
+							discovery of key resources, such as the cover image and <a>EPUB Navigation Document</a>. It
+							also allows Reading Systems to optimize rendering by indicating, for example, whether the
+							resource contains embedded scripting, MathML, or SVG.</p>
+
+						<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
+								Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
+								<code>properties</code> attribute.</p>
+
+						<p>EPUB Creators MUST set the following properties whenever a resource referenced by an
+								<code>item</code> element matches their respective definitions:</p>
+
+						<ul>
+							<li><a href="#sec-mathml">mathml</a></li>
+							<li><a href="#sec-remote-resources">remote-resources</a></li>
+							<li><a href="#sec-scripted">scripted</a></li>
+							<li><a href="#sec-svg">svg</a></li>
+							<li><a href="#sec-switch">switch</a></li>
+						</ul>
+
+						<aside class="example" id="example-item-properties-scripted-mathml"
+							title="Identifying a Scripted Content Document with embedded MathML">
+							<pre class="synopsis">&lt;item
+    properties="scripted mathml"
+    id="c2"
+    href="c2.xhtml"
+    media-type="application/xhtml+xml" /&gt;
+</pre>
+						</aside>
+
+						<p>These properties do not apply recursively to content included into a resource (e.g., via the
+							HTML <code>iframe</code> element). For example, if a non-scripted XHTML Content Document
+							embeds a scripted Content Document, only the embedded document's manifest <code>item</code>
+							<code>properties</code> attribute will have the <code>scripted</code> value.</p>
+
+						<p>EPUB Creators MUST declare exactly one <code>item</code> as the EPUB Navigation Document
+							using the <a href="#sec-nav-prop"><code>nav</code> property</a>.</p>
+
+						<aside class="example" id="example-item-properties-nav"
+							title="Identifying the EPUB Navigation Document">
+							<pre class="synopsis">&lt;item
+    properties="nav"
+    id="c1"
+    href="c1.xhtml"
+    media-type="application/xhtml+xml" /&gt;</pre>
+						</aside>
+
+						<p>If an EPUB Publication contains a cover image, it is recommended to set the <a
+								href="#sec-cover-image"><code>cover-image</code> property</a>, but setting this property
+							is OPTIONAL.</p>
+
+						<aside class="example" id="example-item-properties-cover-image"
+							title="Identifying the cover image">
+							<pre class="synopsis">&lt;item
+    properties="cover-image"
+    id="ci"
+    href="cover.svg"
+    media-type="image/svg+xml" /&gt;</pre>
+						</aside>
+
+						<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+							></a>.</p>
+					</section>
+
+					<section id="sec-item-elem-examples">
+						<h6>Examples</h6>
+
+						<aside class="example" id="example-manifest-cmt"
+							title="A manifest with only Core Media Type Resources">
+							<pre>&lt;package …>
+   …
+   &lt;manifest>
+      &lt;item
+          id="nav" 
+          href="nav.xhtml" 
+          properties="nav"
+          media-type="application/xhtml+xml"/>
+      &lt;item
+          id="intro" 
+          href="intro.xhtml" 
+          media-type="application/xhtml+xml"/>
+      &lt;item
+          id="c1" 
+          href="chap1.xhtml" 
+          media-type="application/xhtml+xml"/>
+      &lt;item
+          id="c1-answerkey" 
+          href="chap1-answerkey.xhtml" 
+          media-type="application/xhtml+xml"/>
+      &lt;item
+          id="c2" 
+          href="chap2.xhtml" 
+          media-type="application/xhtml+xml"/>
+      &lt;item
+          id="c2-answerkey" 
+          href="chap2-answerkey.xhtml" 
+          media-type="application/xhtml+xml"/>
+      &lt;item
+          id="c3" 
+          href="chap3.xhtml" 
+          media-type="application/xhtml+xml"/>
+      &lt;item
+          id="c3-answerkey" 
+          href="chap3-answerkey.xhtml" 
+          media-type="application/xhtml+xml"/>    
+      &lt;item
+          id="notes" 
+          href="notes.xhtml" 
+          media-type="application/xhtml+xml"/>
+      &lt;item
+          id="cover" 
+          href="./images/cover.svg" 
+          properties="cover-image"
+          media-type="image/svg+xml"/>
+      &lt;item
+          id="f1" 
+          href="./images/fig1.jpg" 
+          media-type="image/jpeg"/>
+      &lt;item
+          id="f2" 
+          href="./images/fig2.jpg" 
+          media-type="image/jpeg"/>
+      &lt;item
+          id="css" 
+          href="./style/book.css" 
+          media-type="text/css"/>   
+   &lt;/manifest>
+   …
+&lt;/package></pre>
+						</aside>
+
+						<aside class="example" id="example-manifest-flbk"
+							title="Foreign Content Document in Spine with Fallback">
+							<p>The following example shows the <a href="#sec-manifest-fallbacks">fallback chain
+									mechanism</a> allowing a <a>Foreign Content Document</a> (JPEG) to be listed in the
+								spine with fallback to an SVG Content Document.</p>
+
+							<pre>&lt;package …>
+   …
+   &lt;manifest>
+      …
+      &lt;item
+          id="page-001"
+          href="images/page-001.jpg"
+          media-type="image/jpeg"
+          fallback="#page-001-svg"/>
+
+      &lt;item
+          id="page-001-svg"
+          href="images/page-001.svg"
+          media-type="image/svg+xml"/>
+      … 
+      …
+   &lt;/manifest>
+   &lt;spine>
+      …
+      &lt;itemref idref="page-001"/>
+      …
+   &lt;/spine>
+&lt;/package></pre>
+						</aside>
+
+						<aside class="example"
+							title="Embedded Core Media Type Resource with Link to View as Top-Level Content Document">
+							<p>The following example shows a JPEG embedded in an EPUB Content Document (via the
+									<code>img</code> tag) with a hyperlink that allows it to open as a separate page
+								(e.g., for easier zooming). Although embedding the image using the <code>img</code> tag
+								does not require it to be listed in the <a href="#sec-spine-elem">spine</a> or have a
+								fallback, adding the hyperlink causes the document to open as a <a>Top-Level Content
+									Document</a>. As its use in the spine makes it a <a>Foreign Content Document</a>,
+								the EPUB Creator must include a fallback to an EPUB Content Document.</p>
+
+							<pre>XHTML:
+&lt;html …>
+   …
+   &lt;body>
+      …
+      &lt;img
+          src="images/infographic.jpg"
+          alt="…"/>
+      &lt;a
+          href="images/infographic.jpg">
+         Expand Image
+      &lt;/a>
+      …
+   &lt;/body>
+&lt;/html>
+
+Package Document:
+&lt;package …>
+   …
+   &lt;manifest>
+      …
+      &lt;item
+          id="img01"
+          href="images/infographic.jpg"
+          media-type="image/jpeg"
+          fallback="#infographic-svg"/>
+
+      &lt;item
+          id="infographic-svg"
+          href="images/infographic.svg"
+          media-type="image/svg+xml"/>
+      …
+   &lt;/manifest>
+   &lt;spine>
+      …
+      &lt;itemref
+          idref="img01"
+          properties="layout-pre-paginated"
+          linear="no"/>
+      …
+   &lt;/spine>
+&lt;/package></pre>
+						</aside>
+
+						<aside class="example" title="Link to View Foreign Resource as Top-Level Content Document">
+							<p>The following example shows a link to the raw CSV data file. The data will open in the
+								Reading System as a <a>Top-Level Content Document</a> the EPUB Creator must list it in
+								the spine. As its use in the spine makes it a <a>Foreign Content Document</a>, the EPUB
+								Creator must also provide a fallback to an <a>EPUB Content Document</a>. Because there
+								is no guarantee users will be able to access the data in its raw form, instructions on
+								how to extract the file from the <a>EPUB Container</a> are also provided.</p>
+
+							<pre>XHTML:
+&lt;html …>
+   …
+   &lt;body>
+      …
+      &lt;p>
+         &lt;a href="../data/raw.csv">
+            [Open the raw CSV data for this project.]
+         &lt;/a>
+      &lt;/p>
+      &lt;p class="small">To extract the data file
+         from this publication, unzip the EPUB file.
+         The data is located in the
+      	&lt;code>/EPUB/data/raw.csv&lt;/code> file.
+      &lt;/p>
+      …
+   &lt;/body>
+&lt;/html>
+
+Package Document:
+&lt;package …>
+   …
+   &lt;manifest>
+      …
+      &lt;item
+          id="data01"
+          href="data/raw.csv"
+          media-type="text/csv"
+          fallback="#data-html"/>
+
+      &lt;item
+          id="data-html"
+          href="xhtml/data-table.html"
+          media-type="application/xhtml+xml"/>
+      …
+   &lt;/manifest>
+   &lt;spine>
+      …
+      &lt;itemref
+          idref="data01"
+          linear="no"/>
+      …
+   &lt;/spine>
+&lt;/package></pre>
+						</aside>
+
+						<aside class="example" title="Remote Resources that are Publication Resources">
+							<p>The following example shows a reference to a remote audio file. Because the
+									<code>audio</code> element embeds the audio in its EPUB Content Document, the file
+								is considered a Publication Resource. The EPUB Creator therefore must list the audio
+								file in the manifest and indicate that its parent EPUB Content Document contains a
+								remote resource.</p>
+
+							<pre>XHTML:
+&lt;html …>
+   …
+   &lt;body>
+      …
+      &lt;audio
+          src="http://www.example.com/book/audio/ch01.mp4"
+          controls="controls"/>
+      …
+   &lt;/body>
+&lt;/html>
+
+Package Document:
+&lt;package …>
+   …
+   &lt;manifest>
+      …
+      &lt;item
+          id="audio01"
+          href="http://www.example.com/book/audio/ch01.mp4"
+          media-type="audio/mp4"/>
+   
+      &lt;item
+          id="c01"
+          href="XHTML/chapter001.xhtml"
+          media-type="application/xhtml+xml"
+          properties="remote-resources"/>
+      …
+   &lt;/manifest>
+   …
+&lt;/package></pre>
+						</aside>
+
+						<aside class="example" title="External Resources that are not Publication Resources">
+							<p>The following example shows a hyperlink to an audio file hosted on the web. Reading
+								Systems will open such external content in a new browser window; it is not rendered
+								within the publication. In this case, the EPUB Creator does not list the file in the
+								manifest because it is not a Publication Resource.</p>
+
+							<pre>XHTML:
+&lt;html …>
+   …
+   &lt;body>
+      …
+      &lt;a
+          href="http://www.example.com/book/audio/ch01.mp4">
+         Listen to audio
+      &lt;/a>
+      …
+   &lt;/body>
+&lt;/html>
+
+Manifest:
+No Entry</pre>
+						</aside>
+					</section>
+				</section>
+
+				<section id="sec-opf-bindings">
+					<h4>The <code>bindings</code> Element (Deprecated)</h4>
+
+					<p>The <code>bindings</code> element defines a set of custom handlers for media types not supported
+						by this specification.</p>
+
+					<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
+
+					<p>Refer to the <a
+							href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
+								><code>bindings</code> element definition</a> in [[EPUBPublications-301]] for more
+						information.</p>
+				</section>
+			</section>
+
+			<section id="sec-pkg-spine">
+				<h3>Spine Section</h3>
+
+				<section id="sec-spine-elem">
+					<h4>The <code>spine</code> Element</h4>
+
+					<p>The <code>spine</code> element defines an ordered list of <a href="#sec-itemref-elem">manifest
+								<code>item</code> references</a> that represent the default reading order.</p>
+
+					<dl id="elemdef-opf-spine" class="elemdef">
+						<dt>Element Name:</dt>
+						<dd>
+							<p>
+								<code>spine</code>
+							</p>
+						</dd>
+
+						<dt>Usage:</dt>
+						<dd>
+							<p>REQUIRED third child of <a class="codelink" href="#elemdef-opf-package"
+										><code>package</code></a>, following <a class="codelink"
+									href="#elemdef-opf-manifest"><code>manifest</code></a>.</p>
+						</dd>
+
+						<dt>Attributes:</dt>
+						<dd>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#attrdef-id">
+											<code>id</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-spine-page-progression-direction">
+											<code>page-progression-direction</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#sec-opf2-ncx">
+											<code>toc</code>
+										</a>
+										<code>[optional]</code>
+										<a href="#legacy" class="legacy">(legacy)</a>
+									</p>
+								</li>
+							</ul>
+						</dd>
+
+						<dt>Content Model:</dt>
+						<dd>
+							<p>
+								<a class="codelink" href="#elemdef-spine-itemref">
+									<code>itemref</code>
+								</a>
+								<code>[1 or more]</code>
+							</p>
+						</dd>
+					</dl>
+
+					<p id="confreq-pub-resource">The <code>spine</code> MUST specify at least one <a>EPUB Content
+							Document</a> or <a>Foreign Content Document</a>.</p>
+
+					<p id="spine-inclusion-req">EPUB Creators MUST list in the <code>spine</code> all EPUB and Foreign
+						Content Documents that are hyperlinked to from Publication Resources in the <code>spine</code>,
+						where hyperlinking encompasses any linking mechanism that requires the user to navigate away
+						from the current resource. Common hyperlinking mechanisms include the <code>href</code>
+						attribute of the [[HTML]] <a data-cite="html#the-a-element"><code>a</code></a> and <a
+							data-cite="html#the-area-element"><code>area</code></a> elements and scripted links (e.g.,
+						using DOM Events and/or form elements). The requirement to list hyperlinked resources applies
+						recursively (i.e., EPUB Creators must list all EPUB and Foreign Content Documents hyperlinked to
+						from hyperlinked documents, and so on.).</p>
+
+					<p>EPUB Creators also MUST list in the <code>spine</code> all EPUB and Foreign Content Documents
+						hyperlinked to from the <a>EPUB Navigation Document</a>, regardless of whether EPUB Creators
+						include the Navigation Document in the <code>spine</code>.</p>
+
+					<div class="note">
+						<p>As hyperlinks to resources outside the EPUB Container are not Publication Resources, they are
+							not subject to the requirement to include in the spine (e.g., web pages and web-hosted
+							resources).</p>
+
+						<p>Publication Resources used in the rendering of spine items (e.g., referenced from [[HTML]] <a
+								data-cite="html#embedded-content-2">embedded content</a>) similarly do not have to be
+							included in the spine.</p>
+					</div>
+
+					<p id="attrdef-spine-page-progression-direction">The <code>page-progression-direction</code>
+						attribute sets the global direction in which the content flows. Allowed values are
+							<code>ltr</code> (left-to-right), <code>rtl</code> (right-to-left) and <code>default</code>.
+						When EPUB Creators specify the <code>default</code> value, they are expressing no preference and
+						the Reading System can choose the rendering direction.</p>
+
+					<p>Although the <code>page-progression-direction</code> attribute sets the global flow direction,
+						individual Content Documents and parts of Content Documents MAY override this setting (e.g., via
+						the <code>writing-mode</code> CSS property). Reading Systems may also provide mechanisms to
+						override the default direction (e.g., buttons or settings that allow the application of
+						alternate style sheets).</p>
+
+					<p>The <a href="#legacy">legacy</a>
+						<code>toc</code> attribute takes an IDREF [[XML]] that identifies the manifest item that
+						represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
+				</section>
+
+				<section id="sec-itemref-elem">
+					<h4>The <code>itemref</code> Element</h4>
+
+					<p>The <code>itemref</code> element identifies an <a>EPUB Content Document</a> or <a>Foreign Content
+							Document</a> in the default reading order.</p>
+
+					<dl id="elemdef-spine-itemref" class="elemdef">
+						<dt>Element Name:</dt>
+						<dd>
+							<p>
+								<code>itemref</code>
+							</p>
+						</dd>
+
+						<dt>Usage:</dt>
+						<dd>
+							<p>As a child of <a class="codelink" href="#elemdef-opf-spine"><code>spine</code></a>.
+								Repeatable.</p>
+						</dd>
+
+						<dt>Attributes:</dt>
+						<dd>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#attrdef-id">
+											<code>id</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-itemref-idref">
+											<code>idref</code>
+										</a>
+										<code>[required]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-itemref-linear">
+											<code>linear</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-properties">
+											<code>properties</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+							</ul>
+						</dd>
+
+						<dt>Content Model:</dt>
+						<dd>
+							<p>Empty</p>
+						</dd>
+					</dl>
+
+					<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an <a
+							href="#elemdef-package-item"><code>item</code></a> in the <a>manifest</a> via the
+						IDREF [[XML]] in its <code>idref</code> attribute, and item IDs MUST NOT be referenced more than
+						once. </p>
+
+					<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a) an
+							<a>EPUB Content Document</a> or b) a <a>Foreign Content Document</a> which, <em>regardless
+							of whether it is a <a>Core Media Type Resource</a> or a <a>Foreign Resource</a></em>, MUST
+						include an EPUB Content Document in its <a href="#sec-manifest-fallbacks">fallback
+						chain</a>.</p>
+
+					<div class="note">
+						<p>Although EPUB Publications <a href="#confreq-nav">require an EPUB Navigation Document</a>, it
+							is not mandatory to include it in the <code>spine</code>.</p>
+
+					</div>
+
+					<p id="attrdef-itemref-linear">The <code>linear</code> attribute indicates whether the referenced
+							<code>item</code> contains content that contributes to the primary reading order and that
+						Reading Systems must read sequentially ("<code>yes</code>"), or auxiliary content that enhances
+						or augments the primary content that Reading Systems can access out of sequence
+							("<code>no</code>"). Examples of auxiliary content include notes, descriptions, and answer
+						keys.</p>
+
+					<p>The <code>linear</code> attribute allows Reading Systems to distinguish content that a user
+						should access as part of the default reading order from supplementary content which a Reading
+						System might, for example, present in a popup window or omit from an aural rendering.</p>
+
+					<p>Specifying that content is non-linear does not require Reading Systems to present it in a
+						specific way, however; it is only a hint to the purpose. Reading Systems may present non-linear
+						content where it occurs in the spine, for example, or may skip it until users reach the end of
+						the spine.</p>
+
+					<div class="note">
+						<p>EPUB Creators should list non-linear content at the end of the spine except when it makes
+							sense for users to encounter it between linear spine items.</p>
+
+					</div>
+
+					<p id="linear-itemrefs"> A linear <code>itemref</code> element is one whose <code>linear</code>
+						attribute value is explicitly set to "<code>yes</code>" or that omits the attribute — Reading
+						Systems will assume the value "<code>yes</code>" for <code>itemref</code> elements without the
+						attribute. The spine MUST contain at least one linear <code>itemref</code> element. </p>
+
+					<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide a means
+						of accessing all non-linear content (e.g., hyperlinks in the content or from the <a
+							href="#sec-nav">EPUB Navigation Document</a>).</p>
+
+					<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine Properties
+							Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
+							<code>properties</code> attribute.</p>
+
+					<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+						></a>.</p>
+
+					<aside class="example" title="A basic spine">
+						<p>In this example, the spine entries correspond to <a href="#example-manifest-cmt">the manifest
+								example above</a>.</p>
+
+						<pre>&lt;spine
+    page-progression-direction="ltr">
+   &lt;itemref
+       idref="intro"/>
+   &lt;itemref
+       idref="c1"/>
+   &lt;itemref
+       idref="c1-answerkey"
+       linear="no"/>
+   &lt;itemref
+       idref="c2"/>
+   &lt;itemref
+       idref="c2-answerkey"
+       linear="no"/>
+   &lt;itemref
+       idref="c3"/>
+   &lt;itemref
+       idref="c3-answerkey"
+       linear="no"/>
+   &lt;itemref
+       idref="notes"
+       linear="no"/>
+&lt;/spine>
+</pre>
+					</aside>
+				</section>
+			</section>
+
+			<section id="sec-pkg-collections">
+				<h3>Collections</h3>
+
+				<section id="sec-collection-elem">
+					<h4>The <code>collection</code> Element</h4>
+
+					<p>The <code>collection</code> element defines a related group of resources.</p>
+
+					<dl id="elemdef-collection" class="elemdef">
+						<dt>Element Name:</dt>
+						<dd>
+							<p>
+								<code>collection</code>
+							</p>
+						</dd>
+
+						<dt>Usage:</dt>
+						<dd>
+							<p>OPTIONAL sixth element of <code>package</code>. Repeatable.</p>
+						</dd>
+
+						<dt>Attributes:</dt>
+						<dd>
+							<ul class="nomark">
+								<li>
+									<p>
+										<a href="#attrdef-dir">
+											<code>dir</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-id">
+											<code>id</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-collection-role">
+											<code>role</code>
+										</a>
+										<code>[required]</code>
+									</p>
+								</li>
+								<li>
+									<p>
+										<a href="#attrdef-xml-lang">
+											<code>xml:lang</code>
+										</a>
+										<code>[optional]</code>
+									</p>
+								</li>
+							</ul>
+						</dd>
+
+						<dt>Content Model:</dt>
+						<dd>
+							<p>In this order: <code>metadata</code>
+								<code>[0 or 1]</code>, ( <a href="#elemdef-collection"><code>collection</code></a>
+								<code>[1 or more]</code> or ( <a href="#elemdef-collection"><code>collection</code></a>
+								<code>[0 or more]</code>, <code>link</code>
+								<code>[1 or more]</code> ))</p>
+						</dd>
+					</dl>
+
+					<p>The <code>collection</code> element allows EPUB Creators to assemble resources into logical
+						groups for a variety of potential uses: enabling reassembly into a meaningful unit of content
+						split across multiple <a>EPUB Content Documents</a> (e.g., an index split across multiple
+						documents), identifying resources for specialized purposes (e.g., preview content), or
+						collecting together resources that present additional information about the <a>EPUB
+							Publication</a>.</p>
+
+					<p id="attrdef-collection-role">EPUB Creators MUST identify the role of each <code>collection</code>
+						element in its <code>role</code> attribute, whose value MUST be one or more NMTOKENs
+						[[XMLSCHEMA-2]] and/or <a data-cite="url#absolute-url-with-fragment-string"
+							>absolute-URL-with-fragment strings</a> [[URL]].</p>
+
+					<p>The requirements for authoring specialized collections are defined by their respective
+						specifications.</p>
+
+					<div class="note">
+						<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3 Working
+							Group maintained both a <a href="http://www.idpf.org/epub/registries/roles">registry of role
+								extensions</a> and a list of <a href="http://www.idpf.org/epub/extensions/roles">custom
+								extension roles</a>. This Working Group no longer maintains these registries.</p>
+					</div>
+
+					<aside class="example" title="A multi-document index">
+						<pre>&lt;collection role="index">
+   &lt;link href="subjectIndex01.xhtml"/>
+   &lt;link href="subjectIndex02.xhtml"/>
+   &lt;link href="subjectIndex03.xhtml"/>
+&lt;/collection></pre>
+					</aside>
+				</section>
+
+				<section id="sec-defining-collection-types">
+					<h4>Defining Collection Types (Deprecated)</h4>
+
+					<p>The creation of new <code>collection</code> element roles is now <a href="#deprecated"
+							>deprecated</a>.</p>
+
+					<p>Refer to the <a
+							href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
+								><code>collection</code> element definition</a> in [[EPUBPackages-32]] for more
+						information about the creation of specialized collections, including the requirements and
+						restrictions on their use.</p>
+				</section>
+			</section>
+
+			<section id="sec-pkg-legacy">
+				<h3>Legacy Content</h3>
+
+				<section id="sec-opf2-meta">
+					<h4>The <code>meta</code> Element</h4>
+
+					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"><code>meta</code>
+							element</a> [[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided a
+						means of including generic metadata. The EPUB 3 <a href="#sec-meta-elem"><code>meta</code>
+							element</a>, which uses different attributes and requires text content, replaces this
+						element.</p>
+
+					<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
+								><code>meta</code> element definition</a> in [[OPF-201]] for more information.</p>
+
+					<div class="note">
+						<p>The [[OPF-201]] <code>meta</code> element is retained in EPUB 3 primarily so that EPUB
+							Creators can identify the cover image for compatibility with EPUB 2 Reading Systems. In EPUB
+							3, the cover image must be identified using the <a href="#sec-cover-image"
+									><code>cover-image</code> property</a> on the <a href="#sec-item-elem">manifest
+									<code>item</code></a> for the image.</p>
+
+					</div>
+				</section>
+
+				<section id="sec-opf2-guide">
+					<h4>The <code>guide</code> Element</h4>
+
+					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code>
+							element</a> [[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided
+						machine-processable navigation to key structures. The <a href="#sec-nav-landmarks">landmarks
+							nav</a> in the <a>EPUB Navigation Document</a> replaces this element.</p>
+
+					<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
+								><code>guide</code> element definition</a> in [[OPF-201]] for more information.</p>
+				</section>
+
+				<section id="sec-opf2-ncx">
+					<h4>NCX</h4>
+
+					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a>
+						[[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table of
+						contents. The <a href="#sec-nav">EPUB Navigation Document</a> replaces this document.</p>
+
+					<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
+							definition</a> in [[OPF-201]] for more information.</p>
+				</section>
+			</section>
+		</section>
+		<section id="sec-contentdocs">
+			<h2>EPUB Content Documents</h2>
+
+			<section id="sec-xhtml">
+				<h3>XHTML Content Documents</h3>
+
+				<section id="sec-xhtml-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>This section defines a profile of [[HTML]] for creating XHTML Content Documents. An instance of
+						an XML document that conforms to this profile is a <a>Core Media Type Resource</a> and is
+						referred to in this specification as an <a>XHTML Content Document</a>.</p>
+				</section>
+
+				<section id="sec-xhtml-req">
+					<h4>XHTML Requirements</h4>
+
+					<p>An XHTML Content Document:</p>
+
+					<ul class="conformance-list">
+						<li>
+							<p id="confreq-cd-html-docprops-syntax">MUST be an [[HTML]] document that conforms to the <a
+									data-cite="html#the-xhtml-syntax">XML</a> syntax.</p>
+						</li>
+						<li>
+							<p id="confreq-cd-html-docprops-html">MUST conform to the conformance criteria for all
+								document constructs defined by [[HTML]] unless explicitly overridden in <a
+									href="#sec-xhtml-deviations"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-cd-html-docprops-schema">MAY include extensions to the [[HTML]] grammar as
+								defined in <a href="#sec-xhtml-extensions"></a>, and MUST conform to all content
+								conformance constraints defined therein.</p>
+						</li>
+					</ul>
+					<p>Unless specified otherwise, XHTML Content Documents inherit all definitions of semantics,
+						structure, and processing behaviors from the [[HTML]] specification.</p>
+
+					<div class="note">
+						<p>The recommendation that EPUB Publications follow the accessibility requirements in
+							[[EPUB-A11Y-11]] applies to XHTML Content Documents. See <a href="#confreq-a11y"
+								>Accessibility</a>.</p>
+
+					</div>
+				</section>
+
+				<section id="sec-xhtml-extensions">
+					<h4>HTML Extensions</h4>
+
+					<p>This section defines EPUB 3 <a>XHTML Content Document</a> extensions to the underlying [[HTML]]
+						document model.</p>
+
+					<div class="note">
+						<p>Although [[HTML]] allows user agents to support <a data-cite="html#extensibility-2"
+								>vendor-neutral extensions</a>, unless such extensions are listed in this section, they
+							are not supported features of EPUB 3.</p>
+
+					</div>
+					<section id="sec-xhtml-structural-semantics">
+						<h5>Structural Semantics</h5>
+
+						<p>EPUB Creators MAY use the <a href="#sec-epub-type-attribute"><code>epub:type</code>
+								attribute</a> in <a>XHTML Content Documents</a> to express <a
+								href="#sec-structural-semantics-intro">structural semantics</a>.</p>
+
+						<p>As the [[HTML]] <a data-cite="html#the-head-element"><code>head</code> element</a> contains
+							metadata for the document, structural semantics expressed on this element or any descendant
+							of it have no meaning.</p>
+					</section>
+
+					<section id="sec-xhtml-rdfa">
+						<h5>RDFa</h5>
+
+						<p>The [[HTML-RDFA]] specification defines a set of attributes that EPUB Creators MAY use in
+								<a>XHTML Content Documents</a> to semantically enrich the content. The use of these
+							attributes MUST conform to the requirements defined in [[HTML-RDFA]].</p>
+
+						<p>The [[HTML-RDFA]] specification defines changes to the [[HTML]] content model when authors
+							use RDFa attributes. This modified content model is valid in XHTML Content Documents.</p>
+
+						<div class="note">
+							<p>The listing of RDFa does not express a preference on the part of the Working Group, only
+								that these attributes represent an extension of the HTML grammar. EPUB Creators can also
+								specify <a data-cite="html#microdata">microdata attributes</a> [[HTML]] and <a
+									data-cite="json-ld11#">linked data</a> [[JSON-LD11]] in XHTML Content Documents as
+								both are natively supported.</p>
+
+						</div>
+					</section>
+
+					<section id="sec-xhtml-content-switch">
+						<h5>Content Switching (Deprecated)</h5>
+
+						<p>The <code>switch</code> element provides a simple mechanism through which <a>EPUB
+								Creators</a> can tailor the content displayed to users, one that is not dependent on the
+							scripting capabilities of the <a>EPUB Reading System</a>.</p>
+
+						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
+
+						<p>Refer to the <a
+								href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
+									><code>switch</code> element definition</a> in [[EPUBContentDocs-301]] for more
+							information.</p>
+					</section>
+
+					<section id="sec-xhtml-epub-trigger">
+						<h5>The <code>epub:trigger</code> Element (Deprecated)</h5>
+
+						<p>The <code>trigger</code> element enables the creation of markup-defined user interfaces for
+							controlling multimedia objects, such as audio and video playback, in both scripted and
+							non-scripted contexts.</p>
+
+						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
+
+						<p>Refer to the <a
+								href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
+									><code>epub:trigger</code> element definition</a> in [[EPUBContentDocs-301]] for
+							more information.</p>
+					</section>
+
+					<section id="sec-xhtml-custom-attributes">
+						<h5>Custom Attributes</h5>
+
+						<p><a>XHTML Content Documents</a> MAY contain custom attributes, which are <a
+								data-cite="xml-names#NT-Prefix">prefixed</a> [[XML-NAMES]] attributes whose namespace
+							URL does not include either of the following strings in its <a
+								data-cite="url#concept-domain">domain</a> [[URL]]:</p>
+
+						<ul>
+							<li><code>w3.org</code></li>
+							<li><code>idpf.org</code></li>
+						</ul>
+						<p>When using custom attributes, the content MUST remain consumable by a user without any
+							information loss or other significant deterioration, regardless of the Reading System it is
+							rendered on.</p>
+
+						<div class="note">
+							<p>Custom attributes are usually defined in a Reading System-specific manner and are not
+								intended for use by other Reading Systems. This specification should be extended to
+								provide extensions that multiple independent Reading Systems can use.</p>
+						</div>
+					</section>
+				</section>
+
+				<section id="sec-xhtml-deviations">
+					<h4>HTML Deviations and Constraints</h4>
+
+					<p>This section defines deviations from, and constraints on, the underlying [[HTML]] document model
+						applicable to EPUB 3 <a>XHTML Content Documents</a>.</p>
+
+					<section id="sec-xhtml-mathml">
+						<h5>Embedded MathML</h5>
+
+						<p>XHTML Content Documents support embedded [[MATHML3]]. Occurrences of MathML markup MUST
+							conform to the constraints expressed in the MathML specification [[MATHML3]], with the
+							following additional restrictions:</p>
+
+						<dl class="conformance-list">
+							<dt id="math-pres">Presentation MathML</dt>
+							<dd>
+								<p id="confreq-mathml-pres">The <code>math</code> element MUST contain only <a
+										data-cite="mathml3/chapter3.html#">Presentation MathML</a>, except within the
+										<code>annotation-xml</code> element.</p>
+							</dd>
+
+							<dt id="math-cont">Content MathML</dt>
+							<dd>
+								<p id="confreq-mathml-annot-cont">EPUB Creators MAY include <a
+										data-cite="mathml3/chapter4.html#">Content MathML</a> within MathML markup in
+									XHTML Content Documents, and, when present, MUST include it within an
+										<code>annotation-xml</code> child element of a <code>semantics</code>
+									element.</p>
+								<p id="confreq-mathml-annot-cont-attrs">When EPUB Creators include Content MathML per
+									the previous condition, they MUST set the given <code>annotation-xml</code>
+									element's <code>encoding</code> attribute to either of the functionally-equivalent
+									values <code>MathML-Content</code> or <code>application/mathml-content+xml</code>,
+									and the <code>name</code> attribute to <code>contentequiv</code>.</p>
+							</dd>
+						</dl>
+
+						<p>This subset eases the implementation burden on Reading Systems and promotes accessibility,
+							while retaining compatibility with [[HTML]] user agents.</p>
+
+						<div class="note">
+							<p>The <a href="#mathml"><code>mathml</code> property</a> of the <a>manifest</a>
+								<code>item</code> element indicates that an XHTML Content Document contains embedded
+								MathML.</p>
+
+						</div>
+					</section>
+
+					<section id="sec-xhtml-svg">
+						<h5>Embedded SVG</h5>
+
+						<p><a>XHTML Content Documents</a> support the embedding of <a
+								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
+								fragments</a> [[SVG]] <em>by reference</em> (embedding via reference, for example, from
+							an <code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
+							direct inclusion of the <code>svg</code> element in the XHTML Content Document).</p>
+
+						<p>The content conformance constraints for SVG embedded in XHTML Content Documents are the same
+							as defined for <a>SVG Content Documents</a> in <a href="#sec-svg-restrictions"></a>.</p>
+
+						<div class="note">
+							<p>The <a href="#svg"><code>svg</code> property</a> of the <a>manifest</a>
+								<a href="#sec-item-elem"><code>item</code> element</a> indicates that an XHTML Content
+								Document contains embedded SVG.</p>
+
+						</div>
+					</section>
+
+					<section id="sec-xhtml-deviations-discouraged" class="informative">
+						<h5>Discouraged Constructs</h5>
+
+						<section id="sec-xhtml-deviations-base">
+							<h6>The <code>base</code> Element</h6>
+
+							<p id="confreq-html-vocab-base"> The [[HTML]] <a data-cite="html#the-base-element"
+										><code>base</code></a> element can be used to specify the <a
+									data-cite="html#document-base-url">document base URL</a> for the purposes of parsing
+								URLs. When using it in an <a>EPUB Publication</a>, the interpretation of the
+									<code>base</code> elements may inadvertently result in references to <a>Remote
+									Resources</a>, i.e., resources that are outside the <a>EPUB Container</a>. Using the
+									<code>base</code> element in an <a>EPUB Publication</a> may cause Reading Systems to
+								misinterpret the location of resources (e.g., relative links to other documents in the
+								publication might appear as links to a web site if the <code>base</code> element
+								specifies an absolute URL). To avoid significant interoperability issues, EPUB Creators
+								should not use the <code>base</code> element. </p>
+						</section>
+
+						<section id="sec-xhtml-deviations-rp">
+							<h6>The <code>rp</code> Element</h6>
+
+							<p id="confreq-html-vocab-rp">The [[HTML]] <a data-cite="html#the-rp-element"
+										><code>rp</code></a> element is intended to provide a fallback for older
+									<a>Reading Systems</a> that do not recognize ruby markup (i.e., a parenthesis
+								display around <code>ruby</code> markup). As EPUB 3 Reading Systems are ruby-aware, and
+								can provide fallbacks, EPUB Creators should not use <code>rp</code> elements.</p>
+						</section>
+
+						<section id="sec-xhtml-deviations-embed">
+							<h6>The <code>embed</code> Element</h6>
+
+							<p id="confreq-html-vocab-embed">Since the [[HTML]] <a data-cite="html#the-embed-element"
+										><code>embed</code></a> element does not include intrinsic facilities to provide
+								fallback content for Reading Systems that do not support scripting, <a>EPUB Creators</a>
+								are discouraged from using the element when the referenced resource includes scripting.
+								The [[HTML]] <a data-cite="html#the-object-element"><code>object</code> element</a> is a
+								better alternative, as it includes intrinsic fallback capabilities.</p>
+						</section>
+					</section>
+				</section>
+			</section>
+
+			<section id="sec-svg">
+				<h3>SVG Content Documents</h3>
+
+				<div class="caution">
+					<p><a>Reading Systems</a> may not support all the features of [[SVG]] or supported them across all
+						platforms that Reading Systems run on. When utilizing such features, <a>EPUB Creators</a> should
+						consider the inherent risks on interoperability and document longevity.</p>
+
+				</div>
+
+				<section id="sec-svg-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>The Scalable Vector Graphics (SVG) specification [[SVG]] defines a format for representing
+						final-form vector graphics and text.</p>
+
+					<p>Although <a>EPUB Creators</a> typically use <a href="#sec-xhtml">XHTML Content Documents</a> as
+						the <a data-lt="Top-level Content Document">top-level</a> document type, the use of <a>SVG
+							Content Documents</a> is also permitted. EPUB Creators will typically only need SVGs for
+						certain special cases, such as when final-form page images are the only suitable representation
+						of the content (e.g., for cover art or in the context of manga or comic books).</p>
+
+					<p>This section defines a profile for [[SVG]] documents. An instance of an XML document that
+						conforms to this profile is a <a>Core Media Type Resource</a> and is referred to in this
+						specification as an <a>SVG Content Document</a>.</p>
+
+					<div class="note">
+						<p>This section defines conformance requirements for <a>SVG Content Documents</a>. Refer to <a
+								href="#sec-xhtml-svg"></a> for the conformance requirements for SVG embedded in XHTML
+							Content Documents.</p>
+
+					</div>
+				</section>
+
+				<section id="sec-svg-req">
+					<h4>SVG Requirements</h4>
+
+					<p>An SVG Content Document:</p>
+
+					<ul class="conformance-list">
+						<li>
+							<p id="confreq-cd-svg-docprops-schema">MUST be a <a
+									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles"
+									>conforming SVG stand-alone file</a> [[SVG]] and conform to all content conformance
+								constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
+						</li>
+						<li>
+							<p id="confreq-svg-structural-semantics">MAY specify the <a href="#attrdef-epub-type"
+										><code>epub:type</code></a> attribute for expressing <a
+									href="#app-structural-semantics">structural semantics</a> and use all applicable <a
+									href="#sec-vocab-assoc">vocabulary association mechanisms</a>.</p>
+						</li>
+					</ul>
+					<div class="note">
+						<p>The recommendation that EPUB Publications follow the accessibility requirements in
+							[[EPUB-A11Y-11]] applies to SVG Content Documents. See <a href="#confreq-a11y"
+								>Accessibility</a>.</p>
+
+					</div>
+				</section>
+
+				<section id="sec-svg-restrictions">
+					<h4>Restrictions on SVG</h4>
+
+					<p>This specification restricts the content model of <a>SVG Content Documents</a> and <a
+							href="#sec-xhtml-svg">SVG embedded in XHTML Content Documents</a> as follows:</p>
+
+					<ul class="conformance-list">
+						<li>
+							<p id="confreq-svg-foreignObject">The [[SVG]] <a
+									href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
+										><code>foreignObject</code></a> element:</p>
+							<ul class="conformance-list">
+								<li>
+									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[HTML]] <a
+											data-cite="html#flow-content">flow content</a> or exactly one [[HTML]] <a
+											data-cite="html#the-body-element"><code>body</code> element</a>.</p>
+									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
+											<code>body</code> element is not permitted per the <a data-cite="html#svg-0"
+											>restrictions on SVG</a> defined in [[HTML]].</p>
+								</li>
+								<li>
+									<p id="confreq-svg-foreignObject-xhtml-frag">MUST contain a valid document fragment
+										that conforms to the XHTML Content Document model defined in <a
+											href="#sec-xhtml-req"></a>.</p>
+								</li>
+							</ul>
+						</li>
+						<li>
+							<p id="confreq-svg-title">The [[SVG]] <a
+									href="https://www.w3.org/TR/SVG/struct.html#TitleElement"><code>title</code></a>
+								element MUST contain only valid <a href="#sec-xhtml-req">XHTML Content Document Phrasing
+									content</a>.</p>
+						</li>
+					</ul>
+				</section>
+			</section>
+
+			<section id="sec-common-resource-req">
+				<h3>Common Resource Requirements</h3>
+
+				<p>This section defines requirements for technologies usable in both XHTML and SVG Content
+					Documents.</p>
+
+				<section id="sec-css">
+					<h3>Cascading Style Sheets (CSS)</h3>
+
+					<section id="sec-css-intro" class="informative">
+						<h4>Introduction</h4>
+
+						<p>CSS is an integral part of the Open Web Platform. Readers, publishers, and document authors
+							expect CSS to "just work," as they expect HTML to just work.</p>
+
+						<p>In the past, EPUB defined a profile of CSS that mandated support for certain properties and
+							provided prefixed versions of numerous other properties. Although the CSS Working Group no
+							longer recommends the use of prefixed properties, this specification maintains some prefixed
+							properties to avoid breaking existing content. But with the minor exceptions defined in this
+							section, EPUB defers to the W3C to define CSS.</p>
+
+						<div class="note">
+							<p>Keep in mind that some <a>Reading Systems</a> will not support all desired features of
+								CSS. The following are known to be particularly problematic:</p>
+
+							<ul>
+								<li>
+									<p>Reading System-induced pagination can interact poorly with style sheets as
+										Reading Systems sometimes paginate using columns. This may result in incorrect
+										values for viewport sizes. Fixed and absolute positioning are particularly
+										problematic.</p>
+								</li>
+								<li>
+									<p>Some types of screens will render animations and transitions poorly (e.g., those
+										with high latency).</p>
+								</li>
+							</ul>
+						</div>
+					</section>
+
+					<section id="sec-css-req">
+						<h4>CSS Requirements</h4>
+
+						<p>A CSS style sheet:</p>
+
+						<ul class="conformance-list">
+							<li>
+								<p id="confreq-css-props">MAY include any CSS properties, with the following
+									exceptions:</p>
+								<ul class="conformance-list">
+									<li>
+										<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
+												data-cite="css-writing-modes-3#direction"><code>direction</code>
+												property</a> [[CSS-Writing-Modes-3]].</p>
+									</li>
+									<li>
+										<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT include the <a
+												data-cite="css-writing-modes-3#unicode-bidi"><code>unicode-bidi</code>
+												property</a> [[CSS-Writing-Modes-3]].</p>
+									</li>
+								</ul>
+							</li>
+							<li>
+								<p id="confreq-css-prefixed">MAY include the prefixed properties defined in <a
+										href="#sec-css-prefixed"></a>.</p>
+							</li>
+							<li>
+								<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8
+									as the RECOMMENDED encoding.</p>
+							</li>
+						</ul>
+						<div class="note">
+							<p>This specification restricts the use of the <code>direction</code> and
+									<code>unicode-bidi</code> properties because Reading Systems may not implement, or
+								may switch off, CSS processing. EPUB Creators must use the following format-specific
+								methods when they need control over these aspects of the rendering:</p>
+
+							<ul>
+								<li>
+									<p>the <a data-cite="html#the-dir-attribute"><code>dir</code> attribute</a> [[HTML]]
+										and <a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
+												><code>direction</code> attribute</a> [[SVG]] for inline base
+										directionality.</p>
+								</li>
+								<li>
+									<p>the <a data-cite="html#the-bdo-element"><code>bdo</code> element</a> with the <a
+											data-cite="html#the-dir-attribute"><code>dir</code> attribute</a> [[HTML]]
+										and the <a href="https://www.w3.org/TR/SVG/styling.html#PresentationAttributes"
+											>presentation attribute alternative</a> for <code>unicode-bidi</code>
+										[[SVG]] for bidirectionality.</p>
+								</li>
+							</ul>
+						</div>
+					</section>
+
+					<section id="sec-css-prefixed">
+						<h4>Prefixed Properties</h4>
+
+						<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to
+							world languages were not yet mature. To ensure backwards compatibility for content authored
+							using these prefixes, they have been retained in this specification. Unless otherwise noted,
+							prefixed properties and values behave exactly as their unprefixed equivalents as described
+							in the appropriate CSS specification. The prefixed properties are documented in <a
+								href="#css-prefixes"></a>. </p>
+
+						<div class="caution">
+							<p><a>EPUB Creators</a> should use unprefixed properties and <a>Reading Systems</a> should
+								support current CSS specifications. This specification retains the widely used prefixed
+								properties from [[EPUBContentDocs-301]] but removes support for the less-used ones. EPUB
+								Creators should use CSS-native solutions for the removed properties whenever
+								available.</p>
+
+							<p>The Working Group recommends that EPUB Creators currently using these prefixed properties
+								move to unprefixed versions as soon as support allows, as the Working Group does not
+								anticipate supporting them in the next major version of EPUB.</p>
+
+						</div>
+
+						<p class="note">In some cases, the unprefixed versions of these properties now support
+							additional values. Reading Systems may support these values even with the prefixed
+							property.</p>
+					</section>
+				</section>
+
+				<section id="sec-scripted-content">
+					<h3>Scripting</h3>
+
+					<section id="sec-scripted-support">
+						<h4>Script Inclusion</h4>
+
+						<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in
+							the respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB Content
+							Document contains scripting, this specification refers to it as a <a>Scripted Content
+								Document</a>. This label also applies to <a>XHTML Content Documents</a> when they
+							contain instances of [[HTML]] <a data-cite="html#forms">forms</a>.</p>
+
+						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
+							<code>item</code> element is used to indicate that an EPUB Content Document is a <a>Scripted
+								Content Document</a>.</p>
+
+						<p>When an [[HTML]] <code>script</code> element contains a <a data-cite="html#data-block">data
+								block</a> [[HTML]], it does not represent scripted content.</p>
+
+						<div class="note">
+							<p>[[SVG]] does not define data blocks as of publication, but the same exclusion would apply
+								if a future update adds the concept.</p>
+						</div>
+
+						<p>EPUB Creators should note that Reading Systems are required to behave as though a unique <a
+								data-cite="url#origin">origin</a> [[URL]] has been assigned to each EPUB Publication. In
+							practice, this means that it is not possible for scripts to share data between EPUB
+							Publications.</p>
+
+						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
+							rights and restrictions that a Reading System places on it (refer to <a
+								data-cite="epub-rs-33#sec-scripted-content">Scripting Conformance</a> [[?EPUB-RS-33]]
+							for more information).</p>
+
+						<div class="note">
+							<p>Reading Systems may render Scripted Content Documents in a manner that disables other
+								EPUB capabilities and/or provides a different rendering and user experience (e.g., by
+								disabling pagination).</p>
+						</div>
+					</section>
+
+					<section id="sec-scripted-context">
+						<h4>Scripting Contexts</h4>
+
+						<p>EPUB 3 defines two contexts for script execution:</p>
+
+						<ul>
+							<li><a href="#sec-scripted-container-constrained">container constrained</a> &#8212; when the
+								execution of a script occurs within an <code>iframe</code>; and</li>
+							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a script
+								occurs directly within a <a>Top-level Content Document</a>.</li>
+						</ul>
+
+						<div class="note">
+							<p>Scripts may execute in other contexts, but Reading System support for these contexts is
+								optional. For example, a scripted SVG document may be referenced from an [[HTML]] <a
+									data-cite="html#the-object-element"><code>object</code> tag</a>.</p>
+							<p>Refer to the <a href="https://www.w3.org/TR/epub-rs-33#sec-scripted-content">processing
+									of scripts</a> [[EPUB-RS-33]] for more information.</p>
+						</div>
+
+						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference
+							it via the element's <code>src</code> attribute makes no difference to its executing
+							context.</p>
+
+						<p>Which context EPUB Creators use for their scripts affects both what actions the scripts can
+							perform and the likelihood of support in Reading Systems, as described in the following
+							subsections.</p>
+
+						<div class="note">
+							<p>Refer to <a href="#scripted-contexts-example"></a> for an example of the difference
+								between the two contexts.</p>
+						</div>
+
+						<section id="sec-scripted-container-constrained">
+							<h5>Container-Constrained Scripts</h5>
+
+							<p>A <em>container-constrained script</em> is either of the following:</p>
+
+							<ul>
+								<li>
+									<p>An instance of the [[HTML]] <a data-cite="html#the-script-element"
+												><code>script</code></a> element contained in an <a>XHTML Content
+											Document</a> that is embedded in an XHTML Content Document using the
+										[[HTML]] <a data-cite="html#the-iframe-element"><code>iframe</code></a>
+										element.</p>
+								</li>
+								<li>
+									<p>An instance of the [[SVG]] <a
+											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
+												><code>script</code></a> element contained in an <a>SVG Content
+											Document</a> that is embedded in a XHTML Content Document using the [[HTML]]
+											<a data-cite="html#the-iframe-element"><code>iframe</code></a> element.</p>
+								</li>
+							</ul>
+
+							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
+								instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e.,
+								the one that contains the <code>iframe</code> element). It also MUST NOT contain
+								instructions for manipulating the size of its containing rectangle.</p>
+
+							<p>EPUB Creators should note that <a data-cite="epub-rs-33#sec-scripted-content">support for
+									container-constrained scripting in Reading Systems</a> is only recommended in
+								reflowable documents [[EPUB-RS-33]]. Furthermore, Reading System support in
+								fixed-layouts EPUBs is optional.</p>
+
+							<p>EPUB Creators should ensure container-constrained scripts degrade gracefully in Reading
+								Systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
+
+							<div class="note">
+								<p>EPUB Creators choosing to restrict the usage of scripting to the
+									container-constrained model will ensure a more consistent user experience between
+									scripted and non-scripted content (e.g., consistent pagination behavior).</p>
+
+							</div>
+						</section>
+
+						<section id="sec-scripted-spine">
+							<h5>Spine-Level Scripts</h5>
+
+							<p>A <em>spine-level script</em> is an instance of the [[HTML]] <a
+									data-cite="html#the-script-element"><code>script</code></a> or [[SVG]] <a
+									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
+								element contained in a <a>Top-level Content Document</a>.</p>
+
+							<p>EPUB Creators should note that support for spine-level scripting in Reading Systems is
+								only recommended in <a data-cite="epub-rs-33#confreq-rs-scripted-fxl-support"
+									>fixed-layout documents</a> and <a
+									data-cite="epub-rs-33#confreq-rs-scripted-scrolled">reflowable documents set to
+									scroll</a> [[EPUB-RS-33]]. Furthermore, Reading System support in all other contexts
+								is optional.</p>
+
+							<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include
+								spine-level scripting SHOULD remain consumable by the user without any information loss
+								or other significant deterioration when scripting is disabled or not available (e.g., by
+								employing progressive enhancement techniques or <a href="#sec-scripted-fallbacks"
+									>fallbacks</a>). Failing to account for non-scripted environments in Top-level
+								Content Documents can result in EPUB Publications being unreadable.</p>
+						</section>
+					</section>
+
+					<section id="sec-scripted-content-events" class="informative">
+						<h4>Event Model</h4>
+
+						<p><a>EPUB Creators</a> should consider the wide variety of possible Reading System
+							implementations when adding scripting functionality to their EPUB Publications (e.g., not
+							all devices have physical keyboards, and in many cases a soft keyboard is activated only for
+							text input elements). Consequently, EPUB Creators should not rely on keyboard events alone;
+							they should always provide alternative ways to trigger a desired action.</p>
+					</section>
+
+					<section id="sec-scripted-a11y">
+						<h4>Scripting Accessibility</h4>
+
+						<p id="confreq-cd-scripted-a11y">EPUB Content Documents that contain scripting SHOULD employ
+							relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable
+							by all users.</p>
+					</section>
+
+					<section id="sec-scripted-fallbacks">
+						<h4 id="confreq-cd-scripted-flbk">Scripting Fallbacks</h4>
+
+						<p id="confreq-cd-scripted-fallback">EPUB Content Documents that contain scripting MAY provide
+							fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
+							available for the [[HTML]] <a data-cite="html#the-object-element"><code>object</code></a>
+							and <a data-cite="html#the-canvas-element"><code>canvas</code></a> elements) or, when an
+							intrinsic fallback is not applicable, by using a <a href="#sec-manifest-fallbacks"
+								>manifest-level fallback</a>.</p>
+
+						<p id="confreq-cd-scripted-foreign-resources">EPUB Creators MUST ensure that scripts only
+							generate <a href="#sec-core-media-types">Core Media Type Resources</a> or fragments
+							thereof.</p>
+					</section>
+				</section>
+			</section>
+		</section>
+		<section id="sec-nav">
+			<h2>EPUB Navigation Document</h2>
+
+			<section id="sec-nav-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>The EPUB Navigation Document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
+						Publication</a>. It allows <a>EPUB Creators</a> to include a human- and machine-readable global
+					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
+
+				<p>The EPUB Navigation Document is a special type of <a>XHTML Content Document</a> that defines the <a
+						href="#sec-nav-toc">table of contents</a> for <a>Reading Systems</a>. It may also include other
+					specialized navigation elements, such as a <a href="#sec-nav-pagelist">page list</a> and a list of
+					key <a href="#sec-nav-landmarks">landmarks</a>. These navigation elements have <a
+						href="#sec-nav-def-model">additional restrictions</a> on their content to facilitate their
+					processing.</p>
+
+				<p>The EPUB Navigation Document is not exclusively for machine processing, however. There are no
+					restrictions on the structure or content of the EPUB Navigation Document outside of the specialized
+					navigation elements (i.e., EPUB Creators can mark the rest of the document up like any other XHTML
+					Content Document). As a result, it can also be part of the linear reading order, avoiding the need
+					for duplicate tables of contents. EPUB Creators can hide navigation elements that are only for
+					machine processing (e.g., the page list) with the <a href="#sec-nav-doc-use-spine"
+							><code>hidden</code> attribute</a>.</p>
+
+				<p>Note that Reading Systems may strip scripting, styling, and HTML formatting as they generate
+					navigational interfaces from information found in the EPUB Navigation Document, and this may make
+					the result difficult to read. If EPUB Creators require such formatting and functionality, then they
+					should also include the EPUB Navigation Document in the <a>spine</a>. The use of progressive
+					enhancement techniques for scripting and styling of the navigation document will help ensure the
+					content will retain its integrity when rendered in a non-browser context.</p>
+			</section>
+
+			<section id="sec-nav-def-model">
+				<h3>The <code>nav</code> Element: Restrictions</h3>
+
+				<p>When a <code>nav</code> element carries the <a href="#sec-epub-type-attribute"><code>epub:type</code>
+						attribute</a> in an <a>EPUB Navigation Document</a>, this specification restricts the content
+					model of the element and its descendants as follows:</p>
+
+				<dl class="elemdef">
+					<dt>Content Model:</dt>
+					<dd>
+						<dl class="variablelist">
+							<dt>
+								<a data-cite="html#the-nav-element">
+									<code>nav</code>
+								</a>
+							</dt>
+							<dd>
+								<p>In this order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a data-cite="html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements">
+												<code>h1-h6</code>
+											</a>
+											<code>[0 or 1]</code>
+										</p>
+									</li>
+									<li>
+										<p>
+											<code>ol</code>
+											<code>[exactly 1]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
+
+							<dt>
+								<a data-cite="html#the-ol-element">
+									<code>ol</code>
+								</a>
+							</dt>
+							<dd>
+								<p>In this order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<code>li</code>
+											<code>[1 or more]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
+
+							<dt>
+								<a data-cite="html#the-li-element">
+									<code>li</code>
+								</a>
+							</dt>
+							<dd>
+								<p>In this order:</p>
+								<ul class="nomark">
+									<li>
+										<p> (<code>span</code> or <code>a</code>) <code>[exactly 1]</code></p>
+									</li>
+									<li>
+										<p>
+											<code>ol</code>
+											<code>[conditionally required]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
+
+							<dt><a data-cite="html#the-span-element"><code>span</code></a> and <a
+									data-cite="html#the-a-element"><code>a</code></a></dt>
+							<dd>
+								<p>In any order:</p>
+								<ul class="nomark">
+									<li>
+										<p>
+											<a data-cite="html#phrasing-content">
+												<code>HTML Phrasing content</code>
+											</a>
+											<code>[1 or more]</code>
+										</p>
+									</li>
+								</ul>
+							</dd>
+						</dl>
+						<p>Note that there are no restrictions on the attributes allowed on these elements.</p>
+						<p>Refer the definition below for additional requirements.</p>
+					</dd>
+				</dl>
+
+				<p>The following elaboration of the content model of the <code>nav</code> element explains the purpose
+					and restrictions of the various elements:</p>
+
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-nav-ol">The <code>ol</code> child of the <code>nav</code> element represents the
+							primary level of content navigation.</p>
+					</li>
+					<li>
+						<p id="confreq-nav-a">Each list item of the ordered list represents a heading, structure, or
+							other item of interest. A child <code>a</code> element describes the target that the link
+							points to, while a <code>span</code> element serves as a heading for breaking down lists
+							into distinct groups (for example, an EPUB Creator could segment a large list of
+							illustrations into several lists, one for each chapter).</p>
+					</li>
+					<li>
+						<p id="confreq-nav-a-cnt">The child <code>a</code> or <code>span</code> element MUST provide a
+							non-zero-length text label after concatenation of all child content and application of white
+							space normalization rules. When determining compliance with this requirement, the
+							concatenated label MUST include text content contained in <code>title</code> or
+								<code>alt</code> attributes for non-textual descendant elements.</p>
+					</li>
+					<li>
+						<p id="confreq-nav-a-title">If an <code>a</code> or <code>span</code> element contains instances
+							of <a data-cite="html#embedded-content">HTML embedded content</a> that do not provide
+							intrinsic text alternatives, the element MUST also contain a <code>title</code> attribute
+							with an alternate text rendering of the link label.</p>
+					</li>
+					<li>
+						<p id="confreq-nav-a-href">The URL [[URL]] reference provided in the <code>href</code> attribute
+							of the <code>a</code> element:</p>
+						<ul class="conformance-list">
+							<li>
+								<p id="confreq-nav-a-href-default">MUST, in the case of the <a href="#sec-nav-toc"
+											><code>toc nav</code></a>, <a href="#sec-nav-landmarks"><code>landmarks
+											nav</code></a> and <a href="#sec-nav-pagelist"><code>page-list
+										nav</code></a>, resolve to a <a>Top-level Content Document</a> or fragment
+									therein.</p>
+							</li>
+							<li>
+								<p id="confreq-nav-a-href-other">MAY, for all other <code>nav</code> types, also
+									reference <a>Remote Resources</a>.</p>
+							</li>
+						</ul>
+					</li>
+					<li>
+						<p id="confreq-nav-a-nest">An <code>ol</code> (ordered list) element representing a subsidiary
+							content level (e.g., all the subsection headings of a section) MAY follow an <code>a</code>
+							element.</p>
+					</li>
+					<li>
+						<p id="confreq-nav-span-nest">An <code>ol</code> (ordered list) element MUST follow a
+								<code>span</code> element (<code>span</code> elements cannot occur in "leaf"
+								<code>li</code> elements).</p>
+					</li>
+					<li>
+						<p id="confreq-nav-sublist">Regardless of whether an <code>a</code> or <code>span</code> element
+							precedes it, every sublist MUST adhere to the content requirements defined in this section
+							for constructing the primary navigation list.</p>
+					</li>
+				</ul>
+				<aside class="example" title="Basic patterns of a navigation element">
+					<pre>&lt;nav epub:type="…">
+   &lt;h1>…&lt;/h1>
+   &lt;ol>
+      &lt;li>
+         &lt;a href="chap1.xhtml">
+            A basic leaf node
+         &lt;/a>
+      &lt;/li>
+      &lt;li>
+         &lt;a href="chap2.xhtml">
+            A linked heading
+         &lt;/a>
+         &lt;ol>
+            …
+         &lt;/ol>
+      &lt;/li>
+      &lt;li>
+         &lt;span>An unlinked heading&lt;/span>
+         &lt;ol>
+            …
+         &lt;/ol>
+      &lt;/li>
+   &lt;/ol>
+&lt;/nav></pre>
+				</aside>
+
+				<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, EPUB Creators MAY include
+					the EPUB Navigation Document in the <a href="#sec-spine-elem">spine</a>.</p>
+
+				<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
+					items within <code>nav</code> elements is equivalent to the <a
+						href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:</code>
+						<code>none</code> property</a> [[CSSSnapshot]]. <a>EPUB Creators</a> MAY specify alternative
+					list styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
+							><code>spine</code></a>.</p>
+			</section>
+
+			<section id="sec-nav-def-types">
+				<h3>The <code>nav</code> Element: Types</h3>
+
+				<section id="sec-nav-def-types-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>The <code>nav</code> elements defined in an EPUB Navigation Document are distinguished
+						semantically by the value of their <a href="#sec-epub-type-attribute"><code>epub:type</code>
+							attribute</a>.</p>
+
+					<p>This specification defines three types of navigation aid:</p>
+
+					<dl class="variablelist">
+						<dt>
+							<a href="#sec-nav-toc">
+								<code>toc</code>
+							</a>
+						</dt>
+						<dd>
+							<p>Identifies the <code>nav</code> element that contains the table of contents. The
+									<code>toc</code>
+								<code>nav</code> is the only navigation aid that EPUB Creators must include in the EPUB
+								Navigation Document.</p>
+						</dd>
+
+						<dt>
+							<a href="#sec-nav-pagelist">
+								<code>page-list</code>
+							</a>
+						</dt>
+						<dd>
+							<p>Identifies the <code>nav</code> element that contains a list of pages for a print or
+								other statically paginated source.</p>
+						</dd>
+
+						<dt>
+							<a href="#sec-nav-landmarks">
+								<code>landmarks</code>
+							</a>
+						</dt>
+						<dd>
+							<p>Identifies the <code>nav</code> element that contains a list of points of interest.</p>
+						</dd>
+					</dl>
+
+					<p>An EPUB Navigation Document may contain at most one navigation aid for each of these types.</p>
+
+					<p>The EPUB Navigation Document may include additional navigation types. See <a
+							href="#sec-nav-def-types-other"></a> for more information.</p>
+				</section>
+
+				<section id="sec-nav-toc">
+					<h4>The <code>toc nav</code> Element </h4>
+
+					<p>The <code>toc</code>
+						<code>nav</code> element defines the primary navigational hierarchy. It conceptually corresponds
+						to a table of contents in a printed work (i.e., it provides navigation to the major structural
+						sections of the publication).</p>
+
+					<p>The <code>toc</code>
+						<code>nav</code> element MUST occur exactly once in an EPUB Navigation Document.</p>
+
+					<p>EPUB Creators SHOULD order the references in the <code>toc</code>
+						<code>nav</code> element such that they reflect both:</p>
+
+					<ul>
+						<li>
+							<p>the order of the <a href="#confreq-nav-a-href">referenced EPUB Content Documents</a> in
+								the <a>spine</a>; and</p>
+						</li>
+						<li>
+							<p>the order of the targeted elements within their respective EPUB Content Documents.</p>
+						</li>
+					</ul>
+				</section>
+
+				<section id="sec-nav-pagelist">
+					<h4>The <code>page-list nav</code> Element </h4>
+
+					<p>The <code>page-list</code> element provides navigation to static page boundaries in the content.
+						These boundaries may correspond to a statically paginated source such as print or may be defined
+						exclusively for the <a>EPUB Publication</a>.</p>
+
+
+					<p>The <code>page-list</code>
+						<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more than
+						once.</p>
+
+					<p>The <code>page-list</code>
+						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
+						nested sublists).</p>
+
+					<p>EPUB Creators MAY identify the destinations of the <code>page-list</code> references in their
+						respective EPUB Content Documents using the <a data-cite="epub-ssv-11/#pagebreak"
+								><code>pagebreak</code> term</a> [[EPUB-SSV-11]].</p>
+				</section>
+
+				<section id="sec-nav-landmarks">
+					<h4>The <code>landmarks nav</code> Element</h4>
+
+					<p>The <code>landmarks</code>
+						<code>nav</code> element identifies fundamental structural components in the content to enable
+						Reading Systems to provide the user efficient access to them (e.g., through a dedicated button
+						in the user interface).</p>
+
+					<p>The <code>landmarks</code>
+						<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more than
+						once.</p>
+
+					<p>The <code>landmarks</code>
+						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
+						nested sublists).</p>
+
+					<p>The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is REQUIRED on
+							<code>a</code> element descendants of the <code>landmarks</code>
+						<code>nav</code> element. The structural semantics of each link target within the
+							<code>landmarks</code>
+						<code>nav</code> element is determined by the value of this attribute.</p>
+
+					<aside class="example" title="A basic landmarks nav">
+						<p>In this example, the <code>epub:type</code> attribute value are drawn from structural
+							semantics drawn from [[EPUB-SSV-11]].</p>
+
+						<pre>&lt;nav epub:type="landmarks">
+   &lt;h2>Guide&lt;/h2>
+   &lt;ol>
+       &lt;li>
+          &lt;a epub:type="toc"
+             href="#toc">
+            Table of Contents
+          &lt;/a>
+       &lt;/li>
+       &lt;li>
+          &lt;a epub:type="loi"
+             href="content.html#loi">
+            List of Illustrations
+          &lt;/a>
+       &lt;/li>
+       &lt;li>
+          &lt;a epub:type="bodymatter"
+             href="content.html#bodymatter">
+            Start of Content
+          &lt;/a>
+       &lt;/li>
+   &lt;/ol>
+&lt;/nav></pre>
+					</aside>
+
+					<p>The <code>landmarks</code>
+						<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code> value
+						that reference the same resource, or fragment thereof.</p>
+
+					<p>EPUB Creators should limit the number of items they define in the <code>landmarks</code>
+						<code>nav</code> to only items that a Reading System is likely to use in its user interface. The
+						element is not meant to repeat the table of contents.</p>
+
+					<p>The following landmarks are recommended to include when available:</p>
+
+					<ul>
+						<li><a data-cite="epub-ssv-11#bodymatter"><code>bodymatter</code></a> [[?EPUB-SSV-11]] &#8212;
+							Reading Systems often use this landmark to automatically jump users past the front matter
+							when they begin reading.</li>
+						<li><a data-cite="epub-ssv-11#toc-1"><code>toc</code></a> [[?EPUB-SSV-11]] &#8212; If the table
+							of contents is available in the spine, Reading Systems may use this landmark to take users
+							to the document containing it.</li>
+					</ul>
+
+					<p>Other possibilities for inclusion in the <code>landmarks</code>
+						<code>nav</code> are key reference sections such as indexes and glossaries.</p>
+
+					<p>Although the <code>landmarks</code>
+						<code>nav</code> is intended for Reading System use, EPUB Creators should still ensure that the
+						labels for the <code>landmarks</code>
+						<code>nav</code> are human readable. Reading Systems may expose the links directly to users.</p>
+				</section>
+
+				<section id="sec-nav-def-types-other">
+					<h4>Other <code>nav</code> Elements</h4>
+
+					<p>EPUB Navigation Documents MAY contain one or more <code>nav</code> elements in addition to the
+							<code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
+						<code>nav</code> elements defined in the preceding sections. If these <code>nav</code> elements
+						are intended for Reading System processing, they MUST have an <a href="#sec-epub-type-attribute"
+								><code>epub:type</code> attribute</a> and are subject to the content model restrictions
+						defined in <a href="#sec-nav-def-model"></a>.</p>
+
+					<p>This specification imposes no restrictions on the semantics of any additional <code>nav</code>
+						elements: they MAY represent navigational semantics for any information domain, and they MAY
+						contain link targets with homogeneous or heterogeneous semantics.</p>
+
+					<aside class="example" title="Adding a custom navigation element">
+						<p>In this example, the <code>lot</code> semantic indicates that the EPUB Creator is adding a
+							"list of tables" navigation element.</p>
+
+						<pre>&lt;nav
+    epub:type="lot"
+    aria-labelledby="lot">
+   &lt;h2 id="lot">List of tables&lt;/h2>
+   &lt;ol>
+      &lt;li>
+         &lt;span>Tables in Chapter 1&lt;/span>
+         &lt;ol>
+            &lt;li>
+               &lt;a href="chap1.xhtml#table-1.1">
+                  Table 1.1
+               &lt;/a>
+            &lt;/li>
+            &lt;li>
+               &lt;a href="chap1.xhtml#table-1.2">
+                  Table 1.2
+               &lt;/a>
+            &lt;/li>
+         &lt;/ol>
+      &lt;/li>
+      …
+   &lt;/ol>
+&lt;/nav></pre>
+					</aside>
+				</section>
+			</section>
+
+			<section id="sec-nav-doc-use-spine" class="informative">
+				<h3>Using in the Spine</h3>
+
+				<p>Although it is possible to reuse the EPUB Navigation Document in the <a>spine</a>, it is often the
+					case that not all of the navigation structures, or branches within them, are needed. <a>EPUB
+						Creators</a> will often want to hide the <a href="#sec-nav-pagelist">page list</a> and <a
+						href="#sec-nav-landmarks">landmarks</a> navigation elements or trim the branches of the table of
+					contents for books that have many levels of subsections.</p>
+
+				<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
+						property</a> [[CSSSnapshot]] controls the visual rendering of EPUB Navigation Documents in
+					Reading Systems with <a>Viewports</a>, Reading Systems without Viewports may not support CSS. To
+					better ensure the proper rendering in these Reading Systems, EPUB Creators should use the [[HTML]]
+						<a data-cite="html#the-hidden-attribute"><code>hidden</code></a> attribute to indicate which (if
+					any) portions of the navigation data are excluded from rendering in the content flow.</p>
+
+				<p>The <code>hidden</code> attribute has no effect on how Reading Systems render the navigation data
+					outside of the content flow (such as in dedicated navigation user interfaces provided by Reading
+					Systems).</p>
+
+				<div class="note">
+					<p>The <code>hidden</code> attribute can be used together with the <code>display</code> property to
+						maximize interoperability across all Reading Systems.</p>
+				</div>
+
+				<aside class="example" title="Hiding a nav element in spine">
+					<p>In this example, the presence of the <code>hidden</code> attribute on the <code>nav</code>
+						element indicates the page list will be excluded from rendering in the content flow when the
+						document is rendered in the spine.</p>
+
+					<pre>&lt;nav
+    epub:type="page-list"
+    hidden="">
+   &lt;h2>Pagebreaks of the print version, third edition&lt;/h2>
+   &lt;ol>
+      &lt;li>
+         &lt;a href="frontmatter.xhtml#pi">
+            I
+         &lt;/a>
+      &lt;/li>
+      …
+   &lt;/ol>
+&lt;/nav>
+</pre>
+				</aside>
+
+				<aside class="example" title="Hiding branches of a nav element">
+					<p>In this example, the branch (<code>ol</code> element) not wanted for rendering in the spine has
+						the <code>hidden</code> attribute on it. When rendered, this limits the table of content to the
+						two top-most hierarchical levels.</p>
+
+					<pre>&lt;nav
+    epub:type="toc"
+    id="toc">
+   &lt;h1>Table of contents&lt;/h1>
+   &lt;ol>
+      &lt;li>
+         &lt;a href="chap1.xhtml">
+            Chapter 1
+         &lt;/a>
+         &lt;ol>
+            &lt;li>
+               &lt;a href="chap1.xhtml#sec-1.1">
+                  Chapter 1.1
+               &lt;/a>
+               &lt;ol hidden="">
+                  &lt;li>
+                     &lt;a href="chap1.xhtml#sec-1.1.1">
+                        Section 1.1.1
+                     &lt;/a>
+                  &lt;/li>
+                  …
+               &lt;/ol>
+            &lt;/li>
+            …
+         &lt;/ol>
+      &lt;/li>
+      …
+   &lt;/ol>
+&lt;/nav></pre>
+				</aside>
+			</section>
+		</section>
+		<section id="sec-rendering-control">
+			<h2>Layout Rendering Control</h2>
+
+			<section id="sec-general-rendering-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>Not all rendering information can be expressed through the underlying technologies that EPUB is built
+					upon. For example, although HTML with CSS provides powerful layout capabilities, those capabilities
+					are limited to the scope of the document being rendered.</p>
+
+				<p>This section defines properties that allow EPUB Creators to express package-level rendering
+					intentions (i.e., functionality that can only be implemented by the <a>EPUB Reading System</a>). If
+					a Reading System supports the desired rendering, these properties enable the user to be presented
+					the content as the EPUB Creator optimally designed it.</p>
+			</section>
+
+			<section id="sec-fixed-layouts">
+				<h3>Fixed Layouts</h3>
+
+				<section id="fxl-intro" class="informative">
+					<h4>Introduction</h4>
+
+					<p>EPUB documents, unlike print books or PDF files, are designed to change. The content flows, or
+						reflows, to fit the screen and to fit the needs of the user. As noted in <a
+							data-cite="epub-overview-33#sec-rendering">Rendering and CSS</a> "content presentation
+						adapts to the user, rather than the user having to adapt to a particular presentation of
+						content." [[EPUB-OVERVIEW-33]]</p>
+
+					<p>But this principle does not work for all types of documents. Sometimes content and design are so
+						intertwined it is not possible to separate them. Any change in appearance risks changing the
+						meaning or losing all meaning. <a>Fixed-Layout Documents</a> give <a>EPUB Creators</a> greater
+						control over presentation when a reflowable EPUB is not suitable for the content.</p>
+
+					<p>EPUB Creators define fixed layouts using a <a href="#sec-fxl-package">set of Package Document
+							properties</a> to control the rendering in <a>Reading Systems</a>. In addition, they set <a
+							href="#sec-fxl-package">the dimensions of each Fixed-Layout Document</a> in its respective
+						EPUB Content Document.</p>
+
+					<div class="note" id="note-mechanisms">
+						<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
+							content is necessary, the EPUB Creator's choice of mechanism will depend on many factors
+							including desired degree of precision, file size, accessibility, etc. This section does not
+							attempt to dictate the EPUB Creator's choice of mechanism.</p>
+
+					</div>
+				</section>
+
+				<section id="sec-fxl-package">
+					<h4>Fixed-Layout Package Settings</h4>
+
+					<section id="layout">
+						<h5>Layout</h5>
+
+						<p>The <code>rendition:layout</code> property specifies whether the content is reflowable or
+							pre-paginated.</p>
+
+						<p id="property-layout-global">When the <a href="#layout"><code>rendition:layout</code>
+								property</a> is specified on a <code>meta</code> element, it indicates that the
+							paginated or reflowable layout style applies globally (i.e., for all spine items).</p>
+
+						<p>EPUB Creators MUST use one of the following values with the <code>rendition:layout</code>
+							property:</p>
+
+						<dl class="variablelist">
+							<dt id="def-layout-reflowable">reflowable</dt>
+							<dd>
+								<p>The content is not pre-paginated (i.e., Reading Systems apply dynamic pagination when
+									rendering). Default value.</p>
+							</dd>
+
+							<dt id="def-layout-pre-paginated">pre-paginated</dt>
+							<dd>
+								<p>The content is pre-paginated (i.e., Reading Systems produce exactly one page per
+									spine <a href="#elemdef-spine-itemref"><code>itemref</code></a> when rendering).</p>
+							</dd>
+						</dl>
+
+						<div class="note" id="uaag">
+							<p>Reading Systems typically restrict or deny the application of user or user agent style
+								sheets to pre-paginated documents because dynamic style changes are likely to have
+								unintended consequence on the intrinsic properties of such documents. EPUB Creators
+								should consider the negative impact on usability and accessibility that these
+								restrictions have when choosing to use pre-paginated instead of reflowable content.
+								Refer to <a data-cite="UAAG20#gl-text-config">Guideline 1.4 - Provide text
+									configuration</a> [[UAAG20]] for related information.</p>
+
+						</div>
+
+						<p id="fxl-layout-duplication" data-tests="#fxl-layout-duplication">When the property is set to
+								<code>pre-paginated</code> for a spine item, its content dimensions MUST be set as
+							defined in <a href="#sec-fxl-content-dimensions"></a>.</p>
+
+						<p>EPUB Creators MUST NOT declare the <code>rendition:layout</code> property more than once.</p>
+
+						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
+									><code>refines</code> attribute</a>. Refer to <a href="#layout-overrides"></a> for
+							setting the property for individual <a>EPUB Content Documents</a>.</p>
+
+						<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
+							<p>In this example, the document's layout is set to <code>pre-paginated</code>, i.e., it is
+								defined to be a fixed layout document. Furthermore, media queries [[CSS3-MediaQueries]]
+								are used to apply different style sheets for three different device categories. Note
+								that the media queries only affect the style sheet applied to the document; the size of
+								the content area set in the <code>viewport</code>
+								<code>meta</code> tag is static.</p>
+
+							<p>Package Document</p>
+
+							<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      …
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+
+							<p>XHTML</p>
+
+							<pre>&lt;html …>
+   &lt;head>
+      &lt;meta
+          name="viewport"
+          content="width=1200,
+          height=900"/>
+      
+      &lt;link
+          rel="stylesheet"
+          href="eink-style.css"
+          media="(max-monochrome: 3)"/>
+         
+      &lt;link
+          rel="stylesheet"
+          href="skinnytablet-style.css"
+          media="((color) and (max-height:600px) and (orientation:landscape),
+                  (color) and (max-width:600px) and (orientation:portrait))"/>
+      
+      &lt;link
+          rel="stylesheet"
+          href="fattablet-style.css"
+          media="((color) and (min-height:601px) and (orientation:landscape),
+                  (color) and (min-width:601px) and (orientation:portrait))"/>	
+   &lt;/head>
+   …
+&lt;/html></pre>
+						</aside>
+
+						<section id="layout-overrides">
+							<h6>Layout Overrides</h6>
+
+							<p id="property-layout-local">EPUB Creators MAY specify the following properties locally on
+								spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
+									<a href="#property-layout-global">global value</a> for the given spine item:</p>
+
+							<dl>
+								<dt id="layout-pre-paginated">rendition:layout-pre-paginated</dt>
+								<dd>Specifies that the given spine item is pre-paginated.</dd>
+
+								<dt id="layout-reflowable">rendition:layout-reflowable</dt>
+								<dd>Specifies that the given spine item is reflowable.</dd>
+							</dl>
+
+							<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
+						</section>
+					</section>
+
+					<section id="orientation">
+						<h5>Orientation</h5>
+
+						<p>The <code>rendition:orientation</code> property specifies which orientation the EPUB Creator
+							intends the content to be rendered in. </p>
+
+						<p id="property-orientation-global">When the <a href="#orientation"
+									><code>rendition:orientation</code> property</a> is specified on a <code>meta</code>
+							element, it indicates that the intended orientation applies globally (i.e., for all spine
+							items).</p>
+
+						<p>EPUB Creators MUST use one of the following values with the
+								<code>rendition:orientation</code> property:</p>
+
+						<dl class="variablelist">
+							<dt>landscape</dt>
+							<dd>
+								<p>Reading Systems should render the content in landscape orientation.</p>
+							</dd>
+
+							<dt>portrait</dt>
+							<dd>
+								<p>Reading Systems should render the content in portrait orientation.</p>
+							</dd>
+
+							<dt>auto</dt>
+							<dd>
+								<p>The content is not orientation constrained. Default value.</p>
+							</dd>
+						</dl>
+
+						<p id="fxl-orientation-duplication" data-tests="#fxl-orientation-duplication">EPUB Creators MUST
+							NOT declare the <code>rendition:orientation</code> property more than once.</p>
+
+						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
+									><code>refines</code> attribute</a>. Refer to <a href="#orientation-overrides"></a>
+							for setting the property for individual <a>EPUB Content Documents</a>.</p>
+
+						<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
+							<p>In this example, items in the spine are to be rendered in landscape mode.</p>
+
+							<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+
+      &lt;meta
+          property="rendition:orientation">
+         landscape
+      &lt;/meta>
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+						</aside>
+
+						<section id="orientation-overrides">
+							<h6>Orientation Overrides</h6>
+
+							<p id="property-orientation-local">EPUB Creators MAY specify the following properties
+								locally on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
+								override the <a href="#property-orientation-global">global value</a> for the given spine
+								item:</p>
+
+							<dl>
+								<dt id="orientation-auto">rendition:orientation-auto</dt>
+								<dd>Specifies that the Reading System determines the orientation to render the spine
+									item in.</dd>
+
+								<dt id="orientation-landscape">rendition:orientation-landscape</dt>
+								<dd>Specifies that Reading Systems should render the given spine item in landscape
+									orientation.</dd>
+
+								<dt id="orientation-portrait">rendition:orientation-portrait</dt>
+								<dd>Specifies that Reading Systems should render the given spine item in portrait
+									orientation.</dd>
+							</dl>
+
+							<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
+						</section>
+					</section>
+
+					<section id="spread">
+						<h5>Synthetic Spreads</h5>
+
+						<p>The <code>rendition:spread</code> property specifies the intended Reading System synthetic
+							spread behavior.</p>
+
+						<p id="property-spread-global">When the <code>rendition:spread</code> property is specified on a
+								<code>meta</code> element, it indicates that the intended <a>Synthetic Spread</a>
+							behavior applies globally (i.e., for all spine items).</p>
+
+						<p>EPUB Creators MUST use one of the following values with the <code>rendition:spread</code>
+							property:</p>
+
+						<dl class="variablelist">
+							<dt>none</dt>
+							<dd>
+								<p>Do not incorporate spine items in a Synthetic Spread. Reading Systems should display
+									the items in a single viewport positioned at the center of the screen.</p>
+							</dd>
+
+							<dt>landscape</dt>
+							<dd>
+								<p>Render a Synthetic Spread for spine items only when the device is in landscape
+									orientation.</p>
+							</dd>
+
+							<dt>portrait (deprecated)</dt>
+							<dd>
+								<p>The use of spreads only in portrait orientation is <a href="#deprecated"
+										>deprecated</a>.</p>
+								<p>EPUB Creators should use the value "<code>both</code>" instead, as spreads that are
+									readable in portrait orientation are also readable in landscape.</p>
+							</dd>
+
+							<dt>both</dt>
+							<dd>
+								<p>Render a Synthetic Spread regardless of device orientation.</p>
+							</dd>
+
+							<dt>auto</dt>
+							<dd>
+								<p>The EPUB Creator is not defining an explicit Synthetic Spread behavior. Default
+									value.</p>
+							</dd>
+						</dl>
+
+						<p>EPUB Creators MUST NOT declare the <code>rendition:spread</code> property more than once.</p>
+
+						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
+									><code>refines</code> attribute</a>. Refer to <a href="#spread-overrides"></a> for
+							setting the property for individual <a>EPUB Content Documents</a>.</p>
+
+						<div class="note">
+							<p>When Synthetic Spreads are used in the context of HTML and SVG Content Documents, the
+								dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
+									<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"><code>viewBox</code>
+									attribute</a> represents the size of one page in the spread, respectively.</p>
+						</div>
+
+						<div class="note">
+							<p>Refer to <a href="#sec-spine-elem">spine</a> for information about declaration of global
+								flow directionality using the <code>page-progression-direction</code> attribute and that
+								of local page-progression-direction within content documents.</p>
+						</div>
+
+						<aside class="example" id="spread-none-example"
+							title="A fixed-layout EPUB Publication without synthetic spread">
+							<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      
+      &lt;meta
+          property="rendition:spread">
+         none
+      &lt;/meta>
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+
+							<figure id="spread-none-figure">
+								<figcaption> Rendering of three fixed-layout documents without synthetic spread.
+										<br /><span class="attribution">(Comics courtesy of <a
+											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
+											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+										2.5</a>.)</span>
+								</figcaption>
+								<img src="images/example_spread_none.svg" width="600" aria-details="spread-none-diagram"
+									alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time everywhere"
+								 />
+							</figure>
+
+							<details id="spread-none-diagram" class="desc">
+								<summary>Image description</summary>
+								<p> Two rows of schematic views of tablets (three in each row). The tablets in the top
+									row are in portrait mode, and in landscape mode in the bottom one. The schematic
+									views of the tablets within a row are linked with left-to-right arrows. </p>
+								<p> In the tablets of each row the consecutive panels of a comics are displayed; the
+									panels are centered in their respective tablets. </p>
+							</details>
+						</aside>
+
+
+						<aside class="example" id="spread-landscape-example"
+							title="Specifying the usage of syntetic spreads in landscape orientation only">
+							<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      
+      &lt;meta
+          property="rendition:spread">
+         landscape
+      &lt;/meta>
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+
+
+							<figure id="spread-landscape-figure">
+								<figcaption> Rendering of three fixed-Layout Documents, with synthetic spread in
+									landscape orientation only. <br /><span class="attribution">(Comics courtesy of <a
+											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
+											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+										2.5</a>.)</span>
+								</figcaption>
+								<img src="images/example_spread_landscape.svg" width="600"
+									aria-details="spread-landscape-diagram"
+									alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time in portrait and using synthetic spread in landscape."
+								 />
+							</figure>
+
+							<details id="spread-landscape-diagram" class="desc">
+								<summary>Image description</summary>
+								<p> Two rows of schematic views of tablets (three in top row, and two in the bottom).
+									The tablets in the top row are in portrait mode, and in landscape mode in the bottom
+									one. The schematic views of the tablets within a row are linked with left-to-right
+									arrows. </p>
+								<p> In both rows three panels of a comics are displayed. In the top row the panels are
+									centered in their respective tablets. In the bottom row, the first tablet contains
+									the first and second panels of the comics side by side; the second tablet contains
+									the second and third panels of the comics side-by-side. </p>
+							</details>
+						</aside>
+
+
+						<aside class="example" id="spread-both-example"
+							title="Specifying to use syntetic spreads both in portrait and in landscape orientations">
+							<p>See also <a href="#spread-both-figure"></a>.</p>
+							<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      
+      &lt;meta
+          property="rendition:spread">
+         both
+      &lt;/meta>
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+
+							<figure id="spread-both-figure">
+								<figcaption> Rendering of three fixed-layout documents, with synthetic spread in both
+									portrait and landscape orientations. <br /><span class="attribution">(Comics
+										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
+											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+										2.5</a>.)</span>
+								</figcaption>
+								<img src="images/example_spread_both.svg" width="600" aria-details="spread-both-diagram"
+									alt="Progression of FXL pages both in portrait and in landscape modes, using synthetic spread in both cases."
+								 />
+							</figure>
+
+							<details id="spread-both-diagram" class="desc">
+								<summary>Image description</summary>
+								<p> Two rows of schematic views of tablets (two in each row). The tablets in the top row
+									are in portrait mode, and in landscape mode in the bottom one. The schematic views
+									of the tablets within a row are linked with left-to-right arrows. </p>
+								<p> In both rows three panels of a comics are displayed. The first tablet in a row
+									contains the first and second panels of the comics side by side; the second tablet
+									contains the second and third panels of the comics side-by-side. </p>
+							</details>
+						</aside>
+
+
+						<aside class="example" id="spread-both-with-intro-example"
+							title="Overriding the global spread behavior">
+							<p>In this example, the EPUB Creator overrides the global reflowable setting in the spine
+								for the introductory page. The intention is for Reading Systems to render it as a
+								reflowable document.</p>
+
+							<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      &lt;meta
+          property="rendition:spread">
+         both
+      &lt;/meta>
+   &lt;/metadata>
+   
+   &lt;spine>
+      &lt;itemref
+          idref="introduction"
+          properties="rendition:layout-reflowable"/>
+      …
+   &lt;/spine>
+   …
+&lt;/package></pre>
+
+							<figure id="spread-both-with-intro-figure">
+								<figcaption> Rendering of an introduction document in reflowable layout, followed by
+									three fixed-layout documents with synthetic spread in portrait orientation.
+										<br /><span class="attribution">(Comics courtesy of <a
+											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
+											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+										2.5</a>.)</span>
+								</figcaption>
+								<img src="images/example_spread_both_with_reflowable_intro.svg" width="600"
+									aria-details="spread-both-with-intro-diagram"
+									alt="Progression of FXL pages both in portrait using synthetic spread in both cases, preceded by an introduction with reflowable contnt."
+								 />
+							</figure>
+
+							<details id="spread-both-with-intro-diagram" class="desc">
+								<summary>Image description</summary>
+								<p> A row of schematic views of three tablets in portrait mode, and linked with
+									left-to-right arrows. </p>
+								<p> The first tablet views includes a single, column-like strip (i.e., a rectangle
+									without a bottom edge following beyond the bottom of the tablet) with a text flowing
+									down the strip, and starting with the word "Introduction". This is followed by two
+									schematic tablets with three panels of comics displayed. The first tablet in the row
+									contains the first and second panels of the comics side by side; the second tablet
+									contains the second and third panels of the comics side-by-side. </p>
+							</details>
+						</aside>
+
+						<section id="spread-overrides">
+							<h6>Synthetic Spread Overrides</h6>
+
+							<p id="property-spread-local">EPUB Creators MAY specify the following properties locally on
+								spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
+									<a href="#property-spread-global">global value</a> for the given spine item:</p>
+
+							<dl>
+								<dt id="spread-auto">rendition:spread-auto</dt>
+								<dd>Specifies the Reading System determines when to render a synthetic spread for the
+									spine item. </dd>
+
+								<dt id="spread-both">rendition:spread-both</dt>
+								<dd>Specifies the Reading System should render a synthetic spread for the spine item in
+									both portrait and landscape orientations. </dd>
+
+								<dt id="spread-landscape">rendition:spread-landscape</dt>
+								<dd>Specifies the Reading System should render a synthetic spread for the spine item
+									only when in landscape orientation.</dd>
+
+								<dt id="spread-none">rendition:spread-none</dt>
+								<dd>Specifies the Reading System should not render a synthetic spread for the spine
+									item.</dd>
+
+								<dt id="spread-portrait">rendition:spread-portrait</dt>
+								<dd>
+									<p>The <code>rendition:spread-portrait</code> property is <a href="#deprecated"
+											>deprecated</a>.</p>
+									<p></p>Refer to the <a
+										href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
+											><code>spread-portrait</code> property definition</a>
+									in [[EPUBPublications-301]] for more information.</dd>
+							</dl>
+
+							<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
+						</section>
+					</section>
+
+					<section id="page-spread">
+						<h5>Spread Placement</h5>
+
+						<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to populate
+							the spread by rendering the next <a>EPUB Content Document</a> in the next available
+							unpopulated viewport, where the next available viewport is determined by the given <a
+								href="#sec-spine-elem">page progression direction</a> or by local declarations within
+							Content Documents. An EPUB Creator MAY override this automatic population behavior and force
+							Reading Systems to place a document in a particular viewport by specifying one of the
+							following properties on its spine <code>itemref</code> element:</p>
+
+						<dl>
+							<dt id="page-spread-center">
+								<code>rendition:page-spread-center</code></dt>
+							<dd>The <code>rendition:page-spread-center</code> property is an alias of the <a
+									href="#spread-none"><code>spread-none</code> property</a> for centering a spine
+								item.</dd>
+
+							<dt id="fxl-page-spread-left">
+								<code>rendition:page-spread-left</code>
+							</dt>
+							<dd>The <code>rendition:page-spread-left</code> property is an alias of the <code><a
+										href="#page-spread-left">page-spread-left</a></code> property for placing a
+								spine item in the left-hand slot of a two-page spread.</dd>
+
+							<dt id="fxl-page-spread-right">
+								<code>rendition:page-spread-right</code>
+							</dt>
+							<dd>The <code>rendition:page-spread-right</code> property is an alias of the <code><a
+										href="#page-spread-right">page-spread-right</a></code> property for placing a
+								spine item in the right-hand slot of a two-page spread.</dd>
+						</dl>
+
+						<p>The <code>rendition:page-spread-center</code>, <code>rendition:page-spread-left</code>, and
+								<code>rendition:page-spread-right</code> properties apply to both pre-paginated and
+							reflowable content. They only apply when the Reading System is creating Synthetic
+							Spreads.</p>
+
+						<p>Although EPUB Creators often indicate to use a spread in certain device orientations, the
+							content itself does not represent true spreads (i.e., two consecutive pages that Reading
+							Systems must render side-by-side for readability, such as a two-page map). To indicate that
+							two consecutive pages represent a true spread, EPUB Creators SHOULD use the
+								<code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
+							properties on the spine items for the two adjacent EPUB Content Documents, and omit the
+							properties on spine items where one-up or two-up presentation is equally acceptable.</p>
+
+						<p>EPUB Creators MUST NOT declare more than one <code>page-spread-*</code> property on any given
+							spine item.</p>
+
+						<div class="note" id="note-page-spread-aliases">
+							<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
+								properties were created to allow the use of a single vocabulary for all fixed-layout
+								properties. EPUB Creators can use either property set, but older Reading Systems might
+								only recognize the unprefixed versions.</p>
+
+							<p>The <code>rendition:page-spread-center</code> was created to make it easier for EPUB
+								Creators to understand the process of switching between two-page spreads and single
+								centered pages. EPUB Creators can use either <code>rendition:page-spread-center</code>
+								or <code>spread-none</code> to disable spread behavior in Reading Systems.</p>
+						</div>
+
+						<aside class="example" id="spread-page-spread-right-example"
+							title="Starting the first document on the right">
+							<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+          reflowable
+      &lt;/meta>
+	  
+      &lt;meta
+          property="rendition:spread">
+          landscape
+      &lt;/meta>
+      …
+   &lt;/metadata>
+   &lt;spine page-progression-direction="ltr">
+      …
+      &lt;itemref
+          idref="first-panel"
+          properties="rendition:page-spread-right"/>
+      …
+   &lt;/spine>
+&lt;/package></pre>
+
+							<figure id="spread-page-spread-right-figure">
+								<figcaption> Rendering of three fixed-layout documents, with synthetic spread in
+									landscape orientation starting on the right. <br /><span class="attribution">(Comics
+										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
+											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+										2.5</a>.)</span>
+								</figcaption>
+								<img src="images/example_spread_page_spread_right.svg" width="600"
+									aria-details="spread-page-spread-right-diagram"
+									alt="Progression of FXL pages in landscape modes, showing synthetic spread in both cases but with the first page appearing on the right side of the first page."
+								 />
+							</figure>
+
+							<details id="spread-page-spread-right-diagram" class="desc">
+								<summary>Image description</summary>
+								<p> A row of schematic views of two tablets in landscape mode, and linked with a
+									left-to-right arrow. </p>
+								<p> Three panels of a comics are displayed in the tablets. The first tablet in the row
+									contains the first panels of the comics on the right hand of the tablet, with the
+									left side empty; the second tablet contains the second and third panels of the
+									comics side-by-side. </p>
+							</details>
+						</aside>
+
+						<aside class="example" id="fxl-ex5" title="Placing individual spine items in a spread">
+							<p>In this example, the EPUB Creator intends the Reading System to create a two-page
+								fixed-layout center plate using synthetic spreads in any device orientation. Note that
+								the EPUB Creator has left spread behavior for the other (reflowable) parts undefined,
+								since the global value of <code>rendition:spread</code> initializes to <code>auto</code>
+								by default.</p>
+
+							<pre>&lt;package …>
+   …
+   &lt;spine page-progression-direction="ltr">
+      …
+      &lt;itemref
+          idref="center-plate-left"
+          properties="rendition:spread-both rendition:page-spread-left"/>
+      &lt;itemref
+          idref="center-plate-right"
+          properties="rendition:spread-both rendition:page-spread-right"/>
+      …
+   &lt;/spine>
+&lt;/package></pre>
+						</aside>
+
+						<aside class="example" id="fxl-ex6" title="Creating a centered layout">
+							<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta
+          property="rendition:layout">
+         pre-paginated
+      &lt;/meta>
+      &lt;meta
+          property="rendition:spread">
+         auto
+      &lt;/meta>
+   &lt;/metadata>
+   &lt;spine>
+      …
+      &lt;itemref
+          idref="center-plate"
+          properties="rendition:page-spread-center"/>
+      …
+   &lt;/spine>
+   …
+&lt;/package></pre>
+						</aside>
+					</section>
+
+					<section id="viewport">
+						<h5>Viewport Dimensions (Deprecated)</h5>
+
+						<p>The <code>rendition:viewport</code> property allows <a>EPUB Creators</a> to express the CSS
+							initial containing block (ICB) [[CSS2]] for XHTML and SVG Content Documents whose
+								<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
+
+						<p>Use of the property is <a href="#deprecated">deprecated</a>.</p>
+
+						<p>Refer to the <a
+								href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
+									><code>rendition:viewport</code> property definition</a> in [[EPUBPublications-301]]
+							for more information.</p>
+					</section>
+
+					<section id="sec-fxl-content-dimensions">
+						<h4>Content Document Dimensions</h4>
+
+						<p>This section defines rules for the expression and interpretation of dimensional properties of
+								<a>Fixed-Layout Documents</a>.</p>
+
+						<p id="confreg-fxl-icb">Fixed-Layout Documents specify their <a
+								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
+								containing block</a> [[CSS2]] in the manner applicable to their format:</p>
+
+						<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
+							<dt id="sec-fxl-icb-html" data-tests="#fxl-xhtml-icb">Expressing in XHTML</dt>
+							<dd>
+								<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
+										href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
+										containing block</a> [[CSS2]] dimensions MUST be expressed in a
+										<code>viewport</code>
+									<code>meta</code> tag using the syntax defined in [[CSS-Device-Adapt-1]].</p>
+								<aside class="example"
+									title="Specifying the initial containing block in a viewport meta tag">
+									<pre>&lt;html …>
+   &lt;head>
+      …
+      &lt;meta
+          name="viewport"
+          content="width=1200, height=600"/>
+      …
+   &lt;/head>
+   …
+&lt;/html></pre>
+								</aside>
+							</dd>
+
+							<dt id="sec-fxl-icb-svg">Expressing in SVG</dt>
+							<dd>
+								<p>For SVG <a>Fixed-Layout Documents</a>, the initial containing block [[CSS2]]
+									dimensions MUST be expressed using the <a
+										href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
+											><code>viewBox</code> attribute</a> [[SVG]].</p>
+								<aside class="example"
+									title="Specifying the initial containing block in the viewBox attribute">
+									<p>In this example, the <code>viewBox</code> attribute sets the ICB to an aspect
+										ratio of 844 pixels wide by 1200 pixels high.</p>
+
+									<pre>
+&lt;svg xmlns="http://www.w3.org/2000/svg"
+     version="1.1" 
+     viewBox="0 0 844 1200">
+   …
+&lt;/svg></pre>
+								</aside>
+							</dd>
+						</dl>
+					</section>
+				</section>
+			</section>
+
+			<section id="sec-reflowable-layouts">
+				<h3>Reflowable Layouts</h3>
+
+				<p>Although control over the rendering of <a>EPUB Content Documents</a> to create <a
+						href="#sec-fixed-layouts">fixed layouts</a> is an obvious need not handled by other
+					technologies, there are also considerations for reflowable content that are unique to EPUB
+					Publications (e.g., how to handle the flow of content in the <a>Viewport</a>). This section defines
+					properties that allow <a>EPUB Creators</a> to control presentation aspects of reflowable
+					content.</p>
+
+				<section id="flow">
+					<h4>The <code>rendition:flow</code> Property</h4>
+
+					<p>The <code>rendition:flow</code> property specifies the EPUB Creator preference for how Reading
+						Systems should handle content overflow. </p>
+
+					<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code> property</a> is
+						specified on a <code>meta</code> element, it indicates the EPUB Creator's global preference for
+						overflow content handling (i.e., for all spine items). EPUB Creators MAY indicate a preference
+						for dynamic pagination or scrolling. For scrolled content, it is also possible to specify
+						whether consecutive <a>EPUB Content Documents</a> are to be rendered as a continuous scrolling
+						view or whether each is to be rendered separately (i.e., with a dynamic page break between
+						each).</p>
+
+					<p>EPUB Creators MUST use one of the following values with the <code>rendition:flow</code>
+						property:</p>
+
+					<dl class="variablelist">
+						<dt id="paginated">paginated</dt>
+						<dd id="paginated-dd" data-tests="#pkg-flow-paginated">
+							<p>Dynamically paginate all overflow content.</p>
+						</dd>
+
+						<dt id="scrolled-continuous">scrolled-continuous</dt>
+						<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
+							<p>Render all Content Documents such that overflow content is scrollable, and the EPUB
+								Publication is presented as one continuous scroll from spine item to spine item (except
+								where <a href="#layout-property-flow-overrides">locally overridden</a>).</p>
+							<p>Note that EPUB Creators SHOULD NOT create publications in which different resources have
+								different block flow directions, as continuous scrolled rendition in EPUB Reading
+								Systems would be problematic.</p>
+						</dd>
+
+						<dt id="scrolled-doc">scrolled-doc</dt>
+						<dd id="scrolled-doc-dd" data-tests="#pkg-flow-scrolled-doc">
+							<p>Render all Content Documents such that overflow content is scrollable, and each spine
+								item is presented as a separate scrollable document.</p>
+						</dd>
+
+						<dt id="auto">auto</dt>
+						<dd>
+							<p>Render overflow content using the Reading System default method or a user preference,
+								whichever is applicable. Default value.</p>
+						</dd>
+					</dl>
+
+					<p id="html-body-page-break-before">Note that when two reflowable EPUB Content Documents occur
+						sequentially in the spine, the default rendering for their [[!HTML]] <a
+							data-cite="html#the-body-element"><code>body</code></a> elements is consistent with the <a
+							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
+								><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been set to
+							<code>always</code>. In addition to using the <code>rendition:flow</code> property, EPUB
+						Creators MAY override this behavior through an appropriate style sheet declaration, if the
+						Reading System supports such overrides.</p>
+
+					<p>EPUB Creators MUST NOT declare the <code>rendition:flow</code> property more than once.</p>
+
+					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
+							attribute</a>. Refer to <a href="#layout-property-flow-overrides"></a> for setting the
+						property for individual <a>EPUB Content Documents</a>.</p>
+
+					<figure id="fig-flow-paginated-single">
+						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
+								<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
+						<img src="images/example_rendering_paginated_single_spine.svg" width="600"
+							aria-details="flow-paginated-single-diagram"
+							alt="The continuous progression of paginated content produced for a single document." />
+					</figure>
+
+					<details id="flow-paginated-single-diagram" class="desc">
+						<summary>Image description</summary>
+						<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective
+							arrows, with a text flowing from one rectangle to the next one. The text is sectioned with
+							headers figuring 'Chapter 1', '2', and '3'. The leftmost rectangle is enclosed in a
+							schematic view of a tablet.</p>
+					</details>
+
+					<figure id="fig-flow-paginated-multiple">
+						<figcaption>Rendering of an EPUB publication with multiple spine items, and with the
+								<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
+						<img src="images/example_rendering_paginated_multiple_spine.svg" width="600"
+							aria-details="flow-paginated-multiple-diagram"
+							alt="The continuous progression of paginated content produced for each document with transitions to
+					new pages between documents." />
+					</figure>
+
+					<details id="flow-paginated-multiple-diagram" class="desc">
+						<summary>Image description</summary>
+						<p>Three column-like rectangles linked left-to-middle and middle-to-right with respective
+							arrows, with a text flowing from one rectangle to the next one. The text is sectioned with
+							headers figuring 'Chapter 1', '2'. The section with 'Chapter 2' starts at the top of the
+							rightmost rectangle, leaving an empty space at the bottom of the middle rectangle. The
+							leftmost rectangle is enclosed in a schematic view of a tablet.</p>
+					</details>
+
+					<figure id="fig-flow-scrolled-continuous">
+						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
+								<code>rendition:flow</code> set to <code>scrolled-continuous</code>.</figcaption>
+						<img src="images/example_rendering_scrolled_continuous.svg" width="220"
+							aria-details="flow-scrolled-continuous-diagram"
+							alt="The progression of a continuous scroll of content extends vertically off the user's screen,
+					with new documents added to the bottom as encountered." />
+					</figure>
+
+					<details id="flow-scrolled-continuous-diagram" class="desc">
+						<summary>Image description</summary>
+						<p>A single, column-like strip (i.e., a rectangle without a bottom edge) with a text flowing
+							down the strip. The text is sectioned with headers figuring 'Chapter 1', '2'. The top part
+							of the strip is enclosed in a schematic view of a tablet.</p>
+					</details>
+
+					<figure id="fig-flow-scrolled-doc">
+						<figcaption>Rendering of an EPUB publication with multiple spine items, and with the
+								<code>rendition:flow</code> set to <code>scrolled-doc</code>.</figcaption>
+						<img src="images/example_rendering_scrolled_doc.svg" width="600"
+							aria-details="flow-scrolled-doc-diagram"
+							alt="The progression of scrollable documents depicting how only the content within each document
+					is scrollable." />
+					</figure>
+
+					<details id="flow-scrolled-doc-diagram" class="desc">
+						<summary>Image description</summary>
+						<p>Three column-like strips (i.e., a rectangles without bottom edges) linked left-to-middle and
+							middle-to-right with respective arrows, each containing a text flowing down the strip. The
+							text is sectioned with headers figuring 'Chapter 1', '2' and '3'. Each strip starts with a
+							chapter header and flows down the strip. The top part of the leftmost strip is enclosed in a
+							schematic view of a tablet.</p>
+					</details>
+
+					<section id="layout-property-flow-overrides">
+						<h5>Spine Overrides</h5>
+
+						<p id="layout-property-flow-local">EPUB Creators MAY specify the following properties locally on
+							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
+								href="#property-flow-global">global value</a> for the given spine item:</p>
+
+						<dl>
+							<dt id="flow-auto">rendition:flow-auto</dt>
+							<dd>Indicates no preference for overflow content handling by the EPUB Creator.</dd>
+
+							<dt id="flow-paginated">rendition:flow-paginated</dt>
+							<dd>Indicates the EPUB Creator preference is to dynamically paginate content overflow.</dd>
+
+							<dt id="flow-scrolled-continuous">rendition:flow-scrolled-continuous</dt>
+							<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow
+								content, and that consecutive spine items with this property are to be rendered as a
+								continuous scroll.</dd>
+
+							<dt id="flow-scrolled-doc">rendition:flow-scrolled-doc</dt>
+							<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow
+								content, and each spine item with this property is to be rendered as a separate
+								scrollable document.</dd>
+						</dl>
+
+						<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
+
+						<aside class="example" id="property-flow-ex1"
+							title="Overriding a global paginated flow declaration">
+							<p>In this example, the EPUB Creator's intent is to have a paginated EPUB Publication with a
+								scrollable table of contents.</p>
+							<pre>&lt;package …>
+&lt;metadata …&gt;
+	…
+	&lt;meta
+		property="rendition:flow"&gt;
+		paginated
+	&lt;/meta&gt;
+	…
+&lt;/metadata&gt;
+
+…
+
+&lt;spine&gt;
+	&lt;itemref
+		idref="toc"
+		properties="rendition:flow-scrolled-doc"/&gt;
+	&lt;itemref
+		idref="c01"/&gt;
+&lt;/spine&gt;
+&lt;/package></pre>
+						</aside>
+					</section>
+				</section>
+
+				<section id="align-x-center">
+					<h4>The <code>rendition:align-x-center</code> Property</h4>
+
+					<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should be
+						centered horizontally in the viewport or spread.</p>
+
+					<p>The property MUST NOT be set globally for all EPUB Content Documents (i.e., in a <a
+							href="#sec-meta-elem"><code>meta</code> element</a> without a <a href="#attrdef-refines"
+								><code>refines</code> attribute</a>). It is only available as a spine override for
+						individual EPUB Content Documents via the <a href="#sec-itemref-elem"><code>itemref</code>
+							element's <code>properties</code> attribute</a>.</p>
+
+					<div class="note">
+						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title pages),
+							in the absence of reliable centering control within the content rendering. As support for
+							paged media evolves in CSS, however, this property is expected to be deprecated. EPUB
+							Creators are encouraged to use CSS solutions when effective.</p>
+					</div>
 				</section>
 			</section>
 		</section>


### PR DESCRIPTION
Explodes section 2 and moves ocf up before the package document section as discussed in #2177 

Fixes #2177


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2193.html" title="Last updated on Apr 2, 2022, 12:26 PM UTC (ff25cd2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2193/4540b34...ff25cd2.html" title="Last updated on Apr 2, 2022, 12:26 PM UTC (ff25cd2)">Diff</a>