### PR TITLE
Add additional paragraphs about confidence in reporting

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1019,6 +1019,18 @@
 							href="#app-a11y-vocab">EPUB Accessibility Vocabulary</a>, as explained in more detail in the
 						following sections.</p>
 
+					<p>Although any individual or party can perform a conformance evaluation &#8212; provided they have
+						the knowledge and tools to assess EPUB Publications against the <a href="#sec-wcag-conf"
+							>WCAG</a> and <a href="#sec-epub-req">EPUB</a> requirements of this specification &#8212;
+						users need to be able to trust that evaluations are performed in a comprehensive manner and that
+						conformance claims are not influenced by self-interest in the outcome.</p>
+
+					<p>To address this confidence issue, some regions designate a local authority responsible for all
+						evaluations, in which case there is no flexibility in who can perform evaluations. Where such
+						authorities do not exist, evaluators are encouraged to obtain and reference any applicable <a
+							href="#sec-evaluator-credentials">credentials</a> to strengthen public confidence in their
+						evaluations.</p>
+
 					<div class="note">
 						<p>As each metadata format is unique in what it can express, this specification does not mandate
 							how to express conformance metadata outside of the EPUB Package Document.</p>
@@ -1133,15 +1145,10 @@
 							of the party that evaluated the EPUB Publication.</p>
 
 						<div class="note">
-							<p>Any individual or party can perform a conformance evaluation. The evaluator can be the
-								same party that created the EPUB Publication or a third party.</p>
-						</div>
-
-						<div class="note">
 							<p>If an organization evaluates an EPUB Publication, users will typically want to know the
 								name of that organization. This specification discourages including the name of the
-								individual(s) who carried out the assessment instead of the name of the organization,
-								as this can diminish the trust users have in the claim.</p>
+								individual(s) who carried out the assessment instead of the name of the organization, as
+								this can diminish the trust users have in the claim.</p>
 						</div>
 
 						<aside id="pub-ex" class="example" title="An EPUB Publication evaluated by the publisher">


### PR DESCRIPTION
This PR attempts to address #2217 by adding more detail about confidence in reporting to the introduction. The new text is:

> Although any individual or party can perform a conformance evaluation — provided they have the knowledge and tools to assess EPUB Publications against the [WCAG](#sec-wcag-conf) and [EPUB](#sec-epub-req) requirements of this specification — users need to be able to trust that evaluations are performed in a comprehensive manner and that conformance claims are not influenced by self-interest in the outcome.

> 
> To address this confidence issue, some regions designate a local authority responsible for all evaluations, in which case there is no flexibility in who can perform evaluations. Where such authorities do not exist, evaluators are encouraged to obtain and reference any applicable [credentials](#sec-evaluator-credentials) to strengthen public confidence in their evaluations.

I took this discussion out of the evaluator name field as this isn't specifically about the name of the evaluator but is more generally about reporting. It also touches on credentials.

Let me know if this works to close #2217.

- [Accessibility preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2217/epub33/a11y/index.html)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2217/epub33/a11y/index.html)


