### PR TITLE
Fix broken a tag

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9640,9 +9640,9 @@ html.my-document-playing * {
 					<li>Avoiding links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
 					<li>Using secure connections to external sites and resources (i.e., using the HTTPS protocol).</li>
 					<li>Not using scripts to send or receive data over the network without the consent of the user.</li>
-					<li>Obtaining user consent for the use of Web APIs with privacy implications, such as
-						<a href="https://www.w3.org/TR/geolocation/">Geolocation</a> and 
-						<a href="https://www.w3.org/TR/push-api"/>Push Notifications</a>.</li>
+					<li>Obtaining user consent for the use of Web APIs with privacy implications, such as <a
+							href="https://www.w3.org/TR/geolocation/">Geolocation</a> [[GEOLOCATION]] and <a
+							href="https://www.w3.org/TR/push-api">Push Notifications</a> [[PUSH-API]].</li>
 					<li>Avoiding embedding content not provided by reputable organizations or individuals.</li>
 					<li>Avoiding deprecated features of EPUB due to the potential for undiscovered bugs in
 						implementations.</li>


### PR DESCRIPTION
Missed in the last PR that the first `a` tag was self-closing.

We should also have informative references for the two specs mentioned.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2243.html" title="Last updated on Apr 12, 2022, 9:53 AM UTC (fd48315)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2243/524c0c4...fd48315.html" title="Last updated on Apr 12, 2022, 9:53 AM UTC (fd48315)">Diff</a>