### PR TITLE
Mention permissions for Geolocation and Push APIs

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9642,7 +9642,7 @@ html.my-document-playing * {
 					<li>Not using scripts to send or receive data over the network without the consent of the user.</li>
 					<li>Obtaining user consent for the use of Web APIs with privacy implications, such as
 						<a href="https://www.w3.org/TR/geolocation/">Geolocation</a> and 
-						<a href="https://www.w3.org/TR/push-api""/>Push Notifications</a>.</li>
+						<a href="https://www.w3.org/TR/push-api"/>Push Notifications</a>.</li>
 					<li>Avoiding embedding content not provided by reputable organizations or individuals.</li>
 					<li>Avoiding deprecated features of EPUB due to the potential for undiscovered bugs in
 						implementations.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9640,7 +9640,7 @@ html.my-document-playing * {
 					<li>Avoiding links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
 					<li>Using secure connections to external sites and resources (i.e., using the HTTPS protocol).</li>
 					<li>Not using scripts to send or receive data over the network without the consent of the user.</li>
-					<li>Obtaining consent for the use of Web APIs with privacy implications, such as
+					<li>Obtaining user consent for the use of Web APIs with privacy implications, such as
 						<a href="https://www.w3.org/TR/geolocation/">Geolocation</a> and 
 						<a href="https://www.w3.org/TR/push-api""/>Push Notifications</a>.</li>
 					<li>Avoiding embedding content not provided by reputable organizations or individuals.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9640,6 +9640,9 @@ html.my-document-playing * {
 					<li>Avoiding links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
 					<li>Using secure connections to external sites and resources (i.e., using the HTTPS protocol).</li>
 					<li>Not using scripts to send or receive data over the network without the consent of the user.</li>
+					<li>Obtaining consent for the use of Web APIs with privacy implications, such as
+						<a href="https://www.w3.org/TR/geolocation/">Geolocation</a> and 
+						<a href="https://www.w3.org/TR/push-api""/>Push Notifications</a>.</li>
 					<li>Avoiding embedding content not provided by reputable organizations or individuals.</li>
 					<li>Avoiding deprecated features of EPUB due to the potential for undiscovered bugs in
 						implementations.</li>


### PR DESCRIPTION
In response to https://github.com/w3c/epub-specs/issues/1958#issuecomment-1088653587

Given that this is a non-normative suggestion, does this need to be in the change log?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dauwhe/epub-specs/pull/2242.html" title="Last updated on Apr 12, 2022, 4:12 AM UTC (6c4954f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2242/1ade29a...dauwhe:6c4954f.html" title="Last updated on Apr 12, 2022, 4:12 AM UTC (6c4954f)">Diff</a>