### PR TITLE
Better define logical reading order

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -856,7 +856,7 @@
 										to this practice can result in a suboptimal reading experience (e.g., playback
 										of a table by column instead of row might make more natural sense in some
 										cases). These publications have a logical reading order that cannot match the
-										default order of the elements of the host format (e.g., some languages.</p>
+										default order of the elements of the host format (e.g., some languages).</p>
 									<p>The goal of this objective is not to forbid alternate presentations, but to
 										ensure that deviations are only made to better represent the logical reading
 										order of the content.</p>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -521,8 +521,8 @@
 							review individual pages — or Content Documents, as they are known in EPUB 3 — in isolation.
 							Rather, EPUB Creators MUST evaluate their accessibility as part of the larger work.</p>
 
-						<p>For example, it is not sufficient for EPUB Creators to give individual EPUB Content Documents
-							a logical reading order if they list the documents in the wrong reading order. Likewise,
+						<p>For example, it is not sufficient for EPUB Creators to order the content within individual
+							EPUB Content Documents if they list the documents in the wrong order in the spine. Likewise,
 							including a title for every EPUB Content Document is complementary to providing a title for
 							the publication: the overall accessibility decreases if either is missing.</p>
 
@@ -835,21 +835,31 @@
 
 								<dt id="sec-mo-order-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Every EPUB Publication has a default reading order that allows users to logically
-										progress through the content. It ensures that readers can follow the primary
-										narrative and that they encounter secondary content where it makes the most
-										sense. The default reading order also establishes some less obvious relations,
-										like the progress within a table from cell to cell and row to row.</p>
+									<p>Every EPUB Publication has a default reading order that allows users to progress
+										through the content. The default reading order consists of two parts: the order
+										of references in the spine provides a high-level progression through the EPUB
+										Content Documents that make up the publication, while the markup within each
+										EPUB Content Document provides the default progression through the content
+										elements (i.e., as represented in the document object model [[DOM]]).</p>
+									<p>For many languages, the default reading order also matches the logical reading
+										order &#8212; the way that users will naturally follow the narrative. It ensures
+										that readers can follow the primary narrative and that they encounter secondary
+										content where the author intended it to be read. The default reading order also
+										establishes some less obvious relations, like the progress within a table from
+										cell to cell and row to row.</p>
 									<p>If the sequence of <code>par</code> and <code>seq</code> elements in a Media
 										Overlay Documents does not match this progression, it can cause confusion for
 										readers, whether they are only listening to the audio or trying to also follow
 										visually.</p>
 									<p>Ordering the playback to match the default reading order is the safest way to
 										ensure that users can follow the text. In some cases, however, strict adherence
-										to this practice could result in a suboptimal reading experience (e.g., playback
-										of a table by column instead of row might make more logical sense in some
-										cases). The goal of this objective is not to forbid alternate presentations, but
-										to ensure that any deviations retain the logical flow of the content.</p>
+										to this practice can result in a suboptimal reading experience (e.g., playback
+										of a table by column instead of row might make more natural sense in some
+										cases). These publications have a logical reading order that cannot match the
+										default order of the elements of the host format (e.g., some languages.</p>
+									<p>The goal of this objective is not to forbid alternate presentations, but to
+										ensure that deviations are only made to better represent the logical reading
+										order of the content.</p>
 								</dd>
 
 								<dt id="sec-mo-order-conf">Meeting this Objective</dt>


### PR DESCRIPTION
I've done some editorial rewriting of the understanding section to try and better differentiate "default reading order" from "logical reading order".

Fixes #2222 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2222/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2222/epub33/a11y/index.html)
