### PR TITLE
Move details of media overlays to techniques

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1894,8 +1894,8 @@
 							[[EPUB-SSV-11]] to identify each.</li>
 						<li>Lists &#8212; using the <a data-cite="epub-ssv-11#list"><code>list</code> semantic</a>
 							[[EPUB-SSV-11]] to identify each.</li>
-						<li>Sidebars &#8212; use the <a data-cite="epub-ssv-11#sidebar"><code>sidebar</code>
-								semantic</a> [[EPUB-SSV-11]] to identify each.</li>
+						<li>Sidebars &#8212; use the <a data-cite="epub-ssv-11#aside"><code>aside</code> semantic</a>
+							[[EPUB-SSV-11]] to identify each.</li>
 						<li>Tables &#8212; use the <a data-cite="epub-ssv-11#table"><code>table</code> semantic</a>
 							[[EPUB-SSV-11]] to identify each.</li>
 					</ul>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1881,12 +1881,11 @@
 						before being able to move on. These are called escapable elements, because the user needs to be
 						able to escape from them whenever they choose to simplify the reading experience.</p>
 
-					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] does
-						not allow Reading Systems to determine if playback sequences are escapable unless EPUB Creators
-						add additional semantics to the markup, however. EPUB Creators must use the <a
-							data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[EPUB-33]]
-						to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
-							data-cite="epub-33#sec-smil-seq-elem"><code>par</code></a> elements [[EPUB-33]] to allow
+					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] only
+						supports escapability if EPUB Creators add structural semantics to the markup. EPUB Creators
+						must use the <a data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code> attribute</a>
+						[[EPUB-33]] to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a>
+						and <a data-cite="epub-33#sec-smil-seq-elem"><code>par</code></a> elements [[EPUB-33]] to allow
 						Reading Systems to provide users the option to escape their playback sequences.</p>
 
 					<p>The recommended structures to identify for escapability are:</p>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1796,7 +1796,7 @@
 									><code>endnote</code> semantic</a> [[EPUB-SSV-11]] for individual endnotes.</li>
 						<li>Footnotes &#8212; use the <a data-cite="epub-ssv-11#footnotes"><code>footnotes</code>
 								semantic</a> for a group of footnotes or the <a data-cite="epub-ssv-11#footnote"
-									><code>footnote</code> semantic</a> [[EPUB-SSV-11]]for individual footnotes.</li>
+									><code>footnote</code> semantic</a> [[EPUB-SSV-11]] for individual footnotes.</li>
 						<li>Page breaks &#8212; use the <a data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code>
 								semantic</a> [[EPUB-SSV-11]] for each page break.</li>
 					</ul>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1791,12 +1791,12 @@
 					<p>The recommended structures to identify for skippability are:</p>
 
 					<ul>
-						<li>Endnotes &#8212; use the <a data-cite="epub-ssv-11#endnotes"><code>endnotes</code>
-								semantic</a> for a group of notes or the <a data-cite="epub-ssv-11#endnote"
-									><code>endnote</code> semantic</a> [[EPUB-SSV-11]] for individual endnotes.</li>
-						<li>Footnotes &#8212; use the <a data-cite="epub-ssv-11#footnotes"><code>footnotes</code>
-								semantic</a> for a group of footnotes or the <a data-cite="epub-ssv-11#footnote"
-									><code>footnote</code> semantic</a> [[EPUB-SSV-11]]for individual footnotes.</li>
+						<li>Endnotes &#8212; use the <a data-cite="epub-ssv-11#endnotes"><code>endnotes</code></a> and
+								<a data-cite="epub-ssv-11#endnote"><code>endnote</code></a> semantics [[EPUB-SSV-11]]
+							for groups of notes and individual endnotes, respectively.</li>
+						<li>Footnotes &#8212; use the <a data-cite="epub-ssv-11#footnotes"><code>footnotes</code></a>
+							and <a data-cite="epub-ssv-11#footnote"><code>footnote</code></a> semantics [[EPUB-SSV-11]]
+							for groups of footnotes and individual footnotes, respectively.</li>
 						<li>Page breaks &#8212; use the <a data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code>
 								semantic</a> [[EPUB-SSV-11]] for each page break.</li>
 					</ul>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -84,10 +84,20 @@
 						"date": "04 September 2010",
 						"publisher": "IDPF"
 					},
+					"SVG": {
+						"title": "SVG",
+						"href": "https://www.w3.org/TR/SVG/",
+						"publisher": "W3C"
+					},
 					"SWF": {
 						"title": "SWF File Format Specification Version 19",
 						"href": "https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf",
 						"date": "2012"
+					},
+					"WAI-ARIA": {
+						"title": "Accessible Rich Internet Applications (WAI-ARIA)",
+						"href": "https://www.w3.org/TR/wai-aria/",
+						"publisher": "W3C"
 					},
 					"WCAG2": {
 						"title": "Web Content Accessibility Guidelines (WCAG) 2",
@@ -117,7 +127,7 @@
 					[[EPUB-A11Y-11]] discovery and accessibility requirements for EPUB Publications.</p>
 
 				<p>This document does not cover techniques and best practices already addressed in [[WCAG2]] and
-					[[WAI-ARIA-1.1]] for which no substantive differences in application exist.</p>
+					[[WAI-ARIA]] for which no substantive differences in application exist.</p>
 			</section>
 
 			<section id="sec-terminology">
@@ -176,9 +186,9 @@
 			<p>If EPUB Creators encounter issues that are not covered in these or related techniques, they are
 				encouraged to report the issue to the appropriate community for guidance on how to meet accessibility
 				standards. The <a href="https://www.w3.org/WAI/IG/">W3C Web Accessibility Interest Group</a> has a
-				public mailing list where issues meeting [[WCAG2]] and [[WAI-ARIA-1.1]] requirements can be raised. The
-					<a href="https://github.com/w3c/publ-a11y/issues">W3C Publishing Community Group issue
-				tracker</a> can be used to ask for support implementing EPUB-specific requirements and the <a
+				public mailing list where issues meeting [[WCAG2]] and [[WAI-ARIA]] requirements can be raised. The <a
+					href="https://github.com/w3c/publ-a11y/issues">W3C Publishing Community Group issue tracker</a> can
+				be used to ask for support implementing EPUB-specific requirements and the <a
 					href="https://github.com/w3c/epub-specs/issues">EPUB 3 Working Group's issue tracker</a> to report
 				issues with this document.</p>
 		</section>
@@ -877,7 +887,7 @@
 							<a href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA Role
 							Authoring Guide</a> guide details notable authoring differences between the two attributes.
 						It also includes a mapping table of semantics in the EPUB Structural Semantics Vocabulary to
-						equivalent ARIA roles in [[DPUB-ARIA-1.0]] and [[WAI-ARIA-1.1]].</p>
+						equivalent ARIA roles in [[DPUB-ARIA-1.0]] and [[WAI-ARIA]].</p>
 				</section>
 
 				<section id="sem-002">
@@ -896,10 +906,10 @@
 						chapter, putting each into a separate document.</p>
 
 					<p>Although visually these restructuring decisions can be hidden from readers, they impact the
-						functionality of Assistive Technologies. In the case of [[WAI-ARIA-1.1]] roles, the result is
-						that only the subset present in the currently-loaded EPUB Content Document are exposed to users.
-						An Assistive Technology cannot provide a list of landmarks for the whole publication, as it
-						cannot see outside the current document.</p>
+						functionality of Assistive Technologies. In the case of [[WAI-ARIA]] roles, the result is that
+						only the subset present in the currently-loaded EPUB Content Document are exposed to users. An
+						Assistive Technology cannot provide a list of landmarks for the whole publication, as it cannot
+						see outside the current document.</p>
 
 					<p>To counteract this destructuring effect, EPUB Creators sometimes think to re-add or re-identify
 						structures in the belief that having this information in every document will be helpful to users
@@ -968,9 +978,9 @@
 				<section id="sem-003">
 					<h4>Include EPUB landmarks</h4>
 
-					<p>[[WAI-ARIA-1.1]] <a data-cite="wai-aria-1.1#dfn-landmark">landmarks</a> are similar in nature to
-							<a href="https://www.w3.org/TR/epub/#sec-nav-landmarks">EPUB landmarks</a> [[EPUB-3]]: both
-						are designed to provide users with quick access to the major structures of a document, such as
+					<p>[[WAI-ARIA]] <a data-cite="wai-aria#dfn-landmark">landmarks</a> are similar in nature to <a
+							href="https://www.w3.org/TR/epub/#sec-nav-landmarks">EPUB landmarks</a> [[EPUB-3]]: both are
+						designed to provide users with quick access to the major structures of a document, such as
 						chapters, glossaries and indexes. ARIA landmarks are compiled automatically by Assistive
 						Technologies from the <a href="#sem-001">roles</a> that have been applied to the markup, so EPUB
 						Creators only need to follow the requirement to include roles for the landmarks to be made
@@ -1084,7 +1094,7 @@
 								<p>EPUB 3 <a href="https://www.w3.org/TR/epub/#sec-nav-landmarks">landmarks nav</a></p>
 							</li>
 							<li>
-								<p>ARIA 1.1 <a data-cite="wai-aria-1.1#landmark_roles">landmarks</a></p>
+								<p>ARIA <a data-cite="wai-aria#landmark_roles">landmarks</a></p>
 							</li>
 						</ul>
 					</section>
@@ -1421,8 +1431,8 @@
 		<section id="sec-epub">
 			<h2>EPUB Techniques</h2>
 
-			<section id="sec-epub-page-markers">
-				<h3>Page Markers</h3>
+			<section id="sec-epub-page-navigation">
+				<h3>Page Navigation</h3>
 
 				<section id="page-001">
 					<h4>Provide page break markers</h4>
@@ -1678,6 +1688,336 @@
 					</aside>
 
 					<p>If the page break markers are unique to the EPUB Publication, do not identify a print source.</p>
+				</section>
+			</section>
+
+			<section id="sec-epub-sync-text-audio">
+				<h3>Synchronized Text-Audio Playback</h3>
+
+				<section id="sync-001">
+					<h4>Ensuring complete text coverage</h4>
+
+					<p>Ensuring the complete text of an EPUB Publication is synchronized with audio is key to allowing
+						users who require full synchronized playback, or even audio-only playback, have access to the
+						same information as users who do not require synchronized playback.</p>
+
+					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] allows
+						audio to be synchronized with any element in an EPUB Content Document, so there is no technical
+						barrier to providing synchronized playback.</p>
+
+					<p>The primary consideration for this objective is what constitutes the text content of an EPUB
+						Publication. The minimal candidates for synchronization with audio are all the elements with
+						visible text content.</p>
+
+					<p>In HTML, the class of elements called <a data-cite="html#palpable-content">palpable content</a>
+						[[HTML]] can typically be synchronized with audio or have their own built-in audio. Embedded
+						text in SVG documents, on the other hand, is found in the <a
+							href="https://www.w3.org/TR/SVG/text.html#TextElement"><code>text</code> element</a> [[SVG]]
+						and its descendants.</p>
+
+					<p>The Media Overlays <a data-cite="epub-33#sec-smil-text-elem"><code>text</code> element</a> is
+						used to reference these elements, either to play back the pre-recorded audio in a sibling <a
+							data-cite="epub-33#sec-smil-audio-elem"><code>audio</code> element</a> [[EPUB-33]] or to
+						initiate playback of an audio or video element if the <code>audio</code> element is missing
+						(e.g., for embedded audio and video in the document).</p>
+
+					<div class="note">
+						<p>EPUB Creators should not synchronize hidden text content in an alternative presentation like
+							Media Overlays. Synchronizing audio with invisible text will be confusing for sighted
+							readers following the playback.</p>
+
+						<p>Text content in a collapsed element, like the <a data-cite="html#the-details-element"
+									><code>details</code> element</a> [[HTML]], is not considered hidden content.</p>
+					</div>
+
+					<p>In addition to synchronizing the visible text, synchronized text-audio playback must also address
+						text alternatives for image-based content. Images may have alternative text and descriptions
+						that are not visible to all users. As synchronization is also meant to aid users who cannot see
+						the images, including these text alternatives and descriptions in the playback is essential to
+						providing the user all the information in the EPUB Publication.</p>
+
+					<p>Text alternatives and descriptions in HTML may be represented in the <a
+							data-cite="html#attr-img-alt"><code>alt</code> attribute</a> [[HTML]] and linked by ARIA
+						attributes (e.g., <a data-cite="wai-aria#aria-describedby"><code>aria-describedby</code></a> and
+							<a data-cite="wai-aria#aria-details"><code>aria-details</code></a> [[WAI-ARIA]]).
+						Descriptions for image elements in SVG are typically represented in a <a
+							href="https://www.w3.org/TR/SVG/struct.html#DescElement"><code>desc</code> element</a> but
+						ARIA attributes may also be used.</p>
+				</section>
+
+				<section id="sync-002">
+					<h4>Specifying the reading order</h4>
+
+					<p>The default reading order should typically represent the order in which Reading Systems render
+						content to users during synchronized text-audio playback. For EPUB Publications, this is a
+						combination of the sequence of EPUB Content Documents in the spine and the order of elements
+						within each EPUB Content Document.</p>
+
+					<p>If there are cases where the logical reading order (how a reader would naturally read the
+						content) diverges from the default reading order, EPUB Creators can order the playback sequence
+						of <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
+							data-cite="epub-33#sec-smil-par-elem"><code>par</code></a> elements in a <a
+							data-cite="epub-33#sec-overlay-docs">Media Overlays Document</a> [[EPUB-33]] to match the
+						logical order.</p>
+
+					<p>EPUB Creators need to use caution when making alterations, however, as other accessibility issues
+						can arise when the logical order does not match the default order. For example, the content may
+						not be accessible to users of assistive technologies when the order in the markup does not match
+						how the assistive technology reads the content. In these cases, using playback to create a
+						logical order can make the EPUB Publication fail WCAG conformance requirements.</p>
+
+					<p>One case where the logical may diverge from the reading order and remain accessible is in tables,
+						as assistive technologies typically allow users to choose whether to read by row or by
+						column.</p>
+				</section>
+
+				<section id="sync-003">
+					<h4>Identifying skippable structures</h4>
+
+					<p>Some content elements are not critical to read when following the primary narrative of a work,
+						and that would interrupt a user's concentration if they had to stop and listen to. Footnotes and
+						endnotes are examples of such content, as users may only want to come back and read this content
+						after finishing the EPUB Publication. The announcement of page break numbers can be similarly
+						annoying to readers.</p>
+
+					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] does
+						not allow Reading Systems to determine if playback sequences are skippable unless EPUB Creators
+						add additional semantics to the markup, however. EPUB Creators must use the <a
+							data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[EPUB-33]]
+						to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
+							data-cite="epub-33#sec-smil-par-elem"><code>par</code></a> elements [[EPUB-33]], thereby
+						allowing Reading Systems to provide users the option to skip their playback sequences.</p>
+
+					<p>EPUB Creators do not need to identify every structure to meet this requirement. The recommended
+						structures to identify for skippability are:</p>
+
+					<ul>
+						<li>Endnotes &#8212; use the <a data-cite="epub-ssv-11#endnotes"><code>endnotes</code>
+								semantic</a> for a group of notes or the <a data-cite="epub-ssv-11#endnote"
+									><code>endnote</code> semantic</a> [[EPUB-SSV-11]] for individual endnotes.</li>
+						<li>Footnotes &#8212; use the <a data-cite="epub-ssv-11#footnotes"><code>footnotes</code>
+								semantic</a> for a group of footnotes or the <a data-cite="epub-ssv-11#footnote"
+									><code>footnote</code> semantic</a> [[EPUB-SSV-11]]for individual footnotes.</li>
+						<li>Page breaks &#8212; use the <a data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code>
+								semantic</a> [[EPUB-SSV-11]] for each page break.</li>
+					</ul>
+
+					<aside class="example" title="Identifying a skippable footnote">
+						<p>In this example, the <code>footnote</code> semantic identifies a skippable footnote in the
+							Media Overlay Document.</p>
+
+						<p>Media Overlay Document:</p>
+
+						<pre>&lt;smil
+    xmlns="http://www.w3.org/ns/SMIL" 
+    xmlns:epub="http://www.idpf.org/2007/ops"
+    version="3.0">
+   &lt;body>
+      &lt;!-- a paragraph -->
+      &lt;par id="id1">
+         &lt;text
+             src="chapter1.xhtml#para1"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0:23:22.000"
+             clipEnd="0:24:15.000"/>
+      &lt;/par>
+
+      &lt;!-- a footnote -->
+      &lt;par
+          id="id2"
+          epub:type="footnote">
+         &lt;text
+             src="chapter1.xhtml#fn01"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0:24:15.000"
+             clipEnd="0:24:53.821"/>
+      &lt;/par>
+
+      &lt;!-- another paragraph -->
+      &lt;par id="id3">
+         &lt;text
+             src="chapter1.xhtml#para2"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0:24:53.821"
+             clipEnd="0:25:28.530"/>
+      &lt;/par>
+   &lt;/body>
+&lt;/smil>
+</pre>
+
+						<p>EPUB Content Document:</p>
+
+						<pre>&lt;html … >
+   …
+   &lt;body>
+      &lt;p id="para1">
+         This is the paragraph with the footnote reference …
+      &lt;/p>
+      
+      &lt;p id="fn01" role="doc-footnote">
+         This is the footnote …
+      &lt;/p>
+      
+      &lt;p id="para2">
+         This is the paragraph after the footnote …
+      &lt;/p>
+   &lt;/body>
+&lt;/html></pre>
+					</aside>
+				</section>
+
+				<section id="sync-004">
+					<h4>Identifying escapable structures</h4>
+
+					<p>Some content elements are containers for expressing complex information. A table, for example,
+						has data arranged in rows and cells, where each cell may contain several paragraphs of
+						information. Lists similarly may contain many items, and each item can contain complex
+						information. While users may be interested in some of the information in these structures, they
+						also often want to escape from them to keep reading, not have to listen to the entire content
+						before being able to move on. These are called escapable elements, because the user needs to be
+						able to escape from them whenever they choose to simplify the reading experience.</p>
+
+					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] does
+						not allow Reading Systems to determine if playback sequences are escapable unless EPUB Creators
+						add additional semantics to the markup, however. EPUB Creators must use the <a
+							data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[EPUB-33]]
+						to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
+							data-cite="epub-33#sec-smil-seq-elem"><code>par</code></a> elements [[EPUB-33]] to allow
+						Reading Systems to provide users the option to escape their playback sequences.</p>
+
+					<p>EPUB Creators do not need to identify every structure to meet this requirement. The recommended
+						structures to identify for escapability are:</p>
+
+					<ul>
+						<li>Figures &#8212; use the <a data-cite="epub-ssv-11#figure"><code>figure</code></a> semantic
+							[[EPUB-SSV-11]] to identify each figure.</li>
+						<li>Lists &#8212; use the <a data-cite="epub-ssv-11#list"><code>list</code></a> and <a
+								data-cite="epub-ssv-11#list-item"><code>list-item</code></a> semantics [[EPUB-SSV-11]]
+							to allow escaping from both items and lists.</li>
+						<li>Tables &#8212; use the <a data-cite="epub-ssv-11#table"><code>table</code></a>, <a
+								data-cite="epub-ssv-11#table-row"><code>table-row</code></a>, and <a
+								data-cite="epub-ssv-11#table-cell"><code>table-cell</code></a> semantics [[EPUB-SSV-11]]
+							to allow users to escape from tables, rows and individual cells.</li>
+					</ul>
+
+					<aside class="example" title="Identifying an escapable list">
+						<p>In this example, the <code>list</code> and <code>list-item</code> semantics identify the
+							escapable list and list items in the Media Overlay Document.</p>
+
+						<p>Media Overlay Document:</p>
+
+						<pre>&lt;smil
+    xmlns="http://www.w3.org/ns/SMIL" 
+    xmlns:epub="http://www.idpf.org/2007/ops"
+    version="3.0">
+   &lt;body>
+      &lt;!-- a paragraph, part of the regular document text -->
+      &lt;par id="id1">
+         &lt;text
+             src="c01.xhtml#para1"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0:23:22.000"
+             clipEnd="0:24:15.000"/>
+      &lt;/par>
+
+      &lt;!-- list with many items -->
+      &lt;seq
+          id="id2"
+          epub:textref="c01.xhtml#list1"
+          epub:type="list">
+         
+         
+         &lt;!-- first list item -->
+         &lt;par
+             id="id3"
+             epub:type="list-item">
+            &lt;text
+                src="c01.xhtml#item01"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:24:15.000"
+                clipEnd="0:24:27.905"/>
+         &lt;/par>
+         
+         &lt;!-- second list item -->
+         &lt;par
+             id="id4"
+             epub:type="list-item">
+            &lt;text
+                src="c01.xhtml#item02"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:24:27.905"
+                clipEnd="0:24:48.416"/>
+         &lt;/par>
+         
+         &lt;!-- third list item -->
+         &lt;par
+             id="id5"
+             epub:type="list-item">
+            &lt;text
+                src="c01.xhtml#item03"/>
+            &lt;audio
+                src="chapter1_audio.mp3"
+                clipBegin="0:24:48.416"
+                clipEnd="0:25:31.647"/>
+         &lt;/par>
+         
+         &lt;!-- additional list items omitted for brevity -->
+      &lt;/seq>
+
+      &lt;!-- another paragraph -->
+      &lt;par id="id48">
+         &lt;text
+             src="c01.xhtml#para2"/>
+         &lt;audio
+             src="chapter1_audio.mp3"
+             clipBegin="0:31:03.902"
+             clipEnd="0:32:31.514"/>
+      &lt;/par>
+   &lt;/body>
+&lt;/smil></pre>
+
+						<p>EPUB Content Document:</p>
+
+						<pre>&lt;html … >
+   …
+   &lt;body>
+      &lt;p id="para1">
+         This is the paragraph before the list …
+      &lt;/p>
+      
+      &lt;ul id="list1">
+         &lt;li id="item01">This is the first list item …&lt;/li>
+         &lt;li id="item02">This is the second list item …&lt;/li>
+         &lt;li id="item03">This is the third list item …&lt;/li>
+         …
+      &lt;/ul>
+      
+      &lt;p id="para2">
+         This is the paragraph after the list …
+      &lt;/p>
+   &lt;/body>
+&lt;/html></pre>
+					</aside>
+				</section>
+
+				<section id="sync-005">
+					<h4>Synchronizing the Navigation Document</h4>
+
+					<p>EPUB Creators can add a <a data-cite="epub-33#sec-overlays-docs">Media Overlay Document</a> for
+						the <a data-cite="epub-33#sec-nav">EPUB Navigation Document</a> even when it is not included in
+						the <a data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]]. Doing so allow Reading Systems
+						to announce the link labels regardless of how they present the navigation elements to users
+						(e.g., many Reading Systems applications create custom table of contents panels by extracting
+						the data from the EPUB Navigation Document).</p>
+
+					<p>The process for adding a Media Overlay Document is no different than one for any other
+						document.</p>
 				</section>
 			</section>
 		</section>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1788,8 +1788,7 @@
 							data-cite="epub-33#sec-smil-par-elem"><code>par</code></a> elements [[EPUB-33]], thereby
 						allowing Reading Systems to provide users the option to skip their playback sequences.</p>
 
-					<p>EPUB Creators do not need to identify every structure to meet this requirement. The recommended
-						structures to identify for skippability are:</p>
+					<p>The recommended structures to identify for skippability are:</p>
 
 					<ul>
 						<li>Endnotes &#8212; use the <a data-cite="epub-ssv-11#endnotes"><code>endnotes</code>
@@ -1801,6 +1800,8 @@
 						<li>Page breaks &#8212; use the <a data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code>
 								semantic</a> [[EPUB-SSV-11]] for each page break.</li>
 					</ul>
+
+					<p>EPUB Creators may identify other structures but it is not necessary to meet this requirement.</p>
 
 					<aside class="example" title="Identifying a skippable footnote">
 						<p>In this example, the <code>footnote</code> semantic identifies a skippable footnote in the
@@ -1888,8 +1889,7 @@
 							data-cite="epub-33#sec-smil-seq-elem"><code>par</code></a> elements [[EPUB-33]] to allow
 						Reading Systems to provide users the option to escape their playback sequences.</p>
 
-					<p>EPUB Creators do not need to identify every structure to meet this requirement. The recommended
-						structures to identify for escapability are:</p>
+					<p>The recommended structures to identify for escapability are:</p>
 
 					<ul>
 						<li>Figures &#8212; use the <a data-cite="epub-ssv-11#figure"><code>figure</code></a> semantic
@@ -1902,6 +1902,8 @@
 								data-cite="epub-ssv-11#table-cell"><code>table-cell</code></a> semantics [[EPUB-SSV-11]]
 							to allow users to escape from tables, rows and individual cells.</li>
 					</ul>
+
+					<p>EPUB Creators may identify other structures but it is not necessary to meet this requirement.</p>
 
 					<aside class="example" title="Identifying an escapable list">
 						<p>In this example, the <code>list</code> and <code>list-item</code> semantics identify the

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1798,7 +1798,7 @@
 							and <a data-cite="epub-ssv-11#footnote"><code>footnote</code></a> semantics [[EPUB-SSV-11]]
 							for groups of footnotes and individual footnotes, respectively.</li>
 						<li>Page breaks &#8212; use the <a data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code>
-								semantic</a> [[EPUB-SSV-11]] for each page break.</li>
+								semantic</a> [[EPUB-SSV-11]] to identify each.</li>
 					</ul>
 
 					<p>EPUB Creators may identify other structures but it is not necessary to meet this requirement.</p>
@@ -1891,20 +1891,21 @@
 
 					<ul>
 						<li>Figures &#8212; use the <a data-cite="epub-ssv-11#figure"><code>figure</code> semantic</a>
-							[[EPUB-SSV-11]] to identify each figure.</li>
-						<li>Lists &#8212; use the <a data-cite="epub-ssv-11#list"><code>list</code> semantic</a>
-							[[EPUB-SSV-11]] to allow escaping from lists.</li>
+							[[EPUB-SSV-11]] to identify each.</li>
+						<li>Lists &#8212; using the <a data-cite="epub-ssv-11#list"><code>list</code> semantic</a>
+							[[EPUB-SSV-11]] to identify each.</li>
+						<li>Sidebars &#8212; use the <a data-cite="epub-ssv-11#sidebar"><code>sidebar</code>
+								semantic</a> [[EPUB-SSV-11]] to identify each.</li>
 						<li>Tables &#8212; use the <a data-cite="epub-ssv-11#table"><code>table</code> semantic</a>
-							[[EPUB-SSV-11]] to allow users to escape from tables.</li>
+							[[EPUB-SSV-11]] to identify each.</li>
 					</ul>
 
 					<p>EPUB Creators may identify other structures but it is not necessary to meet this requirement.</p>
 
 					<div class="note">
-						<p>Sometimes escapable structures may contain escapable structures. For example, tables are
-							composed of many rows and cells that users may want to separately escape from. While
-							identifying the nested escapable structures is encouraged, it is not required at this time
-							as the process of escaping from nested structures is not well defined.</p>
+						<p>Identifying nested escapable structures is not recommended at this time. Refer to <a
+								href="https://www.w3.org/TR/epub/#sec-escapability">Escapability</a> [[EPUB-3]] for more
+							information.</p>
 					</div>
 
 					<aside class="example" title="Identifying an escapable list">

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1890,11 +1890,11 @@
 					<p>The recommended structures to identify for escapability are:</p>
 
 					<ul>
-						<li>Figures &#8212; use the <a data-cite="epub-ssv-11#figure"><code>figure</code></a> semantic
+						<li>Figures &#8212; use the <a data-cite="epub-ssv-11#figure"><code>figure</code> semantic</a>
 							[[EPUB-SSV-11]] to identify each figure.</li>
-						<li>Lists &#8212; use the <a data-cite="epub-ssv-11#list"><code>list</code></a> semantic
+						<li>Lists &#8212; use the <a data-cite="epub-ssv-11#list"><code>list</code> semantic</a>
 							[[EPUB-SSV-11]] to allow escaping from lists.</li>
-						<li>Tables &#8212; use the <a data-cite="epub-ssv-11#table"><code>table</code></a> semantic
+						<li>Tables &#8212; use the <a data-cite="epub-ssv-11#table"><code>table</code> semantic</a>
 							[[EPUB-SSV-11]] to allow users to escape from tables.</li>
 					</ul>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -2152,6 +2152,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>07-Apr-2022: Added techniques for addressing synchronized text-audio playback objectives using Media
+					Overlays. See <a href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>
 				<li>10-Nov-2021: Added techniques for setting language in the Package Document. See <a
 						href="https://github.com/w3c/epub-specs/issues/1842">issue 1842</a>.</li>
 				<li>25-Oct-2021: Removed the generic technique labels for each section. See <a

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1908,8 +1908,8 @@
 					</div>
 
 					<aside class="example" title="Identifying an escapable list">
-						<p>In this example, the <code>list</code> and <code>list-item</code> semantics identify the
-							escapable list and list items in the Media Overlay Document.</p>
+						<p>In this example, the <code>list</code> semantic identifies an escapable list in the Media
+							Overlay Document.</p>
 
 						<p>Media Overlay Document:</p>
 
@@ -1934,44 +1934,8 @@
           epub:textref="c01.xhtml#list1"
           epub:type="list">
          
+         &lt;!-- list items omitted for brevity -->
          
-         &lt;!-- first list item -->
-         &lt;par
-             id="id3"
-             epub:type="list-item">
-            &lt;text
-                src="c01.xhtml#item01"/>
-            &lt;audio
-                src="chapter1_audio.mp3"
-                clipBegin="0:24:15.000"
-                clipEnd="0:24:27.905"/>
-         &lt;/par>
-         
-         &lt;!-- second list item -->
-         &lt;par
-             id="id4"
-             epub:type="list-item">
-            &lt;text
-                src="c01.xhtml#item02"/>
-            &lt;audio
-                src="chapter1_audio.mp3"
-                clipBegin="0:24:27.905"
-                clipEnd="0:24:48.416"/>
-         &lt;/par>
-         
-         &lt;!-- third list item -->
-         &lt;par
-             id="id5"
-             epub:type="list-item">
-            &lt;text
-                src="c01.xhtml#item03"/>
-            &lt;audio
-                src="chapter1_audio.mp3"
-                clipBegin="0:24:48.416"
-                clipEnd="0:25:31.647"/>
-         &lt;/par>
-         
-         &lt;!-- additional list items omitted for brevity -->
       &lt;/seq>
 
       &lt;!-- another paragraph -->
@@ -1996,9 +1960,6 @@
       &lt;/p>
       
       &lt;ul id="list1">
-         &lt;li id="item01">This is the first list item …&lt;/li>
-         &lt;li id="item02">This is the second list item …&lt;/li>
-         &lt;li id="item03">This is the third list item …&lt;/li>
          …
       &lt;/ul>
       

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1874,12 +1874,11 @@
 					<h4>Identifying escapable structures</h4>
 
 					<p>Some content elements are containers for expressing complex information. A table, for example,
-						has data arranged in rows and cells, where each cell may contain several paragraphs of
-						information. Lists similarly may contain many items, and each item can contain complex
-						information. While users may be interested in some of the information in these structures, they
-						also often want to escape from them to keep reading, not have to listen to the entire content
-						before being able to move on. These are called escapable elements, because the user needs to be
-						able to escape from them whenever they choose to simplify the reading experience.</p>
+						has data arranged in rows and cells. Lists similarly may contain many items. While users may be
+						interested in some of the information in these structures, they also often want to escape from
+						them to keep reading, not have to listen to the entire content before being able to move on.
+						These are called escapable elements, because the user needs to be able to escape from them
+						whenever they choose to simplify the reading experience.</p>
 
 					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] only
 						supports escapability if EPUB Creators add structural semantics to the markup. EPUB Creators
@@ -1893,16 +1892,20 @@
 					<ul>
 						<li>Figures &#8212; use the <a data-cite="epub-ssv-11#figure"><code>figure</code></a> semantic
 							[[EPUB-SSV-11]] to identify each figure.</li>
-						<li>Lists &#8212; use the <a data-cite="epub-ssv-11#list"><code>list</code></a> and <a
-								data-cite="epub-ssv-11#list-item"><code>list-item</code></a> semantics [[EPUB-SSV-11]]
-							to allow escaping from both items and lists.</li>
-						<li>Tables &#8212; use the <a data-cite="epub-ssv-11#table"><code>table</code></a>, <a
-								data-cite="epub-ssv-11#table-row"><code>table-row</code></a>, and <a
-								data-cite="epub-ssv-11#table-cell"><code>table-cell</code></a> semantics [[EPUB-SSV-11]]
-							to allow users to escape from tables, rows and individual cells.</li>
+						<li>Lists &#8212; use the <a data-cite="epub-ssv-11#list"><code>list</code></a> semantic
+							[[EPUB-SSV-11]] to allow escaping from lists.</li>
+						<li>Tables &#8212; use the <a data-cite="epub-ssv-11#table"><code>table</code></a> semantic
+							[[EPUB-SSV-11]] to allow users to escape from tables.</li>
 					</ul>
 
 					<p>EPUB Creators may identify other structures but it is not necessary to meet this requirement.</p>
+
+					<div class="note">
+						<p>Sometimes escapable structures may contain escapable structures. For example, tables are
+							composed of many rows and cells that users may want to separately escape from. While
+							identifying the nested escapable structures is encouraged, it is not required at this time
+							as the process of escaping from nested structures is not well defined.</p>
+					</div>
 
 					<aside class="example" title="Identifying an escapable list">
 						<p>In this example, the <code>list</code> and <code>list-item</code> semantics identify the

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -776,16 +776,16 @@
 							see the text or are prevented from reading visually due to motion-sickness) or who only
 							benefit from reading with text highlighting (e.g., readers with dyslexia).</p>
 
-						<p>The most basic forms of synchronized text-audio playback provide only minimal instructions to
-							Reading Systems, however. They indicate the text to highlight and the audio clip that
-							corresponds to the text. The result is that users only have basic start and stop options
-							available.</p>
+						<p>Unlike purely linear listening experiences, EPUB with synchronized text-audio playback
+							preserves the user's ability to navigate around the publication, such as via the table of
+							contents, and also introduces audio-centric reading features like phrase navigation, and
+							ways to control which parts of the content are read aloud.</p>
 
-						<p>EPUB Creators need to add additional structure and semantics to allow Reading Systems to
-							present more usable experiences. With greater context, a Reading System can provide the
-							ability to skip past secondary content that interferes with the primary narrative, escape
-							users from deeply nested structures like tables, and allow them to navigate through the
-							sections of the publication without having to go to the table of contents.</p>
+						<p>In order to offer users greater control over content presentation, EPUB Creators need to add
+							structure and semantics so that the Reading System has the necessary context to enable this
+							type of user experience. With greater context, a Reading System can provide the ability to
+							skip past secondary content that interferes with the primary narrative and escape users from
+							deeply nested structures like tables.</p>
 
 						<p>Adding structure and semantics to synchronized text-audio playback broadly falls under the
 							objective of the <a href="https://www.w3.org/TR/WCAG2/#info-and-relationships">Info and
@@ -920,13 +920,14 @@
 								<dd>
 									<p>Being able to read the primary narrative of a work without interruption is
 										central to reading comprehension. EPUB Creators typically structure EPUB
-										Publications to visually represent secondary information such as sidebars and
-										footnotes outside the main narrative flow (e.g., by using different background
-										colours or placement so readers can filter this information visually out while
-										reading).</p>
+										Publications to visually represent secondary information such as page break
+										markers and footnotes outside the main narrative flow (e.g., by using different
+										background colors or placement so readers can filter this information visually
+										out while reading).</p>
 									<p>Readers who prefer auditory playback, however, cannot skip this information with
-										the same ease by default. Synchronized text-audio playback will typically result
-										in Reading Systems rendering secondary content where it occurs.</p>
+										the same ease in a linear audio-based reading experience. And, without
+										structural semantics, synchronized text-audio playback cannot offer skipping
+										content either.</p>
 									<p>When EPUB Creators add structural semantics, however, Reading Systems can create
 										reading experiences that allow users to decide which secondary content to skip
 										by default during playback.</p>
@@ -934,8 +935,7 @@
 
 								<dt id="sec-sync-skippability-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators SHOULD identify all skippable structures if the synchronized
-										text-audio playback format does not handle escaping content by default.</p>
+									<p>EPUB Creators SHOULD identify all skippable structures.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-003">Identifying skippable
 												structures</a> [[EPUB-A11Y-TECH-11]] for more information on meeting
@@ -957,23 +957,23 @@
 								<dt id="sec-sync-escapability-understand">Understanding this Objective</dt>
 								<dd>
 									<p>When reading visually, users can quickly move through, and escape from, highly
-										structured content such as tables, lists, and figures. Table layouts that use
-										rows and columns, for example, allow users to quickly move along either axis to
-										find the information they want, and to easily return to the primary narrative
-										when they finish. Similarly, lists of items allow users to skim their content
-										and escape from them once they locate the desired information.</p>
-									<p>The same ease of escaping from content is not always available in synchronized
-										text-audio playback. Users may not be able to escape from table cells, rows, or
-										even the table itself, unless EPUB Creators encode the structural semantics of
-										those elements.</p>
+										structured content such as sidebars, lists, and figures. Visual readers can skim
+										lists and quickly return to the primary narrative once they locate the desired
+										information, for example. The same is true for reading figures and sidebars, as
+										they are visually offset from the primary narrative so easily jumped into and
+										out of.</p>
+									<p>The same ease of escaping from content is only possible if EPUB Creators encode
+										the structural semantics into the synchronized text/audio format. Users may not
+										be able to escape from lists, sidebars, figures, and other highly structured
+										content, unless EPUB Creators encode the structural semantics of those
+										elements.</p>
 									<p>When EPUB Creators provide this information, Reading Systems can simplify
 										playback for auditory readers to enable a comparable reading experience.</p>
 								</dd>
 
 								<dt id="sec-sync-escapability-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators SHOULD identify all escapable structures if the synchronized
-										text-audio playback format does not handle escaping content by default.</p>
+									<p>EPUB Creators SHOULD identify all escapable structures.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-004">Identifying escapable
 												structures</a> [[EPUB-A11Y-TECH-11]] for more information on meeting

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -803,7 +803,7 @@
 
 						<p>To maximize the effectiveness of synchronized text-audio playback for people with different
 							reading needs, however, EPUB Creators are strongly encouraged to meet the <a
-								href="#sec-mo-obj">OPTIONAL objectives</a> defined in the next section.</p>
+								href="#sec-sync-obj">OPTIONAL objectives</a> defined in the next section.</p>
 
 						<div class="note">
 							<p>EPUB Creators do not have to include synchronized text-audio playback in their EPUB

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1797,7 +1797,6 @@
 				<li>12-Apr-2022: Generalized discussion of synchronized text-audio playback objectives and moved
 					specific details of using Media Overlays to the techniques document. See <a
 						href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>
-				<li>23-Mar-2022: Clarified linking for WCAG conformance versions and levels. See <a
 				<li>08-Apr-2022: Changed the recommendation to include links to all reproduced pages in the page list to
 					a requirement. See <a href="https://github.com/w3c/epub-specs/issues/2220">issue 2220</a>.</li>
 				<li>23-Mar-2022: Clarified linking for WCAG conformance versions and levels. See <a

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -607,7 +607,7 @@
 							meet the Multiple Ways success criterion.</p>
 
 						<div class="note">
-							<p>See <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-epub-page-markers">Page
+							<p>Refer to <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-epub-page-markers">Page
 									Markers</a> [[EPUB-A11Y-TECH-11]] for more information on the inclusion of page
 								navigation in EPUB Publications.</p>
 						</div>
@@ -671,7 +671,7 @@
 										identify that source in the Package Document metadata.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-004">Identifying the pagination
-												source</a> [[EPUB-A11Y-TECH-11]] for specific techniques to meet this
+												source</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
 											objective.</p>
 									</div>
 								</dd>
@@ -711,7 +711,7 @@
 										reproduced or not, but this is not a requirement.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-003">Provide a page list</a>
-											[[EPUB-A11Y-TECH-11]] for specific techniques to meet this objective.</p>
+											[[EPUB-A11Y-TECH-11]] for more information on meeting this objective.</p>
 									</div>
 								</dd>
 							</dl>
@@ -755,7 +755,7 @@
 										identify the page numbers in the markup that controls the playback.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-001">Provide page break
-												markers</a> [[EPUB-A11Y-TECH-11]] for specific techniques to meet this
+												markers</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
 											objective.</p>
 									</div>
 								</dd>
@@ -764,62 +764,63 @@
 					</section>
 				</section>
 
-				<section id="sec-mo">
-					<h4>Media Overlays Playback</h4>
+				<section id="sec-sync-text-audio">
+					<h4>Synchronized Text-Audio Playback</h4>
 
-					<section id="sec-mo-overview" class="informative">
+					<section id="sec-sync-overview" class="informative">
 						<h5>Overview</h5>
 
-						<p>Media Overlays provide an accessible playback experience for anyone who benefits from having
-							text and audio synchronized. They are also useful to users who only require audio playback,
-							or only benefit from reading with text highlighting. Media Overlays also enable a seamless
-							playback experience from beginning to end of an EPUB Publication for all these users.</p>
+						<p>The provision of synchronized text-audio playback helps address various user needs. It not
+							only enables a seamless visual and auditory reading experience from beginning to end of an
+							EPUB Publication, but is useful to users who only require audio playback (e.g., who cannot
+							see the text or are prevented from reading visually due to motion-sickness) or who only
+							benefit from reading with text highlighting (e.g., readers with dyslexia).</p>
 
-						<p>The most basic <a href="https://www.w3.org/TR/epub/#sec-overlays-def">Media Overlay
-								Documents</a> [[EPUB-3]] provide only minimal instructions to Reading Systems, however.
-							They indicate the text to highlight and the audio clip that corresponds to the text. The
-							result is that users only have basic start and stop options available.</p>
+						<p>The most basic forms of synchronized text-audio playback provide only minimal instructions to
+							Reading Systems, however. They indicate the text to highlight and the audio clip that
+							corresponds to the text. The result is that users only have basic start and stop options
+							available.</p>
 
-						<p>EPUB Creators need to add structure and semantics to Media Overlay Documents to allow Reading
-							Systems to present more usable experiences. With richer markup, a Reading System could
-							provide the ability to skip past secondary content that interferes with the primary
-							narrative, escape users from deeply nested structures like tables, and allow them to
-							navigate through the sections of the publication without having to go to the table of
-							contents.</p>
+						<p>EPUB Creators need to add additional structure and semantics to allow Reading Systems to
+							present more usable experiences. With greater context, a Reading System can provide the
+							ability to skip past secondary content that interferes with the primary narrative, escape
+							users from deeply nested structures like tables, and allow them to navigate through the
+							sections of the publication without having to go to the table of contents.</p>
 
-						<p>Adding structure and semantics to Media Overlay Documents broadly falls under the objective
-							of the <a href="https://www.w3.org/TR/WCAG2/#info-and-relationships">Info and Relationships
-								success criterion</a> [[WCAG2]]. Without structured and semantically meaningful playback
-							sequences, the effect is to deprive users of rich navigation of the content.</p>
+						<p>Adding structure and semantics to synchronized text-audio playback broadly falls under the
+							objective of the <a href="https://www.w3.org/TR/WCAG2/#info-and-relationships">Info and
+								Relationships success criterion</a> [[WCAG2]]. Without structured and semantically
+							meaningful playback sequences, the effect is to deprive users of rich navigation of the
+							content.</p>
 					</section>
 
-					<section id="sec-mo-applicability">
+					<section id="sec-sync-applicability">
 						<h5>Applicability</h5>
 
-						<p>Media Overlay Documents MUST meet the requirements in [[EPUB-3]]. It is not necessary to meet
-							any additional requirements beyond those defined in [[EPUB-3]] to be conformant with this
-							specification.</p>
+						<p>EPUB Publications with synchronized text-audio playback MUST conform to all requirements in
+							[[EPUB-3]]. It is not necessary to meet any additional requirements beyond those defined in
+							[[EPUB-3]] to be conformant with this specification.</p>
 
-						<p>To maximize the effectiveness of Media Overlays for people with different reading needs,
-							however, EPUB Creators are strongly encouraged to meet the <a href="#sec-mo-obj">OPTIONAL
-								objectives</a> defined in the next section.</p>
+						<p>To maximize the effectiveness of synchronized text-audio playback for people with different
+							reading needs, however, EPUB Creators are strongly encouraged to meet the <a
+								href="#sec-mo-obj">OPTIONAL objectives</a> defined in the next section.</p>
 
 						<div class="note">
-							<p>EPUB Creators do not have to include Media Overlays in their EPUB Publications, only
-								ensure they conform to these requirements when present.</p>
+							<p>EPUB Creators do not have to include synchronized text-audio playback in their EPUB
+								Publications, only ensure it conforms to these requirements when present.</p>
 						</div>
 					</section>
 
-					<section id="sec-mo-obj">
+					<section id="sec-sync-obj">
 						<h5>Objectives</h5>
 
-						<section id="sec-mo-complete">
+						<section id="sec-sync-complete">
 							<h6>Completeness</h6>
 
 							<dl>
 								<dt id="sec-mo-comlete-obj">Objective</dt>
 								<dd>
-									<p>Ensure that the full text is available in audio.</p>
+									<p>Ensure that all text content is available in audio.</p>
 								</dd>
 
 								<dt id="sec-mo-complete-understand">Understanding this Objective</dt>
@@ -837,19 +838,24 @@
 
 								<dt id="sec-mo-complete-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators MUST provide synchronized audio playback via Media Overlays for all
-										textual content.</p>
+									<p>EPUB Creators MUST provide synchronized audio playback for all visible textual
+										content as well as all textual alternatives for visual media.</p>
+									<div class="note">
+										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-004">Ensuring complete text
+												coverage</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
+											objective.</p>
+									</div>
 								</dd>
 							</dl>
 						</section>
 
-						<section id="sec-mo-order">
+						<section id="sec-sync-order">
 							<h6>Reading Order</h6>
 
 							<dl>
 								<dt id="sec-mo-order-obj">Objective</dt>
 								<dd>
-									<p>Ensure Media Overlay playback matches logical reading order.</p>
+									<p>Ensure synchronized text-audio playback matches logical reading order.</p>
 								</dd>
 
 								<dt id="sec-mo-order-understand">Understanding this Objective</dt>
@@ -866,25 +872,24 @@
 										content where the author intended it to be read. The default reading order also
 										establishes some less obvious relations, like the progress within a table from
 										cell to cell and row to row.</p>
-									<p>If the sequence of <code>par</code> and <code>seq</code> elements in a Media
-										Overlay Documents does not match this progression, it can cause confusion for
-										readers, whether they are only listening to the audio or trying to also follow
-										visually.</p>
+									<p>If the sequence of the synchronized text-audio playback does not match this
+										progression, it can cause confusion for readers, whether they are only listening
+										to the audio or trying to also follow visually.</p>
 									<p>Ordering the playback to match the default reading order is the safest way to
 										ensure that users can follow the text. In some cases, however, strict adherence
 										to this practice can result in a suboptimal reading experience (e.g., playback
 										of a table by column instead of row might make more natural sense in some
 										cases). These publications have a logical reading order that cannot match the
-										default order of the elements of the host format (e.g., some languages).</p>
+										default order of the elements of the host format.</p>
 									<p>The goal of this objective is not to forbid alternate presentations, but to
 										ensure that deviations are only made to better represent the logical reading
 										order of the content.</p>
 								</dd>
 
-								<dt id="sec-mo-order-conf">Meeting this Objective</dt>
+								<dt id="sec-sync-order-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators SHOULD order the <code>par</code> and <code>seq</code> elements in
-										a Media Overlays Document such that they reflect both:</p>
+									<p>EPUB Creators SHOULD order the synchronized text-audio playback instructions such
+										that they reflect both:</p>
 									<ul>
 										<li>the order of the referenced EPUB Content Documents in the <a
 												href="https://www.w3.org/TR/epub/#dfn-spine">spine</a> [[EPUB-3]];
@@ -893,20 +898,25 @@
 									</ul>
 									<p>If EPUB Creators use a different ordering, that ordering MUST still result in a
 										logical playback of the content.</p>
+									<div class="note">
+										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-002">Specifying the reading
+												order</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
+											objective.</p>
+									</div>
 								</dd>
 							</dl>
 						</section>
 
-						<section id="sec-mo-skippability">
+						<section id="sec-sync-skippability">
 							<h6>Skippability</h6>
 
 							<dl>
-								<dt id="sec-mo-skippability-obj">Objective</dt>
+								<dt id="sec-sync-skippability-obj">Objective</dt>
 								<dd>
 									<p>Enable users to automatically skip over content.</p>
 								</dd>
 
-								<dt id="sec-mo-skippability-understand">Understanding this Objective</dt>
+								<dt id="sec-sync-skippability-understand">Understanding this Objective</dt>
 								<dd>
 									<p>Being able to read the primary narrative of a work without interruption is
 										central to reading comprehension. EPUB Creators typically structure EPUB
@@ -915,32 +925,36 @@
 										colours or placement so readers can filter this information visually out while
 										reading).</p>
 									<p>Readers who prefer auditory playback, however, cannot skip this information with
-										the same ease by default. Media overlays playback will typically result in
-										Reading Systems rendering secondary content where it occurs.</p>
-									<p>When EPUB Creators add structural semantics to Media Overlay Documents, however,
-										Reading Systems can create reading experiences that allow users to decide which
-										secondary content to skip by default during playback.</p>
+										the same ease by default. Synchronized text-audio playback will typically result
+										in Reading Systems rendering secondary content where it occurs.</p>
+									<p>When EPUB Creators add structural semantics, however, Reading Systems can create
+										reading experiences that allow users to decide which secondary content to skip
+										by default during playback.</p>
 								</dd>
 
-								<dt id="sec-mo-skippability-conf">Meeting this Objective</dt>
+								<dt id="sec-sync-skippability-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators SHOULD identify all <a
-											href="https://www.w3.org/TR/epub/#sec-skippability">skippable structures</a>
-										[[EPUB-3]] in Media Overlay Documents.</p>
+									<p>EPUB Creators SHOULD identify all skippable structures if the synchronized
+										text-audio playback format does not handle escaping content by default.</p>
+									<div class="note">
+										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-003">Identifying skippable
+												structures</a> [[EPUB-A11Y-TECH-11]] for more information on meeting
+											this objective.</p>
+									</div>
 								</dd>
 							</dl>
 						</section>
 
-						<section id="sec-mo-escapability">
+						<section id="sec-sync-escapability">
 							<h6>Escapability</h6>
 
 							<dl>
-								<dt id="sec-mo-escapability-obj">Objective</dt>
+								<dt id="sec-sync-escapability-obj">Objective</dt>
 								<dd>
 									<p>Enable users to automatically escape from structured content.</p>
 								</dd>
 
-								<dt id="sec-mo-escapability-understand">Understanding this Objective</dt>
+								<dt id="sec-sync-escapability-understand">Understanding this Objective</dt>
 								<dd>
 									<p>When reading visually, users can quickly move through, and escape from, highly
 										structured content such as tables, lists, and figures. Table layouts that use
@@ -948,50 +962,59 @@
 										find the information they want, and to easily return to the primary narrative
 										when they finish. Similarly, lists of items allow users to skim their content
 										and escape from them once they locate the desired information.</p>
-									<p>The same ease of escaping from content is not available in Media Overlay
-										Documents by default. Users cannot escape from table cells, rows, or even the
-										table itself, unless EPUB Creators encode the structural semantics of those
-										elements in the document.</p>
+									<p>The same ease of escaping from content is not always available in synchronized
+										text-audio playback. Users may not be able to escape from table cells, rows, or
+										even the table itself, unless EPUB Creators encode the structural semantics of
+										those elements.</p>
 									<p>When EPUB Creators provide this information, Reading Systems can simplify
 										playback for auditory readers to enable a comparable reading experience.</p>
 								</dd>
 
-								<dt id="sec-mo-escapability-conf">Meeting this Objective</dt>
+								<dt id="sec-sync-escapability-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators SHOULD identify all <a
-											href="https://www.w3.org/TR/epub/#sec-escapability">escapable structures</a>
-										[[EPUB-3]] in the Media Overlay Documents.</p>
+									<p>EPUB Creators SHOULD identify all escapable structures if the synchronized
+										text-audio playback format does not handle escaping content by default.</p>
+									<div class="note">
+										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-004">Identifying escapable
+												structures</a> [[EPUB-A11Y-TECH-11]] for more information on meeting
+											this objective.</p>
+									</div>
 								</dd>
 							</dl>
 						</section>
 
-						<section id="sec-mo-navdoc">
+						<section id="sec-sync-navdoc">
 							<h6>Navigation Document</h6>
 
 							<dl>
-								<dt id="sec-mo-navdoc-obj">Objective</dt>
+								<dt id="sec-sync-navdoc-obj">Objective</dt>
 								<dd>
 									<p>Ensure auditory playback is possible for the navigation aids in the EPUB
 										Navigation Document when presented by Reading Systems.</p>
 								</dd>
 
-								<dt id="sec-mo-navdoc-understand">Understanding this Objective</dt>
+								<dt id="sec-sync-navdoc-understand">Understanding this Objective</dt>
 								<dd>
 									<p>Reading Systems typically provide their own interfaces to the navigation aids in
 										the EPUB Navigation Document. For example, they open the table of contents as a
 										specialized interface on top of the content the user is reading.</p>
 									<p>To access these interfaces, users typically must rely on text-to-speech playback,
 										when available, to hear the entries.</p>
-									<p>Providing a Media Overlay Document for the EPUB Navigation Document provides
-										Reading Systems the ability to use auditory labels for the links, improving the
-										experience for auditory readers.</p>
+									<p>Providing synchronized text-audio playback for the EPUB Navigation Document
+										provides Reading Systems the ability to use auditory labels for the links,
+										improving the experience for auditory readers.</p>
 								</dd>
 
-								<dt id="sec-mo-navdoc-conf">Meeting this Objective</dt>
+								<dt id="sec-sync-navdoc-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators SHOULD include a Media Overlay Document for the <a
+									<p>EPUB Creators SHOULD provide synchronized text-audio playback for the <a
 											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB Navigation
 											Document</a> [[EPUB-3]].</p>
+									<div class="note">
+										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-005">Synchronizing the
+												Navigation Document</a> [[EPUB-A11Y-TECH-11]] for more information on
+											meeting this objective.</p>
+									</div>
 								</dd>
 							</dl>
 						</section>
@@ -1140,8 +1163,8 @@
 						<div class="note">
 							<p>If an organization evaluates an EPUB Publication, users will typically want to know the
 								name of that organization. This specification discourages including the name of the
-								individual(s) who carried out the assessment instead of the name of the organization,
-								as this can diminish the trust users have in the claim.</p>
+								individual(s) who carried out the assessment instead of the name of the organization, as
+								this can diminish the trust users have in the claim.</p>
 						</div>
 
 						<aside id="pub-ex" class="example" title="An EPUB Publication evaluated by the publisher">
@@ -1764,6 +1787,9 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>07-Apr-2021: Generalized discussion of synchronized text-audio playback objectives and moved
+					specific details of using Media Overlays to the techniques document. See <a
+						href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>
 				<li>23-Mar-2021: Clarified linking for WCAG conformance versions and levels. See <a
 						href="https://github.com/w3c/epub-specs/issues/2099">issue 2099</a>.</li>
 				<li>21-Mar-2022: Note that not all metadata expressions can be achieved in EPUB 2 due to the absence of

--- a/epub33/core/biblio.js
+++ b/epub33/core/biblio.js
@@ -86,6 +86,11 @@ var biblio = {
 	"US-ASCII": {
 		"title": "&quot;Coded Character Set - 7-bit American Standard Code for Information Interchange&quot;, ANSI X3.4, 1986."
 	},
+	"WAI-ARIA": {
+		"title": "Accessible Rich Internet Applications (WAI-ARIA)",
+		"href": "https://www.w3.org/TR/wai-aria/",
+		"publisher": "W3C"
+	},
 	"WCAG2": {
 		"title": "Web Content Accessibility Guidelines (WCAG) 2",
 		"href": "https://www.w3.org/TR/WCAG2/",

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9157,13 +9157,13 @@ html.my-document-playing * {
 
 					<ul>
 						<li>
-							<p>footnote</p>
+							<p><a data-cite="epub-ssv-11#footnote"><code>footnote</code></a> [[EPUB-SSV-11]]</p>
 						</li>
 						<li>
-							<p>endnote</p>
+							<p><a data-cite="epub-ssv-11#endnote"><code>endnote</code></a> [[EPUB-SSV-11]]</p>
 						</li>
 						<li>
-							<p>pagebreak</p>
+							<p><a data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code></a> [[EPUB-SSV-11]]</p>
 						</li>
 					</ul>
 
@@ -9252,28 +9252,30 @@ html.my-document-playing * {
 
 					<ul>
 						<li>
-							<p>table</p>
+							<p><a data-cite="epub-ssv-11#table"><code>table</code></a> [[EPUB-SSV-11]]</p>
 						</li>
 						<li>
-							<p>table-row</p>
+							<p><a data-cite="epub-ssv-11#list"><code>list</code></a> [[EPUB-SSV-11]]</p>
 						</li>
 						<li>
-							<p>table-cell</p>
+							<p><a data-cite="epub-ssv-11#figure"><code>figure</code></a> [[EPUB-SSV-11]]</p>
 						</li>
 						<li>
-							<p>list</p>
-						</li>
-						<li>
-							<p>list-item</p>
-						</li>
-						<li>
-							<p>figure</p>
+							<p><a data-cite="epub-ssv-11#aside"><code>aside</code></a> [[EPUB-SSV-11]]</p>
 						</li>
 					</ul>
 
 					<p>This list is non-exhaustive list, however. It represents terms from the Structural Semantics
 						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems are most likely to offer the option of
 						escapability.</p>
+
+					<div class="note">
+						<p>Sometimes escapable structures may contain escapable structures. For example, tables are
+							composed of many rows and cells that users may want to separately escape from. Reading
+							System support for escaping from such structures is complex and not well supported at this
+							time. EPUB Creators should avoid identifying nested escapable structures until better
+							support is available.</p>
+					</div>
 
 					<aside class="example" title="Escapable structures">
 						<p>In this example, the Media Overlay Document for an EPUB Content Document contains a
@@ -11082,7 +11084,8 @@ html.my-document-playing * {
 					</dd>
 				</dl>
 
-				<p>Additional examples on the usage of different types of resources can be found in <a href="#sec-item-elem-examples"></a>.</p>
+				<p>Additional examples on the usage of different types of resources can be found in <a
+						href="#sec-item-elem-examples"></a>.</p>
 			</section>
 
 			<section id="scripted-contexts-example">


### PR DESCRIPTION
This is my best attempt to make the accessibility objectives less tied to media overlays.

In place of "Media Overlays", I've used "Synchronized Text-Audio Playback" for the main specification.

I've also added a technique to match each objective. These should work as starters, but they need thorough review.

The examples I added for skippability and escapability were largely copied from the ones already in the media overlays section of the core spec. I just tweaked them to exemplify different semantics. I didn't try to make examples for the reading order and complete text techniques, as these would be complex and time-consuming to build. I don't think they're critical to have.

Let me know if you think I have anything wrong, or have thoughts on how to improve what's there.

Fixes #2221 


- [Accessibility preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2221/epub33/a11y/index.html)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2221/epub33/a11y/index.html)
- [Accessibility Techniques preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2221/epub33/a11y-tech/index.html)
- [Accessibility Techniques diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2221/epub33/a11y-tech/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2237.html" title="Last updated on Apr 12, 2022, 7:04 PM UTC (4433c5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2237/809b2e8...4433c5e.html" title="Last updated on Apr 12, 2022, 7:04 PM UTC (4433c5e)">Diff</a>