### PR TITLE
Fixes to page navigation requirements

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1776,6 +1776,11 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>12-Apr-2022: Restored recommendation to include links to all reproduced pages in the page list and
+					added a requirement to link to all page break markers to address concerns with the previous change.
+					Clarified that meeting the page navigation requirements is required, but adding page navigation is
+					only recommended in some circumstances. See <a href="https://github.com/w3c/epub-specs/pull/2246"
+						>pull request 2246</a>.</li>
 				<li>08-Apr-2022: Changed the recommendation to include links to all reproduced pages in the page list to
 					a requirement. See <a href="https://github.com/w3c/epub-specs/issues/2220">issue 2220</a>.</li>
 				<li>23-Mar-2022: Clarified linking for WCAG conformance versions and levels. See <a

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -634,8 +634,8 @@
 						<p>EPUB Creators MAY include page navigation in reflowable EPUB Publications without statically
 							paginated equivalents.</p>
 
-						<p>When page navigation is included, the objectives defined in this section apply to the EPUB
-							Publication.</p>
+						<p>When EPUB Creators include page navigation, the objectives defined in this section apply to
+							the EPUB Publication.</p>
 					</section>
 
 					<section id="sec-page-nav-obj">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -616,8 +616,8 @@
 					<section id="sec-page-nav-applicability">
 						<h5>Applicability</h5>
 
-						<p>An EPUB Publication SHOULD meet the page navigation objectives defined in this section
-							whenever any of the following cases is true:</p>
+						<p>An EPUB Publication SHOULD include page navigation whenever any of the following cases is
+							true:</p>
 
 						<ul>
 							<li>the EPUB Creator identifies the EPUB Publication as the dynamically paginated equivalent
@@ -633,6 +633,9 @@
 
 						<p>EPUB Creators MAY include page navigation in reflowable EPUB Publications without statically
 							paginated equivalents.</p>
+
+						<p>When page navigation is included, the objectives defined in this section apply to the EPUB
+							Publication.</p>
 					</section>
 
 					<section id="sec-page-nav-obj">
@@ -704,9 +707,11 @@
 								<dt id="sec-page-list-conf">Meeting this Objective</dt>
 								<dd>
 									<p>An EPUB Publication MUST include a page list.</p>
-									<p>EPUB Creators MUST include links to all pages of content reproduced from the
+									<p>EPUB Creators SHOULD include links to all pages of content reproduced from the
 										source (i.e., they do not have to provide links for blank pages or content not
 										reproduced in the digital edition).</p>
+									<p>EPUB Creators MUST include links to all <a href="#sec-page-breaks-obj">page break
+											markers</a> in the content.</p>
 									<p>EPUB Creators should include links for all pages in the source whether they are
 										reproduced or not, but this is not a requirement.</p>
 									<div class="note">


### PR DESCRIPTION
The concerns raised by @gregoriopellegrino in #2238 made me notice that our requirements on page navigation changed from a requirement to a recommendation because of this paragraph:

> An EPUB Publication SHOULD meet the page navigation objectives defined in this section whenever any of the following cases is true:

EPUB Creators should include page navigation in the listed circumstances, but they still have to meet the requirements. I believe we changed this to try and work around requiring objectives that aren't necessarily required to be met.

I believe we can better address this split by returning the above sentence back to its original form:

> An EPUB Publication SHOULD include page navigation whenever any of the following cases is true:

We can address the need to meet the objectives without making a normative statements about at what conformance level by simply adding the following paragraph to the end of the applicability section:

> When EPUB Creators include page navigation, the objectives defined in this section apply to the EPUB Publication.

This pull request implements both these changes.

To address @gregoriopellegrino's concerns with the previous pull request, I've returned the requirement to link to all page breaks to a SHOULD.

To address the concern about this leading to page lists with only a single entry (the minimum you have to specify to be valid), I've added the following new bullet:

> EPUB Creators MUST include links to all [page break markers](#sec-page-breaks-obj) in the content.

Not only does this make us consistent with the forthcoming [2.4.13 SC to provide page navigation](https://www.w3.org/TR/WCAG22/#page-break-navigation), but it only allows omissions from the page list when there are no markers in the text. That will provide flexibility for books that may not have markers but are reproduced from another source.

Let me know if this works for everyone now.

- [Accessibility preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2220-redux/epub33/a11y/index.html)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2220-redux/epub33/a11y/index.html)
