### PR TITLE
Updated the term description for EPUB Creator (Issue 2216)

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -364,13 +364,22 @@
 						<dfn id="dfn-epub-creator" data-lt="EPUB Creators">EPUB Creator</dfn>
 					</dt>
 					<dd>
-						<p>The person(s) or organization responsible for the creation of an <a>EPUB Publication</a>.</p>
-						<p>Depending on the process used to produce EPUB Publications, EPUB Creator may sometimes refer
-							to responsibilities of the organization (e.g., the publisher) or the individuals preparing
-							the publication (e.g., technical editors).</p>
+						<p>An individual, organization, or process that produces an <a>EPUB Publication</a>.</p>
+
 						<div class="note">
+							<p>
+								The creation of an EPUB Publication often involves the work of many individuals, 
+								and may be split across multiple organizations (e.g., when a publisher outsources 
+								all or part of the work).
+								Depending on the process used to produce an EPUB Publication, responsibilities may 
+								fall on the organization (e.g., the publisher), the individuals preparing the publication 
+								(e.g., technical editors), or automatic procedures (e.g., as part of a publication pipeline).
+								As a result, not every party or process may be responsible for ensuring every requirement is
+								met, but there is always an EPUB Creator responsible for the conformance of the
+								final EPUB Publication.
+							</p>
 							<p>Previous versions of this specification referred to the EPUB Creator as the <span
-									id="dfn-author">Author</span>.</p>
+								id="dfn-author">Author</span>.</p>
 						</div>
 					</dd>
 


### PR DESCRIPTION
This is a proposal to move ahead on issue #2216, adopting the 
[proposal of Matt](https://github.com/w3c/epub-specs/issues/2216#issuecomment-1090734556).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2234.html" title="Last updated on Apr 8, 2022, 12:24 PM UTC (27f96f7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2234/1287600...27f96f7.html" title="Last updated on Apr 8, 2022, 12:24 PM UTC (27f96f7)">Diff</a>