### PR TITLE
Add links to page navigation techniques

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -664,6 +664,11 @@
 											markers</a> and/or a <a href="#sec-page-list">page list</a> that correspond
 										to a statically-paginated version of the publication, EPUB Creators MUST
 										identify that source in the Package Document metadata.</p>
+									<div class="note">
+										<p>Refer to <a data-cite="epub-a11y-tech-11#page-004">Identifying the pagination
+												source</a> [[EPUB-A11Y-TECH-11]] for specific techniques to meet this
+											objective.</p>
+									</div>
 								</dd>
 							</dl>
 						</section>
@@ -699,6 +704,10 @@
 										reproduced in the digital edition).</p>
 									<p>EPUB Creators should include links for all pages in the source whether they are
 										reproduced or not, but this is not a requirement.</p>
+									<div class="note">
+										<p>Refer to <a data-cite="epub-a11y-tech-11#page-003">Provide a page list</a>
+											[[EPUB-A11Y-TECH-11]] for specific techniques to meet this objective.</p>
+									</div>
 								</dd>
 							</dl>
 						</section>
@@ -739,6 +748,11 @@
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
 										of the content (e.g., EPUB 3 Media Overlays [[?EPUB-3]]), EPUB Creators MUST
 										identify the page numbers in the markup that controls the playback.</p>
+									<div class="note">
+										<p>Refer to <a data-cite="epub-a11y-tech-11#page-001">Provide page break
+												markers</a> [[EPUB-A11Y-TECH-11]] for specific techniques to meet this
+											objective.</p>
+									</div>
 								</dd>
 							</dl>
 						</section>


### PR DESCRIPTION
As we haven't yet defined techniques for media overlays, since they're still optional, I can only link the page navigation objectives.

Fixes #2119 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2219/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2219/epub33/a11y/index.html)
