### PR TITLE
Make comment about AAA success criteria a note

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -457,6 +457,12 @@
 							<p id="confreq-wcag-a">MUST, for whichever version of WCAG 2 selected, meet the requirements
 								of Level A, but it is strongly recommended that it meet the requirements of Level
 								AA.</p>
+							<div class="note">
+								<p>Although, as <a href="https://www.w3.org/TR/WCAG21/#h-note-29">noted in WCAG</a>,
+									conforming at level AAA is typically not possible, and not required by this
+									specification, EPUB Creators are encouraged to follow the practices detailed in AAA
+									success criteria when producing accessible EPUB Publications.</p>
+							</div>
 						</li>
 					</ul>
 
@@ -481,13 +487,6 @@
 								>Section 508 of the Rehabilitation Act of 1973</a> in the United States. EPUB
 							Publications will need to meet more than just the basic Level A success criteria to be
 							compliant with these laws.</p>
-					</div>
-
-					<div class="note">
-						<p>Although, as <a href="https://www.w3.org/TR/WCAG21/#h-note-29">noted in WCAG</a>, conforming
-							at level AAA is typically not possible, and not required by this specification, EPUB
-							Creators are encouraged to follow the practices detailed in AAA success criteria when
-							producing accessible EPUB Publications.</p>
 					</div>
 
 					<p>Keeping pace with WCAG has the benefit of continuously enhancing access for users. As web

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -483,6 +483,13 @@
 							compliant with these laws.</p>
 					</div>
 
+					<div class="note">
+						<p>Although, as <a href="https://www.w3.org/TR/WCAG21/#h-note-29">noted in WCAG</a>, conforming
+							at level AAA is typically not possible, and not required by this specification, EPUB
+							Creators are encouraged to follow the practices detailed in AAA success criteria when
+							producing accessible EPUB Publications.</p>
+					</div>
+
 					<p>Keeping pace with WCAG has the benefit of continuously enhancing access for users. As web
 						technologies change and improve, and awareness of conditions that impede access evolve, the
 						standard adds new requirements. Meeting these additional requirements helps ensure EPUB
@@ -491,10 +498,9 @@
 
 					<p>Similarly, legal frameworks and policies often cite Level AA conformance as the benchmark for
 						accessibility. The reason is that it provides the greatest range of improvements that EPUB
-						Creators can realistically implement (EPUB Creators should try to meet the AAA requirements if
-						they can, but fully conforming at AAA is typically not possible). When EPUB Creators meet only
-						Level A conformance, they compromise their content for various user groups, resulting in a less
-						optimal reading experience.</p>
+						Creators can realistically implement. When EPUB Creators meet only Level A conformance, they
+						compromise their content for various user groups, resulting in a less optimal reading
+						experience.</p>
 
 					<div class="note">
 						<p>The <a href="https://www.w3.org/WAI/GL/">W3C Accessibility Guidelines Working Group</a> is


### PR DESCRIPTION
This pull request takes the parenthetical about not ignoring AAA success criteria out of the paragraph explaining legal frameworks and adds it as a note to the bullet that requires A support.

This seems to be the best place for it, as it explains why we only mention A and AA in the bullet.

Fixes #2223 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2223/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2223/epub33/a11y/index.html)
