### PR TITLE
Switch uses of "informative" to "non-normative"

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1341,9 +1341,9 @@
 
 					<p>Although it is not strictly required to set this information to meet [[WCAG2]] <a
 							href="https://www.w3.org/TR/WCAG2/#language-of-page">Success Criterion 3.1.1</a>, as it is
-						only informative, it should be considered a best practice to always set this field with the
-						proper language information. (Note that EPUB3 requires the language always be specified, so
-						omitting will fail validation requirements.)</p>
+						non-normative, it should be considered a best practice to always set this field with the proper
+						language information. (Note that EPUB3 requires the language always be specified, so omitting
+						will fail validation requirements.)</p>
 
 					<p>Although Reading Systems do not use this language information to render the text content of the
 						EPUB Publication, they do use it to optimize the reading experience for users (e.g., to preload

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1403,7 +1403,7 @@
 
 			<div class="note">
 				<p>Refer to the <a href="https://w3c.github.io/epub-specs/docs/optimized-pubs/">Guide to Optimized
-						Publication Standards</a> for an informative list of standards.</p>
+						Publication Standards</a> for a non-normative list of standards.</p>
 			</div>
 
 			<aside class="example" title="Expressing conformance to an optimization standard">
@@ -1701,7 +1701,7 @@
 				<li>21-Mar-2022: Note that not all metadata expressions can be achieved in EPUB 2 due to the absence of
 					the <code>refines</code> attribute. See <a href="https://github.com/w3c/epub-specs/issues/2042"
 						>issue 2042</a>.</li>
-				<li>28-Sep-2021: The section on optimized publication has been made informative and rewritten to
+				<li>28-Sep-2021: The section on optimized publication has been made non-normative and rewritten to
 					highlight best practices for identifying conformance to such standards. See <a
 						href="https://github.com/w3c/epub-specs/pulls/1833">pull request 1833</a>.</li>
 				<li>23-Sep-2021: Added section explaining effects of internationalization on techniques used. See <a
@@ -1717,10 +1717,10 @@
 				<li>29-Apr-2021: Change conformance identifiers to use hyphens and dashes so they are not confused for
 					plain language strings. See <a href="https://github.com/w3c/epub-specs/issues/1455">issue
 					1455</a>.</li>
-				<li>26-Mar-2021: Added informative section detailing when to re-evaluate EPUB Publications. See <a
+				<li>26-Mar-2021: Added non-normative section detailing when to re-evaluate EPUB Publications. See <a
 						href="https://github.com/w3c/epub-specs/issues/1470">issue 1470</a>.</li>
-				<li>12-Mar-2021: Changed the distribution section to informative but added a note that the requirements
-					must be followed where required by law (e.g., in the EU). See <a
+				<li>12-Mar-2021: Changed the distribution section to non-normative but added a note that the
+					requirements must be followed where required by law (e.g., in the EU). See <a
 						href="https://github.com/w3c/epub-specs/issues/1487">issue 1487</a>.</li>
 				<li>08-Mar-2021: Add objective for the sequence of <code>par</code> and <code>seq</code> elements in
 					media overlay documents to reflect a logical reading order. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -123,8 +123,8 @@
 					specification, are nonetheless available for <a>EPUB Creators</a> and Reading System developers to
 					use.</p>
 
-				<p>The informative <a data-cite="epub-overview-33#">EPUB 3 Overview</a> [[EPUB-OVERVIEW-33]] provides a
-					general introduction to EPUB 3. A list of technical changes from the previous version is also
+				<p>The non-normative <a data-cite="epub-overview-33#">EPUB 3 Overview</a> [[EPUB-OVERVIEW-33]] provides
+					a general introduction to EPUB 3. A list of technical changes from the previous version is also
 					available in the <a href="#change-log">change log</a>.</p>
 			</section>
 
@@ -176,7 +176,7 @@
 
 				<p>The container format not only provides a means of determining that the zipped content represents an
 					EPUB Publication (the <code>mimetype</code> file), but also provides a universally named directory
-					of informative resources (<code>/META-INF</code>). Key among these resources is the
+					of non-normative resources (<code>/META-INF</code>). Key among these resources is the
 						<code>container.xml</code> file, which directs Reading Systems to the available Package
 					Documents. Refer to <a href="#sec-ocf"></a> for more information about the Container format.</p>
 
@@ -184,7 +184,7 @@
 					dependent assets in a ZIP package as presented here. Additional information about the primary
 					features and functionality that EPUB Publications provide to enhance the reading experience is
 					available from the referenced specifications, and a more general introduction to the features of
-					EPUB 3 is provided in the informative [[EPUB-OVERVIEW-33]].</p>
+					EPUB 3 is provided in the non-normative [[EPUB-OVERVIEW-33]].</p>
 
 				<p>Refer to [[EPUB-RS-33]] for the processing requirements for Reading Systems. Although it is not
 					necessary that <a>EPUB Creators</a> read that document to create EPUB Publications, an understanding
@@ -660,7 +660,7 @@
 			</section>
 
 			<section id="conformance">
-				<p>All algorithm explanations are <em>informative</em>.</p>
+				<p>All algorithm explanations are <em>non-normative</em>.</p>
 			</section>
 
 			<section id="sec-intro-shorthands" class="informative">
@@ -1634,7 +1634,6 @@
 
 						<p>This problem is more commonly encountered when <a data-cite="epub-multi-rend-11#container"
 								>creating multiple renditions</a> [[EPUB-MULTI-REND-11]] of the publication.</p>
-
 					</div>
 				</section>
 
@@ -1751,7 +1750,6 @@
 							mid-character truncation. See the section on <a
 								data-cite="international-specs/#char_truncation">"Truncating or limiting the length of
 								strings"</a> in [[international-specs]] for more information. </p>
-
 					</div>
 
 					<div class="note">
@@ -1842,7 +1840,6 @@
 							Path by their <a data-cite="url#percent-encode">percent encoded</a> alternative. For
 							example, <code>A/B/C/file&#160;name.xhtml</code> becomes
 								<code>A/B/C/file%20name.xhtml</code>. </p>
-
 					</div>
 
 					<p> A string <var>url</var> is a <dfn id="dfn-valid-relative-container-url-with-fragment-string"
@@ -2197,7 +2194,6 @@
 										Package Document, this specification does not define how to interpret, or select
 										from, the available options. Refer to [[EPUB-MULTI-REND-11]] for more
 										information on how to bundle more than one rendering of the content.</p>
-
 								</div>
 							</section>
 
@@ -2237,7 +2233,6 @@
 								<div class="note">
 									<p>This specification currently does not define uses for the <code>links</code>
 										element. Refer to [[EPUB-Multi-Rend-11]] for an example of its use.</p>
-
 								</div>
 							</section>
 
@@ -2629,7 +2624,6 @@
 							<div class="note">
 								<p>Adding a digital signature is not a guarantee that a malicious actor cannot tamper
 									with an EPUB Publication as Reading Systems do not have to check signatures.</p>
-
 							</div>
 
 							<p>The OPTIONAL <code>signatures.xml</code> file in the <code>META-INF</code> directory
@@ -2695,7 +2689,6 @@
 										element larger. If EPUB Creators sign files together, they can list the set of
 										signed files in a single XML Signature <code>Manifest</code> element and
 										reference them by one or more <code>Signature</code> elements.</p>
-
 								</div>
 
 								<p id="sig-restrictions">EPUB Creators can sign any or all files in the container in
@@ -2720,7 +2713,6 @@
 										their signature, but also wants to allow the addition of signatures, they could
 										use an XPath transform to sign just the existing signatures. The details of such
 										a transform are outside the scope of this specification, however.</p>
-
 								</div>
 
 								<p>The [[XMLDSIG-CORE1]] specification does not associate any semantics with a
@@ -2907,7 +2899,6 @@
 						advised to use font obfuscation as defined in this section only when no other options are
 						available to them. See also the <a href="#fobfus-limitations">limitations of
 						obfuscation</a>.</p>
-
 				</div>
 
 				<section id="fobfus-intro" class="informative">
@@ -4302,8 +4293,8 @@
 
 						<div class="note">
 							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
-								Working Group maintained an <a href="http://www.idpf.org/epub/vocab/package/types"
-									>informative registry of specialized EPUB Publication types</a> for use with this
+								Working Group maintained a <a href="http://www.idpf.org/epub/vocab/package/types"
+									>non-normative registry of specialized EPUB Publication types</a> for use with this
 								element. This Working Group no longer maintains this registry and does not anticipate
 								developing new specialized publication types.</p>
 						</div>
@@ -5514,7 +5505,6 @@ No Entry</pre>
 					<div class="note">
 						<p>EPUB Creators should list non-linear content at the end of the spine except when it makes
 							sense for users to encounter it between linear spine items.</p>
-
 					</div>
 
 					<p id="linear-itemrefs"> A linear <code>itemref</code> element is one whose <code>linear</code>
@@ -5700,7 +5690,6 @@ No Entry</pre>
 							3, the cover image must be identified using the <a href="#sec-cover-image"
 									><code>cover-image</code> property</a> on the <a href="#sec-item-elem">manifest
 									<code>item</code></a> for the image.</p>
-
 					</div>
 				</section>
 
@@ -5770,7 +5759,6 @@ No Entry</pre>
 						<p>The recommendation that EPUB Publications follow the accessibility requirements in
 							[[EPUB-A11Y-11]] applies to XHTML Content Documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
-
 					</div>
 				</section>
 
@@ -5784,8 +5772,8 @@ No Entry</pre>
 						<p>Although [[HTML]] allows user agents to support <a data-cite="html#extensibility-2"
 								>vendor-neutral extensions</a>, unless such extensions are listed in this section, they
 							are not supported features of EPUB 3.</p>
-
 					</div>
+
 					<section id="sec-xhtml-structural-semantics">
 						<h5>Structural Semantics</h5>
 
@@ -5814,7 +5802,6 @@ No Entry</pre>
 								specify <a data-cite="html#microdata">microdata attributes</a> [[HTML]] and <a
 									data-cite="json-ld11#">linked data</a> [[JSON-LD11]] in XHTML Content Documents as
 								both are natively supported.</p>
-
 						</div>
 					</section>
 
@@ -5915,7 +5902,6 @@ No Entry</pre>
 							<p>The <a href="#mathml"><code>mathml</code> property</a> of the <a>manifest</a>
 								<code>item</code> element indicates that an XHTML Content Document contains embedded
 								MathML.</p>
-
 						</div>
 					</section>
 
@@ -5935,7 +5921,6 @@ No Entry</pre>
 							<p>The <a href="#svg"><code>svg</code> property</a> of the <a>manifest</a>
 								<a href="#sec-item-elem"><code>item</code> element</a> indicates that an XHTML Content
 								Document contains embedded SVG.</p>
-
 						</div>
 					</section>
 
@@ -5989,7 +5974,6 @@ No Entry</pre>
 					<p><a>Reading Systems</a> may not support all the features of [[SVG]] or supported them across all
 						platforms that Reading Systems run on. When utilizing such features, <a>EPUB Creators</a> should
 						consider the inherent risks on interoperability and document longevity.</p>
-
 				</div>
 
 				<section id="sec-svg-intro" class="informative">
@@ -6012,7 +5996,6 @@ No Entry</pre>
 						<p>This section defines conformance requirements for <a>SVG Content Documents</a>. Refer to <a
 								href="#sec-xhtml-svg"></a> for the conformance requirements for SVG embedded in XHTML
 							Content Documents.</p>
-
 					</div>
 				</section>
 
@@ -6039,7 +6022,6 @@ No Entry</pre>
 						<p>The recommendation that EPUB Publications follow the accessibility requirements in
 							[[EPUB-A11Y-11]] applies to SVG Content Documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
-
 					</div>
 				</section>
 
@@ -6195,7 +6177,6 @@ No Entry</pre>
 							<p>The Working Group recommends that EPUB Creators currently using these prefixed properties
 								move to unprefixed versions as soon as support allows, as the Working Group does not
 								anticipate supporting them in the next major version of EPUB.</p>
-
 						</div>
 
 						<p class="note">In some cases, the unprefixed versions of these properties now support
@@ -6317,7 +6298,6 @@ No Entry</pre>
 								<p>EPUB Creators choosing to restrict the usage of scripting to the
 									container-constrained model will ensure a more consistent user experience between
 									scripted and non-scripted content (e.g., consistent pagination behavior).</p>
-
 							</div>
 						</section>
 
@@ -6952,7 +6932,6 @@ No Entry</pre>
 							content is necessary, the EPUB Creator's choice of mechanism will depend on many factors
 							including desired degree of precision, file size, accessibility, etc. This section does not
 							attempt to dictate the EPUB Creator's choice of mechanism.</p>
-
 					</div>
 				</section>
 
@@ -6994,7 +6973,6 @@ No Entry</pre>
 								restrictions have when choosing to use pre-paginated instead of reflowable content.
 								Refer to <a data-cite="UAAG20#gl-text-config">Guideline 1.4 - Provide text
 									configuration</a> [[UAAG20]] for related information.</p>
-
 						</div>
 
 						<p id="fxl-layout-duplication" data-tests="#fxl-layout-duplication">When the property is set to
@@ -8598,8 +8576,8 @@ No Entry</pre>
 								Document</a>. While EPUB Creators may use Media Overlays with <a>SVG Content
 								Documents</a>, playback behavior might not be consistent and therefore interoperability
 							is not guaranteed.</p>
-
 					</div>
+
 					<section id="sec-media-overlays-structure">
 						<h5>Overlay Structure</h5>
 
@@ -8868,7 +8846,6 @@ No Entry</pre>
 						<div class="note">
 							<p>See <a data-cite="epub-tts-10#">EPUB 3 Text-to-Speech Support</a> [[EPUB-TTS-10]] for
 								more information about using TTS technologies in EPUB Publications.</p>
-
 						</div>
 					</section>
 				</section>
@@ -9464,7 +9441,6 @@ html.my-document-playing * {
 					future versions of EPUB. The approach of a separate specification ensures that the evolution of EPUB
 					does not lock accessibility in time (i.e., it allows producers of older versions of EPUB to
 					reference the latest accessibility requirements).</p>
-
 			</div>
 		</section>
 		<section id="sec-security-privacy" class="informative">
@@ -10116,7 +10092,6 @@ html.my-document-playing * {
 						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"
 									><var>property</var> data type</a> for more information about its default
 							vocabulary.</p>
-
 					</div>
 				</section>
 
@@ -10259,7 +10234,6 @@ html.my-document-playing * {
 							often reject new prefixes until their developers update the tools to the latest version of
 							the specification, for example. EPUB Creators should declare all prefixes they use to avoid
 							such issues.</p>
-
 					</div>
 
 					<p><a>EPUB Creators</a> MAY use reserved prefixes in attributes that expect a <a
@@ -10382,7 +10356,7 @@ html.my-document-playing * {
 
 					<dt>Example</dt>
 					<dd>
-						<p>Provides informative usage examples.</p>
+						<p>Provides non-normative usage examples.</p>
 					</dd>
 
 					<dt>Extends</dt>
@@ -10780,7 +10754,7 @@ html.my-document-playing * {
 			<section id="app-package-schema">
 				<h3>Package Document Schema</h3>
 
-				<p>A non-normative schema for Package Documents is available at <a
+				<p>A schema for Package Documents is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
 						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.</p>
 
@@ -10790,13 +10764,11 @@ html.my-document-playing * {
 				<div class="note">
 					<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG
 						and ISO Schematron schemas alone.</p>
-
 				</div>
 
 				<div class="note">
 					<p>These schemas may be updated and corrected outside of formal revisions of this specification. As
 						a result, they are subject to change at any time. </p>
-
 				</div>
 			</section>
 
@@ -10806,7 +10778,7 @@ html.my-document-playing * {
 				<section id="app-schema-container">
 					<h4>Schema for <code>container.xml</code></h4>
 
-					<p>A non-normative schema for <code>container.xml</code> files is available at <a
+					<p>A schema for <code>container.xml</code> files is available at <a
 							href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl">
 							<code>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl</code></a>.</p>
 
@@ -10832,7 +10804,7 @@ html.my-document-playing * {
 			<section id="app-schema-overlays">
 				<h3>Media Overlays Schema</h3>
 
-				<p>A non-normative schema for Media Overlays is available at <a
+				<p>A schema for Media Overlays is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl"
 						>https://github.com/w3c/epubcheck/tree/main/src/master/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl</a>.</p>
 
@@ -10842,7 +10814,6 @@ html.my-document-playing * {
 				<div class="note">
 					<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG
 						and ISO Schematron schemas alone.</p>
-
 				</div>
 			</section>
 		</section>
@@ -11862,7 +11833,7 @@ EPUB/images/cover.png</pre>
 					1538</a>.</li>
 				<li>15-Mar-2021: Removed the normative dependencies on XML schemas and added element and attribute
 					definitions for the <code>container.xml</code>, <code>encryption.xml</code> and
-						<code>signatures.xml</code> files. All schemas are considered informative. See <a
+						<code>signatures.xml</code> files. All schemas are considered non-normative. See <a
 						href="https://github.com/w3c/epub-specs/issues/1566">issue 1566</a>.</li>
 				<li>10-Mar-2021: Require that resources referenced from an EPUB Publication not be located in the
 						<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205"

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -1,19 +1,15 @@
 <section id="app-meta-property-vocab" class="vocab">
 	<h3>Meta Properties Vocabulary</h3>
-	
 	<p>The properties in this vocabulary are usable in the <a href="#sec-meta-elem"><code>meta</code>
 			element's</a>
 		<code>property</code> attribute.</p>
-	
 	<p>Unless indicated otherwise in its "Extends" field, the properties defined in this section are used to
 		define <a href="#subexpression">subexpressions</a>: in other words, a <code><a href="#elemdef-meta"
 				>meta</a></code> element carrying a property defined in this section MUST have a <code><a
 				href="#attrdef-refines">refines</a></code> attribute referencing a resource or expression being
 		augmented.</p>
-	
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
-		<code>http://idpf.org/epub/vocab/package/meta/#</code>.</p>
-	
+			<code>http://idpf.org/epub/vocab/package/meta/#</code>.</p>
 	<section id="sec-alternate-script">
 		<h5>alternate-script</h5>
 		<table class="propdef" id="alternate-script">
@@ -54,17 +50,17 @@
 		</table>
 		<aside class="example" title="Author name expressed in English and Japanese">
 			<pre>&lt;metadata …>
-   …
-   &lt;dc:creator id="creator">
-      Haruki Murakami
-   &lt;/dc:creator>
-   &lt;meta
-       refines="#creator"
-       property="alternate-script"
-       xml:lang="ja">
-      村上 春樹
-   &lt;/meta>
-   …
+…
+&lt;dc:creator id="creator">
+Haruki Murakami
+&lt;/dc:creator>
+&lt;meta
+refines="#creator"
+property="alternate-script"
+xml:lang="ja">
+村上 春樹
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -88,101 +84,14 @@
 				<tr>
 					<th>Allowed value(s):</th>
 					<td>
-						<ul>
-							<li>
-								<p>one of the following case-insensitive reserved authority values:</p>
-								<dl id="authorities">
-									<dt id="aat">
-										<a
-											href="http://www.getty.edu/research/tools/vocabularies/aat/index.html"
-											>AAT</a>
-									</dt>
-									<dd>
-										<p>The Getty Art and Architecture Taxonomy.</p>
-									</dd>
-									<dt id="bic">
-										<a href="http://www.bic.org.uk/7/BIC-Standard-Subject-Categories/"
-											>BIC</a>
-									</dt>
-									<dd>
-										<p>The main UK subject scheme for the book supply chain.</p>
-									</dd>
-									<dt id="bisac">
-										<a href="http://bisg.org/page/BISACSubjectCodes">BISAC</a>
-									</dt>
-									<dd>
-										<p>The main US subject scheme for the book supply chain.</p>
-									</dd>
-									<dt id="clc">
-										<a href="http://clc.nlc.gov.cn/">CLC</a>
-									</dt>
-									<dd>
-										<p>The main subject classification scheme used in China.</p>
-									</dd>
-									<dt id="ddc">
-										<a href="https://www.oclc.org/en/dewey/resources.html">DDC</a>
-									</dt>
-									<dd>
-										<p>The Dewey Decimal Classification system.</p>
-									</dd>
-									<dt id="clil">
-										<a href="http://clil.centprod.com/information/detailDoc.html?docId=34"
-											>CLIL</a>
-									</dt>
-									<dd>
-										<p>The main French subject scheme for the book supply chain.</p>
-									</dd>
-									<dt id="eurovoc">
-										<a href="http://eurovoc.europa.eu/">EuroVoc</a>
-									</dt>
-									<dd>
-										<p>The European multilingual thesaurus.</p>
-									</dd>
-									<dt id="medtop">
-										<a href="https://iptc.org/standards/media-topics/">MEDTOP</a>
-									</dt>
-									<dd>
-										<p>IPTC Media Topics classification scheme for the news industry.</p>
-									</dd>
-									<dt id="lcsh">
-										<a href="http://id.loc.gov/authorities/subjects.html">LCSH</a>
-									</dt>
-									<dd>
-										<p>Library of Congress Subject Headings.</p>
-									</dd>
-									<dt id="ndc">
-										<a href="http://www.jla.or.jp/">NDC</a>
-									</dt>
-									<dd>
-										<p>The main Japanese subject scheme.</p>
-									</dd>
-									<dt id="thema">
-										<a href="http://www.editeur.org/151/thema/">Thema</a>
-									</dt>
-									<dd>
-										<p>The international subject scheme for the book supply chain, providing
-											codes that work across many languages.</p>
-									</dd>
-									<dt id="udc">
-										<a href="http://www.udcc.org/">UDC</a>
-									</dt>
-									<dd>
-										<p>The Universal Decimal Classification system.</p>
-									</dd>
-									<dt id="wgs">
-										<a href="https://vlb.de/files/wgsneuversion2_0.pdf">WGS</a>
-									</dt>
-									<dd>
-										<p>The main German subject scheme for the book supply chain.</p>
-									</dd>
-								</dl>
-							</li>
-							<li>
-								<p>an <a data-cite="url#absolute-url-string">absolute-URL
-										string</a> [[URL]] that identifies the scheme. The URL SHOULD refer to a
-									resource that provides more information about the scheme.</p>
-							</li>
-						</ul>
+						<code>xsd:string</code>
+						<div class="note">
+							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB
+								3 Working Group maintained a <a
+									href="https://idpf.github.io/epub-registries/authorities/">registry of
+									subject authorities</a> for use with this property. This Working Group no
+								longer maintains this registry.</p>
+						</div>
 					</td>
 				</tr>
 				<tr>
@@ -203,17 +112,17 @@
 		</table>
 		<aside class="example" title="Expressing A BISAC subject heading">
 			<pre>&lt;metadata …>
-   …
-   &lt;dc:subject
-      id="subject01"&gt;
-     FICTION / Occult &amp;amp; Supernatural
-   &lt;/dc:subject&gt;
-   &lt;meta
-       refines="#subject01"
-       property="authority">
-      BISAC
-   &lt;/meta>
-   …
+…
+&lt;dc:subject
+id="subject01"&gt;
+FICTION / Occult &amp;amp; Supernatural
+&lt;/dc:subject&gt;
+&lt;meta
+refines="#subject01"
+property="authority">
+BISAC
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -268,18 +177,18 @@
 		<aside class="example" title="Indicating a publication belongs to a set">
 			<p>In this example, the publication belongs to the Harry Potter set of books.</p>
 			<pre>&lt;metadata&gt;
-   …
-   &lt;meta
-       property="belongs-to-collection"
-       id="c02"&gt;
-      Harry Potter
-   &lt;/meta&gt;
-   &lt;meta
-       refines="#c02"
-       property="collection-type"&gt;
-      set
-   &lt;/meta&gt;
-   …
+…
+&lt;meta
+property="belongs-to-collection"
+id="c02"&gt;
+Harry Potter
+&lt;/meta&gt;
+&lt;meta
+refines="#c02"
+property="collection-type"&gt;
+set
+&lt;/meta&gt;
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -320,8 +229,9 @@
 							</dd>
 						</dl>
 						<div class="note">
-							<p>Although Reading Systems are not required to support these values, specifying them
-								provides the option to group related EPUB Publications in more meaningful ways.</p>
+							<p>Although Reading Systems are not required to support these values, specifying
+								them provides the option to group related EPUB Publications in more meaningful
+								ways.</p>
 						</div>
 					</td>
 				</tr>
@@ -348,21 +258,20 @@
 			</tbody>
 		</table>
 		<aside class="example" title="Identifying a publication belongs to a series">
-			<p>In this example, the publication belongs to the series The New French Cuisine
-				Masters.</p>
+			<p>In this example, the publication belongs to the series The New French Cuisine Masters.</p>
 			<pre>&lt;metadata …>
-   …
-   &lt;meta
-       property="belongs-to-collection"
-       id="c01"&gt;
-      The New French Cuisine Masters
-   &lt;/meta&gt;
-   &lt;meta
-       refines="#c01"
-       property="collection-type"&gt;
-      series
-   &lt;/meta&gt;
-   …
+…
+&lt;meta
+property="belongs-to-collection"
+id="c01"&gt;
+The New French Cuisine Masters
+&lt;/meta&gt;
+&lt;meta
+refines="#c01"
+property="collection-type"&gt;
+series
+&lt;/meta&gt;
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -438,20 +347,19 @@
 				</tr>
 			</tbody>
 		</table>
-		
 		<aside class="example" title="Expressing an author name for sorting">
 			<pre>&lt;metadata …>
-   …
-   &lt;dc:creator
-       id="creator01">
-      Lewis Carroll
-   &lt;/dc:creator>
-   &lt;meta
-       refines="#creator01"
-       property="file-as">
-      Carroll, Lewis
-   &lt;/meta>
-   …
+…
+&lt;dc:creator
+id="creator01">
+Lewis Carroll
+&lt;/dc:creator>
+&lt;meta
+refines="#creator01"
+property="file-as">
+Carroll, Lewis
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -496,47 +404,46 @@
 			</tbody>
 		</table>
 		<aside class="example" title="Identifying a publication's position in a set">
-			<p>In this example, the publication is the second in the Lord of the Rings set of
-				books.</p>
+			<p>In this example, the publication is the second in the Lord of the Rings set of books.</p>
 			<pre>&lt;metadata …>
-   …
-   &lt;meta property="belongs-to-collection" id="c01"&gt;
-      The Lord of the Rings
-   &lt;/meta&gt;
-   &lt;meta
-       refines="#c01"
-       property="collection-type"&gt;
-      set
-   &lt;/meta&gt;
-   &lt;meta
-       refines="#c01"
-       property="group-position"&gt;
-      2
-   &lt;/meta&gt;
-   …
+…
+&lt;meta property="belongs-to-collection" id="c01"&gt;
+The Lord of the Rings
+&lt;/meta&gt;
+&lt;meta
+refines="#c01"
+property="collection-type"&gt;
+set
+&lt;/meta&gt;
+&lt;meta
+refines="#c01"
+property="group-position"&gt;
+2
+&lt;/meta&gt;
+…
 &lt;/metadata></pre>
 		</aside>
 		<aside class="example" title="Expressing a decimal-separated value for position">
-			<p>In this example, the decimal-separated value in the <code>group-position</code> attribute indicates this
-				publication is volume 98, issue 4 of a periodical.</p>
+			<p>In this example, the decimal-separated value in the <code>group-position</code> attribute
+				indicates this publication is volume 98, issue 4 of a periodical.</p>
 			<pre>&lt;metadata …&gt;
-   …
-   &lt;meta
-       property="belongs-to-collection"
-       id="cygnus-x-1">
-      Physical Review D
-   &lt;/meta>
-   &lt;meta
-       refines="#cygnus-x-1"
-       property="collection-type">
-      series
-   &lt;/meta>
-   &lt;meta
-       refines="#cygnus-x-1"
-       property="group-position">
-      98.4
-   &lt;/meta>
-   …
+…
+&lt;meta
+property="belongs-to-collection"
+id="cygnus-x-1">
+Physical Review D
+&lt;/meta>
+&lt;meta
+refines="#cygnus-x-1"
+property="collection-type">
+series
+&lt;/meta>
+&lt;meta
+refines="#cygnus-x-1"
+property="group-position">
+98.4
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -582,30 +489,30 @@
 			</tbody>
 		</table>
 		<aside class="example" title="Indicating an identifier is an ISBN">
-			<p>In this example, the ONIX code list 5 scheme defines the meaning of the numeric value <code>15</code>.</p>
+			<p>In this example, the ONIX code list 5 scheme defines the meaning of the numeric value
+					<code>15</code>.</p>
 			<pre>&lt;metadata …>
-   …
-   &lt;dc:identifier
-       id="isbn-id">
-      urn:isbn:9780101010101
-   &lt;/dc:identifier>
-   &lt;meta
-      refines="#isbn-id"
-      property="identifier-type"
-      scheme="onix:codelist5">
-     15
-   &lt;/meta>
-   …
+…
+&lt;dc:identifier
+id="isbn-id">
+urn:isbn:9780101010101
+&lt;/dc:identifier>
+&lt;meta
+refines="#isbn-id"
+property="identifier-type"
+scheme="onix:codelist5">
+15
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
 	<section id="sec-meta-auth">
 		<h5>meta-auth (Deprecated)</h5>
 		<p id="meta-auth">Use of this property is <a href="#deprecated">deprecated</a>.</p>
-		
-		<p>Refer to the <a 
-			href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"><code>meta-auth</code>
-			property definition</a> in [[!EPUBPublications-30]] for more information.</p>
+		<p>Refer to the <a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"
+					><code>meta-auth</code> property definition</a> in [[!EPUBPublications-30]] for more
+			information.</p>
 	</section>
 	<section id="sec-role">
 		<h5>role</h5>
@@ -655,55 +562,55 @@
 			</tbody>
 		</table>
 		<aside class="example" title="Differentiating creator roles">
-			<p>In this example, MARC Relators vocabulary values differentiate the author from the
-				illustrator of a work.</p>
+			<p>In this example, MARC Relators vocabulary values differentiate the author from the illustrator of
+				a work.</p>
 			<pre>&lt;metadata …>
-   …
-   &lt;dc:creator
-      id="creator01">
-     Lewis Carroll
-   &lt;/dc:creator>
-   &lt;meta
-       refines="#creator01"
-       property="role"
-       scheme="marc:relators">
-      aut
-   &lt;/meta>
+…
+&lt;dc:creator
+id="creator01">
+Lewis Carroll
+&lt;/dc:creator>
+&lt;meta
+refines="#creator01"
+property="role"
+scheme="marc:relators">
+aut
+&lt;/meta>
 
-   &lt;dc:creator
-       id="creator02">
-      John Tenniel
-   &lt;/dc:creator>
-   &lt;meta
-       refines="#creator02"
-       property="role"
-       scheme="marc:relators">
-      ill
-   &lt;/meta>
-   …
+&lt;dc:creator
+id="creator02">
+John Tenniel
+&lt;/dc:creator>
+&lt;meta
+refines="#creator02"
+property="role"
+scheme="marc:relators">
+ill
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 		<aside class="example" title="Identifying a creator who has multiple roles">
 			<p>In this example, the creator is both the author and illustrator of the work.</p>
 			<pre>&lt;metadata …>
-   …
-   &lt;dc:creator
-       id="creator01">
-      Maurice Sendak
-   &lt;/dc:creator>
-   &lt;meta
-       refines="#creator01"
-       property="role"
-       scheme="marc:relators">
-      aut
-   &lt;/meta>
-   &lt;meta
-       refines="#creator01"
-       property="role"
-       scheme="marc:relators">
-      ill
-   &lt;/meta>
-   …
+…
+&lt;dc:creator
+id="creator01">
+Maurice Sendak
+&lt;/dc:creator>
+&lt;meta
+refines="#creator01"
+property="role"
+scheme="marc:relators">
+aut
+&lt;/meta>
+&lt;meta
+refines="#creator01"
+property="role"
+scheme="marc:relators">
+ill
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -750,37 +657,38 @@
 				</tr>
 			</tbody>
 		</table>
-		<p class="note">See [[EPUB-A11Y-TECH-11]] for information on how to provide accessible page navigation.</p>
+		<p class="note">See [[EPUB-A11Y-TECH-11]] for information on how to provide accessible page
+			navigation.</p>
 		<aside class="example" title="Identifying the print pagination source of a publication">
 			<pre>&lt;metadata …>
-   …
-   &lt;dc:identifier
-       id="isbn-id">
-      urn:isbn:9780101010101
-   &lt;/dc:identifier>
-   &lt;meta
-       refines="#isbn-id"
-       property="identifier-type"
-       scheme="onix:codelist5">
-      15
-   &lt;/meta>
+…
+&lt;dc:identifier
+id="isbn-id">
+urn:isbn:9780101010101
+&lt;/dc:identifier>
+&lt;meta
+refines="#isbn-id"
+property="identifier-type"
+scheme="onix:codelist5">
+15
+&lt;/meta>
 
-   &lt;dc:source
-       id="src-id">
-      urn:isbn:9780375704024
-   &lt;/dc:source>
-   &lt;meta
-       refines="#src-id"
-       property="identifier-type"
-       scheme="onix:codelist5">
-      15
-   &lt;/meta>
-   &lt;meta
-       refines="#src-id"
-       property="source-of">
-      pagination
-   &lt;/meta>
-   …
+&lt;dc:source
+id="src-id">
+urn:isbn:9780375704024
+&lt;/dc:source>
+&lt;meta
+refines="#src-id"
+property="identifier-type"
+scheme="onix:codelist5">
+15
+&lt;/meta>
+&lt;meta
+refines="#src-id"
+property="source-of">
+pagination
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -825,22 +733,22 @@
 		<aside class="example" title="Expressing a BISAC code for a subject heading">
 			<p>The following example shows a BISAC code for a subject heading.</p>
 			<pre>&lt;metadata …>
-   …
-   &lt;dc:subject
-       id="subject01"&gt;
-      FICTION / Occult &amp;amp; Supernatural
-   &lt;/dc:subject&gt;
-   &lt;meta
-       refines="#subject01"
-       property="authority">
-      BISAC
-   &lt;/meta>
-   &lt;meta
-       refines="#subject01"
-       property="term">
-      FIC024000
-   &lt;/meta>
-   …
+…
+&lt;dc:subject
+id="subject01"&gt;
+FICTION / Occult &amp;amp; Supernatural
+&lt;/dc:subject&gt;
+&lt;meta
+refines="#subject01"
+property="authority">
+BISAC
+&lt;/meta>
+&lt;meta
+refines="#subject01"
+property="term">
+FIC024000
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -892,112 +800,112 @@
 		</table>
 		<aside class="example" title="Expressing different title types">
 			<pre>&lt;metadata …>
-   …
-   &lt;dc:title id="t1">
-      A Dictionary of Modern English Usage
-   &lt;/dc:title>
-   &lt;meta
-       refines="#t1"
-       property="title-type">
-      main
-   &lt;/meta>
+…
+&lt;dc:title id="t1">
+A Dictionary of Modern English Usage
+&lt;/dc:title>
+&lt;meta
+refines="#t1"
+property="title-type">
+main
+&lt;/meta>
 
-   &lt;dc:title id="t2">
-      First Edition
-   &lt;/dc:title>
-   &lt;meta
-       refines="#t2"
-       property="title-type">
-      edition
-   &lt;/meta>
+&lt;dc:title id="t2">
+First Edition
+&lt;/dc:title>
+&lt;meta
+refines="#t2"
+property="title-type">
+edition
+&lt;/meta>
 
-   &lt;dc:title id="t3">
-      Fowler's
-   &lt;/dc:title>
-   &lt;meta
-       refines="#t3"
-       property="title-type">
-      short
-   &lt;/meta>
-   …
+&lt;dc:title id="t3">
+Fowler's
+&lt;/dc:title>
+&lt;meta
+refines="#t3"
+property="title-type">
+short
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 		<aside class="example" title="Expressing complex titles">
-			<p id="cookbook-ex">This example shows how to classify the title "The Great Cookbooks of the
-				World: Mon premier guide de cuisson, un Mémoire. The New French Cuisine Masters, Volume Two.
-				Special Anniversary Edition".</p>
+			<p id="cookbook-ex">This example shows how to classify the title "The Great Cookbooks of the World:
+				Mon premier guide de cuisson, un Mémoire. The New French Cuisine Masters, Volume Two. Special
+				Anniversary Edition".</p>
 			<pre>&lt;metadata …>
-   …
-   &lt;dc:title
-       id="t1"
-       xml:lang="fr">
-      Mon premier guide de cuisson, un Mémoire
-   &lt;/dc:title>
-   &lt;meta
-       refines="#t1"
-       property="title-type">
-      main
-   &lt;/meta>
-   &lt;meta
-       refines="#t1"
-       property="display-seq">
-      2
-   &lt;/meta>
+…
+&lt;dc:title
+id="t1"
+xml:lang="fr">
+Mon premier guide de cuisson, un Mémoire
+&lt;/dc:title>
+&lt;meta
+refines="#t1"
+property="title-type">
+main
+&lt;/meta>
+&lt;meta
+refines="#t1"
+property="display-seq">
+2
+&lt;/meta>
 
-   &lt;dc:title id="t2">
-      The Great Cookbooks of the World
-   &lt;/dc:title>
-   &lt;meta
-       refines="#t2"
-       property="title-type">
-      collection
-   &lt;/meta>
-   &lt;meta
-       refines="#t2"
-       property="display-seq">
-      1
-   &lt;/meta>
+&lt;dc:title id="t2">
+The Great Cookbooks of the World
+&lt;/dc:title>
+&lt;meta
+refines="#t2"
+property="title-type">
+collection
+&lt;/meta>
+&lt;meta
+refines="#t2"
+property="display-seq">
+1
+&lt;/meta>
 
-   &lt;dc:title id="t3">
-      The New French Cuisine Masters
-   &lt;/dc:title>
-   &lt;meta
-       refines="#t3"
-       property="title-type">
-      collection
-   &lt;/meta>
-   &lt;meta
-       refines="#t3"
-       property="display-seq">
-      3
-   &lt;/meta>
+&lt;dc:title id="t3">
+The New French Cuisine Masters
+&lt;/dc:title>
+&lt;meta
+refines="#t3"
+property="title-type">
+collection
+&lt;/meta>
+&lt;meta
+refines="#t3"
+property="display-seq">
+3
+&lt;/meta>
 
-   &lt;dc:title id="t4">
-      Special Anniversary Edition
-   &lt;/dc:title>
-   &lt;meta
-       refines="#t4"
-       property="title-type">
-      edition
-   &lt;/meta>
-   &lt;meta
-       refines="#t4"
-       property="display-seq">
-      4
-   &lt;/meta>
+&lt;dc:title id="t4">
+Special Anniversary Edition
+&lt;/dc:title>
+&lt;meta
+refines="#t4"
+property="title-type">
+edition
+&lt;/meta>
+&lt;meta
+refines="#t4"
+property="display-seq">
+4
+&lt;/meta>
 
-   &lt;dc:title id="t5">
-      The Great Cookbooks of the World: 
-      Mon premier guide de cuisson, un Mémoire. 
-      The New French Cuisine Masters, Volume Two. 
-      Special Anniversary Edition
-   &lt;/dc:title>
-   &lt;meta
-       refines="#t5"
-       property="title-type">
-      expanded
-   &lt;/meta>
-   …
+&lt;dc:title id="t5">
+The Great Cookbooks of the World: 
+Mon premier guide de cuisson, un Mémoire. 
+The New French Cuisine Masters, Volume Two. 
+Special Anniversary Edition
+&lt;/dc:title>
+&lt;meta
+refines="#t5"
+property="title-type">
+expanded
+&lt;/meta>
+…
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -1006,70 +914,70 @@
 		<aside class="example" title="A typical set of refines metadata in an EPUB Publication">
 			<pre>&lt;metadata …>
 
-   &lt;dc:identifier id="pub-id">
-      urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
-   &lt;/dc:identifier>
+&lt;dc:identifier id="pub-id">
+urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
+&lt;/dc:identifier>
 
-   &lt;dc:identifier id="isbn-id">
-      urn:isbn:9780101010101
-   &lt;/dc:identifier>
-   &lt;meta
-       refines="#isbn-id"
-       property="identifier-type"
-       scheme="onix:codelist5">
-      15
-   &lt;/meta>
+&lt;dc:identifier id="isbn-id">
+urn:isbn:9780101010101
+&lt;/dc:identifier>
+&lt;meta
+refines="#isbn-id"
+property="identifier-type"
+scheme="onix:codelist5">
+15
+&lt;/meta>
 
-   &lt;dc:source id="src-id">
-      urn:isbn:9780375704024
-   &lt;/dc:source>
-   &lt;meta
-       refines="#src-id"
-       property="identifier-type"
-       scheme="onix:codelist5">
-      15
-   &lt;/meta>
+&lt;dc:source id="src-id">
+urn:isbn:9780375704024
+&lt;/dc:source>
+&lt;meta
+refines="#src-id"
+property="identifier-type"
+scheme="onix:codelist5">
+15
+&lt;/meta>
 
-   &lt;dc:title id="title">
-      Norwegian Wood
-   &lt;/dc:title>
-   &lt;meta
-       refines="#title"
-       property="title-type">
-      main
-   &lt;/meta>
+&lt;dc:title id="title">
+Norwegian Wood
+&lt;/dc:title>
+&lt;meta
+refines="#title"
+property="title-type">
+main
+&lt;/meta>
 
-   &lt;dc:language>
-      en
-   &lt;/dc:language>
+&lt;dc:language>
+en
+&lt;/dc:language>
 
-   &lt;dc:creator
-       id="creator">
-      Haruki Murakami
-   &lt;/dc:creator>
-   &lt;meta
-       refines="#creator"
-       property="role"
-       scheme="marc:relators"
-       id="role">
-      aut
-   &lt;/meta>
-   &lt;meta
-       refines="#creator"
-       property="alternate-script"
-       xml:lang="ja">
-      村上 春樹
-   &lt;/meta>
-   &lt;meta
-       refines="#creator"
-       property="file-as">
-      Murakami, Haruki
-   &lt;/meta>
+&lt;dc:creator
+id="creator">
+Haruki Murakami
+&lt;/dc:creator>
+&lt;meta
+refines="#creator"
+property="role"
+scheme="marc:relators"
+id="role">
+aut
+&lt;/meta>
+&lt;meta
+refines="#creator"
+property="alternate-script"
+xml:lang="ja">
+村上 春樹
+&lt;/meta>
+&lt;meta
+refines="#creator"
+property="file-as">
+Murakami, Haruki
+&lt;/meta>
 
-   &lt;meta
-       property="dcterms:modified">
-      2011-01-01T12:00:00Z
-   &lt;/meta>
+&lt;meta
+property="dcterms:modified">
+2011-01-01T12:00:00Z
+&lt;/meta>
 
 &lt;/metadata></pre>
 		</aside>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -1,15 +1,19 @@
 <section id="app-meta-property-vocab" class="vocab">
 	<h3>Meta Properties Vocabulary</h3>
+	
 	<p>The properties in this vocabulary are usable in the <a href="#sec-meta-elem"><code>meta</code>
 			element's</a>
 		<code>property</code> attribute.</p>
+	
 	<p>Unless indicated otherwise in its "Extends" field, the properties defined in this section are used to
 		define <a href="#subexpression">subexpressions</a>: in other words, a <code><a href="#elemdef-meta"
 				>meta</a></code> element carrying a property defined in this section MUST have a <code><a
 				href="#attrdef-refines">refines</a></code> attribute referencing a resource or expression being
 		augmented.</p>
+	
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 			<code>http://idpf.org/epub/vocab/package/meta/#</code>.</p>
+	
 	<section id="sec-alternate-script">
 		<h5>alternate-script</h5>
 		<table class="propdef" id="alternate-script">
@@ -50,17 +54,17 @@
 		</table>
 		<aside class="example" title="Author name expressed in English and Japanese">
 			<pre>&lt;metadata …>
-…
-&lt;dc:creator id="creator">
-Haruki Murakami
-&lt;/dc:creator>
-&lt;meta
-refines="#creator"
-property="alternate-script"
-xml:lang="ja">
-村上 春樹
-&lt;/meta>
-…
+   …
+   &lt;dc:creator id="creator">
+      Haruki Murakami
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator"
+       property="alternate-script"
+       xml:lang="ja">
+      村上 春樹
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -112,17 +116,17 @@ xml:lang="ja">
 		</table>
 		<aside class="example" title="Expressing A BISAC subject heading">
 			<pre>&lt;metadata …>
-…
-&lt;dc:subject
-id="subject01"&gt;
-FICTION / Occult &amp;amp; Supernatural
-&lt;/dc:subject&gt;
-&lt;meta
-refines="#subject01"
-property="authority">
-BISAC
-&lt;/meta>
-…
+   …
+   &lt;dc:subject
+      id="subject01"&gt;
+     FICTION / Occult &amp;amp; Supernatural
+   &lt;/dc:subject&gt;
+   &lt;meta
+       refines="#subject01"
+       property="authority">
+      BISAC
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -177,18 +181,18 @@ BISAC
 		<aside class="example" title="Indicating a publication belongs to a set">
 			<p>In this example, the publication belongs to the Harry Potter set of books.</p>
 			<pre>&lt;metadata&gt;
-…
-&lt;meta
-property="belongs-to-collection"
-id="c02"&gt;
-Harry Potter
-&lt;/meta&gt;
-&lt;meta
-refines="#c02"
-property="collection-type"&gt;
-set
-&lt;/meta&gt;
-…
+   …
+   &lt;meta
+       property="belongs-to-collection"
+       id="c02"&gt;
+      Harry Potter
+   &lt;/meta&gt;
+   &lt;meta
+       refines="#c02"
+       property="collection-type"&gt;
+      set
+   &lt;/meta&gt;
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -229,9 +233,8 @@ set
 							</dd>
 						</dl>
 						<div class="note">
-							<p>Although Reading Systems are not required to support these values, specifying
-								them provides the option to group related EPUB Publications in more meaningful
-								ways.</p>
+							<p>Although Reading Systems are not required to support these values, specifying them
+								provides the option to group related EPUB Publications in more meaningful ways.</p>
 						</div>
 					</td>
 				</tr>
@@ -258,20 +261,21 @@ set
 			</tbody>
 		</table>
 		<aside class="example" title="Identifying a publication belongs to a series">
-			<p>In this example, the publication belongs to the series The New French Cuisine Masters.</p>
+			<p>In this example, the publication belongs to the series The New French Cuisine
+				Masters.</p>
 			<pre>&lt;metadata …>
-…
-&lt;meta
-property="belongs-to-collection"
-id="c01"&gt;
-The New French Cuisine Masters
-&lt;/meta&gt;
-&lt;meta
-refines="#c01"
-property="collection-type"&gt;
-series
-&lt;/meta&gt;
-…
+   …
+   &lt;meta
+       property="belongs-to-collection"
+       id="c01"&gt;
+      The New French Cuisine Masters
+   &lt;/meta&gt;
+   &lt;meta
+       refines="#c01"
+       property="collection-type"&gt;
+      series
+   &lt;/meta&gt;
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -347,19 +351,20 @@ series
 				</tr>
 			</tbody>
 		</table>
+		
 		<aside class="example" title="Expressing an author name for sorting">
 			<pre>&lt;metadata …>
-…
-&lt;dc:creator
-id="creator01">
-Lewis Carroll
-&lt;/dc:creator>
-&lt;meta
-refines="#creator01"
-property="file-as">
-Carroll, Lewis
-&lt;/meta>
-…
+   …
+   &lt;dc:creator
+       id="creator01">
+      Lewis Carroll
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator01"
+       property="file-as">
+      Carroll, Lewis
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -404,46 +409,47 @@ Carroll, Lewis
 			</tbody>
 		</table>
 		<aside class="example" title="Identifying a publication's position in a set">
-			<p>In this example, the publication is the second in the Lord of the Rings set of books.</p>
+			<p>In this example, the publication is the second in the Lord of the Rings set of
+				books.</p>
 			<pre>&lt;metadata …>
-…
-&lt;meta property="belongs-to-collection" id="c01"&gt;
-The Lord of the Rings
-&lt;/meta&gt;
-&lt;meta
-refines="#c01"
-property="collection-type"&gt;
-set
-&lt;/meta&gt;
-&lt;meta
-refines="#c01"
-property="group-position"&gt;
-2
-&lt;/meta&gt;
-…
+   …
+   &lt;meta property="belongs-to-collection" id="c01"&gt;
+      The Lord of the Rings
+   &lt;/meta&gt;
+   &lt;meta
+       refines="#c01"
+       property="collection-type"&gt;
+      set
+   &lt;/meta&gt;
+   &lt;meta
+       refines="#c01"
+       property="group-position"&gt;
+      2
+   &lt;/meta&gt;
+   …
 &lt;/metadata></pre>
 		</aside>
 		<aside class="example" title="Expressing a decimal-separated value for position">
-			<p>In this example, the decimal-separated value in the <code>group-position</code> attribute
-				indicates this publication is volume 98, issue 4 of a periodical.</p>
+			<p>In this example, the decimal-separated value in the <code>group-position</code> attribute indicates this
+				publication is volume 98, issue 4 of a periodical.</p>
 			<pre>&lt;metadata …&gt;
-…
-&lt;meta
-property="belongs-to-collection"
-id="cygnus-x-1">
-Physical Review D
-&lt;/meta>
-&lt;meta
-refines="#cygnus-x-1"
-property="collection-type">
-series
-&lt;/meta>
-&lt;meta
-refines="#cygnus-x-1"
-property="group-position">
-98.4
-&lt;/meta>
-…
+   …
+   &lt;meta
+       property="belongs-to-collection"
+       id="cygnus-x-1">
+      Physical Review D
+   &lt;/meta>
+   &lt;meta
+       refines="#cygnus-x-1"
+       property="collection-type">
+      series
+   &lt;/meta>
+   &lt;meta
+       refines="#cygnus-x-1"
+       property="group-position">
+      98.4
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -489,30 +495,30 @@ property="group-position">
 			</tbody>
 		</table>
 		<aside class="example" title="Indicating an identifier is an ISBN">
-			<p>In this example, the ONIX code list 5 scheme defines the meaning of the numeric value
-					<code>15</code>.</p>
+			<p>In this example, the ONIX code list 5 scheme defines the meaning of the numeric value <code>15</code>.</p>
 			<pre>&lt;metadata …>
-…
-&lt;dc:identifier
-id="isbn-id">
-urn:isbn:9780101010101
-&lt;/dc:identifier>
-&lt;meta
-refines="#isbn-id"
-property="identifier-type"
-scheme="onix:codelist5">
-15
-&lt;/meta>
-…
+   …
+   &lt;dc:identifier
+       id="isbn-id">
+      urn:isbn:9780101010101
+   &lt;/dc:identifier>
+   &lt;meta
+      refines="#isbn-id"
+      property="identifier-type"
+      scheme="onix:codelist5">
+     15
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
 	<section id="sec-meta-auth">
 		<h5>meta-auth (Deprecated)</h5>
 		<p id="meta-auth">Use of this property is <a href="#deprecated">deprecated</a>.</p>
-		<p>Refer to the <a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"
-					><code>meta-auth</code> property definition</a> in [[!EPUBPublications-30]] for more
-			information.</p>
+		
+		<p>Refer to the <a 
+			href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"><code>meta-auth</code>
+			property definition</a> in [[!EPUBPublications-30]] for more information.</p>
 	</section>
 	<section id="sec-role">
 		<h5>role</h5>
@@ -562,55 +568,55 @@ scheme="onix:codelist5">
 			</tbody>
 		</table>
 		<aside class="example" title="Differentiating creator roles">
-			<p>In this example, MARC Relators vocabulary values differentiate the author from the illustrator of
-				a work.</p>
+			<p>In this example, MARC Relators vocabulary values differentiate the author from the
+				illustrator of a work.</p>
 			<pre>&lt;metadata …>
-…
-&lt;dc:creator
-id="creator01">
-Lewis Carroll
-&lt;/dc:creator>
-&lt;meta
-refines="#creator01"
-property="role"
-scheme="marc:relators">
-aut
-&lt;/meta>
+   …
+   &lt;dc:creator
+      id="creator01">
+     Lewis Carroll
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator01"
+       property="role"
+       scheme="marc:relators">
+      aut
+   &lt;/meta>
 
-&lt;dc:creator
-id="creator02">
-John Tenniel
-&lt;/dc:creator>
-&lt;meta
-refines="#creator02"
-property="role"
-scheme="marc:relators">
-ill
-&lt;/meta>
-…
+   &lt;dc:creator
+       id="creator02">
+      John Tenniel
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator02"
+       property="role"
+       scheme="marc:relators">
+      ill
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 		<aside class="example" title="Identifying a creator who has multiple roles">
 			<p>In this example, the creator is both the author and illustrator of the work.</p>
 			<pre>&lt;metadata …>
-…
-&lt;dc:creator
-id="creator01">
-Maurice Sendak
-&lt;/dc:creator>
-&lt;meta
-refines="#creator01"
-property="role"
-scheme="marc:relators">
-aut
-&lt;/meta>
-&lt;meta
-refines="#creator01"
-property="role"
-scheme="marc:relators">
-ill
-&lt;/meta>
-…
+   …
+   &lt;dc:creator
+       id="creator01">
+      Maurice Sendak
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator01"
+       property="role"
+       scheme="marc:relators">
+      aut
+   &lt;/meta>
+   &lt;meta
+       refines="#creator01"
+       property="role"
+       scheme="marc:relators">
+      ill
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -657,38 +663,37 @@ ill
 				</tr>
 			</tbody>
 		</table>
-		<p class="note">See [[EPUB-A11Y-TECH-11]] for information on how to provide accessible page
-			navigation.</p>
+		<p class="note">See [[EPUB-A11Y-TECH-11]] for information on how to provide accessible page navigation.</p>
 		<aside class="example" title="Identifying the print pagination source of a publication">
 			<pre>&lt;metadata …>
-…
-&lt;dc:identifier
-id="isbn-id">
-urn:isbn:9780101010101
-&lt;/dc:identifier>
-&lt;meta
-refines="#isbn-id"
-property="identifier-type"
-scheme="onix:codelist5">
-15
-&lt;/meta>
+   …
+   &lt;dc:identifier
+       id="isbn-id">
+      urn:isbn:9780101010101
+   &lt;/dc:identifier>
+   &lt;meta
+       refines="#isbn-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      15
+   &lt;/meta>
 
-&lt;dc:source
-id="src-id">
-urn:isbn:9780375704024
-&lt;/dc:source>
-&lt;meta
-refines="#src-id"
-property="identifier-type"
-scheme="onix:codelist5">
-15
-&lt;/meta>
-&lt;meta
-refines="#src-id"
-property="source-of">
-pagination
-&lt;/meta>
-…
+   &lt;dc:source
+       id="src-id">
+      urn:isbn:9780375704024
+   &lt;/dc:source>
+   &lt;meta
+       refines="#src-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      15
+   &lt;/meta>
+   &lt;meta
+       refines="#src-id"
+       property="source-of">
+      pagination
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -733,22 +738,22 @@ pagination
 		<aside class="example" title="Expressing a BISAC code for a subject heading">
 			<p>The following example shows a BISAC code for a subject heading.</p>
 			<pre>&lt;metadata …>
-…
-&lt;dc:subject
-id="subject01"&gt;
-FICTION / Occult &amp;amp; Supernatural
-&lt;/dc:subject&gt;
-&lt;meta
-refines="#subject01"
-property="authority">
-BISAC
-&lt;/meta>
-&lt;meta
-refines="#subject01"
-property="term">
-FIC024000
-&lt;/meta>
-…
+   …
+   &lt;dc:subject
+       id="subject01"&gt;
+      FICTION / Occult &amp;amp; Supernatural
+   &lt;/dc:subject&gt;
+   &lt;meta
+       refines="#subject01"
+       property="authority">
+      BISAC
+   &lt;/meta>
+   &lt;meta
+       refines="#subject01"
+       property="term">
+      FIC024000
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -800,112 +805,112 @@ FIC024000
 		</table>
 		<aside class="example" title="Expressing different title types">
 			<pre>&lt;metadata …>
-…
-&lt;dc:title id="t1">
-A Dictionary of Modern English Usage
-&lt;/dc:title>
-&lt;meta
-refines="#t1"
-property="title-type">
-main
-&lt;/meta>
+   …
+   &lt;dc:title id="t1">
+      A Dictionary of Modern English Usage
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t1"
+       property="title-type">
+      main
+   &lt;/meta>
 
-&lt;dc:title id="t2">
-First Edition
-&lt;/dc:title>
-&lt;meta
-refines="#t2"
-property="title-type">
-edition
-&lt;/meta>
+   &lt;dc:title id="t2">
+      First Edition
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t2"
+       property="title-type">
+      edition
+   &lt;/meta>
 
-&lt;dc:title id="t3">
-Fowler's
-&lt;/dc:title>
-&lt;meta
-refines="#t3"
-property="title-type">
-short
-&lt;/meta>
-…
+   &lt;dc:title id="t3">
+      Fowler's
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t3"
+       property="title-type">
+      short
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 		<aside class="example" title="Expressing complex titles">
-			<p id="cookbook-ex">This example shows how to classify the title "The Great Cookbooks of the World:
-				Mon premier guide de cuisson, un Mémoire. The New French Cuisine Masters, Volume Two. Special
-				Anniversary Edition".</p>
+			<p id="cookbook-ex">This example shows how to classify the title "The Great Cookbooks of the
+				World: Mon premier guide de cuisson, un Mémoire. The New French Cuisine Masters, Volume Two.
+				Special Anniversary Edition".</p>
 			<pre>&lt;metadata …>
-…
-&lt;dc:title
-id="t1"
-xml:lang="fr">
-Mon premier guide de cuisson, un Mémoire
-&lt;/dc:title>
-&lt;meta
-refines="#t1"
-property="title-type">
-main
-&lt;/meta>
-&lt;meta
-refines="#t1"
-property="display-seq">
-2
-&lt;/meta>
+   …
+   &lt;dc:title
+       id="t1"
+       xml:lang="fr">
+      Mon premier guide de cuisson, un Mémoire
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t1"
+       property="title-type">
+      main
+   &lt;/meta>
+   &lt;meta
+       refines="#t1"
+       property="display-seq">
+      2
+   &lt;/meta>
 
-&lt;dc:title id="t2">
-The Great Cookbooks of the World
-&lt;/dc:title>
-&lt;meta
-refines="#t2"
-property="title-type">
-collection
-&lt;/meta>
-&lt;meta
-refines="#t2"
-property="display-seq">
-1
-&lt;/meta>
+   &lt;dc:title id="t2">
+      The Great Cookbooks of the World
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t2"
+       property="title-type">
+      collection
+   &lt;/meta>
+   &lt;meta
+       refines="#t2"
+       property="display-seq">
+      1
+   &lt;/meta>
 
-&lt;dc:title id="t3">
-The New French Cuisine Masters
-&lt;/dc:title>
-&lt;meta
-refines="#t3"
-property="title-type">
-collection
-&lt;/meta>
-&lt;meta
-refines="#t3"
-property="display-seq">
-3
-&lt;/meta>
+   &lt;dc:title id="t3">
+      The New French Cuisine Masters
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t3"
+       property="title-type">
+      collection
+   &lt;/meta>
+   &lt;meta
+       refines="#t3"
+       property="display-seq">
+      3
+   &lt;/meta>
 
-&lt;dc:title id="t4">
-Special Anniversary Edition
-&lt;/dc:title>
-&lt;meta
-refines="#t4"
-property="title-type">
-edition
-&lt;/meta>
-&lt;meta
-refines="#t4"
-property="display-seq">
-4
-&lt;/meta>
+   &lt;dc:title id="t4">
+      Special Anniversary Edition
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t4"
+       property="title-type">
+      edition
+   &lt;/meta>
+   &lt;meta
+       refines="#t4"
+       property="display-seq">
+      4
+   &lt;/meta>
 
-&lt;dc:title id="t5">
-The Great Cookbooks of the World: 
-Mon premier guide de cuisson, un Mémoire. 
-The New French Cuisine Masters, Volume Two. 
-Special Anniversary Edition
-&lt;/dc:title>
-&lt;meta
-refines="#t5"
-property="title-type">
-expanded
-&lt;/meta>
-…
+   &lt;dc:title id="t5">
+      The Great Cookbooks of the World: 
+      Mon premier guide de cuisson, un Mémoire. 
+      The New French Cuisine Masters, Volume Two. 
+      Special Anniversary Edition
+   &lt;/dc:title>
+   &lt;meta
+       refines="#t5"
+       property="title-type">
+      expanded
+   &lt;/meta>
+   …
 &lt;/metadata></pre>
 		</aside>
 	</section>
@@ -914,70 +919,70 @@ expanded
 		<aside class="example" title="A typical set of refines metadata in an EPUB Publication">
 			<pre>&lt;metadata …>
 
-&lt;dc:identifier id="pub-id">
-urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
-&lt;/dc:identifier>
+   &lt;dc:identifier id="pub-id">
+      urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
+   &lt;/dc:identifier>
 
-&lt;dc:identifier id="isbn-id">
-urn:isbn:9780101010101
-&lt;/dc:identifier>
-&lt;meta
-refines="#isbn-id"
-property="identifier-type"
-scheme="onix:codelist5">
-15
-&lt;/meta>
+   &lt;dc:identifier id="isbn-id">
+      urn:isbn:9780101010101
+   &lt;/dc:identifier>
+   &lt;meta
+       refines="#isbn-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      15
+   &lt;/meta>
 
-&lt;dc:source id="src-id">
-urn:isbn:9780375704024
-&lt;/dc:source>
-&lt;meta
-refines="#src-id"
-property="identifier-type"
-scheme="onix:codelist5">
-15
-&lt;/meta>
+   &lt;dc:source id="src-id">
+      urn:isbn:9780375704024
+   &lt;/dc:source>
+   &lt;meta
+       refines="#src-id"
+       property="identifier-type"
+       scheme="onix:codelist5">
+      15
+   &lt;/meta>
 
-&lt;dc:title id="title">
-Norwegian Wood
-&lt;/dc:title>
-&lt;meta
-refines="#title"
-property="title-type">
-main
-&lt;/meta>
+   &lt;dc:title id="title">
+      Norwegian Wood
+   &lt;/dc:title>
+   &lt;meta
+       refines="#title"
+       property="title-type">
+      main
+   &lt;/meta>
 
-&lt;dc:language>
-en
-&lt;/dc:language>
+   &lt;dc:language>
+      en
+   &lt;/dc:language>
 
-&lt;dc:creator
-id="creator">
-Haruki Murakami
-&lt;/dc:creator>
-&lt;meta
-refines="#creator"
-property="role"
-scheme="marc:relators"
-id="role">
-aut
-&lt;/meta>
-&lt;meta
-refines="#creator"
-property="alternate-script"
-xml:lang="ja">
-村上 春樹
-&lt;/meta>
-&lt;meta
-refines="#creator"
-property="file-as">
-Murakami, Haruki
-&lt;/meta>
+   &lt;dc:creator
+       id="creator">
+      Haruki Murakami
+   &lt;/dc:creator>
+   &lt;meta
+       refines="#creator"
+       property="role"
+       scheme="marc:relators"
+       id="role">
+      aut
+   &lt;/meta>
+   &lt;meta
+       refines="#creator"
+       property="alternate-script"
+       xml:lang="ja">
+      村上 春樹
+   &lt;/meta>
+   &lt;meta
+       refines="#creator"
+       property="file-as">
+      Murakami, Haruki
+   &lt;/meta>
 
-&lt;meta
-property="dcterms:modified">
-2011-01-01T12:00:00Z
-&lt;/meta>
+   &lt;meta
+       property="dcterms:modified">
+      2011-01-01T12:00:00Z
+   &lt;/meta>
 
 &lt;/metadata></pre>
 		</aside>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -455,8 +455,8 @@
 					<li id="confreq-selection-attr">MAY include any of the selection attributes defined in <a
 							href="#rendition-selection-attr">Rendition Selection Attributes</a>.</li>
 					<li id="confreq-selection-default">MAY Include selection attributes on the <a
-							data-cite="epub-33#sec-container.xml-rootfiles-elem"><code>rootfile</code> element</a> [[EPUB-33]]
-						for the <a>Default Rendition</a></li>
+							data-cite="epub-33#sec-container.xml-rootfiles-elem"><code>rootfile</code> element</a>
+						[[EPUB-33]] for the <a>Default Rendition</a></li>
 					<li id="confreq-selection-min">SHOULD include at least one selection attribute ‒ in addition to the
 						OPTIONAL label ‒ on each subsequent <code>rootfile</code> element.</li>
 				</ul>
@@ -937,7 +937,8 @@
 
 				<ul class="conformancelist">
 					<li id="confreq-map-xhtml">MUST conform to all content conformance constraints for XHTML Content
-						Documents as defined in <a data-cite="epub-33#sec-xhtml-req">XHTML Requirements</a> [[EPUB-33]].</li>
+						Documents as defined in <a data-cite="epub-33#sec-xhtml-req">XHTML Requirements</a>
+						[[EPUB-33]].</li>
 					<li id="confreq-map-content-model">MUST conform to all content conformance constraints specific for
 						EPUB Rendition Mapping Documents expressed in <a href="#rendition-mapping-doc-def">EPUB
 							Rendition Mapping Document Definition</a>.</li>
@@ -1193,8 +1194,9 @@
 			<section id="rendition-mapping-proc-model" class="informative">
 				<h3>Processing Model</h3>
 
-				<p>This section provides an informative model by which the Rendition Mapping Document could be processed
-					by a Reading System. It does not address how or when a Reading System should switch Renditions. </p>
+				<p>This section provides a non-normative model by which the Rendition Mapping Document could be
+					processed by a Reading System. It does not address how or when a Reading System should switch
+					Renditions. </p>
 
 				<p>The desired outcome of the Rendition Mapping Document's mapping capabilities is to display content in
 					the new Rendition that is equivalent to their location in the current Rendition, so that a user

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -80,7 +80,7 @@
 	<body>
 		<section id="abstract">
 			<p>This document provides a starting point for content authors and software developers wishing to understand
-				the EPUB® 3 specifications. It consists entirely of informative overview material that describes the
+				the EPUB® 3 specifications. It consists entirely of non-normative overview material that describes the
 				features available in EPUB 3.</p>
 
 		</section>
@@ -109,15 +109,17 @@
 				<dt> Working Group Notes: </dt>
 				<dd>
 					<ul>
-						<li>EPUB Accessibility - EU Accessibility Act Mapping [[EPUB-A11Y-EAA-MAPPING]]: aims to demonstrate
-							that the technical requirements of the <a href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">European Accessibility Act</a> related to ebooks are met
-							by the EPUB standard.</li>
+						<li>EPUB Accessibility - EU Accessibility Act Mapping [[EPUB-A11Y-EAA-MAPPING]]: aims to
+							demonstrate that the technical requirements of the <a
+								href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">European
+								Accessibility Act</a> related to ebooks are met by the EPUB standard.</li>
 						<li>EPUB Accessibility Techniques 1.1 [[EPUB-A11Y-TECH-11]]: provides guidance on how to meet
-						the EPUB Accessibility 1.1 [[EPUB-A11Y-11]] discovery and accessibility requirements for EPUB
-						Publications. </li>
+							the EPUB Accessibility 1.1 [[EPUB-A11Y-11]] discovery and accessibility requirements for
+							EPUB Publications. </li>
 						<li>EPUB Multiple-Rendition Publications 1.1 [[EPUB-MULTI-REND-11]]: defines the creation and
 							rendering of EPUB Publications consisting of more than one Rendition. </li>
-						<li>EPUB 3 Structural Semantics Vocabulary 1.1 [[EPUB-SSV-11]]: defines a set of properties relating to the description of structural semantics of written works.</li>
+						<li>EPUB 3 Structural Semantics Vocabulary 1.1 [[EPUB-SSV-11]]: defines a set of properties
+							relating to the description of structural semantics of written works.</li>
 						<li>EPUB 3 Text-to-Speech Enhancements 1.0 [[EPUB-TTS-10]]: describes authoring features and
 							reading system support for improving the voicing of EPUB 3 publications. </li>
 					</ul>
@@ -125,11 +127,10 @@
 			</dl>
 			<p>This overview document concentrates on the authoring format of EPUB 3.3.</p>
 
-			<div class="note">
-				The recommendation-track documents include detailed change logs on the substantive changes since the previous official releases. See the change log for 
-				<a data-cite="epub-33#change-log">EPUB 3.3</a>, <a data-cite="epub-rs-33#change-log">EPUB Reading Systems 3.3</a>, and <a data-cite="epub-a11y-11#change-log">EPUB Accessibility 1.1</a>,
-				respectively.
-			</div>
+			<div class="note"> The recommendation-track documents include detailed change logs on the substantive
+				changes since the previous official releases. See the change log for <a data-cite="epub-33#change-log"
+					>EPUB 3.3</a>, <a data-cite="epub-rs-33#change-log">EPUB Reading Systems 3.3</a>, and <a
+					data-cite="epub-a11y-11#change-log">EPUB Accessibility 1.1</a>, respectively. </div>
 
 		</section>
 		<section id="sec-features">
@@ -174,14 +175,13 @@
 							><code>collection</code> element</a> [[EPUB-33]], which allows grouping of logically related
 						<a>Publication Resources</a>. This element exists to enable the development of specialized
 					content identification, processing, and rendering features such as the ability to define embedded
-					preview content or assemble an index or dictionary from its constituent XHTML Content
-					Documents.</p>
+					preview content or assemble an index or dictionary from its constituent XHTML Content Documents.</p>
 
-				<p class="note"> The <code>collection</code> element is not currently used in any specifications that are
-					actively maintained by the EPUB 3 Working Group. </p>
+				<p class="note"> The <code>collection</code> element is not currently used in any specifications that
+					are actively maintained by the EPUB 3 Working Group. </p>
 
-				<p>The Package Document is specified in the dedicated <a data-cite="epub-33#sec-package-doc"
-						>section</a> of [[EPUB-33]].</p>
+				<p>The Package Document is specified in the dedicated <a data-cite="epub-33#sec-package-doc">section</a>
+					of [[EPUB-33]].</p>
 			</section>
 
 			<section id="sec-nav">
@@ -230,12 +230,13 @@
 
 					<p>Note that EPUB Reading Systems are not <em>required</em> to use these advanced XHTML features,
 						such as ruby annotations, when generating a Reading System specific table of contents. However,
-						EPUB Creators may also include the Navigation Document in the <a data-cite="epub-33#sec-spine-elem"
-							>spine</a> [[EPUB-33]] to make use of the richer markup.</p>
+						EPUB Creators may also include the Navigation Document in the <a
+							data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]] to make use of the richer
+						markup.</p>
 
 					<p>Navigation Documents also provide a flexible means of tailoring the navigation display using CSS
-						and the <a data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a> [[EPUB-33]]
-						while not impacting access to information for accessible Reading Systems.</p>
+						and the <a data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a>
+						[[EPUB-33]] while not impacting access to information for accessible Reading Systems.</p>
 
 					<p>The structure and semantics of Navigation Documents are defined in the dedicated <a
 							data-cite="epub-33#sec-nav">section</a> of [[EPUB-33]].</p>
@@ -445,9 +446,9 @@
 
 			<p> EPUB 3 leverages the features in XHTML, SVG, CSS, or MathML for global language support, and it also
 				relies on [[Unicode]] for encoding the content. This means that content documents in EPUB 3 have the
-				possibility to use different character sets and express bidirectional text, ruby annotations, or typography
-				for many different languages and cultures. Features have also been added to the various components
-				defined by EPUB 3 to ensure language support. </p>
+				possibility to use different character sets and express bidirectional text, ruby annotations, or
+				typography for many different languages and cultures. Features have also been added to the various
+				components defined by EPUB 3 to ensure language support. </p>
 
 			<section id="sec-gls-metadata">
 				<h2>Metadata</h2>
@@ -533,11 +534,11 @@
 					flexible navigation system.</p>
 
 				<p>The Navigation Document can also be reused in the body of an EPUB Publication by including it in the
-						<a data-cite="epub-33#sec-spine-elem"><code>spine</code></a>. To avoid the situation in 
-						highly structured documents where it might not be desirable to display the complete table of contents to
+						<a data-cite="epub-33#sec-spine-elem"><code>spine</code></a>. To avoid the situation in highly
+					structured documents where it might not be desirable to display the complete table of contents to
 					users in the body of the publication, the display level can be modified using the <a
-						data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a> [[EPUB-33]]. This attribute is
-					ignored by Reading Systems when they render the table of contents outside the <a
+						data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a> [[EPUB-33]]. This
+					attribute is ignored by Reading Systems when they render the table of contents outside the <a
 						data-cite="epub-33#sec-spine-elem"><code>spine</code></a> (e.g., in their own specialized
 					views), which avoids minimizing the information that is available.</p>
 
@@ -561,10 +562,10 @@
 					[[DPUB-ARIA-1.0]] roles, enhancing the ability of Assistive Technologies to interact with the
 					content.</p>
 
-					<p>EPUB 3 also includes the <code>epub:type</code> attribute, which allows the inclusion of additional information
-						to any element in an EPUB Content Document to express its purpose and meaning within the 
-						work. Refer to the section on <a data-cite="epub-33#app-structural-semantics">Expressing Structural Semantics</a> [EPUB-33] 
-						for more information.</p>	
+				<p>EPUB 3 also includes the <code>epub:type</code> attribute, which allows the inclusion of additional
+					information to any element in an EPUB Content Document to express its purpose and meaning within the
+					work. Refer to the section on <a data-cite="epub-33#app-structural-semantics">Expressing Structural
+						Semantics</a> [EPUB-33] for more information.</p>
 			</section>
 
 			<section id="sec-access-layout">
@@ -572,16 +573,16 @@
 
 				<p>At its core, EPUB is designed for dynamic layout: content is typically intended to be formatted on
 					the fly rather than being typeset in a paginated manner in advance. This core capability is useful
-					for optimizing rendering onto different-sized device screens or window sizes, and it facilitates
-					and simplifies content accessibility.</p>
+					for optimizing rendering onto different-sized device screens or window sizes, and it facilitates and
+					simplifies content accessibility.</p>
 
 				<p>While it is possible to incorporate more highly formatted content in EPUB — for example via bitmap
 					images or SVG graphics, or even use of CSS explicit positioning and/or table elements to achieve
 					particular visual layouts — EPUB Creators are strongly discouraged from utilizing such techniques.
-					These techniques are not reliable in EPUB since many Reading Systems render content in a
-					paginated manner rather than creating a single scrolling <a>Viewport</a> and since each Reading System
-					might define its own pagination algorithm. In general, it is preferable to achieve visual richness by
-          using CSS Style Sheets without absolute sizing or positioning.</p>
+					These techniques are not reliable in EPUB since many Reading Systems render content in a paginated
+					manner rather than creating a single scrolling <a>Viewport</a> and since each Reading System might
+					define its own pagination algorithm. In general, it is preferable to achieve visual richness by
+					using CSS Style Sheets without absolute sizing or positioning.</p>
 
 				<p class="ednote"> If and when the WG publishes a fxl accessibility note then it is worth referring to
 					it from here </p>
@@ -591,13 +592,14 @@
 				<h2>Aural Renditions and Media Overlays</h2>
 
 				<p>Aural renderings of content are important for accessibility and are a desirable feature for many
-					users. A baseline to facilitate aural rendering is to utilize semantic HTML designed for
-					dynamic layout. Refer to <a href="#sec-tts"></a> for more information on how to use the native
-					facilities that XHTML Content Documents include.</p>
+					users. A baseline to facilitate aural rendering is to utilize semantic HTML designed for dynamic
+					layout. Refer to <a href="#sec-tts"></a> for more information on how to use the native facilities
+					that XHTML Content Documents include.</p>
 
 				<p><a data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[EPUB-33]] provide the ability to
 					synchronize the text and audio content of an EPUB Publication. Beyond benefiting accessibility,
-					overlays have other applications, e.g., synchronizing text and audio as a tool for learning to read.</p>
+					overlays have other applications, e.g., synchronizing text and audio as a tool for learning to
+					read.</p>
 			</section>
 
 			<!-- <section id="sec-access-fallbacks">
@@ -642,14 +644,12 @@
 
 				<p>It was realized that a need existed for a format standard that could be used for delivery as well as
 					interchange, and work began in late 2005 on a single-file container format for OEPBS, which was
-					approved by the IDPF as the OEBPS Container Format (OCF) in 2006. 
-
-					Work on a 2.0 revision of OEBPS began in parallel which was renamed EPUB 2.0 in October 2007 and approved in 
-					September 2010. This revision consisted of a triumvirate of specifications: Open Package Format (OPF), 
-					Open Publication Format (OPF), and OCF. EPUB 2.0.1, which was a maintenance update to the 2.0 specification 
-					set, primarily intended to clarify and correct errata in the specifications. See [[OPF-201]] [[OPS-201]]
-					[[OCF-201]].
-				</p>
+					approved by the IDPF as the OEBPS Container Format (OCF) in 2006. Work on a 2.0 revision of OEBPS
+					began in parallel which was renamed EPUB 2.0 in October 2007 and approved in September 2010. This
+					revision consisted of a triumvirate of specifications: Open Package Format (OPF), Open Publication
+					Format (OPF), and OCF. EPUB 2.0.1, which was a maintenance update to the 2.0 specification set,
+					primarily intended to clarify and correct errata in the specifications. See [[OPF-201]] [[OPS-201]]
+					[[OCF-201]]. </p>
 
 			</section>
 			<section id="epub30">
@@ -658,12 +658,12 @@
 				<p>Work on a major revision of the EPUB specifications began in 2010, with the goal of aligning EPUB
 					more closely with HTML, and in the process bringing new, native multimedia features, sophisticated
 					CSS layout rendering and font embedding, scripted interactivity, enhanced global language support,
-					and improved accessibility. A new specification for EPUB Media Overlays was also introduced, allowing for 
-					text and audio synchronization in EPUB Publications. To better align the specification names with
-					the standard, the Open Package Format specification was renamed EPUB Publications and the Open
-					Publication Format specification was renamed EPUB Content Documents. The EPUB 3.0 specifications
-					were approved in October 2011. See [[EPUBPublications-30]] [[EPUBContentDocs-30]] [[OCF-30]]
-					[[EPUBMediaOverlays-30]] [[EPUBChanges-30]].</p>
+					and improved accessibility. A new specification for EPUB Media Overlays was also introduced,
+					allowing for text and audio synchronization in EPUB Publications. To better align the specification
+					names with the standard, the Open Package Format specification was renamed EPUB Publications and the
+					Open Publication Format specification was renamed EPUB Content Documents. The EPUB 3.0
+					specifications were approved in October 2011. See [[EPUBPublications-30]] [[EPUBContentDocs-30]]
+					[[OCF-30]] [[EPUBMediaOverlays-30]] [[EPUBChanges-30]].</p>
 			</section>
 
 			<section id="epub301">
@@ -683,8 +683,8 @@
 					is always valid to use; a revision of EPUB is not needed). The use of CSS was also clarified, and
 					the use of EPUB-specific properties reduced.</p>
 				<p>Many EPUB-specific features were also removed from the standard, in particular content switching,
-					triggers, and bindings. This change necessitated a new Package Document version number. See [[EPUB-31]]
-					[[EPUBPackages-31]] [[EPUBContentDocs-31]] [[OCF-31]] [[EPUBMediaOverlays-31]]
+					triggers, and bindings. This change necessitated a new Package Document version number.
+					See [[EPUB-31]] [[EPUBPackages-31]] [[EPUBContentDocs-31]] [[OCF-31]] [[EPUBMediaOverlays-31]]
 					[[EPUBChanges-31]]</p>
 			</section>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2558,8 +2558,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<li>11-Feb-2022: Fix the contradictory support statements for Media Overlays. Support is recommended
 					when rendering of prerecorded audio is supported, as in previous versions of EPUB 3. See <a
 						href="https://github.com/w3c/epub-specs/issues/1991">issue 1991</a>.</li>
-				<li>04-Feb-2022: Changed the informative security considerations for controlling network access, opening
-					external links, and managing local storage to normative recommendations. See <a
+				<li>04-Feb-2022: Changed the non-normative security considerations for controlling network access,
+					opening external links, and managing local storage to normative recommendations. See <a
 						href="https://github.com/w3c/epub-specs/issues/1957">issue 1957</a>.</li>
 				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
 					model for Reading Systems and additional recommendations for ensuring security and privacy. See <a

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -369,7 +369,7 @@
 				</ul>
 
 				<div class="note">
-					<p>An informative schema for validating lexicons is available at <a
+					<p>A non-normative schema for validating lexicons is available at <a
 							href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
 								><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng</code></a>
 						[[PRONUNCIATION-LEXICON]].</p>


### PR DESCRIPTION
The only other change is to drop "non-normative" from some of the schema descriptions since it's redundant to say it in a non-normative section, and it appears to have caused at least some confusion about whether some of the schemas are actually normative.

Fixes #2227


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2232.html" title="Last updated on Apr 6, 2022, 1:01 PM UTC (376a013)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2232/cedd1d0...376a013.html" title="Last updated on Apr 6, 2022, 1:01 PM UTC (376a013)">Diff</a>