### PR TITLE
Cleanup of evaluator info section

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -989,6 +989,16 @@
 					<p>The metadata uses a combination of properties from DCMI Metadata Terms [[DCTERMS]] and the <a
 							href="#app-a11y-vocab">EPUB Accessibility Vocabulary</a>, as explained in more detail in the
 						following sections.</p>
+
+					<div class="note">
+						<p>As each metadata format is unique in what it can express, this specification does not mandate
+							how to express conformance metadata outside of the EPUB Package Document.</p>
+
+						<p>Ensuring consistency between internal and external accessibility metadata expressions is the
+							responsibility of authors, publishers, and distributors. Refer to <a
+								href="#sec-distribution"></a> for for a discussion of the effects of distribution on
+							accessibility.</p>
+					</div>
 				</section>
 
 				<section id="sec-conf-reporting-pub">
@@ -1074,20 +1084,31 @@
 				<section id="sec-conf-reporting-eval">
 					<h4>Evaluator Information</h4>
 
-					<p>EPUB Publications MUST include an <a href="#certifiedBy"><code id="a11y-certifiedBy"
-								>a11y:certifiedBy</code></a> property that specifies the name of the party that
-						evaluated the EPUB Publication.</p>
+					<section id="sec-evaluator-name">
+						<h5>Evaluator Name</h5>
 
-					<div class="note">
-						<p>Any individual or party can perform a conformance evaluation. The evaluator can be the same
-							party that created the EPUB Publication or a third party.</p>
-					</div>
+						<p>The Package Document metadata MUST include an <a href="#certifiedBy"><code
+									id="a11y-certifiedBy">a11y:certifiedBy</code></a> property that specifies the name
+							of the party that evaluated the EPUB Publication.</p>
 
-					<aside class="example" title="A self evaluation">
-						<p>In this example, the publisher is stating they self-evaluated the EPUB Publication (the
-							values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code> property are the
-							same).</p>
-						<pre>&lt;metadata …>
+						<div class="note">
+							<p>Any individual or party can perform a conformance evaluation. The evaluator can be the
+								same party that created the EPUB Publication or a third party.</p>
+						</div>
+
+						<div class="note">
+							<p>If an organization evaluates an EPUB Publication, users will typically want to know the
+								name of that organization. This specification discourages including the name of the
+								individual(s) who carried out the assessment instead of the name of the organization,
+								as this can diminish the trust users have in the claim.</p>
+						</div>
+
+						<aside id="pub-ex" class="example" title="An EPUB Publication evaluated by the publisher">
+							<p>In this example, the publisher is stating they self-evaluated the EPUB Publication (the
+								values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code> property are
+								the same).</p>
+
+							<pre>&lt;metadata …>
   …
   &lt;dc:publisher>
      Acme Publishing Inc.
@@ -1106,12 +1127,13 @@
   &lt;/meta>
   …
 &lt;/metadata></pre>
-					</aside>
+						</aside>
 
-					<aside class="example" title="Third-party evaluation">
-						<p>In this example, a third party has evaluated the EPUB 3 Publication (the values of the
-								<code>dc:publisher</code> and <code>a11y:certifiedBy</code> property differ).</p>
-						<pre>&lt;metadata …>
+						<aside class="example" title="An EPUB Publication evaluated by a third-party">
+							<p>In this example, a third party has evaluated the EPUB 3 Publication (the values of the
+									<code>dc:publisher</code> and <code>a11y:certifiedBy</code> property differ).</p>
+
+							<pre>&lt;metadata …>
   …
   &lt;dc:publisher>
      Acme Publishing Inc.
@@ -1129,10 +1151,14 @@
   &lt;/meta>
   …
 &lt;/metadata></pre>
-					</aside>
+						</aside>
 
-					<aside class="example" title="A self-evaluated EPUB 3 Publication">
-						<pre>&lt;metadata …>
+						<aside class="example" title="An EPUB Publication evaluated by the author">
+							<p>In this example, the author is stating they self-evaluated the EPUB Publication (the
+								values of the <code>dc:creator</code> and <code>a11y:certifiedBy</code> property are the
+								same).</p>
+
+							<pre>&lt;metadata …>
   …
   &lt;dc:creator>
      Jane Doe
@@ -1151,10 +1177,13 @@
   &lt;/meta>
   …
 &lt;/metadata></pre>
-					</aside>
+						</aside>
 
-					<aside class="example" title="A self-evaluated EPUB 2 Publication">
-						<pre>&lt;metadata …>
+						<aside class="example" title="A self-evaluated EPUB 2 Publication">
+							<p>This example is the same as the <a href="#pub-ex">publisher example</a>, but expressed in
+								an EPUB 2 Package Document.</p>
+
+							<pre>&lt;metadata …>
   …
   &lt;dc:publisher>
      Acme Publishing Inc.
@@ -1169,21 +1198,19 @@
       content="Acme Publishing Inc."/>
   …
 &lt;/metadata></pre>
-					</aside>
+						</aside>
+					</section>
 
-					<div class="note">
-						<p>If an organization evaluates an EPUB Publication, users will typically want to know the name
-							of that organization. This specification discourages including the name of the individual(s)
-							who carried out the assessment, instead of the name of the organization, as this can
-							diminish the trust users have in the claim.</p>
-					</div>
+					<section id="sec-evaluation-date">
+						<h5>Evaluation Date</h5>
 
-					<p>The date the evaluation was performed on MAY be specified by linking a <a
-							data-cite="dcterms#http://purl.org/dc/terms/date"><code>dcterms:date</code> property</a>
-						[[DCTERMS]] to the certifier.</p>
+						<p>If the date the evaluation was performed on is known, include that information in a <a
+								data-cite="dcterms#http://purl.org/dc/terms/date"><code>dcterms:date</code> property</a>
+							[[DCTERMS]] <a data-cite="epub-33#subexpression">associated with</a> [[EPUB-33]] the <a
+								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
-					<aside class="example" title="Expressing the evaluation date">
-						<pre>&lt;metadata …>
+						<aside class="example" title="Expressing the evaluation date">
+							<pre>&lt;metadata …>
    …
    &lt;meta
        property="a11y:certifiedBy"
@@ -1198,16 +1225,22 @@
    &lt;/meta>
    …
 &lt;/metadata></pre>
-					</aside>
+						</aside>
+					</section>
 
-					<p>If the party that evaluates the content has a credential or badge that establishes their
-						authority to evaluate content, include that information in an <a href="#certifierCredential"
-								><code id="a11y-certifierCredential">a11y:certifierCredential</code> property</a>.</p>
+					<section id="sec-evaluator-credentials">
+						<h5>Evaluator Credentials</h5>
 
-					<aside class="example" title="Expressing a basic credential">
-						<p>In this example, the <code>refines</code> attribute associates the credential with the
-							certifier.</p>
-						<pre>&lt;metadata …>
+						<p>If the evaluator has credentials or badges that establish their authority to evaluate
+							content, include that information in an <a href="#certifierCredential"><code
+									id="a11y-certifierCredential">a11y:certifierCredential</code> properties</a>
+							<a data-cite="epub-33#subexpression">associated with</a> [[EPUB-33]] the <a
+								href="#sec-evaluator-name">evaluator's name</a>.</p>
+
+						<aside class="example" title="Expressing a basic credential">
+							<p>In this example, the <code>refines</code> attribute associates the credential with the
+								certifier.</p>
+							<pre>&lt;metadata …>
    …
    &lt;meta
        property="dcterms:conformsTo"
@@ -1228,15 +1261,21 @@
       A+ Accessibility Rating
    &lt;/meta>
 &lt;/metadata></pre>
-					</aside>
+						</aside>
+					</section>
 
-					<p>If the party that evaluated the content provides a publicly-readable report of its assessment,
-						provide a link to the assessment in an <a href="#certifierReport"><code
-								id="a11y-certifierReport">a11y:certifierReport</code> property</a>.</p>
+					<section id="sec-evaluator-report">
+						<h5>Evaluator Report</h5>
 
-					<aside class="example" title="A remotely hosted accessibility report">
-						<p>The following example shows a link to a remotely hosted accessibility report.</p>
-						<pre>&lt;metadata …>
+						<p>If the evaluator provides a publicly-readable report of its assessment, provide a link to the
+							assessment in an <a href="#certifierReport"><code id="a11y-certifierReport"
+									>a11y:certifierReport</code> property</a>
+							<a data-cite="epub-33#subexpression">associated with</a> [[EPUB-33]] the <a
+								href="#sec-evaluator-name">evaluator's name</a>.</p>
+
+						<aside class="example" title="A remotely hosted accessibility report">
+							<p>The following example shows a link to a remotely hosted accessibility report.</p>
+							<pre>&lt;metadata …>
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
@@ -1255,10 +1294,10 @@
        refines="#certifier"
        href="http://www.example.com/a11y/report/9780000000001"/>
 &lt;/metadata></pre>
-					</aside>
+						</aside>
 
-					<aside class="example" title="A locally hosted accessibility report">
-						<pre>&lt;metadata …>
+						<aside class="example" title="A locally hosted accessibility report">
+							<pre>&lt;metadata …>
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
@@ -1277,20 +1316,8 @@
        refines="#certifier"
        href="reports/a11y.xhtml"/>
 &lt;/metadata></pre>
-					</aside>
-
-					<div class="note">
-						<p>As each metadata format is unique in what it can express, this specification does not mandate
-							how to express conformance metadata outside of the EPUB Package Document.</p>
-					</div>
-
-					<div class="note">
-						<p>This specification does not define requirements for accessibility metadata external to an
-							EPUB 3 publication as part of distribution metadata. Ensuring consistency between internal
-							and external accessibility metadata expressions is the responsibility of authors,
-							publishers, and distributors. For further discussion of the effects of distribution on
-							accessibility, see <a href="#sec-distribution"></a>.</p>
-					</div>
+						</aside>
+					</section>
 				</section>
 
 				<section id="sec-conf-reporting-re-eval" class="informative">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9908,8 +9908,8 @@ html.my-document-playing * {
 						accessibility enhancements like built-in read aloud or Media Overlays functionality where
 						interaction with assistive technologies is not essential.</p>
 
-					<p>Refer to <a data-cite="dpub-aria-1.0#">Digital Publishing WAI-ARIA Module</a> [[?DPUB-ARIA]] for
-						more information about accessible publishing roles.</p>
+					<p>Refer to <a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA
+						Module</a> [[?DPUB-ARIA]] for more information about accessible publishing roles.</p>
 				</div>
 
 				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value


### PR DESCRIPTION
This pull request does a bit of tidying to the section on the evaluator information, specifically:

- it adds subsections for each property we define in the section. With all the examples and notes, it was really hard to find out what is covered. This puts each property in the table of contents, too.
- it adds descriptions for a couple of evaluator examples that were missing them and whose titles were unclear about their purpose. I also cleaned up the titles for all the examples in this section
- it adds mention of associating the other properties with the evaluator's name (only credentials mentioned this but did so using the term "linking"). The term "associated with" is linked to the definition of subexpressions in the core spec.
- it takes a couple of notes that were floating at the end of the section about expressing metadata in external metadata formats and moves them into the introduction. These are not specific to the evaluator information, so this seemed like the best spot. I also merged the two notes as they overlapped in what they were talking about

There's also a minor change to the core spec to use an unversioned link to dpub-aria module.

Despite the branch name, this does not address the core issue in #2217. I'm going to look at that next.

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2217/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2217/epub33/a11y/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2226.html" title="Last updated on Apr 5, 2022, 11:49 AM UTC (ec5bfa5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2226/c62eed8...ec5bfa5.html" title="Last updated on Apr 5, 2022, 11:49 AM UTC (ec5bfa5)">Diff</a>