### PR TITLE
Add terminology linking to a11y docs

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -49,6 +49,7 @@
 					branch: "main"
 				},
 				xref: ["epub-33"],
+				profile: "web-platform",
 				localBiblio: {
 					"A11Y-DISCOV-VOCAB": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -377,8 +377,8 @@
 					</li>
 					<li>
 						<p>motion simulation — if a resource simulates motion, it can cause a user to become nauseated
-							(e.g., a video game drawn on the [[HTML]] <a data-cite="html#the-canvas-element"
-									><code>canvas</code> element</a> or parallax scrolling with CSS).</p>
+							(e.g., a video game drawn on the [[HTML]] <a data-lt="canvas"
+								><code>canvas</code> element</a> or parallax scrolling with CSS).</p>
 					</li>
 					<li>
 						<p>sound — certain sound patterns, such as ringing and buzzing, can cause seizures, while loud
@@ -863,7 +863,7 @@
 					<p>Since each attribute offers different advantages, it is not necessary that they be used together.
 						Due to the lack of restrictions on where <a>EPUB Creators</a> can use the <code>type</code>
 						attribute, pairing the attributes may cause accessibility issues (e.g., putting roles on the
-						[[HTML]] <code>body</code> element).</p>
+						[[HTML]] <a data-lt="body"><code>body</code> element</a>).</p>
 
 					<p>In particular, the use of the <code>type</code> attribute is not a means of satisfying
 						requirements for ARIA roles in WCAG.</p>
@@ -898,11 +898,11 @@
 
 					<p>To counteract this destructuring effect, EPUB Creators sometimes think to re-add or re-identify
 						structures in the belief that having this information in every document will be helpful to users
-						(e.g., adding an extra [[HTML]] <code>section</code> element around a chapter to indicate it
-						belongs to a part, or putting the part semantic on the <code>body</code> tag). All this practice
-						does, however, is add repetition that is not only disruptive when reading but can make the
-						structure of the publication harder to follow. EPUB Creators are therefore advised not to
-						attempt to rebuild structures in these ways.</p>
+						(e.g., adding an extra [[HTML]] <a data-lt="section"><code>section</code> element</a> around a
+						chapter to indicate it belongs to a part, or putting the part semantic on the
+						<code>body</code> tag). All this practice does, however, is add repetition that is not only
+						disruptive when reading but can make the structure of the publication harder to follow. EPUB
+						Creators are therefore advised not to attempt to rebuild structures in these ways.</p>
 
 					<p>For example, consider a book that has five parts and each part contains five chapters.
 						Structurally, each chapter belongs to its part (i.e., is grouped with it), as in the following
@@ -1148,8 +1148,9 @@
 						to end, even though the content is often split across numerous <a>EPUB Content Documents</a>. As
 						a result, their natural expectation is that the headings reflect their position in the overall
 						hierarchy of the publication, despite the publication not actually being a single document
-						(e.g., if a part heading is expressed in an [[HTML]] <code>h1</code> element, each chapter that
-						belongs to the part will have an <code>h2</code> heading).</p>
+						(e.g., if a part heading is expressed in an [[HTML]] <a data-lt="h1"
+						><code>h1</code> element</a>, each chapter that belongs to the part will have an <a data-lt="h2"
+								><code>h2</code></a> heading).</p>
 
 					<p>Technique <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G141">G141: Organizing a page
 							using headings</a> instructs <a>EPUB Creators</a> on correctly using numbered headings
@@ -1464,10 +1465,9 @@
 &lt;/html></pre>
 					</aside>
 
-					<p>Do not use the [[HTML]] <a data-cite="html#the-a-element"><code>a</code> element</a> to identify
-						page break locations in EPUB 3 Publications. Although this element was previously defined as the
-						anchor for a hyperlink destination, its purpose has been changed in [[HTML]] for use solely as a
-						link.</p>
+					<p>Do not use the [[HTML]] <a data-lt="a"><code>a</code> element</a> to identify page break
+						locations in EPUB 3 Publications. Although this element was previously defined as the anchor for
+						a hyperlink destination, its purpose has been changed in [[HTML]] for use solely as a link.</p>
 				</section>
 
 				<section id="page-002">
@@ -1696,11 +1696,10 @@
 						Publication. The minimal candidates for synchronization with audio are all the elements with
 						visible text content.</p>
 
-					<p>In HTML, the class of elements called <a data-cite="html#palpable-content">palpable content</a>
-						[[HTML]] can typically be synchronized with audio or have their own built-in audio. Embedded
-						text in SVG documents, on the other hand, is found in the <a
-							href="https://www.w3.org/TR/SVG/text.html#TextElement"><code>text</code> element</a> [[SVG]]
-						and its descendants.</p>
+					<p>In HTML, the class of elements called <a>palpable content</a> [[HTML]] can typically be
+						synchronized with audio or have their own built-in audio. Embedded text in SVG documents, on the
+						other hand, is found in the <a href="https://www.w3.org/TR/SVG/text.html#TextElement"
+								><code>text</code> element</a> [[SVG]] and its descendants.</p>
 
 					<p>The Media Overlays <a data-cite="epub-33#sec-smil-text-elem"><code>text</code> element</a> is
 						used to reference these elements, either to play back the pre-recorded audio in a sibling <a
@@ -1713,8 +1712,8 @@
 							presentation like Media Overlays. Synchronizing audio with invisible text will be confusing
 							for sighted readers following the playback.</p>
 
-						<p>Text content in a collapsed element, like the <a data-cite="html#the-details-element"
-									><code>details</code> element</a> [[HTML]], is not considered hidden content.</p>
+						<p>Text content in a collapsed element, like the <a data-lt="details"><code>details</code>
+								element</a> [[HTML]], is not considered hidden content.</p>
 					</div>
 
 					<p>In addition to synchronizing the visible text, synchronized text-audio playback must also address
@@ -1724,7 +1723,7 @@
 						providing the user all the information in the EPUB Publication.</p>
 
 					<p>Text alternatives and descriptions in HTML may be represented in the <a
-							data-cite="html#attr-img-alt"><code>alt</code> attribute</a> [[HTML]] and linked by ARIA
+							data-lt="html#attr-img-alt"><code>alt</code> attribute</a> [[HTML]] and linked by ARIA
 						attributes (e.g., <a data-cite="wai-aria#aria-describedby"><code>aria-describedby</code></a> and
 							<a data-cite="wai-aria#aria-details"><code>aria-details</code></a> [[WAI-ARIA]]).
 						Descriptions for image elements in SVG are typically represented in a <a

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -125,19 +125,11 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This document uses <a data-cite="epub-33#sec-terminology">terminology defined in EPUB 3</a>
-					[[EPUB-3]]:</p>
-
-				<p>In addition, it uses the <a data-cite="WCAG2#dfn-assistive-technologies">WCAG 2 definition</a> of
-						<dfn data-lt="assistive technologies">Assistive Technology</dfn>.</p>
+				<p>This document uses terminology defined in <a data-cite="epub-a11y-11#sec-terminology">EPUB 3.3</a>
+					[[EPUB-33]] and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.1</a>
+					[[EPUB-A11Y-11]]:</p>
 
 				<p>Only the first instance of a term in a section links to its definition.</p>
-
-				<div class="note">
-					<p>An Assistive Technology is not always a separate application from a <a>Reading System</a>.
-						Reading Systems often integrate features of standalone Assistive Technologies, such as
-						text-to-speech playback.</p>
-				</div>
 			</section>
 		</section>
 		<section id="sec-about">
@@ -1389,8 +1381,8 @@
 					between the available options. This functionality technically meets the requirements of [[WCAG2]] in
 					terms of ensuring the user can access the accessible version.</p>
 
-				<p>In practice, however, the [[EPUB-MULTI-REND-11]] specification is not broadly supported in
-					Reading Systems at the time of publication. As a result, a user who obtains an EPUB Publication that
+				<p>In practice, however, the [[EPUB-MULTI-REND-11]] specification is not broadly supported in Reading
+					Systems at the time of publication. As a result, a user who obtains an EPUB Publication that
 					contains more than one rendition will only have access to the default. Unless this rendition is the
 					accessible one, the EPUB Publication might not be readable by them.</p>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -48,6 +48,7 @@
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
+				xref: ["epub-33"],
 				localBiblio: {
 					"A11Y-DISCOV-VOCAB": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
@@ -124,7 +125,7 @@
 				<h3>Purpose and Scope</h3>
 
 				<p>This document, EPUB Accessibility Techniques, provides guidance on how to meet the
-					[[EPUB-A11Y-11]] discovery and accessibility requirements for EPUB Publications.</p>
+					[[EPUB-A11Y-11]] discovery and accessibility requirements for <a>EPUB Publications</a>.</p>
 
 				<p>This document does not cover techniques and best practices already addressed in [[WCAG2]] and
 					[[WAI-ARIA]] for which no substantive differences in application exist.</p>
@@ -133,40 +134,17 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This document uses the following terminology defined in EPUB 3 [[EPUB-3]]:</p>
+				<p>This document uses terminology defined in EPUB 3 [[EPUB-3]]:</p>
 
-				<ul>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB Content Document</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB Creator</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-navigation-document">EPUB Navigation Document</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB Publication</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-media-overlay-document">Media Overlays Document</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-package-document">Package Document</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">Reading System</a>
-					</li>
-				</ul>
+				<p>In addition, it uses the <a href="https://www.w3.org/TR/WCAG2/#dfn-assistive-technologies">WCAG 2
+						definition</a> of <dfn data-lt="assistive technologies">Assistive Technology</dfn>.</p>
 
-				<p>In addition, it uses the definition of <a
-						href="https://www.w3.org/TR/WCAG2/#dfn-assistive-technologies">assistive technology</a> as
-					defined in [[WCAG2]].</p>
+				<p>Only the first instance of a term in a section links to its definition.</p>
 
 				<div class="note">
-					<p>An assistive technology is not always a separate application from a Reading System. Reading
-						Systems often integrate features of standalone assistive technologies, such as text-to-speech
-						playback.</p>
+					<p>An Assistive Technology is not always a separate application from a <a>Reading System</a>.
+						Reading Systems often integrate features of standalone Assistive Technologies, such as
+						text-to-speech playback.</p>
 				</div>
 			</section>
 		</section>
@@ -174,9 +152,10 @@
 			<h2>About the Techniques</h2>
 
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
-				EPUB Creators create EPUB Publications that conform to the requirements in [[EPUB-A11Y-11]], but they
-				are not all applicable in all situations and there may be other ways to meet the requirements of that
-				specification. As a result, this document should not be read as providing prescriptive requirements.</p>
+					<a>EPUB Creators</a> create <a>EPUB Publications</a> that conform to the requirements in
+				[[EPUB-A11Y-11]], but they are not all applicable in all situations and there may be other ways to meet
+				the requirements of that specification. As a result, this document should not be read as providing
+				prescriptive requirements.</p>
 
 			<p>These techniques also do not address issues in digital publishing for which no universally accessible
 				solutions exist. The W3C's Digital Publishing Interest Group has published a note that outlines many of
@@ -200,8 +179,8 @@
 
 				<p>An access mode is defined as a "human sense perceptual system or cognitive faculty through which a
 					user may process or perceive the content of a digital resource." [[ISO24751-3]] For example, if an
-					EPUB Publication contains images and video, visual perception is required to consume the content
-					exactly as it was created.</p>
+						<a>EPUB Publication</a> contains images and video, visual perception is required to consume the
+					content exactly as it was created.</p>
 
 				<p>There are four access modes that are typically specified for EPUB Publications:</p>
 
@@ -253,20 +232,20 @@
 			<section id="meta-002">
 				<h3>Identify sufficient access modes</h3>
 
-				<p>The access modes sufficient to consume an EPUB Publication express a broader picture of the potential
-					usability than do the <a href="#meta-001">basic access modes</a>. Where the basic access modes
-					identify the default nature of the media used in the publication, sufficient access modes identify
-					which modes, or sets of modes, a user requires to read the publication. Sufficient access modes
-					account for the affordances and adaptations that have been provided, allowing a user to determine
-					whether the content will be usable regardless of its default nature.</p>
+				<p>The access modes sufficient to consume an <a>EPUB Publication</a> express a broader picture of the
+					potential usability than do the <a href="#meta-001">basic access modes</a>. Where the basic access
+					modes identify the default nature of the media used in the publication, sufficient access modes
+					identify which modes, or sets of modes, a user requires to read the publication. Sufficient access
+					modes account for the affordances and adaptations that have been provided, allowing a user to
+					determine whether the content will be usable regardless of its default nature.</p>
 
 				<p>Sufficient access modes are identified in the [[schema-org]] <a
 						href="https://schema.org/accessModeSufficient"><code>accessModeSufficient</code> property</a>.
 					Repeat the property for each set of sufficient access modes.</p>
 
 				<p>For example, consider an EPUB Publication that contains graphics and charts, as well as descriptions
-					for all these images. The publication has both textual and visual content, so the EPUB Creator will
-					include the following metadata entries to indicate this:</p>
+					for all these images. The publication has both textual and visual content, so the <a>EPUB
+						Creator</a> will include the following metadata entries to indicate this:</p>
 
 				<pre>&lt;meta
     property="schema:accessMode">
@@ -341,19 +320,19 @@
 
 				<div class="note">
 					<p>The <code>accessModeSufficient</code> property, as defined in [[schema-org]], allows more
-						complicated expressions than can be represented in the EPUB 2 or 3 Package Document (e.g.,
-						definition of lists of values and inclusion of a human-readable description). A future version
-						of EPUB might allow for richer metadata, but the basic expression shown in this section is
-						sufficient for discovery purposes.</p>
+						complicated expressions than can be represented in the EPUB 2 or 3 <a>Package Document</a>
+						(e.g., definition of lists of values and inclusion of a human-readable description). A future
+						version of EPUB might allow for richer metadata, but the basic expression shown in this section
+						is sufficient for discovery purposes.</p>
 				</div>
 			</section>
 
 			<section id="meta-003">
 				<h3>Identify accessibility features</h3>
 
-				<p>Identifying all the accessibility features and adaptations included in an EPUB Publication allows
-					users to determine whether the content is usable at a more fine-grained level than the access modes
-					do.</p>
+				<p>Identifying all the accessibility features and adaptations included in an <a>EPUB Publication</a>
+					allows users to determine whether the content is usable at a more fine-grained level than the access
+					modes do.</p>
 
 				<p>For example, a math textbook might have a textual access mode, but that alone does not indicate
 					whether MathML markup is available. Whether a visual work only provides alternative text or whether
@@ -407,8 +386,8 @@
 					</li>
 				</ul>
 
-				<p>EPUB Creators have to report whether their EPUB Publications contain resources that present any of
-					these hazards to users, as they can have real physical effects.</p>
+				<p><a>EPUB Creators</a> have to report whether their <a>EPUB Publications</a> contain resources that
+					present any of these hazards to users, as they can have real physical effects.</p>
 
 				<div class="note">
 					<p>What precisely constitutes a sound hazard, and how to test for these hazards, is not standardized
@@ -459,7 +438,7 @@
 				<h3>Include an accessibility summary</h3>
 
 				<p>An accessibility summary provides a brief, human-readable description of the accessibility
-					characteristics of an EPUB Publication, or lack thereof.</p>
+					characteristics of an <a>EPUB Publication</a>, or lack thereof.</p>
 
 				<p>If an EPUB Publication does not meet the requirements for content accessibility in [[EPUB-A11Y-11]],
 					the reason(s) it fails should be noted in the summary.</p>
@@ -498,9 +477,9 @@
 			<section id="meta-006">
 				<h3>Identify ARIA Conformance</h3>
 
-				<p>The use of the <code>schema:accesibilityAPI</code> property is no longer necessary for EPUB
-					Publications. EPUB Creators are not responsible for the interaction between Reading Systems and the
-					underlying platform APIs.</p>
+				<p>The use of the <code>schema:accesibilityAPI</code> property is no longer necessary for <a>EPUB
+						Publications</a>. <a>EPUB Creators</a> are not responsible for the interaction between
+						<a>Reading Systems</a> and the underlying platform APIs.</p>
 
 				<p>Meeting the requirements of [[WCAG2]] is a better measure of the accessibility of scripting, as this
 					property does not differentiate between ARIA markup used for document structure or for identifying
@@ -510,9 +489,10 @@
 			<section id="meta-007">
 				<h3>Identify Input Control Methods</h3>
 
-				<p>The use of the <code>schema:accesibilityControl</code> property is no longer necessary for EPUB
-					Publications. This property does not differentiate issues arising from the Reading System interface
-					from those in the underlying content, which has led to confusion about its use.</p>
+				<p>The use of the <code>schema:accesibilityControl</code> property is no longer necessary for <a>EPUB
+						Publications</a>. This property does not differentiate issues arising from the <a>Reading
+						System</a> interface from those in the underlying content, which has led to confusion about its
+					use.</p>
 
 				<p>Meeting the requirements of [[WCAG2]] will mitigate most known issues with the content and is
 					sufficient for authoring purposes.</p>
@@ -521,9 +501,9 @@
 			<section id="sec-meta-ex">
 				<h3>Examples</h3>
 
-				<p>The following examples show the metadata that would be added to an EPUB Publication that has textual
-					and visual access modes, is sufficient for reading by text, contains alternative text and MathML
-					markup, and has a flashing hazard.</p>
+				<p>The following examples show the metadata that would be added to an <a>EPUB Publication</a> that has
+					textual and visual access modes, is sufficient for reading by text, contains alternative text and
+					MathML markup, and has a flashing hazard.</p>
 
 				<aside class="example" title="EPUB 3">
 					<pre>&lt;package … >
@@ -647,11 +627,11 @@
 					repeat those techniques.</p>
 
 				<p>In general, the differences between the application of WCAG techniques to web pages and their
-					application to EPUB Content Documents is minimal, but the following sections outline some key
+					application to <a>EPUB Content Documents</a> is minimal, but the following sections outline some key
 					differences.</p>
 
 				<p>One point to note is that the WCAG techniques cover a greater range of technologies and content types
-					than are typically found in an EPUB Publication, so many are not applicable.</p>
+					than are typically found in an <a>EPUB Publication</a>, so many are not applicable.</p>
 
 				<p>The following sets of techniques are the most applicable to EPUB Content Documents:</p>
 
@@ -721,16 +701,16 @@
 						specifies that each web page have a meaningful order (i.e., that the visual presentation of the
 						content match the underlying markup).</p>
 
-					<p>As EPUB allows two documents to be rendered together in a <a
+					<p>As EPUB allows two <a>EPUB Content Documents</a> to be rendered together in a <a
 							href="https://www.w3.org/TR/epub/#spread">synthetic spread</a> [[EPUB-3]], the order of
 						content within a single document cannot always be evaluated in isolation. Content may span
 						visually from one document to the next. For example, a sidebar might span the bottom of two
 						pages.</p>
 
-					<p>Ordering each document separately by the visual display will lead to users of assistive
-						technologies encountering gaps between the start and end of the spanned text. If the markup
-						cannot be arranged to provide a more logical reading experience (e.g., the beginning of the
-						spanned content at the end of the first page followed by the conclusion at the start of the
+					<p>Ordering each document separately by the visual display will lead to users of <a>Assistive
+							Technologies</a> encountering gaps between the start and end of the spanned text. If the
+						markup cannot be arranged to provide a more logical reading experience (e.g., the beginning of
+						the spanned content at the end of the first page followed by the conclusion at the start of the
 						next), another means of satisfying this criteria will be necessary to avoid failure (e.g., a
 						hyperlink could be provided to allow a user to jump from the break point on the first page to
 						the continuation on the next).</p>
@@ -741,18 +721,20 @@
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#multiple-ways">Success Criterion
 						2.4.5</a> requires there be more than one way to locate a web page within a set of web pages. By
-						default, EPUB Publications meet this WCAG requirement so long as EPUB Creators follow the EPUB
-						requirements to <a href="https://www.w3.org/TR/epub/#sec-spine-elem">include all EPUB Content
-							Documents in the spine</a> and <a href="https://www.w3.org/TR/epub/#sec-itemref-elem">ensure
-							access to all non-linear documents</a> [[EPUB-3]].</p>
+						default, <a>EPUB Publications</a> meet this WCAG requirement so long as <a>EPUB Creators</a>
+						follow the EPUB requirements to <a href="https://www.w3.org/TR/epub/#sec-spine-elem">include all
+							EPUB Content Documents in the spine</a> and <a
+							href="https://www.w3.org/TR/epub/#sec-itemref-elem">ensure access to all non-linear
+							documents</a> [[EPUB-3]].</p>
 
 					<p>The reason an EPUB Publication passes by meeting these requirements has to do with differences in
 						how a user interacts with the set of documents in an EPUB Publication. In particular, although
-						an EPUB Publication typically consists of many Content Documents, Reading Systems automatically
-						provide the ability for the user to move seamlessly from one document to the next, so long as
-						they are listed in the <a href="https://www.w3.org/TR/epub/#sec-spine-elem"
-						>spine</a> [[EPUB-3]]. To the user, an EPUB Publication is a single document they have complete
-						access to, not a set of disconnected pages that they need links to move through.</p>
+						an EPUB Publication typically consists of many <a>EPUB Content Documents</a>, <a>Reading
+							Systems</a> automatically provide the ability for the user to move seamlessly from one
+						document to the next, so long as they are listed in the <a
+							href="https://www.w3.org/TR/epub/#sec-spine-elem">spine</a> [[EPUB-3]]. To the user, an EPUB
+						Publication is a single document they have complete access to, not a set of disconnected pages
+						that they need links to move through.</p>
 
 					<p>The required table of contents provides a second method to access the major headings of the
 						publication. The user can jump to any heading and continue to navigate from there, regardless of
@@ -768,15 +750,15 @@
 
 					<ul>
 						<li>
-							<p>adding at least one link to every Content Document in the spine to the table of contents,
-								when feasible;</p>
+							<p>adding at least one link to every EPUB Content Document in the spine to the table of
+								contents, when feasible;</p>
 						</li>
 						<li>
 							<p>adding an index to locate major topics; and</p>
 						</li>
 						<li>
-							<p>adding additional navigation aids to the EPUB Navigation Document (e.g., lists of figures
-								and tables).</p>
+							<p>adding additional navigation aids to the <a>EPUB Navigation Document</a> (e.g., lists of
+								figures and tables).</p>
 						</li>
 					</ul>
 
@@ -789,11 +771,11 @@
 							usability challenges to this approach.</p>
 
 						<p>Factors such as device screen sizes can make the table of contents for publications with a
-							deep hierarchy of headings unreadable, so EPUB Creators will trim headings below a certain
-							depth to improve the readability. Further, Reading Systems do not always provide structured
-							access to the headings in the table of contents, or provide shortcuts to navigate the links.
-							The result is that users have to listen to each link one at a time to find where they want
-							to go, a tedious and time-consuming process.</p>
+							deep hierarchy of headings unreadable, so <a>EPUB Creators</a> will trim headings below a
+							certain depth to improve the readability. Further, <a>Reading Systems</a> do not always
+							provide structured access to the headings in the table of contents, or provide shortcuts to
+							navigate the links. The result is that users have to listen to each link one at a time to
+							find where they want to go, a tedious and time-consuming process.</p>
 
 						<p>Although it is expected that Reading Systems will improve access to the table of contents as
 							accessibility support for EPUB evolves — making complete tables of contents usable by
@@ -805,9 +787,9 @@
 
 						<ul>
 							<li>
-								<p>ensuring that there is at least one link to every EPUB Content Document — allowing
-									the user to reach each document simplifies navigation to the minor headings within
-									them; and</p>
+								<p>ensuring that there is at least one link to every <a>EPUB Content Document</a> —
+									allowing the user to reach each document simplifies navigation to the minor headings
+									within them; and</p>
 							</li>
 							<li>
 								<p>only omitting minor headings from the table of contents — although a subjective
@@ -822,17 +804,18 @@
 					<h4>Ensure the order of table of contents entries matches linear order</h4>
 
 					<p>The table of contents provides users more than just links into the content. It is also a means to
-						understand the structure and ordering of an EPUB Publication. Consequently, users may have
-						difficulty locating where they are in a publication, where they want to go, and also how to
+						understand the structure and ordering of an <a>EPUB Publication</a>. Consequently, users may
+						have difficulty locating where they are in a publication, where they want to go, and also how to
 						return to previous locations when the order of entries in the table of contents does not match
 						the linear reading order.</p>
 
-					<p>EPUB Creators should therefore ensure that the entries in the table of contents always match the
-						linear order of the content. Specifically, the order of entries should reflect both:</p>
+					<p><a>EPUB Creators</a> should therefore ensure that the entries in the table of contents always
+						match the linear order of the content. Specifically, the order of entries should reflect
+						both:</p>
 
 					<ul>
-						<li>the order of EPUB Content Documents in the <code>spine</code>; and</li>
-						<li>the order of each referenced section within its respective Content Document.</li>
+						<li>the order of <a>EPUB Content Documents</a> in the <a>spine</a>; and</li>
+						<li>the order of each referenced section within its respective EPUB Content Document.</li>
 					</ul>
 
 					<p>Only if there is a logical case for an alternative arrangement of entries should the ordering
@@ -846,8 +829,9 @@
 
 					<p>EPUB Creators should avoid including links to supplementary content at the end of the table of
 						contents. Links to figure, tables, illustrations and similar content is better included as a
-						separate navigation elements (either in the EPUB Navigation Document or in the spine). EPUB
-						Creators can include links to these additional navigation lists in the table of contents.</p>
+						separate navigation elements (either in the <a>EPUB Navigation Document</a> or in the spine).
+						EPUB Creators can include links to these additional navigation lists in the table of
+						contents.</p>
 				</section>
 			</section>
 
@@ -858,10 +842,10 @@
 					<h4>ARIA roles and <code>epub:type</code></h4>
 
 					<div class="note">
-						<p>The following guidance is only for EPUB Content Documents. The <code>type</code> attribute is
-							the only means of adding structural information to Media Overlay Documents so that features
-							like lists and tables can be navigated more efficiently. It is also required in the EPUB
-							Navigation Document to identify key structures.</p>
+						<p>The following guidance is only for <a>EPUB Content Documents</a>. The <code>type</code>
+							attribute is the only means of adding structural information to <a>Media Overlay
+								Documents</a> so that features like lists and tables can be navigated more efficiently.
+							It is also required in the <a>EPUB Navigation Document</a> to identify key structures.</p>
 					</div>
 
 					<p>Although the <code>role</code> attribute may seem similar in nature to the <a
@@ -870,15 +854,16 @@
 						overlap.</p>
 
 					<p>The key difference between these attributes is that the <code>role</code> attribute bridges
-						accessibility in content while the <code>type</code> attribute provides hooks to enable Reading
-						System behaviors. Omitting roles lessens the accessibility for users of Assistive Technologies,
-						in other words, while omitting types diminishes certain functionality in Reading Systems (e.g.,
-						pop-up footnotes or special presentations of the content).</p>
+						accessibility in content while the <code>type</code> attribute provides hooks to enable
+							<a>Reading System</a> behaviors. Omitting roles lessens the accessibility for users of
+							<a>Assistive Technologies</a>, in other words, while omitting types diminishes certain
+						functionality in <a>Reading Systems</a> (e.g., pop-up footnotes or special presentations of the
+						content).</p>
 
 					<p>Since each attribute offers different advantages, it is not necessary that they be used together.
-						Due to the lack of restrictions on where EPUB Creators can use the <code>type</code> attribute,
-						pairing the attributes may cause accessibility issues (e.g., putting roles on the [[HTML]]
-							<code>body</code> element).</p>
+						Due to the lack of restrictions on where <a>EPUB Creators</a> can use the <code>type</code>
+						attribute, pairing the attributes may cause accessibility issues (e.g., putting roles on the
+						[[HTML]] <code>body</code> element).</p>
 
 					<p>In particular, the use of the <code>type</code> attribute is not a means of satisfying
 						requirements for ARIA roles in WCAG.</p>
@@ -893,23 +878,23 @@
 				<section id="sem-002">
 					<h4>Do not repeat semantics across chunked content</h4>
 
-					<p>Although EPUB Publications appear as single contiguous documents to users when read, they are
-						typically composed of many individual EPUB Content Documents. This practice keeps the amount of
-						markup that has to be rendered small to reduce the load time in Reading Systems (i.e., to
-						minimize the time the user has to wait for a document to appear). It is rare, at least for
-						books, for an EPUB Publication to contain only one Content Document with all the content in
-						it.</p>
+					<p>Although <a>EPUB Publications</a> appear as single contiguous documents to users when read, they
+						are typically composed of many individual <a>EPUB Content Documents</a>. This practice keeps the
+						amount of markup that has to be rendered small to reduce the load time in <a>Reading Systems</a>
+						(i.e., to minimize the time the user has to wait for a document to appear). It is rare, at least
+						for books, for an EPUB Publication to contain only one EPUB Content Document with all the
+						content in it.</p>
 
-					<p>When content is chunked in this way, it often requires the EPUB Creator to make decisions about
-						how best to restructure the information. A part, for example, will typically not include all the
-						chapters that belong to it. The EPUB Creator will instead separate the part heading from each
-						chapter, putting each into a separate document.</p>
+					<p>When content is chunked in this way, it often requires the <a>EPUB Creator</a> to make decisions
+						about how best to restructure the information. A part, for example, will typically not include
+						all the chapters that belong to it. The EPUB Creator will instead separate the part heading from
+						each chapter, putting each into a separate document.</p>
 
 					<p>Although visually these restructuring decisions can be hidden from readers, they impact the
-						functionality of Assistive Technologies. In the case of [[WAI-ARIA]] roles, the result is that
-						only the subset present in the currently-loaded EPUB Content Document are exposed to users. An
-						Assistive Technology cannot provide a list of landmarks for the whole publication, as it cannot
-						see outside the current document.</p>
+						functionality of <a>Assistive Technologies</a>. In the case of [[WAI-ARIA]] roles, the result is
+						that only the subset present in the currently-loaded EPUB Content Document are exposed to users.
+						An Assistive Technology cannot provide a list of landmarks for the whole publication, as it
+						cannot see outside the current document.</p>
 
 					<p>To counteract this destructuring effect, EPUB Creators sometimes think to re-add or re-identify
 						structures in the belief that having this information in every document will be helpful to users
@@ -936,7 +921,7 @@
 &lt;/section></pre>
 
 					<p>Since this would lead to a large content file, the part heading is typically split out into its
-						own Content Document so that it will appear on its own page:</p>
+						own EPUB Content Document so that it will appear on its own page:</p>
 
 					<pre>&lt;html … >
    …
@@ -946,7 +931,7 @@
    &lt;/body>
 &lt;/html></pre>
 
-					<p>Each chapter is then separated into a separate Content Document:</p>
+					<p>Each chapter is then separated into a separate EPUB Content Document:</p>
 
 					<pre>&lt;html … >
    …
@@ -981,24 +966,26 @@
 					<p>[[WAI-ARIA]] <a data-cite="wai-aria#dfn-landmark">landmarks</a> are similar in nature to <a
 							href="https://www.w3.org/TR/epub/#sec-nav-landmarks">EPUB landmarks</a> [[EPUB-3]]: both are
 						designed to provide users with quick access to the major structures of a document, such as
-						chapters, glossaries and indexes. ARIA landmarks are compiled automatically by Assistive
-						Technologies from the <a href="#sem-001">roles</a> that have been applied to the markup, so EPUB
-						Creators only need to follow the requirement to include roles for the landmarks to be made
-						available to users.</p>
+						chapters, glossaries and indexes. ARIA landmarks are compiled automatically by <a>Assistive
+							Technologies</a> from the <a href="#sem-001">roles</a> that have been applied to the markup,
+						so <a>EPUB Creators</a> only need to follow the requirement to include roles for the landmarks
+						to be made available to users.</p>
 
 					<p>Although automatic generation of ARIA landmarks simplifies authoring, it also means that ARIA
-						landmarks are limited to how the EPUB Publication has been chunked up into Content Documents. An
-						Assistive Technology can only present the landmarks available in the currently-loaded document;
-						it cannot provide a complete picture of all the landmarks in a multi-document publication (see
-						the <a href="#sem-002">previous section</a> for more discussion about content chunking).</p>
+						landmarks are limited to how the EPUB Publication has been chunked up into <a>EPUB Content
+							Documents</a>. An Assistive Technology can only present the landmarks available in the
+						currently-loaded document; it cannot provide a complete picture of all the landmarks in a
+						multi-document publication (see the <a href="#sem-002">previous section</a> for more discussion
+						about content chunking).</p>
 
 					<p>EPUB landmarks, on the other hand, are compiled by the EPUB Creator prior to distribution, and
 						are not directly linked to the use of the <a
 							href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
 						><code>type</code> attribute</a> [[EPUB-3]] in the content. They are designed to simplify
-						linking to major sections of the publication in a machine-readable way, as Reading Systems do
-						not scan the entire publication for landmarks, either. EPUB landmarks are typically not as
-						numerous as ARIA landmarks, as Reading Systems only expose so many of these navigation aids.</p>
+						linking to major sections of the publication in a machine-readable way, as <a>Reading
+							Systems</a> do not scan the entire publication for landmarks, either. EPUB landmarks are
+						typically not as numerous as ARIA landmarks, as Reading Systems only expose so many of these
+						navigation aids.</p>
 
 					<p>Given these differences in application, however, it is important to include EPUB landmarks and
 						not rely only on the presence of ARIA roles to facilitate navigation, and vice versa. Each aids
@@ -1108,13 +1095,13 @@
 					<h4>Include publication and document titles</h4>
 
 					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#page-titled">Success Criterion 2.4.2</a> requires
-						that each web page include a title. EPUB has a similar requirement for EPUB Publications:
-						publications require a [[DCTERMS]] <code>title</code> element in the Package Document metadata.
-						The [[WCAG2]] requirement is not satisfied by the EPUB requirement, however.</p>
+						that each web page include a title. EPUB has a similar requirement for <a>EPUB Publications</a>:
+						publications require a [[DCTERMS]] <code>title</code> element in the <a>Package Document</a>
+						metadata. The [[WCAG2]] requirement is not satisfied by the EPUB requirement, however.</p>
 
-					<p>When authoring an EPUB Publication each EPUB Content Document also requires a descriptive title
-						that describes its content. If not provided, Assistive Technologies often will announce the name
-						of the file to users.</p>
+					<p>When authoring an EPUB Publication each <a>EPUB Content Document</a> also requires a descriptive
+						title that describes its content. If not provided, <a>Assistive Technologies</a> often will
+						announce the name of the file to users.</p>
 
 					<aside class="example" title="Title for an EPUB Content Document">
 						<pre>&lt;html …>
@@ -1157,20 +1144,20 @@
 				<section id="titles-002">
 					<h4>Ensure numbered headings reflect publication hierarchy</h4>
 
-					<p>To a user, an EPUB Publication appears as a single document that they read from beginning to end,
-						even though the content is often split across numerous EPUB Content Documents. As a result,
-						their natural expectation is that the headings reflect their position in the overall hierarchy
-						of the publication, despite the publication not actually being a single document (e.g., if a
-						part heading is expressed in an [[HTML]] <code>h1</code> element, each chapter that belongs to
-						the part will have an <code>h2</code> heading).</p>
+					<p>To a user, an <a>EPUB Publication</a> appears as a single document that they read from beginning
+						to end, even though the content is often split across numerous <a>EPUB Content Documents</a>. As
+						a result, their natural expectation is that the headings reflect their position in the overall
+						hierarchy of the publication, despite the publication not actually being a single document
+						(e.g., if a part heading is expressed in an [[HTML]] <code>h1</code> element, each chapter that
+						belongs to the part will have an <code>h2</code> heading).</p>
 
 					<p>Technique <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G141">G141: Organizing a page
-							using headings</a> instructs EPUB Creators on correctly using numbered headings within a
-						document, but with EPUB Publications the numbered headings also need to remain consistent across
-						documents. Practically, this means that each EPUB Content Document does not have to begin with
-						an <code>h1</code> heading unless the first heading is a top-level heading — the first heading
-						needs to have a numbered heading element that reflects its actual position in the
-						publication.</p>
+							using headings</a> instructs <a>EPUB Creators</a> on correctly using numbered headings
+						within a document, but with EPUB Publications the numbered headings also need to remain
+						consistent across documents. Practically, this means that each EPUB Content Document does not
+						have to begin with an <code>h1</code> heading unless the first heading is a top-level heading —
+						the first heading needs to have a numbered heading element that reflects its actual position in
+						the publication.</p>
 
 					<p>EPUB Creators also to need chunk their content so that the first heading in a document always has
 						the highest number. For example, if a document starts with an <code>h3</code> heading, there
@@ -1263,8 +1250,8 @@
 					<p>The first version of these techniques only required alternative text for images regardless of
 						their complexity. This exception is no longer valid.</p>
 
-					<p>EPUB Creators must now ensure that their image-based content meets [[WCAG2]] requirements for
-						alternative text and extended descriptions to conform with [[EPUB-A11Y-11]].</p>
+					<p><a>EPUB Creators</a> must now ensure that their image-based content meets [[WCAG2]] requirements
+						for alternative text and extended descriptions to conform with [[EPUB-A11Y-11]].</p>
 
 					<section id="sec-desc-001-res">
 						<h5>Helpful Resources</h5>
@@ -1292,9 +1279,9 @@
 						and <a href="https://www.w3.org/TR/WCAG2/#language-of-parts">3.1.2</a> deal with the language of
 						a page and changes of language with in, respectively.</p>
 
-					<p>For EPUB Publications, the Package Document is also an important source of metadata information
-						about the publication. For example, Reading Systems expose details of the publications to users
-						in their bookshelves using this information.</p>
+					<p>For <a>EPUB Publications</a>, the <a>Package Document</a> is also an important source of metadata
+						information about the publication. For example, <a>Reading Systems</a> expose details of the
+						publications to users in their bookshelves using this information.</p>
 
 					<p>Consequently, it is necessary to provide the language of all text content in the Package Document
 						to conform with these WCAG success criteria. The easiest way to meet this requirement is to add
@@ -1333,8 +1320,8 @@
 				<section id="lang-002">
 					<h4>Language of the EPUB Publication</h4>
 
-					<p>In addition to being able to express the language of text content, the Package Document also
-						allows EPUB Creators to identify the languages of the EPUB Publication in <a
+					<p>In addition to being able to express the language of text content, the <a>Package Document</a>
+						also allows <a>EPUB Creators</a> to identify the languages of the <a>EPUB Publication</a> in <a
 							href="https://www.w3.org/TR/epub/#sec-opf-dclanguage"><code>dc:language</code> elements</a>
 						[[EPUB-3]].</p>
 
@@ -1355,13 +1342,13 @@
 						language information. (Note that EPUB3 requires the language always be specified, so omitting
 						will fail validation requirements.)</p>
 
-					<p>Although Reading Systems do not use this language information to render the text content of the
-						EPUB Publication, they do use it to optimize the reading experience for users (e.g., to preload
-						text-to-speech engines so users do not have a delay when synthesizing the text).</p>
+					<p>Although <a>Reading Systems</a> do not use this language information to render the text content
+						of the EPUB Publication, they do use it to optimize the reading experience for users (e.g., to
+						preload text-to-speech engines so users do not have a delay when synthesizing the text).</p>
 
-					<p class="note">The languages specified in the Package Document have no effect on individual EPUB
-						Content Documents (i.e., the language of each document must be specified using the language
-						expression mechanisms it provides).</p>
+					<p class="note">The languages specified in the Package Document have no effect on individual <a>EPUB
+							Content Documents</a> (i.e., the language of each document must be specified using the
+						language expression mechanisms it provides).</p>
 				</section>
 			</section>
 
@@ -1375,9 +1362,9 @@
 						requires that text equivalents be provided for all non-text content to meet Level A. In some
 						regions (e.g., Asia), it is not uncommon to find images of individual text characters, despite
 						the availability of Unicode character equivalents. This practice occurs for various reasons,
-						such as ease of translation of older documents and for compatibility across Reading Systems. The
-						use of images in most instances leads to the text not being accessible to non-visual users,
-						however.</p>
+						such as ease of translation of older documents and for compatibility across <a>Reading
+							Systems</a>. The use of images in most instances leads to the text not being accessible to
+						non-visual users, however.</p>
 
 					<p>When individual characters are replaced by images, there is invariably a negative effect on
 						text-to-speech playback, even when alternative text is provided (e.g., if single characters
@@ -1397,7 +1384,7 @@
 			<section id="sec-wcag-alt">
 				<h3>Accessible Alternatives</h3>
 
-				<p>As EPUB Publications can be composed of more than one rendition, it is possible that different
+				<p>As <a>EPUB Publications</a> can be composed of more than one rendition, it is possible that different
 					versions of the content will have different levels of accessibility. For example, an image-based
 					version of the content that lacks alternative text or descriptions could be bundled with a
 					WCAG-compliant text-based serialization. This type of accessible bundling is acceptable, as
@@ -1406,23 +1393,23 @@
 						version</a> is available.</p>
 
 				<p>The [[EPUBMultipleRenditions-10]] specification defines a set of features for creating these types of
-					EPUB Publications. It specifies a set of attributes that allow a Reading System to automatically
-					select a preferred rendition for the user or to provide the user the option to manually select
-					between the available options. This functionality technically meets the requirements of [[WCAG2]] in
-					terms of ensuring the user can access the accessible version.</p>
+					EPUB Publications. It specifies a set of attributes that allow a <a>Reading System</a> to
+					automatically select a preferred rendition for the user or to provide the user the option to
+					manually select between the available options. This functionality technically meets the requirements
+					of [[WCAG2]] in terms of ensuring the user can access the accessible version.</p>
 
 				<p>In practice, however, the [[EPUBMultipleRenditions-10]] specification is not broadly supported in
 					Reading Systems at the time of publication. As a result, a user who obtains an EPUB Publication that
 					contains more than one rendition will only have access to the default. Unless this rendition is the
 					accessible one, the EPUB Publication might not be readable by them.</p>
 
-				<p>EPUB Creators therefore need to use their best discretion when implementing this functionality to
-					meet accessibility requirements. EPUB Publications that contain multiple renditions are conformant
-					to the [[EPUB-A11Y-11]] specification if at least one rendition meets all the content requirements,
-					but EPUB Creators at a minimum need to note that a Reading System that supports multiple renditions
-					is required in their <a href="#meta-005">accessibility summary</a>. Any other methods the EPUB
-					Creator can use to make this dependence known is advisable (e.g., in the <a href="#dist-002"
-						>distribution metadata</a>).</p>
+				<p><a>EPUB Creators</a> therefore need to use their best discretion when implementing this functionality
+					to meet accessibility requirements. EPUB Publications that contain multiple renditions are
+					conformant to the [[EPUB-A11Y-11]] specification if at least one rendition meets all the content
+					requirements, but EPUB Creators at a minimum need to note that a Reading System that supports
+					multiple renditions is required in their <a href="#meta-005">accessibility summary</a>. Any other
+					methods the EPUB Creator can use to make this dependence known is advisable (e.g., in the <a
+						href="#dist-002">distribution metadata</a>).</p>
 
 				<p>This section will be updated with techniques for using multiple renditions when there is enough
 					support in Reading Systems to broadly recommend their use.</p>
@@ -1443,7 +1430,7 @@
 							data-cite="dpub-aria-1.0#doc-pagebreak">doc-pagebreak</a>, respectively.</p>
 
 					<p>It is recommended that both semantics be applied to EPUB 3 content to ensure maximum
-						compatibility with Reading Systems and Assistive Technologies.</p>
+						compatibility with <a>Reading Systems</a> and <a>Assistive Technologies</a>.</p>
 
 					<aside class="example" title="Expressing a page break">
 						<p>In this example, the EPUB Creator identifies an HTML <code>span</code> element as a page
@@ -1490,15 +1477,15 @@
 						in the audio playback of a publication it is not only distracting, but can be confusing, as well
 						(e.g., the number could be read out in the middle of a sentence).</p>
 
-					<p>To mitigate this potential annoyance to readers, EPUB Creators need to identify page
-						announcements in the EPUB 3 media overlays document when they are included. Identification
-						allows a Reading System to provide a playback experience where the numbers are automatically
+					<p>To mitigate this potential annoyance to readers, <a>EPUB Creators</a> need to identify page
+						announcements in <a>Media Overlay Documents</a> when they are included. Identification allows a
+							<a>Reading System</a> to provide a playback experience where the numbers are automatically
 						skipped.</p>
 
-					<p>To identify page numbers in EPUB 3 Publications, attach an <code>epub:type</code> attribute with
-						the value "<a href="https://www.w3.org/TR/epub/#pagebreak"><code>pagebreak</code></a>"
+					<p>To identify page numbers in Media Overlay Documents, attach an <code>epub:type</code> attribute
+						with the value "<a href="https://www.w3.org/TR/epub/#pagebreak"><code>pagebreak</code></a>"
 						[[EPUB-SSV]] to each <a href="https://www.w3.org/TR/epub/#sec-smil-par-elem"><code>par</code>
-							element</a> [[EPUB-3]] that identifies a page number in the media overlay documents.</p>
+							element</a> [[EPUB-3]] that identifies a page number.</p>
 
 					<aside class="example" title="A page number identified in a Media Overlays Document">
 						<pre>&lt;smil
@@ -1554,10 +1541,10 @@
 						each page marker in the text, provided they are available and the Reading System provides such
 						functionality.</p>
 
-					<p>When a page list is included, Reading Systems can provide users direct access to the list or use
-						it to provide automatic page jump functionality.</p>
+					<p>When a page list is included, <a>Reading Systems</a> can provide users direct access to the list
+						or use it to provide automatic page jump functionality.</p>
 
-					<p>The EPUB Navigation Document allows the inclusion of a <a
+					<p>The <a>EPUB Navigation Document</a> allows the inclusion of a <a
 							href="https://www.w3.org/TR/epub/#sec-nav-pagelist"><code>page-list</code>
 							<code>nav</code></a> [[EPUB-3]], while the EPUB 2 NCX file provides the same functionality
 						through the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1.2"
@@ -1627,14 +1614,14 @@
 				<section id="page-004">
 					<h4>Identify the pagination source</h4>
 
-					<p>Users typically want to know the source of the page break markers included in an EPUB Publication
-						when they are derived from a static media. Considerations like which printing, by which
-						publisher or imprint, and whether the pagination comes from the hard or soft cover edition will
-						affect decisions about its usefulness (e.g., does it exactly match the pagination of a print
-						book used in a classroom).</p>
+					<p>Users typically want to know the source of the page break markers included in an <a>EPUB
+							Publication</a> when they are derived from a static media. Considerations like which
+						printing, by which publisher or imprint, and whether the pagination comes from the hard or soft
+						cover edition will affect decisions about its usefulness (e.g., does it exactly match the
+						pagination of a print book used in a classroom).</p>
 
 					<p>To allow users to determine the suitability of the pagination, identify the ISBN of the source
-						work in the Package Document metadata.</p>
+						work in the <a>Package Document</a> metadata.</p>
 
 					<aside class="example" title="Expressing the source of pagination">
 						<p>In this example, the <code>dc:source</code> element contains the ISBN of the print source of
@@ -1697,13 +1684,13 @@
 				<section id="sync-001">
 					<h4>Ensuring complete text coverage</h4>
 
-					<p>Ensuring the complete text of an EPUB Publication is synchronized with audio is key to allowing
-						users who require full synchronized playback, or even audio-only playback, have access to the
-						same information as users who do not require synchronized playback.</p>
+					<p>Ensuring the complete text of an <a>EPUB Publication</a> is synchronized with audio is key to
+						allowing users who require full synchronized playback, or even audio-only playback, have access
+						to the same information as users who do not require synchronized playback.</p>
 
 					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] allows
-						audio to be synchronized with any element in an EPUB Content Document, so there is no technical
-						barrier to providing synchronized playback.</p>
+						audio to be synchronized with any element in an <a>EPUB Content Document</a>, so there is no
+						technical barrier to providing synchronized playback.</p>
 
 					<p>The primary consideration for this objective is what constitutes the text content of an EPUB
 						Publication. The minimal candidates for synchronization with audio are all the elements with
@@ -1722,9 +1709,9 @@
 						(e.g., for embedded audio and video in the document).</p>
 
 					<div class="note">
-						<p>EPUB Creators should not synchronize hidden text content in an alternative presentation like
-							Media Overlays. Synchronizing audio with invisible text will be confusing for sighted
-							readers following the playback.</p>
+						<p><a>EPUB Creators</a> should not synchronize hidden text content in an alternative
+							presentation like Media Overlays. Synchronizing audio with invisible text will be confusing
+							for sighted readers following the playback.</p>
 
 						<p>Text content in a collapsed element, like the <a data-cite="html#the-details-element"
 									><code>details</code> element</a> [[HTML]], is not considered hidden content.</p>
@@ -1748,26 +1735,26 @@
 				<section id="sync-002">
 					<h4>Specifying the reading order</h4>
 
-					<p>The default reading order should typically represent the order in which Reading Systems render
-						content to users during synchronized text-audio playback. For EPUB Publications, this is a
-						combination of the sequence of EPUB Content Documents in the spine and the order of elements
-						within each EPUB Content Document.</p>
+					<p>The default reading order should typically represent the order in which <a>Reading Systems</a>
+						render content to users during synchronized text-audio playback. For <a>EPUB Publications</a>,
+						this is a combination of the sequence of <a>EPUB Content Documents</a> in the spine and the
+						order of elements within each EPUB Content Document.</p>
 
 					<p>If there are cases where the logical reading order (how a reader would naturally read the
-						content) diverges from the default reading order, EPUB Creators can order the playback sequence
-						of <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
+						content) diverges from the default reading order, <a>EPUB Creators</a> can order the playback
+						sequence of <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
 							data-cite="epub-33#sec-smil-par-elem"><code>par</code></a> elements in a <a
 							data-cite="epub-33#sec-overlay-docs">Media Overlays Document</a> [[EPUB-33]] to match the
 						logical order.</p>
 
 					<p>EPUB Creators need to use caution when making alterations, however, as other accessibility issues
 						can arise when the logical order does not match the default order. For example, the content may
-						not be accessible to users of assistive technologies when the order in the markup does not match
-						how the assistive technology reads the content. In these cases, using playback to create a
-						logical order can make the EPUB Publication fail WCAG conformance requirements.</p>
+						not be accessible to users of <a>Assistive Technologies</a> when the order in the markup does
+						not match how the Assistive Technology reads the content. In these cases, using playback to
+						create a logical order can make the EPUB Publication fail WCAG conformance requirements.</p>
 
 					<p>One case where the logical may diverge from the reading order and remain accessible is in tables,
-						as assistive technologies typically allow users to choose whether to read by row or by
+						as Assistive Technologies typically allow users to choose whether to read by row or by
 						column.</p>
 				</section>
 
@@ -1777,12 +1764,12 @@
 					<p>Some content elements are not critical to read when following the primary narrative of a work,
 						and that would interrupt a user's concentration if they had to stop and listen to. Footnotes and
 						endnotes are examples of such content, as users may only want to come back and read this content
-						after finishing the EPUB Publication. The announcement of page break numbers can be similarly
-						annoying to readers.</p>
+						after finishing the <a>EPUB Publication</a>. The announcement of page break numbers can be
+						similarly annoying to readers.</p>
 
 					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] does
-						not allow Reading Systems to determine if playback sequences are skippable unless EPUB Creators
-						add additional semantics to the markup, however. EPUB Creators must use the <a
+						not allow <a>Reading Systems</a> to determine if playback sequences are skippable unless <a>EPUB
+							Creators</a> add additional semantics to the markup, however. EPUB Creators must use the <a
 							data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[EPUB-33]]
 						to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
 							data-cite="epub-33#sec-smil-par-elem"><code>par</code></a> elements [[EPUB-33]], thereby
@@ -1881,11 +1868,12 @@
 						whenever they choose to simplify the reading experience.</p>
 
 					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] only
-						supports escapability if EPUB Creators add structural semantics to the markup. EPUB Creators
-						must use the <a data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code> attribute</a>
-						[[EPUB-33]] to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a>
-						and <a data-cite="epub-33#sec-smil-seq-elem"><code>par</code></a> elements [[EPUB-33]] to allow
-						Reading Systems to provide users the option to escape their playback sequences.</p>
+						supports escapability if <a>EPUB Creators</a> add structural semantics to the markup. EPUB
+						Creators must use the <a data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code>
+							attribute</a> [[EPUB-33]] to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"
+								><code>seq</code></a> and <a data-cite="epub-33#sec-smil-seq-elem"><code>par</code></a>
+						elements [[EPUB-33]] to allow <a>Reading Systems</a> to provide users the option to escape their
+						playback sequences.</p>
 
 					<p>The recommended structures to identify for escapability are:</p>
 
@@ -1909,8 +1897,8 @@
 					</div>
 
 					<aside class="example" title="Identifying an escapable list">
-						<p>In this example, the <code>list</code> semantic identifies an escapable list in the Media
-							Overlay Document.</p>
+						<p>In this example, the <code>list</code> semantic identifies an escapable list in the <a>Media
+								Overlay Document</a>.</p>
 
 						<p>Media Overlay Document:</p>
 
@@ -1975,12 +1963,11 @@
 				<section id="sync-005">
 					<h4>Synchronizing the Navigation Document</h4>
 
-					<p>EPUB Creators can add a <a data-cite="epub-33#sec-overlays-docs">Media Overlay Document</a> for
-						the <a data-cite="epub-33#sec-nav">EPUB Navigation Document</a> even when it is not included in
-						the <a data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]]. Doing so allow Reading Systems
-						to announce the link labels regardless of how they present the navigation elements to users
-						(e.g., many Reading Systems applications create custom table of contents panels by extracting
-						the data from the EPUB Navigation Document).</p>
+					<p><a>EPUB Creators</a> can add a <a>Media Overlay Document</a> for the <a>EPUB Navigation
+							Document</a> even when it is not included in the <a>spine</a>. Doing so allow <a>Reading
+							Systems</a> to announce the link labels regardless of how they present the navigation
+						elements to users (e.g., many Reading Systems applications create custom table of contents
+						panels by extracting the data from the EPUB Navigation Document).</p>
 
 					<p>The process for adding a Media Overlay Document is no different than one for any other
 						document.</p>
@@ -1993,7 +1980,7 @@
 			<section id="dist-001">
 				<h3>Do not restrict access through digital rights management</h3>
 
-				<p>EPUB Publications typically require preservation of the publisher's and author's intellectual
+				<p><a>EPUB Publications</a> typically require preservation of the publisher's and author's intellectual
 					property when distributed (e.g., so that they can be made available for individual sale through
 					online bookstores or distributed through library systems). The most common way to address this need
 					has been through the application of digital rights management (DRM) schemes to the packaged EPUB
@@ -2001,11 +1988,11 @@
 					as the ability to limit access to a single user and to limit the length of time the person can
 					access the publication (e.g., library loans).</p>
 
-				<p>In general, DRM can be made to work interoperably with Assistive Technologies, but problems arise
-					when DRM restrictions remove direct access to an EPUB Publication or restrict access to the content
-					within it. Unless the Reading System implementing the DRM provides API level access to the content,
-					it can prove difficult, or even impossible, to generate text-to-speech playback, or for a
-					refreshable braille display to have access to the underlying text, as well as cause other
+				<p>In general, DRM can be made to work interoperably with <a>Assistive Technologies</a>, but problems
+					arise when DRM restrictions remove direct access to an EPUB Publication or restrict access to the
+					content within it. Unless the <a>Reading System</a> implementing the DRM provides API level access
+					to the content, it can prove difficult, or even impossible, to generate text-to-speech playback, or
+					for a refreshable braille display to have access to the underlying text, as well as cause other
 					accessibility issues.</p>
 
 				<p>The application of digital rights management therefore must not impair or impede the functionality of
@@ -2015,18 +2002,18 @@
 			<section id="dist-002">
 				<h3>Include accessibility metadata in distribution records</h3>
 
-				<p>When an EPUB Publication is ingested into a distribution system, such as a bookstore or library, a
-					metadata record is often provided separately to the distributor. In these scenarios, the metadata
-					used to enable discovery of the publication typically comes from the distribution record alone, not
-					from the metadata in the Package Document.</p>
+				<p>When an <a>EPUB Publication</a> is ingested into a distribution system, such as a bookstore or
+					library, a metadata record is often provided separately to the distributor. In these scenarios, the
+					metadata used to enable discovery of the publication typically comes from the distribution record
+					alone, not from the metadata in the Package Document.</p>
 
 				<p>The result is that it is necessary to include as much accessibility metadata in distribution records
 					as their vocabularies allow.</p>
 
 				<div class="note">
 					<p>The use of distribution records does not remove the requirement to include accessibility metadata
-						in the Package Document. The metadata in the Package Document ensures accessibility information
-						is always available with the publication.</p>
+						in the <a>Package Document</a>. The metadata in the Package Document ensures accessibility
+						information is always available with the publication.</p>
 				</div>
 
 				<aside class="example" title="ONIX accessibility metadata">
@@ -2111,7 +2098,7 @@
 
 			<p>Note that this change log only identifies substantive changes since <a
 					href="http://idpf.org/epub/a11y/techniques/">EPUB Accessibility Techniques 1.0</a> &#8212; those
-				that affect the conformance of EPUB Publications or are similarly noteworthy.</p>
+				that affect the conformance of <a>EPUB Publications</a> or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+label%3ASpec-AccessibilityTechs+label%3AAccessibility11+"

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -64,16 +64,6 @@
 						"href": "https://www.w3.org/TR/epub/",
 						"publisher": "W3C"
 					},
-					"EPUBMultipleRenditions-10": {
-						"authors":[
-						"Jim Lester",
-						"Takeshi Kania",
-						"Matt Garrish"],
-						"title": "EPUB Multiple-Rendition Publications 1.0",
-						"href": "http://www.idpf.org/epub/renditions/multiple/epub-multiple-renditions-20150826.html",
-						"date": "26 August 2015",
-						"publisher": "IDPF"
-					},
 					"ISO24751-3": {
 						"title": " ISO/IEC 24751-3:2008 Information technology -- Individualized adaptability and accessibility in e-learning, education and training -- Part 3: &quot;Access for all&quot; digital resource description",
 						"href": "http://www.iso.org/iso/catalogue_detail?csnumber=43604",
@@ -134,10 +124,11 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This document uses terminology defined in EPUB 3 [[EPUB-3]]:</p>
+				<p>This document uses <a data-cite="epub-33#sec-terminology">terminology defined in EPUB 3</a>
+					[[EPUB-3]]:</p>
 
-				<p>In addition, it uses the <a href="https://www.w3.org/TR/WCAG2/#dfn-assistive-technologies">WCAG 2
-						definition</a> of <dfn data-lt="assistive technologies">Assistive Technology</dfn>.</p>
+				<p>In addition, it uses the <a data-cite="WCAG2#dfn-assistive-technologies">WCAG 2 definition</a> of
+						<dfn data-lt="assistive technologies">Assistive Technology</dfn>.</p>
 
 				<p>Only the first instance of a term in a section links to its definition.</p>
 
@@ -372,8 +363,7 @@
 					<li>
 						<p>flashing — if a resource flashes more than three times a second, it can cause seizures (e.g.,
 							videos and animations). See also [[WCAG2]] <a
-								href="https://www.w3.org/TR/WCAG2/#seizures-and-physical-reactions">Guideline
-							2.3</a>.</p>
+								data-cite="WCAG2#seizures-and-physical-reactions">Guideline 2.3</a>.</p>
 					</li>
 					<li>
 						<p>motion simulation — if a resource simulates motion, it can cause a user to become nauseated
@@ -697,9 +687,9 @@
 				<section id="access-001">
 					<h4>Ensure meaningful order of content across spreads</h4>
 
-					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#meaningful-sequence">Success Criterion 1.3.2</a>
-						specifies that each web page have a meaningful order (i.e., that the visual presentation of the
-						content match the underlying markup).</p>
+					<p>[[WCAG2]] <a data-cite="WCAG2#meaningful-sequence">Success Criterion 1.3.2</a> specifies that
+						each web page have a meaningful order (i.e., that the visual presentation of the content match
+						the underlying markup).</p>
 
 					<p>As EPUB allows two <a>EPUB Content Documents</a> to be rendered together in a <a
 							href="https://www.w3.org/TR/epub/#spread">synthetic spread</a> [[EPUB-3]], the order of
@@ -719,13 +709,12 @@
 				<section id="access-002">
 					<h4>Provide multiple ways to access the content</h4>
 
-					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#multiple-ways">Success Criterion
-						2.4.5</a> requires there be more than one way to locate a web page within a set of web pages. By
-						default, <a>EPUB Publications</a> meet this WCAG requirement so long as <a>EPUB Creators</a>
-						follow the EPUB requirements to <a href="https://www.w3.org/TR/epub/#sec-spine-elem">include all
-							EPUB Content Documents in the spine</a> and <a
-							href="https://www.w3.org/TR/epub/#sec-itemref-elem">ensure access to all non-linear
-							documents</a> [[EPUB-3]].</p>
+					<p>[[WCAG2]] <a data-cite="WCAG2#multiple-ways">Success Criterion 2.4.5</a> requires there be more
+						than one way to locate a web page within a set of web pages. By default, <a>EPUB
+							Publications</a> meet this WCAG requirement so long as <a>EPUB Creators</a> follow the EPUB
+						requirements to <a href="https://www.w3.org/TR/epub/#sec-spine-elem">include all EPUB Content
+							Documents in the spine</a> and <a href="https://www.w3.org/TR/epub/#sec-itemref-elem">ensure
+							access to all non-linear documents</a> [[EPUB-3]].</p>
 
 					<p>The reason an EPUB Publication passes by meeting these requirements has to do with differences in
 						how a user interacts with the set of documents in an EPUB Publication. In particular, although
@@ -1094,10 +1083,10 @@
 				<section id="titles-001">
 					<h4>Include publication and document titles</h4>
 
-					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#page-titled">Success Criterion 2.4.2</a> requires
-						that each web page include a title. EPUB has a similar requirement for <a>EPUB Publications</a>:
-						publications require a [[DCTERMS]] <code>title</code> element in the <a>Package Document</a>
-						metadata. The [[WCAG2]] requirement is not satisfied by the EPUB requirement, however.</p>
+					<p>[[WCAG2]] <a data-cite="WCAG2#page-titled">Success Criterion 2.4.2</a> requires that each web
+						page include a title. EPUB has a similar requirement for <a>EPUB Publications</a>: publications
+						require a [[DCTERMS]] <code>title</code> element in the <a>Package Document</a> metadata. The
+						[[WCAG2]] requirement is not satisfied by the EPUB requirement, however.</p>
 
 					<p>When authoring an EPUB Publication each <a>EPUB Content Document</a> also requires a descriptive
 						title that describes its content. If not provided, <a>Assistive Technologies</a> often will
@@ -1219,12 +1208,12 @@
 				<section id="titles-003">
 					<h4>Heading topic or purpose</h4>
 
-					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#non-text-content">Success Criterion 2.4.6</a>
-						currently states that all headings must describe their topic or purpose. The implication of this
-						wording is that all chapters in a novel, for example, have a topic or purpose and that the topic
-						or purpose is always clearly reflected by the title of the chapter. Not only is this not always
-						the case, but this success criterion also complicates the use of chapter numbers as headings
-						since these do not establish a topic.</p>
+					<p>[[WCAG2]] <a data-cite="WCAG2#non-text-content">Success Criterion 2.4.6</a> currently states that
+						all headings must describe their topic or purpose. The implication of this wording is that all
+						chapters in a novel, for example, have a topic or purpose and that the topic or purpose is
+						always clearly reflected by the title of the chapter. Not only is this not always the case, but
+						this success criterion also complicates the use of chapter numbers as headings since these do
+						not establish a topic.</p>
 
 					<p>After discussion in the <a href="https://github.com/w3c/wcag/issues/2039">Accessibility
 							Guidelines Working Group's issue tracker</a>, it is clear that the <a
@@ -1276,9 +1265,9 @@
 				<section id="lang-001">
 					<h4>Language of Package Document</h4>
 
-					<p>[[WCAG2]] Success Criterions <a href="https://www.w3.org/TR/WCAG2/#language-of-page">3.1.1</a>
-						and <a href="https://www.w3.org/TR/WCAG2/#language-of-parts">3.1.2</a> deal with the language of
-						a page and changes of language with in, respectively.</p>
+					<p>[[WCAG2]] Success Criterions <a data-cite="WCAG2#language-of-page">3.1.1</a> and <a
+							data-cite="WCAG2#language-of-parts">3.1.2</a> deal with the language of a page and changes
+						of language with in, respectively.</p>
 
 					<p>For <a>EPUB Publications</a>, the <a>Package Document</a> is also an important source of metadata
 						information about the publication. For example, <a>Reading Systems</a> expose details of the
@@ -1338,10 +1327,10 @@
 					</aside>
 
 					<p>Although it is not strictly required to set this information to meet [[WCAG2]] <a
-							href="https://www.w3.org/TR/WCAG2/#language-of-page">Success Criterion 3.1.1</a>, as it is
-						non-normative, it should be considered a best practice to always set this field with the proper
-						language information. (Note that EPUB3 requires the language always be specified, so omitting
-						will fail validation requirements.)</p>
+							data-cite="WCAG2#language-of-page">Success Criterion 3.1.1</a>, as it is non-normative, it
+						should be considered a best practice to always set this field with the proper language
+						information. (Note that EPUB3 requires the language always be specified, so omitting will fail
+						validation requirements.)</p>
 
 					<p>Although <a>Reading Systems</a> do not use this language information to render the text content
 						of the EPUB Publication, they do use it to optimize the reading experience for users (e.g., to
@@ -1359,13 +1348,13 @@
 				<section id="text-001">
 					<h4>Use Unicode for text content</h4>
 
-					<p>[[WCAG2]] <a href="https://www.w3.org/TR/WCAG2/#non-text-content">Success Criterion 1.1.1</a>
-						requires that text equivalents be provided for all non-text content to meet Level A. In some
-						regions (e.g., Asia), it is not uncommon to find images of individual text characters, despite
-						the availability of Unicode character equivalents. This practice occurs for various reasons,
-						such as ease of translation of older documents and for compatibility across <a>Reading
-							Systems</a>. The use of images in most instances leads to the text not being accessible to
-						non-visual users, however.</p>
+					<p>[[WCAG2]] <a data-cite="WCAG2#non-text-content">Success Criterion 1.1.1</a> requires that text
+						equivalents be provided for all non-text content to meet Level A. In some regions (e.g., Asia),
+						it is not uncommon to find images of individual text characters, despite the availability of
+						Unicode character equivalents. This practice occurs for various reasons, such as ease of
+						translation of older documents and for compatibility across <a>Reading Systems</a>. The use of
+						images in most instances leads to the text not being accessible to non-visual users,
+						however.</p>
 
 					<p>When individual characters are replaced by images, there is invariably a negative effect on
 						text-to-speech playback, even when alternative text is provided (e.g., if single characters
@@ -1376,9 +1365,9 @@
 					<p>The use of Unicode characters for all text content avoids this problem, allowing content to
 						successfully meet the minimum requirement for Level A.</p>
 
-					<p>For compliance with Level AA, EPUB Creators are directed to <a
-							href="https://www.w3.org/TR/WCAG2/#images-of-text">Success Criterion 1.4.5</a> which further
-						restricts the use of images of text to only a set of essential cases.</p>
+					<p>For compliance with Level AA, EPUB Creators are directed to <a data-cite="WCAG2#images-of-text"
+							>Success Criterion 1.4.5</a> which further restricts the use of images of text to only a set
+						of essential cases.</p>
 				</section>
 			</section>
 
@@ -1390,16 +1379,16 @@
 					version of the content that lacks alternative text or descriptions could be bundled with a
 					WCAG-compliant text-based serialization. This type of accessible bundling is acceptable, as
 					[[WCAG2]] allows non-conforming content provided a <a
-						href="https://www.w3.org/TR/WCAG2/#dfn-conforming-alternate-version">conforming alternate
-						version</a> is available.</p>
+						data-cite="WCAG2#dfn-conforming-alternate-version">conforming alternate version</a> is
+					available.</p>
 
-				<p>The [[EPUBMultipleRenditions-10]] specification defines a set of features for creating these types of
-					EPUB Publications. It specifies a set of attributes that allow a <a>Reading System</a> to
-					automatically select a preferred rendition for the user or to provide the user the option to
-					manually select between the available options. This functionality technically meets the requirements
-					of [[WCAG2]] in terms of ensuring the user can access the accessible version.</p>
+				<p>The [[EPUB-MULTI-REND-11]] specification defines a set of features for creating these types of EPUB
+					Publications. It specifies a set of attributes that allow a <a>Reading System</a> to automatically
+					select a preferred rendition for the user or to provide the user the option to manually select
+					between the available options. This functionality technically meets the requirements of [[WCAG2]] in
+					terms of ensuring the user can access the accessible version.</p>
 
-				<p>In practice, however, the [[EPUBMultipleRenditions-10]] specification is not broadly supported in
+				<p>In practice, however, the [[EPUB-MULTI-REND-11]] specification is not broadly supported in
 					Reading Systems at the time of publication. As a result, a user who obtains an EPUB Publication that
 					contains more than one rendition will only have access to the default. Unless this rendition is the
 					accessible one, the EPUB Publication might not be readable by them.</p>
@@ -1723,7 +1712,7 @@
 						providing the user all the information in the EPUB Publication.</p>
 
 					<p>Text alternatives and descriptions in HTML may be represented in the <a
-							data-lt="html#attr-img-alt"><code>alt</code> attribute</a> [[HTML]] and linked by ARIA
+							data-cite="html#attr-img-alt"><code>alt</code> attribute</a> [[HTML]] and linked by ARIA
 						attributes (e.g., <a data-cite="wai-aria#aria-describedby"><code>aria-describedby</code></a> and
 							<a data-cite="wai-aria#aria-details"><code>aria-details</code></a> [[WAI-ARIA]]).
 						Descriptions for image elements in SVG are typically represented in a <a

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -690,13 +690,13 @@
 						visually from one document to the next. For example, a sidebar might span the bottom of two
 						pages.</p>
 
-					<p>Ordering each document separately by the visual display will lead to users of <a>Assistive
-							Technologies</a> encountering gaps between the start and end of the spanned text. If the
-						markup cannot be arranged to provide a more logical reading experience (e.g., the beginning of
-						the spanned content at the end of the first page followed by the conclusion at the start of the
-						next), another means of satisfying this criteria will be necessary to avoid failure (e.g., a
-						hyperlink could be provided to allow a user to jump from the break point on the first page to
-						the continuation on the next).</p>
+					<p>Ordering each document separately by the visual display will lead to users of <a
+							data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a> encountering
+						gaps between the start and end of the spanned text. If the markup cannot be arranged to provide
+						a more logical reading experience (e.g., the beginning of the spanned content at the end of the
+						first page followed by the conclusion at the start of the next), another means of satisfying
+						this criteria will be necessary to avoid failure (e.g., a hyperlink could be provided to allow a
+						user to jump from the break point on the first page to the continuation on the next).</p>
 				</section>
 
 				<section id="access-002">
@@ -837,10 +837,10 @@
 
 					<p>The key difference between these attributes is that the <code>role</code> attribute bridges
 						accessibility in content while the <code>type</code> attribute provides hooks to enable
-							<a>Reading System</a> behaviors. Omitting roles lessens the accessibility for users of
-							<a>Assistive Technologies</a>, in other words, while omitting types diminishes certain
-						functionality in <a>Reading Systems</a> (e.g., pop-up footnotes or special presentations of the
-						content).</p>
+							<a>Reading System</a> behaviors. Omitting roles lessens the accessibility for users of <a
+							data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a>, in other
+						words, while omitting types diminishes certain functionality in <a>Reading Systems</a> (e.g.,
+						pop-up footnotes or special presentations of the content).</p>
 
 					<p>Since each attribute offers different advantages, it is not necessary that they be used together.
 						Due to the lack of restrictions on where <a>EPUB Creators</a> can use the <code>type</code>
@@ -873,10 +873,11 @@
 						each chapter, putting each into a separate document.</p>
 
 					<p>Although visually these restructuring decisions can be hidden from readers, they impact the
-						functionality of <a>Assistive Technologies</a>. In the case of [[WAI-ARIA]] roles, the result is
-						that only the subset present in the currently-loaded EPUB Content Document are exposed to users.
-						An Assistive Technology cannot provide a list of landmarks for the whole publication, as it
-						cannot see outside the current document.</p>
+						functionality of <a data-cite="epub-a11y-11#dfn-assistive-technology">Assistive
+						Technologies</a>. In the case of [[WAI-ARIA]] roles, the result is that only the subset present
+						in the currently-loaded EPUB Content Document are exposed to users. An Assistive Technology
+						cannot provide a list of landmarks for the whole publication, as it cannot see outside the
+						current document.</p>
 
 					<p>To counteract this destructuring effect, EPUB Creators sometimes think to re-add or re-identify
 						structures in the belief that having this information in every document will be helpful to users
@@ -948,10 +949,11 @@
 					<p>[[WAI-ARIA]] <a data-cite="wai-aria#dfn-landmark">landmarks</a> are similar in nature to <a
 							href="https://www.w3.org/TR/epub/#sec-nav-landmarks">EPUB landmarks</a> [[EPUB-3]]: both are
 						designed to provide users with quick access to the major structures of a document, such as
-						chapters, glossaries and indexes. ARIA landmarks are compiled automatically by <a>Assistive
-							Technologies</a> from the <a href="#sem-001">roles</a> that have been applied to the markup,
-						so <a>EPUB Creators</a> only need to follow the requirement to include roles for the landmarks
-						to be made available to users.</p>
+						chapters, glossaries and indexes. ARIA landmarks are compiled automatically by <a
+							data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a> from the <a
+							href="#sem-001">roles</a> that have been applied to the markup, so <a>EPUB Creators</a> only
+						need to follow the requirement to include roles for the landmarks to be made available to
+						users.</p>
 
 					<p>Although automatic generation of ARIA landmarks simplifies authoring, it also means that ARIA
 						landmarks are limited to how the EPUB Publication has been chunked up into <a>EPUB Content
@@ -1082,7 +1084,8 @@
 						[[WCAG2]] requirement is not satisfied by the EPUB requirement, however.</p>
 
 					<p>When authoring an EPUB Publication each <a>EPUB Content Document</a> also requires a descriptive
-						title that describes its content. If not provided, <a>Assistive Technologies</a> often will
+						title that describes its content. If not provided, <a
+							data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a> often will
 						announce the name of the file to users.</p>
 
 					<aside class="example" title="Title for an EPUB Content Document">
@@ -1413,7 +1416,8 @@
 							data-cite="dpub-aria-1.0#doc-pagebreak">doc-pagebreak</a>, respectively.</p>
 
 					<p>It is recommended that both semantics be applied to EPUB 3 content to ensure maximum
-						compatibility with <a>Reading Systems</a> and <a>Assistive Technologies</a>.</p>
+						compatibility with <a>Reading Systems</a> and <a
+							data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a>.</p>
 
 					<aside class="example" title="Expressing a page break">
 						<p>In this example, the EPUB Creator identifies an HTML <code>span</code> element as a page
@@ -1730,9 +1734,10 @@
 
 					<p>EPUB Creators need to use caution when making alterations, however, as other accessibility issues
 						can arise when the logical order does not match the default order. For example, the content may
-						not be accessible to users of <a>Assistive Technologies</a> when the order in the markup does
-						not match how the Assistive Technology reads the content. In these cases, using playback to
-						create a logical order can make the EPUB Publication fail WCAG conformance requirements.</p>
+						not be accessible to users of <a data-cite="epub-a11y-11#dfn-assistive-technology">Assistive
+							Technologies</a> when the order in the markup does not match how the Assistive Technology
+						reads the content. In these cases, using playback to create a logical order can make the EPUB
+						Publication fail WCAG conformance requirements.</p>
 
 					<p>One case where the logical may diverge from the reading order and remain accessible is in tables,
 						as Assistive Technologies typically allow users to choose whether to read by row or by
@@ -1969,11 +1974,12 @@
 					as the ability to limit access to a single user and to limit the length of time the person can
 					access the publication (e.g., library loans).</p>
 
-				<p>In general, DRM can be made to work interoperably with <a>Assistive Technologies</a>, but problems
-					arise when DRM restrictions remove direct access to an EPUB Publication or restrict access to the
-					content within it. Unless the <a>Reading System</a> implementing the DRM provides API level access
-					to the content, it can prove difficult, or even impossible, to generate text-to-speech playback, or
-					for a refreshable braille display to have access to the underlying text, as well as cause other
+				<p>In general, DRM can be made to work interoperably with <a
+						data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a>, but problems arise
+					when DRM restrictions remove direct access to an EPUB Publication or restrict access to the content
+					within it. Unless the <a>Reading System</a> implementing the DRM provides API level access to the
+					content, it can prove difficult, or even impossible, to generate text-to-speech playback, or for a
+					refreshable braille display to have access to the underlying text, as well as cause other
 					accessibility issues.</p>
 
 				<p>The application of digital rights management therefore must not impair or impede the functionality of

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -50,7 +50,7 @@
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
-				xref: ["epub-33","html"],
+				xref: ["epub-33"],
 				localBiblio: {
 					"A11Y-DISCOV-VOCAB": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
@@ -233,10 +233,11 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This specification uses terminology defined in EPUB 3 [[EPUB-3]].</p>
-
-				<p>In addition, it uses the <a href="https://www.w3.org/TR/WCAG2/#dfn-assistive-technologies">WCAG 2
-						definition</a> of <dfn data-lt="assistive technologies">Assistive Technology</dfn>.</p>
+				<p>This document uses <a data-cite="epub-33#sec-terminology">terminology defined in EPUB 3</a>
+					[[EPUB-3]]:</p>
+				
+				<p>In addition, it uses the <a data-cite="WCAG2#dfn-assistive-technologies">WCAG 2 definition</a> of
+						<dfn data-lt="assistive technologies">Assistive Technology</dfn>.</p>
 
 				<p>Only the first instance of a term in a section links to its definition.</p>
 
@@ -423,8 +424,8 @@
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-wcag-20">MUST, at the minimum, meet the requirements of WCAG 2.0 [[WCAG20]],
-								but it is strongly recommended that it meet the requirements of the <a
-									href="https://www.w3.org/TR/WCAG2/">latest recommended version of WCAG 2</a>.</p>
+								but it is strongly recommended that it meet the requirements of the <a data-cite="WCAG2"
+									>latest recommended version of WCAG 2</a>.</p>
 						</li>
 
 						<li>
@@ -432,10 +433,10 @@
 								of Level A, but it is strongly recommended that it meet the requirements of Level
 								AA.</p>
 							<div class="note">
-								<p>Although, as <a href="https://www.w3.org/TR/WCAG21/#h-note-29">noted in WCAG</a>,
-									conforming at level AAA is typically not possible, and not required by this
-									specification, <a>EPUB Creators</a> are encouraged to follow the practices detailed
-									in AAA success criteria when producing accessible EPUB Publications.</p>
+								<p>Although, as <a data-cite="WCAG21#h-note-29">noted in WCAG</a>, conforming at level
+									AAA is typically not possible, and not required by this specification, <a>EPUB
+										Creators</a> are encouraged to follow the practices detailed in AAA success
+									criteria when producing accessible EPUB Publications.</p>
 							</div>
 						</li>
 					</ul>
@@ -490,11 +491,10 @@
 					<section id="sec-wcag-eval-page-pub">
 						<h5>Page and Publication</h5>
 
-						<p>The WCAG <a href="https://www.w3.org/TR/WCAG2/#wcag-2-layers-of-guidance">principles</a>
-							[[WCAG2]] focus on the evaluation of individual web pages, but an <a>EPUB Publication</a>
-							more closely resembles what WCAG refers to as a <a
-								href="https://www.w3.org/TR/WCAG2/#dfn-set-of-web-pages">set of web pages</a>: "[a]
-							collection of web pages that share a common purpose" [[WCAG2]].</p>
+						<p>The WCAG <a data-cite="WCAG2#wcag-2-layers-of-guidance">principles</a> [[WCAG2]] focus on the
+							evaluation of individual web pages, but an <a>EPUB Publication</a> more closely resembles
+							what WCAG refers to as a <a data-cite="WCAG2#dfn-set-of-web-pages">set of web pages</a>:
+							"[a] collection of web pages that share a common purpose" [[WCAG2]].</p>
 
 						<p>Consequently, when evaluating the accessibility of an EPUB Publication, <a>EPUB Creators</a>
 							cannot review individual pages — or Content Documents, as they are known in EPUB 3 — in
@@ -518,29 +518,28 @@
 					<section id="sec-wcag-application">
 						<h5>Applying the Conformance Criteria</h5>
 
-						<p>When evaluating an <a>EPUB Publication</a>, the WCAG <a
-								href="https://www.w3.org/TR/WCAG2/#conformance-reqs">conformance criteria</a> [[WCAG2]]
-							are applied as follows:</p>
+						<p>When evaluating an <a>EPUB Publication</a>, the WCAG <a data-cite="WCAG2#conformance-reqs"
+								>conformance criteria</a> [[WCAG2]] are applied as follows:</p>
 
 						<ul>
 							<li>When determining compliance with a conformance level, the whole EPUB Publication MUST
 								meet the conformance requirements of the level claimed.</li>
 
 							<li><a>EPUB Creators</a> MUST NOT use EPUB's fallback mechanisms to provide a <a
-									href="https://www.w3.org/TR/WCAG2/#dfn-conforming-alternate-version">conforming
-									alternate version</a> [[WCAG2]], as there is no reliable way for users to access
-								such fallbacks. If an EPUB Creator uses fallbacks, both the primary content and its
-								fallback(s) MUST meet the requirements for the conformance level claimed. EPUB-specific
-								fallback mechanisms include <a href="https://www.w3.org/TR/epub/#sec-manifest-fallbacks"
-									>manifest fallbacks</a> [[EPUB-3]], <a
-									href="https://www.w3.org/TR/epub/#sec-opf-bindings">bindings</a> [[EPUB-3]] and
-								content switching via the <a href="https://www.w3.org/TR/epub/#sec-xhtml-content-switch"
-										><code>epub:switch</code> element</a> [[EPUB-3]].</li>
+									data-cite="WCAG2#dfn-conforming-alternate-version">conforming alternate version</a>
+								[[WCAG2]], as there is no reliable way for users to access such fallbacks. If an EPUB
+								Creator uses fallbacks, both the primary content and its fallback(s) MUST meet the
+								requirements for the conformance level claimed. EPUB-specific fallback mechanisms
+								include <a href="https://www.w3.org/TR/epub/#sec-manifest-fallbacks">manifest
+									fallbacks</a> [[EPUB-3]], <a href="https://www.w3.org/TR/epub/#sec-opf-bindings"
+									>bindings</a> [[EPUB-3]] and content switching via the <a
+									href="https://www.w3.org/TR/epub/#sec-xhtml-content-switch"><code>epub:switch</code>
+									element</a> [[EPUB-3]].</li>
 
-							<li>The "<a href="https://www.w3.org/TR/WCAG2/#cc2">Full Pages</a>" requirement [WCAG2] --
-								that parts of a page cannot be excluded when making a conformance claim -- applies to
-								every <a>EPUB Content Document</a> in the EPUB Publication (i.e., they must all conform
-								in full to the conformance level claimed).</li>
+							<li>The "<a data-cite="WCAG2#cc2">Full Pages</a>" requirement [WCAG2] -- that parts of a
+								page cannot be excluded when making a conformance claim -- applies to every <a>EPUB
+									Content Document</a> in the EPUB Publication (i.e., they must all conform in full to
+								the conformance level claimed).</li>
 						</ul>
 					</section>
 				</section>
@@ -574,9 +573,9 @@
 								Publication</a> can be complicated without static references.</p>
 
 						<p>The inclusion of page navigation represents one method of achieving the <a
-								href="https://www.w3.org/TR/WCAG2/#multiple-ways">Multiple Ways success criterion</a>
-							[[WCAG2]], as it provides another meaningful way for users to access the content (e.g., in
-							addition to the table of contents, linear reading order and any other navigation aids).</p>
+								data-cite="WCAG2#multiple-ways">Multiple Ways success criterion</a> [[WCAG2]], as it
+							provides another meaningful way for users to access the content (e.g., in addition to the
+							table of contents, linear reading order and any other navigation aids).</p>
 
 						<p>Given the importance of page navigation in mixed print/digital environments, the requirement
 							to include this feature has higher precedence than it would solely as one of many ways to
@@ -770,10 +769,9 @@
 							escape users from deeply nested structures like tables.</p>
 
 						<p>Adding structure and semantics to synchronized text-audio playback broadly falls under the
-							objective of the <a href="https://www.w3.org/TR/WCAG2/#info-and-relationships">Info and
-								Relationships success criterion</a> [[WCAG2]]. Without structured and semantically
-							meaningful playback sequences, the effect is to deprive users of rich navigation of the
-							content.</p>
+							objective of the <a data-cite="WCAG2#info-and-relationships">Info and Relationships success
+								criterion</a> [[WCAG2]]. Without structured and semantically meaningful playback
+							sequences, the effect is to deprive users of rich navigation of the content.</p>
 					</section>
 
 					<section id="sec-sync-applicability">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -235,7 +235,7 @@
 
 				<p>This document uses <a data-cite="epub-33#sec-terminology">terminology defined in EPUB 3</a>
 					[[EPUB-3]]:</p>
-				
+
 				<p>In addition, it uses the <a data-cite="WCAG2#dfn-assistive-technologies">WCAG 2 definition</a> of
 						<dfn data-lt="assistive technologies">Assistive Technology</dfn>.</p>
 
@@ -424,8 +424,8 @@
 					<ul class="conformance-list">
 						<li>
 							<p id="confreq-wcag-20">MUST, at the minimum, meet the requirements of WCAG 2.0 [[WCAG20]],
-								but it is strongly recommended that it meet the requirements of the <a data-cite="WCAG2"
-									>latest recommended version of WCAG 2</a>.</p>
+								but it is strongly recommended that it meet the requirements of the <a
+									data-cite="WCAG2#">latest recommended version of WCAG 2</a>.</p>
 						</li>
 
 						<li>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -235,15 +235,14 @@
 
 				<p>This specification uses terminology defined in EPUB 3 [[EPUB-3]].</p>
 
-				<p>In addition, it uses the definition of <a
-						href="https://www.w3.org/TR/WCAG2/#dfn-assistive-technologies">assistive technology</a> as
-					defined in [[WCAG2]].</p>
-				
+				<p>In addition, it uses the <a href="https://www.w3.org/TR/WCAG2/#dfn-assistive-technologies">WCAG 2
+						definition</a> of <dfn data-lt="assistive technologies">Assistive Technology</dfn>.</p>
+
 				<p>Only the first instance of a term in a section links to its definition.</p>
-				
+
 				<div class="note">
-					<p>An assistive technology is not always a separate application from a <a>Reading System</a>.
-						Reading Systems often integrate features of standalone assistive technologies, such as
+					<p>An Assistive Technology is not always a separate application from a <a>Reading System</a>.
+						Reading Systems often integrate features of standalone Assistive Technologies, such as
 						text-to-speech playback.</p>
 				</div>
 			</section>
@@ -1556,14 +1555,14 @@
 				typically does not control the accessibility of the digital rights management (DRM) scheme applied to
 				their EPUB Publications, they do control what usage rights to apply to their EPUB Publications. So even
 				though a DRM scheme may allow an Author to block access to the text of the publication, the EPUB Creator
-				needs to take care not to apply such a restriction as it could block the ability for assistive
-				technologies to read the text aloud.</p>
+				needs to take care not to apply such a restriction as it could block the ability for <a>Assistive
+					Technologies</a> to read the text aloud.</p>
 
 			<p>To minimize the effects of distribution on accessibility, this specification advises EPUB Creators adhere
 				to the following distribution practices:</p>
 
 			<ul>
-				<li>they must not impose restrictions that impair access by assistive technologies; and</li>
+				<li>they must not impose restrictions that impair access by Assistive Technologies; and</li>
 				<li>they must include accessibility metadata in the record format required for distribution of an EPUB
 					Publication (e.g., [[ONIX]] or [[MARC21]]) when the format supports such metadata.</li>
 			</ul>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -711,9 +711,9 @@
 								<dt id="sec-page-breaks-understand">Understanding this Objective</dt>
 								<dd>
 									<p>Inserting page break markers into an <a>EPUB Publication</a> provides users with
-										context about where they are in the text. Assistive technologies can use this
-										information to announce the current page number the user is on, for example, if
-										the user wants to cite something on the page.</p>
+										context about where they are in the text. <a>Assistive Technologies</a> can use
+										this information to announce the current page number the user is on, for
+										example, if the user wants to cite something on the page.</p>
 									<p>The inclusion of page break markers can also allow users to move quickly forwards
 										and backwards by page without having to access the page list each time.</p>
 									<p>The inclusion of these markers also simplifies the creation of a <a

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -239,7 +239,7 @@
 				<p>In addition, it defines the following term:</p>
 
 				<dl>
-					<dt><dfn>Assistive Technology</dfn></dt>
+					<dt><dfn id="dfn-assistive-technology">Assistive Technology</dfn></dt>
 					<dd>
 						<p>This specification uses the <a data-cite="WCAG2#dfn-assistive-technologies">definition of
 								assistive technology</a> from [[WCAG2]].</p>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -238,7 +238,9 @@
 				<p>In addition, it uses the definition of <a
 						href="https://www.w3.org/TR/WCAG2/#dfn-assistive-technologies">assistive technology</a> as
 					defined in [[WCAG2]].</p>
-
+				
+				<p>Only the first instance of a term in a section links to its definition.</p>
+				
 				<div class="note">
 					<p>An assistive technology is not always a separate application from a <a>Reading System</a>.
 						Reading Systems often integrate features of standalone assistive technologies, such as

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -236,16 +236,20 @@
 				<p>This document uses <a data-cite="epub-33#sec-terminology">terminology defined in EPUB 3</a>
 					[[EPUB-3]]:</p>
 
-				<p>In addition, it uses the <a data-cite="WCAG2#dfn-assistive-technologies">WCAG 2 definition</a> of
-						<dfn data-lt="assistive technologies">Assistive Technology</dfn>.</p>
+				<p>In addition, it defines the following term:</p>
+
+				<dl>
+					<dt><dfn>Assistive Technology</dfn></dt>
+					<dd>
+						<p>This specification uses the <a data-cite="WCAG2#dfn-assistive-technologies">definition of
+								assistive technology</a> from [[WCAG2]].</p>
+						<p>In the case of EPUB, an Assistive Technology is not always a separate application from a
+								<a>Reading System</a>. Reading Systems often integrate features of standalone Assistive
+							Technologies, such as text-to-speech playback.</p>
+					</dd>
+				</dl>
 
 				<p>Only the first instance of a term in a section links to its definition.</p>
-
-				<div class="note">
-					<p>An Assistive Technology is not always a separate application from a <a>Reading System</a>.
-						Reading Systems often integrate features of standalone Assistive Technologies, such as
-						text-to-speech playback.</p>
-				</div>
 			</section>
 
 			<section id="conformance"></section>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -50,6 +50,7 @@
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
+				xref: ["epub-33","html"],
 				localBiblio: {
 					"A11Y-DISCOV-VOCAB": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
@@ -138,7 +139,7 @@
 				<p>This specification, EPUB Accessibility, addresses two key needs in the EPUB ecosystem:</p>
 
 				<ul>
-					<li>discoverability of the accessible qualities of EPUB Publications; and</li>
+					<li>discoverability of the accessible qualities of <a>EPUB Publications</a>; and</li>
 					<li>evaluation and certification of accessible EPUB Publications.</li>
 				</ul>
 
@@ -148,7 +149,7 @@
 					certification. At a minimum, all EPUB Publications that conform to this specification meet the
 					accessibility metadata requirements described in <a href="#sec-discovery"></a>.</p>
 
-				<p>Although EPUB Creators have always been able to create EPUB Publications with a high degree of
+				<p>Although <a>EPUB Creators</a> have always been able to create EPUB Publications with a high degree of
 					accessibility, this specification sets formal requirements for certifying content accessible. These
 					requirements provide EPUB Creators a clear set of guidelines to evaluate their content against and
 					allows certification of quality. An accessible EPUB Publication is one that meets the accessibility
@@ -179,21 +180,14 @@
 			<section id="sec-success-techniques" class="informative">
 				<h3>Success Techniques</h3>
 
-				<p>This specification takes an abstract approach to the accessibility requirements for EPUB
-					Publications, similar to how WCAG [[WCAG2]] separates its accessibility guidelines from the
+				<p>This specification takes an abstract approach to the accessibility requirements for <a>EPUB
+						Publications</a>, similar to how WCAG [[WCAG2]] separates its accessibility guidelines from the
 					techniques to achieve them. This approach allows the guidelines to remain stable even as the format
 					evolves.</p>
 
 				<p>To facilitate this approach, the companion <a data-cite="epub-a11y-tech-11#">EPUB Accessibility
 						Techniques</a> [[EPUB-A11Y-TECH-11]] document outlines conformance techniques. These techniques
 					explain how to meet the requirements of this specification for different versions of EPUB.</p>
-
-				<div class="ednote">
-					<p>A task force of the EPUB 3 Working Group is currently producing <a
-							href="https://w3c.github.io/epub-specs/epub33/fxl-a11y/">techniques for accessible fixed
-							layout publications</a>. When that document is formally published, it should be mentioned in
-						this section.</p>
-				</div>
 
 				<section id="sec-sc-i18n">
 					<h4>Internationalization</h4>
@@ -206,10 +200,10 @@
 					<p>At the same time, the language and writing conventions of the authored text will influence the
 						techniques necessary to meet the accessibility requirements. EPUB <a
 							data-cite="epub-33#confreq-xml-enc">requires support for Unicode text</a> [[EPUB-3]], for
-						example, which ensures the correct character data can be used (i.e., EPUB Creators do not have
-						to use images of text). Although this is an important feature, it is often not enough on its own
-						to ensure that the text is fully accessible in any given language (e.g., additional information
-						about directionality, emphasis, pronunciation, etc. may also be needed).</p>
+						example, which ensures the correct character data can be used (i.e., <a>EPUB Creators</a> do not
+						have to use images of text). Although this is an important feature, it is often not enough on
+						its own to ensure that the text is fully accessible in any given language (e.g., additional
+						information about directionality, emphasis, pronunciation, etc. may also be needed).</p>
 
 					<p>As a consequence, there may be language- or culture-specific practices for meeting accessibility
 						requirements. Whether these practices are defined within this specification and its techniques
@@ -221,12 +215,12 @@
 			<section id="sec-application" class="informative">
 				<h3>Application to Older Versions</h3>
 
-				<p>This specification is applicable to any EPUB Publication, even if the content conforms to an older
-					version of EPUB that does not refer to this specification (e.g., EPUB 2 [[OPF-201]]).</p>
+				<p>This specification is applicable to any <a>EPUB Publication</a>, even if the content conforms to an
+					older version of EPUB that does not refer to this specification (e.g., EPUB 2 [[OPF-201]]).</p>
 
 				<p>Creators of such EPUB Publications should create content in conformance with the accessibility and
-					discoverability requirements of this specification. EPUB Creators should also upgrade to the latest
-					version of EPUB to get access to the most advanced accessibility features and techniques.</p>
+					discoverability requirements of this specification. <a>EPUB Creators</a> should also upgrade to the
+					latest version of EPUB to get access to the most advanced accessibility features and techniques.</p>
 
 				<p>Note that not all metadata expressions defined in this specification are supported in older version
 					of EPUB. EPUB 2, in particular, does not support the <a
@@ -239,37 +233,16 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This specification uses the following terminology defined in EPUB 3 [[EPUB-3]]:</p>
-
-				<ul>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-content-document">EPUB Content Document</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB Creator</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB Publication</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-media-overlay-document">Media Overlays Document</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-package-document">Package Document</a>
-					</li>
-					<li>
-						<a href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">Reading System</a>
-					</li>
-				</ul>
+				<p>This specification uses terminology defined in EPUB 3 [[EPUB-3]].</p>
 
 				<p>In addition, it uses the definition of <a
 						href="https://www.w3.org/TR/WCAG2/#dfn-assistive-technologies">assistive technology</a> as
 					defined in [[WCAG2]].</p>
 
 				<div class="note">
-					<p>An assistive technology is not always a separate application from a Reading System. Reading
-						Systems often integrate features of standalone assistive technologies, such as text-to-speech
-						playback.</p>
+					<p>An assistive technology is not always a separate application from a <a>Reading System</a>.
+						Reading Systems often integrate features of standalone assistive technologies, such as
+						text-to-speech playback.</p>
 				</div>
 			</section>
 
@@ -281,10 +254,10 @@
 			<section id="sec-disc-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>Unlike web pages, EPUB Creators distribute EPUB Publications through many channels for personal
-					consumption — a model that has made EPUB a successful format for ebooks and other types of digital
-					publications. A consequence of this model, however, is that specific details about the accessibility
-					of a publication must travel with it.</p>
+				<p>Unlike web pages, <a>EPUB Creators</a> distribute <a>EPUB Publications</a> through many channels for
+					personal consumption — a model that has made EPUB a successful format for ebooks and other types of
+					digital publications. A consequence of this model, however, is that specific details about the
+					accessibility of a publication must travel with it.</p>
 
 				<p>An online bookstore aggregating content from publishers and authors, for example, does not know the
 					production quality that went into each submission unless the publisher informs them through
@@ -307,10 +280,10 @@
 			<section id="sec-disc-package">
 				<h3>Package Metadata</h3>
 
-				<p>All EPUB Publications MUST include [[schema-org]] accessibility metadata in the Package Document that
-					exposes their accessible properties, regardless of whether the publications also meet the <a
-						href="#sec-accessible-pubs">accessibility</a> or <a href="#sec-optimized-pubs">optimization</a>
-					requirements.</p>
+				<p>All <a>EPUB Publications</a> MUST include [[schema-org]] accessibility metadata in the <a>Package
+						Document</a> that exposes their accessible properties, regardless of whether the publications
+					also meet the <a href="#sec-accessible-pubs">accessibility</a> or <a href="#sec-optimized-pubs"
+						>optimization</a> requirements.</p>
 
 				<p>EPUB Publications MUST include the following accessibility metadata:</p>
 
@@ -355,8 +328,8 @@
 					</li>
 				</ul>
 
-				<p>EPUB Creators MAY include additional [[schema-org]] accessibility metadata not specified in this
-					section.</p>
+				<p><a>EPUB Creators</a> MAY include additional [[schema-org]] accessibility metadata not specified in
+					this section.</p>
 
 				<div class="note">
 					<p>For the complete list of approved terms to use with these properties, refer to the <a
@@ -389,9 +362,9 @@
 				<h3>Introduction</h3>
 
 				<p>EPUB builds on the Open Web Platform, with HTML, CSS, JavaScript and SVG, the core technologies used
-					for content authoring. The use of these technologies means that EPUB Creators can author EPUB
-					Publications with a high degree of accessibility simply through the proper application of
-					established web accessibility techniques.</p>
+					for content authoring. The use of these technologies means that <a>EPUB Creators</a> can author
+						<a>EPUB Publications</a> with a high degree of accessibility simply through the proper
+					application of established web accessibility techniques.</p>
 
 				<p>The primary source producing accessible web content is the W3C Web Content Accessibility Guidelines
 					(WCAG) [[WCAG2]]. This specification leverages the extensive work done in WCAG to establish
@@ -417,7 +390,7 @@
 				<p>This specification does not repeat the requirements or techniques introduced in those documents, as
 					it risks breaking compatibility between the two standards (e.g., putting guidance out of sync, or in
 					conflict). At the same time, although this specification does not call out those requirements, it
-					does not diminish their importance in creating EPUB Publications that are accessible.</p>
+					does not diminish their importance in creating <a>EPUB Publications</a> that are accessible.</p>
 
 				<p>This specification instead defines how to apply WCAG to an EPUB Publication — which is a <a
 						href="#sec-wcag-eval-page-pub">collection of web documents</a> as opposed to a single page — and
@@ -430,9 +403,9 @@
 					that need clarification in the context of an EPUB Publication. It does not mean that the rest of the
 					WCAG techniques are not applicable.</p>
 
-				<p>As a result, although EPUB Creators can read this section without deep knowledge of WCAG conformance,
-					to implement the accessibility requirements of this specification requires an understanding of
-					WCAG.</p>
+				<p>As a result, although <a>EPUB Creators</a> can read this section without deep knowledge of WCAG
+					conformance, to implement the accessibility requirements of this specification requires an
+					understanding of WCAG.</p>
 
 				<p>Because this specification adds requirements that are not a part of WCAG, an EPUB Publication can
 					conform to WCAG without conforming to this specification.</p>
@@ -444,7 +417,7 @@
 				<section id="sec-wcag-conf">
 					<h4>WCAG Conformance Requirements</h4>
 
-					<p>To conform to this specification, an EPUB Publication:</p>
+					<p>To conform to this specification, an <a>EPUB Publication</a>:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -460,8 +433,8 @@
 							<div class="note">
 								<p>Although, as <a href="https://www.w3.org/TR/WCAG21/#h-note-29">noted in WCAG</a>,
 									conforming at level AAA is typically not possible, and not required by this
-									specification, EPUB Creators are encouraged to follow the practices detailed in AAA
-									success criteria when producing accessible EPUB Publications.</p>
+									specification, <a>EPUB Creators</a> are encouraged to follow the practices detailed
+									in AAA success criteria when producing accessible EPUB Publications.</p>
 							</div>
 						</li>
 					</ul>
@@ -517,19 +490,21 @@
 						<h5>Page and Publication</h5>
 
 						<p>The WCAG <a href="https://www.w3.org/TR/WCAG2/#wcag-2-layers-of-guidance">principles</a>
-							[[WCAG2]] focus on the evaluation of individual web pages, but an EPUB Publication more
-							closely resembles what WCAG refers to as a <a
+							[[WCAG2]] focus on the evaluation of individual web pages, but an <a>EPUB Publication</a>
+							more closely resembles what WCAG refers to as a <a
 								href="https://www.w3.org/TR/WCAG2/#dfn-set-of-web-pages">set of web pages</a>: "[a]
 							collection of web pages that share a common purpose" [[WCAG2]].</p>
 
-						<p>Consequently, when evaluating the accessibility of an EPUB Publication, EPUB Creators cannot
-							review individual pages — or Content Documents, as they are known in EPUB 3 — in isolation.
-							Rather, EPUB Creators MUST evaluate their accessibility as part of the larger work.</p>
+						<p>Consequently, when evaluating the accessibility of an EPUB Publication, <a>EPUB Creators</a>
+							cannot review individual pages — or Content Documents, as they are known in EPUB 3 — in
+							isolation. Rather, EPUB Creators MUST evaluate their accessibility as part of the larger
+							work.</p>
 
 						<p>For example, it is not sufficient for EPUB Creators to order the content within individual
-							EPUB Content Documents if they list the documents in the wrong order in the spine. Likewise,
-							including a title for every EPUB Content Document is complementary to providing a title for
-							the publication: the overall accessibility decreases if either is missing.</p>
+								<a>EPUB Content Documents</a> if they list the documents in the wrong order in the
+								<a>spine</a>. Likewise, including a title for every EPUB Content Document is
+							complementary to providing a title for the publication: the overall accessibility decreases
+							if either is missing.</p>
 
 						<p>EPUB Creators MUST evaluate the WCAG guidelines for content to be perceivable, operable,
 							understandable, and robust against the full EPUB Publication, not only against each Content
@@ -542,7 +517,7 @@
 					<section id="sec-wcag-application">
 						<h5>Applying the Conformance Criteria</h5>
 
-						<p>When evaluating an EPUB Publication, the WCAG <a
+						<p>When evaluating an <a>EPUB Publication</a>, the WCAG <a
 								href="https://www.w3.org/TR/WCAG2/#conformance-reqs">conformance criteria</a> [[WCAG2]]
 							are applied as follows:</p>
 
@@ -550,7 +525,7 @@
 							<li>When determining compliance with a conformance level, the whole EPUB Publication MUST
 								meet the conformance requirements of the level claimed.</li>
 
-							<li>EPUB Creators MUST NOT use EPUB's fallback mechanisms to provide a <a
+							<li><a>EPUB Creators</a> MUST NOT use EPUB's fallback mechanisms to provide a <a
 									href="https://www.w3.org/TR/WCAG2/#dfn-conforming-alternate-version">conforming
 									alternate version</a> [[WCAG2]], as there is no reliable way for users to access
 								such fallbacks. If an EPUB Creator uses fallbacks, both the primary content and its
@@ -563,8 +538,8 @@
 
 							<li>The "<a href="https://www.w3.org/TR/WCAG2/#cc2">Full Pages</a>" requirement [WCAG2] --
 								that parts of a page cannot be excluded when making a conformance claim -- applies to
-								every Content Document in the EPUB Publication (i.e., they must all conform in full to
-								the conformance level claimed).</li>
+								every <a>EPUB Content Document</a> in the EPUB Publication (i.e., they must all conform
+								in full to the conformance level claimed).</li>
 						</ul>
 					</section>
 				</section>
@@ -592,10 +567,10 @@
 							of reflowable media does not disadvantage those users.</p>
 
 						<p>Providing page navigation also helps in reflowable publications that do not have a statically
-							paginated equivalent. The default pagination of these publications by Reading Systems is not
-							static since it changes depending on the viewport size and user's font settings. As a
-							result, coordinating locations among users of the same EPUB Publication can be complicated
-							without static references.</p>
+							paginated equivalent. The default pagination of these publications by <a>Reading Systems</a>
+							is not static since it changes depending on the <a>viewport</a> size and user's font
+							settings. As a result, coordinating locations among users of the same <a>EPUB
+								Publication</a> can be complicated without static references.</p>
 
 						<p>The inclusion of page navigation represents one method of achieving the <a
 								href="https://www.w3.org/TR/WCAG2/#multiple-ways">Multiple Ways success criterion</a>
@@ -616,12 +591,13 @@
 					<section id="sec-page-nav-applicability">
 						<h5>Applicability</h5>
 
-						<p>An EPUB Publication SHOULD include page navigation whenever any of the following cases is
-							true:</p>
+						<p>An <a>EPUB Publication</a> SHOULD include page navigation whenever any of the following cases
+							is true:</p>
 
 						<ul>
-							<li>the EPUB Creator identifies the EPUB Publication as the dynamically paginated equivalent
-								of a statically paginated publication (e.g., included in a print/digital bundle);</li>
+							<li>the <a>EPUB Creator</a> identifies the EPUB Publication as the dynamically paginated
+								equivalent of a statically paginated publication (e.g., included in a print/digital
+								bundle);</li>
 
 							<li>the EPUB Creator offers the EPUB Publication as an alternative to a statically paginated
 								publication in an environment where they can reasonably predict the use of both versions
@@ -652,7 +628,7 @@
 
 								<dt id="sec-page-src-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Users need to know the source of the pagination in an EPUB Publication to
+									<p>Users need to know the source of the pagination in an <a>EPUB Publication</a> to
 										determine whether it will be useful for their needs. Print publications, for
 										example, produced in both hard and soft cover editions will have different
 										pagination. Different editions of the same book often also have different
@@ -660,7 +636,7 @@
 									<p>Including a recognizable identifier for the statically paginated source, such as
 										its ISBN or ISSN, ensures that users can determine which version the pagination
 										corresponds to.</p>
-									<p>If EPUB Creators insert pagination as a navigation aid for digital-only
+									<p>If <a>EPUB Creators</a> insert pagination as a navigation aid for digital-only
 										publications, they must not specify a source (i.e., do not identify the current
 										publication as the source of its own pagination).</p>
 								</dd>
@@ -671,7 +647,7 @@
 									<p>When an EPUB Publication includes <a href="#sec-page-breaks">page break
 											markers</a> and/or a <a href="#sec-page-list">page list</a> that correspond
 										to a statically-paginated version of the publication, EPUB Creators MUST
-										identify that source in the Package Document metadata.</p>
+										identify that source in the <a>Package Document</a> metadata.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-004">Identifying the pagination
 												source</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
@@ -693,12 +669,12 @@
 								<dt id="sec-page-list-understand">Understanding this Objective</dt>
 								<dd>
 									<p>The page list is the primary means of navigating to page break locations as it
-										provides a list of links to each of the static page break locations in the EPUB
-										Publication.</p>
-									<p>Reading Systems typically use this list to generate a "go to page" interface in
-										which users can plug in the page number that they wish to move to, but sometimes
-										offer users the ability to access the full list and select the page number to go
-										to.</p>
+										provides a list of links to each of the static page break locations in the
+											<a>EPUB Publication</a>.</p>
+									<p><a>Reading Systems</a> typically use this list to generate a "go to page"
+										interface in which users can plug in the page number that they wish to move to,
+										but sometimes offer users the ability to access the full list and select the
+										page number to go to.</p>
 									<p>Without a page list, page navigation becomes extremely difficult as it would rely
 										on navigating the individual <a href="#sec-page-breaks">page break markers</a>
 										(if they are even present).</p>
@@ -707,9 +683,9 @@
 								<dt id="sec-page-list-conf">Meeting this Objective</dt>
 								<dd>
 									<p>An EPUB Publication MUST include a page list.</p>
-									<p>EPUB Creators SHOULD include links to all pages of content reproduced from the
-										source (i.e., they do not have to provide links for blank pages or content not
-										reproduced in the digital edition).</p>
+									<p><a>EPUB Creators</a> SHOULD include links to all pages of content reproduced from
+										the source (i.e., they do not have to provide links for blank pages or content
+										not reproduced in the digital edition).</p>
 									<p>EPUB Creators MUST include links to all <a href="#sec-page-breaks-obj">page break
 											markers</a> in the content.</p>
 									<p>EPUB Creators should include links for all pages in the source whether they are
@@ -733,8 +709,8 @@
 
 								<dt id="sec-page-breaks-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Inserting page break markers into an EPUB Publication provides users with context
-										about where they are in the text. Assistive technologies can use this
+									<p>Inserting page break markers into an <a>EPUB Publication</a> provides users with
+										context about where they are in the text. Assistive technologies can use this
 										information to announce the current page number the user is on, for example, if
 										the user wants to cite something on the page.</p>
 									<p>The inclusion of page break markers can also allow users to move quickly forwards
@@ -747,7 +723,7 @@
 								<dt id="sec-page-break-conf">Meeting this Objective</dt>
 								<dd>
 									<p>Inclusion of page break markers in an EPUB Publication is OPTIONAL.</p>
-									<p>If an EPUB Creator includes page break markers:</p>
+									<p>If an <a>EPUB Creator</a> includes page break markers:</p>
 									<ul>
 										<li>they SHOULD include page break markers for all pages reproduced from the
 											source (i.e., blank pages and content not reproduced in the digital edition
@@ -777,20 +753,20 @@
 
 						<p>The provision of synchronized text-audio playback helps address various user needs. It not
 							only enables a seamless visual and auditory reading experience from beginning to end of an
-							EPUB Publication, but is useful to users who only require audio playback (e.g., who cannot
-							see the text or are prevented from reading visually due to motion-sickness) or who only
-							benefit from reading with text highlighting (e.g., readers with dyslexia).</p>
+								<a>EPUB Publication</a>, but is useful to users who only require audio playback (e.g.,
+							who cannot see the text or are prevented from reading visually due to motion-sickness) or
+							who only benefit from reading with text highlighting (e.g., readers with dyslexia).</p>
 
 						<p>Unlike purely linear listening experiences, EPUB with synchronized text-audio playback
 							preserves the user's ability to navigate around the publication, such as via the table of
 							contents, and also introduces audio-centric reading features like phrase navigation, and
 							ways to control which parts of the content are read aloud.</p>
 
-						<p>In order to offer users greater control over content presentation, EPUB Creators need to add
-							structure and semantics so that the Reading System has the necessary context to enable this
-							type of user experience. With greater context, a Reading System can provide the ability to
-							skip past secondary content that interferes with the primary narrative and escape users from
-							deeply nested structures like tables.</p>
+						<p>In order to offer users greater control over content presentation, <a>EPUB Creators</a> need
+							to add structure and semantics so that the <a>Reading System</a> has the necessary context
+							to enable this type of user experience. With greater context, a Reading System can provide
+							the ability to skip past secondary content that interferes with the primary narrative and
+							escape users from deeply nested structures like tables.</p>
 
 						<p>Adding structure and semantics to synchronized text-audio playback broadly falls under the
 							objective of the <a href="https://www.w3.org/TR/WCAG2/#info-and-relationships">Info and
@@ -802,12 +778,12 @@
 					<section id="sec-sync-applicability">
 						<h5>Applicability</h5>
 
-						<p>EPUB Publications with synchronized text-audio playback MUST conform to all requirements in
-							[[EPUB-3]]. It is not necessary to meet any additional requirements beyond those defined in
-							[[EPUB-3]] to be conformant with this specification.</p>
+						<p><a>EPUB Publications</a> with synchronized text-audio playback MUST conform to all
+							requirements in [[EPUB-3]]. It is not necessary to meet any additional requirements beyond
+							those defined in [[EPUB-3]] to be conformant with this specification.</p>
 
 						<p>To maximize the effectiveness of synchronized text-audio playback for people with different
-							reading needs, however, EPUB Creators are strongly encouraged to meet the <a
+							reading needs, however, <a>EPUB Creators</a> are strongly encouraged to meet the <a
 								href="#sec-sync-obj">OPTIONAL objectives</a> defined in the next section.</p>
 
 						<div class="note">
@@ -843,8 +819,8 @@
 
 								<dt id="sec-mo-complete-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators MUST provide synchronized audio playback for all visible textual
-										content as well as all textual alternatives for visual media.</p>
+									<p><a>EPUB Creators</a> MUST provide synchronized audio playback for all visible
+										textual content as well as all textual alternatives for visual media.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-004">Ensuring complete text
 												coverage</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
@@ -865,12 +841,13 @@
 
 								<dt id="sec-mo-order-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Every EPUB Publication has a default reading order that allows users to progress
-										through the content. The default reading order consists of two parts: the order
-										of references in the spine provides a high-level progression through the EPUB
-										Content Documents that make up the publication, while the markup within each
-										EPUB Content Document provides the default progression through the content
-										elements (i.e., as represented in the document object model [[DOM]]).</p>
+									<p>Every <a>EPUB Publication</a> has a default reading order that allows users to
+										progress through the content. The default reading order consists of two parts:
+										the order of references in the spine provides a high-level progression through
+										the <a>EPUB Content Documents</a> that make up the publication, while the markup
+										within each EPUB Content Document provides the default progression through the
+										content elements (i.e., as represented in the document object model
+										[[DOM]]).</p>
 									<p>For many languages, the default reading order also matches the logical reading
 										order &#8212; the way that users will naturally follow the narrative. It ensures
 										that readers can follow the primary narrative and that they encounter secondary
@@ -893,8 +870,8 @@
 
 								<dt id="sec-sync-order-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators SHOULD order the synchronized text-audio playback instructions such
-										that they reflect both:</p>
+									<p><a>EPUB Creators</a> SHOULD order the synchronized text-audio playback
+										instructions such that they reflect both:</p>
 									<ul>
 										<li>the order of the referenced EPUB Content Documents in the <a
 												href="https://www.w3.org/TR/epub/#dfn-spine">spine</a> [[EPUB-3]];
@@ -924,18 +901,18 @@
 								<dt id="sec-sync-skippability-understand">Understanding this Objective</dt>
 								<dd>
 									<p>Being able to read the primary narrative of a work without interruption is
-										central to reading comprehension. EPUB Creators typically structure EPUB
-										Publications to visually represent secondary information such as page break
-										markers and footnotes outside the main narrative flow (e.g., by using different
-										background colors or placement so readers can filter this information visually
-										out while reading).</p>
+										central to reading comprehension. <a>EPUB Creators</a> typically structure
+											<a>EPUB Publications</a> to visually represent secondary information such as
+										page break markers and footnotes outside the main narrative flow (e.g., by using
+										different background colors or placement so readers can filter this information
+										visually out while reading).</p>
 									<p>Readers who prefer auditory playback, however, cannot skip this information with
 										the same ease in a linear audio-based reading experience. And, without
 										structural semantics, synchronized text-audio playback cannot offer skipping
 										content either.</p>
-									<p>When EPUB Creators add structural semantics, however, Reading Systems can create
-										reading experiences that allow users to decide which secondary content to skip
-										by default during playback.</p>
+									<p>When EPUB Creators add structural semantics, however, <a>Reading Systems</a> can
+										create reading experiences that allow users to decide which secondary content to
+										skip by default during playback.</p>
 								</dd>
 
 								<dt id="sec-sync-skippability-conf">Meeting this Objective</dt>
@@ -967,12 +944,12 @@
 										information, for example. The same is true for reading figures and sidebars, as
 										they are visually offset from the primary narrative so easily jumped into and
 										out of.</p>
-									<p>The same ease of escaping from content is only possible if EPUB Creators encode
-										the structural semantics into the synchronized text/audio format. Users may not
-										be able to escape from lists, sidebars, figures, and other highly structured
-										content, unless EPUB Creators encode the structural semantics of those
-										elements.</p>
-									<p>When EPUB Creators provide this information, Reading Systems can simplify
+									<p>The same ease of escaping from content is only possible if <a>EPUB Creators</a>
+										encode the structural semantics into the synchronized text/audio format. Users
+										may not be able to escape from lists, sidebars, figures, and other highly
+										structured content, unless EPUB Creators encode the structural semantics of
+										those elements.</p>
+									<p>When EPUB Creators provide this information, <a>Reading Systems</a> can simplify
 										playback for auditory readers to enable a comparable reading experience.</p>
 								</dd>
 
@@ -994,8 +971,8 @@
 							<dl>
 								<dt id="sec-sync-navdoc-obj">Objective</dt>
 								<dd>
-									<p>Ensure auditory playback is possible for the navigation aids in the EPUB
-										Navigation Document when presented by Reading Systems.</p>
+									<p>Ensure auditory playback is possible for the navigation aids in the <a>EPUB
+											Navigation Document</a> when presented by <a>Reading Systems</a>.</p>
 								</dd>
 
 								<dt id="sec-sync-navdoc-understand">Understanding this Objective</dt>
@@ -1012,7 +989,7 @@
 
 								<dt id="sec-sync-navdoc-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators SHOULD provide synchronized text-audio playback for the <a
+									<p><a>EPUB Creators</a> SHOULD provide synchronized text-audio playback for the <a
 											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB Navigation
 											Document</a> [[EPUB-3]].</p>
 									<div class="note">
@@ -1033,8 +1010,8 @@
 				<section id="sec-conf-reporting-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>Evaluators report the accessibility conformance of an EPUB Publication through the expression of
-						metadata properties in the EPUB Package Document.</p>
+					<p>Evaluators report the accessibility conformance of an <a>EPUB Publication</a> through the
+						expression of metadata properties in the <a>Package Document</a>.</p>
 
 					<p>This metadata establishes both:</p>
 
@@ -1073,9 +1050,9 @@
 				<section id="sec-conf-reporting-pub">
 					<h4>Publication Conformance</h4>
 
-					<p>To indicate conformance to the accessibility requirements of this specification, an EPUB
-						Publication's <a data-cite="epub-33#sec-pkg-metadata">metadata section</a> [[EPUB-33]] MUST
-						specify a <a
+					<p>To indicate conformance to the accessibility requirements of this specification, an <a>EPUB
+							Publication</a> [[EPUB-33]] MUST specify in its <a data-cite="epub-33#sec-pkg-metadata"
+							>metadata section</a> a <a
 							href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/conformsTo"
 								><code id="dcterms-conformsTo">conformsTo</code> property</a> [[DCTERMS]] exactly
 						matching (i.e., both in case and spacing) the following pattern:</p>
@@ -1106,8 +1083,8 @@
 					</dl>
 
 					<aside class="example" title="A basic conformance statement">
-						<p>In this example, the EPUB Creator is stating that their publication conforms to the EPUB
-							Accessibility 1.1 specification at WCAG 2.1 Level AA.</p>
+						<p>In this example, the <a>EPUB Creator</a> is stating that their publication conforms to the
+							EPUB Accessibility 1.1 specification at WCAG 2.1 Level AA.</p>
 
 						<pre>&lt;package …>
    &lt;metadata …>
@@ -1138,7 +1115,7 @@
 						<p>The list of valid conformance strings will increase as W3C releases new versions of WCAG.</p>
 
 						<p>In addition, <a href="https://www.w3.org/TR/wcag-3.0/">WCAG 3.0</a> is set to introduce new
-							level names (currently Bronze, Silver and Gold). Those names would likely replace A, AA, and
+							level names (currently Bronze, Silver and Gold). Those names will likely replace A, AA, and
 							AAA in the string pattern, but conformance will be addressed after that specification
 							becomes a <a href="https://www.w3.org/Consortium/Process/#RecsW3C">W3C
 							Recommendation</a>.</p>
@@ -1168,9 +1145,9 @@
 					<section id="sec-evaluator-name">
 						<h5>Evaluator Name</h5>
 
-						<p>The Package Document metadata MUST include an <a href="#certifiedBy"><code
+						<p>The <a>Package Document</a> metadata MUST include an <a href="#certifiedBy"><code
 									id="a11y-certifiedBy">a11y:certifiedBy</code></a> property that specifies the name
-							of the party that evaluated the EPUB Publication.</p>
+							of the party that evaluated the <a>EPUB Publication</a>.</p>
 
 						<div class="note">
 							<p>If an organization evaluates an EPUB Publication, users will typically want to know the
@@ -1349,8 +1326,8 @@
 							<a data-cite="epub-33#subexpression">associated with</a> [[EPUB-33]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
-						<aside class="example" title="A remotely hosted accessibility report">
-							<p>The following example shows a link to a remotely hosted accessibility report.</p>
+						<aside class="example" title="An external accessibility report">
+							<p>The following example shows a link to an accessibility report hosted on a web site.</p>
 							<pre>&lt;metadata …>
    &lt;meta
        property="dcterms:conformsTo"
@@ -1372,7 +1349,9 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<aside class="example" title="A locally hosted accessibility report">
+						<aside class="example" title="A local accessibility report">
+							<p>The following example shows a link to an accessibility report included in the <a>EPUB
+									Container</a>.</p>
 							<pre>&lt;metadata …>
    &lt;meta
        property="dcterms:conformsTo"
@@ -1400,12 +1379,12 @@
 					<h4>Re-Evaluating Conformance</h4>
 
 					<div class="note">
-						<p>The following guidance is to help EPUB Creators determine when a new evaluation is necessary.
-							It is not a requirement to conform to this specification.</p>
+						<p>The following guidance is provided only to help <a>EPUB Creators</a> determine when a new
+							evaluation is necessary. It is not a conformance requirement of this specification.</p>
 					</div>
 
-					<p>How long a conformance evaluation of an EPUB Publication is good for is a complex question.
-						Unlike web sites, which are continuously evolving, EPUB Creators may not update EPUB
+					<p>How long a conformance evaluation of an <a>EPUB Publication</a> is good for is a complex
+						question. Unlike web sites, which are continuously evolving, EPUB Creators may not update EPUB
 						Publications after their initial publication. As a result, an unmodified EPUB Publication will
 						always conform to its last evaluation.</p>
 
@@ -1419,7 +1398,7 @@
 						the structure and functionality of an EPUB Publication, such as:</p>
 
 					<ul>
-						<li>modifications to the nature or order of markup in EPUB Content Documents;</li>
+						<li>modifications to the nature or order of markup in <a>EPUB Content Documents</a>;</li>
 						<li>additions or modifications to images that convey information;</li>
 						<li>modifications to formatting that affects the readability (e.g., contrast); and</li>
 						<li>additions or modifications to interactive controls, forms, etc.</li>
@@ -1443,7 +1422,7 @@
 						<li>additions or modifications to decorative images;</li>
 						<li>modifications to the formatting that do not affect the understanding of the content or
 							change the text display; and</li>
-						<li>modifications to Package Document metadata.</li>
+						<li>modifications to <a>Package Document</a> metadata.</li>
 					</ul>
 
 					<p>Individuals qualified to assess the accessibility of EPUB Publications should make the
@@ -1469,14 +1448,15 @@
 				specific need or reading modality is often not conformant to WCAG exactly because it targets a specific
 				audience.</p>
 
-			<p>For example, an EPUB Publication with synchronized text and audio can contain a full audio recording of
-				the content but limit the text content to only the major headings. In this case, the EPUB Publication is
-				consumable by users who needs to hear the content (i.e., they can listen to the full publication and can
-				navigate between headings), but it is not usable by anyone who cannot hear the audio.</p>
+			<p>For example, an <a>EPUB Publication</a> with synchronized text and audio can contain a full audio
+				recording of the content but limit the text content to only the major headings. In this case, the EPUB
+				Publication is consumable by users who needs to hear the content (i.e., they can listen to the full
+				publication and can navigate between headings), but it is not usable by anyone who cannot hear the
+				audio.</p>
 
-			<p>In other words, when EPUB Creators optimize an EPUB Publication for specific reading modalities, the
-				failure to achieve a WCAG conformance level does not make it any less accessible to the intended
-				audience.</p>
+			<p>In other words, when an <a>EPUB Creator</a> optimizes an EPUB Publication for a specific reading
+				modality, the failure to achieve a WCAG conformance level does not make it any less accessible to the
+				intended audience.</p>
 
 			<p>Defining requirements for optimized publications is outside the scope of this specification, as is
 				formally recognizing other standards and guidelines that address these specific needs. The general model
@@ -1556,18 +1536,18 @@
 			<h2>Distribution</h2>
 
 			<div class="note">
-				<p>Although EPUB Creators do not have to follow the recommendations in this section to conform to this
-					specification, some jurisdictions require EPUB Creators to follow similar practices. <a
+				<p>Although <a>EPUB Creators</a> do not have to follow the recommendations in this section to conform to
+					this specification, some jurisdictions require EPUB Creators to follow similar practices. <a
 						href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">Directive
 						2019/882</a>, for example, includes similar requirements for digital publications distributed in
 					the European Union.</p>
 			</div>
 
-			<p>The creation of accessible EPUB Publications does not guarantee that the publication will be obtainable
-				or consumable by users in an accessible fashion. Depending on how EPUB Creators distribute their EPUB
-				Publications, other factors will influence their overall accessibility. For example, an accessible
-				interface for locating and obtaining content is an essential part of the distribution process, as is the
-				ability to search and review accessibility metadata.</p>
+			<p>The creation of accessible <a>EPUB Publications</a> does not guarantee that the publication will be
+				obtainable or consumable by users in an accessible fashion. Depending on how EPUB Creators distribute
+				their EPUB Publications, other factors will influence their overall accessibility. For example, an
+				accessible interface for locating and obtaining content is an essential part of the distribution
+				process, as is the ability to search and review accessibility metadata.</p>
 
 			<p>While much of the distribution process is outside the control of EPUB Creators, so outside the scope of
 				this specification, there are factors an EPUB Creator can control. For example, while an EPUB Creator
@@ -1600,16 +1580,16 @@
 				users. Meeting accessibility requirements is about optimally using the available technologies, and no
 				new features are introduced by this specification.</p>
 
-			<p>The inclusion of accessibility metadata by EPUB Creators similarly does not introduce security or privacy
-				issues for the EPUB Creator, as describing an EPUB Publication only provides a general idea of its
-				suitability for different user groups.</p>
+			<p>The inclusion of accessibility metadata by <a>EPUB Creators</a> similarly does not introduce security or
+				privacy issues for the EPUB Creator, as describing an <a>EPUB Publication</a> only provides a general
+				idea of its suitability for different user groups.</p>
 
-			<p>The use of accessibility metadata in reading systems, bookstores and any other interface that can build a
-				profile of the user, on the other hand, has the potential to violate individual privacy laws. While it
-				might seem helpful to store and anticipate the type of content a user is most likely to consume, for
-				example, or how best to initiate its playback, developers should not engage in such profiling unless
-				explicit permission is obtained from the user and a means of easily removing the profile is
-				available.</p>
+			<p>The use of accessibility metadata in <a>Reading Systems</a>, bookstores and any other interface that can
+				build a profile of the user, on the other hand, has the potential to violate individual privacy laws.
+				While it might seem helpful to store and anticipate the type of content a user is most likely to
+				consume, for example, or how best to initiate its playback, developers should not engage in such
+				profiling unless explicit permission is obtained from the user and a means of easily removing the
+				profile is available.</p>
 
 			<p>Even in the case where a user assents to the application maintaining information about their
 				accessibility needs, developers must ensure that this information is kept private (e.g., it must not be
@@ -1628,8 +1608,8 @@
 				<section id="app-vocab-about">
 					<h4>About this vocabulary</h4>
 
-					<p>This vocabulary defines properties for describing the accessibility of EPUB Publications in the
-						Package Document metadata.</p>
+					<p>This vocabulary defines properties for describing the accessibility of <a>EPUB Publications</a>
+						in the <a>Package Document</a> metadata.</p>
 				</section>
 
 				<section id="app-vocab-ref">
@@ -1639,7 +1619,8 @@
 							<code>http://www.idpf.org/epub/vocab/package/a11y/#</code>.</p>
 
 					<p>This specification reserves the prefix "<code>a11y:</code>" for use with properties in this
-						vocabulary. EPUB Creators do not have to declare the prefix in the Package Document.</p>
+						vocabulary. <a>EPUB Creators</a> do not have to declare the prefix in the <a>Package
+							Document</a>.</p>
 				</section>
 				<section id="app-vocab-properties">
 					<h3>Conformance properties</h3>
@@ -1658,7 +1639,7 @@
 							<tr>
 								<th>Description:</th>
 								<td>Identifies a party responsible for the testing and certification of the
-									accessibility of an EPUB Publication.</td>
+									accessibility of an <a>EPUB Publication</a>.</td>
 							</tr>
 							<tr>
 								<th>Allowed value(s):</th>
@@ -1791,8 +1772,8 @@
 			<h2>Change Log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a href="http://idpf.org/epub/a11y/"
-					>EPUB Accessibility 1.0</a> &#8212; those that affect the conformance of EPUB Publications or are
-				similarly noteworthy.</p>
+					>EPUB Accessibility 1.0</a> &#8212; those that affect the conformance of <a>EPUB Publications</a> or
+				are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+label%3ASpec-Accessibility+label%3AAccessibility11"


### PR DESCRIPTION
This PR makes similar changes to #2245 to use respec's xref feature to links to the terminology and html elements.

In adding the linking to the terminology, I removed the list of terms from the terminology sections. We added these in the ISO process as a workaround to having to repeat definitions (and not having the ability to link out), but there's no easy way to verify if the lists are complete plus it's a long-term maintenance headache.

I've instead gone through and linked the first instance of each epub-defined term, like we do for the other specifications. (So this also addresses issue #2241 for these two documents.)

Other than that, I've made some very minor editorial corrections (fixing term names, fixing capitalization, etc.).


- [Accessibility preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/add-linking/epub33/a11y/index.html)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/add-linking/epub33/a11y/index.html)
- [Accessibility Techniques preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/add-linking/epub33/a11y-tech/index.html)
- [Accessibility Techniques diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/add-linking/epub33/a11y-tech/index.html)
