### PR TITLE
Remove restriction on authority property value

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4302,9 +4302,9 @@
 
 						<div class="note">
 							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
-								Working Group maintained an <a href="http://www.idpf.org/epub/vocab/package/types"
-									>informative registry of specialized EPUB Publication types</a> for use with this
-								element. This Working Group no longer maintains this registry and does not anticipate
+								Working Group maintained a <a href="http://www.idpf.org/epub/vocab/package/types"
+									>non-normative registry of specialized EPUB Publication types</a> for use with this
+								element. This Working Group no longer maintains the registry and does not anticipate
 								developing new specialized publication types.</p>
 						</div>
 					</section>
@@ -11702,6 +11702,9 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>6-Apr-2022: Removed the restrictions on the value of the <code>authority</code> property and added a
+					note referencing the old IDPF registry. See <a href="https://github.com/w3c/epub-specs/issues/2118"
+						>issue 2200</a>.</li>
 				<li>31-Mar-2022: Removed the restriction on deprecated MathML features and added a general caution that
 					any technology may make changes that can cause an EPUB Publication to become invalid. See <a
 						href="https://github.com/w3c/epub-specs/issues/2118">issue 2118</a>.</li>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -88,101 +88,14 @@
 				<tr>
 					<th>Allowed value(s):</th>
 					<td>
-						<ul>
-							<li>
-								<p>one of the following case-insensitive reserved authority values:</p>
-								<dl id="authorities">
-									<dt id="aat">
-										<a
-											href="http://www.getty.edu/research/tools/vocabularies/aat/index.html"
-											>AAT</a>
-									</dt>
-									<dd>
-										<p>The Getty Art and Architecture Taxonomy.</p>
-									</dd>
-									<dt id="bic">
-										<a href="http://www.bic.org.uk/7/BIC-Standard-Subject-Categories/"
-											>BIC</a>
-									</dt>
-									<dd>
-										<p>The main UK subject scheme for the book supply chain.</p>
-									</dd>
-									<dt id="bisac">
-										<a href="http://bisg.org/page/BISACSubjectCodes">BISAC</a>
-									</dt>
-									<dd>
-										<p>The main US subject scheme for the book supply chain.</p>
-									</dd>
-									<dt id="clc">
-										<a href="http://clc.nlc.gov.cn/">CLC</a>
-									</dt>
-									<dd>
-										<p>The main subject classification scheme used in China.</p>
-									</dd>
-									<dt id="ddc">
-										<a href="https://www.oclc.org/en/dewey/resources.html">DDC</a>
-									</dt>
-									<dd>
-										<p>The Dewey Decimal Classification system.</p>
-									</dd>
-									<dt id="clil">
-										<a href="http://clil.centprod.com/information/detailDoc.html?docId=34"
-											>CLIL</a>
-									</dt>
-									<dd>
-										<p>The main French subject scheme for the book supply chain.</p>
-									</dd>
-									<dt id="eurovoc">
-										<a href="http://eurovoc.europa.eu/">EuroVoc</a>
-									</dt>
-									<dd>
-										<p>The European multilingual thesaurus.</p>
-									</dd>
-									<dt id="medtop">
-										<a href="https://iptc.org/standards/media-topics/">MEDTOP</a>
-									</dt>
-									<dd>
-										<p>IPTC Media Topics classification scheme for the news industry.</p>
-									</dd>
-									<dt id="lcsh">
-										<a href="http://id.loc.gov/authorities/subjects.html">LCSH</a>
-									</dt>
-									<dd>
-										<p>Library of Congress Subject Headings.</p>
-									</dd>
-									<dt id="ndc">
-										<a href="http://www.jla.or.jp/">NDC</a>
-									</dt>
-									<dd>
-										<p>The main Japanese subject scheme.</p>
-									</dd>
-									<dt id="thema">
-										<a href="http://www.editeur.org/151/thema/">Thema</a>
-									</dt>
-									<dd>
-										<p>The international subject scheme for the book supply chain, providing
-											codes that work across many languages.</p>
-									</dd>
-									<dt id="udc">
-										<a href="http://www.udcc.org/">UDC</a>
-									</dt>
-									<dd>
-										<p>The Universal Decimal Classification system.</p>
-									</dd>
-									<dt id="wgs">
-										<a href="https://vlb.de/files/wgsneuversion2_0.pdf">WGS</a>
-									</dt>
-									<dd>
-										<p>The main German subject scheme for the book supply chain.</p>
-									</dd>
-								</dl>
-							</li>
-							<li>
-								<p>an <a data-cite="url#absolute-url-string">absolute-URL
-										string</a> [[URL]] that identifies the scheme. The URL SHOULD refer to a
-									resource that provides more information about the scheme.</p>
-							</li>
-						</ul>
+						<code>xsd:string</code>
+						<div class="note">
+							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB
+								3 Working Group maintained a <a
+									href="https://idpf.github.io/epub-registries/authorities/">registry of
+									subject authorities</a> for use with this property. This Working Group no
+								longer maintains the registry.</p>
+						</div>
 					</td>
 				</tr>
 				<tr>


### PR DESCRIPTION
For consideration as a way of closing #2200.

Removes the restrictions on the value of the authority property and copies and modifies the note we used for the old dc:type registry.

Fixes #2200


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2233.html" title="Last updated on Apr 6, 2022, 2:28 PM UTC (e81e90c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2233/1287600...e81e90c.html" title="Last updated on Apr 6, 2022, 2:28 PM UTC (e81e90c)">Diff</a>