### PR TITLE
Improved the example with the new concepts

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10860,7 +10860,7 @@ html.my-document-playing * {
 			<h2>Detailed Examples</h2>
 
 			<section id="publication-resources-example">
-				<h3>Publication Resources</h3>
+				<h3>Resources</h3>
 
 				<p>Consider the following extracts of a <a>Package Document</a> and an <a>XHTML Content
 					Document</a>:</p>
@@ -10868,7 +10868,12 @@ html.my-document-playing * {
 				<pre>&lt;package …>
     &lt;metadata …>
         …
-        &lt;link rel="record" href="meta/data.xml" media-type="application/marc"/>
+        &lt;link rel="record" 
+            href="meta/data.xml" 
+            media-type="application/marc"/>
+        &lt;link rel="record" 
+            href="https://www.example.org/meta/data2.xml" 
+            media-type="application/marc"/>
         …
     &lt;/metadata>
     &lt;manifest>
@@ -10885,6 +10890,9 @@ html.my-document-playing * {
             media-type="text/css"/>
         &lt;item id="font_otf"
             href="fonts/font-file.otf"
+            media-type="font/otf"/>
+        &lt;item id="font_otf_remote"
+            href="https://www.example.org/fonts/font-file2.otf"
             media-type="font/otf"/>
         &lt;item id="font_cff"
             href="fonts/font-file.cff"
@@ -10931,14 +10939,16 @@ html.my-document-playing * {
     &lt;body>
         &lt;img src="media/image1_png"/>
         …
-        &lt;a href="media/image_3.png">…&lt;/a>
+        &lt;a href="media/image_2.png">…&lt;/a>
         …
         &lt;picture>
             &lt;source srcset="media/image_3.heic" type="image/heic"/>
             &lt;img src="media/image_3.png"/>
         &lt;/picture>
-        
+        …        
         &lt;iframe src="widget.xhtml">&lt;/iframe>
+        …
+        &lt;a href="https://www.example.org/some_content">…&lt;/a>
     &lt;/body>
 &lt;/html>					
 				</pre>
@@ -10949,69 +10959,86 @@ html.my-document-playing * {
 				<dl>
 					<dt><code>meta/data.xml</code></dt>
 					<dd>
-						<p>The resource is a metadata record. It is linked via a <a href="#sec-link-elem"
-									><code>link</code> element</a> in the Package Document metadata. It is therefore a
-								<a>Linked Resource</a> on the <a>manifest plane</a> and not listed in the
-								<a>manifest</a>.</p>
+						<p>The resource is a metadata record, stored in the container. It is linked via a 
+							<a href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It is therefore a
+							<a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in the <a>manifest</a>. It is not part
+							on any other planes.
+						</p>
+					</dd>
+
+					<dt><code>https://www.example.org/meta/data2.xml</code></dt>
+					<dd>
+						<p>The resource is a metadata record, stored remotely. It is linked via a 
+							<a href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It is therefore a
+							<a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in the
+							<a>manifest</a>. It is not part on any other planes.</p>
 					</dd>
 
 					<dt><code>page.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is listed in the spine. It is a <a>Publication
-								Resource</a> on the <a>manifest plane</a>, an <a>EPUB Content Document</a> on the
-								<a>spine plane</a>, and not present on the <a>content plane</a>. No fallback is
+							Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an <a>EPUB Content Document</a> on the
+							<a>spine plane</a>, and is not present on the <a>content plane</a>. No fallback is
 							necessary.</p>
 					</dd>
 
 					<dt><code>nav.xhtml</code></dt>
 					<dd>
 						<p>The resource is the <a>EPUB Navigation Document</a>. It is not listed in the spine. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a> and not present on either the
-								<a>spine plane</a> or the <a>content plane</a>. No fallback is necessary.</p>
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, and is not present on either the
+							<a>spine plane</a> or the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>style.css</code></dt>
 					<dd>
 						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[HTML]]
-								<a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, not present on the <a>spine
-								plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
+							<a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, 
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
 							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.otf</code></dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
-							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, not present on
-							the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content
+							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content
+							plane</a>. No fallback is necessary.</p>
+					</dd>
+
+					<dt><code>https://www.example.org/fonts/font-file2.otf</code></dt>
+					<dd>
+						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
+							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Remote Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content
 							plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.cff</code></dt>
 					<dd>
 						<p>The resource is a font file in Compact Font Format. It is not listed in the spine but is
-							referenced from a CSS file. Its media type is not listed as a <a
-								href="#sec-core-media-types">core media type</a>. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, not present on the <a>spine plane</a>, and is an <a>Exempt
-								Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
+							referenced from a CSS file. Its media type is not listed as a 
+							<a href="#sec-core-media-types">core media type</a>. It is a <a>Publication Resource</a> on
+							the <a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine plane</a>,
+							and is an <a>Exempt Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>speech/cmn.pls</code></dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
 							from an [[HTML]] <a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, not present on the <a>spine
-								plane</a>, and is an <a>Exempt Resource</a> on the <a>content plane</a>. No fallback is
-							necessary.</p>
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							not present on the <a>spine plane</a>, and is an <a>Exempt Resource</a> on the <a>content plane</a>. 
+							No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_1.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, not present on the <a>spine
-								plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
-							fallback is necessary.</p>
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. 
+							No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_2.png</code></dt>
@@ -11019,49 +11046,60 @@ html.my-document-playing * {
 						<p>The resource is a PNG image file. It is referenced via an [[HTML]] <a
 								data-cite="html#the-a-element"><code>a</code> element</a>. Because it is referenced from
 							a hyperlink, it <em>must</em> be listed in the spine. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, a <a>Foreign Content Document</a> on the <a>spine plane</a>, and
-							a <a>Core Media Type Resource</a> on the <a>content plane</a>. As a <a>Foreign Content
-								Document</a> a fallback is required, and is provided via a <a
-								href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
+							the <a>manifest plane</a>, a <a>Container Resource</a>, a <a>Foreign Content Document</a> on the <a>spine plane</a>, 
+							and a <a>Core Media Type Resource</a> on the <a>content plane</a>. As a <a>Foreign Content
+							Document</a> a fallback is required, which is provided via a <a href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
 					<dt><code>image_desc.xhtml</code></dt>
 					<dd>
-						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not listed
-							in the spine (i.e., it replaces the existing spine reference when needed). It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, an EPUB Content Document on
-								<a>spine plane</a>, and not present on the <a>content plane</a>. No fallback is
-							necessary.</p>
+						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not explicitly listed
+							in the spine (but it "replaces" the existing spine item when needed). It is a
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an EPUB Content Document on
+							<a>spine plane</a>, and, because it is not "used" when rendering another Content Document, it is not present
+							on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_3.heic</code></dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
 							referenced from an [[HTML]] <a data-cite="html#the-source-element"><code>source</code>
-								element</a>. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, not
-							present on the <a>spine plane</a>, and is a <a>Foreign Resource</a> on the <a>content
-								plane</a>. As a <a>Foreign Resource</a>, a fallback is required and is provided via the
-							sibling [[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>.</p>
+							element</a>. Its media type is not listed as a <a href="#sec-core-media-types">core media type</a>. 
+							It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Foreign Resource</a> on the <a>content
+							plane</a>. As a <a>Foreign Resource</a>, a fallback is required, which is provided via the
+							sibling [[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>
+							in an [[HTML]] <a data-cite="html#the-picture-element"><code>picture</code> element.</p>
 					</dd>
 
 					<dt><code>image/image_3.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a> that is an
-							intrinsic fallback of the [[HTML]] <a data-cite="html#the-picture-element"
-									><code>picture</code> element</a>. It is a <a>Publication Resource</a> on the
-								<a>manifest plane</a>, not present on the <a>spine plane</a>, and is a <a>Core Media
-								Type Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
+							[[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a> that is used as an
+							intrinsic fallback of the [[HTML]] <a data-cite="html#the-picture-element"><code>picture</code> element</a>. 
+							It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. 
+							No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>widget.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-cite="html#the-iframe-element"><code>iframe</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, not present on <a>spine
-								plane</a>, and a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
-							fallback is necessary.</p>
+							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on <a>spine plane</a>, and, because it is "used" when rendering another Content Document, 
+							a <a>Core Media Type Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
+
+					<dt><code>https://www.example.org/some_content</code></dt>
+					<dd>
+						<p>
+							The resource is referenced via an [[HTML]] <a data-cite="html#the-a-element"><code>a</code> element</a>
+							and is not stored in the <a>EPUB Container</a>. Reading Systems will normally open this link via a separate browser instance.
+							It is not any planes defined by this specification.
+						</p>
+					</dd>
+
 				</dl>
 			</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11101,11 +11101,12 @@ html.my-document-playing * {
 					<dd>
 						<p>The resource is referenced via an [[HTML]] <a data-cite="html#the-a-element"><code>a</code>
 								element</a> and is not stored in the <a>EPUB Container</a>. Reading Systems will
-							normally open this link via a separate browser instance. It is not any planes defined by
+							normally open this link via a separate browser instance. It is not on any planes defined by
 							this specification.</p>
 					</dd>
-
 				</dl>
+
+				<p>Additional examples on the usage of different types of resources can be found in <a href="#sec-item-elem-examples"></a>.</p>
 			</section>
 
 			<section id="scripted-contexts-example">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10959,86 +10959,87 @@ html.my-document-playing * {
 				<dl>
 					<dt><code>meta/data.xml</code></dt>
 					<dd>
-						<p>The resource is a metadata record, stored in the container. It is linked via a 
-							<a href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It is therefore a
-							<a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in the <a>manifest</a>. It is not part
-							on any other planes.
-						</p>
+						<p>The resource is a metadata record, stored in the container. It is linked via a <a
+								href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It
+							is therefore a <a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in
+							the <a>manifest</a>. It is not part on any other planes. </p>
 					</dd>
 
 					<dt><code>https://www.example.org/meta/data2.xml</code></dt>
 					<dd>
-						<p>The resource is a metadata record, stored remotely. It is linked via a 
-							<a href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It is therefore a
-							<a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in the
-							<a>manifest</a>. It is not part on any other planes.</p>
+						<p>The resource is a metadata record, stored remotely. It is linked via a <a
+								href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It
+							is therefore a <a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in
+							the <a>manifest</a>. It is not part on any other planes.</p>
 					</dd>
 
 					<dt><code>page.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is listed in the spine. It is a <a>Publication
-							Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an <a>EPUB Content Document</a> on the
-							<a>spine plane</a>, and is not present on the <a>content plane</a>. No fallback is
-							necessary.</p>
+								Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an <a>EPUB
+								Content Document</a> on the <a>spine plane</a>, and is not present on the <a>content
+								plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>nav.xhtml</code></dt>
 					<dd>
 						<p>The resource is the <a>EPUB Navigation Document</a>. It is not listed in the spine. It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, and is not present on either the
-							<a>spine plane</a> or the <a>content plane</a>. No fallback is necessary.</p>
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							and is not present on either the <a>spine plane</a> or the <a>content plane</a>. No fallback
+							is necessary.</p>
 					</dd>
 
 					<dt><code>style.css</code></dt>
 					<dd>
 						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[HTML]]
-							<a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, 
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
-							fallback is necessary.</p>
+								<a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the
+								<a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.otf</code></dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
-							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content
-							plane</a>. No fallback is necessary.</p>
+							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a
+								<a>Container Resource</a>, is not present on the <a>spine plane</a>, and is a <a>Core
+								Media Type Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>https://www.example.org/fonts/font-file2.otf</code></dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
-							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Remote Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content
-							plane</a>. No fallback is necessary.</p>
+							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Remote
+								Resource</a>, is not present on the <a>spine plane</a>, and is a <a>Core Media Type
+								Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.cff</code></dt>
 					<dd>
 						<p>The resource is a font file in Compact Font Format. It is not listed in the spine but is
-							referenced from a CSS file. Its media type is not listed as a 
-							<a href="#sec-core-media-types">core media type</a>. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine plane</a>,
-							and is an <a>Exempt Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
+							referenced from a CSS file. Its media type is not listed as a <a
+								href="#sec-core-media-types">core media type</a>. It is a <a>Publication Resource</a> on
+							the <a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine
+								plane</a>, and is an <a>Exempt Resource</a> on the <a>content plane</a>. No fallback is
+							necessary.</p>
 					</dd>
 
 					<dt><code>speech/cmn.pls</code></dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
 							from an [[HTML]] <a data-cite="html#the-link-element"><code>link</code> element</a>. It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							not present on the <a>spine plane</a>, and is an <a>Exempt Resource</a> on the <a>content plane</a>. 
-							No fallback is necessary.</p>
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							not present on the <a>spine plane</a>, and is an <a>Exempt Resource</a> on the <a>content
+								plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_1.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>. It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. 
-							No fallback is necessary.</p>
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the
+								<a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_2.png</code></dt>
@@ -11046,58 +11047,62 @@ html.my-document-playing * {
 						<p>The resource is a PNG image file. It is referenced via an [[HTML]] <a
 								data-cite="html#the-a-element"><code>a</code> element</a>. Because it is referenced from
 							a hyperlink, it <em>must</em> be listed in the spine. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, a <a>Container Resource</a>, a <a>Foreign Content Document</a> on the <a>spine plane</a>, 
-							and a <a>Core Media Type Resource</a> on the <a>content plane</a>. As a <a>Foreign Content
-							Document</a> a fallback is required, which is provided via a <a href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
+							the <a>manifest plane</a>, a <a>Container Resource</a>, a <a>Foreign Content Document</a> on
+							the <a>spine plane</a>, and a <a>Core Media Type Resource</a> on the <a>content plane</a>.
+							As a <a>Foreign Content Document</a> a fallback is required, which is provided via a <a
+								href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
 					<dt><code>image_desc.xhtml</code></dt>
 					<dd>
-						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not explicitly listed
-							in the spine (but it "replaces" the existing spine item when needed). It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an EPUB Content Document on
-							<a>spine plane</a>, and, because it is not "used" when rendering another Content Document, it is not present
-							on the <a>content plane</a>. No fallback is necessary.</p>
+						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not
+							explicitly listed in the spine (but it "replaces" the existing spine item when needed). It
+							is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							an EPUB Content Document on <a>spine plane</a>, and, because it is not "used" when rendering
+							another Content Document, it is not present on the <a>content plane</a>. No fallback is
+							necessary.</p>
 					</dd>
 
 					<dt><code>image/image_3.heic</code></dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
 							referenced from an [[HTML]] <a data-cite="html#the-source-element"><code>source</code>
-							element</a>. Its media type is not listed as a <a href="#sec-core-media-types">core media type</a>. 
-							It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Foreign Resource</a> on the <a>content
-							plane</a>. As a <a>Foreign Resource</a>, a fallback is required, which is provided via the
-							sibling [[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>
-							in an [[HTML]] <a data-cite="html#the-picture-element"><code>picture</code> element.</p>
+								element</a>. Its media type is not listed as a <a href="#sec-core-media-types">core
+								media type</a>. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a
+								<a>Container Resource</a>, is not present on the <a>spine plane</a>, and is a <a>Foreign
+								Resource</a> on the <a>content plane</a>. As a <a>Foreign Resource</a>, a fallback is
+							required, which is provided via the sibling [[HTML]] <a data-cite="html#the-img-element"
+									><code>img</code> element</a> in an [[HTML]] <a data-cite="html#the-picture-element"
+									><code>picture</code> element</a>.</p>
 					</dd>
 
 					<dt><code>image/image_3.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a> that is used as an
-							intrinsic fallback of the [[HTML]] <a data-cite="html#the-picture-element"><code>picture</code> element</a>. 
-							It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. 
-							No fallback is necessary.</p>
+							intrinsic fallback of the [[HTML]] <a data-cite="html#the-picture-element"
+									><code>picture</code> element</a>. It is a <a>Publication Resource</a> on the
+								<a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine
+								plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>widget.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-cite="html#the-iframe-element"><code>iframe</code> element</a>. It is a
-							<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on <a>spine plane</a>, and, because it is "used" when rendering another Content Document, 
-							a <a>Core Media Type Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on <a>spine plane</a>, and, because it is "used" when rendering another
+							Content Document, a <a>Core Media Type Resource</a> on the <a>content plane</a>. No fallback
+							is necessary.</p>
 					</dd>
 
 					<dt><code>https://www.example.org/some_content</code></dt>
 					<dd>
-						<p>
-							The resource is referenced via an [[HTML]] <a data-cite="html#the-a-element"><code>a</code> element</a>
-							and is not stored in the <a>EPUB Container</a>. Reading Systems will normally open this link via a separate browser instance.
-							It is not any planes defined by this specification.
-						</p>
+						<p>The resource is referenced via an [[HTML]] <a data-cite="html#the-a-element"><code>a</code>
+								element</a> and is not stored in the <a>EPUB Container</a>. Reading Systems will
+							normally open this link via a separate browser instance. It is not any planes defined by
+							this specification.</p>
 					</dd>
 
 				</dl>


### PR DESCRIPTION
Added

- a linked element stored remotely
- a font stored remotely
- a hyperlink target stored remotely

I have also made some additional improvements.

If the decision is to define a separate plane for container and remote resources, the relevant text must be completed (but it stands as is now in case we do not define a new plane).

Careful, this is a PR on #2214, not on the main branch!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2225.html" title="Last updated on Apr 5, 2022, 1:30 PM UTC (736df09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2225/1144879...736df09.html" title="Last updated on Apr 5, 2022, 1:30 PM UTC (736df09)">Diff</a>