### PR TITLE
Have added export classes to definitions (see issue 2207)

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -285,7 +285,7 @@
 
 				<dl class="termlist">
 					<dt>
-						<dfn id="dfn-codec" data-lt="Codecs">Codec</dfn>
+						<dfn class="export" id="dfn-codec" data-lt="Codecs">Codec</dfn>
 					</dt>
 					<dd>
 						<p>Codec refers to content that has intrinsic binary format qualities, such as video and audio
@@ -294,7 +294,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-local-resource" data-lt="Container Resources">Container Resource</dfn>
+						<dfn class="export" id="dfn-local-resource" data-lt="Container Resources">Container Resource</dfn>
 					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> that is located within the <a>EPUB Container</a>, as opposed to
@@ -304,7 +304,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-container-root-url">Container Root URL</dfn>
+						<dfn class="export" id="dfn-container-root-url">Container Root URL</dfn>
 					</dt>
 					<dd>
 						<p>The <a data-cite="url#concept-url">URL</a> [[URL]] of the <a>Root Directory</a> representing
@@ -313,7 +313,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-content-url">Content URL</dfn>
+						<dfn class="export" id="dfn-content-url">Content URL</dfn>
 					</dt>
 					<dd>
 						<p> The <a data-cite="url#concept-url">URL</a> of a file or directory in the <a>OCF Abstract
@@ -321,7 +321,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-core-media-type-resource" data-lt="Core Media Type Resources">Core Media Type
+						<dfn class="export" id="dfn-core-media-type-resource" data-lt="Core Media Type Resources">Core Media Type
 							Resource</dfn>
 					</dt>
 					<dd>
@@ -335,11 +335,11 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-epub-container" data-lt="EPUB Containers">EPUB Container</dfn>
+						<dfn class="export" id="dfn-epub-container" data-lt="EPUB Containers">EPUB Container</dfn>
 					</dt>
 
 					<dt>
-						<dfn id="dfn-zip-container">OCF ZIP Container</dfn>
+						<dfn class="export" id="dfn-zip-container">OCF ZIP Container</dfn>
 					</dt>
 					<dd>
 						<p>The ZIP-based packaging and distribution format for <a>EPUB Publications</a> defined in <a
@@ -348,7 +348,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-epub-content-document" data-lt="EPUB Content Documents">EPUB Content Document</dfn>
+						<dfn class="export" id="dfn-epub-content-document" data-lt="EPUB Content Documents">EPUB Content Document</dfn>
 					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> referenced from the spine or a <a>manifest fallback chain</a>
@@ -361,7 +361,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-epub-creator" data-lt="EPUB Creators">EPUB Creator</dfn>
+						<dfn class="export" id="dfn-epub-creator" data-lt="EPUB Creators">EPUB Creator</dfn>
 					</dt>
 					<dd>
 						<p>The person(s) or organization responsible for the creation of an <a>EPUB Publication</a>.</p>
@@ -375,7 +375,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-epub-navigation-document" data-lt="EPUB Navigation Documents">EPUB Navigation
+						<dfn class="export" id="dfn-epub-navigation-document" data-lt="EPUB Navigation Documents">EPUB Navigation
 							Document</dfn>
 					</dt>
 					<dd>
@@ -385,7 +385,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-epub-publication" data-lt="EPUB Publications">EPUB Publication</dfn>
+						<dfn class="export" id="dfn-epub-publication" data-lt="EPUB Publications">EPUB Publication</dfn>
 					</dt>
 					<dd>
 						<p>A logical document entity consisting of a set of interrelated <a
@@ -394,14 +394,14 @@
 							specification does not restrict the nature of the content.</p>
 					</dd>
 
-					<dt><dfn id="dfn-epub-reading-system" data-lt="EPUB Reading Systems|Reading System|Reading Systems"
+					<dt><dfn class="export" id="dfn-epub-reading-system" data-lt="EPUB Reading Systems|Reading System|Reading Systems"
 							>EPUB Reading System</dfn> (or Reading System)</dt>
 					<dd>
 						<p>A system that processes <a>EPUB Publications</a> for presentation to a user in a manner
 							conformant with this specification.</p>
 					</dd>
 
-					<dt><dfn id="dfn-epub-conformance-checker" data-lt="EPUB Conformance Checkers">EPUB Conformance
+					<dt><dfn class="export" id="dfn-epub-conformance-checker" data-lt="EPUB Conformance Checkers">EPUB Conformance
 							Checker</dfn></dt>
 					<dd>
 						<p>An application that verifies the requirements of this specification against <a>EPUB
@@ -409,7 +409,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-exempt-resource" data-lt="Exempt Resources">Exempt Resource</dfn>
+						<dfn class="export" id="dfn-exempt-resource" data-lt="Exempt Resources">Exempt Resource</dfn>
 					</dt>
 					<dd>
 						<p>Exempt Resources are a special class of <a>Publication Resources</a> that Reading Systems are
@@ -419,7 +419,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-file-name" data-lt="File Names">File Name</dfn>
+						<dfn class="export" id="dfn-file-name" data-lt="File Names">File Name</dfn>
 					</dt>
 					<dd>
 						<p>The name of any type of file within an <a>OCF Abstract Container</a>, whether a directory or
@@ -427,7 +427,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-file-path" data-lt="File Paths">File Path</dfn>
+						<dfn class="export" id="dfn-file-path" data-lt="File Paths">File Path</dfn>
 					</dt>
 					<dd>
 						<p>The File Path of a file or directory is its full path relative to the root directory, as
@@ -437,7 +437,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-fixed-layout-document" data-lt="Fixed-Layout Documents">Fixed-Layout Document</dfn>
+						<dfn class="export" id="dfn-fixed-layout-document" data-lt="Fixed-Layout Documents">Fixed-Layout Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> with fixed dimensions directly referenced from the
@@ -446,7 +446,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-foreign-content-document" data-lt="Foreign Content Documents">Foreign Content
+						<dfn class="export" id="dfn-foreign-content-document" data-lt="Foreign Content Documents">Foreign Content
 							Document</dfn>
 					</dt>
 					<dd>
@@ -462,7 +462,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-foreign-resource" data-lt="Foreign Resources">Foreign Resource</dfn>
+						<dfn class="export" id="dfn-foreign-resource" data-lt="Foreign Resources">Foreign Resource</dfn>
 					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> with a MIME media type [[RFC2046]] that does not match any of
@@ -479,7 +479,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-linked-resource" data-lt="Linked Resources">Linked Resource</dfn>
+						<dfn class="export" id="dfn-linked-resource" data-lt="Linked Resources">Linked Resource</dfn>
 					</dt>
 					<dd>
 						<p>A resource that is only referenced from a <a>Package Document</a>
@@ -490,7 +490,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-manifest" data-lt="Manifests">Manifest</dfn>
+						<dfn class="export" id="dfn-manifest" data-lt="Manifests">Manifest</dfn>
 					</dt>
 					<dd>
 						<p>The section of the <a>Package Document</a> that lists the <a>Publication Resources</a>.</p>
@@ -498,7 +498,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-media-overlay-document" data-lt="Media Overlay Documents">Media Overlay
+						<dfn class="export" id="dfn-media-overlay-document" data-lt="Media Overlay Documents">Media Overlay
 							Document</dfn>
 					</dt>
 					<dd>
@@ -508,7 +508,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-non-codec" data-lt="Non-Codecs">Non-Codec</dfn>
+						<dfn class="export" id="dfn-non-codec" data-lt="Non-Codecs">Non-Codec</dfn>
 					</dt>
 					<dd>
 						<p>Non-Codec refers to content types that benefit from compression due to the nature of their
@@ -517,7 +517,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-ocf-abstract-container" data-lt="OCF Abstract Containers">OCF Abstract
+						<dfn class="export" id="dfn-ocf-abstract-container" data-lt="OCF Abstract Containers">OCF Abstract
 							Container</dfn>
 					</dt>
 					<dd>
@@ -526,7 +526,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-package-document"
+						<dfn class="export" id="dfn-package-document"
 							data-lt="Package Documents|Package Document(s)|Package Document's">Package Document</dfn>
 					</dt>
 					<dd>
@@ -537,7 +537,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-publication-resource" data-lt="Publication Resources">Publication Resource</dfn>
+						<dfn class="export" id="dfn-publication-resource" data-lt="Publication Resources">Publication Resource</dfn>
 					</dt>
 					<dd>
 						<p>A resource that contains content or instructions that contribute to the logic and rendering
@@ -566,7 +566,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-remote-resource" data-lt="Remote Resources">Remote Resource</dfn>
+						<dfn class="export" id="dfn-remote-resource" data-lt="Remote Resources">Remote Resource</dfn>
 					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> that is located outside of the <a>EPUB Container</a>,
@@ -578,7 +578,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-root-directory">Root Directory</dfn>
+						<dfn class="export" id="dfn-root-directory">Root Directory</dfn>
 					</dt>
 					<dd>
 						<p>The root directory represents the base of the <a>OCF Abstract Container</a> file system. This
@@ -586,7 +586,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-scripted-content-document" data-lt="Scripted Content Documents">Scripted Content
+						<dfn class="export" id="dfn-scripted-content-document" data-lt="Scripted Content Documents">Scripted Content
 							Document</dfn>
 					</dt>
 					<dd>
@@ -596,7 +596,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-spine">Spine</dfn>
+						<dfn class="export" id="dfn-spine">Spine</dfn>
 					</dt>
 					<dd>
 						<p>The section of the <a>Package Document</a> that defines an ordered list of <a>EPUB Content
@@ -606,7 +606,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-svg-content-document" data-lt="SVG Content Documents">SVG Content Document</dfn>
+						<dfn class="export" id="dfn-svg-content-document" data-lt="SVG Content Documents">SVG Content Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> that conforms to the constraints expressed in <a
@@ -614,14 +614,14 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-synthetic-spread" data-lt="Synthetic Spreads">Synthetic Spread</dfn>
+						<dfn class="export" id="dfn-synthetic-spread" data-lt="Synthetic Spreads">Synthetic Spread</dfn>
 					</dt>
 					<dd>
 						<p>The rendering of two adjacent pages simultaneously on a device screen.</p>
 					</dd>
 
 					<dt>
-						<dfn id="dfn-top-level-content-document" data-lt="Top-level Content Documents">Top-level Content
+						<dfn class="export" id="dfn-top-level-content-document" data-lt="Top-level Content Documents">Top-level Content
 							Document</dfn>
 					</dt>
 					<dd>
@@ -631,7 +631,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-unique-identifier">Unique Identifier</dfn>
+						<dfn class="export" id="dfn-unique-identifier">Unique Identifier</dfn>
 					</dt>
 					<dd>
 						<p>The primary identifier for an <a>EPUB Publication</a>. The Unique Identifier is the
@@ -642,7 +642,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-viewport">Viewport</dfn>
+						<dfn class="export" id="dfn-viewport">Viewport</dfn>
 					</dt>
 					<dd>
 						<p>The region of an <a>EPUB Reading System</a> in which an <a>EPUB Publication</a> is rendered
@@ -650,7 +650,7 @@
 					</dd>
 
 					<dt>
-						<dfn id="dfn-xhtml-content-document" data-lt="XHTML Content Documents">XHTML Content
+						<dfn class="export" id="dfn-xhtml-content-document" data-lt="XHTML Content Documents">XHTML Content
 							Document</dfn>
 					</dt>
 					<dd>
@@ -792,7 +792,7 @@
 				<section id="sec-manifest-plane">
 					<h4>The Manifest Plane</h4>
 
-					<p>To <dfn>manifest plane</dfn> defines all the resources of an <a>EPUB Publication</a>. It is
+					<p>To <dfn class="export">manifest plane</dfn> defines all the resources of an <a>EPUB Publication</a>. It is
 						analogous to the <a>Package Document</a>
 						<a>manifest</a>, but includes resources not present in that list.</p>
 
@@ -839,7 +839,7 @@
 				<section id="sec-spine-plane">
 					<h4>The Spine Plane</h4>
 
-					<p>The <dfn>spine plane</dfn> defines resources used in the default reading order established by the
+					<p>The <dfn class="export">spine plane</dfn> defines resources used in the default reading order established by the
 							<a>spine</a>, which includes both <a href="#attrdef-itemref-linear">linear and non-linear
 							content</a>. The spine instructs <a>Reading Systems</a> on how to load these resources as
 						the user progresses through the <a>EPUB Publication</a>. Although many resources may be bundled
@@ -886,7 +886,7 @@
 				<section id="sec-content-plane">
 					<h4>The Content Plane</h4>
 
-					<p>The <dfn>content plane</dfn> classifies resources that are used when rendering <a>EPUB Content
+					<p>The <dfn class="export">content plane</dfn> classifies resources that are used when rendering <a>EPUB Content
 							Documents</a> and <a>Foreign Content Documents</a>. These types of resources include
 						embedded media, CSS style sheets, scripts, and fonts. These resources fall into three categories
 						based on their Reading System support: <a>Core Media Type Resources</a>, <a>Foreign
@@ -1287,7 +1287,7 @@
 				<section id="sec-manifest-fallbacks">
 					<h5>Manifest Fallbacks</h5>
 
-					<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create a <dfn>manifest
+					<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create a <dfn class="export">manifest
 							fallback chain</dfn> for a <a>Publication Resource</a>, allowing Reading Systems to select
 						an alternative format they can render.</p>
 
@@ -1860,7 +1860,7 @@
 								<code>A/B/C/file%20name.xhtml</code>. </p>
 					</div>
 
-					<p> A string <var>url</var> is a <dfn id="dfn-valid-relative-container-url-with-fragment-string"
+					<p> A string <var>url</var> is a <dfn class="export" id="dfn-valid-relative-container-url-with-fragment-string"
 							>valid-relative-ocf-URL-with-fragment string</dfn> if it is a <a
 							data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL
 							string</a>, optionally followed by <code>U+0023 (#)</code> and a <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1788,7 +1788,7 @@
 				<section id="sec-file-names-to-path-names">
 					<h4>Deriving File Paths</h4>
 
-					<p>To <dfn class="lint-ignore">derive the File Path</dfn>, given a file or directory <var>file</var>
+					<p>To <strong>derive the File Path</strong>, given a file or directory <var>file</var>
 						in the <a href="#sec-container-abstract">OCF Abstract Container</a>, apply the following steps
 						(expressed using the terminology of [[INFRA]]):</p>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -163,7 +163,7 @@
 
 				<dl>
 					<dt>
-						<dfn id="dfn-content-display-area">Content Display Area</dfn>
+						<dfn class="export" id="dfn-content-display-area">Content Display Area</dfn>
 					</dt>
 					<dd>
 						<p>The area within the <a>Viewport</a> dedicated to the display of <a>EPUB Content
@@ -2319,7 +2319,7 @@
 			</section>
 		</section>
 		<section id="app-epubReadingSystem">
-			<h2><dfn>epubReadingSystem</dfn> Object</h2>
+			<h2><dfn class="export">epubReadingSystem</dfn> Object</h2>
 
 			<p class="issue atrisk" title="Are there enough implementations?">Although this section is
 					<em>normative</em>, it is not clear whether implementations of this interface are widespread enough
@@ -2359,7 +2359,7 @@ partial interface Navigator {
 			<section id="app-ers-desc">
 				<h3>Description</h3>
 
-				<p>The <code><dfn>Navigator.epubReadingSystem</dfn></code> object provides an interface through which a
+				<p>The <code><dfn class="export">Navigator.epubReadingSystem</dfn></code> object provides an interface through which a
 						<a>Scripted Content Document</a> can query information about a user's Reading System.</p>
 
 				<p>The object exposes <a href="#app-ers-properties">properties</a> of the Reading System (its name and

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2321,11 +2321,6 @@
 		<section id="app-epubReadingSystem">
 			<h2><dfn class="export">epubReadingSystem</dfn> Object</h2>
 
-			<p class="issue atrisk" title="Are there enough implementations?">Although this section is
-					<em>normative</em>, it is not clear whether implementations of this interface are widespread enough
-				to warrant this status. If it turns out not to be the case, this section will be marked as
-					<em>non-normative</em> in the final version of the specification.</p>
-
 			<p class="note">Reading Systems act as the core rendering engines of EPUB Publications and provide a
 				scripting environment based on the [[DOM]] specification. So, although this interface definition uses
 				the [[WEBIDL]] notation for implementation by Reading Systems, web browsers generally do not have to
@@ -2334,8 +2329,7 @@
 			<section id="app-ers-idl">
 				<h3>Interface Definition</h3>
 
-				<p>This specification extends the the <a data-cite="html#the-navigator-object"><dfn>Navigator</dfn>
-						object</a> [[HTML]] as follows.</p>
+				<p>This specification extends the {{Navigator}} object [[HTML]] as follows.</p>
 
 				<pre class="idl">[Exposed=(Window)]
 interface EpubReadingSystem {
@@ -2350,8 +2344,7 @@ partial interface Navigator {
 
 				<div class="note">
 					<p>This specification does not define an <code>epubReadingSystem</code> property extension for the
-							<a data-cite="html#the-workernavigator-object"><code>WorkerNavigator</code> object</a>
-						[[HTML]]. Reading Systems therefore do not have to expose the <code>epubReadingSystem</code>
+						{{WorkerNavigator}} object [[HTML]]. Reading Systems therefore do not have to expose the <code>epubReadingSystem</code>
 						object in the scripting context of Workers, and EPUB Creators cannot rely on its presence.</p>
 				</div>
 			</section>


### PR DESCRIPTION
Hopefully by merging this, as well as [PR on adding epub to specref](https://github.com/w3c/browser-specs/pull/581) we can use xref better.

In general, I added an export for all terms appearing in the terminology sections, plus some additional ones (like the 'planes', for example). I did find some `<dfn>`-s that I hesitated or did not export:

- For Core:
    - [§4.1.4 Deriving File Paths](https://w3c.github.io/epub-specs/epub33/core/#sec-file-names-to-path-names) has a dfn for “derive the File Path”, which is not even referenced in the document. I think it is a mistake to have that as a dfn
    - [§5.5.2 Metadata Values](https://w3c.github.io/epub-specs/epub33/core/#sec-metadata-values) the term “value” is set as a dfn. It is referenced from elsewhere in the document so, in this respect, it is fine to have it, but I do not think it is to be exported.
- For RS:
    - in [§15 epubReadingSystem Object](https://w3c.github.io/epub-specs/epub33/rs/#app-epubReadingSystem) the HTML navigator object is set as a dfn. We should definitely not export this, but I wonder whether it is correct to use a dfn in the first place. It is a reference to an existing definition defined elsewhere, after all. B.t.w., respec does not behave as if it was a dfn, probably because it is part of a hyperlink… 
    - the values [§15.3 Properties](https://w3c.github.io/epub-specs/epub33/rs/#app-ers-properties) are set as dfn-s. I think that is fine, but we should not export these (they are way too generic). The same holds for the `hasFeature` method in [§15.4.1.1](https://w3c.github.io/epub-specs/epub33/rs/#app-ers-hasFeature-desc)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2235.html" title="Last updated on Apr 7, 2022, 1:24 PM UTC (24e90e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2235/1287600...24e90e1.html" title="Last updated on Apr 7, 2022, 1:24 PM UTC (24e90e1)">Diff</a>