### PR TITLE
Editorial updates to conformance identification

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -994,9 +994,12 @@
 				<section id="sec-conf-reporting-pub">
 					<h4>Publication Conformance</h4>
 
-					<p>To indicate that an EPUB Publication conforms to the accessibility requirements of this
-						specification, it MUST include a <code id="dcterms-conformsTo">conformsTo</code> property whose
-						value MUST exactly match (i.e., both in case and spacing) the following pattern:</p>
+					<p>To indicate conformance to the accessibility requirements of this specification, an EPUB
+						Publication's <a data-cite="epub-33#sec-pkg-metadata">metadata section</a> [[EPUB-33]] MUST
+						specify a <a
+							href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/conformsTo"
+								><code id="dcterms-conformsTo">conformsTo</code> property</a> [[DCTERMS]] exactly
+						matching (i.e., both in case and spacing) the following pattern:</p>
 
 					<p class="conf-pattern">EPUB-A11Y-<a href="#acc-ver"><var>A11Y-VER</var></a>_WCAG-<a
 							href="#wcag-ver"><var>WCAG-VER</var></a>-<a href="#wcag-lvl"><var>WCAG-LVL</var></a></p>
@@ -1006,22 +1009,40 @@
 					<dl class="varlist">
 						<dt id="acc-ver"><var>A11Y-VER</var></dt>
 						<dd>
-							<p>EPUB Creators MUST specify the version number of the EPUB Accessibility specification the
-								publication conforms to, not including the decimal points. EPUB Creators MUST use the
-								value <code>11</code> to indicate this version of this specification.</p>
+							<p>Specifies the version number of the EPUB Accessibility specification the publication
+								conforms to. The value MUST NOT include decimal points (e.g., the value <code>11</code>
+								indicates this version of this specification).</p>
 						</dd>
 						<dt id="wcag-ver"><var>WCAG-VER</var></dt>
 						<dd>
-							<p>EPUB Creators MUST specify the version number of WCAG the publication conforms to, not
-								including the decimal points (e.g., <code>20</code> for WCAG 2.0 or <code>21</code> for
-								WCAG 2.1).</p>
+							<p>Specifies the version number of WCAG the publication conforms to. The value MUST NOT
+								include decimal points (e.g., <code>20</code> for WCAG 2.0 or <code>21</code> for WCAG
+								2.1).</p>
 						</dd>
 						<dt id="wcag-lvl"><var>WCAG-LVL</var></dt>
 						<dd>
-							<p>EPUB Creators MUST specify the WCAG conformance level the publication conforms to (e.g.,
-									<code>A</code> or <code>AA</code>).</p>
+							<p>Specifies the WCAG conformance level the publication conforms to (e.g., <code>A</code> or
+									<code>AA</code>).</p>
 						</dd>
 					</dl>
+
+					<aside class="example" title="A basic conformance statement">
+						<p>In this example, the EPUB Creator is stating that their publication conforms to the EPUB
+							Accessibility 1.1 specification at WCAG 2.1 Level AA.</p>
+
+						<pre>&lt;package …>
+   &lt;metadata …>
+      …
+      &lt;meta 
+          property="dcterms:conformsTo"
+          id="conf">
+         EPUB-A11Y-11_WCAG-21-AA
+      &lt;/meta>
+      …
+   &lt;/metadata>
+   …
+&lt;/package></pre>
+					</aside>
 
 					<p>The following conformance strings are valid as of publication of this specification:</p>
 
@@ -1036,30 +1057,21 @@
 
 					<div class="note">
 						<p>The list of valid conformance strings will increase as W3C releases new versions of WCAG.</p>
-					</div>
 
-					<aside class="example" title="A basic conformance statement">
-						<p>In this example, the EPUB Creator is stating that publication conforms to the EPUB
-							Accessibility 1.1 specification at WCAG 2.1 Level AA.</p>
-						<pre>&lt;metadata …>
-   …
-   &lt;meta 
-       property="dcterms:conformsTo"
-       id="conf">
-      EPUB-A11Y-11_WCAG-21-AA
-   &lt;/meta>
-   …
-&lt;/metadata></pre>
-					</aside>
-
-					<div class="note">
-						<p>The future <a href="https://www.w3.org/TR/wcag-3.0/">3.0 version of WCAG</a> is likely to
-							also introduce new level names (currently Bronze, Silver and Gold). Those names would
-							replace A, AA, and AAA in the string pattern.</p>
+						<p>In addition, <a href="https://www.w3.org/TR/wcag-3.0/">WCAG 3.0</a> is set to introduce new
+							level names (currently Bronze, Silver and Gold). Those names would likely replace A, AA, and
+							AAA in the string pattern, but conformance will be addressed after that specification
+							becomes a <a href="https://www.w3.org/Consortium/Process/#RecsW3C">W3C
+							Recommendation</a>.</p>
 					</div>
 
 					<div class="note">
-						<p>EPUB Creators may use a conformance URL, as defined in the <a
+						<p>The requirement to include a <code>dcterms:conformsTo</code> identifer does not prevent EPUB
+							Publications from conforming to other standards, including other accessibility standards and
+							guidelines (e.g., a specification that covers specific natural language issues). An EPUB
+							Publication may have multiple <code>dcterms:conformsTo</code> statements.</p>
+
+						<p>EPUB Creators may also use a conformance URL, as defined in the <a
 								href="https://www.w3.org/TR/WCAG/#conformance-required">Required Components of a
 								Conformance Claim</a> [[WCAG2]], with the <code>conformsTo</code> property for EPUB
 							Publications that only meet WCAG conformance requirements (i.e., that do not fully conform


### PR DESCRIPTION
This pull request adds an additional explanation that we are not preventing the use of other dcterms:conformsTo properties to the note that already existed to clarify that you can claim wcag-only conformance.

It also does the following cleanup:

- makes the requirement in first paragraph that the metadata specify a property to avoid mentioning the creator
- removes the "musts" from what each segment of the string specifies, as we already control that by defining the segments. The normative requirement on two of the values is that they not include decimal points, so I've made those normative.
- the example is moved up after the explanation of the segments and the package element added to it
- the note about additional wcag versions is merged with the note about new wcag levels in 3.0 since these are related

Fixes #2215 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2215/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2215/epub33/a11y/index.html)
