### PR TITLE
Using DPUB ARIA

### DIFF
--- a/epub33/core/biblio.js
+++ b/epub33/core/biblio.js
@@ -3,6 +3,18 @@ var biblio = {
 		"title": "CSS Snapshot",
 		"href": "https://www.w3.org/TR/CSS/"
 	},
+	"DPUB-ARIA" : {
+		"authors": [
+			"Matt Garrish",
+			"Tzviya Siegman",
+			"Markus Gylling",
+			"Shane McCarron"
+		],
+		"title": "Digital Publishing WAI-ARIA Module 1.0",
+		"href": "https://www.w3.org/TR/dpub-aria/",
+		"date": "14 December 2017",
+		"publisher": "W3C"
+	},
 	"EPUBContentDocs-301": {
 		"authors":[
 		"Markus Gylling",

--- a/epub33/core/biblio.js
+++ b/epub33/core/biblio.js
@@ -4,15 +4,8 @@ var biblio = {
 		"href": "https://www.w3.org/TR/CSS/"
 	},
 	"DPUB-ARIA" : {
-		"authors": [
-			"Matt Garrish",
-			"Tzviya Siegman",
-			"Markus Gylling",
-			"Shane McCarron"
-		],
-		"title": "Digital Publishing WAI-ARIA Module 1.0",
+		"title": "Digital Publishing WAI-ARIA Module",
 		"href": "https://www.w3.org/TR/dpub-aria/",
-		"date": "14 December 2017",
 		"publisher": "W3C"
 	},
 	"EPUBContentDocs-301": {

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9955,8 +9955,8 @@ html.my-document-playing * {
 						accessibility enhancements like built-in read aloud or Media Overlays functionality where
 						interaction with assistive technologies is not essential.</p>
 
-					<p>Refer to <a data-cite="dpub-aria-1.0#">Digital Publishing WAI-ARIA Module 1.0</a>
-						[[DPUB-ARIA-1.0]] for more information about accessible publishing roles.</p>
+					<p>Refer to <a data-cite="dpub-aria-1.0#">Digital Publishing WAI-ARIA Module</a> [[?DPUB-ARIA]] 
+						for more information about accessible publishing roles.</p>
 				</div>
 
 				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value


### PR DESCRIPTION
... instead of DPUB ARIA 1.0. (Although the reference itself still has the title with 1.0, ie, a future version may have to update it.) I also turned the reference into an informative one.

Fix #2190


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2196.html" title="Last updated on Apr 2, 2022, 12:39 PM UTC (1196d05)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2196/8ff55fe...1196d05.html" title="Last updated on Apr 2, 2022, 12:39 PM UTC (1196d05)">Diff</a>