### PR TITLE
Add note about prefixed properties not supporting newer syntaxes

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -294,7 +294,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-local-resource" data-lt="Container Resources">Container Resource</dfn>
+						<dfn class="export" id="dfn-local-resource" data-lt="Container Resources">Container
+							Resource</dfn>
 					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> that is located within the <a>EPUB Container</a>, as opposed to
@@ -321,8 +322,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-core-media-type-resource" data-lt="Core Media Type Resources">Core Media Type
-							Resource</dfn>
+						<dfn class="export" id="dfn-core-media-type-resource" data-lt="Core Media Type Resources">Core
+							Media Type Resource</dfn>
 					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> that conforms to one of the MIME media types [[RFC2046]] listed
@@ -348,7 +349,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-epub-content-document" data-lt="EPUB Content Documents">EPUB Content Document</dfn>
+						<dfn class="export" id="dfn-epub-content-document" data-lt="EPUB Content Documents">EPUB Content
+							Document</dfn>
 					</dt>
 					<dd>
 						<p>A <a>Publication Resource</a> referenced from the spine or a <a>manifest fallback chain</a>
@@ -365,27 +367,23 @@
 					</dt>
 					<dd>
 						<p>An individual, organization, or process that produces an <a>EPUB Publication</a>.</p>
-
 						<div class="note">
-							<p>
-								The creation of an EPUB Publication often involves the work of many individuals, 
-								and may be split across multiple organizations (e.g., when a publisher outsources 
-								all or part of the work).
-								Depending on the process used to produce an EPUB Publication, responsibilities may 
-								fall on the organization (e.g., the publisher), the individuals preparing the publication 
-								(e.g., technical editors), or automatic procedures (e.g., as part of a publication pipeline).
-								As a result, not every party or process may be responsible for ensuring every requirement is
-								met, but there is always an EPUB Creator responsible for the conformance of the
-								final EPUB Publication.
-							</p>
+							<p> The creation of an EPUB Publication often involves the work of many individuals, and may
+								be split across multiple organizations (e.g., when a publisher outsources all or part of
+								the work). Depending on the process used to produce an EPUB Publication,
+								responsibilities may fall on the organization (e.g., the publisher), the individuals
+								preparing the publication (e.g., technical editors), or automatic procedures (e.g., as
+								part of a publication pipeline). As a result, not every party or process may be
+								responsible for ensuring every requirement is met, but there is always an EPUB Creator
+								responsible for the conformance of the final EPUB Publication. </p>
 							<p>Previous versions of this specification referred to the EPUB Creator as the <span
-								id="dfn-author">Author</span>.</p>
+									id="dfn-author">Author</span>.</p>
 						</div>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-epub-navigation-document" data-lt="EPUB Navigation Documents">EPUB Navigation
-							Document</dfn>
+						<dfn class="export" id="dfn-epub-navigation-document" data-lt="EPUB Navigation Documents">EPUB
+							Navigation Document</dfn>
 					</dt>
 					<dd>
 						<p>A specialization of the <a>XHTML Content Document</a> that contains human- and
@@ -403,15 +401,16 @@
 							specification does not restrict the nature of the content.</p>
 					</dd>
 
-					<dt><dfn class="export" id="dfn-epub-reading-system" data-lt="EPUB Reading Systems|Reading System|Reading Systems"
-							>EPUB Reading System</dfn> (or Reading System)</dt>
+					<dt><dfn class="export" id="dfn-epub-reading-system"
+							data-lt="EPUB Reading Systems|Reading System|Reading Systems">EPUB Reading System</dfn> (or
+						Reading System)</dt>
 					<dd>
 						<p>A system that processes <a>EPUB Publications</a> for presentation to a user in a manner
 							conformant with this specification.</p>
 					</dd>
 
-					<dt><dfn class="export" id="dfn-epub-conformance-checker" data-lt="EPUB Conformance Checkers">EPUB Conformance
-							Checker</dfn></dt>
+					<dt><dfn class="export" id="dfn-epub-conformance-checker" data-lt="EPUB Conformance Checkers">EPUB
+							Conformance Checker</dfn></dt>
 					<dd>
 						<p>An application that verifies the requirements of this specification against <a>EPUB
 								Publications</a> and reports on their conformance.</p>
@@ -446,7 +445,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-fixed-layout-document" data-lt="Fixed-Layout Documents">Fixed-Layout Document</dfn>
+						<dfn class="export" id="dfn-fixed-layout-document" data-lt="Fixed-Layout Documents">Fixed-Layout
+							Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> with fixed dimensions directly referenced from the
@@ -455,8 +455,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-foreign-content-document" data-lt="Foreign Content Documents">Foreign Content
-							Document</dfn>
+						<dfn class="export" id="dfn-foreign-content-document" data-lt="Foreign Content Documents"
+							>Foreign Content Document</dfn>
 					</dt>
 					<dd>
 						<p>Any <a>Publication Resource</a> referenced from a <a>spine</a>
@@ -507,8 +507,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-media-overlay-document" data-lt="Media Overlay Documents">Media Overlay
-							Document</dfn>
+						<dfn class="export" id="dfn-media-overlay-document" data-lt="Media Overlay Documents">Media
+							Overlay Document</dfn>
 					</dt>
 					<dd>
 						<p>An XML document that associates the <a>XHTML Content Document</a> with pre-recorded audio
@@ -526,8 +526,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-ocf-abstract-container" data-lt="OCF Abstract Containers">OCF Abstract
-							Container</dfn>
+						<dfn class="export" id="dfn-ocf-abstract-container" data-lt="OCF Abstract Containers">OCF
+							Abstract Container</dfn>
 					</dt>
 					<dd>
 						<p>The OCF Abstract Container defines a file system model for the contents of the <a>OCF ZIP
@@ -546,7 +546,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-publication-resource" data-lt="Publication Resources">Publication Resource</dfn>
+						<dfn class="export" id="dfn-publication-resource" data-lt="Publication Resources">Publication
+							Resource</dfn>
 					</dt>
 					<dd>
 						<p>A resource that contains content or instructions that contribute to the logic and rendering
@@ -595,8 +596,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-scripted-content-document" data-lt="Scripted Content Documents">Scripted Content
-							Document</dfn>
+						<dfn class="export" id="dfn-scripted-content-document" data-lt="Scripted Content Documents"
+							>Scripted Content Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> that includes scripting or an <a>XHTML Content Document</a>
@@ -615,7 +616,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-svg-content-document" data-lt="SVG Content Documents">SVG Content Document</dfn>
+						<dfn class="export" id="dfn-svg-content-document" data-lt="SVG Content Documents">SVG Content
+							Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> that conforms to the constraints expressed in <a
@@ -630,8 +632,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-top-level-content-document" data-lt="Top-level Content Documents">Top-level Content
-							Document</dfn>
+						<dfn class="export" id="dfn-top-level-content-document" data-lt="Top-level Content Documents"
+							>Top-level Content Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> or <a>Foreign Content Document</a> referenced from the
@@ -659,8 +661,8 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-xhtml-content-document" data-lt="XHTML Content Documents">XHTML Content
-							Document</dfn>
+						<dfn class="export" id="dfn-xhtml-content-document" data-lt="XHTML Content Documents">XHTML
+							Content Document</dfn>
 					</dt>
 					<dd>
 						<p>An <a>EPUB Content Document</a> that conforms to the profile of [[HTML]] defined in <a
@@ -801,8 +803,8 @@
 				<section id="sec-manifest-plane">
 					<h4>The Manifest Plane</h4>
 
-					<p>To <dfn class="export">manifest plane</dfn> defines all the resources of an <a>EPUB Publication</a>. It is
-						analogous to the <a>Package Document</a>
+					<p>To <dfn class="export">manifest plane</dfn> defines all the resources of an <a>EPUB
+							Publication</a>. It is analogous to the <a>Package Document</a>
 						<a>manifest</a>, but includes resources not present in that list.</p>
 
 					<p>The primary resources in this group are designated <a>Publication Resources</a>, which are all
@@ -848,11 +850,12 @@
 				<section id="sec-spine-plane">
 					<h4>The Spine Plane</h4>
 
-					<p>The <dfn class="export">spine plane</dfn> defines resources used in the default reading order established by the
-							<a>spine</a>, which includes both <a href="#attrdef-itemref-linear">linear and non-linear
-							content</a>. The spine instructs <a>Reading Systems</a> on how to load these resources as
-						the user progresses through the <a>EPUB Publication</a>. Although many resources may be bundled
-						in an <a>EPUB Container</a>, they are not all allowed by default in the spine.</p>
+					<p>The <dfn class="export">spine plane</dfn> defines resources used in the default reading order
+						established by the <a>spine</a>, which includes both <a href="#attrdef-itemref-linear">linear
+							and non-linear content</a>. The spine instructs <a>Reading Systems</a> on how to load these
+						resources as the user progresses through the <a>EPUB Publication</a>. Although many resources
+						may be bundled in an <a>EPUB Container</a>, they are not all allowed by default in the
+						spine.</p>
 
 					<p>EPUB 3 defines a special class of resources called <a>EPUB Content Documents</a> that <a>EPUB
 							Creators</a> can use in the spine without any restrictions. EPUB Content Documents encompass
@@ -895,10 +898,10 @@
 				<section id="sec-content-plane">
 					<h4>The Content Plane</h4>
 
-					<p>The <dfn class="export">content plane</dfn> classifies resources that are used when rendering <a>EPUB Content
-							Documents</a> and <a>Foreign Content Documents</a>. These types of resources include
-						embedded media, CSS style sheets, scripts, and fonts. These resources fall into three categories
-						based on their Reading System support: <a>Core Media Type Resources</a>, <a>Foreign
+					<p>The <dfn class="export">content plane</dfn> classifies resources that are used when rendering
+							<a>EPUB Content Documents</a> and <a>Foreign Content Documents</a>. These types of resources
+						include embedded media, CSS style sheets, scripts, and fonts. These resources fall into three
+						categories based on their Reading System support: <a>Core Media Type Resources</a>, <a>Foreign
 							Resources</a>, and <a>Exempt Resources</a>.</p>
 
 					<p>A Core Media Type Resource is one that <a>Reading Systems</a> have to support, so it can be used
@@ -1296,9 +1299,9 @@
 				<section id="sec-manifest-fallbacks">
 					<h5>Manifest Fallbacks</h5>
 
-					<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create a <dfn class="export">manifest
-							fallback chain</dfn> for a <a>Publication Resource</a>, allowing Reading Systems to select
-						an alternative format they can render.</p>
+					<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create a <dfn class="export"
+							>manifest fallback chain</dfn> for a <a>Publication Resource</a>, allowing Reading Systems
+						to select an alternative format they can render.</p>
 
 					<p>Fallback chains are created using the <a href="#attrdef-item-fallback"><code>fallback</code>
 							attribute</a> on manifest <a href="#sec-item-elem"><code>item</code> elements</a>. This
@@ -1797,8 +1800,8 @@
 				<section id="sec-file-names-to-path-names">
 					<h4>Deriving File Paths</h4>
 
-					<p>To <strong>derive the File Path</strong>, given a file or directory <var>file</var>
-						in the <a href="#sec-container-abstract">OCF Abstract Container</a>, apply the following steps
+					<p>To <strong>derive the File Path</strong>, given a file or directory <var>file</var> in the <a
+							href="#sec-container-abstract">OCF Abstract Container</a>, apply the following steps
 						(expressed using the terminology of [[INFRA]]):</p>
 
 					<ol class="algorithm">
@@ -1869,7 +1872,8 @@
 								<code>A/B/C/file%20name.xhtml</code>. </p>
 					</div>
 
-					<p> A string <var>url</var> is a <dfn class="export" id="dfn-valid-relative-container-url-with-fragment-string"
+					<p> A string <var>url</var> is a <dfn class="export"
+							id="dfn-valid-relative-container-url-with-fragment-string"
 							>valid-relative-ocf-URL-with-fragment string</dfn> if it is a <a
 							data-cite="url#path-relative-scheme-less-url-string">path-relative-scheme-less-URL
 							string</a>, optionally followed by <code>U+0023 (#)</code> and a <a
@@ -6203,10 +6207,6 @@ No Entry</pre>
 								move to unprefixed versions as soon as support allows, as the Working Group does not
 								anticipate supporting them in the next major version of EPUB.</p>
 						</div>
-
-						<p class="note">In some cases, the unprefixed versions of these properties now support
-							additional values. Reading Systems may support these values even with the prefixed
-							property.</p>
 					</section>
 				</section>
 
@@ -10414,6 +10414,11 @@ html.my-document-playing * {
 
 			<p>This appendix describes the prefixed CSS properties supported by EPUB. </p>
 
+			<p class="note">The prefix definitions are no longer being synchronized with their CSS counterparts. In some
+				cases, the unprefixed versions of these properties now support additional values. Reading Systems may
+				not support the new syntax with the prefixed properties, so EPUB Creators are advised to use the
+				unprefixed versions for newer features.</p>
+
 			<section id="sec-css-prefixed-writing-modes">
 				<h5>CSS Writing Modes</h5>
 
@@ -11091,7 +11096,8 @@ html.my-document-playing * {
 					</dd>
 				</dl>
 
-				<p>Additional examples on the usage of different types of resources can be found in <a href="#sec-item-elem-examples"></a>.</p>
+				<p>Additional examples on the usage of different types of resources can be found in <a
+						href="#sec-item-elem-examples"></a>.</p>
 			</section>
 
 			<section id="scripted-contexts-example">


### PR DESCRIPTION
Adds the note as described in #2153 to the appendix and removes the older version that was getting lost under the caution box in the body.

Fixes #2153


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2240.html" title="Last updated on Apr 8, 2022, 4:09 PM UTC (6f6ef35)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2240/5094ff7...6f6ef35.html" title="Last updated on Apr 8, 2022, 4:09 PM UTC (6f6ef35)">Diff</a>