### PR TITLE
Adding an Oxford Comma

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -533,7 +533,7 @@
 					<dd>
 						<p>A <a>Publication Resource</a> that describes the rendering of an <a>EPUB Publication</a>, as
 							defined in <a href="#sec-package-doc"></a>. The Package Document carries meta information
-							about the EPUB Publication, provides a manifest of resources and defines a default reading
+							about the EPUB Publication, provides a manifest of resources, and defines a default reading
 							order.</p>
 					</dd>
 


### PR DESCRIPTION
I did not change the hyphenation because there is no agreement on it...

Fix #2181


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2197.html" title="Last updated on Apr 2, 2022, 7:32 AM UTC (11efc1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2197/8ff55fe...11efc1e.html" title="Last updated on Apr 2, 2022, 7:32 AM UTC (11efc1e)">Diff</a>