### PR TITLE
Fix and explain remote resources

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10860,7 +10860,7 @@ html.my-document-playing * {
 			<h2>Detailed Examples</h2>
 
 			<section id="publication-resources-example">
-				<h3>Publication Resources</h3>
+				<h3>Resources</h3>
 
 				<p>Consider the following extracts of a <a>Package Document</a> and an <a>XHTML Content
 					Document</a>:</p>
@@ -10868,7 +10868,12 @@ html.my-document-playing * {
 				<pre>&lt;package …>
     &lt;metadata …>
         …
-        &lt;link rel="record" href="meta/data.xml" media-type="application/marc"/>
+        &lt;link rel="record" 
+            href="meta/data.xml" 
+            media-type="application/marc"/>
+        &lt;link rel="record" 
+            href="https://www.example.org/meta/data2.xml" 
+            media-type="application/marc"/>
         …
     &lt;/metadata>
     &lt;manifest>
@@ -10885,6 +10890,9 @@ html.my-document-playing * {
             media-type="text/css"/>
         &lt;item id="font_otf"
             href="fonts/font-file.otf"
+            media-type="font/otf"/>
+        &lt;item id="font_otf_remote"
+            href="https://www.example.org/fonts/font-file2.otf"
             media-type="font/otf"/>
         &lt;item id="font_cff"
             href="fonts/font-file.cff"
@@ -10931,14 +10939,16 @@ html.my-document-playing * {
     &lt;body>
         &lt;img src="media/image1_png"/>
         …
-        &lt;a href="media/image_3.png">…&lt;/a>
+        &lt;a href="media/image_2.png">…&lt;/a>
         …
         &lt;picture>
             &lt;source srcset="media/image_3.heic" type="image/heic"/>
             &lt;img src="media/image_3.png"/>
         &lt;/picture>
-        
+        …        
         &lt;iframe src="widget.xhtml">&lt;/iframe>
+        …
+        &lt;a href="https://www.example.org/some_content">…&lt;/a>
     &lt;/body>
 &lt;/html>					
 				</pre>
@@ -10949,69 +10959,86 @@ html.my-document-playing * {
 				<dl>
 					<dt><code>meta/data.xml</code></dt>
 					<dd>
-						<p>The resource is a metadata record. It is linked via a <a href="#sec-link-elem"
-									><code>link</code> element</a> in the Package Document metadata. It is therefore a
-								<a>Linked Resource</a> on the <a>manifest plane</a> and not listed in the
-								<a>manifest</a>.</p>
+						<p>The resource is a metadata record, stored in the container. It is linked via a 
+							<a href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It is therefore a
+							<a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in the <a>manifest</a>. It is not part
+							on any other planes.
+						</p>
+					</dd>
+
+					<dt><code>https://www.example.org/meta/data2.xml</code></dt>
+					<dd>
+						<p>The resource is a metadata record, stored remotely. It is linked via a 
+							<a href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It is therefore a
+							<a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in the
+							<a>manifest</a>. It is not part on any other planes.</p>
 					</dd>
 
 					<dt><code>page.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is listed in the spine. It is a <a>Publication
-								Resource</a> on the <a>manifest plane</a>, an <a>EPUB Content Document</a> on the
-								<a>spine plane</a>, and not present on the <a>content plane</a>. No fallback is
+							Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an <a>EPUB Content Document</a> on the
+							<a>spine plane</a>, and is not present on the <a>content plane</a>. No fallback is
 							necessary.</p>
 					</dd>
 
 					<dt><code>nav.xhtml</code></dt>
 					<dd>
 						<p>The resource is the <a>EPUB Navigation Document</a>. It is not listed in the spine. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a> and not present on either the
-								<a>spine plane</a> or the <a>content plane</a>. No fallback is necessary.</p>
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, and is not present on either the
+							<a>spine plane</a> or the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>style.css</code></dt>
 					<dd>
 						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[HTML]]
-								<a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, not present on the <a>spine
-								plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
+							<a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, 
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
 							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.otf</code></dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
-							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, not present on
-							the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content
+							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content
+							plane</a>. No fallback is necessary.</p>
+					</dd>
+
+					<dt><code>https://www.example.org/fonts/font-file2.otf</code></dt>
+					<dd>
+						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
+							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Remote Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content
 							plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.cff</code></dt>
 					<dd>
 						<p>The resource is a font file in Compact Font Format. It is not listed in the spine but is
-							referenced from a CSS file. Its media type is not listed as a <a
-								href="#sec-core-media-types">core media type</a>. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, not present on the <a>spine plane</a>, and is an <a>Exempt
-								Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
+							referenced from a CSS file. Its media type is not listed as a 
+							<a href="#sec-core-media-types">core media type</a>. It is a <a>Publication Resource</a> on
+							the <a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine plane</a>,
+							and is an <a>Exempt Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>speech/cmn.pls</code></dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
 							from an [[HTML]] <a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, not present on the <a>spine
-								plane</a>, and is an <a>Exempt Resource</a> on the <a>content plane</a>. No fallback is
-							necessary.</p>
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							not present on the <a>spine plane</a>, and is an <a>Exempt Resource</a> on the <a>content plane</a>. 
+							No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_1.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, not present on the <a>spine
-								plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
-							fallback is necessary.</p>
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. 
+							No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_2.png</code></dt>
@@ -11019,49 +11046,60 @@ html.my-document-playing * {
 						<p>The resource is a PNG image file. It is referenced via an [[HTML]] <a
 								data-cite="html#the-a-element"><code>a</code> element</a>. Because it is referenced from
 							a hyperlink, it <em>must</em> be listed in the spine. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, a <a>Foreign Content Document</a> on the <a>spine plane</a>, and
-							a <a>Core Media Type Resource</a> on the <a>content plane</a>. As a <a>Foreign Content
-								Document</a> a fallback is required, and is provided via a <a
-								href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
+							the <a>manifest plane</a>, a <a>Container Resource</a>, a <a>Foreign Content Document</a> on the <a>spine plane</a>, 
+							and a <a>Core Media Type Resource</a> on the <a>content plane</a>. As a <a>Foreign Content
+							Document</a> a fallback is required, which is provided via a <a href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
 					<dt><code>image_desc.xhtml</code></dt>
 					<dd>
-						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not listed
-							in the spine (i.e., it replaces the existing spine reference when needed). It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, an EPUB Content Document on
-								<a>spine plane</a>, and not present on the <a>content plane</a>. No fallback is
-							necessary.</p>
+						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not explicitly listed
+							in the spine (but it "replaces" the existing spine item when needed). It is a
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an EPUB Content Document on
+							<a>spine plane</a>, and, because it is not "used" when rendering another Content Document, it is not present
+							on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_3.heic</code></dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
 							referenced from an [[HTML]] <a data-cite="html#the-source-element"><code>source</code>
-								element</a>. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, not
-							present on the <a>spine plane</a>, and is a <a>Foreign Resource</a> on the <a>content
-								plane</a>. As a <a>Foreign Resource</a>, a fallback is required and is provided via the
-							sibling [[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>.</p>
+							element</a>. Its media type is not listed as a <a href="#sec-core-media-types">core media type</a>. 
+							It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Foreign Resource</a> on the <a>content
+							plane</a>. As a <a>Foreign Resource</a>, a fallback is required, which is provided via the
+							sibling [[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>
+							in an [[HTML]] <a data-cite="html#the-picture-element"><code>picture</code> element.</p>
 					</dd>
 
 					<dt><code>image/image_3.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a> that is an
-							intrinsic fallback of the [[HTML]] <a data-cite="html#the-picture-element"
-									><code>picture</code> element</a>. It is a <a>Publication Resource</a> on the
-								<a>manifest plane</a>, not present on the <a>spine plane</a>, and is a <a>Core Media
-								Type Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
+							[[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a> that is used as an
+							intrinsic fallback of the [[HTML]] <a data-cite="html#the-picture-element"><code>picture</code> element</a>. 
+							It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. 
+							No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>widget.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-cite="html#the-iframe-element"><code>iframe</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, not present on <a>spine
-								plane</a>, and a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
-							fallback is necessary.</p>
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on <a>spine plane</a>, and, because it is "used" when rendering another Content Document, 
+							a <a>Core Media Type Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
+
+					<dt><code>https://www.example.org/some_content</code></dt>
+					<dd>
+						<p>
+							The resource is referenced via an [[HTML]] <a data-cite="html#the-a-element"><code>a</code> element</a>
+							and is not stored in the <a>EPUB Container</a>. Reading Systems will normally open this link via a separate browser instance.
+							It is not any planes defined by this specification.
+						</p>
+					</dd>
+
 				</dl>
 			</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6308,22 +6308,25 @@ No Entry</pre>
 											Document</a> that is embedded in a XHTML Content Document using the [[HTML]]
 											<a data-cite="html#the-iframe-element"><code>iframe</code></a> element.</p>
 								</li>
-							</ul> >>>>>>> remotes/origin/main <p id="confreq-cd-scripted-container">A
-								container-constrained script MUST NOT contain instructions for modifying the DOM of the
-								EPUB Content Document that embeds it (i.e., the one that contains the
-									<code>iframe</code> element). It also MUST NOT contain instructions for manipulating
-								the size of its containing rectangle.</p>
+							</ul>
+
+							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
+								instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e.,
+								the one that contains the <code>iframe</code> element). It also MUST NOT contain
+								instructions for manipulating the size of its containing rectangle.</p>
+
 							<p>EPUB Creators should note that <a data-cite="epub-rs-33#sec-scripted-content">support for
 									container-constrained scripting in Reading Systems</a> is only recommended in
 								reflowable documents [[EPUB-RS-33]]. Furthermore, Reading System support in
 								fixed-layouts EPUBs is optional.</p>
+
 							<p>EPUB Creators should ensure container-constrained scripts degrade gracefully in Reading
 								Systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
+
 							<div class="note">
 								<p>EPUB Creators choosing to restrict the usage of scripting to the
 									container-constrained model will ensure a more consistent user experience between
 									scripted and non-scripted content (e.g., consistent pagination behavior).</p>
-
 							</div>
 						</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11101,11 +11101,12 @@ html.my-document-playing * {
 					<dd>
 						<p>The resource is referenced via an [[HTML]] <a data-cite="html#the-a-element"><code>a</code>
 								element</a> and is not stored in the <a>EPUB Container</a>. Reading Systems will
-							normally open this link via a separate browser instance. It is not any planes defined by
+							normally open this link via a separate browser instance. It is not on any planes defined by
 							this specification.</p>
 					</dd>
-
 				</dl>
+
+				<p>Additional examples on the usage of different types of resources can be found in <a href="#sec-item-elem-examples"></a>.</p>
 			</section>
 
 			<section id="scripted-contexts-example">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -294,6 +294,16 @@
 					</dd>
 
 					<dt>
+						<dfn id="dfn-local-resource" data-lt="Container Resources">Container Resource</dfn>
+					</dt>
+					<dd>
+						<p>A <a>Publication Resource</a> that is located within the <a>EPUB Container</a>, as opposed to
+							a <a>Remote Resource</a> which is not.</p>
+						<p>Refer to <a href="#sec-resource-locations"></a> for media type-specific rules for resource
+							locations.</p>
+					</dd>
+
+					<dt>
 						<dfn id="dfn-container-root-url">Container Root URL</dfn>
 					</dt>
 					<dd>
@@ -482,15 +492,6 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-local-resource" data-lt="Local Resources">Local Resource</dfn>
-					</dt>
-					<dd>
-						<p>A resource that is located inside the <a>EPUB Container</a>.</p>
-						<p>Refer to <a href="#sec-resource-locations"></a> for media type specific rules for resource
-							locations.</p>
-					</dd>
-
-					<dt>
 						<dfn id="dfn-manifest" data-lt="Manifests">Manifest</dfn>
 					</dt>
 					<dd>
@@ -559,19 +560,21 @@
 									the EPUB Container.</p>
 							</li>
 						</ul>
-						<p>Examples of resources that are not Publication Resources include those identified in Package
-							Document <a href="#sec-link-elem"><code>link</code> elements</a> and those identified in
-							outbound hyperlinks that resolve to <a>Remote Resources</a> (e.g., referenced from the
-								<code>href</code> attribute of an [[HTML]] <a data-cite="!html#the-a-element"
-									><code>a</code> element</a>).</p>
+						<div class="note">
+							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
+									<code>href</code> attribute of an [[HTML]] <a data-cite="!html#the-a-element"
+										><code>a</code> element</a>) are not Publication Resources.</p>
+						</div>
 					</dd>
 
 					<dt>
 						<dfn id="dfn-remote-resource" data-lt="Remote Resources">Remote Resource</dfn>
 					</dt>
 					<dd>
-						<p>A resource that is located outside of the <a>EPUB Container</a>, typically, but not
-							necessarily, online.</p>
+						<p>A <a>Publication Resource</a> that is located outside of the <a>EPUB Container</a>,
+							typically, but not necessarily, on the web.</p>
+						<p>Publication Resources within the EPUB Container are referred to as <a>Container
+							Resources</a>.</p>
 						<p>Refer to <a href="#sec-resource-locations"></a> for media type specific rules for resource
 							locations.</p>
 					</dd>
@@ -803,9 +806,7 @@
 						<p>The primary resources in this group are designated <a>Publication Resources</a>, which are
 							all the resources used in rendering an EPUB Publication to the user. <a>EPUB Creators</a>
 							always have to list these resources in the <a href="#sec-manifest-elem"
-									><code>manifest</code> element</a> but they do not have to locate them all in the
-								<a>EPUB Container</a>. EPUB 3 allows <a href="#sec-resource-locations">audio, video,
-								font and script data resources</a> to be hosted outside the Container.</p>
+									><code>manifest</code> element</a>.</p>
 
 						<p>Publication Resources are further classified by their use(s) in the <a>spine plane</a> and
 								<a>content plane</a>.</p>
@@ -822,6 +823,26 @@
 							this way, they are like an extension of the manifest.)</p>
 
 						<p>Refer to <a href="#sec-link-elem"></a> for more information about Linked Resources.</p>
+
+						<p>Resources in the manifest plane are also sometimes broken down by where they are located.
+							Although most Publication Resources have to be located in the EPUB Container (called
+								<a>Container Resources</a>), EPUB 3 allows <a href="#sec-resource-locations">audio,
+								video, font and script data resources</a> to be hosted outside the Container. These
+							exceptions were made to speed up the download and loading of EPUB Publications, as these
+							resources are typically quite large, and, in the case of fonts, not essential to the
+							presentation. When remotely hosted, these Publication Resources are referred to as <a>Remote
+								Resources</a>.</p>
+
+						<p>Since Linked Resources are not essential to the rendering of an EPUB Publication, there are
+							no requirements on where they are located and consequently no special naming of them based
+							on their location. They may be located within the EPUB Container or outside it.</p>
+
+						<div class="note">
+							<p>Hyperlinked content outside the EPUB Container (e.g., web pages) are not Publication
+								Resources, and consequently are not listed in the manifest. Reading Systems will
+								normally open these links in a separate browser instance, not as part of the EPUB
+								Publication.</p>
+						</div>
 					</section>
 
 					<section id="sec-spine-plane">
@@ -876,13 +897,11 @@
 					<section id="sec-content-plane">
 						<h5>The Content Plane</h5>
 
-						<p>
-							The <dfn>content plane</dfn> classifies resources that are used when rendering <a>EPUB Content Documents</a> 
-							and <a>Foreign Content Documents</a>.
-							These types of resources include embedded media, CSS style sheets, scripts, and fonts. 
-							These resources fall into three categories based on their Reading System support: <a>Core Media Type Resources</a>, <a>Foreign Resources</a>, 
-							and <a>Exempt Resources</a>.
-						</p>	
+						<p> The <dfn>content plane</dfn> classifies resources that are used when rendering <a>EPUB
+								Content Documents</a> and <a>Foreign Content Documents</a>. These types of resources
+							include embedded media, CSS style sheets, scripts, and fonts. These resources fall into
+							three categories based on their Reading System support: <a>Core Media Type Resources</a>,
+								<a>Foreign Resources</a>, and <a>Exempt Resources</a>. </p>
 
 						<p>A Core Media Type Resource is one that <a>Reading Systems</a> have to support, so it can be
 							used without restriction in EPUB or Foreign Content Documents. For more information about
@@ -1287,12 +1306,13 @@
 										><code>video</code></a> — including any child <a
 									data-cite="html#the-source-element"><code>source</code></a> elements — are Exempt
 								Resources.</p>
-              <div class="note">
-							  <p>Although Reading Systems are encouraged to support at least one of the H.264 [[?H264]]
-                  and VP8 [[?RFC6386]] video codecs, support for video codecs is not a conformance
-                  requirement. EPUB Creators must consider factors such as breadth of adoption, playback
-                  quality, and technology royalties when deciding which video formats to include.</p>
-              </div>
+							<div class="note">
+								<p>Although Reading Systems are encouraged to support at least one of the H.264
+									[[?H264]] and VP8 [[?RFC6386]] video codecs, support for video codecs is not a
+									conformance requirement. EPUB Creators must consider factors such as breadth of
+									adoption, playback quality, and technology royalties when deciding which video
+									formats to include.</p>
+							</div>
 						</dd>
 					</dl>
 
@@ -1436,7 +1456,7 @@
 							<a href="#sec-item-elem"><code>item</code></a> references a <a>Remote Resource</a>.</p>
 					</div>
 
-					<aside class="example" title="Referencing a local resource">
+					<aside class="example" title="Referencing a Container Resource">
 						<p>In this example, the audio file referenced from the [[HTML]] <a
 								data-cite="html#the-audio-element"><code>audio</code> element</a> is located inside the
 								<a>EPUB Container</a>.</p>
@@ -1452,7 +1472,7 @@
 &lt;/html></pre>
 					</aside>
 
-					<aside class="example" title="Referencing a remote resource">
+					<aside class="example" title="Referencing a Remote Resource">
 						<p>In this example, the audio file referenced from the [[HTML]] <a
 								data-cite="html#the-audio-element"><code>audio</code> element</a> is hosted on the
 							web.</p>
@@ -3124,15 +3144,14 @@ XHTML:
 &lt;/html></pre>
 						</aside>
 
-						<p id="linked-res-location">EPUB Creators MAY locate Linked Resources <a
-								data-lt="Local Resource">locally</a> or <a data-lt="Remote Resource">remotely</a>, but
-							should consider that <a>Reading Systems</a> are not required to retrieve Remote Resources
-							(i.e., Reading Systems might not make Remote Resources available).</p>
+						<p id="linked-res-location">EPUB Creators MAY locate Linked Resources within the <a>EPUB
+								Container</a> or externally, but should consider that <a>Reading Systems</a> are not
+							required to retrieve resources outside the EPUB Container.</p>
 
 						<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
 								attribute</a> is OPTIONAL when a Linked Resource is located outside the EPUB Container,
 							as more than one media type could be served from the same URL [[URL]]. EPUB Creators MUST
-							specify the attribute for all <a>Local Resources</a>.</p>
+							specify the attribute for all Linked Resources within the EPUB Container.</p>
 
 						<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of
 							the Linked Resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed
@@ -3303,8 +3322,8 @@ XHTML:
 						</dl>
 
 						<p id="confreq-rendition-manifest">EPUB Creators MUST list all <a>Publication Resources</a> in
-							the <code>manifest</code>, regardless of whether they are <a data-lt="Local Resource"
-								>Local</a> or <a>Remote Resources</a>, using <a class="codelink" href="#sec-item-elem"
+							the <code>manifest</code>, regardless of whether they are <a>Container Resources</a> or
+								<a>Remote Resources</a>, using <a class="codelink" href="#sec-item-elem"
 									><code>item</code> elements</a>.</p>
 
 						<p>Note that the <code>manifest</code> is not self-referencing: EPUB Creators MUST NOT specify
@@ -3704,7 +3723,7 @@ Package Document:
 										<code>audio</code> element embeds the audio in its EPUB Content Document, the
 									file is considered a Publication Resource. The EPUB Creator therefore must list the
 									audio file in the manifest and indicate that its parent EPUB Content Document
-									contains a remote resource.</p>
+									contains a <a>Remote Resource</a>.</p>
 
 								<pre>XHTML:
 &lt;html …>
@@ -4431,13 +4450,12 @@ No Entry</pre>
 										><code>base</code></a> element can be used to specify the <a
 									data-cite="html#document-base-url">document base URL</a> for the purposes of parsing
 								URLs. When using it in an <a>EPUB Publication</a>, the interpretation of the
-									<code>base</code> elements may inadvertently result in references to <a>Remote
-									Resources</a>, i.e., resources that are outside the <a>EPUB Container</a>. Using the
-									<code>base</code> element in an <a>EPUB Publication</a> may cause Reading Systems to
-								misinterpret the location of resources (e.g., relative links to other documents in the
-								publication might appear as links to a web site if the <code>base</code> element
-								specifies an absolute URL). To avoid significant interoperability issues, EPUB Creators
-								should not use the <code>base</code> element. </p>
+									<code>base</code> element may inadvertently result in references to <a>Remote
+									Resources</a>. It may also cause Reading Systems to misinterpret the location of
+								hyperlinks (e.g., relative links to other documents in the publication might appear as
+								links to a web site if the <code>base</code> element specifies an absolute URL). To
+								avoid significant interoperability issues, EPUB Creators should not use the
+									<code>base</code> element. </p>
 						</section>
 
 						<section id="sec-xhtml-deviations-rp">
@@ -5030,7 +5048,8 @@ No Entry</pre>
 							</li>
 							<li>
 								<p id="confreq-nav-a-href-other">MAY, for all other <code>nav</code> types, also
-									reference <a>Remote Resources</a>.</p>
+									reference content outside the <a>EPUB Container</a> (e.g., web-hosted
+									resources).</p>
 							</li>
 						</ul>
 					</li>
@@ -5168,8 +5187,8 @@ No Entry</pre>
 					<h4>The <code>page-list nav</code> Element </h4>
 
 					<p>The <code>page-list</code> element provides navigation to static page boundaries in the content.
-						These boundaries may correspond to a statically paginated source such as print or may be defined exclusively 
-						for the <a>EPUB Publication</a>.</p>
+						These boundaries may correspond to a statically paginated source such as print or may be defined
+						exclusively for the <a>EPUB Publication</a>.</p>
 
 
 					<p>The <code>page-list</code>
@@ -6386,10 +6405,9 @@ No Entry</pre>
 				<section id="sec-container-abstract-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>The <a>OCF Abstract Container</a> file system model uses a single common <a>Root Directory</a>
-						for all the contents. All <a>Local Resources</a> for the <a>EPUB Publication</a> are located
-						within the directory tree headed by the Root Directory, but no specific file system structure
-						for them is mandated by this specification.</p>
+					<p>The <a>OCF Abstract Container</a> file system model uses a single common <a>Root Directory</a>.
+						All <a>Container Resources</a> are located within the directory tree headed by the Root
+						Directory, but no specific file system structure for them is mandated by this specification.</p>
 
 					<p>The file system model also includes a mandatory directory named <code>META-INF</code> that is a
 						direct child of the Root Directory and stores the following special files:</p>
@@ -9546,13 +9564,13 @@ html.my-document-playing * {
 					include:</p>
 
 				<dl>
-					<dt>Embedding of remote resources</dt>
+					<dt>Embedding of Remote Resources</dt>
 					<dd>
-						<p>EPUB 3 allows some resources to be <a href="#dfn-remote-resource">remotely hosted</a>,
-							specifically resources whose sizes can negatively affect the downloading and opening of the
-							EPUB Publication (e.g., audio, video, and fonts). Although helpful for users when used as
-							intended, these exemptions can also be used to inject malicious content into a
-							publication.</p>
+						<p>EPUB 3 allows some <a>Publication Resources</a> to be <a href="#sec-resource-locations"
+								>remotely hosted</a>, specifically resources whose sizes can negatively affect the
+							downloading and opening of the EPUB Publication (e.g., audio, video, and fonts). Although
+							helpful for users when used as intended, these exemptions can also be used to inject
+							malicious content into a publication.</p>
 						<p>This threat is not limited to accessing content created by a bad actor. If EPUB Creators
 							embed content from untrustworthy sources (e.g., third party audio and video), there is
 							always the possibility that users may receive compromised resources.</p>
@@ -9561,7 +9579,7 @@ html.my-document-playing * {
 							embedded in the EPUB Container.</p>
 						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB Creator
 							and specific to each Reading System implementation. Consequently, if the EPUB Creator hosts
-							remote resources on a web server they control, the server effectively cannot use security
+							Remote Resources on a web server they control, the server effectively cannot use security
 							features that require specifying allowable origins, such as headers for <a
 								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
 								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
@@ -9678,7 +9696,7 @@ html.my-document-playing * {
 				<p>Some practical steps include:</p>
 
 				<ul>
-					<li>Ensuring the use of stable links to <a>remote resources</a>.</li>
+					<li>Ensuring the use of stable links to <a>Remote Resources</a>.</li>
 					<li>Avoiding third-party resources, especially those hosted on servers outside the control of the
 						EPUB Creator.</li>
 					<li>Avoiding links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
@@ -9955,8 +9973,8 @@ html.my-document-playing * {
 						accessibility enhancements like built-in read aloud or Media Overlays functionality where
 						interaction with assistive technologies is not essential.</p>
 
-					<p>Refer to <a data-cite="dpub-aria-1.0#">Digital Publishing WAI-ARIA Module</a> [[?DPUB-ARIA]] 
-						for more information about accessible publishing roles.</p>
+					<p>Refer to <a data-cite="dpub-aria-1.0#">Digital Publishing WAI-ARIA Module</a> [[?DPUB-ARIA]] for
+						more information about accessible publishing roles.</p>
 				</div>
 
 				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10959,86 +10959,87 @@ html.my-document-playing * {
 				<dl>
 					<dt><code>meta/data.xml</code></dt>
 					<dd>
-						<p>The resource is a metadata record, stored in the container. It is linked via a 
-							<a href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It is therefore a
-							<a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in the <a>manifest</a>. It is not part
-							on any other planes.
-						</p>
+						<p>The resource is a metadata record, stored in the container. It is linked via a <a
+								href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It
+							is therefore a <a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in
+							the <a>manifest</a>. It is not part on any other planes. </p>
 					</dd>
 
 					<dt><code>https://www.example.org/meta/data2.xml</code></dt>
 					<dd>
-						<p>The resource is a metadata record, stored remotely. It is linked via a 
-							<a href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It is therefore a
-							<a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in the
-							<a>manifest</a>. It is not part on any other planes.</p>
+						<p>The resource is a metadata record, stored remotely. It is linked via a <a
+								href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It
+							is therefore a <a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in
+							the <a>manifest</a>. It is not part on any other planes.</p>
 					</dd>
 
 					<dt><code>page.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is listed in the spine. It is a <a>Publication
-							Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an <a>EPUB Content Document</a> on the
-							<a>spine plane</a>, and is not present on the <a>content plane</a>. No fallback is
-							necessary.</p>
+								Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an <a>EPUB
+								Content Document</a> on the <a>spine plane</a>, and is not present on the <a>content
+								plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>nav.xhtml</code></dt>
 					<dd>
 						<p>The resource is the <a>EPUB Navigation Document</a>. It is not listed in the spine. It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, and is not present on either the
-							<a>spine plane</a> or the <a>content plane</a>. No fallback is necessary.</p>
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							and is not present on either the <a>spine plane</a> or the <a>content plane</a>. No fallback
+							is necessary.</p>
 					</dd>
 
 					<dt><code>style.css</code></dt>
 					<dd>
 						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[HTML]]
-							<a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, 
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
-							fallback is necessary.</p>
+								<a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the
+								<a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.otf</code></dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
-							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content
-							plane</a>. No fallback is necessary.</p>
+							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a
+								<a>Container Resource</a>, is not present on the <a>spine plane</a>, and is a <a>Core
+								Media Type Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>https://www.example.org/fonts/font-file2.otf</code></dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
-							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Remote Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content
-							plane</a>. No fallback is necessary.</p>
+							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Remote
+								Resource</a>, is not present on the <a>spine plane</a>, and is a <a>Core Media Type
+								Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.cff</code></dt>
 					<dd>
 						<p>The resource is a font file in Compact Font Format. It is not listed in the spine but is
-							referenced from a CSS file. Its media type is not listed as a 
-							<a href="#sec-core-media-types">core media type</a>. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine plane</a>,
-							and is an <a>Exempt Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
+							referenced from a CSS file. Its media type is not listed as a <a
+								href="#sec-core-media-types">core media type</a>. It is a <a>Publication Resource</a> on
+							the <a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine
+								plane</a>, and is an <a>Exempt Resource</a> on the <a>content plane</a>. No fallback is
+							necessary.</p>
 					</dd>
 
 					<dt><code>speech/cmn.pls</code></dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
 							from an [[HTML]] <a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							not present on the <a>spine plane</a>, and is an <a>Exempt Resource</a> on the <a>content plane</a>. 
-							No fallback is necessary.</p>
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							not present on the <a>spine plane</a>, and is an <a>Exempt Resource</a> on the <a>content
+								plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_1.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>. It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. 
-							No fallback is necessary.</p>
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the
+								<a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_2.png</code></dt>
@@ -11046,58 +11047,62 @@ html.my-document-playing * {
 						<p>The resource is a PNG image file. It is referenced via an [[HTML]] <a
 								data-cite="html#the-a-element"><code>a</code> element</a>. Because it is referenced from
 							a hyperlink, it <em>must</em> be listed in the spine. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, a <a>Container Resource</a>, a <a>Foreign Content Document</a> on the <a>spine plane</a>, 
-							and a <a>Core Media Type Resource</a> on the <a>content plane</a>. As a <a>Foreign Content
-							Document</a> a fallback is required, which is provided via a <a href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
+							the <a>manifest plane</a>, a <a>Container Resource</a>, a <a>Foreign Content Document</a> on
+							the <a>spine plane</a>, and a <a>Core Media Type Resource</a> on the <a>content plane</a>.
+							As a <a>Foreign Content Document</a> a fallback is required, which is provided via a <a
+								href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
 					<dt><code>image_desc.xhtml</code></dt>
 					<dd>
-						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not explicitly listed
-							in the spine (but it "replaces" the existing spine item when needed). It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an EPUB Content Document on
-							<a>spine plane</a>, and, because it is not "used" when rendering another Content Document, it is not present
-							on the <a>content plane</a>. No fallback is necessary.</p>
+						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not
+							explicitly listed in the spine (but it "replaces" the existing spine item when needed). It
+							is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							an EPUB Content Document on <a>spine plane</a>, and, because it is not "used" when rendering
+							another Content Document, it is not present on the <a>content plane</a>. No fallback is
+							necessary.</p>
 					</dd>
 
 					<dt><code>image/image_3.heic</code></dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
 							referenced from an [[HTML]] <a data-cite="html#the-source-element"><code>source</code>
-							element</a>. Its media type is not listed as a <a href="#sec-core-media-types">core media type</a>. 
-							It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Foreign Resource</a> on the <a>content
-							plane</a>. As a <a>Foreign Resource</a>, a fallback is required, which is provided via the
-							sibling [[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>
-							in an [[HTML]] <a data-cite="html#the-picture-element"><code>picture</code> element.</p>
+								element</a>. Its media type is not listed as a <a href="#sec-core-media-types">core
+								media type</a>. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a
+								<a>Container Resource</a>, is not present on the <a>spine plane</a>, and is a <a>Foreign
+								Resource</a> on the <a>content plane</a>. As a <a>Foreign Resource</a>, a fallback is
+							required, which is provided via the sibling [[HTML]] <a data-cite="html#the-img-element"
+									><code>img</code> element</a> in an [[HTML]] <a data-cite="html#the-picture-element"
+									><code>picture</code> element</a>.</p>
 					</dd>
 
 					<dt><code>image/image_3.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a> that is used as an
-							intrinsic fallback of the [[HTML]] <a data-cite="html#the-picture-element"><code>picture</code> element</a>. 
-							It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. 
-							No fallback is necessary.</p>
+							intrinsic fallback of the [[HTML]] <a data-cite="html#the-picture-element"
+									><code>picture</code> element</a>. It is a <a>Publication Resource</a> on the
+								<a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine
+								plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>widget.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-cite="html#the-iframe-element"><code>iframe</code> element</a>. It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on <a>spine plane</a>, and, because it is "used" when rendering another Content Document, 
-							a <a>Core Media Type Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on <a>spine plane</a>, and, because it is "used" when rendering another
+							Content Document, a <a>Core Media Type Resource</a> on the <a>content plane</a>. No fallback
+							is necessary.</p>
 					</dd>
 
 					<dt><code>https://www.example.org/some_content</code></dt>
 					<dd>
-						<p>
-							The resource is referenced via an [[HTML]] <a data-cite="html#the-a-element"><code>a</code> element</a>
-							and is not stored in the <a>EPUB Container</a>. Reading Systems will normally open this link via a separate browser instance.
-							It is not any planes defined by this specification.
-						</p>
+						<p>The resource is referenced via an [[HTML]] <a data-cite="html#the-a-element"><code>a</code>
+								element</a> and is not stored in the <a>EPUB Container</a>. Reading Systems will
+							normally open this link via a separate browser instance. It is not any planes defined by
+							this specification.</p>
 					</dd>
 
 				</dl>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -133,18 +133,19 @@
 					while this specification details the rendering requirements for them in EPUB Reading Systems.</p>
 
 				<p>An EPUB Reading System can take many forms. It might have a visual display area for rendering the
-					content to users, for example, or it might only provide audio playback of the content. 
-					Therefore, there is no single set of rules that applies to all Reading Systems. Rather, this specification
+					content to users, for example, or it might only provide audio playback of the content. Therefore,
+					there is no single set of rules that applies to all Reading Systems. Rather, this specification
 					breaks down the rendering requirements based on a Reading System's capabilities and the features it
 					supports.</p>
 
-				<p>Moreover, this specification allows for a great deal of flexibility for developers to create unique user interfaces, 
-				   and requirements for things like metadata processing are intentionally minimal to allow for such flexibility.</p>
+				<p>Moreover, this specification allows for a great deal of flexibility for developers to create unique
+					user interfaces, and requirements for things like metadata processing are intentionally minimal to
+					allow for such flexibility.</p>
 
 				<p>So, although this specification identifies the formal requirements for Reading Systems, it is not
-					possible to understand this document in isolation. Developers should also familiarize themselves with the
-					full content structure of an EPUB Publication in order to understand the complete range of information that
-					is available.</p>
+					possible to understand this document in isolation. Developers should also familiarize themselves
+					with the full content structure of an EPUB Publication in order to understand the complete range of
+					information that is available.</p>
 
 				<div class="note">
 					<p>A conforming Reading System is not necessarily a single dedicated program or device but might
@@ -156,8 +157,7 @@
 				<h3>Terminology</h3>
 
 				<p>This specification uses <a data-cite="epub-33#sec-terminology">terminology defined in EPUB 3.3</a>
-					[[EPUB-33]] as well as the term defined in this section. Terms appear capitalized wherever
-					used.</p>
+					[[EPUB-33]] as well as the term defined in this section. Terms appear capitalized wherever used.</p>
 
 				<p>Only the first instance of a term in a section links to its definition.</p>
 
@@ -192,8 +192,8 @@
 					<p>This specification does not require EPUB Reading Systems to support scripting, HTML forms or the
 						HTML DOM. Reading Systems conformant with this specification are only expected to be able to
 						process a conforming <a>EPUB Content Document</a>. As <a href="#sec-scripted-content">support
-							for scripting and HTML forms</a> is not compulsory, a conformant Reading System might not be a
-						fully-conformant HTML user agent.</p>
+							for scripting and HTML forms</a> is not compulsory, a conformant Reading System might not be
+						a fully-conformant HTML user agent.</p>
 				</section>
 
 
@@ -229,7 +229,7 @@
 			<section id="sec-epub-rs-conf-remote-res">
 				<h4>Remote Resources</h4>
 
-				<p id="confreq-rs-remote">Reading Systems SHOULD support <a>remote resources</a>, as defined in <a
+				<p id="confreq-rs-remote">Reading Systems SHOULD support <a>Remote Resources</a>, as defined in <a
 						data-cite="epub-33#sec-resource-locations">Resource Locations</a> [[EPUB-33]].</p>
 			</section>
 
@@ -336,8 +336,8 @@
 			<section id="sec-epub-rs-network-access">
 				<h3>Network Access</h3>
 
-				<p>Reading Systems MAY support network access to <a href="#sec-epub-rs-conf-remote-res">retrieve remote
-						resources</a> and to allow <a>Scripted Content Documents</a> to <a
+				<p>Reading Systems MAY support network access to <a href="#sec-epub-rs-conf-remote-res">retrieve Remote
+						Resources</a> and to allow <a>Scripted Content Documents</a> to <a
 						href="#confreq-rs-scripted-limit">communicate with web-hosted APIs and retrieve
 					resources</a>.</p>
 
@@ -517,9 +517,9 @@
 			<section id="sec-pkg-doc-manifest">
 				<h3>Manifest</h3>
 
-				<p id="confreq-rs-pkg-manifest-unknown" data-tests="#pkg-manifest-unknown">Reading Systems MUST
-					ignore values of the <a data-cite="epub-33#sec-item-resource-properties"><code>properties</code> 
-					attribute</a> [[EPUB-33]] they do not recognize.</p>
+				<p id="confreq-rs-pkg-manifest-unknown" data-tests="#pkg-manifest-unknown">Reading Systems MUST ignore
+					values of the <a data-cite="epub-33#sec-item-resource-properties"><code>properties</code>
+						attribute</a> [[EPUB-33]] they do not recognize.</p>
 
 				<p id="confreq-rendition-rs-manifest" data-tests="#pkg-manifest-unlisted-resource">Reading Systems
 					SHOULD NOT use <a>Linked Resources</a> in the rendering of an EPUB Publication due to the inherent
@@ -537,9 +537,9 @@
 					display the content.</p>
 
 				<p>When <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallbacks</a> [[EPUB-33]] are provided
-					for <a>Top-level Content Documents</a>, Reading Systems MAY choose from the available options
-					to find the optimal version to render in a given context (e.g., by inspecting the properties
-					attribute for each).</p>
+					for <a>Top-level Content Documents</a>, Reading Systems MAY choose from the available options to
+					find the optimal version to render in a given context (e.g., by inspecting the properties attribute
+					for each).</p>
 
 				<p>A Reading System MUST terminate the fallback chain at the first reference to a manifest item it has
 					already encountered.</p>
@@ -914,8 +914,8 @@
 
 					<li>
 						<p id="confreq-rs-scripted-origin">
-							<span id="confreq-rs-scripted-origin-shared" data-tests="#scr-support_origin">It MUST
-								assign a unique <a data-cite="url#origin">origin</a> [[URL]], shared by all <a
+							<span id="confreq-rs-scripted-origin-shared" data-tests="#scr-support_origin">It MUST assign
+								a unique <a data-cite="url#origin">origin</a> [[URL]], shared by all <a
 									data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> of the EPUB
 								Publication.</span>
 							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin">That <a
@@ -1107,10 +1107,11 @@
 					<section id="layout">
 						<h5>The <code>rendition:layout</code> Property</h5>
 
-					  <p>The default value <code>reflowable</code> MUST be assumed by EPUB Reading Systems as the global
-						  value if no <a data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
-							data-cite="epub-33#layout"><code>rendition:layout</code> property</a> occurs in the <a
-							data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a> [[EPUB-33]].</p>
+						<p>The default value <code>reflowable</code> MUST be assumed by EPUB Reading Systems as the
+							global value if no <a data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a>
+							carrying the <a data-cite="epub-33#layout"><code>rendition:layout</code> property</a> occurs
+							in the <a data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a>
+							[[EPUB-33]].</p>
 
 						<p id="layout-pre-paginated" data-tests="#fxl-layout-pre-paginated-spreads">When the
 								<code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading
@@ -1133,22 +1134,24 @@
 							</dd>
 						</dl>
 
-  					<p>When a spine <code>itemref</code> element's <a data-cite="epub-33#attrdef-properties"
-								><code>properties</code> attribute</a> contains an <a
-							data-cite="epub-33#layout-overrides">override of the global rendition:layout property</a>
-	  					[[EPUB-33]], Reading Systems MUST follow the requirements for the override's global value when
-		  				displaying that spine item (e.g., a spine item that specifies <code>layout-prepaginated</code>
-			  			is rendered following the requirements of the global <code>pre-paginated</code> value).</p>
+						<p>When a spine <code>itemref</code> element's <a data-cite="epub-33#attrdef-properties"
+									><code>properties</code> attribute</a> contains an <a
+								data-cite="epub-33#layout-overrides">override of the global rendition:layout
+								property</a> [[EPUB-33]], Reading Systems MUST follow the requirements for the
+							override's global value when displaying that spine item (e.g., a spine item that specifies
+								<code>layout-prepaginated</code> is rendered following the requirements of the global
+								<code>pre-paginated</code> value).</p>
 					</section>
 
 					<section id="orientation">
 						<h5>The <code>rendition:orientation</code> Property</h5>
 
-  					<p id="fxl-orientation-default" data-tests="#fxl-orientation-default">The default value
-							<code>auto</code> MUST be assumed by EPUB Reading Systems as the global value if no <a
-							data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
-							data-cite="epub-33#orientation"><code>rendition:orientation</code> property</a> occurs in
-	  					the <a data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a> [[EPUB-33]].</p>
+						<p id="fxl-orientation-default" data-tests="#fxl-orientation-default">The default value
+								<code>auto</code> MUST be assumed by EPUB Reading Systems as the global value if no <a
+								data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
+								data-cite="epub-33#orientation"><code>rendition:orientation</code> property</a> occurs
+							in the <a data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a>
+							[[EPUB-33]].</p>
 
 						<p>The <code>rendition:orientation</code> property values have the following processing
 							requirements:</p>
@@ -1178,21 +1181,21 @@
 					<section id="spread">
 						<h5>The <code>rendition:spread</code> Property</h5>
 
-  					<p id="fxl-spread-default" data-tests="#fxl-spread-default">The default value <code>auto</code>
-              MUST be assumed by EPUB Reading Systems as the global value if no <a
-							data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
-							data-cite="epub-33#spread"><code>rendition:spread</code> property</a> occurs in the <a
-							data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a> [[EPUB-33]].</p>
+						<p id="fxl-spread-default" data-tests="#fxl-spread-default">The default value <code>auto</code>
+							MUST be assumed by EPUB Reading Systems as the global value if no <a
+								data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
+								data-cite="epub-33#spread"><code>rendition:spread</code> property</a> occurs in the <a
+								data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a> [[EPUB-33]].</p>
 
 						<p>The <code>rendition:spread</code> property values have the following processing
 							requirements:</p>
 
 						<dl class="variablelist">
 							<dt id="def-spread-none" data-tests="#fxl-spread-none">none</dt>
-  						<dd>
-	  						<p>Reading Systems MUST NOT incorporate spine items in a <a>Synthetic Spread</a>. Reading
-		  						Systems SHOULD create a single <a>Viewport</a> positioned at the center of the
-			  					screen.</p>
+							<dd>
+								<p>Reading Systems MUST NOT incorporate spine items in a <a>Synthetic Spread</a>.
+									Reading Systems SHOULD create a single <a>Viewport</a> positioned at the center of
+									the screen.</p>
 							</dd>
 							<dt id="def-spread-landscape" data-tests="#fxl-spread-landscape">landscape</dt>
 							<dd>
@@ -1217,54 +1220,55 @@
 						</dl>
 					</section>
 
-				<section id="page-spread">
-					<h4>The <code>rendition:page-spread-*</code> Properties</h4>
+					<section id="page-spread">
+						<h4>The <code>rendition:page-spread-*</code> Properties</h4>
 
-					<p>The <a data-cite="epub-33#fxl-page-spread-left"><span id="page-spread-left"
-								data-tests="#fxl-page-spread-left"><code>rendition:page-spread-left</code></span>
-							property</a> [[EPUB-33]] indicates that the given spine item SHOULD be rendered in the
-						left-hand slot in the spread, and <a data-cite="epub-33#fxl-page-spread-right"><span
-								id="page-spread-right"><code>rendition:page-spread-right</code></span> property</a>
-						[[EPUB-33]] that it SHOULD be rendered in the right-hand slot.</p>
+						<p>The <a data-cite="epub-33#fxl-page-spread-left"><span id="page-spread-left"
+									data-tests="#fxl-page-spread-left"><code>rendition:page-spread-left</code></span>
+								property</a> [[EPUB-33]] indicates that the given spine item SHOULD be rendered in the
+							left-hand slot in the spread, and <a data-cite="epub-33#fxl-page-spread-right"><span
+									id="page-spread-right"><code>rendition:page-spread-right</code></span> property</a>
+							[[EPUB-33]] that it SHOULD be rendered in the right-hand slot.</p>
 
-					<p>Reading Systems that support the <a href="#def-spread-none"><code>spread-none</code> property</a>
-						MUST recognize the <a data-cite="epub-33#fxl-page-spread-center"><span id="page-spread-center"
-									><code>rendition:page-spread-center</code></span> property</a> as an alias for it,
-						otherwise they MUST ignore the <code>rendition:page-spread-center</code> property.</p>
+						<p>Reading Systems that support the <a href="#def-spread-none"><code>spread-none</code>
+								property</a> MUST recognize the <a data-cite="epub-33#fxl-page-spread-center"><span
+									id="page-spread-center"><code>rendition:page-spread-center</code></span>
+								property</a> as an alias for it, otherwise they MUST ignore the
+								<code>rendition:page-spread-center</code> property.</p>
 
-					<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-						properties apply to both pre-paginated and reflowable content, and they only apply when the
-						Reading System is creating Synthetic Spreads.</p>
+						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
+							properties apply to both pre-paginated and reflowable content, and they only apply when the
+							Reading System is creating Synthetic Spreads.</p>
 
-					<p>The <code id="page-break-precedence">rendition:page-spread-*</code> properties MUST take
-						precedence over whatever value of the <a
-							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-								><code>page-break-before</code> property</a> [[CSSSnapshot]] has been set for an
-							<a>XHTML Content Document</a>.</p>
+						<p>The <code id="page-break-precedence">rendition:page-spread-*</code> properties MUST take
+							precedence over whatever value of the <a
+								href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
+									><code>page-break-before</code> property</a> [[CSSSnapshot]] has been set for an
+								<a>XHTML Content Document</a>.</p>
 
-					<p id="page-layout-both" data-tests="#page-layout-both">When a <a href="#def-layout-reflowable"
-							>reflowable</a> spine item follows a <a href="#def-layout-pre-paginated">pre-paginated</a>
-						one, the reflowable one SHOULD start on the next page &#8212; as defined by the <a
-							data-cite="epub-33#attrdef-spine-page-progression-direction"
-								><code>page-progression-direction</code> attribute</a> [[EPUB-33]] &#8212; when it lacks
-						a <code>rendition:page-spread-*</code> property value.</p>
+						<p id="page-layout-both" data-tests="#page-layout-both">When a <a href="#def-layout-reflowable"
+								>reflowable</a> spine item follows a <a href="#def-layout-pre-paginated"
+								>pre-paginated</a> one, the reflowable one SHOULD start on the next page &#8212; as
+							defined by the <a data-cite="epub-33#attrdef-spine-page-progression-direction"
+									><code>page-progression-direction</code> attribute</a> [[EPUB-33]] &#8212; when it
+							lacks a <code>rendition:page-spread-*</code> property value.</p>
 
-					<p id="page-spread-flow" data-tests="#page-layout-both-flow">If the reflowable spine item has a
-							<code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by inserting a
-						blank page).</p>
+						<p id="page-spread-flow" data-tests="#page-layout-both-flow">If the reflowable spine item has a
+								<code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by
+							inserting a blank page).</p>
 
-					<p>Similarly, when a pre-paginated spine item follows a reflowable one, the pre-paginated one SHOULD
-						start on the next page (as defined by the <code>page-progression-direction</code> attribute)
-						when it lacks a <code>rendition:page-spread-*</code> property value. If the pre-paginated spine
-						item has a <code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by
-						inserting a blank page).</p>
+						<p>Similarly, when a pre-paginated spine item follows a reflowable one, the pre-paginated one
+							SHOULD start on the next page (as defined by the <code>page-progression-direction</code>
+							attribute) when it lacks a <code>rendition:page-spread-*</code> property value. If the
+							pre-paginated spine item has a <code>rendition:page-spread-*</code> specification, it MUST
+							be honored (e.g., by inserting a blank page).</p>
 
-					<p id="fxl-page-spread-combined" data-tests="#fxl-page-spread-combined">When a Reading System
-						encounters two spine items that represent a true spread (i.e., two adjacent spine items with the
-							<code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-	 					properties), it SHOULD create the spread with no space between the adjacent pages.</p>
-		  		</section>
-  			</section>
+						<p id="fxl-page-spread-combined" data-tests="#fxl-page-spread-combined">When a Reading System
+							encounters two spine items that represent a true spread (i.e., two adjacent spine items with
+							the <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
+							properties), it SHOULD create the spread with no space between the adjacent pages.</p>
+					</section>
+				</section>
 
 				<section id="sec-fxl-dimensions">
 					<h4>Initial Containing Block Dimensions</h4>
@@ -1340,7 +1344,7 @@
 						<dd id="paginated-dd" data-tests="#pkg-flow-paginated">
 							<p>The Reading System SHOULD dynamically paginate all overflow content.</p>
 						</dd>
-            
+
 						<dt id="scrolled-continuous">scrolled-continuous</dt>
 						<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
 							<p>The Reading System SHOULD render all Content Documents such that overflow content is
@@ -1348,14 +1352,14 @@
 								item to spine item (except where <a data-cite="epub-33#layout-property-flow-overrides"
 									>locally overridden</a> [[EPUB-33]]).</p>
 						</dd>
-            
+
 						<dt id="scrolled-doc">scrolled-doc</dt>
 						<dd id="scrolled-doc-dd" data-tests="#pkg-flow-scrolled-doc">
 							<p>The Reading System SHOULD render all Content Documents such that users can scroll
 								overflow content, and SHOULD present each spine item as a separate scrollable
 								document.</p>
 						</dd>
-            
+
 						<dt id="auto">auto</dt>
 						<dd>
 							<p>The Reading System MAY render overflow content using its default method or a user
@@ -1554,7 +1558,7 @@
 								</tr>
 							</tbody>
 						</table>
-            
+
 						<p>Note that the last two links are <a data-cite="epub-33#urls-in-ocf-constraints"
 								>disallowed</a> in an EPUB Publications to ensure better interoperability with
 							non-conforming or legacy Reading Systems and toolchains.</p>
@@ -1700,15 +1704,15 @@
 				<p id="confreq-ocf-fobfus">Reading Systems SHOULD support deobfuscation of fonts as defined in <a
 						data-cite="epub-33#sec-font-obfuscation">Font Obfuscation</a> [[EPUB-33]].</p>
 
-				<p>To restore the original data, Reading Systems should simply reverse the process: the source
-					file becomes the obfuscated data, and the destination file contains the raw data.</p>
+				<p>To restore the original data, Reading Systems should simply reverse the process: the source file
+					becomes the obfuscated data, and the destination file contains the raw data.</p>
 
 				<div class="note">
-					<p>EPUB 3 allowed font obfuscation prior to EPUB 3.0.1, but did not specify the order of
-						obfuscation and compression. As a result, Reading Systems might encounter invalid fonts after
-						decompression and deobfuscation. In such instances, deobfuscating the data before inflating it
-						may return a valid font. Reading Systems do not have to support this method of retrieval, but
-						developers should consider it when supporting EPUB 3 content generally.</p>
+					<p>EPUB 3 allowed font obfuscation prior to EPUB 3.0.1, but did not specify the order of obfuscation
+						and compression. As a result, Reading Systems might encounter invalid fonts after decompression
+						and deobfuscation. In such instances, deobfuscating the data before inflating it may return a
+						valid font. Reading Systems do not have to support this method of retrieval, but developers
+						should consider it when supporting EPUB 3 content generally.</p>
 				</div>
 			</section>
 		</section>
@@ -1847,10 +1851,10 @@
 
 					<div class="note">
 						<p>EPUB Creators may associate a Media Overlay Document directly with an <a>EPUB Navigation
-              Document</a>t in order to provide synchronized playback of its contents, regardless of 
-              whether the <a>XHTML Content Document</a> in which it resides is included in the
-              <a>spine</a>. See <a data-cite="epub-33#sec-mo-nav-doc">EPUB Navigation Document</a>
-              [[EPUB-33]] for more information.</p>
+								Document</a>t in order to provide synchronized playback of its contents, regardless of
+							whether the <a>XHTML Content Document</a> in which it resides is included in the
+								<a>spine</a>. See <a data-cite="epub-33#sec-mo-nav-doc">EPUB Navigation Document</a>
+							[[EPUB-33]] for more information.</p>
 					</div>
 
 					<div class="note" id="note-table-reading-mode">
@@ -2135,8 +2139,8 @@
 				or seek to avoid in their applications.</p>
 
 			<p>The W3C's User Agent Accessibility Guidelines [[UAAG20]] provides many useful practices developers should
-				apply to improve their Reading Systems as many browser accessibility issues have parallels in EPUB-specific 
-				user agents.</p>
+				apply to improve their Reading Systems as many browser accessibility issues have parallels in
+				EPUB-specific user agents.</p>
 
 			<p>The following list outlines some additional EPUB-specific areas where a lack of accessibility impacts the
 				reading experience for users:</p>
@@ -2148,10 +2152,10 @@
 					assistive technologies to properly announce the content.</li>
 				<li>User Interface Controls &#8212; Ensure that all controls (e.g., search boxes, annotation controls,
 					and buttons to load features such as the table of contents) are exposed to assistive technologies
-					and that their actions do not rely on specific modalities (e.g., they only operate through touch or a
-					mouse).</li>
-				<li>Search &#8212; Search access to the full text content of all EPUB Content Documents is necessary 
-					to ensure users can locate information easily.</li>
+					and that their actions do not rely on specific modalities (e.g., they only operate through touch or
+					a mouse).</li>
+				<li>Search &#8212; Search access to the full text content of all EPUB Content Documents is necessary to
+					ensure users can locate information easily.</li>
 				<li>Display Control &#8212; Provide methods for users to tailor the styling of the content to their
 					preferences (e.g., to change and increase fonts, increase line and word spacing, and apply alternate
 					contrasts).</li>
@@ -2233,14 +2237,14 @@
 					<dt>Remote resources</dt>
 					<dd>
 						<p><a>Remote resources</a> present the same risks as any EPUB Publication loaded from an
-							untrusted source. Even if the publisher of the EPUB Publication is trusted, remote resources
+							untrusted source. Even if the publisher of the EPUB Publication is trusted, Remote Resources
 							may be compromised.</p>
-						<p>Calls to remote resources can also be used to track information about users (e.g., through
+						<p>Calls to Remote Resources can also be used to track information about users (e.g., through
 							server logs). Reading Systems should limit the information they expose through HTTP requests
 							to only what is essential to obtain the resource.</p>
 						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB Creator
 							and specific to each Reading System implementation. Consequently, if the EPUB Creator hosts
-							remote resources on a web server they control, the server effectively cannot use security
+							Remote Resources on a web server they control, the server effectively cannot use security
 							features that require specifying allowable origins, such as headers for <a
 								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
 								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
@@ -2250,7 +2254,7 @@
 
 					<dt>External links</dt>
 					<dd>
-						<p>Like remote resources, external links may be used to trick unwitting users into opening
+						<p>Like Remote Resources, external links may be used to trick unwitting users into opening
 							malicious resources on the web designed to exploit the Reading System or operating
 							system.</p>
 						<p>Likewise, Reading Systems should also avoid exposing potentially identifying information
@@ -2311,7 +2315,7 @@
 					distribution, display, or sale &#8212; should also be aware of the potential risks in ingestion. It
 					is advised that content processors check content for malicious content on ingestion, in addition to
 					the validation steps that usually occur. This could include running virus scans, validating external
-					links and remote resources, and other precautions.</p>
+					links and Eemote Resources, and other precautions.</p>
 			</section>
 		</section>
 		<section id="app-epubReadingSystem">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -193,7 +193,7 @@
 						HTML DOM. Reading Systems conformant with this specification are only expected to be able to
 						process a conforming <a>EPUB Content Document</a>. As <a href="#sec-scripted-content">support
 							for scripting and HTML forms</a> is not compulsory, a conformant Reading System might not be
-						a fully-conformant HTML user agent.</p>
+						a fully conformant HTML user agent.</p>
 				</section>
 
 


### PR DESCRIPTION
I've gone through and cleaned up the definitions and text to make sure "remote resources" is being used consistently for publication resources we've exempted from being in the container.

I've also changed "local resource" to "container resource" to make it more obvious what it is "local" to.

I've also done my best to fix #2194 by adding a couple more paragraphs to break down why some publication resources can be outside the container and why we don't care where linked resources are (plus an explanation that external hyperlinks don't fall into this discussion). If someone still wants to come up with a "plane" for this, I'm open to suggestions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2214.html" title="Last updated on Apr 6, 2022, 2:14 PM UTC (e88f14e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2214/8f16c4d...e88f14e.html" title="Last updated on Apr 6, 2022, 2:14 PM UTC (e88f14e)">Diff</a>