### PR TITLE
Turned section titles into sentence case

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -979,7 +979,7 @@
 						but it is recommended to include a link to the start of the body matter as well as to any major
 						reference sections (e.g., table of contents, endnotes, bibliography, glossary, index).</p>
 
-					<aside class="example" title="Landmarks expressed in the EPUB 3 Navigation Document">
+					<aside class="example" title="Landmarks expressed in the EPUB 3 navigation document">
 						<pre>&lt;nav epub:type="landmarks">
    &lt;ol>
       &lt;li>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -1452,7 +1452,7 @@
 					</aside>
 
 					<p>Do not use the [[HTML]] <a data-lt="a"><code>a</code> element</a> to identify page break
-						locations in EPUB 3 Publications. Although this element was previously defined as the anchor for
+						locations in EPUB 3 publications. Although this element was previously defined as the anchor for
 						a hyperlink destination, its purpose has been changed in [[HTML]] for use solely as a link.</p>
 				</section>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -113,7 +113,7 @@
 			<h2>Overview</h2>
 
 			<section id="sec-purpose-scope">
-				<h3>Purpose and Scope</h3>
+				<h3>Purpose and scope</h3>
 
 				<p>This document, EPUB Accessibility Techniques, provides guidance on how to meet the
 					[[EPUB-A11Y-11]] discovery and accessibility requirements for <a>EPUB Publications</a>.</p>
@@ -133,7 +133,7 @@
 			</section>
 		</section>
 		<section id="sec-about">
-			<h2>About the Techniques</h2>
+			<h2>About the techniques</h2>
 
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
 					<a>EPUB Creators</a> create <a>EPUB Publications</a> that conform to the requirements in
@@ -156,7 +156,7 @@
 				issues with this document.</p>
 		</section>
 		<section id="sec-discovery">
-			<h2>Discovery Metadata Techniques</h2>
+			<h2>Discovery metadata techniques</h2>
 
 			<section id="meta-001">
 				<h3>Identify primary access modes</h3>
@@ -458,7 +458,7 @@
 			</section>
 
 			<section id="meta-006">
-				<h3>Identify ARIA Conformance</h3>
+				<h3>Identify ARIA conformance</h3>
 
 				<p>The use of the <code>schema:accesibilityAPI</code> property is no longer necessary for <a>EPUB
 						Publications</a>. <a>EPUB Creators</a> are not responsible for the interaction between
@@ -470,7 +470,7 @@
 			</section>
 
 			<section id="meta-007">
-				<h3>Identify Input Control Methods</h3>
+				<h3>Identify input control methods</h3>
 
 				<p>The use of the <code>schema:accesibilityControl</code> property is no longer necessary for <a>EPUB
 						Publications</a>. This property does not differentiate issues arising from the <a>Reading
@@ -600,10 +600,10 @@
 			</section>
 		</section>
 		<section id="sec-wcag">
-			<h2>WCAG Techniques</h2>
+			<h2>WCAG techniques</h2>
 
 			<section id="sec-wcag-general">
-				<h3>General Guidance</h3>
+				<h3>General guidance</h3>
 
 				<p>Techniques for meeting the requirements of the [[WCAG2]] are defined in <a
 						href="https://www.w3.org/WAI/WCAG21/Techniques/">Techniques for WCAG</a>. This document does not
@@ -651,7 +651,7 @@
 					any alternative formats embedded in the EPUB Publication (e.g., a PDF form).</p>
 
 				<section id="sec-wcag-general-res">
-					<h4>Helpful Resources</h4>
+					<h4>Helpful resources</h4>
 
 					<p>EPUB Creators not familiar with the [[WCAG2]] may find the number of techniques daunting, as they
 						are intended to provide broad coverage of possible solutions.</p>
@@ -675,7 +675,7 @@
 			</section>
 
 			<section id="sec-wcag-content-access">
-				<h3>Content Access</h3>
+				<h3>Content access</h3>
 
 				<section id="access-001">
 					<h4>Ensure meaningful order of content across spreads</h4>
@@ -745,7 +745,7 @@
 					</ul>
 
 					<section id="sec-access-002-toc">
-						<h5>Note About the Table of Contents</h5>
+						<h5>Note about the table of contents</h5>
 
 						<p>A common question about the EPUB table of contents is what completeness it needs to have with
 							respect to the headings of the publication. Although the obvious answer seems like it should
@@ -1052,7 +1052,7 @@
 					</aside>
 
 					<section id="sec-sem-003-res">
-						<h5>Helpful Resources</h5>
+						<h5>Helpful resources</h5>
 
 						<p>The following resources explain EPUB and ARIA landmarks in more detail.</p>
 
@@ -1073,7 +1073,7 @@
 			</section>
 
 			<section id="sec-wcag-titles">
-				<h3>Titles and Headings</h3>
+				<h3>Titles and headings</h3>
 
 				<section id="titles-001">
 					<h4>Include publication and document titles</h4>
@@ -1240,7 +1240,7 @@
 						for alternative text and extended descriptions to conform with [[EPUB-A11Y-11]].</p>
 
 					<section id="sec-desc-001-res">
-						<h5>Helpful Resources</h5>
+						<h5>Helpful resources</h5>
 
 						<p>The following documents provide guidance on including extended descriptions:</p>
 
@@ -1259,7 +1259,7 @@
 				<h3>Language</h3>
 
 				<section id="lang-001">
-					<h4>Language of Package Document</h4>
+					<h4>Language of package document</h4>
 
 					<p>[[WCAG2]] Success Criterions <a data-cite="WCAG2#language-of-page">3.1.1</a> and <a
 							data-cite="WCAG2#language-of-parts">3.1.2</a> deal with the language of a page and changes
@@ -1368,7 +1368,7 @@
 			</section>
 
 			<section id="sec-wcag-alt">
-				<h3>Accessible Alternatives</h3>
+				<h3>Accessible alternatives</h3>
 
 				<p>As <a>EPUB Publications</a> can be composed of more than one rendition, it is possible that different
 					versions of the content will have different levels of accessibility. For example, an image-based
@@ -1405,7 +1405,7 @@
 			<h2>EPUB Techniques</h2>
 
 			<section id="sec-epub-page-navigation">
-				<h3>Page Navigation</h3>
+				<h3>Page navigation</h3>
 
 				<section id="page-001">
 					<h4>Provide page break markers</h4>
@@ -1665,7 +1665,7 @@
 			</section>
 
 			<section id="sec-epub-sync-text-audio">
-				<h3>Synchronized Text-Audio Playback</h3>
+				<h3>Synchronized text-audio playback</h3>
 
 				<section id="sync-001">
 					<h4>Ensuring complete text coverage</h4>
@@ -1947,7 +1947,7 @@
 				</section>
 
 				<section id="sync-005">
-					<h4>Synchronizing the Navigation Document</h4>
+					<h4>Synchronizing the navigation document</h4>
 
 					<p><a>EPUB Creators</a> can add a <a>Media Overlay Document</a> for the <a>EPUB Navigation
 							Document</a> even when it is not included in the <a>spine</a>. Doing so allow <a>Reading
@@ -1961,7 +1961,7 @@
 			</section>
 		</section>
 		<section id="sec-distribution">
-			<h2>Distribution Techniques</h2>
+			<h2>Distribution techniques</h2>
 
 			<section id="dist-001">
 				<h3>Do not restrict access through digital rights management</h3>
@@ -2059,7 +2059,7 @@
 				</aside>
 
 				<section id="sec-dist-002-res">
-					<h4>Helpful Resources</h4>
+					<h4>Helpful resources</h4>
 
 					<p>See the following resources for more information about including accessibility metadata in
 						distribution records:</p>
@@ -2081,7 +2081,7 @@
 			</section>
 		</section>
 		<section id="change-log" class="appendix">
-			<h2>Change Log</h2>
+			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
 					href="http://idpf.org/epub/a11y/techniques/">EPUB Accessibility Techniques 1.0</a> &#8212; those

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -116,7 +116,7 @@
 				<h3>Purpose and scope</h3>
 
 				<p>This document, EPUB Accessibility Techniques, provides guidance on how to meet the
-					[[EPUB-A11Y-11]] discovery and accessibility requirements for <a>EPUB Publications</a>.</p>
+					[[EPUB-A11Y-11]] discovery and accessibility requirements for <a>EPUB publications</a>.</p>
 
 				<p>This document does not cover techniques and best practices already addressed in [[WCAG2]] and
 					[[WAI-ARIA]] for which no substantive differences in application exist.</p>
@@ -136,7 +136,7 @@
 			<h2>About the techniques</h2>
 
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
-					<a>EPUB Creators</a> create <a>EPUB Publications</a> that conform to the requirements in
+					<a>EPUB creators</a> create <a>EPUB publications</a> that conform to the requirements in
 				[[EPUB-A11Y-11]], but they are not all applicable in all situations and there may be other ways to meet
 				the requirements of that specification. As a result, this document should not be read as providing
 				prescriptive requirements.</p>
@@ -146,7 +146,7 @@
 				these issues [[DPUB-Accessibility]]. As solutions become available, they will be incorporated into the
 				appropriate document, whether this one or one it refers to.</p>
 
-			<p>If EPUB Creators encounter issues that are not covered in these or related techniques, they are
+			<p>If EPUB creators encounter issues that are not covered in these or related techniques, they are
 				encouraged to report the issue to the appropriate community for guidance on how to meet accessibility
 				standards. The <a href="https://www.w3.org/WAI/IG/">W3C Web Accessibility Interest Group</a> has a
 				public mailing list where issues meeting [[WCAG2]] and [[WAI-ARIA]] requirements can be raised. The <a
@@ -163,10 +163,10 @@
 
 				<p>An access mode is defined as a "human sense perceptual system or cognitive faculty through which a
 					user may process or perceive the content of a digital resource." [[ISO24751-3]] For example, if an
-						<a>EPUB Publication</a> contains images and video, visual perception is required to consume the
+						<a>EPUB publication</a> contains images and video, visual perception is required to consume the
 					content exactly as it was created.</p>
 
-				<p>There are four access modes that are typically specified for EPUB Publications:</p>
+				<p>There are four access modes that are typically specified for EPUB publications:</p>
 
 				<ul>
 					<li>
@@ -187,7 +187,7 @@
 					</li>
 				</ul>
 
-				<p>For a user to determine whether an EPUB Publication is suitable for their needs, they need to know
+				<p>For a user to determine whether an EPUB publication is suitable for their needs, they need to know
 					which of these access modes are required to consume the content. List all applicable access modes in
 					the [[schema-org]] <a href="https://schema.org/accessMode"><code>accessMode</code> property</a>,
 					repeating the property for each applicable mode.</p>
@@ -216,7 +216,7 @@
 			<section id="meta-002">
 				<h3>Identify sufficient access modes</h3>
 
-				<p>The access modes sufficient to consume an <a>EPUB Publication</a> express a broader picture of the
+				<p>The access modes sufficient to consume an <a>EPUB publication</a> express a broader picture of the
 					potential usability than do the <a href="#meta-001">basic access modes</a>. Where the basic access
 					modes identify the default nature of the media used in the publication, sufficient access modes
 					identify which modes, or sets of modes, a user requires to read the publication. Sufficient access
@@ -227,9 +227,9 @@
 						href="https://schema.org/accessModeSufficient"><code>accessModeSufficient</code> property</a>.
 					Repeat the property for each set of sufficient access modes.</p>
 
-				<p>For example, consider an EPUB Publication that contains graphics and charts, as well as descriptions
+				<p>For example, consider an EPUB publication that contains graphics and charts, as well as descriptions
 					for all these images. The publication has both textual and visual content, so the <a>EPUB
-						Creator</a> will include the following metadata entries to indicate this:</p>
+						creator</a> will include the following metadata entries to indicate this:</p>
 
 				<pre>&lt;meta
     property="schema:accessMode">
@@ -244,7 +244,7 @@
 					publication, or whether a visual one is, only that two modes are required by default. This
 					discrepancy is why sufficiency is also important to know.</p>
 
-				<p>The first set of sufficiency metadata the EPUB Creator inputs will establish the textual and visual
+				<p>The first set of sufficiency metadata the EPUB creator inputs will establish the textual and visual
 					requirement:</p>
 
 				<pre>&lt;meta
@@ -255,7 +255,7 @@
 				<p>The order in which the access modes are listed is not important. The only requirement is that they be
 					separated by commas.</p>
 
-				<p>Since the EPUB Creator has also included descriptions for all the images, the EPUB Creator can also
+				<p>Since the EPUB creator has also included descriptions for all the images, the EPUB creator can also
 					indicate that a purely textual access mode is sufficient to read the content:</p>
 
 				<pre>&lt;meta
@@ -292,9 +292,9 @@
    textual
 &lt;/meta></pre>
 
-				<p>Note that sufficiency of access is often a subjective determination of the EPUB Creator based on
+				<p>Note that sufficiency of access is often a subjective determination of the EPUB creator based on
 					their understanding of what information is essential to comprehending the text. Some information
-					loss occurs by not being able to view a video, for example, but the EPUB Creator might regard the
+					loss occurs by not being able to view a video, for example, but the EPUB creator might regard the
 					visual or auditory losses as inconsequential if a transcript provides all the necessary information
 					to understand the concepts being conveyed.</p>
 
@@ -304,7 +304,7 @@
 
 				<div class="note">
 					<p>The <code>accessModeSufficient</code> property, as defined in [[schema-org]], allows more
-						complicated expressions than can be represented in the EPUB 2 or 3 <a>Package Document</a>
+						complicated expressions than can be represented in the EPUB 2 or 3 <a>package document</a>
 						(e.g., definition of lists of values and inclusion of a human-readable description). A future
 						version of EPUB might allow for richer metadata, but the basic expression shown in this section
 						is sufficient for discovery purposes.</p>
@@ -314,7 +314,7 @@
 			<section id="meta-003">
 				<h3>Identify accessibility features</h3>
 
-				<p>Identifying all the accessibility features and adaptations included in an <a>EPUB Publication</a>
+				<p>Identifying all the accessibility features and adaptations included in an <a>EPUB publication</a>
 					allows users to determine whether the content is usable at a more fine-grained level than the access
 					modes do.</p>
 
@@ -369,12 +369,12 @@
 					</li>
 				</ul>
 
-				<p><a>EPUB Creators</a> have to report whether their <a>EPUB Publications</a> contain resources that
+				<p><a>EPUB creators</a> have to report whether their <a>EPUB publications</a> contain resources that
 					present any of these hazards to users, as they can have real physical effects.</p>
 
 				<div class="note">
 					<p>What precisely constitutes a sound hazard, and how to test for these hazards, is not standardized
-						as of publication of this document. EPUB Creators will have to use their discretion on when to
+						as of publication of this document. EPUB creators will have to use their discretion on when to
 						specify a sound hazard until additional guidance is developed. This technique will be updated
 						whenever there is more clarity on this issue.</p>
 				</div>
@@ -403,11 +403,11 @@
 &lt;/meta></pre>
 				</aside>
 
-				<p>Do not skip reporting hazards just because an EPUB Publication does not contain any content that
+				<p>Do not skip reporting hazards just because an EPUB publication does not contain any content that
 					could present risks. Users cannot infer a meaning when no metadata is present. The value
 						"<code>none</code>" can be used in such cases instead of repeating each non-hazard.</p>
 
-				<p>If an EPUB Publication contains a hazard, provide additional information about its source and nature
+				<p>If an EPUB publication contains a hazard, provide additional information about its source and nature
 					in the <a href="#meta-005">accessibility summary</a>.</p>
 
 				<p>If hazards cannot be definitively determined, report the value "<code>unknown</code>".</p>
@@ -421,9 +421,9 @@
 				<h3>Include an accessibility summary</h3>
 
 				<p>An accessibility summary provides a brief, human-readable description of the accessibility
-					characteristics of an <a>EPUB Publication</a>, or lack thereof.</p>
+					characteristics of an <a>EPUB publication</a>, or lack thereof.</p>
 
-				<p>If an EPUB Publication does not meet the requirements for content accessibility in [[EPUB-A11Y-11]],
+				<p>If an EPUB publication does not meet the requirements for content accessibility in [[EPUB-A11Y-11]],
 					the reason(s) it fails should be noted in the summary.</p>
 
 				<p>An accessibility summary is provided using the [[schema-org]] <a
@@ -461,8 +461,8 @@
 				<h3>Identify ARIA conformance</h3>
 
 				<p>The use of the <code>schema:accesibilityAPI</code> property is no longer necessary for <a>EPUB
-						Publications</a>. <a>EPUB Creators</a> are not responsible for the interaction between
-						<a>Reading Systems</a> and the underlying platform APIs.</p>
+						publications</a>. <a>EPUB creators</a> are not responsible for the interaction between
+						<a>reading systems</a> and the underlying platform APIs.</p>
 
 				<p>Meeting the requirements of [[WCAG2]] is a better measure of the accessibility of scripting, as this
 					property does not differentiate between ARIA markup used for document structure or for identifying
@@ -473,8 +473,8 @@
 				<h3>Identify input control methods</h3>
 
 				<p>The use of the <code>schema:accesibilityControl</code> property is no longer necessary for <a>EPUB
-						Publications</a>. This property does not differentiate issues arising from the <a>Reading
-						System</a> interface from those in the underlying content, which has led to confusion about its
+						publications</a>. This property does not differentiate issues arising from the <a>reading
+						system</a> interface from those in the underlying content, which has led to confusion about its
 					use.</p>
 
 				<p>Meeting the requirements of [[WCAG2]] will mitigate most known issues with the content and is
@@ -484,7 +484,7 @@
 			<section id="sec-meta-ex">
 				<h3>Examples</h3>
 
-				<p>The following examples show the metadata that would be added to an <a>EPUB Publication</a> that has
+				<p>The following examples show the metadata that would be added to an <a>EPUB publication</a> that has
 					textual and visual access modes, is sufficient for reading by text, contains alternative text and
 					MathML markup, and has a flashing hazard.</p>
 
@@ -610,13 +610,13 @@
 					repeat those techniques.</p>
 
 				<p>In general, the differences between the application of WCAG techniques to web pages and their
-					application to <a>EPUB Content Documents</a> is minimal, but the following sections outline some key
+					application to <a>EPUB content documents</a> is minimal, but the following sections outline some key
 					differences.</p>
 
 				<p>One point to note is that the WCAG techniques cover a greater range of technologies and content types
-					than are typically found in an <a>EPUB Publication</a>, so many are not applicable.</p>
+					than are typically found in an <a>EPUB publication</a>, so many are not applicable.</p>
 
-				<p>The following sets of techniques are the most applicable to EPUB Content Documents:</p>
+				<p>The following sets of techniques are the most applicable to EPUB content documents:</p>
 
 				<ul>
 					<li>
@@ -648,15 +648,15 @@
 				</ul>
 
 				<p>Other techniques will apply depending on the technologies used (e.g., a [[SWF]] video in EPUB 2) or
-					any alternative formats embedded in the EPUB Publication (e.g., a PDF form).</p>
+					any alternative formats embedded in the EPUB publication (e.g., a PDF form).</p>
 
 				<section id="sec-wcag-general-res">
 					<h4>Helpful resources</h4>
 
-					<p>EPUB Creators not familiar with the [[WCAG2]] may find the number of techniques daunting, as they
+					<p>EPUB creators not familiar with the [[WCAG2]] may find the number of techniques daunting, as they
 						are intended to provide broad coverage of possible solutions.</p>
 
-					<p>Assistance applying these techniques to EPUB Content Documents is available from the following
+					<p>Assistance applying these techniques to EPUB content documents is available from the following
 						sources:</p>
 
 					<ul>
@@ -684,14 +684,14 @@
 						each web page have a meaningful order (i.e., that the visual presentation of the content match
 						the underlying markup).</p>
 
-					<p>As EPUB allows two <a>EPUB Content Documents</a> to be rendered together in a <a
+					<p>As EPUB allows two <a>EPUB content documents</a> to be rendered together in a <a
 							href="https://www.w3.org/TR/epub/#spread">synthetic spread</a> [[EPUB-3]], the order of
 						content within a single document cannot always be evaluated in isolation. Content may span
 						visually from one document to the next. For example, a sidebar might span the bottom of two
 						pages.</p>
 
 					<p>Ordering each document separately by the visual display will lead to users of <a
-							data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a> encountering
+							data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> encountering
 						gaps between the start and end of the spanned text. If the markup cannot be arranged to provide
 						a more logical reading experience (e.g., the beginning of the spanned content at the end of the
 						first page followed by the conclusion at the start of the next), another means of satisfying
@@ -704,18 +704,18 @@
 
 					<p>[[WCAG2]] <a data-cite="WCAG2#multiple-ways">Success Criterion 2.4.5</a> requires there be more
 						than one way to locate a web page within a set of web pages. By default, <a>EPUB
-							Publications</a> meet this WCAG requirement so long as <a>EPUB Creators</a> follow the EPUB
-						requirements to <a href="https://www.w3.org/TR/epub/#sec-spine-elem">include all EPUB Content
-							Documents in the spine</a> and <a href="https://www.w3.org/TR/epub/#sec-itemref-elem">ensure
+							publications</a> meet this WCAG requirement so long as <a>EPUB creators</a> follow the EPUB
+						requirements to <a href="https://www.w3.org/TR/epub/#sec-spine-elem">include all EPUB content
+							documents in the spine</a> and <a href="https://www.w3.org/TR/epub/#sec-itemref-elem">ensure
 							access to all non-linear documents</a> [[EPUB-3]].</p>
 
-					<p>The reason an EPUB Publication passes by meeting these requirements has to do with differences in
-						how a user interacts with the set of documents in an EPUB Publication. In particular, although
-						an EPUB Publication typically consists of many <a>EPUB Content Documents</a>, <a>Reading
-							Systems</a> automatically provide the ability for the user to move seamlessly from one
+					<p>The reason an EPUB publication passes by meeting these requirements has to do with differences in
+						how a user interacts with the set of documents in an EPUB publication. In particular, although
+						an EPUB publication typically consists of many <a>EPUB content documents</a>, <a>reading
+							systems</a> automatically provide the ability for the user to move seamlessly from one
 						document to the next, so long as they are listed in the <a
 							href="https://www.w3.org/TR/epub/#sec-spine-elem">spine</a> [[EPUB-3]]. To the user, an EPUB
-						Publication is a single document they have complete access to, not a set of disconnected pages
+						publication is a single document they have complete access to, not a set of disconnected pages
 						that they need links to move through.</p>
 
 					<p>The required table of contents provides a second method to access the major headings of the
@@ -723,23 +723,23 @@
 						how the publication is chunked.</p>
 
 					<p>Following these two requirements therefore satisfies the need for multiple ways to access the
-						content. Reading Systems also typically provide search capabilities, something the EPUB Creator
+						content. Reading systems also typically provide search capabilities, something the EPUB creator
 						cannot provide, so users also have a third option available in most cases.</p>
 
-					<p>Although EPUB Creators only need to follow EPUB requirements to meet this criterion, they are
+					<p>Although EPUB creators only need to follow EPUB requirements to meet this criterion, they are
 						still encouraged to provide additional methods to improve access beyond the minimum. Some
 						suggestions include:</p>
 
 					<ul>
 						<li>
-							<p>adding at least one link to every EPUB Content Document in the spine to the table of
+							<p>adding at least one link to every EPUB content document in the spine to the table of
 								contents, when feasible;</p>
 						</li>
 						<li>
 							<p>adding an index to locate major topics; and</p>
 						</li>
 						<li>
-							<p>adding additional navigation aids to the <a>EPUB Navigation Document</a> (e.g., lists of
+							<p>adding additional navigation aids to the <a>EPUB navigation document</a> (e.g., lists of
 								figures and tables).</p>
 						</li>
 					</ul>
@@ -753,23 +753,23 @@
 							usability challenges to this approach.</p>
 
 						<p>Factors such as device screen sizes can make the table of contents for publications with a
-							deep hierarchy of headings unreadable, so <a>EPUB Creators</a> will trim headings below a
-							certain depth to improve the readability. Further, <a>Reading Systems</a> do not always
+							deep hierarchy of headings unreadable, so <a>EPUB creators</a> will trim headings below a
+							certain depth to improve the readability. Further, <a>reading systems</a> do not always
 							provide structured access to the headings in the table of contents, or provide shortcuts to
 							navigate the links. The result is that users have to listen to each link one at a time to
 							find where they want to go, a tedious and time-consuming process.</p>
 
-						<p>Although it is expected that Reading Systems will improve access to the table of contents as
+						<p>Although it is expected that reading systems will improve access to the table of contents as
 							accessibility support for EPUB evolves — making complete tables of contents usable by
 							everyone — there are legitimate usability reasons why they are not provided now.</p>
 
-						<p>When EPUB Creators choose not to provide links to all the headings, however, they should
+						<p>When EPUB creators choose not to provide links to all the headings, however, they should
 							optimize the linking they do provide for the best overall reading experience. Some
 							considerations on how to achieve this include:</p>
 
 						<ul>
 							<li>
-								<p>ensuring that there is at least one link to every <a>EPUB Content Document</a> —
+								<p>ensuring that there is at least one link to every <a>EPUB content document</a> —
 									allowing the user to reach each document simplifies navigation to the minor headings
 									within them; and</p>
 							</li>
@@ -786,18 +786,18 @@
 					<h4>Ensure the order of table of contents entries matches linear order</h4>
 
 					<p>The table of contents provides users more than just links into the content. It is also a means to
-						understand the structure and ordering of an <a>EPUB Publication</a>. Consequently, users may
+						understand the structure and ordering of an <a>EPUB publication</a>. Consequently, users may
 						have difficulty locating where they are in a publication, where they want to go, and also how to
 						return to previous locations when the order of entries in the table of contents does not match
 						the linear reading order.</p>
 
-					<p><a>EPUB Creators</a> should therefore ensure that the entries in the table of contents always
+					<p><a>EPUB creators</a> should therefore ensure that the entries in the table of contents always
 						match the linear order of the content. Specifically, the order of entries should reflect
 						both:</p>
 
 					<ul>
-						<li>the order of <a>EPUB Content Documents</a> in the <a>spine</a>; and</li>
-						<li>the order of each referenced section within its respective EPUB Content Document.</li>
+						<li>the order of <a>EPUB content documents</a> in the <a>spine</a>; and</li>
+						<li>the order of each referenced section within its respective EPUB content document.</li>
 					</ul>
 
 					<p>Only if there is a logical case for an alternative arrangement of entries should the ordering
@@ -806,13 +806,13 @@
 						table of contents for a magazine might be ordered to list all the major articles first, followed
 						by features, etc.</p>
 
-					<p>When the ordering of the table of contents does not match the content, EPUB Creators should
+					<p>When the ordering of the table of contents does not match the content, EPUB creators should
 						include an explanation why in the <a href="#meta-005">accessibility summary</a>.</p>
 
-					<p>EPUB Creators should avoid including links to supplementary content at the end of the table of
+					<p>EPUB creators should avoid including links to supplementary content at the end of the table of
 						contents. Links to figure, tables, illustrations and similar content is better included as a
-						separate navigation elements (either in the <a>EPUB Navigation Document</a> or in the spine).
-						EPUB Creators can include links to these additional navigation lists in the table of
+						separate navigation elements (either in the <a>EPUB navigation document</a> or in the spine).
+						EPUB creators can include links to these additional navigation lists in the table of
 						contents.</p>
 				</section>
 			</section>
@@ -824,33 +824,33 @@
 					<h4>ARIA roles and <code>epub:type</code></h4>
 
 					<div class="note">
-						<p>The following guidance is only for <a>EPUB Content Documents</a>. The <code>type</code>
-							attribute is the only means of adding structural information to <a>Media Overlay
-								Documents</a> so that features like lists and tables can be navigated more efficiently.
-							It is also required in the <a>EPUB Navigation Document</a> to identify key structures.</p>
+						<p>The following guidance is only for <a>EPUB content documents</a>. The <code>type</code>
+							attribute is the only means of adding structural information to <a>media overlay
+								documents</a> so that features like lists and tables can be navigated more efficiently.
+							It is also required in the <a>EPUB navigation document</a> to identify key structures.</p>
 					</div>
 
 					<p>Although the <code>role</code> attribute may seem similar in nature to the <a
 							href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
-						><code>type</code> attribute</a> [[EPUB-3]], their target uses in EPUB Content Documents do not
+						><code>type</code> attribute</a> [[EPUB-3]], their target uses in EPUB content documents do not
 						overlap.</p>
 
 					<p>The key difference between these attributes is that the <code>role</code> attribute bridges
 						accessibility in content while the <code>type</code> attribute provides hooks to enable
-							<a>Reading System</a> behaviors. Omitting roles lessens the accessibility for users of <a
-							data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a>, in other
-						words, while omitting types diminishes certain functionality in <a>Reading Systems</a> (e.g.,
+							<a>reading system</a> behaviors. Omitting roles lessens the accessibility for users of <a
+							data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a>, in other
+						words, while omitting types diminishes certain functionality in <a>reading systems</a> (e.g.,
 						pop-up footnotes or special presentations of the content).</p>
 
 					<p>Since each attribute offers different advantages, it is not necessary that they be used together.
-						Due to the lack of restrictions on where <a>EPUB Creators</a> can use the <code>type</code>
+						Due to the lack of restrictions on where <a>EPUB creators</a> can use the <code>type</code>
 						attribute, pairing the attributes may cause accessibility issues (e.g., putting roles on the
 						[[HTML]] <a data-lt="body"><code>body</code> element</a>).</p>
 
 					<p>In particular, the use of the <code>type</code> attribute is not a means of satisfying
 						requirements for ARIA roles in WCAG.</p>
 
-					<p>For EPUB Creators looking to move from the <code>type</code> attribute to using ARIA roles, the
+					<p>For EPUB creators looking to move from the <code>type</code> attribute to using ARIA roles, the
 							<a href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA Role
 							Authoring Guide</a> guide details notable authoring differences between the two attributes.
 						It also includes a mapping table of semantics in the EPUB Structural Semantics Vocabulary to
@@ -860,32 +860,32 @@
 				<section id="sem-002">
 					<h4>Do not repeat semantics across chunked content</h4>
 
-					<p>Although <a>EPUB Publications</a> appear as single contiguous documents to users when read, they
-						are typically composed of many individual <a>EPUB Content Documents</a>. This practice keeps the
-						amount of markup that has to be rendered small to reduce the load time in <a>Reading Systems</a>
+					<p>Although <a>EPUB publications</a> appear as single contiguous documents to users when read, they
+						are typically composed of many individual <a>EPUB content documents</a>. This practice keeps the
+						amount of markup that has to be rendered small to reduce the load time in <a>reading systems</a>
 						(i.e., to minimize the time the user has to wait for a document to appear). It is rare, at least
-						for books, for an EPUB Publication to contain only one EPUB Content Document with all the
+						for books, for an EPUB publication to contain only one EPUB content document with all the
 						content in it.</p>
 
-					<p>When content is chunked in this way, it often requires the <a>EPUB Creator</a> to make decisions
+					<p>When content is chunked in this way, it often requires the <a>EPUB creator</a> to make decisions
 						about how best to restructure the information. A part, for example, will typically not include
-						all the chapters that belong to it. The EPUB Creator will instead separate the part heading from
+						all the chapters that belong to it. The EPUB creator will instead separate the part heading from
 						each chapter, putting each into a separate document.</p>
 
 					<p>Although visually these restructuring decisions can be hidden from readers, they impact the
-						functionality of <a data-cite="epub-a11y-11#dfn-assistive-technology">Assistive
-						Technologies</a>. In the case of [[WAI-ARIA]] roles, the result is that only the subset present
-						in the currently-loaded EPUB Content Document are exposed to users. An Assistive Technology
+						functionality of <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive
+						technologies</a>. In the case of [[WAI-ARIA]] roles, the result is that only the subset present
+						in the currently-loaded EPUB content document are exposed to users. An assistive technology
 						cannot provide a list of landmarks for the whole publication, as it cannot see outside the
 						current document.</p>
 
-					<p>To counteract this destructuring effect, EPUB Creators sometimes think to re-add or re-identify
+					<p>To counteract this destructuring effect, EPUB creators sometimes think to re-add or re-identify
 						structures in the belief that having this information in every document will be helpful to users
 						(e.g., adding an extra [[HTML]] <a data-lt="section"><code>section</code> element</a> around a
 						chapter to indicate it belongs to a part, or putting the part semantic on the
 						<code>body</code> tag). All this practice does, however, is add repetition that is not only
 						disruptive when reading but can make the structure of the publication harder to follow. EPUB
-						Creators are therefore advised not to attempt to rebuild structures in these ways.</p>
+						creators are therefore advised not to attempt to rebuild structures in these ways.</p>
 
 					<p>For example, consider a book that has five parts and each part contains five chapters.
 						Structurally, each chapter belongs to its part (i.e., is grouped with it), as in the following
@@ -904,7 +904,7 @@
 &lt;/section></pre>
 
 					<p>Since this would lead to a large content file, the part heading is typically split out into its
-						own EPUB Content Document so that it will appear on its own page:</p>
+						own EPUB content document so that it will appear on its own page:</p>
 
 					<pre>&lt;html … >
    …
@@ -914,7 +914,7 @@
    &lt;/body>
 &lt;/html></pre>
 
-					<p>Each chapter is then separated into a separate EPUB Content Document:</p>
+					<p>Each chapter is then separated into a separate EPUB content document:</p>
 
 					<pre>&lt;html … >
    …
@@ -940,7 +940,7 @@
 &lt;/html></pre>
 
 					<p>Doing so introduces a new <code>part</code> landmark into each document, which will cause an
-						Assistive Technology to inform the user that the landmark is available to navigate to.</p>
+						assistive technology to inform the user that the landmark is available to navigate to.</p>
 				</section>
 
 				<section id="sem-003">
@@ -950,32 +950,32 @@
 							href="https://www.w3.org/TR/epub/#sec-nav-landmarks">EPUB landmarks</a> [[EPUB-3]]: both are
 						designed to provide users with quick access to the major structures of a document, such as
 						chapters, glossaries and indexes. ARIA landmarks are compiled automatically by <a
-							data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a> from the <a
-							href="#sem-001">roles</a> that have been applied to the markup, so <a>EPUB Creators</a> only
+							data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> from the <a
+							href="#sem-001">roles</a> that have been applied to the markup, so <a>EPUB creators</a> only
 						need to follow the requirement to include roles for the landmarks to be made available to
 						users.</p>
 
 					<p>Although automatic generation of ARIA landmarks simplifies authoring, it also means that ARIA
-						landmarks are limited to how the EPUB Publication has been chunked up into <a>EPUB Content
-							Documents</a>. An Assistive Technology can only present the landmarks available in the
+						landmarks are limited to how the EPUB publication has been chunked up into <a>EPUB content
+							documents</a>. An assistive technology can only present the landmarks available in the
 						currently-loaded document; it cannot provide a complete picture of all the landmarks in a
 						multi-document publication (see the <a href="#sem-002">previous section</a> for more discussion
 						about content chunking).</p>
 
-					<p>EPUB landmarks, on the other hand, are compiled by the EPUB Creator prior to distribution, and
+					<p>EPUB landmarks, on the other hand, are compiled by the EPUB creator prior to distribution, and
 						are not directly linked to the use of the <a
 							href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
 						><code>type</code> attribute</a> [[EPUB-3]] in the content. They are designed to simplify
-						linking to major sections of the publication in a machine-readable way, as <a>Reading
-							Systems</a> do not scan the entire publication for landmarks, either. EPUB landmarks are
-						typically not as numerous as ARIA landmarks, as Reading Systems only expose so many of these
+						linking to major sections of the publication in a machine-readable way, as <a>reading
+							systems</a> do not scan the entire publication for landmarks, either. EPUB landmarks are
+						typically not as numerous as ARIA landmarks, as reading systems only expose so many of these
 						navigation aids.</p>
 
 					<p>Given these differences in application, however, it is important to include EPUB landmarks and
 						not rely only on the presence of ARIA roles to facilitate navigation, and vice versa. Each aids
 						navigation in its own way.</p>
 
-					<p>The EPUB specification does not require that EPUB Creators include a specific set of landmarks,
+					<p>The EPUB specification does not require that EPUB creators include a specific set of landmarks,
 						but it is recommended to include a link to the start of the body matter as well as to any major
 						reference sections (e.g., table of contents, endnotes, bibliography, glossary, index).</p>
 
@@ -1079,16 +1079,16 @@
 					<h4>Include publication and document titles</h4>
 
 					<p>[[WCAG2]] <a data-cite="WCAG2#page-titled">Success Criterion 2.4.2</a> requires that each web
-						page include a title. EPUB has a similar requirement for <a>EPUB Publications</a>: publications
-						require a [[DCTERMS]] <code>title</code> element in the <a>Package Document</a> metadata. The
+						page include a title. EPUB has a similar requirement for <a>EPUB publications</a>: publications
+						require a [[DCTERMS]] <code>title</code> element in the <a>package document</a> metadata. The
 						[[WCAG2]] requirement is not satisfied by the EPUB requirement, however.</p>
 
-					<p>When authoring an EPUB Publication each <a>EPUB Content Document</a> also requires a descriptive
+					<p>When authoring an EPUB publication each <a>EPUB content document</a> also requires a descriptive
 						title that describes its content. If not provided, <a
-							data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a> often will
+							data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> often will
 						announce the name of the file to users.</p>
 
-					<aside class="example" title="Title for an EPUB Content Document">
+					<aside class="example" title="Title for an EPUB content document">
 						<pre>&lt;html …>
    &lt;head>
       &lt;title>Chapter 1&lt;/title>
@@ -1129,8 +1129,8 @@
 				<section id="titles-002">
 					<h4>Ensure numbered headings reflect publication hierarchy</h4>
 
-					<p>To a user, an <a>EPUB Publication</a> appears as a single document that they read from beginning
-						to end, even though the content is often split across numerous <a>EPUB Content Documents</a>. As
+					<p>To a user, an <a>EPUB publication</a> appears as a single document that they read from beginning
+						to end, even though the content is often split across numerous <a>EPUB content documents</a>. As
 						a result, their natural expectation is that the headings reflect their position in the overall
 						hierarchy of the publication, despite the publication not actually being a single document
 						(e.g., if a part heading is expressed in an [[HTML]] <a data-lt="h1"
@@ -1138,14 +1138,14 @@
 								><code>h2</code></a> heading).</p>
 
 					<p>Technique <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G141">G141: Organizing a page
-							using headings</a> instructs <a>EPUB Creators</a> on correctly using numbered headings
-						within a document, but with EPUB Publications the numbered headings also need to remain
-						consistent across documents. Practically, this means that each EPUB Content Document does not
+							using headings</a> instructs <a>EPUB creators</a> on correctly using numbered headings
+						within a document, but with EPUB publications the numbered headings also need to remain
+						consistent across documents. Practically, this means that each EPUB content document does not
 						have to begin with an <code>h1</code> heading unless the first heading is a top-level heading —
 						the first heading needs to have a numbered heading element that reflects its actual position in
 						the publication.</p>
 
-					<p>EPUB Creators also to need chunk their content so that the first heading in a document always has
+					<p>EPUB creators also to need chunk their content so that the first heading in a document always has
 						the highest number. For example, if a document starts with an <code>h3</code> heading, there
 						should not be an <code>h2</code> heading later in the document (e.g., do not include the start
 						of a new section with the trailing subsections of the previous). It is acceptable for there to
@@ -1153,7 +1153,7 @@
 						document could all have <code>h3</code> headings).</p>
 
 					<aside class="example" title="Heading order across documents">
-						<p>In this example, there are two consecutive EPUB Content Documents in a textbook. The first
+						<p>In this example, there are two consecutive EPUB content documents in a textbook. The first
 							contains the section heading (<code>h2</code>) and the first two subsections
 								(<code>h3</code>). The second contains the final two subsections (<code>h3</code>).</p>
 						<pre>&lt;html …>
@@ -1236,7 +1236,7 @@
 					<p>The first version of these techniques only required alternative text for images regardless of
 						their complexity. This exception is no longer valid.</p>
 
-					<p><a>EPUB Creators</a> must now ensure that their image-based content meets [[WCAG2]] requirements
+					<p><a>EPUB creators</a> must now ensure that their image-based content meets [[WCAG2]] requirements
 						for alternative text and extended descriptions to conform with [[EPUB-A11Y-11]].</p>
 
 					<section id="sec-desc-001-res">
@@ -1265,11 +1265,11 @@
 							data-cite="WCAG2#language-of-parts">3.1.2</a> deal with the language of a page and changes
 						of language with in, respectively.</p>
 
-					<p>For <a>EPUB Publications</a>, the <a>Package Document</a> is also an important source of metadata
-						information about the publication. For example, <a>Reading Systems</a> expose details of the
+					<p>For <a>EPUB publications</a>, the <a>package document</a> is also an important source of metadata
+						information about the publication. For example, <a>reading systems</a> expose details of the
 						publications to users in their bookshelves using this information.</p>
 
-					<p>Consequently, it is necessary to provide the language of all text content in the Package Document
+					<p>Consequently, it is necessary to provide the language of all text content in the package document
 						to conform with these WCAG success criteria. The easiest way to meet this requirement is to add
 						an <code>xml:lang</code> attribute on the root <a
 							href="https://www.w3.org/TR/epub/#sec-package-elem"><code>package</code> element</a>
@@ -1281,7 +1281,7 @@
 &lt;/package></code></pre>
 					</aside>
 
-					<p>If individual metadata fields within the Package Document are expressed in a different language,
+					<p>If individual metadata fields within the package document are expressed in a different language,
 						it is similarly required that the language change be identified by an <code>xml:lang</code>
 						attribute on the element for the field.</p>
 
@@ -1295,23 +1295,23 @@
 &lt;/package></code></pre>
 					</aside>
 
-					<p>Providing this information enables Reading Systems to correctly render the text content in the
+					<p>Providing this information enables reading systems to correctly render the text content in the
 						proper language for users.</p>
 
-					<p class="note">The languages specified in the Package Document have no effect on individual EPUB
-						Content Documents (i.e., the language of each document must be specified using the language
+					<p class="note">The languages specified in the package document have no effect on individual EPUB
+						content documents (i.e., the language of each document must be specified using the language
 						expression mechanisms it provides).</p>
 				</section>
 
 				<section id="lang-002">
-					<h4>Language of the EPUB Publication</h4>
+					<h4>Language of the EPUB publication</h4>
 
-					<p>In addition to being able to express the language of text content, the <a>Package Document</a>
-						also allows <a>EPUB Creators</a> to identify the languages of the <a>EPUB Publication</a> in <a
+					<p>In addition to being able to express the language of text content, the <a>package document</a>
+						also allows <a>EPUB creators</a> to identify the languages of the <a>EPUB publication</a> in <a
 							href="https://www.w3.org/TR/epub/#sec-opf-dclanguage"><code>dc:language</code> elements</a>
 						[[EPUB-3]].</p>
 
-					<aside class="example" title="Setting the language of an EPUB Publication to Italian">
+					<aside class="example" title="Setting the language of an EPUB publication to Italian">
 						<pre><code>&lt;package …>
    &lt;metadata …>
       …
@@ -1328,12 +1328,12 @@
 						information. (Note that EPUB3 requires the language always be specified, so omitting will fail
 						validation requirements.)</p>
 
-					<p>Although <a>Reading Systems</a> do not use this language information to render the text content
-						of the EPUB Publication, they do use it to optimize the reading experience for users (e.g., to
+					<p>Although <a>reading systems</a> do not use this language information to render the text content
+						of the EPUB publication, they do use it to optimize the reading experience for users (e.g., to
 						preload text-to-speech engines so users do not have a delay when synthesizing the text).</p>
 
-					<p class="note">The languages specified in the Package Document have no effect on individual <a>EPUB
-							Content Documents</a> (i.e., the language of each document must be specified using the
+					<p class="note">The languages specified in the package document have no effect on individual <a>EPUB
+							content documents</a> (i.e., the language of each document must be specified using the
 						language expression mechanisms it provides).</p>
 				</section>
 			</section>
@@ -1348,7 +1348,7 @@
 						equivalents be provided for all non-text content to meet Level A. In some regions (e.g., Asia),
 						it is not uncommon to find images of individual text characters, despite the availability of
 						Unicode character equivalents. This practice occurs for various reasons, such as ease of
-						translation of older documents and for compatibility across <a>Reading Systems</a>. The use of
+						translation of older documents and for compatibility across <a>reading systems</a>. The use of
 						images in most instances leads to the text not being accessible to non-visual users,
 						however.</p>
 
@@ -1361,7 +1361,7 @@
 					<p>The use of Unicode characters for all text content avoids this problem, allowing content to
 						successfully meet the minimum requirement for Level A.</p>
 
-					<p>For compliance with Level AA, EPUB Creators are directed to <a data-cite="WCAG2#images-of-text"
+					<p>For compliance with Level AA, EPUB creators are directed to <a data-cite="WCAG2#images-of-text"
 							>Success Criterion 1.4.5</a> which further restricts the use of images of text to only a set
 						of essential cases.</p>
 				</section>
@@ -1370,7 +1370,7 @@
 			<section id="sec-wcag-alt">
 				<h3>Accessible alternatives</h3>
 
-				<p>As <a>EPUB Publications</a> can be composed of more than one rendition, it is possible that different
+				<p>As <a>EPUB publications</a> can be composed of more than one rendition, it is possible that different
 					versions of the content will have different levels of accessibility. For example, an image-based
 					version of the content that lacks alternative text or descriptions could be bundled with a
 					WCAG-compliant text-based serialization. This type of accessible bundling is acceptable, as
@@ -1379,26 +1379,26 @@
 					available.</p>
 
 				<p>The [[EPUB-MULTI-REND-11]] specification defines a set of features for creating these types of EPUB
-					Publications. It specifies a set of attributes that allow a <a>Reading System</a> to automatically
+					publications. It specifies a set of attributes that allow a <a>reading system</a> to automatically
 					select a preferred rendition for the user or to provide the user the option to manually select
 					between the available options. This functionality technically meets the requirements of [[WCAG2]] in
 					terms of ensuring the user can access the accessible version.</p>
 
-				<p>In practice, however, the [[EPUB-MULTI-REND-11]] specification is not broadly supported in Reading
-					Systems at the time of publication. As a result, a user who obtains an EPUB Publication that
+				<p>In practice, however, the [[EPUB-MULTI-REND-11]] specification is not broadly supported in reading
+					systems at the time of publication. As a result, a user who obtains an EPUB publication that
 					contains more than one rendition will only have access to the default. Unless this rendition is the
-					accessible one, the EPUB Publication might not be readable by them.</p>
+					accessible one, the EPUB publication might not be readable by them.</p>
 
-				<p><a>EPUB Creators</a> therefore need to use their best discretion when implementing this functionality
-					to meet accessibility requirements. EPUB Publications that contain multiple renditions are
+				<p><a>EPUB creators</a> therefore need to use their best discretion when implementing this functionality
+					to meet accessibility requirements. EPUB publications that contain multiple renditions are
 					conformant to the [[EPUB-A11Y-11]] specification if at least one rendition meets all the content
-					requirements, but EPUB Creators at a minimum need to note that a Reading System that supports
+					requirements, but EPUB creators at a minimum need to note that a reading system that supports
 					multiple renditions is required in their <a href="#meta-005">accessibility summary</a>. Any other
-					methods the EPUB Creator can use to make this dependence known is advisable (e.g., in the <a
+					methods the EPUB creator can use to make this dependence known is advisable (e.g., in the <a
 						href="#dist-002">distribution metadata</a>).</p>
 
 				<p>This section will be updated with techniques for using multiple renditions when there is enough
-					support in Reading Systems to broadly recommend their use.</p>
+					support in reading systems to broadly recommend their use.</p>
 			</section>
 		</section>
 		<section id="sec-epub">
@@ -1416,11 +1416,11 @@
 							data-cite="dpub-aria-1.0#doc-pagebreak">doc-pagebreak</a>, respectively.</p>
 
 					<p>It is recommended that both semantics be applied to EPUB 3 content to ensure maximum
-						compatibility with <a>Reading Systems</a> and <a
-							data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a>.</p>
+						compatibility with <a>reading systems</a> and <a
+							data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a>.</p>
 
 					<aside class="example" title="Expressing a page break">
-						<p>In this example, the EPUB Creator identifies an HTML <code>span</code> element as a page
+						<p>In this example, the EPUB creator identifies an HTML <code>span</code> element as a page
 							break.</p>
 						<pre>&lt;span
     id="page001"
@@ -1439,7 +1439,7 @@
 						list</a> is the only way a user can jump to the locations.</p>
 
 					<aside class="example" title="Adding a hyperlink destination">
-						<p>In this example, the EPUB Creator adds an XHTML 1.1 <code>span</code> element to use as a
+						<p>In this example, the EPUB creator adds an XHTML 1.1 <code>span</code> element to use as a
 							hyperlink destination.</p>
 						<pre>&lt;html …>
    …
@@ -1463,12 +1463,12 @@
 						in the audio playback of a publication it is not only distracting, but can be confusing, as well
 						(e.g., the number could be read out in the middle of a sentence).</p>
 
-					<p>To mitigate this potential annoyance to readers, <a>EPUB Creators</a> need to identify page
-						announcements in <a>Media Overlay Documents</a> when they are included. Identification allows a
-							<a>Reading System</a> to provide a playback experience where the numbers are automatically
+					<p>To mitigate this potential annoyance to readers, <a>EPUB creators</a> need to identify page
+						announcements in <a>media overlay documents</a> when they are included. Identification allows a
+							<a>reading system</a> to provide a playback experience where the numbers are automatically
 						skipped.</p>
 
-					<p>To identify page numbers in Media Overlay Documents, attach an <code>epub:type</code> attribute
+					<p>To identify page numbers in media overlay documents, attach an <code>epub:type</code> attribute
 						with the value "<a href="https://www.w3.org/TR/epub/#pagebreak"><code>pagebreak</code></a>"
 						[[EPUB-SSV]] to each <a href="https://www.w3.org/TR/epub/#sec-smil-par-elem"><code>par</code>
 							element</a> [[EPUB-3]] that identifies a page number.</p>
@@ -1524,13 +1524,13 @@
 
 					<p>A page list — a list of hyperlinks to the static page break locations — is the most effective way
 						for users to find static page locations. Without a page list, the user would have to navigate
-						each page marker in the text, provided they are available and the Reading System provides such
+						each page marker in the text, provided they are available and the reading system provides such
 						functionality.</p>
 
-					<p>When a page list is included, <a>Reading Systems</a> can provide users direct access to the list
+					<p>When a page list is included, <a>reading systems</a> can provide users direct access to the list
 						or use it to provide automatic page jump functionality.</p>
 
-					<p>The <a>EPUB Navigation Document</a> allows the inclusion of a <a
+					<p>The <a>EPUB navigation document</a> allows the inclusion of a <a
 							href="https://www.w3.org/TR/epub/#sec-nav-pagelist"><code>page-list</code>
 							<code>nav</code></a> [[EPUB-3]], while the EPUB 2 NCX file provides the same functionality
 						through the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1.2"
@@ -1601,13 +1601,13 @@
 					<h4>Identify the pagination source</h4>
 
 					<p>Users typically want to know the source of the page break markers included in an <a>EPUB
-							Publication</a> when they are derived from a static media. Considerations like which
+							publication</a> when they are derived from a static media. Considerations like which
 						printing, by which publisher or imprint, and whether the pagination comes from the hard or soft
 						cover edition will affect decisions about its usefulness (e.g., does it exactly match the
 						pagination of a print book used in a classroom).</p>
 
 					<p>To allow users to determine the suitability of the pagination, identify the ISBN of the source
-						work in the <a>Package Document</a> metadata.</p>
+						work in the <a>package document</a> metadata.</p>
 
 					<aside class="example" title="Expressing the source of pagination">
 						<p>In this example, the <code>dc:source</code> element contains the ISBN of the print source of
@@ -1645,7 +1645,7 @@
 					</aside>
 
 					<p>The <code>source-of</code> property is particularly useful when there are multiple sources for an
-						EPUB Publication as it disambiguates which one the pagination came from.</p>
+						EPUB publication as it disambiguates which one the pagination came from.</p>
 
 					<p>If an ISBN is not available, include as much information as possible about the source publication
 						(e.g., the publisher, date, edition, and binding).</p>
@@ -1660,7 +1660,7 @@
 &lt;/metadata></pre>
 					</aside>
 
-					<p>If the page break markers are unique to the EPUB Publication, do not identify a print source.</p>
+					<p>If the page break markers are unique to the EPUB publication, do not identify a print source.</p>
 				</section>
 			</section>
 
@@ -1670,16 +1670,16 @@
 				<section id="sync-001">
 					<h4>Ensuring complete text coverage</h4>
 
-					<p>Ensuring the complete text of an <a>EPUB Publication</a> is synchronized with audio is key to
+					<p>Ensuring the complete text of an <a>EPUB publication</a> is synchronized with audio is key to
 						allowing users who require full synchronized playback, or even audio-only playback, have access
 						to the same information as users who do not require synchronized playback.</p>
 
 					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] allows
-						audio to be synchronized with any element in an <a>EPUB Content Document</a>, so there is no
+						audio to be synchronized with any element in an <a>EPUB content document</a>, so there is no
 						technical barrier to providing synchronized playback.</p>
 
 					<p>The primary consideration for this objective is what constitutes the text content of an EPUB
-						Publication. The minimal candidates for synchronization with audio are all the elements with
+						publication. The minimal candidates for synchronization with audio are all the elements with
 						visible text content.</p>
 
 					<p>In HTML, the class of elements called <a>palpable content</a> [[HTML]] can typically be
@@ -1694,7 +1694,7 @@
 						(e.g., for embedded audio and video in the document).</p>
 
 					<div class="note">
-						<p><a>EPUB Creators</a> should not synchronize hidden text content in an alternative
+						<p><a>EPUB creators</a> should not synchronize hidden text content in an alternative
 							presentation like Media Overlays. Synchronizing audio with invisible text will be confusing
 							for sighted readers following the playback.</p>
 
@@ -1706,7 +1706,7 @@
 						text alternatives for image-based content. Images may have alternative text and descriptions
 						that are not visible to all users. As synchronization is also meant to aid users who cannot see
 						the images, including these text alternatives and descriptions in the playback is essential to
-						providing the user all the information in the EPUB Publication.</p>
+						providing the user all the information in the EPUB publication.</p>
 
 					<p>Text alternatives and descriptions in HTML may be represented in the <a
 							data-cite="html#attr-img-alt"><code>alt</code> attribute</a> [[HTML]] and linked by ARIA
@@ -1720,27 +1720,27 @@
 				<section id="sync-002">
 					<h4>Specifying the reading order</h4>
 
-					<p>The default reading order should typically represent the order in which <a>Reading Systems</a>
-						render content to users during synchronized text-audio playback. For <a>EPUB Publications</a>,
-						this is a combination of the sequence of <a>EPUB Content Documents</a> in the spine and the
-						order of elements within each EPUB Content Document.</p>
+					<p>The default reading order should typically represent the order in which <a>reading systems</a>
+						render content to users during synchronized text-audio playback. For <a>EPUB publications</a>,
+						this is a combination of the sequence of <a>EPUB content documents</a> in the spine and the
+						order of elements within each EPUB content document.</p>
 
 					<p>If there are cases where the logical reading order (how a reader would naturally read the
-						content) diverges from the default reading order, <a>EPUB Creators</a> can order the playback
+						content) diverges from the default reading order, <a>EPUB creators</a> can order the playback
 						sequence of <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
 							data-cite="epub-33#sec-smil-par-elem"><code>par</code></a> elements in a <a
 							data-cite="epub-33#sec-overlay-docs">Media Overlays Document</a> [[EPUB-33]] to match the
 						logical order.</p>
 
-					<p>EPUB Creators need to use caution when making alterations, however, as other accessibility issues
+					<p>EPUB creators need to use caution when making alterations, however, as other accessibility issues
 						can arise when the logical order does not match the default order. For example, the content may
-						not be accessible to users of <a data-cite="epub-a11y-11#dfn-assistive-technology">Assistive
-							Technologies</a> when the order in the markup does not match how the Assistive Technology
+						not be accessible to users of <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive
+							technologies</a> when the order in the markup does not match how the assistive technology
 						reads the content. In these cases, using playback to create a logical order can make the EPUB
-						Publication fail WCAG conformance requirements.</p>
+						publication fail WCAG conformance requirements.</p>
 
 					<p>One case where the logical may diverge from the reading order and remain accessible is in tables,
-						as Assistive Technologies typically allow users to choose whether to read by row or by
+						as assistive technologies typically allow users to choose whether to read by row or by
 						column.</p>
 				</section>
 
@@ -1750,16 +1750,16 @@
 					<p>Some content elements are not critical to read when following the primary narrative of a work,
 						and that would interrupt a user's concentration if they had to stop and listen to. Footnotes and
 						endnotes are examples of such content, as users may only want to come back and read this content
-						after finishing the <a>EPUB Publication</a>. The announcement of page break numbers can be
+						after finishing the <a>EPUB publication</a>. The announcement of page break numbers can be
 						similarly annoying to readers.</p>
 
 					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] does
-						not allow <a>Reading Systems</a> to determine if playback sequences are skippable unless <a>EPUB
-							Creators</a> add additional semantics to the markup, however. EPUB Creators must use the <a
+						not allow <a>reading systems</a> to determine if playback sequences are skippable unless <a>EPUB
+							creators</a> add additional semantics to the markup, however. EPUB creators must use the <a
 							data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[EPUB-33]]
 						to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
 							data-cite="epub-33#sec-smil-par-elem"><code>par</code></a> elements [[EPUB-33]], thereby
-						allowing Reading Systems to provide users the option to skip their playback sequences.</p>
+						allowing reading systems to provide users the option to skip their playback sequences.</p>
 
 					<p>The recommended structures to identify for skippability are:</p>
 
@@ -1774,13 +1774,13 @@
 								semantic</a> [[EPUB-SSV-11]] to identify each.</li>
 					</ul>
 
-					<p>EPUB Creators may identify other structures but it is not necessary to meet this requirement.</p>
+					<p>EPUB creators may identify other structures but it is not necessary to meet this requirement.</p>
 
 					<aside class="example" title="Identifying a skippable footnote">
 						<p>In this example, the <code>footnote</code> semantic identifies a skippable footnote in the
-							Media Overlay Document.</p>
+							media overlay document.</p>
 
-						<p>Media Overlay Document:</p>
+						<p>Media overlay document:</p>
 
 						<pre>&lt;smil
     xmlns="http://www.w3.org/ns/SMIL" 
@@ -1822,7 +1822,7 @@
 &lt;/smil>
 </pre>
 
-						<p>EPUB Content Document:</p>
+						<p>EPUB content document:</p>
 
 						<pre>&lt;html … >
    …
@@ -1854,11 +1854,11 @@
 						whenever they choose to simplify the reading experience.</p>
 
 					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] only
-						supports escapability if <a>EPUB Creators</a> add structural semantics to the markup. EPUB
-						Creators must use the <a data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code>
+						supports escapability if <a>EPUB creators</a> add structural semantics to the markup. EPUB
+						creators must use the <a data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code>
 							attribute</a> [[EPUB-33]] to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"
 								><code>seq</code></a> and <a data-cite="epub-33#sec-smil-seq-elem"><code>par</code></a>
-						elements [[EPUB-33]] to allow <a>Reading Systems</a> to provide users the option to escape their
+						elements [[EPUB-33]] to allow <a>reading systems</a> to provide users the option to escape their
 						playback sequences.</p>
 
 					<p>The recommended structures to identify for escapability are:</p>
@@ -1874,7 +1874,7 @@
 							[[EPUB-SSV-11]] to identify each.</li>
 					</ul>
 
-					<p>EPUB Creators may identify other structures but it is not necessary to meet this requirement.</p>
+					<p>EPUB creators may identify other structures but it is not necessary to meet this requirement.</p>
 
 					<div class="note">
 						<p>Identifying nested escapable structures is not recommended at this time. Refer to <a
@@ -1883,10 +1883,10 @@
 					</div>
 
 					<aside class="example" title="Identifying an escapable list">
-						<p>In this example, the <code>list</code> semantic identifies an escapable list in the <a>Media
-								Overlay Document</a>.</p>
+						<p>In this example, the <code>list</code> semantic identifies an escapable list in the <a>media
+								overlay document</a>.</p>
 
-						<p>Media Overlay Document:</p>
+						<p>Media overlay document:</p>
 
 						<pre>&lt;smil
     xmlns="http://www.w3.org/ns/SMIL" 
@@ -1925,7 +1925,7 @@
    &lt;/body>
 &lt;/smil></pre>
 
-						<p>EPUB Content Document:</p>
+						<p>EPUB content document:</p>
 
 						<pre>&lt;html … >
    …
@@ -1949,13 +1949,13 @@
 				<section id="sync-005">
 					<h4>Synchronizing the navigation document</h4>
 
-					<p><a>EPUB Creators</a> can add a <a>Media Overlay Document</a> for the <a>EPUB Navigation
-							Document</a> even when it is not included in the <a>spine</a>. Doing so allow <a>Reading
-							Systems</a> to announce the link labels regardless of how they present the navigation
-						elements to users (e.g., many Reading Systems applications create custom table of contents
-						panels by extracting the data from the EPUB Navigation Document).</p>
+					<p><a>EPUB creators</a> can add a <a>media overlay document</a> for the <a>EPUB navigation
+							document</a> even when it is not included in the <a>spine</a>. Doing so allow <a>reading
+							systems</a> to announce the link labels regardless of how they present the navigation
+						elements to users (e.g., many reading systems applications create custom table of contents
+						panels by extracting the data from the EPUB navigation document).</p>
 
-					<p>The process for adding a Media Overlay Document is no different than one for any other
+					<p>The process for adding a media overlay document is no different than one for any other
 						document.</p>
 				</section>
 			</section>
@@ -1966,46 +1966,46 @@
 			<section id="dist-001">
 				<h3>Do not restrict access through digital rights management</h3>
 
-				<p><a>EPUB Publications</a> typically require preservation of the publisher's and author's intellectual
+				<p><a>EPUB publications</a> typically require preservation of the publisher's and author's intellectual
 					property when distributed (e.g., so that they can be made available for individual sale through
 					online bookstores or distributed through library systems). The most common way to address this need
 					has been through the application of digital rights management (DRM) schemes to the packaged EPUB
-					Publication. DRM enables a variety of security features that aren't native to the EPUB format, such
+					publication. DRM enables a variety of security features that aren't native to the EPUB format, such
 					as the ability to limit access to a single user and to limit the length of time the person can
 					access the publication (e.g., library loans).</p>
 
 				<p>In general, DRM can be made to work interoperably with <a
-						data-cite="epub-a11y-11#dfn-assistive-technology">Assistive Technologies</a>, but problems arise
-					when DRM restrictions remove direct access to an EPUB Publication or restrict access to the content
-					within it. Unless the <a>Reading System</a> implementing the DRM provides API level access to the
+						data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a>, but problems arise
+					when DRM restrictions remove direct access to an EPUB publication or restrict access to the content
+					within it. Unless the <a>reading system</a> implementing the DRM provides API level access to the
 					content, it can prove difficult, or even impossible, to generate text-to-speech playback, or for a
 					refreshable braille display to have access to the underlying text, as well as cause other
 					accessibility issues.</p>
 
 				<p>The application of digital rights management therefore must not impair or impede the functionality of
-					Assistive Technologies on EPUB Publications users have the right to access.</p>
+					assistive technologies on EPUB publications users have the right to access.</p>
 			</section>
 
 			<section id="dist-002">
 				<h3>Include accessibility metadata in distribution records</h3>
 
-				<p>When an <a>EPUB Publication</a> is ingested into a distribution system, such as a bookstore or
+				<p>When an <a>EPUB publication</a> is ingested into a distribution system, such as a bookstore or
 					library, a metadata record is often provided separately to the distributor. In these scenarios, the
 					metadata used to enable discovery of the publication typically comes from the distribution record
-					alone, not from the metadata in the Package Document.</p>
+					alone, not from the metadata in the package document.</p>
 
 				<p>The result is that it is necessary to include as much accessibility metadata in distribution records
 					as their vocabularies allow.</p>
 
 				<div class="note">
 					<p>The use of distribution records does not remove the requirement to include accessibility metadata
-						in the <a>Package Document</a>. The metadata in the Package Document ensures accessibility
+						in the <a>package document</a>. The metadata in the package document ensures accessibility
 						information is always available with the publication.</p>
 				</div>
 
 				<aside class="example" title="ONIX accessibility metadata">
 					<p>In this example, the ONIX record includes accessibility metadata that states that the EPUB
-						Publication has no accessibility features disabled (10), includes a table of contents (11) and
+						publication has no accessibility features disabled (10), includes a table of contents (11) and
 						has a correct reading order (13).</p>
 					<pre>&lt;ONIXMessage release="3.0">
    &lt;Header>
@@ -2085,7 +2085,7 @@
 
 			<p>Note that this change log only identifies substantive changes since <a
 					href="http://idpf.org/epub/a11y/techniques/">EPUB Accessibility Techniques 1.0</a> &#8212; those
-				that affect the conformance of <a>EPUB Publications</a> or are similarly noteworthy.</p>
+				that affect the conformance of <a>EPUB publications</a> or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc+label%3ASpec-AccessibilityTechs+label%3AAccessibility11+"
@@ -2094,7 +2094,7 @@
 			<ul>
 				<li>07-Apr-2022: Added techniques for addressing synchronized text-audio playback objectives using Media
 					Overlays. See <a href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>
-				<li>10-Nov-2021: Added techniques for setting language in the Package Document. See <a
+				<li>10-Nov-2021: Added techniques for setting language in the package document. See <a
 						href="https://github.com/w3c/epub-specs/issues/1842">issue 1842</a>.</li>
 				<li>25-Oct-2021: Removed the generic technique labels for each section. See <a
 						href="https://github.com/w3c/epub-specs/issues/1866">issue 1866</a>.</li>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -737,7 +737,7 @@
 											reproduced or not), but this is not a requirement.</li>
 									</ul>
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
-										of the content (e.g., EPUB 3 Media Overlays [[?EPUB-3]]), EPUB creators MUST
+										of the content (e.g., EPUB 3 media overlays [[?EPUB-3]]), EPUB creators MUST
 										identify the page numbers in the markup that controls the playback.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-001">Provide page break
@@ -1187,7 +1187,7 @@
 						</aside>
 
 						<aside class="example" title="An EPUB publication evaluated by a third-party">
-							<p>In this example, a third party has evaluated the EPUB 3 Publication (the values of the
+							<p>In this example, a third party has evaluated the EPUB 3 publication (the values of the
 									<code>dc:publisher</code> and <code>a11y:certifiedBy</code> property differ).</p>
 
 							<pre>&lt;metadata …>
@@ -1494,7 +1494,7 @@
 			</div>
 
 			<aside class="example" title="Expressing conformance to an optimization standard">
-				<p>In this example, the conformance statement indicates the EPUB 3 Publication conforms to the DAISY
+				<p>In this example, the conformance statement indicates the EPUB 3 publication conforms to the DAISY
 					Navigable Audio-only EPUB 3 Guidelines [[DAISYAudio]].</p>
 				<pre>&lt;metadata …>
    …

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -178,7 +178,7 @@
 			</section>
 
 			<section id="sec-success-techniques" class="informative">
-				<h3>Success Techniques</h3>
+				<h3>Success techniques</h3>
 
 				<p>This specification takes an abstract approach to the accessibility requirements for <a>EPUB
 						Publications</a>, similar to how WCAG [[WCAG2]] separates its accessibility guidelines from the
@@ -213,7 +213,7 @@
 			</section>
 
 			<section id="sec-application" class="informative">
-				<h3>Application to Older Versions</h3>
+				<h3>Application to older versions</h3>
 
 				<p>This specification is applicable to any <a>EPUB Publication</a>, even if the content conforms to an
 					older version of EPUB that does not refer to this specification (e.g., EPUB 2 [[OPF-201]]).</p>
@@ -284,7 +284,7 @@
 			</section>
 
 			<section id="sec-disc-package">
-				<h3>Package Metadata</h3>
+				<h3>Package metadata</h3>
 
 				<p>All <a>EPUB Publications</a> MUST include [[schema-org]] accessibility metadata in the <a>Package
 						Document</a> that exposes their accessible properties, regardless of whether the publications
@@ -353,7 +353,7 @@
 			</section>
 
 			<section id="sec-disc-linked-rec">
-				<h3>Linked Metadata Records</h3>
+				<h3>Linked metadata records</h3>
 
 				<p>Accessibility metadata can also be included in <a href="https://www.w3.org/TR/epub/#sec-link-elem"
 						>linked records</a> [[EPUB-3]] (i.e., metadata records referenced from <code>link</code>
@@ -362,7 +362,7 @@
 			</section>
 		</section>
 		<section id="sec-accessible-pubs">
-			<h2>Accessible Publications</h2>
+			<h2>Accessible publications</h2>
 
 			<section id="sec-accessible-pubs-intro" class="informative">
 				<h3>Introduction</h3>
@@ -418,10 +418,10 @@
 			</section>
 
 			<section id="sec-acc-pub-wcag">
-				<h3>WCAG Conformance</h3>
+				<h3>WCAG conformance</h3>
 
 				<section id="sec-wcag-conf">
-					<h4>WCAG Conformance Requirements</h4>
+					<h4>WCAG conformance requirements</h4>
 
 					<p>To conform to this specification, an <a>EPUB Publication</a>:</p>
 
@@ -490,10 +490,10 @@
 				</section>
 
 				<section id="sec-wcag-eval">
-					<h4>Evaluating WCAG Conformance</h4>
+					<h4>Evaluating WCAG conformance</h4>
 
 					<section id="sec-wcag-eval-page-pub">
-						<h5>Page and Publication</h5>
+						<h5>Page and publication</h5>
 
 						<p>The WCAG <a data-cite="WCAG2#wcag-2-layers-of-guidance">principles</a> [[WCAG2]] focus on the
 							evaluation of individual web pages, but an <a>EPUB Publication</a> more closely resembles
@@ -520,7 +520,7 @@
 					</section>
 
 					<section id="sec-wcag-application">
-						<h5>Applying the Conformance Criteria</h5>
+						<h5>Applying the conformance criteria</h5>
 
 						<p>When evaluating an <a>EPUB Publication</a>, the WCAG <a data-cite="WCAG2#conformance-reqs"
 								>conformance criteria</a> [[WCAG2]] are applied as follows:</p>
@@ -550,10 +550,10 @@
 			</section>
 
 			<section id="sec-epub-req">
-				<h3>EPUB Requirements</h3>
+				<h3>EPUB requirements</h3>
 
 				<section id="sec-page-nav">
-					<h4>Page Navigation</h4>
+					<h4>Page navigation</h4>
 
 					<section id="sec-page-nav-overview" class="informative">
 						<h5>Overview</h5>
@@ -622,7 +622,7 @@
 						<h5>Objectives</h5>
 
 						<section id="sec-page-src">
-							<h6>Pagination Source</h6>
+							<h6>Pagination source</h6>
 
 							<dl>
 								<dt id="sec-page-src-obj">Objective</dt>
@@ -662,7 +662,7 @@
 						</section>
 
 						<section id="sec-page-list">
-							<h6>Page List</h6>
+							<h6>Page list</h6>
 
 							<dl>
 								<dt id="sec-page-list-obj">Objective</dt>
@@ -703,7 +703,7 @@
 						</section>
 
 						<section id="sec-page-breaks">
-							<h6>Page Breaks</h6>
+							<h6>Page breaks</h6>
 
 							<dl>
 								<dt id="sec-page-breaks-obj">Objective</dt>
@@ -750,7 +750,7 @@
 				</section>
 
 				<section id="sec-sync-text-audio">
-					<h4>Synchronized Text-Audio Playback</h4>
+					<h4>Synchronized text-audio playback</h4>
 
 					<section id="sec-sync-overview" class="informative">
 						<h5>Overview</h5>
@@ -834,7 +834,7 @@
 						</section>
 
 						<section id="sec-sync-order">
-							<h6>Reading Order</h6>
+							<h6>Reading order</h6>
 
 							<dl>
 								<dt id="sec-mo-order-obj">Objective</dt>
@@ -969,7 +969,7 @@
 						</section>
 
 						<section id="sec-sync-navdoc">
-							<h6>Navigation Document</h6>
+							<h6>Navigation document</h6>
 
 							<dl>
 								<dt id="sec-sync-navdoc-obj">Objective</dt>
@@ -1008,7 +1008,7 @@
 			</section>
 
 			<section id="sec-conf-reporting">
-				<h3>Conformance Reporting</h3>
+				<h3>Conformance reporting</h3>
 
 				<section id="sec-conf-reporting-intro" class="informative">
 					<h4>Introduction</h4>
@@ -1051,7 +1051,7 @@
 				</section>
 
 				<section id="sec-conf-reporting-pub">
-					<h4>Publication Conformance</h4>
+					<h4>Publication conformance</h4>
 
 					<p>To indicate conformance to the accessibility requirements of this specification, an <a>EPUB
 							Publication</a> [[EPUB-33]] MUST specify in its <a data-cite="epub-33#sec-pkg-metadata"
@@ -1143,10 +1143,10 @@
 				</section>
 
 				<section id="sec-conf-reporting-eval">
-					<h4>Evaluator Information</h4>
+					<h4>Evaluator information</h4>
 
 					<section id="sec-evaluator-name">
-						<h5>Evaluator Name</h5>
+						<h5>Evaluator name</h5>
 
 						<p>The <a>Package Document</a> metadata MUST include an <a href="#certifiedBy"><code
 									id="a11y-certifiedBy">a11y:certifiedBy</code></a> property that specifies the name
@@ -1258,7 +1258,7 @@
 					</section>
 
 					<section id="sec-evaluation-date">
-						<h5>Evaluation Date</h5>
+						<h5>Evaluation date</h5>
 
 						<p>If the date the evaluation was performed on is known, include that information in a <a
 								data-cite="dcterms#http://purl.org/dc/terms/date"><code>dcterms:date</code> property</a>
@@ -1285,7 +1285,7 @@
 					</section>
 
 					<section id="sec-evaluator-credentials">
-						<h5>Evaluator Credentials</h5>
+						<h5>Evaluator credentials</h5>
 
 						<p>If the evaluator has credentials or badges that establish their authority to evaluate
 							content, include that information in an <a href="#certifierCredential"><code
@@ -1321,7 +1321,7 @@
 					</section>
 
 					<section id="sec-evaluator-report">
-						<h5>Evaluator Report</h5>
+						<h5>Evaluator report</h5>
 
 						<p>If the evaluator provides a publicly-readable report of its assessment, provide a link to the
 							assessment in an <a href="#certifierReport"><code id="a11y-certifierReport"
@@ -1379,7 +1379,7 @@
 				</section>
 
 				<section id="sec-conf-reporting-re-eval" class="informative">
-					<h4>Re-Evaluating Conformance</h4>
+					<h4>Re-Evaluating conformance</h4>
 
 					<div class="note">
 						<p>The following guidance is provided only to help <a>EPUB Creators</a> determine when a new
@@ -1444,7 +1444,7 @@
 			</section>
 		</section>
 		<section id="sec-optimized-pubs" class="informative">
-			<h2>Optimized Publications</h2>
+			<h2>Optimized publications</h2>
 
 			<p>Although WCAG [[WCAG2]] provides a general set of guidelines for making content broadly accessible,
 				conformant content is not always optimal for specific user groups. Conversely, content optimized for a
@@ -1577,7 +1577,7 @@
 			</div>
 		</section>
 		<section id="privacy" class="informative">
-			<h2>Privacy and Security</h2>
+			<h2>Privacy and security</h2>
 
 			<p>The authoring of accessible content does not introduce any new privacy or security considerations for
 				users. Meeting accessibility requirements is about optimally using the available technologies, and no
@@ -1603,7 +1603,7 @@
 				used to indirectly profile the abilities of users.</p>
 		</section>
 		<section id="app-a11y-vocab" class="appendix vocab">
-			<h2>EPUB Accessibility Vocabulary</h2>
+			<h2>EPUB accessibility vocabulary</h2>
 
 			<section id="app-vocab-overview">
 				<h3>Overview</h3>
@@ -1772,7 +1772,7 @@
 			</section>
 		</section>
 		<section id="change-log" class="appendix informative">
-			<h2>Change Log</h2>
+			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a href="http://idpf.org/epub/a11y/"
 					>EPUB Accessibility 1.0</a> &#8212; those that affect the conformance of <a>EPUB Publications</a> or

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -8,7 +8,7 @@
 		<script src="../common/js/data-test-display.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
-				subtitle: "Conformance and Discoverability Requirements for EPUB Publications",
+				subtitle: "Conformance and Discoverability Requirements for EPUB publications",
 				group: "epub",
 				wgPublicList: "public-epub3",
 				specStatus: "ED",
@@ -120,7 +120,7 @@
 		<section id="abstract">
 			<p>This specification specifies content conformance requirements for verifying the accessibility of EPUB®
 				Publications. It also specifies accessibility metadata requirements for the discoverability of EPUB
-				Publications.</p>
+				publications.</p>
 		</section>
 		<section id="sotd">
 			<div class="ednote">
@@ -139,32 +139,32 @@
 				<p>This specification, EPUB Accessibility, addresses two key needs in the EPUB ecosystem:</p>
 
 				<ul>
-					<li>discoverability of the accessible qualities of <a>EPUB Publications</a>; and</li>
-					<li>evaluation and certification of accessible EPUB Publications.</li>
+					<li>discoverability of the accessible qualities of <a>EPUB publications</a>; and</li>
+					<li>evaluation and certification of accessible EPUB publications.</li>
 				</ul>
 
 				<p>The provision of accessibility metadata facilitates informed decisions about the usability of an EPUB
-					Publication. Consumers can review the qualities of the content and decide whether an EPUB
-					Publication is appropriate for their needs, regardless of whether it meets the bar of accessible
-					certification. At a minimum, all EPUB Publications that conform to this specification meet the
+					publication. Consumers can review the qualities of the content and decide whether an EPUB
+					publication is appropriate for their needs, regardless of whether it meets the bar of accessible
+					certification. At a minimum, all EPUB publications that conform to this specification meet the
 					accessibility metadata requirements described in <a href="#sec-discovery"></a>.</p>
 
-				<p>Although <a>EPUB Creators</a> have always been able to create EPUB Publications with a high degree of
+				<p>Although <a>EPUB creators</a> have always been able to create EPUB publications with a high degree of
 					accessibility, this specification sets formal requirements for certifying content accessible. These
-					requirements provide EPUB Creators a clear set of guidelines to evaluate their content against and
-					allows certification of quality. An accessible EPUB Publication is one that meets the accessibility
+					requirements provide EPUB creators a clear set of guidelines to evaluate their content against and
+					allows certification of quality. An accessible EPUB publication is one that meets the accessibility
 					requirements described in <a href="#sec-accessible-pubs"></a>.</p>
 
-				<p>The specification also discusses the practice of optimizing EPUB Publications for specific reading
+				<p>The specification also discusses the practice of optimizing EPUB publications for specific reading
 					modalities. In these cases, the content cannot meet the broad accessibility requirements of this
-					specification, but by following its discoverability and reporting requirements EPUB Creators can
+					specification, but by following its discoverability and reporting requirements EPUB creators can
 					improve the ability of users to determine if the content still meets their needs. Refer to <a
 						href="#sec-optimized-pubs"></a> for more information.</p>
 
 				<p>The specification also addresses the impact of distribution on the accessibility and discoverability
 					of content in <a href="#sec-distribution"></a>.</p>
 
-				<p>This specification does not target a single version of EPUB. It is applicable to EPUB Publications
+				<p>This specification does not target a single version of EPUB. It is applicable to EPUB publications
 					that conform to any version or profile, including future versions of the standard.</p>
 
 				<p>Ideally, these guidelines help evaluate any digital publication built on Open Web Platform
@@ -181,7 +181,7 @@
 				<h3>Success techniques</h3>
 
 				<p>This specification takes an abstract approach to the accessibility requirements for <a>EPUB
-						Publications</a>, similar to how WCAG [[WCAG2]] separates its accessibility guidelines from the
+						publications</a>, similar to how WCAG [[WCAG2]] separates its accessibility guidelines from the
 					techniques to achieve them. This approach allows the guidelines to remain stable even as the format
 					evolves.</p>
 
@@ -200,7 +200,7 @@
 					<p>At the same time, the language and writing conventions of the authored text will influence the
 						techniques necessary to meet the accessibility requirements. EPUB <a
 							data-cite="epub-33#confreq-xml-enc">requires support for Unicode text</a> [[EPUB-3]], for
-						example, which ensures the correct character data can be used (i.e., <a>EPUB Creators</a> do not
+						example, which ensures the correct character data can be used (i.e., <a>EPUB creators</a> do not
 						have to use images of text). Although this is an important feature, it is often not enough on
 						its own to ensure that the text is fully accessible in any given language (e.g., additional
 						information about directionality, emphasis, pronunciation, etc. may also be needed).</p>
@@ -215,19 +215,19 @@
 			<section id="sec-application" class="informative">
 				<h3>Application to older versions</h3>
 
-				<p>This specification is applicable to any <a>EPUB Publication</a>, even if the content conforms to an
+				<p>This specification is applicable to any <a>EPUB publication</a>, even if the content conforms to an
 					older version of EPUB that does not refer to this specification (e.g., EPUB 2 [[OPF-201]]).</p>
 
-				<p>Creators of such EPUB Publications should create content in conformance with the accessibility and
-					discoverability requirements of this specification. <a>EPUB Creators</a> should also upgrade to the
+				<p>Creators of such EPUB publications should create content in conformance with the accessibility and
+					discoverability requirements of this specification. <a>EPUB creators</a> should also upgrade to the
 					latest version of EPUB to get access to the most advanced accessibility features and techniques.</p>
 
 				<p>Note that not all metadata expressions defined in this specification are supported in older version
 					of EPUB. EPUB 2, in particular, does not support the <a
 						href="https://www.w3.org/TR/epub-33/#attrdef-refines"><code>refines</code> attribute</a>
-					[[EPUB-33]]. If EPUB Creators cannot avoid expressions that require this attribute, they will have
+					[[EPUB-33]]. If EPUB creators cannot avoid expressions that require this attribute, they will have
 					to accept a certain amount of ambiguity in their statements (i.e., relationships between expression
-					may only be apparent by their placement in the Package Document metadata).</p>
+					may only be apparent by their placement in the package document metadata).</p>
 			</section>
 
 			<section id="sec-terminology">
@@ -239,13 +239,14 @@
 				<p>In addition, it defines the following term:</p>
 
 				<dl>
-					<dt><dfn id="dfn-assistive-technology">Assistive Technology</dfn></dt>
+					<dt><dfn id="dfn-assistive-technology" data-lt="assistive techonolgies">assistive
+						technology</dfn></dt>
 					<dd>
 						<p>This specification uses the <a data-cite="WCAG2#dfn-assistive-technologies">definition of
 								assistive technology</a> from [[WCAG2]].</p>
-						<p>In the case of EPUB, an Assistive Technology is not always a separate application from a
-								<a>Reading System</a>. Reading Systems often integrate features of standalone Assistive
-							Technologies, such as text-to-speech playback.</p>
+						<p>In the case of EPUB, an assistive technology is not always a separate application from a
+								<a>reading system</a>. Reading systems often integrate features of standalone assistive
+							technologies, such as text-to-speech playback.</p>
 					</dd>
 				</dl>
 
@@ -260,7 +261,7 @@
 			<section id="sec-disc-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>Unlike web pages, <a>EPUB Creators</a> distribute <a>EPUB Publications</a> through many channels for
+				<p>Unlike web pages, <a>EPUB creators</a> distribute <a>EPUB publications</a> through many channels for
 					personal consumption — a model that has made EPUB a successful format for ebooks and other types of
 					digital publications. A consequence of this model, however, is that specific details about the
 					accessibility of a publication must travel with it.</p>
@@ -269,8 +270,8 @@
 					production quality that went into each submission unless the publisher informs them through
 					metadata.</p>
 
-				<p>Ensuring that any interested party can discover the accessible qualities of an EPUB Publication is
-					therefore a primary concern. An EPUB Publication can have more than one set of sufficient <a
+				<p>Ensuring that any interested party can discover the accessible qualities of an EPUB publication is
+					therefore a primary concern. An EPUB publication can have more than one set of sufficient <a
 						href="#confreq-schema-accessMode">access modes</a> depending on the alternatives provided to
 					enable reading in another mode. For example, if alternative text and descriptions are provided for
 					all the images in a publication, it would have both its default textual and visual sufficient access
@@ -286,12 +287,12 @@
 			<section id="sec-disc-package">
 				<h3>Package metadata</h3>
 
-				<p>All <a>EPUB Publications</a> MUST include [[schema-org]] accessibility metadata in the <a>Package
-						Document</a> that exposes their accessible properties, regardless of whether the publications
+				<p>All <a>EPUB publications</a> MUST include [[schema-org]] accessibility metadata in the <a>package
+						document</a> that exposes their accessible properties, regardless of whether the publications
 					also meet the <a href="#sec-accessible-pubs">accessibility</a> or <a href="#sec-optimized-pubs"
 						>optimization</a> requirements.</p>
 
-				<p>EPUB Publications MUST include the following accessibility metadata:</p>
+				<p>EPUB publications MUST include the following accessibility metadata:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -320,13 +321,13 @@
 					</li>
 				</ul>
 
-				<p>EPUB Publications SHOULD include the following [[schema-org]] accessibility metadata:</p>
+				<p>EPUB publications SHOULD include the following [[schema-org]] accessibility metadata:</p>
 
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-schema-accessModeSufficient"><a href="https://schema.org/accessibilityHazard"
 								>accessModeSufficient</a> — a set of one or more access modes sufficient to consume the
-							content without significant loss of information. An EPUB Publication can have more than one
+							content without significant loss of information. An EPUB publication can have more than one
 							set of sufficient access modes for its consumption depending on the types of content it
 							includes (i.e., unlike <a href="#confreq-schema-accessMode">access modes</a>, this property
 							takes into account any alternatives for content that is not broadly accessible, such as the
@@ -334,7 +335,7 @@
 					</li>
 				</ul>
 
-				<p><a>EPUB Creators</a> MAY include additional [[schema-org]] accessibility metadata not specified in
+				<p><a>EPUB creators</a> MAY include additional [[schema-org]] accessibility metadata not specified in
 					this section.</p>
 
 				<div class="note">
@@ -368,20 +369,20 @@
 				<h3>Introduction</h3>
 
 				<p>EPUB builds on the Open Web Platform, with HTML, CSS, JavaScript and SVG, the core technologies used
-					for content authoring. The use of these technologies means that <a>EPUB Creators</a> can author
-						<a>EPUB Publications</a> with a high degree of accessibility simply through the proper
+					for content authoring. The use of these technologies means that <a>EPUB creators</a> can author
+						<a>EPUB publications</a> with a high degree of accessibility simply through the proper
 					application of established web accessibility techniques.</p>
 
 				<p>The primary source producing accessible web content is the W3C Web Content Accessibility Guidelines
 					(WCAG) [[WCAG2]]. This specification leverages the extensive work done in WCAG to establish
 					benchmarks for accessible content, and the same four high-level content principles — perceivable,
-					operable, understandable, and robust — are central to creating EPUB Publications that are
+					operable, understandable, and robust — are central to creating EPUB publications that are
 					accessible.</p>
 
 				<p>This section defines how to apply the conformance criteria defined in WCAG and addresses qualities
-					unique to EPUB Publications.</p>
+					unique to EPUB publications.</p>
 
-				<p>EPUB Publications authored to comply with the requirements in this section will have a high degree of
+				<p>EPUB publications authored to comply with the requirements in this section will have a high degree of
 					accessibility for users with a wide variety of reading needs and preferences.</p>
 			</section>
 
@@ -396,24 +397,24 @@
 				<p>This specification does not repeat the requirements or techniques introduced in those documents, as
 					it risks breaking compatibility between the two standards (e.g., putting guidance out of sync, or in
 					conflict). At the same time, although this specification does not call out those requirements, it
-					does not diminish their importance in creating <a>EPUB Publications</a> that are accessible.</p>
+					does not diminish their importance in creating <a>EPUB publications</a> that are accessible.</p>
 
-				<p>This specification instead defines how to apply WCAG to an EPUB Publication — which is a <a
+				<p>This specification instead defines how to apply WCAG to an EPUB publication — which is a <a
 						href="#sec-wcag-eval-page-pub">collection of web documents</a> as opposed to a single page — and
 					adds an <a href="#sec-epub-req">additional set of requirements</a>. These requirements are no more
 					or less important than those covered in WCAG; they are simply necessary to follow for EPUB
-					Publications. (Each requirement explains its relationship to WCAG in its respective section.)</p>
+					publications. (Each requirement explains its relationship to WCAG in its respective section.)</p>
 
 				<p>The same is true of the techniques in the EPUB Accessibility Techniques document
-					[[EPUB-A11Y-TECH-11]]. It provides coverage of techniques that are unique to EPUB Publications, or
-					that need clarification in the context of an EPUB Publication. It does not mean that the rest of the
+					[[EPUB-A11Y-TECH-11]]. It provides coverage of techniques that are unique to EPUB publications, or
+					that need clarification in the context of an EPUB publication. It does not mean that the rest of the
 					WCAG techniques are not applicable.</p>
 
-				<p>As a result, although <a>EPUB Creators</a> can read this section without deep knowledge of WCAG
+				<p>As a result, although <a>EPUB creators</a> can read this section without deep knowledge of WCAG
 					conformance, to implement the accessibility requirements of this specification requires an
 					understanding of WCAG.</p>
 
-				<p>Because this specification adds requirements that are not a part of WCAG, an EPUB Publication can
+				<p>Because this specification adds requirements that are not a part of WCAG, an EPUB publication can
 					conform to WCAG without conforming to this specification.</p>
 			</section>
 
@@ -423,7 +424,7 @@
 				<section id="sec-wcag-conf">
 					<h4>WCAG conformance requirements</h4>
 
-					<p>To conform to this specification, an <a>EPUB Publication</a>:</p>
+					<p>To conform to this specification, an <a>EPUB publication</a>:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -439,8 +440,8 @@
 							<div class="note">
 								<p>Although, as <a data-cite="WCAG21#h-note-29">noted in WCAG</a>, conforming at level
 									AAA is typically not possible, and not required by this specification, <a>EPUB
-										Creators</a> are encouraged to follow the practices detailed in AAA success
-									criteria when producing accessible EPUB Publications.</p>
+										creators</a> are encouraged to follow the practices detailed in AAA success
+									criteria when producing accessible EPUB publications.</p>
 							</div>
 						</li>
 					</ul>
@@ -450,12 +451,12 @@
 						requirements in effect in those regions.</p>
 
 					<p>This specification sets the baseline requirement to WCAG 2.0 Level A, for example, primarily to
-						provide EPUB Creators backwards compatibility for older content and flexibility to encourage
+						provide EPUB creators backwards compatibility for older content and flexibility to encourage
 						adoption of accessible production where no formal requirements exist. Most accessibility
 						practitioners do not recognize this level as providing a high degree of accessibility,
 						however.</p>
 
-					<p>Ideally, EPUB Creators should try to conform to the latest version of WCAG 2 at Level AA, but
+					<p>Ideally, EPUB creators should try to conform to the latest version of WCAG 2 at Level AA, but
 						local and national laws, or procurer or distributor requirements, will define the formal
 						thresholds they must meet.</p>
 
@@ -464,19 +465,19 @@
 								href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">Directive
 								2019/882</a> in the European Union and <a href="https://www.access-board.gov/ict/"
 								>Section 508 of the Rehabilitation Act of 1973</a> in the United States. EPUB
-							Publications will need to meet more than just the basic Level A success criteria to be
+							publications will need to meet more than just the basic Level A success criteria to be
 							compliant with these laws.</p>
 					</div>
 
 					<p>Keeping pace with WCAG has the benefit of continuously enhancing access for users. As web
 						technologies change and improve, and awareness of conditions that impede access evolve, the
 						standard adds new requirements. Meeting these additional requirements helps ensure EPUB
-						Publications employ the most up-to-date techniques. Meeting the requirements of older versions,
+						publications employ the most up-to-date techniques. Meeting the requirements of older versions,
 						while still helpful, can result in a less optimal reading experience.</p>
 
 					<p>Similarly, legal frameworks and policies often cite Level AA conformance as the benchmark for
 						accessibility. The reason is that it provides the greatest range of improvements that EPUB
-						Creators can realistically implement. When EPUB Creators meet only Level A conformance, they
+						creators can realistically implement. When EPUB creators meet only Level A conformance, they
 						compromise their content for various user groups, resulting in a less optimal reading
 						experience.</p>
 
@@ -484,7 +485,7 @@
 						<p>The <a href="https://www.w3.org/WAI/GL/">W3C Accessibility Guidelines Working Group</a> is
 							currently developing WCAG 3. As this version potentially represents a significant departure
 							from WCAG 2, a future version of this specification will address conformance requirements
-							related to it. EPUB Creators are encouraged to adopt WCAG 3 once it is stable and widely
+							related to it. EPUB creators are encouraged to adopt WCAG 3 once it is stable and widely
 							recognized, but conformance to the new version is not a requirement of this standard.</p>
 					</div>
 				</section>
@@ -496,43 +497,43 @@
 						<h5>Page and publication</h5>
 
 						<p>The WCAG <a data-cite="WCAG2#wcag-2-layers-of-guidance">principles</a> [[WCAG2]] focus on the
-							evaluation of individual web pages, but an <a>EPUB Publication</a> more closely resembles
+							evaluation of individual web pages, but an <a>EPUB publication</a> more closely resembles
 							what WCAG refers to as a <a data-cite="WCAG2#dfn-set-of-web-pages">set of web pages</a>:
 							"[a] collection of web pages that share a common purpose" [[WCAG2]].</p>
 
-						<p>Consequently, when evaluating the accessibility of an EPUB Publication, <a>EPUB Creators</a>
+						<p>Consequently, when evaluating the accessibility of an EPUB publication, <a>EPUB creators</a>
 							cannot review individual pages — or Content Documents, as they are known in EPUB 3 — in
-							isolation. Rather, EPUB Creators MUST evaluate their accessibility as part of the larger
+							isolation. Rather, EPUB creators MUST evaluate their accessibility as part of the larger
 							work.</p>
 
-						<p>For example, it is not sufficient for EPUB Creators to order the content within individual
-								<a>EPUB Content Documents</a> if they list the documents in the wrong order in the
-								<a>spine</a>. Likewise, including a title for every EPUB Content Document is
+						<p>For example, it is not sufficient for EPUB creators to order the content within individual
+								<a>EPUB content documents</a> if they list the documents in the wrong order in the
+								<a>spine</a>. Likewise, including a title for every EPUB content document is
 							complementary to providing a title for the publication: the overall accessibility decreases
 							if either is missing.</p>
 
-						<p>EPUB Creators MUST evaluate the WCAG guidelines for content to be perceivable, operable,
-							understandable, and robust against the full EPUB Publication, not only against each Content
+						<p>EPUB creators MUST evaluate the WCAG guidelines for content to be perceivable, operable,
+							understandable, and robust against the full EPUB publication, not only against each Content
 							Document within it.</p>
 
 						<p>The EPUB Accessibility Techniques [[?EPUB-A11Y-TECH-11]] provide more information about
-							applying these guidelines to EPUB Publications.</p>
+							applying these guidelines to EPUB publications.</p>
 					</section>
 
 					<section id="sec-wcag-application">
 						<h5>Applying the conformance criteria</h5>
 
-						<p>When evaluating an <a>EPUB Publication</a>, the WCAG <a data-cite="WCAG2#conformance-reqs"
+						<p>When evaluating an <a>EPUB publication</a>, the WCAG <a data-cite="WCAG2#conformance-reqs"
 								>conformance criteria</a> [[WCAG2]] are applied as follows:</p>
 
 						<ul>
-							<li>When determining compliance with a conformance level, the whole EPUB Publication MUST
+							<li>When determining compliance with a conformance level, the whole EPUB publication MUST
 								meet the conformance requirements of the level claimed.</li>
 
-							<li><a>EPUB Creators</a> MUST NOT use EPUB's fallback mechanisms to provide a <a
+							<li><a>EPUB creators</a> MUST NOT use EPUB's fallback mechanisms to provide a <a
 									data-cite="WCAG2#dfn-conforming-alternate-version">conforming alternate version</a>
 								[[WCAG2]], as there is no reliable way for users to access such fallbacks. If an EPUB
-								Creator uses fallbacks, both the primary content and its fallback(s) MUST meet the
+								creator uses fallbacks, both the primary content and its fallback(s) MUST meet the
 								requirements for the conformance level claimed. EPUB-specific fallback mechanisms
 								include <a href="https://www.w3.org/TR/epub/#sec-manifest-fallbacks">manifest
 									fallbacks</a> [[EPUB-3]], <a href="https://www.w3.org/TR/epub/#sec-opf-bindings"
@@ -542,7 +543,7 @@
 
 							<li>The "<a data-cite="WCAG2#cc2">Full Pages</a>" requirement [WCAG2] -- that parts of a
 								page cannot be excluded when making a conformance claim -- applies to every <a>EPUB
-									Content Document</a> in the EPUB Publication (i.e., they must all conform in full to
+									content document</a> in the EPUB publication (i.e., they must all conform in full to
 								the conformance level claimed).</li>
 						</ul>
 					</section>
@@ -571,10 +572,10 @@
 							of reflowable media does not disadvantage those users.</p>
 
 						<p>Providing page navigation also helps in reflowable publications that do not have a statically
-							paginated equivalent. The default pagination of these publications by <a>Reading Systems</a>
+							paginated equivalent. The default pagination of these publications by <a>reading systems</a>
 							is not static since it changes depending on the <a>viewport</a> size and user's font
 							settings. As a result, coordinating locations among users of the same <a>EPUB
-								Publication</a> can be complicated without static references.</p>
+								publication</a> can be complicated without static references.</p>
 
 						<p>The inclusion of page navigation represents one method of achieving the <a
 								data-cite="WCAG2#multiple-ways">Multiple Ways success criterion</a> [[WCAG2]], as it
@@ -588,34 +589,34 @@
 						<div class="note">
 							<p>Refer to <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-epub-page-markers">Page
 									Markers</a> [[EPUB-A11Y-TECH-11]] for more information on the inclusion of page
-								navigation in EPUB Publications.</p>
+								navigation in EPUB publications.</p>
 						</div>
 					</section>
 
 					<section id="sec-page-nav-applicability">
 						<h5>Applicability</h5>
 
-						<p>An <a>EPUB Publication</a> SHOULD include page navigation whenever any of the following cases
+						<p>An <a>EPUB publication</a> SHOULD include page navigation whenever any of the following cases
 							is true:</p>
 
 						<ul>
-							<li>the <a>EPUB Creator</a> identifies the EPUB Publication as the dynamically paginated
+							<li>the <a>EPUB creator</a> identifies the EPUB publication as the dynamically paginated
 								equivalent of a statically paginated publication (e.g., included in a print/digital
 								bundle);</li>
 
-							<li>the EPUB Creator offers the EPUB Publication as an alternative to a statically paginated
+							<li>the EPUB creator offers the EPUB publication as an alternative to a statically paginated
 								publication in an environment where they can reasonably predict the use of both versions
 								(e.g., educational settings); or</li>
 
-							<li>the EPUB Creator generates the EPUB Publication and a statically paginated publication
+							<li>the EPUB creator generates the EPUB publication and a statically paginated publication
 								from a workflow that allows the retention of page break locations across formats.</li>
 						</ul>
 
-						<p>EPUB Creators MAY include page navigation in reflowable EPUB Publications without statically
+						<p>EPUB creators MAY include page navigation in reflowable EPUB publications without statically
 							paginated equivalents.</p>
 
-						<p>When EPUB Creators include page navigation, the objectives defined in this section apply to
-							the EPUB Publication.</p>
+						<p>When EPUB creators include page navigation, the objectives defined in this section apply to
+							the EPUB publication.</p>
 					</section>
 
 					<section id="sec-page-nav-obj">
@@ -632,7 +633,7 @@
 
 								<dt id="sec-page-src-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Users need to know the source of the pagination in an <a>EPUB Publication</a> to
+									<p>Users need to know the source of the pagination in an <a>EPUB publication</a> to
 										determine whether it will be useful for their needs. Print publications, for
 										example, produced in both hard and soft cover editions will have different
 										pagination. Different editions of the same book often also have different
@@ -640,7 +641,7 @@
 									<p>Including a recognizable identifier for the statically paginated source, such as
 										its ISBN or ISSN, ensures that users can determine which version the pagination
 										corresponds to.</p>
-									<p>If <a>EPUB Creators</a> insert pagination as a navigation aid for digital-only
+									<p>If <a>EPUB creators</a> insert pagination as a navigation aid for digital-only
 										publications, they must not specify a source (i.e., do not identify the current
 										publication as the source of its own pagination).</p>
 								</dd>
@@ -648,10 +649,10 @@
 								<dt id="sec-page-src-conf">Meeting this Objective</dt>
 
 								<dd>
-									<p>When an EPUB Publication includes <a href="#sec-page-breaks">page break
+									<p>When an EPUB publication includes <a href="#sec-page-breaks">page break
 											markers</a> and/or a <a href="#sec-page-list">page list</a> that correspond
-										to a statically-paginated version of the publication, EPUB Creators MUST
-										identify that source in the <a>Package Document</a> metadata.</p>
+										to a statically-paginated version of the publication, EPUB creators MUST
+										identify that source in the <a>package document</a> metadata.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-004">Identifying the pagination
 												source</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
@@ -674,8 +675,8 @@
 								<dd>
 									<p>The page list is the primary means of navigating to page break locations as it
 										provides a list of links to each of the static page break locations in the
-											<a>EPUB Publication</a>.</p>
-									<p><a>Reading Systems</a> typically use this list to generate a "go to page"
+											<a>EPUB publication</a>.</p>
+									<p><a>Reading systems</a> typically use this list to generate a "go to page"
 										interface in which users can plug in the page number that they wish to move to,
 										but sometimes offer users the ability to access the full list and select the
 										page number to go to.</p>
@@ -686,13 +687,13 @@
 
 								<dt id="sec-page-list-conf">Meeting this Objective</dt>
 								<dd>
-									<p>An EPUB Publication MUST include a page list.</p>
-									<p><a>EPUB Creators</a> SHOULD include links to all pages of content reproduced from
+									<p>An EPUB publication MUST include a page list.</p>
+									<p><a>EPUB creators</a> SHOULD include links to all pages of content reproduced from
 										the source (i.e., they do not have to provide links for blank pages or content
 										not reproduced in the digital edition).</p>
-									<p>EPUB Creators MUST include links to all <a href="#sec-page-breaks-obj">page break
+									<p>EPUB creators MUST include links to all <a href="#sec-page-breaks-obj">page break
 											markers</a> in the content.</p>
-									<p>EPUB Creators should include links for all pages in the source whether they are
+									<p>EPUB creators should include links for all pages in the source whether they are
 										reproduced or not, but this is not a requirement.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-003">Provide a page list</a>
@@ -713,8 +714,8 @@
 
 								<dt id="sec-page-breaks-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Inserting page break markers into an <a>EPUB Publication</a> provides users with
-										context about where they are in the text. <a>Assistive Technologies</a> can use
+									<p>Inserting page break markers into an <a>EPUB publication</a> provides users with
+										context about where they are in the text. <a>Assistive technologies</a> can use
 										this information to announce the current page number the user is on, for
 										example, if the user wants to cite something on the page.</p>
 									<p>The inclusion of page break markers can also allow users to move quickly forwards
@@ -726,8 +727,8 @@
 
 								<dt id="sec-page-break-conf">Meeting this Objective</dt>
 								<dd>
-									<p>Inclusion of page break markers in an EPUB Publication is OPTIONAL.</p>
-									<p>If an <a>EPUB Creator</a> includes page break markers:</p>
+									<p>Inclusion of page break markers in an EPUB publication is OPTIONAL.</p>
+									<p>If an <a>EPUB creator</a> includes page break markers:</p>
 									<ul>
 										<li>they SHOULD include page break markers for all pages reproduced from the
 											source (i.e., blank pages and content not reproduced in the digital edition
@@ -736,7 +737,7 @@
 											reproduced or not), but this is not a requirement.</li>
 									</ul>
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
-										of the content (e.g., EPUB 3 Media Overlays [[?EPUB-3]]), EPUB Creators MUST
+										of the content (e.g., EPUB 3 Media Overlays [[?EPUB-3]]), EPUB creators MUST
 										identify the page numbers in the markup that controls the playback.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-001">Provide page break
@@ -757,7 +758,7 @@
 
 						<p>The provision of synchronized text-audio playback helps address various user needs. It not
 							only enables a seamless visual and auditory reading experience from beginning to end of an
-								<a>EPUB Publication</a>, but is useful to users who only require audio playback (e.g.,
+								<a>EPUB publication</a>, but is useful to users who only require audio playback (e.g.,
 							who cannot see the text or are prevented from reading visually due to motion-sickness) or
 							who only benefit from reading with text highlighting (e.g., readers with dyslexia).</p>
 
@@ -766,9 +767,9 @@
 							contents, and also introduces audio-centric reading features like phrase navigation, and
 							ways to control which parts of the content are read aloud.</p>
 
-						<p>In order to offer users greater control over content presentation, <a>EPUB Creators</a> need
-							to add structure and semantics so that the <a>Reading System</a> has the necessary context
-							to enable this type of user experience. With greater context, a Reading System can provide
+						<p>In order to offer users greater control over content presentation, <a>EPUB creators</a> need
+							to add structure and semantics so that the <a>reading system</a> has the necessary context
+							to enable this type of user experience. With greater context, a reading system can provide
 							the ability to skip past secondary content that interferes with the primary narrative and
 							escape users from deeply nested structures like tables.</p>
 
@@ -781,17 +782,17 @@
 					<section id="sec-sync-applicability">
 						<h5>Applicability</h5>
 
-						<p><a>EPUB Publications</a> with synchronized text-audio playback MUST conform to all
+						<p><a>EPUB publications</a> with synchronized text-audio playback MUST conform to all
 							requirements in [[EPUB-3]]. It is not necessary to meet any additional requirements beyond
 							those defined in [[EPUB-3]] to be conformant with this specification.</p>
 
 						<p>To maximize the effectiveness of synchronized text-audio playback for people with different
-							reading needs, however, <a>EPUB Creators</a> are strongly encouraged to meet the <a
+							reading needs, however, <a>EPUB creators</a> are strongly encouraged to meet the <a
 								href="#sec-sync-obj">OPTIONAL objectives</a> defined in the next section.</p>
 
 						<div class="note">
-							<p>EPUB Creators do not have to include synchronized text-audio playback in their EPUB
-								Publications, only ensure it conforms to these requirements when present.</p>
+							<p>EPUB creators do not have to include synchronized text-audio playback in their EPUB
+								publications, only ensure it conforms to these requirements when present.</p>
 						</div>
 					</section>
 
@@ -822,7 +823,7 @@
 
 								<dt id="sec-mo-complete-conf">Meeting this Objective</dt>
 								<dd>
-									<p><a>EPUB Creators</a> MUST provide synchronized audio playback for all visible
+									<p><a>EPUB creators</a> MUST provide synchronized audio playback for all visible
 										textual content as well as all textual alternatives for visual media.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-004">Ensuring complete text
@@ -844,11 +845,11 @@
 
 								<dt id="sec-mo-order-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Every <a>EPUB Publication</a> has a default reading order that allows users to
+									<p>Every <a>EPUB publication</a> has a default reading order that allows users to
 										progress through the content. The default reading order consists of two parts:
 										the order of references in the spine provides a high-level progression through
-										the <a>EPUB Content Documents</a> that make up the publication, while the markup
-										within each EPUB Content Document provides the default progression through the
+										the <a>EPUB content documents</a> that make up the publication, while the markup
+										within each EPUB content document provides the default progression through the
 										content elements (i.e., as represented in the document object model
 										[[DOM]]).</p>
 									<p>For many languages, the default reading order also matches the logical reading
@@ -873,15 +874,15 @@
 
 								<dt id="sec-sync-order-conf">Meeting this Objective</dt>
 								<dd>
-									<p><a>EPUB Creators</a> SHOULD order the synchronized text-audio playback
+									<p><a>EPUB creators</a> SHOULD order the synchronized text-audio playback
 										instructions such that they reflect both:</p>
 									<ul>
-										<li>the order of the referenced EPUB Content Documents in the <a
+										<li>the order of the referenced EPUB content documents in the <a
 												href="https://www.w3.org/TR/epub/#dfn-spine">spine</a> [[EPUB-3]];
 											and</li>
-										<li>the order of each element within its respective EPUB Content Document.</li>
+										<li>the order of each element within its respective EPUB content document.</li>
 									</ul>
-									<p>If EPUB Creators use a different ordering, that ordering MUST still result in a
+									<p>If EPUB creators use a different ordering, that ordering MUST still result in a
 										logical playback of the content.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-002">Specifying the reading
@@ -904,8 +905,8 @@
 								<dt id="sec-sync-skippability-understand">Understanding this Objective</dt>
 								<dd>
 									<p>Being able to read the primary narrative of a work without interruption is
-										central to reading comprehension. <a>EPUB Creators</a> typically structure
-											<a>EPUB Publications</a> to visually represent secondary information such as
+										central to reading comprehension. <a>EPUB creators</a> typically structure
+											<a>EPUB publications</a> to visually represent secondary information such as
 										page break markers and footnotes outside the main narrative flow (e.g., by using
 										different background colors or placement so readers can filter this information
 										visually out while reading).</p>
@@ -913,14 +914,14 @@
 										the same ease in a linear audio-based reading experience. And, without
 										structural semantics, synchronized text-audio playback cannot offer skipping
 										content either.</p>
-									<p>When EPUB Creators add structural semantics, however, <a>Reading Systems</a> can
+									<p>When EPUB creators add structural semantics, however, <a>reading systems</a> can
 										create reading experiences that allow users to decide which secondary content to
 										skip by default during playback.</p>
 								</dd>
 
 								<dt id="sec-sync-skippability-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators SHOULD identify all skippable structures.</p>
+									<p>EPUB creators SHOULD identify all skippable structures.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-003">Identifying skippable
 												structures</a> [[EPUB-A11Y-TECH-11]] for more information on meeting
@@ -947,18 +948,18 @@
 										information, for example. The same is true for reading figures and sidebars, as
 										they are visually offset from the primary narrative so easily jumped into and
 										out of.</p>
-									<p>The same ease of escaping from content is only possible if <a>EPUB Creators</a>
+									<p>The same ease of escaping from content is only possible if <a>EPUB creators</a>
 										encode the structural semantics into the synchronized text/audio format. Users
 										may not be able to escape from lists, sidebars, figures, and other highly
-										structured content, unless EPUB Creators encode the structural semantics of
+										structured content, unless EPUB creators encode the structural semantics of
 										those elements.</p>
-									<p>When EPUB Creators provide this information, <a>Reading Systems</a> can simplify
+									<p>When EPUB creators provide this information, <a>reading systems</a> can simplify
 										playback for auditory readers to enable a comparable reading experience.</p>
 								</dd>
 
 								<dt id="sec-sync-escapability-conf">Meeting this Objective</dt>
 								<dd>
-									<p>EPUB Creators SHOULD identify all escapable structures.</p>
+									<p>EPUB creators SHOULD identify all escapable structures.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-004">Identifying escapable
 												structures</a> [[EPUB-A11Y-TECH-11]] for more information on meeting
@@ -975,26 +976,26 @@
 								<dt id="sec-sync-navdoc-obj">Objective</dt>
 								<dd>
 									<p>Ensure auditory playback is possible for the navigation aids in the <a>EPUB
-											Navigation Document</a> when presented by <a>Reading Systems</a>.</p>
+											navigation document</a> when presented by <a>reading systems</a>.</p>
 								</dd>
 
 								<dt id="sec-sync-navdoc-understand">Understanding this Objective</dt>
 								<dd>
-									<p>Reading Systems typically provide their own interfaces to the navigation aids in
-										the EPUB Navigation Document. For example, they open the table of contents as a
+									<p>Reading systems typically provide their own interfaces to the navigation aids in
+										the EPUB navigation document. For example, they open the table of contents as a
 										specialized interface on top of the content the user is reading.</p>
 									<p>To access these interfaces, users typically must rely on text-to-speech playback,
 										when available, to hear the entries.</p>
-									<p>Providing synchronized text-audio playback for the EPUB Navigation Document
-										provides Reading Systems the ability to use auditory labels for the links,
+									<p>Providing synchronized text-audio playback for the EPUB navigation document
+										provides reading systems the ability to use auditory labels for the links,
 										improving the experience for auditory readers.</p>
 								</dd>
 
 								<dt id="sec-sync-navdoc-conf">Meeting this Objective</dt>
 								<dd>
-									<p><a>EPUB Creators</a> SHOULD provide synchronized text-audio playback for the <a
-											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB Navigation
-											Document</a> [[EPUB-3]].</p>
+									<p><a>EPUB creators</a> SHOULD provide synchronized text-audio playback for the <a
+											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB navigation
+											document</a> [[EPUB-3]].</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-005">Synchronizing the
 												Navigation Document</a> [[EPUB-A11Y-TECH-11]] for more information on
@@ -1013,8 +1014,8 @@
 				<section id="sec-conf-reporting-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>Evaluators report the accessibility conformance of an <a>EPUB Publication</a> through the
-						expression of metadata properties in the <a>Package Document</a>.</p>
+					<p>Evaluators report the accessibility conformance of an <a>EPUB publication</a> through the
+						expression of metadata properties in the <a>package document</a>.</p>
 
 					<p>This metadata establishes both:</p>
 
@@ -1028,7 +1029,7 @@
 						following sections.</p>
 
 					<p>Although any individual or party can perform a conformance evaluation &#8212; provided they have
-						the knowledge and tools to assess EPUB Publications against the <a href="#sec-wcag-conf"
+						the knowledge and tools to assess EPUB publications against the <a href="#sec-wcag-conf"
 							>WCAG</a> and <a href="#sec-epub-req">EPUB</a> requirements of this specification &#8212;
 						users need to be able to trust that evaluations are performed in a comprehensive manner and that
 						conformance claims are not influenced by self-interest in the outcome.</p>
@@ -1041,7 +1042,7 @@
 
 					<div class="note">
 						<p>As each metadata format is unique in what it can express, this specification does not mandate
-							how to express conformance metadata outside of the EPUB Package Document.</p>
+							how to express conformance metadata outside of the EPUB package document.</p>
 
 						<p>Ensuring consistency between internal and external accessibility metadata expressions is the
 							responsibility of authors, publishers, and distributors. Refer to <a
@@ -1054,7 +1055,7 @@
 					<h4>Publication conformance</h4>
 
 					<p>To indicate conformance to the accessibility requirements of this specification, an <a>EPUB
-							Publication</a> [[EPUB-33]] MUST specify in its <a data-cite="epub-33#sec-pkg-metadata"
+							publication</a> [[EPUB-33]] MUST specify in its <a data-cite="epub-33#sec-pkg-metadata"
 							>metadata section</a> a <a
 							href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/conformsTo"
 								><code id="dcterms-conformsTo">conformsTo</code> property</a> [[DCTERMS]] exactly
@@ -1086,7 +1087,7 @@
 					</dl>
 
 					<aside class="example" title="A basic conformance statement">
-						<p>In this example, the <a>EPUB Creator</a> is stating that their publication conforms to the
+						<p>In this example, the <a>EPUB creator</a> is stating that their publication conforms to the
 							EPUB Accessibility 1.1 specification at WCAG 2.1 Level AA.</p>
 
 						<pre>&lt;package …>
@@ -1126,18 +1127,18 @@
 
 					<div class="note">
 						<p>The requirement to include a <code>dcterms:conformsTo</code> identifer does not prevent EPUB
-							Publications from conforming to other standards, including other accessibility standards and
+							publications from conforming to other standards, including other accessibility standards and
 							guidelines (e.g., a specification that covers specific natural language issues). An EPUB
-							Publication may have multiple <code>dcterms:conformsTo</code> statements.</p>
+							publication may have multiple <code>dcterms:conformsTo</code> statements.</p>
 
-						<p>EPUB Creators may also use a conformance URL, as defined in the <a
+						<p>EPUB creators may also use a conformance URL, as defined in the <a
 								href="https://www.w3.org/TR/WCAG/#conformance-required">Required Components of a
 								Conformance Claim</a> [[WCAG2]], with the <code>conformsTo</code> property for EPUB
-							Publications that only meet WCAG conformance requirements (i.e., that do not fully conform
+							publications that only meet WCAG conformance requirements (i.e., that do not fully conform
 							to this specification).</p>
 
 						<p>As [[WCAG2]] does not define how to specify the conformance level in the URL, however, EPUB
-							Creators will have to find an alternative means of relating this information when necessary
+							creators will have to find an alternative means of relating this information when necessary
 							(e.g., through the accessibility summary).</p>
 					</div>
 				</section>
@@ -1148,19 +1149,19 @@
 					<section id="sec-evaluator-name">
 						<h5>Evaluator name</h5>
 
-						<p>The <a>Package Document</a> metadata MUST include an <a href="#certifiedBy"><code
+						<p>The <a>package document</a> metadata MUST include an <a href="#certifiedBy"><code
 									id="a11y-certifiedBy">a11y:certifiedBy</code></a> property that specifies the name
-							of the party that evaluated the <a>EPUB Publication</a>.</p>
+							of the party that evaluated the <a>EPUB publication</a>.</p>
 
 						<div class="note">
-							<p>If an organization evaluates an EPUB Publication, users will typically want to know the
+							<p>If an organization evaluates an EPUB publication, users will typically want to know the
 								name of that organization. This specification discourages including the name of the
 								individual(s) who carried out the assessment instead of the name of the organization, as
 								this can diminish the trust users have in the claim.</p>
 						</div>
 
-						<aside id="pub-ex" class="example" title="An EPUB Publication evaluated by the publisher">
-							<p>In this example, the publisher is stating they self-evaluated the EPUB Publication (the
+						<aside id="pub-ex" class="example" title="An EPUB publication evaluated by the publisher">
+							<p>In this example, the publisher is stating they self-evaluated the EPUB publication (the
 								values of the <code>dc:publisher</code> and <code>a11y:certifiedBy</code> property are
 								the same).</p>
 
@@ -1185,7 +1186,7 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<aside class="example" title="An EPUB Publication evaluated by a third-party">
+						<aside class="example" title="An EPUB publication evaluated by a third-party">
 							<p>In this example, a third party has evaluated the EPUB 3 Publication (the values of the
 									<code>dc:publisher</code> and <code>a11y:certifiedBy</code> property differ).</p>
 
@@ -1209,8 +1210,8 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<aside class="example" title="An EPUB Publication evaluated by the author">
-							<p>In this example, the author is stating they self-evaluated the EPUB Publication (the
+						<aside class="example" title="An EPUB publication evaluated by the author">
+							<p>In this example, the author is stating they self-evaluated the EPUB publication (the
 								values of the <code>dc:creator</code> and <code>a11y:certifiedBy</code> property are the
 								same).</p>
 
@@ -1237,7 +1238,7 @@
 
 						<aside class="example" title="A self-evaluated EPUB 2 Publication">
 							<p>This example is the same as the <a href="#pub-ex">publisher example</a>, but expressed in
-								an EPUB 2 Package Document.</p>
+								an EPUB 2 package document.</p>
 
 							<pre>&lt;metadata …>
   …
@@ -1354,7 +1355,7 @@
 
 						<aside class="example" title="A local accessibility report">
 							<p>The following example shows a link to an accessibility report included in the <a>EPUB
-									Container</a>.</p>
+									container</a>.</p>
 							<pre>&lt;metadata …>
    &lt;meta
        property="dcterms:conformsTo"
@@ -1379,45 +1380,45 @@
 				</section>
 
 				<section id="sec-conf-reporting-re-eval" class="informative">
-					<h4>Re-Evaluating conformance</h4>
+					<h4>Re-evaluating conformance</h4>
 
 					<div class="note">
-						<p>The following guidance is provided only to help <a>EPUB Creators</a> determine when a new
+						<p>The following guidance is provided only to help <a>EPUB creators</a> determine when a new
 							evaluation is necessary. It is not a conformance requirement of this specification.</p>
 					</div>
 
-					<p>How long a conformance evaluation of an <a>EPUB Publication</a> is good for is a complex
-						question. Unlike web sites, which are continuously evolving, EPUB Creators may not update EPUB
-						Publications after their initial publication. As a result, an unmodified EPUB Publication will
+					<p>How long a conformance evaluation of an <a>EPUB publication</a> is good for is a complex
+						question. Unlike web sites, which are continuously evolving, EPUB creators may not update EPUB
+						publications after their initial publication. As a result, an unmodified EPUB publication will
 						always conform to its last evaluation.</p>
 
-					<p>It is common in publishing, however, to release updated versions of an EPUB Publication to fix
+					<p>It is common in publishing, however, to release updated versions of an EPUB publication to fix
 						errors and typos in the work, as well as to periodically release new editions. As not all
-						changes to an EPUB Publication substantively change its accessibility, this complicates the
-						question of when EPUB Creators should perform a new evaluation, as well as whether a full or
+						changes to an EPUB publication substantively change its accessibility, this complicates the
+						question of when EPUB creators should perform a new evaluation, as well as whether a full or
 						partial re-evaluation will suffice.</p>
 
-					<p>As a rule, EPUB Creators must re-evaluate their content whenever they make substantive changes to
-						the structure and functionality of an EPUB Publication, such as:</p>
+					<p>As a rule, EPUB creators must re-evaluate their content whenever they make substantive changes to
+						the structure and functionality of an EPUB publication, such as:</p>
 
 					<ul>
-						<li>modifications to the nature or order of markup in <a>EPUB Content Documents</a>;</li>
+						<li>modifications to the nature or order of markup in <a>EPUB content documents</a>;</li>
 						<li>additions or modifications to images that convey information;</li>
 						<li>modifications to formatting that affects the readability (e.g., contrast); and</li>
 						<li>additions or modifications to interactive controls, forms, etc.</li>
 					</ul>
 
-					<p>If the EPUB Publication includes substantively the same markup and content as the previous
-						release, the EPUB Creator may only need to evaluate the new modifications to re-confirm
+					<p>If the EPUB publication includes substantively the same markup and content as the previous
+						release, the EPUB creator may only need to evaluate the new modifications to re-confirm
 						conformance.</p>
 
 					<p>If an updated version of this specification or [[WCAG2]] has been published since the last
-						release of the EPUB Publication, however, this specification also recommends performing a new
-						evaluation to ensure conformance to the latest standards. EPUB Creators may not have to perform
+						release of the EPUB publication, however, this specification also recommends performing a new
+						evaluation to ensure conformance to the latest standards. EPUB creators may not have to perform
 						a full re-evaluation even in this case (i.e., they may only need to check new or modified
 						success criteria unless the standards undergo major changes to methodology or conformance).</p>
 
-					<p>Conversely, EPUB Creators do not need to perform a re-evaluation when making non-substantive
+					<p>Conversely, EPUB creators do not need to perform a re-evaluation when making non-substantive
 						changes, such as:</p>
 
 					<ul>
@@ -1425,20 +1426,20 @@
 						<li>additions or modifications to decorative images;</li>
 						<li>modifications to the formatting that do not affect the understanding of the content or
 							change the text display; and</li>
-						<li>modifications to <a>Package Document</a> metadata.</li>
+						<li>modifications to <a>package document</a> metadata.</li>
 					</ul>
 
-					<p>Individuals qualified to assess the accessibility of EPUB Publications should make the
+					<p>Individuals qualified to assess the accessibility of EPUB publications should make the
 						determination of whether changes are substantive or not. An editor, for example, may not realize
 						the impact of seemingly minor formatting changes.</p>
 
 					<p>Even in the case of non-substantive changes, this specification recommends an updated evaluation
 						(full or partial) if the accessibility standards have changed.</p>
 
-					<p>EPUB Creators should consider even more progressive approaches than those described here. Waiting
-						for content changes before reviewing and updating the accessibility of EPUB Publications can
+					<p>EPUB creators should consider even more progressive approaches than those described here. Waiting
+						for content changes before reviewing and updating the accessibility of EPUB publications can
 						leave them lacking recent improvements. For example, a publisher might prioritize periodic
-						reviews of their top-selling EPUB Publications to ensure they remain maximally usable to the
+						reviews of their top-selling EPUB publications to ensure they remain maximally usable to the
 						widest possible audience.</p>
 				</section>
 			</section>
@@ -1451,40 +1452,40 @@
 				specific need or reading modality is often not conformant to WCAG exactly because it targets a specific
 				audience.</p>
 
-			<p>For example, an <a>EPUB Publication</a> with synchronized text and audio can contain a full audio
+			<p>For example, an <a>EPUB publication</a> with synchronized text and audio can contain a full audio
 				recording of the content but limit the text content to only the major headings. In this case, the EPUB
-				Publication is consumable by users who needs to hear the content (i.e., they can listen to the full
+				publication is consumable by users who needs to hear the content (i.e., they can listen to the full
 				publication and can navigate between headings), but it is not usable by anyone who cannot hear the
 				audio.</p>
 
-			<p>In other words, when an <a>EPUB Creator</a> optimizes an EPUB Publication for a specific reading
+			<p>In other words, when an <a>EPUB creator</a> optimizes an EPUB publication for a specific reading
 				modality, the failure to achieve a WCAG conformance level does not make it any less accessible to the
 				intended audience.</p>
 
 			<p>Defining requirements for optimized publications is outside the scope of this specification, as is
 				formally recognizing other standards and guidelines that address these specific needs. The general model
-				of this specification can be used as a basis for identifying how an EPUB Creator has optimized their
+				of this specification can be used as a basis for identifying how an EPUB creator has optimized their
 				content, however.</p>
 
-			<p>In particular, if an EPUB Publication meets the requirements of an optimization standard, the following
+			<p>In particular, if an EPUB publication meets the requirements of an optimization standard, the following
 				best practices are recommended:</p>
 
 			<ul>
-				<li>The EPUB Publication should meet the <a href="#sec-discovery">discovery metadata requirements</a> of
+				<li>The EPUB publication should meet the <a href="#sec-discovery">discovery metadata requirements</a> of
 					this specification so its accessible properties are machine-readable.</li>
-				<li>The EPUB Publication should identify the standard or guidelines it follows in a
+				<li>The EPUB publication should identify the standard or guidelines it follows in a
 						<code>conformsTo</code> property in accordance with [[DCTERMS]] so this information can be made
 					available to users.</li>
 				<li>If the standard does not define conformance values for the <code>conformsTo</code> property, EPUB
-					Creators should use a URL [[URL]] to where the standard is publicly available so users can look up
+					creators should use a URL [[URL]] to where the standard is publicly available so users can look up
 					the specific details of the standard.</li>
 				<li>If the identifier is not sufficient for a user to understand conformance (e.g., the guidelines are
-					not publicly available), EPUB Creators should provide additional information about they have
+					not publicly available), EPUB creators should provide additional information about they have
 					optimized the content in the <a href="#confreq-schema-accessibilitySummary">accessibility
 						summary</a>.</li>
 			</ul>
 
-			<p>When creating guidelines for optimized EPUB Publications, it is recommended that these practices be
+			<p>When creating guidelines for optimized EPUB publications, it is recommended that these practices be
 				integrated as a formal requirement for conformance.</p>
 
 			<div class="note">
@@ -1505,7 +1506,7 @@
 			</aside>
 
 			<aside class="example" title="Describing conformance in a summary">
-				<p>In this example, the accessibility summary for an EPUB Publication explains that it is optimized for
+				<p>In this example, the accessibility summary for an EPUB publication explains that it is optimized for
 					braille rendering.</p>
 				<pre>&lt;metadata …>
    …
@@ -1539,40 +1540,40 @@
 			<h2>Distribution</h2>
 
 			<div class="note">
-				<p>Although <a>EPUB Creators</a> do not have to follow the recommendations in this section to conform to
-					this specification, some jurisdictions require EPUB Creators to follow similar practices. <a
+				<p>Although <a>EPUB creators</a> do not have to follow the recommendations in this section to conform to
+					this specification, some jurisdictions require EPUB creators to follow similar practices. <a
 						href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">Directive
 						2019/882</a>, for example, includes similar requirements for digital publications distributed in
 					the European Union.</p>
 			</div>
 
-			<p>The creation of accessible <a>EPUB Publications</a> does not guarantee that the publication will be
-				obtainable or consumable by users in an accessible fashion. Depending on how EPUB Creators distribute
-				their EPUB Publications, other factors will influence their overall accessibility. For example, an
+			<p>The creation of accessible <a>EPUB publications</a> does not guarantee that the publication will be
+				obtainable or consumable by users in an accessible fashion. Depending on how EPUB creators distribute
+				their EPUB publications, other factors will influence their overall accessibility. For example, an
 				accessible interface for locating and obtaining content is an essential part of the distribution
 				process, as is the ability to search and review accessibility metadata.</p>
 
-			<p>While much of the distribution process is outside the control of EPUB Creators, so outside the scope of
-				this specification, there are factors an EPUB Creator can control. For example, while an EPUB Creator
+			<p>While much of the distribution process is outside the control of EPUB creators, so outside the scope of
+				this specification, there are factors an EPUB creator can control. For example, while an EPUB creator
 				typically does not control the accessibility of the digital rights management (DRM) scheme applied to
-				their EPUB Publications, they do control what usage rights to apply to their EPUB Publications. So even
-				though a DRM scheme may allow an Author to block access to the text of the publication, the EPUB Creator
-				needs to take care not to apply such a restriction as it could block the ability for <a>Assistive
-					Technologies</a> to read the text aloud.</p>
+				their EPUB publications, they do control what usage rights to apply to their EPUB publications. So even
+				though a DRM scheme may allow an Author to block access to the text of the publication, the EPUB creator
+				needs to take care not to apply such a restriction as it could block the ability for <a>assistive
+					technologies</a> to read the text aloud.</p>
 
-			<p>To minimize the effects of distribution on accessibility, this specification advises EPUB Creators adhere
+			<p>To minimize the effects of distribution on accessibility, this specification advises EPUB creators adhere
 				to the following distribution practices:</p>
 
 			<ul>
-				<li>they must not impose restrictions that impair access by Assistive Technologies; and</li>
+				<li>they must not impose restrictions that impair access by assistive technologies; and</li>
 				<li>they must include accessibility metadata in the record format required for distribution of an EPUB
-					Publication (e.g., [[ONIX]] or [[MARC21]]) when the format supports such metadata.</li>
+					publication (e.g., [[ONIX]] or [[MARC21]]) when the format supports such metadata.</li>
 			</ul>
 
 			<div class="note">
 				<p>A distributor may implement a digital rights management scheme that inherently impairs accessibility
-					through no fault of the EPUB Creator. Following the guidance in this section does not restrict EPUB
-					Creators from using such distributors. The intent is only that the EPUB Creator not impair
+					through no fault of the EPUB creator. Following the guidance in this section does not restrict EPUB
+					creators from using such distributors. The intent is only that the EPUB creator not impair
 					accessibility by activating a feature that would normally not be active.</p>
 			</div>
 		</section>
@@ -1583,11 +1584,11 @@
 				users. Meeting accessibility requirements is about optimally using the available technologies, and no
 				new features are introduced by this specification.</p>
 
-			<p>The inclusion of accessibility metadata by <a>EPUB Creators</a> similarly does not introduce security or
-				privacy issues for the EPUB Creator, as describing an <a>EPUB Publication</a> only provides a general
+			<p>The inclusion of accessibility metadata by <a>EPUB creators</a> similarly does not introduce security or
+				privacy issues for the EPUB creator, as describing an <a>EPUB publication</a> only provides a general
 				idea of its suitability for different user groups.</p>
 
-			<p>The use of accessibility metadata in <a>Reading Systems</a>, bookstores and any other interface that can
+			<p>The use of accessibility metadata in <a>reading systems</a>, bookstores and any other interface that can
 				build a profile of the user, on the other hand, has the potential to violate individual privacy laws.
 				While it might seem helpful to store and anticipate the type of content a user is most likely to
 				consume, for example, or how best to initiate its playback, developers should not engage in such
@@ -1611,8 +1612,8 @@
 				<section id="app-vocab-about">
 					<h4>About this vocabulary</h4>
 
-					<p>This vocabulary defines properties for describing the accessibility of <a>EPUB Publications</a>
-						in the <a>Package Document</a> metadata.</p>
+					<p>This vocabulary defines properties for describing the accessibility of <a>EPUB publications</a>
+						in the <a>package document</a> metadata.</p>
 				</section>
 
 				<section id="app-vocab-ref">
@@ -1622,8 +1623,8 @@
 							<code>http://www.idpf.org/epub/vocab/package/a11y/#</code>.</p>
 
 					<p>This specification reserves the prefix "<code>a11y:</code>" for use with properties in this
-						vocabulary. <a>EPUB Creators</a> do not have to declare the prefix in the <a>Package
-							Document</a>.</p>
+						vocabulary. <a>EPUB creators</a> do not have to declare the prefix in the <a>package
+							document</a>.</p>
 				</section>
 				<section id="app-vocab-properties">
 					<h3>Conformance properties</h3>
@@ -1642,7 +1643,7 @@
 							<tr>
 								<th>Description:</th>
 								<td>Identifies a party responsible for the testing and certification of the
-									accessibility of an <a>EPUB Publication</a>.</td>
+									accessibility of an <a>EPUB publication</a>.</td>
 							</tr>
 							<tr>
 								<th>Allowed value(s):</th>
@@ -1775,7 +1776,7 @@
 			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a href="http://idpf.org/epub/a11y/"
-					>EPUB Accessibility 1.0</a> &#8212; those that affect the conformance of <a>EPUB Publications</a> or
+					>EPUB Accessibility 1.0</a> &#8212; those that affect the conformance of <a>EPUB publications</a> or
 				are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
@@ -1814,7 +1815,7 @@
 				<li>29-Apr-2021: Change conformance identifiers to use hyphens and dashes so they are not confused for
 					plain language strings. See <a href="https://github.com/w3c/epub-specs/issues/1455">issue
 					1455</a>.</li>
-				<li>26-Mar-2021: Added non-normative section detailing when to re-evaluate EPUB Publications. See <a
+				<li>26-Mar-2021: Added non-normative section detailing when to re-evaluate EPUB publications. See <a
 						href="https://github.com/w3c/epub-specs/issues/1470">issue 1470</a>.</li>
 				<li>12-Mar-2021: Changed the distribution section to non-normative but added a note that the
 					requirements must be followed where required by law (e.g., in the EU). See <a
@@ -1843,7 +1844,7 @@
 						<code>certifierReport</code> properties and examples. See <a
 						href="https://github.com/w3c/epub-specs/issues/1410">issue 1410</a>.</li>
 				<li>16-Nov-2020: References to the optional accessibility control and API metadata have been removed
-					from the discoverability section. These metadata properties are more applicable to Reading Systems.
+					from the discoverability section. These metadata properties are more applicable to reading systems.
 					See <a href="https://github.com/w3c/epub-specs/issues/1327">issue 1327</a>.</li>
 				<li>26-Sept-2020: The revisions made to the Accessibility 1.0 specification as part of publishing it as
 					an ISO standard have been incorporated into the initial draft text.</li>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -502,7 +502,7 @@
 							"[a] collection of web pages that share a common purpose" [[WCAG2]].</p>
 
 						<p>Consequently, when evaluating the accessibility of an EPUB publication, <a>EPUB creators</a>
-							cannot review individual pages — or Content Documents, as they are known in EPUB 3 — in
+							cannot review individual pages — or EPUB content documents, as they are known in EPUB 3 — in
 							isolation. Rather, EPUB creators MUST evaluate their accessibility as part of the larger
 							work.</p>
 
@@ -513,8 +513,8 @@
 							if either is missing.</p>
 
 						<p>EPUB creators MUST evaluate the WCAG guidelines for content to be perceivable, operable,
-							understandable, and robust against the full EPUB publication, not only against each Content
-							Document within it.</p>
+							understandable, and robust against the full EPUB publication, not only against each EPUB
+							content document within it.</p>
 
 						<p>The EPUB Accessibility Techniques [[?EPUB-A11Y-TECH-11]] provide more information about
 							applying these guidelines to EPUB publications.</p>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -998,7 +998,7 @@
 											document</a> [[EPUB-3]].</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-005">Synchronizing the
-												Navigation Document</a> [[EPUB-A11Y-TECH-11]] for more information on
+												navigation document</a> [[EPUB-A11Y-TECH-11]] for more information on
 											meeting this objective.</p>
 									</div>
 								</dd>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -80,8 +80,7 @@
 		<style>
 			pre {
 				white-space: break-spaces !important;
-			}
-		</style>
+			}</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -89,7 +88,7 @@
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
 				web content — including HTML, CSS, SVG, and other resources — for distribution in a single-file
 				container.</p>
-			<p>This specification defines the authoring requirements for EPUB Publications and represents the third
+			<p>This specification defines the authoring requirements for EPUB publications and represents the third
 				major revision of the standard.</p>
 		</section>
 		<section id="sotd"></section>
@@ -106,26 +105,26 @@
 					including books, magazines, and educational, professional, and scientific publications.</p>
 
 				<p>This specification represents the core of EPUB 3 and includes the conformance requirements for
-						<a>EPUB Publications</a> — the product of the standard. The other specifications that comprise
+						<a>EPUB publications</a> — the product of the standard. The other specifications that comprise
 					EPUB 3 are as follows:</p>
 
 				<ul>
 					<li>
 						<p><a data-cite="epub-rs-33#">EPUB 3 Reading Systems</a> [[EPUB-RS-33]] — defines the processing
-							requirements for <a>EPUB Reading Systems</a> — the applications that consume EPUB
-							Publications and present their content to users.</p>
+							requirements for <a>EPUB reading systems</a> — the applications that consume EPUB
+							publications and present their content to users.</p>
 					</li>
 					<li>
 						<p><a data-cite="epub-a11y-11#">EPUB Accessibility</a> [[EPUB-A11Y-11]] — defines accessibility
-							conformance and discovery requirements for EPUB Publications.</p>
+							conformance and discovery requirements for EPUB publications.</p>
 					</li>
 				</ul>
 
 				<p>These specifications represent the formal list recognized as belonging to EPUB 3 and that contain
 					functionality normatively referenced as part of the standard. The development of extension
-					specifications periodically adds new functionality to EPUB Publications. Features and functionality
+					specifications periodically adds new functionality to EPUB publications. Features and functionality
 					defined outside of core revisions to the standard, while not formally recognized in this
-					specification, are nonetheless available for <a>EPUB Creators</a> and Reading System developers to
+					specification, are nonetheless available for <a>EPUB creators</a> and reading system developers to
 					use.</p>
 
 				<p>The non-normative <a data-cite="epub-overview-33#">EPUB 3 Overview</a> [[EPUB-OVERVIEW-33]] provides
@@ -137,17 +136,17 @@
 				<h3>Organization</h3>
 
 				<p>This section reviews the organization of the EPUB specifications through the central product they
-					define: the <a>EPUB Publication</a>.</p>
+					define: the <a>EPUB publication</a>.</p>
 
-				<p>An EPUB Publication is typically represented by a single <a>Package Document</a>. This document
-					includes metadata used by <a>Reading Systems</a> to present the content to the user, such as the
+				<p>An EPUB publication is typically represented by a single <a>package document</a>. This document
+					includes metadata used by <a>reading systems</a> to present the content to the user, such as the
 					title and author for display in a bookshelf as well as rendering metadata (e.g., whether the content
 					is reflowable or has a fixed layout). It also provides a manifest of resources and includes a
 						<a>spine</a> that lists the default sequence in which to render documents as a user progresses
-					through the content. Refer to <a href="#sec-package-doc"></a> for the requirements for the Package
-					Document.</p>
+					through the content. Refer to <a href="#sec-package-doc"></a> for the requirements for the package
+					document.</p>
 
-				<p>An EPUB Publication also includes another key file called the <a>EPUB Navigation Document</a>. This
+				<p>An EPUB publication also includes another key file called the <a>EPUB navigation document</a>. This
 					document provides critical navigation capabilities, such as the table of contents, that allow users
 					to navigate the content quickly and easily. Refer to <a href="#sec-nav"></a> for more information
 					about this document.</p>
@@ -160,40 +159,40 @@
 				</figure>
 				-->
 
-				<p>The actual content of an EPUB Publication &#8212; what users are presented with when they begin
+				<p>The actual content of an EPUB publication &#8212; what users are presented with when they begin
 					reading &#8212; is built on the Open Web Platform and comes in two flavors: <a
-						data-lt="XHTML Content Document">XHTML</a> and <a data-lt="SVG Content Document">SVG</a>. Called
-						<a>EPUB Content Documents</a>, these documents typically reference many additional resources
+						data-lt="XHTML content document">XHTML</a> and <a data-lt="SVG content document">SVG</a>. Called
+						<a>EPUB content documents</a>, these documents typically reference many additional resources
 					required for their proper rendering, such as images, audio and video clips, scripts, and style
 					sheets.</p>
 
 				<p>Refer to <a href="#sec-contentdocs"></a> for detailed information about the rules and requirements to
-					produce EPUB Content Documents, and [[EPUB-A11Y-11]] for accessibility requirements.</p>
+					produce EPUB content documents, and [[EPUB-A11Y-11]] for accessibility requirements.</p>
 
-				<p><a>Media Overlay Documents</a> complement EPUB Content Documents. They provide declarative markup for
-					synchronizing the text in EPUB Content Documents with prerecorded audio. The result is the ability
-					to create a read-aloud experience where <a>Reading Systems</a> highlight the text as it is narrated.
-					Refer to <a href="#sec-media-overlays"></a> for the definition of Media Overlay Documents.</p>
+				<p><a>Media overlay documents</a> complement EPUB content documents. They provide declarative markup for
+					synchronizing the text in EPUB content documents with prerecorded audio. The result is the ability
+					to create a read-aloud experience where <a>reading systems</a> highlight the text as it is narrated.
+					Refer to <a href="#sec-media-overlays"></a> for the definition of media overlay documents.</p>
 
-				<p>A ZIP-based archive with the file extension <code>.epub</code> bundles the EPUB Publication's
-					resources for distribution. As conformant ZIP archives, EPUB Publications can be unzipped by many
+				<p>A ZIP-based archive with the file extension <code>.epub</code> bundles the EPUB publication's
+					resources for distribution. As conformant ZIP archives, EPUB publications can be unzipped by many
 					software programs, simplifying both their production and consumption.</p>
 
 				<p>The container format not only provides a means of determining that the zipped content represents an
-					EPUB Publication (the <code>mimetype</code> file), but also provides a universally named directory
+					EPUB publication (the <code>mimetype</code> file), but also provides a universally named directory
 					of non-normative resources (<code>/META-INF</code>). Key among these resources is the
-						<code>container.xml</code> file, which directs Reading Systems to the available Package
-					Documents. Refer to <a href="#sec-ocf"></a> for more information about the Container format.</p>
+						<code>container.xml</code> file, which directs reading systems to the available package
+					documents. Refer to <a href="#sec-ocf"></a> for more information about the container format.</p>
 
-				<p>While conceptually simple, an EPUB Publication is more than just a collection of HTML pages and
+				<p>While conceptually simple, an EPUB publication is more than just a collection of HTML pages and
 					dependent assets in a ZIP package as presented here. Additional information about the primary
-					features and functionality that EPUB Publications provide to enhance the reading experience is
+					features and functionality that EPUB publications provide to enhance the reading experience is
 					available from the referenced specifications, and a more general introduction to the features of
 					EPUB 3 is provided in the non-normative [[EPUB-OVERVIEW-33]].</p>
 
-				<p>Refer to [[EPUB-RS-33]] for the processing requirements for Reading Systems. Although it is not
-					necessary that <a>EPUB Creators</a> read that document to create EPUB Publications, an understanding
-					of how Reading Systems present the content can help craft publications for optimal presentation to
+				<p>Refer to [[EPUB-RS-33]] for the processing requirements for reading systems. Although it is not
+					necessary that <a>EPUB creators</a> read that document to create EPUB publications, an understanding
+					of how reading systems present the content can help craft publications for optimal presentation to
 					users.</p>
 			</section>
 
@@ -203,12 +202,12 @@
 				<div class="caution">
 					<p>The technologies EPUB 3 builds on are constantly evolving. Some, typically referred to as
 						"living" or "evergreen" standards, are subject to change daily and their impact on the validity
-						of EPUB Publications is immediate. Others are updated less frequently and the changes may not
-						affect <a>EPUB Publications</a> until EPUB 3 undergoes a new revision.</p>
+						of EPUB publications is immediate. Others are updated less frequently and the changes may not
+						affect <a>EPUB publications</a> until EPUB 3 undergoes a new revision.</p>
 					<p>In all cases, it is possible that previously valid features may become obsolete (e.g., due to a
-						lack of support or because of security issues). <a>EPUB Creators</a> should therefore be
-						cautious about using any feature without broad support and keep their <a>EPUB Conformance
-							Checkers</a> up to date.</p>
+						lack of support or because of security issues). <a>EPUB creators</a> should therefore be
+						cautious about using any feature without broad support and keep their <a>EPUB conformance
+							checkers</a> up to date.</p>
 				</div>
 
 				<section id="sec-overview-relations-html">
@@ -218,8 +217,8 @@
 						it. That standard, in turn, references various technologies that continue to evolve, such as
 						MathML, SVG, CSS, and JavaScript.</p>
 
-					<p>The benefit of this approach for EPUB is that <a>EPUB Publications</a> always keep pace with
-						changes to the web without the need for new revisions. <a>EPUB Creators</a>, however, must keep
+					<p>The benefit of this approach for EPUB is that <a>EPUB publications</a> always keep pace with
+						changes to the web without the need for new revisions. <a>EPUB creators</a>, however, must keep
 						track of the various changes to HTML and the technologies it references to ensure they keep
 						their processes up to date.</p>
 
@@ -227,8 +226,8 @@
 						of semantics, structure and processing behaviors from HTML unless otherwise specified.</p>
 
 					<p>In addition, this specification <a href="#sec-xhtml-extensions">defines a set of extensions</a>
-						to the [[HTML]] document model that EPUB Creators may include in <a>XHTML Content
-						Documents</a>.</p>
+						to the [[HTML]] document model that EPUB creators may include in <a>XHTML content
+						documents</a>.</p>
 				</section>
 
 				<section id="sec-overview-relations-svg">
@@ -239,7 +238,7 @@
 						specification is the authoritative reference.</p>
 
 					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. <a>EPUB
-							Creators</a>, however, must keep track of changes to the SVG standard to ensure they keep
+							creators</a>, however, must keep track of changes to the SVG standard to ensure they keep
 						their processes up to date.</p>
 				</section>
 
@@ -271,7 +270,7 @@
 					<h4>Relationship to URL</h4>
 
 					<p>This specification refers to the [[URL]] standard for terminology and processing related to URLs
-						expressed in EPUB Publications. It is anticipated that new and revised web formats will adopt
+						expressed in EPUB publications. It is anticipated that new and revised web formats will adopt
 						this standard, but until then this may put this specification in conflict with the internal
 						requirements for some formats (e.g., valid relative paths), specifically with respect to the use
 						of internationalized URLs. If a format does not allow internationalized URLs (i.e., URLs must
@@ -290,7 +289,7 @@
 
 				<dl class="termlist">
 					<dt>
-						<dfn class="export" id="dfn-codec" data-lt="Codecs">Codec</dfn>
+						<dfn class="export" id="dfn-codec" data-lt="codecs">codec</dfn>
 					</dt>
 					<dd>
 						<p>Codec refers to content that has intrinsic binary format qualities, such as video and audio
@@ -299,193 +298,193 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-local-resource" data-lt="Container Resources">Container
-							Resource</dfn>
+						<dfn class="export" id="dfn-local-resource" data-lt="container resources">container
+							resource</dfn>
 					</dt>
 					<dd>
-						<p>A <a>Publication Resource</a> that is located within the <a>EPUB Container</a>, as opposed to
-							a <a>Remote Resource</a> which is not.</p>
+						<p>A <a>publication resource</a> that is located within the <a>EPUB container</a>, as opposed to
+							a <a>remote resource</a> which is not.</p>
 						<p>Refer to <a href="#sec-resource-locations"></a> for media type-specific rules for resource
 							locations.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-container-root-url">Container Root URL</dfn>
+						<dfn class="export" id="dfn-container-root-url">container root URL</dfn>
 					</dt>
 					<dd>
-						<p>The <a>URL</a> [[URL]] of the <a>Root Directory</a> representing
-							the <a>OCF Abstract Container</a>. It is implementation specific, but EPUB Creators must
-							assume it has properties defined in <a href="#sec-container-iri"></a>.</p>
+						<p>The <a>URL</a> [[URL]] of the <a>root directory</a> representing the <a>OCF abstract
+								container</a>. It is implementation specific, but EPUB creators must assume it has
+							properties defined in <a href="#sec-container-iri"></a>.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-content-url">Content URL</dfn>
+						<dfn class="export" id="dfn-content-url">content URL</dfn>
 					</dt>
 					<dd>
-						<p> The <a>URL</a> of a file or directory in the <a>OCF Abstract
-								Container</a>, defined in <a href="#sec-container-iri"></a>. </p>
+						<p> The <a>URL</a> of a file or directory in the <a>OCF abstract container</a>, defined in <a
+								href="#sec-container-iri"></a>. </p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-core-media-type-resource" data-lt="Core Media Type Resources">Core
-							Media Type Resource</dfn>
+						<dfn class="export" id="dfn-core-media-type-resource" data-lt="core media type resources">core
+							media type resource</dfn>
 					</dt>
 					<dd>
-						<p>A <a>Publication Resource</a> that conforms to one of the MIME media types [[RFC2046]] listed
+						<p>A <a>publication resource</a> that conforms to one of the MIME media types [[RFC2046]] listed
 							in <a href="#sec-core-media-types"></a> and, therefore, does not require the provision of a
-								<a href="#sec-foreign-resources">fallback</a> (cf. <a>Foreign Resource</a>).</p>
-						<p>The designation "Core Media Type Resource" only applies when a resource is used in the
-							rendering of <a>EPUB Content Documents</a> and <a>Foreign Content Documents</a>. A Core
-							Media Type Resource cannot be used in the <a>spine</a>, for example, without a fallback
-							unless it also has the media type of an EPUB Content Document.</p>
+								<a href="#sec-foreign-resources">fallback</a> (cf. <a>foreign resource</a>).</p>
+						<p>The designation "core media type resource" only applies when a resource is used in the
+							rendering of <a>EPUB content documents</a> and <a>foreign content documents</a>. A core
+							media type resource cannot be used in the <a>spine</a>, for example, without a fallback
+							unless it also has the media type of an EPUB content document.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-epub-container" data-lt="EPUB Containers">EPUB Container</dfn>
+						<dfn class="export" id="dfn-epub-container" data-lt="EPUB containers">EPUB container</dfn>
 					</dt>
 
 					<dt>
-						<dfn class="export" id="dfn-zip-container">OCF ZIP Container</dfn>
+						<dfn class="export" id="dfn-zip-container">OCF ZIP container</dfn>
 					</dt>
 					<dd>
-						<p>The ZIP-based packaging and distribution format for <a>EPUB Publications</a> defined in <a
+						<p>The ZIP-based packaging and distribution format for <a>EPUB publications</a> defined in <a
 								href="#sec-container-zip"></a>.</p>
-						<p>EPUB Container and OCF ZIP Container are synonymous.</p>
+						<p>EPUB container and OCF ZIP container are synonymous.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-epub-content-document" data-lt="EPUB Content Documents">EPUB Content
-							Document</dfn>
+						<dfn class="export" id="dfn-epub-content-document" data-lt="EPUB content documents">EPUB content
+							document</dfn>
 					</dt>
 					<dd>
-						<p>A <a>Publication Resource</a> referenced from the spine or a <a>manifest fallback chain</a>
-							that conforms to either the <a data-lt="XHTML Content Document">XHTML</a> or <a
-								data-lt="SVG Content Document">SVG Content Document</a> definitions.</p>
-						<p>EPUB Content Documents contain all or part of the content of an EPUB Publication (i.e., the
+						<p>A <a>publication resource</a> referenced from the spine or a <a>manifest fallback chain</a>
+							that conforms to either the <a data-lt="XHTML content document">XHTML</a> or <a
+								data-lt="SVG content document">SVG content document</a> definitions.</p>
+						<p>EPUB content documents contain all or part of the content of an EPUB publication (i.e., the
 							textual, visual and/or audio content).</p>
-						<p><a>EPUB Creators</a> can include EPUB Content Documents in the spine without the provision of
+						<p><a>EPUB creators</a> can include EPUB content documents in the spine without the provision of
 								<a href="#sec-foreign-resources">fallbacks</a>.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-epub-creator" data-lt="EPUB Creators">EPUB Creator</dfn>
+						<dfn class="export" id="dfn-epub-creator" data-lt="EPUB creators">EPUB creator</dfn>
 					</dt>
 					<dd>
-						<p>An individual, organization, or process that produces an <a>EPUB Publication</a>.</p>
+						<p>An individual, organization, or process that produces an <a>EPUB publication</a>.</p>
 						<div class="note">
-							<p> The creation of an EPUB Publication often involves the work of many individuals, and may
+							<p> The creation of an EPUB publication often involves the work of many individuals, and may
 								be split across multiple organizations (e.g., when a publisher outsources all or part of
-								the work). Depending on the process used to produce an EPUB Publication,
+								the work). Depending on the process used to produce an EPUB publication,
 								responsibilities may fall on the organization (e.g., the publisher), the individuals
 								preparing the publication (e.g., technical editors), or automatic procedures (e.g., as
 								part of a publication pipeline). As a result, not every party or process may be
-								responsible for ensuring every requirement is met, but there is always an EPUB Creator
-								responsible for the conformance of the final EPUB Publication. </p>
-							<p>Previous versions of this specification referred to the EPUB Creator as the <span
+								responsible for ensuring every requirement is met, but there is always an EPUB creator
+								responsible for the conformance of the final EPUB publication. </p>
+							<p>Previous versions of this specification referred to the EPUB creator as the <span
 									id="dfn-author">Author</span>.</p>
 						</div>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-epub-navigation-document" data-lt="EPUB Navigation Documents">EPUB
-							Navigation Document</dfn>
+						<dfn class="export" id="dfn-epub-navigation-document" data-lt="EPUB navigation documents">EPUB
+							navigation document</dfn>
 					</dt>
 					<dd>
-						<p>A specialization of the <a>XHTML Content Document</a> that contains human- and
-							machine-readable global navigation information. The EPUB Navigation Document conforms to the
+						<p>A specialization of the <a>XHTML content document</a> that contains human- and
+							machine-readable global navigation information. The EPUB navigation document conforms to the
 							constraints expressed in <a href="#sec-nav"></a>.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-epub-publication" data-lt="EPUB Publications">EPUB Publication</dfn>
+						<dfn class="export" id="dfn-epub-publication" data-lt="EPUB publications">EPUB publication</dfn>
 					</dt>
 					<dd>
 						<p>A logical document entity consisting of a set of interrelated <a
-								data-lt="Publication Resource">resources</a> packaged in an <a>EPUB Container</a>.</p>
-						<p>An EPUB Publication typically represents a single intellectual or artistic work, but this
+								data-lt="publication resource">resources</a> packaged in an <a>EPUB container</a>.</p>
+						<p>An EPUB publication typically represents a single intellectual or artistic work, but this
 							specification does not restrict the nature of the content.</p>
 					</dd>
 
 					<dt><dfn class="export" id="dfn-epub-reading-system"
-							data-lt="EPUB Reading Systems|Reading System|Reading Systems">EPUB Reading System</dfn> (or
-						Reading System)</dt>
+							data-lt="EPUB reading systems|reading system|reading systems">EPUB reading system</dfn> (or
+						reading system)</dt>
 					<dd>
-						<p>A system that processes <a>EPUB Publications</a> for presentation to a user in a manner
+						<p>A system that processes <a>EPUB publications</a> for presentation to a user in a manner
 							conformant with this specification.</p>
 					</dd>
 
-					<dt><dfn class="export" id="dfn-epub-conformance-checker" data-lt="EPUB Conformance Checkers">EPUB
-							Conformance Checker</dfn></dt>
+					<dt><dfn class="export" id="dfn-epub-conformance-checker" data-lt="EPUB conformance checkers">EPUB
+							conformance checker</dfn></dt>
 					<dd>
 						<p>An application that verifies the requirements of this specification against <a>EPUB
-								Publications</a> and reports on their conformance.</p>
+								publications</a> and reports on their conformance.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-exempt-resource" data-lt="Exempt Resources">Exempt Resource</dfn>
+						<dfn class="export" id="dfn-exempt-resource" data-lt="exempt resources">exempt resource</dfn>
 					</dt>
 					<dd>
-						<p>Exempt Resources are a special class of <a>Publication Resources</a> that Reading Systems are
-							not required to support the rendering of, but EPUB Creators do not have to provide <a
+						<p>Exempt resources are a special class of <a>publication resources</a> that reading systems are
+							not required to support the rendering of, but EPUB creators do not have to provide <a
 								href="#sec-foreign-resources">fallbacks</a> for.</p>
 						<p>Refer to <a href="#sec-exempt-resources"></a> for more information.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-file-name" data-lt="File Names">File Name</dfn>
+						<dfn class="export" id="dfn-file-name" data-lt="file names">file name</dfn>
 					</dt>
 					<dd>
-						<p>The name of any type of file within an <a>OCF Abstract Container</a>, whether a directory or
+						<p>The name of any type of file within an <a>OCF abstract container</a>, whether a directory or
 							a file within a directory.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-file-path" data-lt="File Paths">File Path</dfn>
+						<dfn class="export" id="dfn-file-path" data-lt="file paths">file path</dfn>
 					</dt>
 					<dd>
-						<p>The File Path of a file or directory is its full path relative to the root directory, as
+						<p>The file path of a file or directory is its full path relative to the root directory, as
 							defined by the algorithm specified in <a href="#sec-file-names-to-path-names"></a>.</p>
-						<!-- <p>The File Path of a file or directory <var>file</var> is the <a data-cite="url#concept-url-path">path</a> of the <a>content URL</a> for <var>file</var>. 
-						It is derived from the <a>File Name</a> of <var>file</var> following the steps specified in <a href="#sec-file-names-to-path-names"></a>.</p> -->
+						<!-- <p>The file path of a file or directory <var>file</var> is the <a data-cite="url#concept-url-path">path</a> of the <a>content URL</a> for <var>file</var>. 
+						It is derived from the <a>file name</a> of <var>file</var> following the steps specified in <a href="#sec-file-names-to-path-names"></a>.</p> -->
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-fixed-layout-document" data-lt="Fixed-Layout Documents">Fixed-Layout
-							Document</dfn>
+						<dfn class="export" id="dfn-fixed-layout-document" data-lt="fixed-layout documents">fixed-layout
+							document</dfn>
 					</dt>
 					<dd>
-						<p>An <a>EPUB Content Document</a> with fixed dimensions directly referenced from the
-								<a>spine</a>. Fixed-Layout Documents are designated <code>pre-paginated</code> in the
-								<a>Package Document</a>, as defined in <a href="#sec-fixed-layouts"></a>.</p>
+						<p>An <a>EPUB content document</a> with fixed dimensions directly referenced from the
+								<a>spine</a>. Fixed-layout documents are designated <code>pre-paginated</code> in the
+								<a>package document</a>, as defined in <a href="#sec-fixed-layouts"></a>.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-foreign-content-document" data-lt="Foreign Content Documents"
-							>Foreign Content Document</dfn>
+						<dfn class="export" id="dfn-foreign-content-document" data-lt="foreign content documents"
+							>foreign content document</dfn>
 					</dt>
 					<dd>
-						<p>Any <a>Publication Resource</a> referenced from a <a>spine</a>
+						<p>Any <a>publication resource</a> referenced from a <a>spine</a>
 							<a href="#sec-itemref-elem"><code>itemref</code> element</a>, or a <a>manifest fallback
-								chain</a>, that is not an <a>EPUB Content Document</a>.</p>
-						<p>When a Foreign Content Document is referenced from a spine <code>itemref</code> element, it
-							requires a <a>manifest fallback chain</a> with at least one EPUB Content Document.</p>
+								chain</a>, that is not an <a>EPUB content document</a>.</p>
+						<p>When a foreign content document is referenced from a spine <code>itemref</code> element, it
+							requires a <a>manifest fallback chain</a> with at least one EPUB content document.</p>
 						<div class="note">
-							<p>With the exception of XHTML and SVG, all <a>Core Media Type Resources</a> are Foreign
-								Content Documents when referenced directly from the spine.</p>
+							<p>With the exception of XHTML and SVG, all <a>core media type resources</a> are foreign
+								content documents when referenced directly from the spine.</p>
 						</div>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-foreign-resource" data-lt="Foreign Resources">Foreign Resource</dfn>
+						<dfn class="export" id="dfn-foreign-resource" data-lt="foreign resources">foreign resource</dfn>
 					</dt>
 					<dd>
-						<p>A <a>Publication Resource</a> with a MIME media type [[RFC2046]] that does not match any of
-							those listed in <a href="#sec-core-media-types"></a>. Foreign Resources are subject to the
+						<p>A <a>publication resource</a> with a MIME media type [[RFC2046]] that does not match any of
+							those listed in <a href="#sec-core-media-types"></a>. Foreign resources are subject to the
 							fallback requirements defined in <a href="#sec-foreign-resources"></a>.</p>
-						<p>The designation "Foreign Resource" only applies to resources used in the rendering of <a>EPUB
-								Content Documents</a> and <a>Foreign Content Documents</a>.</p>
+						<p>The designation "foreign resource" only applies to resources used in the rendering of <a>EPUB
+								content documents</a> and <a>foreign content documents</a>.</p>
 						<div class="note">
-							<p>Foreign Resource and <a>Foreign Content Document</a> are not interchangeable terms. The
+							<p>Foreign resource and <a>foreign content document</a> are not interchangeable terms. The
 								types of resources considered foreign when used in the spine is greater than the types
 								of resources considered foreign when used in <a href="#sec-contentdocs">Content
 									Documents</a>.</p>
@@ -493,75 +492,75 @@
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-linked-resource" data-lt="Linked Resources">Linked Resource</dfn>
+						<dfn class="export" id="dfn-linked-resource" data-lt="linked resources">linked resource</dfn>
 					</dt>
 					<dd>
-						<p>A resource that is only referenced from a <a>Package Document</a>
+						<p>A resource that is only referenced from a <a>package document</a>
 							<a href="#sec-link-elem"><code>link</code> element</a> (i.e., not also used in the rendering
-							of an <a>EPUB Publication</a>.</p>
-						<p>Linked Resources are not <a>Publication Resources</a> but may be stored in the <a>EPUB
-								Container</a>. They do not require fallbacks.</p>
+							of an <a>EPUB publication</a>.</p>
+						<p>Linked resources are not <a>publication resources</a> but may be stored in the <a>EPUB
+								container</a>. They do not require fallbacks.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-manifest" data-lt="Manifests">Manifest</dfn>
+						<dfn class="export" id="dfn-manifest" data-lt="manifests">manifest</dfn>
 					</dt>
 					<dd>
-						<p>The section of the <a>Package Document</a> that lists the <a>Publication Resources</a>.</p>
+						<p>The section of the <a>package document</a> that lists the <a>publication resources</a>.</p>
 						<p>Refer to <a href="#sec-manifest-elem"></a> for more information.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-media-overlay-document" data-lt="Media Overlay Documents">Media
-							Overlay Document</dfn>
+						<dfn class="export" id="dfn-media-overlay-document" data-lt="media overlay documents">media
+							overlay document</dfn>
 					</dt>
 					<dd>
-						<p>An XML document that associates the <a>XHTML Content Document</a> with pre-recorded audio
+						<p>An XML document that associates the <a>XHTML content document</a> with pre-recorded audio
 							narration to provide a synchronized playback experience, as defined in <a
 								href="#sec-media-overlays"></a>.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-non-codec" data-lt="Non-Codecs">Non-Codec</dfn>
+						<dfn class="export" id="dfn-non-codec" data-lt="non-codecs">non-codec</dfn>
 					</dt>
 					<dd>
-						<p>Non-Codec refers to content types that benefit from compression due to the nature of their
+						<p>Non-codec refers to content types that benefit from compression due to the nature of their
 							internal data structure, such as file formats based on character strings (for example, HTML,
 							CSS, etc.).</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-ocf-abstract-container" data-lt="OCF Abstract Containers">OCF
-							Abstract Container</dfn>
+						<dfn class="export" id="dfn-ocf-abstract-container" data-lt="OCF abstract containers">OCF
+							abstract container</dfn>
 					</dt>
 					<dd>
-						<p>The OCF Abstract Container defines a file system model for the contents of the <a>OCF ZIP
-								Container</a>, as defined in <a href="#sec-container-abstract"></a>.</p>
+						<p>The OCF abstract container defines a file system model for the contents of the <a>OCF ZIP
+								container</a>, as defined in <a href="#sec-container-abstract"></a>.</p>
 					</dd>
 
 					<dt>
 						<dfn class="export" id="dfn-package-document"
-							data-lt="Package Documents|Package Document(s)|Package Document's">Package Document</dfn>
+							data-lt="package documents|package document(s)|package document's">package document</dfn>
 					</dt>
 					<dd>
-						<p>A <a>Publication Resource</a> that describes the rendering of an <a>EPUB Publication</a>, as
-							defined in <a href="#sec-package-doc"></a>. The Package Document carries meta information
-							about the EPUB Publication, provides a manifest of resources, and defines a default reading
+						<p>A <a>publication resource</a> that describes the rendering of an <a>EPUB publication</a>, as
+							defined in <a href="#sec-package-doc"></a>. The package document carries meta information
+							about the EPUB publication, provides a manifest of resources, and defines a default reading
 							order.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-publication-resource" data-lt="Publication Resources">Publication
-							Resource</dfn>
+						<dfn class="export" id="dfn-publication-resource" data-lt="publication resources">publication
+							resource</dfn>
 					</dt>
 					<dd>
 						<p>A resource that contains content or instructions that contribute to the logic and rendering
-							of an <a>EPUB Publication</a>. In the absence of this resource, <a>Reading Systems</a> may
-							not render the EPUB Publication as the <a>EPUB Creator</a> intends. Examples of Publication
-							Resources include the <a>Package Document</a>, <a>EPUB Content Document</a>, CSS Style
+							of an <a>EPUB publication</a>. In the absence of this resource, <a>reading systems</a> may
+							not render the EPUB publication as the <a>EPUB creator</a> intends. Examples of publication
+							resources include the <a>package document</a>, <a>EPUB content document</a>, CSS Style
 							Sheets, audio, video, images, embedded fonts, and scripts.</p>
-						<p>EPUB Creators typically list Publication Resources in the Package Document <a
-								href="#sec-manifest-elem">manifest</a> and bundle them in the <a>EPUB Container</a>,
+						<p>EPUB creators typically list publication resources in the package document <a
+								href="#sec-manifest-elem">manifest</a> and bundle them in the <a>EPUB container</a>,
 							with the following exceptions:</p>
 						<ul>
 							<li>
@@ -570,109 +569,109 @@
 							</li>
 							<li>
 								<p>they may locate resources listed in <a href="#sec-resource-locations"></a> outside
-									the EPUB Container.</p>
+									the EPUB container.</p>
 							</li>
 						</ul>
 						<div class="note">
 							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
-									<code>href</code> attribute of an [[HTML]] <a data-lt="a"
-										><code>a</code> element</a>) are not Publication Resources.</p>
+									<code>href</code> attribute of an [[HTML]] <a data-lt="a"><code>a</code>
+								element</a>) are not publication resources.</p>
 						</div>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-remote-resource" data-lt="Remote Resources">Remote Resource</dfn>
+						<dfn class="export" id="dfn-remote-resource" data-lt="remote resources">remote resource</dfn>
 					</dt>
 					<dd>
-						<p>A <a>Publication Resource</a> that is located outside of the <a>EPUB Container</a>,
+						<p>A <a>publication resource</a> that is located outside of the <a>EPUB container</a>,
 							typically, but not necessarily, on the web.</p>
-						<p>Publication Resources within the EPUB Container are referred to as <a>Container
-							Resources</a>.</p>
+						<p>Publication resources within the EPUB container are referred to as <a>container
+							resources</a>.</p>
 						<p>Refer to <a href="#sec-resource-locations"></a> for media type specific rules for resource
 							locations.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-root-directory">Root Directory</dfn>
+						<dfn class="export" id="dfn-root-directory">root directory</dfn>
 					</dt>
 					<dd>
-						<p>The root directory represents the base of the <a>OCF Abstract Container</a> file system. This
+						<p>The root directory represents the base of the <a>OCF abstract container</a> file system. This
 							directory is <a data-cite="epub-rs-33#confreq-zip-rootdir">virtual in nature</a>.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-scripted-content-document" data-lt="Scripted Content Documents"
-							>Scripted Content Document</dfn>
+						<dfn class="export" id="dfn-scripted-content-document" data-lt="scripted content documents"
+							>scripted content document</dfn>
 					</dt>
 					<dd>
-						<p>An <a>EPUB Content Document</a> that includes scripting or an <a>XHTML Content Document</a>
+						<p>An <a>EPUB content document</a> that includes scripting or an <a>XHTML content document</a>
 							that contains [[HTML]] <a>forms</a>.</p>
 						<p>Refer to <a href="#sec-scripted-content"></a> for more information.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-spine">Spine</dfn>
+						<dfn class="export" id="dfn-spine">spine</dfn>
 					</dt>
 					<dd>
-						<p>The section of the <a>Package Document</a> that defines an ordered list of <a>EPUB Content
-								Documents</a> and <a>Foreign Content Documents</a>. This list represents the default
-							reading order of the <a>EPUB Publication</a>.</p>
+						<p>The section of the <a>package document</a> that defines an ordered list of <a>EPUB content
+								documents</a> and <a>foreign content documents</a>. This list represents the default
+							reading order of the <a>EPUB publication</a>.</p>
 						<p>Refer to <a href="#sec-spine-elem"></a> for more information.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-svg-content-document" data-lt="SVG Content Documents">SVG Content
-							Document</dfn>
+						<dfn class="export" id="dfn-svg-content-document" data-lt="SVG content documents">SVG content
+							document</dfn>
 					</dt>
 					<dd>
-						<p>An <a>EPUB Content Document</a> that conforms to the constraints expressed in <a
+						<p>An <a>EPUB content document</a> that conforms to the constraints expressed in <a
 								href="#sec-svg"></a>.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-synthetic-spread" data-lt="Synthetic Spreads">Synthetic Spread</dfn>
+						<dfn class="export" id="dfn-synthetic-spread" data-lt="synthetic spreads">synthetic spread</dfn>
 					</dt>
 					<dd>
 						<p>The rendering of two adjacent pages simultaneously on a device screen.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-top-level-content-document" data-lt="Top-level Content Documents"
-							>Top-level Content Document</dfn>
+						<dfn class="export" id="dfn-top-level-content-document" data-lt="top-level content documents"
+							>top-level content document</dfn>
 					</dt>
 					<dd>
-						<p>An <a>EPUB Content Document</a> or <a>Foreign Content Document</a> referenced from the
+						<p>An <a>EPUB content document</a> or <a>foreign content document</a> referenced from the
 								<a>spine</a>, whether directly or via a <a href="#sec-manifest-fallbacks">fallback
 								chain</a>.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-unique-identifier">Unique Identifier</dfn>
+						<dfn class="export" id="dfn-unique-identifier">unique identifier</dfn>
 					</dt>
 					<dd>
-						<p>The primary identifier for an <a>EPUB Publication</a>. The Unique Identifier is the
+						<p>The primary identifier for an <a>EPUB publication</a>. The unique identifier is the
 								<a>value</a> of the <a href="#sec-opf-dcidentifier"><code>dc:identifier</code>
 								element</a> specified by the <a href="#attrdef-package-unique-identifier"
-									><code>unique-identifier</code> attribute</a> in the <a>Package Document</a>.</p>
-						<p>Significant revision, abridgement, etc. of the content requires a new Unique Identifier.</p>
+									><code>unique-identifier</code> attribute</a> in the <a>package document</a>.</p>
+						<p>Significant revision, abridgement, etc. of the content requires a new unique identifier.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-viewport">Viewport</dfn>
+						<dfn class="export" id="dfn-viewport">viewport</dfn>
 					</dt>
 					<dd>
-						<p>The region of an <a>EPUB Reading System</a> in which an <a>EPUB Publication</a> is rendered
+						<p>The region of an <a>EPUB reading system</a> in which an <a>EPUB publication</a> is rendered
 							visually to a user.</p>
 					</dd>
 
 					<dt>
-						<dfn class="export" id="dfn-xhtml-content-document" data-lt="XHTML Content Documents">XHTML
-							Content Document</dfn>
+						<dfn class="export" id="dfn-xhtml-content-document" data-lt="XHTML content documents">XHTML
+							content document</dfn>
 					</dt>
 					<dd>
-						<p>An <a>EPUB Content Document</a> that conforms to the profile of [[HTML]] defined in <a
+						<p>An <a>EPUB content document</a> that conforms to the profile of [[HTML]] defined in <a
 								href="#sec-xhtml"></a>.</p>
-						<p>XHTML Content Documents use the <a data-cite="html#the-xhtml-syntax">XML syntax</a> defined
+						<p>XHTML content documents use the <a data-cite="html#the-xhtml-syntax">XML syntax</a> defined
 							in [[HTML]].</p>
 					</dd>
 				</dl>
@@ -685,11 +684,11 @@
 			<section id="sec-intro-shorthands" class="informative">
 				<h3>Authoring shorthands</h3>
 
-				<p>In <a>Package Document</a> metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
+				<p>In <a>package document</a> metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
 						prefixes</a> are used without declaration.</p>
 
 				<p>References to Dublin Core elements [[DCTERMS]] use the <code>dc:</code> prefix. This prefix must be
-					declared in the <a>Package Document</a> for their use to be valid
+					declared in the <a>package document</a> for their use to be valid
 						(<code>xmlns:dc="http://purl.org/dc/elements/1.1/"</code>)</p>
 
 				<p>The <code>epub</code> namespace prefix [[XML-NAMES]] is also used on elements and attributes without
@@ -697,21 +696,21 @@
 			</section>
 		</section>
 		<section id="sec-epub-conf">
-			<h2>EPUB Publication conformance</h2>
+			<h2>EPUB publication conformance</h2>
 
-			<p>An EPUB Publication:</p>
+			<p>An EPUB publication:</p>
 
 			<ul class="conformance-list">
 				<li>
 					<p id="confreq-package">MUST define at least one rendering of its content as follows:</p>
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-package-doc">MUST contain a <a>Package Document</a> that conforms to <a
-									href="#sec-package-doc"></a> and meet all <a>Publication Resource</a> requirements
-								for the Package Document.</p>
+							<p id="confreq-package-doc">MUST contain a <a>package document</a> that conforms to <a
+									href="#sec-package-doc"></a> and meet all <a>publication resource</a> requirements
+								for the package document.</p>
 						</li>
 						<li>
-							<p id="confreq-nav">MUST contain an <a>EPUB Navigation Document</a> that conforms to <a
+							<p id="confreq-nav">MUST contain an <a>EPUB navigation document</a> that conforms to <a
 									href="#sec-nav"></a>.</p>
 						</li>
 					</ul>
@@ -721,12 +720,12 @@
 						[[EPUB-A11Y-11]].</p>
 				</li>
 				<li>
-					<p id="confreq-ocf">MUST be packaged in an <a>EPUB Container</a> as defined in <a href="#sec-ocf"
+					<p id="confreq-ocf">MUST be packaged in an <a>EPUB container</a> as defined in <a href="#sec-ocf"
 						></a>.</p>
 				</li>
 			</ul>
 
-			<p id="confreq-res-location">In addition, all Publication Resources MUST adhere to the requirements in <a
+			<p id="confreq-res-location">In addition, all publication resources MUST adhere to the requirements in <a
 					href="#sec-publication-resources"></a>.</p>
 
 			<p>The rest of this specification covers specific conformance details.</p>
@@ -735,31 +734,31 @@
 				<h3>Conformance checking</h3>
 
 				<p>Due to the complexity of this specification and number of technologies used in <a>EPUB
-						Publications</a>, <a>EPUB Creators</a> are advised to use an <a>EPUB Conformance Checker</a> to
+						publications</a>, <a>EPUB creators</a> are advised to use an <a>EPUB conformance checker</a> to
 					verify the conformance of their content.</p>
 
-				<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto EPUB Conformance
-					Checker used by the publishing industry and has been updated with each new version of EPUB. It is
+				<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto EPUB conformance
+					checker used by the publishing industry and has been updated with each new version of EPUB. It is
 					integrated into a number of authoring tools and also available in alternative interfaces and other
 					languages (for more information, refer to its <a
 						href="https://www.w3.org/publishing/epubcheck/docs/apps-and-tools/">Apps and Tools
 					page</a>).</p>
 
-				<p>When verifying their EPUB Publications, EPUB Creators should ensure they do not violate the
+				<p>When verifying their EPUB publications, EPUB creators should ensure they do not violate the
 					requirements of this specification (practices identified by the keywords "MUST", "MUST NOT", and
-					"REQUIRED"). These types of issues will often result in EPUB Publications not rendering or rendering
+					"REQUIRED"). These types of issues will often result in EPUB publications not rendering or rendering
 					in inconsistent ways. These issues are typically reported as errors or critical errors.</p>
 
-				<p>EPUB Creators should also ensure that their EPUB Publications do not violate the recommendations of
+				<p>EPUB creators should also ensure that their EPUB publications do not violate the recommendations of
 					this specification (practices identified by the keywords "SHOULD", "SHOULD NOT", and "RECOMMENDED").
-					Failure to follow these practices does not result in an invalid EPUB Publication but may lead to
+					Failure to follow these practices does not result in an invalid EPUB publication but may lead to
 					interoperability problems and other issues that impact the user reading experience. These issues are
 					typically reported as warnings.</p>
 
 				<div class="note">
-					<p>Vendors, distributors, and other retailers of EPUB Publications should consider the importance of
+					<p>Vendors, distributors, and other retailers of EPUB publications should consider the importance of
 						recommended practices before basing their acceptance or rejection on a zero-issue outcome from
-						an EPUB Conformance Checker. There will be legitimate reasons why EPUB Creators cannot follow
+						an EPUB conformance checker. There will be legitimate reasons why EPUB creators cannot follow
 						recommended practices in all cases.</p>
 				</div>
 			</section>
@@ -770,10 +769,10 @@
 			<section id="sec-pub-res-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>An <a>EPUB Publication</a> is made up of many different categories of resources, not all of which are
-					mutually exclusive. Some resources are <a>Publication Resources</a>, some are not. Some Publication
-					Resources are allowed in the <a>spine</a> by default, while all others require fallbacks. Some
-					resources can be used in rendering <a>EPUB Content Documents</a>, while others can only be used with
+				<p>An <a>EPUB publication</a> is made up of many different categories of resources, not all of which are
+					mutually exclusive. Some resources are <a>publication resources</a>, some are not. Some publication
+					resources are allowed in the <a>spine</a> by default, while all others require fallbacks. Some
+					resources can be used in rendering <a>EPUB content documents</a>, while others can only be used with
 					fallbacks.</p>
 
 				<p>Trying to understand these differences by reading the technical definitions of each category of
@@ -784,19 +783,19 @@
 
 				<ul>
 					<li>The <a>manifest plane</a> &#8212; The manifest plane holds all the resources of the EPUB
-						Publication (namely, <a>Publication Resources</a> and <a>Linked Resources</a>).</li>
+						publication (namely, <a>publication resources</a> and <a>linked resources</a>).</li>
 					<li>The <a>spine plane</a> &#8212; The spine plane holds only the resources used in rendering the
-							<a>spine</a> (namely, <a>EPUB Content Documents</a> and <a>Foreign Content
-						Documents</a>).</li>
+							<a>spine</a> (namely, <a>EPUB content documents</a> and <a>foreign content
+						documents</a>).</li>
 					<li>The <a>content plane</a> &#8212; The content plane holds only the resources used in the
-						rendering of EPUB and Foreign Content Documents (namely, <a>Core Media Type Resources</a>,
-							<a>Foreign Resources</a> and <a>Exempt Resources</a>).</li>
+						rendering of EPUB and foreign content documents (namely, <a>core media type resources</a>,
+							<a>foreign resources</a> and <a>exempt resources</a>).</li>
 				</ul>
 
 				<p>The same resource may exist on more than one plane and will be referred to differently in this
-					specification depending on which plane is being discussed. For example, a Core Media Type Resource
-					used in the rendering of an EPUB Content Document (on the content plane) may also be a Foreign
-					Content Document if it is also listed in the spine (the spine plane).</p>
+					specification depending on which plane is being discussed. For example, a core media type resource
+					used in the rendering of an EPUB content document (on the content plane) may also be a foreign
+					content document if it is also listed in the spine (the spine plane).</p>
 
 				<p>The following sections describe these planes in more detail.</p>
 
@@ -809,46 +808,46 @@
 					<h4>The manifest plane</h4>
 
 					<p>To <dfn class="export">manifest plane</dfn> defines all the resources of an <a>EPUB
-							Publication</a>. It is analogous to the <a>Package Document</a>
+							publication</a>. It is analogous to the <a>package document</a>
 						<a>manifest</a>, but includes resources not present in that list.</p>
 
-					<p>The primary resources in this group are designated <a>Publication Resources</a>, which are all
-						the resources used in rendering an EPUB Publication to the user. <a>EPUB Creators</a> always
+					<p>The primary resources in this group are designated <a>publication resources</a>, which are all
+						the resources used in rendering an EPUB publication to the user. <a>EPUB creators</a> always
 						have to list these resources in the <a href="#sec-manifest-elem"><code>manifest</code>
 							element</a>.</p>
 
-					<p>Publication Resources are further classified by their use(s) in the <a>spine plane</a> and
+					<p>Publication resources are further classified by their use(s) in the <a>spine plane</a> and
 							<a>content plane</a>.</p>
 
-					<p>The manifest plane also contains a set of <a>Linked Resources</a>. These resources are tangential
+					<p>The manifest plane also contains a set of <a>linked resources</a>. These resources are tangential
 						to the direct rendering. They include, for example, metadata records and links to external
-						content (e.g., where to purchase an EPUB Publication).</p>
+						content (e.g., where to purchase an EPUB publication).</p>
 
-					<p>Unlike Publication Resources, they are not listed in the Package Document manifest (i.e., because
-						they are not essential to rendering the EPUB Publication). They are instead defined in <a
-							href="#sec-link-elem"><code>link</code> elements</a> in the Package Document metadata. These
+					<p>Unlike publication resources, they are not listed in the package document manifest (i.e., because
+						they are not essential to rendering the EPUB publication). They are instead defined in <a
+							href="#sec-link-elem"><code>link</code> elements</a> in the package document metadata. These
 						elements define their nature and purpose similar to how manifest <a href="#sec-item-elem"
-								><code>item</code> elements</a> define Publication Resource. (In this way, they are like
+								><code>item</code> elements</a> define publication resource. (In this way, they are like
 						an extension of the manifest.)</p>
 
-					<p>Refer to <a href="#sec-link-elem"></a> for more information about Linked Resources.</p>
+					<p>Refer to <a href="#sec-link-elem"></a> for more information about linked resources.</p>
 
 					<p>Resources in the manifest plane are also sometimes broken down by where they are located.
-						Although most Publication Resources have to be located in the EPUB Container (called
-							<a>Container Resources</a>), EPUB 3 allows <a href="#sec-resource-locations">audio, video,
-							font and script data resources</a> to be hosted outside the Container. These exceptions were
-						made to speed up the download and loading of EPUB Publications, as these resources are typically
+						Although most publication resources have to be located in the EPUB container (called
+							<a>container resources</a>), EPUB 3 allows <a href="#sec-resource-locations">audio, video,
+							font and script data resources</a> to be hosted outside the container. These exceptions were
+						made to speed up the download and loading of EPUB publications, as these resources are typically
 						quite large, and, in the case of fonts, not essential to the presentation. When remotely hosted,
-						these Publication Resources are referred to as <a>Remote Resources</a>.</p>
+						these publication resources are referred to as <a>remote resources</a>.</p>
 
-					<p>Since Linked Resources are not essential to the rendering of an EPUB Publication, there are no
+					<p>Since linked resources are not essential to the rendering of an EPUB publication, there are no
 						requirements on where they are located and consequently no special naming of them based on their
-						location. They may be located within the EPUB Container or outside it.</p>
+						location. They may be located within the EPUB container or outside it.</p>
 
 					<div class="note">
-						<p>Hyperlinked content outside the EPUB Container (e.g., web pages) are not Publication
-							Resources, and consequently are not listed in the manifest. Reading Systems will normally
-							open these links in a separate browser instance, not as part of the EPUB Publication.</p>
+						<p>Hyperlinked content outside the EPUB container (e.g., web pages) are not publication
+							resources, and consequently are not listed in the manifest. Reading systems will normally
+							open these links in a separate browser instance, not as part of the EPUB publication.</p>
 					</div>
 				</section>
 
@@ -857,46 +856,46 @@
 
 					<p>The <dfn class="export">spine plane</dfn> defines resources used in the default reading order
 						established by the <a>spine</a>, which includes both <a href="#attrdef-itemref-linear">linear
-							and non-linear content</a>. The spine instructs <a>Reading Systems</a> on how to load these
-						resources as the user progresses through the <a>EPUB Publication</a>. Although many resources
-						may be bundled in an <a>EPUB Container</a>, they are not all allowed by default in the
+							and non-linear content</a>. The spine instructs <a>reading systems</a> on how to load these
+						resources as the user progresses through the <a>EPUB publication</a>. Although many resources
+						may be bundled in an <a>EPUB container</a>, they are not all allowed by default in the
 						spine.</p>
 
-					<p>EPUB 3 defines a special class of resources called <a>EPUB Content Documents</a> that <a>EPUB
-							Creators</a> can use in the spine without any restrictions. EPUB Content Documents encompass
-						both <a>XHTML Content Documents</a> and <a>SVG Content Documents</a>.</p>
+					<p>EPUB 3 defines a special class of resources called <a>EPUB content documents</a> that <a>EPUB
+							creators</a> can use in the spine without any restrictions. EPUB content documents encompass
+						both <a>XHTML content documents</a> and <a>SVG content documents</a>.</p>
 
-					<p>To use any other type of resource in the spine, called a <a>Foreign Content Document</a>,
-						requires including a fallback to an EPUB Content Document. This extensibility model allows EPUB
-						Creators to experiment with formats while ensuring that Reading Systems are always able to
-						render something for the user to read, as there is no guarantee of support for Foreign Content
-						Documents.</p>
+					<p>To use any other type of resource in the spine, called a <a>foreign content document</a>,
+						requires including a fallback to an EPUB content document. This extensibility model allows EPUB
+						creators to experiment with formats while ensuring that reading systems are always able to
+						render something for the user to read, as there is no guarantee of support for foreign content
+						documents.</p>
 
-					<p>A mechanism called <a href="#sec-manifest-fallbacks">manifest fallbacks</a> allows EPUB Creators
-						to provide fallbacks for Foreign Content Documents. In this model, the <a>manifest</a> entry for
-						the Foreign Content Document must include a <a href="#attrdef-item-fallback"
+					<p>A mechanism called <a href="#sec-manifest-fallbacks">manifest fallbacks</a> allows EPUB creators
+						to provide fallbacks for foreign content documents. In this model, the <a>manifest</a> entry for
+						the foreign content document must include a <a href="#attrdef-item-fallback"
 								><code>fallback</code> attribute</a> that points to the next possible resource for
-						Reading Systems to try when they do not support its format. Although not common, a fallback
+						reading systems to try when they do not support its format. Although not common, a fallback
 						resource can specify another fallback, thereby making chains many resources deep. The one
-						requirement is that there must be at least one EPUB Content Document in a <a>manifest fallback
+						requirement is that there must be at least one EPUB content document in a <a>manifest fallback
 							chain</a>.</p>
 
 					<p>Although they are not directly listed in the spine, all of the resources in the fallback chain
 						are considered part of the spine, and by extension part of the spine plane, since any may be
-						used by a Reading System.</p>
+						used by a reading system.</p>
 
 					<p>Refer to <a href="#sec-manifest-fallbacks"></a> for more information.</p>
 
 					<div class="caution" id="caution-fallbacks">
 						<p>Although manifest fallbacks fulfill the technical requirements of EPUB, there is little
-							practical support for them in Reading Systems. Their use is strongly discouraged as it can
+							practical support for them in reading systems. Their use is strongly discouraged as it can
 							lead to unreadable publications.</p>
 					</div>
 
 					<div class="note">
-						<p>It is possible to provide manifest fallbacks for EPUB Content Documents, but this is not
-							required or common. For example, a <a>Scripted Content Document</a> could have a fallback to
-							an unscripted alternative for Reading Systems that do not support scripting.</p>
+						<p>It is possible to provide manifest fallbacks for EPUB content documents, but this is not
+							required or common. For example, a <a>scripted content document</a> could have a fallback to
+							an unscripted alternative for reading systems that do not support scripting.</p>
 					</div>
 				</section>
 
@@ -904,42 +903,42 @@
 					<h4>The content plane</h4>
 
 					<p>The <dfn class="export">content plane</dfn> classifies resources that are used when rendering
-							<a>EPUB Content Documents</a> and <a>Foreign Content Documents</a>. These types of resources
+							<a>EPUB content documents</a> and <a>foreign content documents</a>. These types of resources
 						include embedded media, CSS style sheets, scripts, and fonts. These resources fall into three
-						categories based on their Reading System support: <a>Core Media Type Resources</a>, <a>Foreign
-							Resources</a>, and <a>Exempt Resources</a>.</p>
+						categories based on their reading system support: <a>core media type resources</a>, <a>foreign
+							resources</a>, and <a>exempt resources</a>.</p>
 
-					<p>A Core Media Type Resource is one that <a>Reading Systems</a> have to support, so it can be used
-						without restriction in EPUB or Foreign Content Documents. For more information about Core Media
-						Type Resources, refer to <a href="#sec-core-media-types"></a>.</p>
+					<p>A core media type resource is one that <a>reading systems</a> have to support, so it can be used
+						without restriction in EPUB or foreign content documents. For more information about core media
+						type resources, refer to <a href="#sec-core-media-types"></a>.</p>
 
 					<div class="note">
-						<p>Being a Core Media Type Resource does not mean that Reading Systems will always render the
-							resource, as not all Reading Systems support all features of EPUB 3. A Reading System
-							without a <a>Viewport</a>, for example, will not render visual content such as images.</p>
+						<p>Being a core media type resource does not mean that reading systems will always render the
+							resource, as not all reading systems support all features of EPUB 3. A reading system
+							without a <a>viewport</a>, for example, will not render visual content such as images.</p>
 					</div>
 
-					<p>The opposite of Core Media Type Resources are Foreign Resources. These are resources that Reading
-						Systems are not guaranteed to support the rendering of. As a result, similar to how using
-						Foreign Content Documents in the spine requires fallbacks to ensure their rendering, using
-						Foreign Resources in content documents also requires fallbacks. These fallbacks are provided in
+					<p>The opposite of core media type resources are foreign resources. These are resources that reading
+						systems are not guaranteed to support the rendering of. As a result, similar to how using
+						foreign content documents in the spine requires fallbacks to ensure their rendering, using
+						foreign resources in content documents also requires fallbacks. These fallbacks are provided in
 						one of two ways: using the capabilities of the host format or via manifest fallbacks.</p>
 
 					<p>The preferred method is to use the fallback capabilities of the host format. Many HTML elements,
-						for example, have intrinsic fallback capabilities. One example is the <a
-							data-lt="picture"><code>picture</code> element</a> [[HTML]], which allows EPUB
-						Creators to specify multiple alternative image formats.</p>
+						for example, have intrinsic fallback capabilities. One example is the <a data-lt="picture"
+								><code>picture</code> element</a> [[HTML]], which allows EPUB creators to specify
+						multiple alternative image formats.</p>
 
 					<p>If an intrinsic fallback method is not available, it is also possible to use manifest fallbacks,
 						but this method, as <a href="#caution-fallbacks">cautioned against</a> in the previous section,
-						is discouraged. For more information about Foreign Resources, refer to <a
+						is discouraged. For more information about foreign resources, refer to <a
 							href="#sec-foreign-resources"></a>.</p>
 
-					<p>Falling between Core Media Type Resources and Foreign Resources are Exempt Resources. These are
-						most closely associated with Foreign Resources, as there is no guarantee that Reading Systems
-						will render them. But like Core Media Types, they do not require fallbacks.</p>
+					<p>Falling between core media type resources and foreign resources are exempt resources. These are
+						most closely associated with foreign resources, as there is no guarantee that reading systems
+						will render them. But like core media types, they do not require fallbacks.</p>
 
-					<p>Exempt Resources tend to address specific cases for which there are no Core Media Types defined,
+					<p>Exempt resources tend to address specific cases for which there are no core media types defined,
 						but for which providing a fallback would prove cumbersome or unnecessary. These include
 						embedding video, adding accessibility tracks, and linking to resources from the [[HTML]] <a
 							data-lt="link"><code>link</code> element</a>.</p>
@@ -947,46 +946,46 @@
 					<p>Refer to <a href="#sec-exempt-resources"></a> for more information about these exceptions.</p>
 
 					<div class="note">
-						<p>A common point of confusion arising from Core Media Type Resources is the listing of XHTML
-							and SVG as Core Media Type Resources with the requirement the markup conform to their
-							respective <a>EPUB Content Document</a> definitions. This allows EPUB Creators to embed both
-							XHTML and SVG documents in EPUB Content Documents while keeping consistent requirements for
-							authoring and Reading System support.</p>
+						<p>A common point of confusion arising from core media type resources is the listing of XHTML
+							and SVG as core media type resources with the requirement the markup conform to their
+							respective <a>EPUB content document</a> definitions. This allows EPUB creators to embed both
+							XHTML and SVG documents in EPUB content documents while keeping consistent requirements for
+							authoring and reading system support.</p>
 
-						<p>In practice, it means that EPUB Creators can put XHTML and SVG Core Media Type Resources in
+						<p>In practice, it means that EPUB creators can put XHTML and SVG core media type resources in
 							the spine without any modification or fallback (they are also conforming XHTML and SVG
-							Content Documents), but this is a unique case. All other Core Media Type Resources become
-							Foreign Content Documents when used in the spine (i.e., Foreign Content Documents include
-							all Foreign Resources and all Core Media Type Resources except for XHTML and SVG).</p>
+							content documents), but this is a unique case. All other core media type resources become
+							foreign content documents when used in the spine (i.e., foreign content documents include
+							all foreign resources and all core media type resources except for XHTML and SVG).</p>
 					</div>
 				</section>
 			</section>
 
 			<section id="sec-core-media-types">
-				<h3>Core Media Types</h3>
+				<h3>Core media types</h3>
 
-				<p><a>EPUB Creators</a> MAY include <a>Publication Resources</a> that conform to the MIME media type
+				<p><a>EPUB creators</a> MAY include <a>publication resources</a> that conform to the MIME media type
 					[[RFC2046]] specifications defined in the following table without fallbacks when they are used in
-						<a>EPUB Content Documents</a> and <a>Foreign Content Documents</a>. These resources are
-					classified as <a>Core Media Type Resources</a>.</p>
+						<a>EPUB content documents</a> and <a>foreign content documents</a>. These resources are
+					classified as <a>core media type resources</a>.</p>
 
-				<p>With the exception of XHTML Content Documents and SVG Content Documents, EPUB Creators MUST provide
-						<a href="#sec-manifest-fallbacks">manifest fallbacks</a> for Core Media Type Resources
-					referenced directly from the <a>spine</a>. In this case, they are <a>Foreign Content
-					Documents</a>.</p>
+				<p>With the exception of XHTML content documents and SVG content documents, EPUB creators MUST provide
+						<a href="#sec-manifest-fallbacks">manifest fallbacks</a> for core media type resources
+					referenced directly from the <a>spine</a>. In this case, they are <a>foreign content
+					documents</a>.</p>
 
 				<p>The columns in the table represent the following information:</p>
 
 				<ul>
 					<li>
 						<p><strong>Media Type</strong>—The MIME media type [[RFC2046]] used to represent the given
-							Publication Resource in the <a href="#sec-manifest-elem">manifest</a>.</p>
+							publication resource in the <a href="#sec-manifest-elem">manifest</a>.</p>
 						<p>If the table lists more than one media type, the first one is the preferred media type. EPUB
-							Creators should use the preferred media type for all new EPUB Publications.</p>
+							creators should use the preferred media type for all new EPUB publications.</p>
 					</li>
-					<li><strong>Content Type Definition</strong>—The specification to which the given Core Media Type
-						Resource must conform.</li>
-					<li><strong>Applies to</strong>—The Publication Resource type(s) that the Media Type and Content
+					<li><strong>Content Type Definition</strong>—The specification to which the given core media type
+						resource must conform.</li>
+					<li><strong>Applies to</strong>—The publication resource type(s) that the Media Type and Content
 						Type Definition applies to.</li>
 				</ul>
 
@@ -1028,7 +1027,7 @@
 								<code>image/svg+xml</code>
 							</td>
 							<td>
-								<a href="#sec-svg">SVG Content Documents</a>
+								<a href="#sec-svg">SVG content documents</a>
 							</td>
 							<td>SVG documents</td>
 						</tr>
@@ -1124,7 +1123,7 @@
 								<code>application/xhtml+xml</code>
 							</td>
 							<td>
-								<a href="#sec-xhtml">XHTML Content Documents</a>
+								<a href="#sec-xhtml">XHTML content documents</a>
 							</td>
 							<td>HTML documents that use the <a data-cite="html#the-xhtml-syntax">XML syntax</a>
 								[[HTML]].</td>
@@ -1160,29 +1159,29 @@
 				</table>
 
 				<div class="note">
-					<p>Inclusion as a Core Media Type Resource does not mean that all Reading Systems will support the
-						rendering of a resource. Reading System support also depends on the capabilities of the
-						application (e.g., a Reading System with a <a>Viewport</a> must support image Core Media Type
-						Resources, but a Reading System without a Viewport does not). Refer to <a
-							data-cite="epub-rs-33#sec-epub-rs-conf-cmt">Core Media Types</a> [[EPUB-RS-33]] for more
-						information about which Reading Systems rendering capabilities require support for which Core
-						Media Type Resources.</p>
+					<p>Inclusion as a core media type resource does not mean that all reading systems will support the
+						rendering of a resource. Reading system support also depends on the capabilities of the
+						application (e.g., a reading system with a <a>viewport</a> must support image core media type
+						resources, but a reading system without a viewport does not). Refer to <a
+							data-cite="epub-rs-33#sec-epub-rs-conf-cmt">Core media types</a> [[EPUB-RS-33]] for more
+						information about which reading systems rendering capabilities require support for which core
+						media type resources.</p>
 
-					<p>The Working Group typically only includes formats as Core Media Type Resources when they have
-						broad support in web browser cores &#8212; the rendering engines that EPUB 3 Reading Systems
-						build upon. They are an agreement between Reading System developers and EPUB Creators to ensure
-						the predictability of rendering of EPUB Publications.</p>
+					<p>The Working Group typically only includes formats as core media type resources when they have
+						broad support in web browser cores &#8212; the rendering engines that EPUB 3 reading systems
+						build upon. They are an agreement between reading system developers and EPUB creators to ensure
+						the predictability of rendering of EPUB publications.</p>
 				</div>
 			</section>
 
 			<section id="sec-foreign-resources">
-				<h3>Foreign Resources</h3>
+				<h3>Foreign resources</h3>
 
-				<p>A <a>Foreign Resource</a>, unlike a <a href="#sec-core-media-types">Core Media Type Resource</a> is
-					one which is not guaranteed <a>Reading System</a> support when used in an <a>EPUB Content
-						Document</a> or <a>Foreign Content Document</a>.</p>
+				<p>A <a>foreign resource</a>, unlike a <a href="#sec-core-media-types">core media type resource</a> is
+					one which is not guaranteed <a>reading system</a> support when used in an <a>EPUB content
+						document</a> or <a>foreign content document</a>.</p>
 
-				<p id="confreq-cmt">EPUB Creators MUST provide fallbacks for Foreign Resources, where fallbacks take one
+				<p id="confreq-cmt">EPUB creators MUST provide fallbacks for foreign resources, where fallbacks take one
 					of the following forms:</p>
 
 				<ul>
@@ -1193,7 +1192,7 @@
 					</li>
 					<li>
 						<p><a href="#sec-manifest-fallbacks">manifest fallback</a> chains defined on <a
-								href="#sec-item-elem"><code>item</code> elements</a> in the <a>Package Document</a>.</p>
+								href="#sec-item-elem"><code>item</code> elements</a> in the <a>package document</a>.</p>
 					</li>
 				</ul>
 
@@ -1206,94 +1205,94 @@
 			</section>
 
 			<section id="sec-exempt-resources">
-				<h3>Exempt Resources</h3>
+				<h3>Exempt resources</h3>
 
-				<p>An <a>Exempt Resource</a> shares properties with both <a>Foreign Resources</a> and <a>Core Media Type
-						Resources</a>. It is most similar to a <a>Foreign Resource</a> in that it is not guaranteed
-						<a>Reading System</a> support, but, like a Core Media Type Resource, does not require a
+				<p>An <a>exempt resource</a> shares properties with both <a>foreign resources</a> and <a>core media type
+						resources</a>. It is most similar to a <a>foreign resource</a> in that it is not guaranteed
+						<a>reading system</a> support, but, like a core media type resource, does not require a
 					fallback.</p>
 
-				<p>There are only a small set of special cases for Exempt Resources. Video, for example, are exempt from
-					fallbacks because there is no consensus on a Core Media Type video format at this time (i.e., there
-					is no format to fallback to). Similarly, audio and video tracks are exempt to allow EPUB Creators to
-					meet accessibility requirements using whatever format Reading Systems support best.</p>
+				<p>There are only a small set of special cases for exempt resources. Video, for example, are exempt from
+					fallbacks because there is no consensus on a core media type video format at this time (i.e., there
+					is no format to fallback to). Similarly, audio and video tracks are exempt to allow EPUB creators to
+					meet accessibility requirements using whatever format reading systems support best.</p>
 
-				<p>The following list details cases of content-specific Exempt Resources, including any restrictions on
-					where EPUB Creators can use them.</p>
+				<p>The following list details cases of content-specific exempt resources, including any restrictions on
+					where EPUB creators can use them.</p>
 
 				<dl>
 					<dt id="exempt-fonts">Fonts</dt>
 					<dd id="confreq-resources-cd-fonts">
-						<p>All font resources not already covered as <a href="#cmt-grp-font">font Core Media Types</a>
-							are Exempt Resources.</p>
-						<p>This exemption allows EPUB Creators to use any font format without a fallback, regardless of
-							Reading System support expectations, as CSS rules will ensure a fallback font in case of no
+						<p>All font resources not already covered as <a href="#cmt-grp-font">font core media types</a>
+							are exempt resources.</p>
+						<p>This exemption allows EPUB creators to use any font format without a fallback, regardless of
+							reading system support expectations, as CSS rules will ensure a fallback font in case of no
 							support.</p>
-						<p>Refer to the <a data-cite="epub-rs-33#confreq-css-rs-fonts">Reading System support
+						<p>Refer to the <a data-cite="epub-rs-33#confreq-css-rs-fonts">reading system support
 								requirements for fonts</a> [[EPUB-RS-33]] for more information.</p>
 					</dd>
 
 					<dt id="exempt-links">Linked resources</dt>
 					<dd id="confreq-resources-cd-fallback-link">
-						<p>Any resource referenced from the [[HTML]] <a data-lt="link"
-									><code>link</code> element</a> that is not already a Core Media Type Resource (e.g.,
-							CSS style sheets) is an Exempt Resource.</p>
+						<p>Any resource referenced from the [[HTML]] <a data-lt="link"><code>link</code> element</a>
+							that is not already a core media type resource (e.g., CSS style sheets) is an exempt
+							resource.</p>
 					</dd>
 
 					<dt id="exempt-track" class="tbl-group">Tracks</dt>
 					<dd id="confreq-resources-cd-fallback-track">
 						<p>All audio and video tracks (e.g., [[?WebVTT]] captions, subtitles and descriptions)
-							referenced from the [[HTML]] <a data-lt="track"><code>track</code> element</a>
-							are Exempt Resources.</p>
+							referenced from the [[HTML]] <a data-lt="track"><code>track</code> element</a> are exempt
+							resources.</p>
 					</dd>
 
 					<dt id="exempt-video" class="tbl-group">Video</dt>
 					<dd id="confreq-resources-cd-fallback-video">
-						<p>All video codecs referenced from the [[HTML]] <a data-lt="video"
-									><code>video</code></a> — including any child <a data-lt="source"
-									><code>source</code></a> elements — are Exempt Resources.</p>
+						<p>All video codecs referenced from the [[HTML]] <a data-lt="video"><code>video</code></a>
+							— including any child <a data-lt="source"><code>source</code></a> elements — are exempt
+							resources.</p>
 						<div class="note">
-							<p>Although Reading Systems are encouraged to support at least one of the H.264 [[?H264]]
+							<p>Although reading systems are encouraged to support at least one of the H.264 [[?H264]]
 								and VP8 [[?RFC6386]] video codecs, support for video codecs is not a conformance
-								requirement. EPUB Creators must consider factors such as breadth of adoption, playback
+								requirement. EPUB creators must consider factors such as breadth of adoption, playback
 								quality, and technology royalties when deciding which video formats to include.</p>
 						</div>
 					</dd>
 				</dl>
 
 				<div class="note">
-					<p>The exemptions made above do not apply to the spine. If an Exempt Resource is used in the spine,
-						and it is not also an EPUB Content Document, it will require a fallback in that context.</p>
+					<p>The exemptions made above do not apply to the spine. If an exempt resource is used in the spine,
+						and it is not also an EPUB content document, it will require a fallback in that context.</p>
 				</div>
 
 				<p id="confreq-foreign-no-fallback">In addition to the content-specific exemptions, a resource is
-					classified as an Exempt Resource if:</p>
+					classified as an exempt resource if:</p>
 
 				<ul>
 					<li>
 						<p>it is not referenced from a <a href="#sec-itemref-elem">spine <code>itemref</code>
-								element</a> (i.e., used as a <a>Foreign Content Document</a>);
+								element</a> (i.e., used as a <a>foreign content document</a>);
 								<strong><em>and</em></strong></p>
 					</li>
 					<li>
-						<p>it is not embedded directly in EPUB Content Documents (e.g., via
-							[[?HTML]] <a>embedded content</a>  and [[?SVG]] <a
-								href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"><code>image</code></a> and
-								<a href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
+						<p>it is not embedded directly in EPUB content documents (e.g., via [[?HTML]] <a>embedded
+								content</a> and [[?SVG]] <a href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"
+									><code>image</code></a> and <a
+								href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
 									><code>foreignObject</code></a> elements).</p>
 					</li>
 				</ul>
 
-				<p>This exemption allows EPUB Creators to include resources in the <a>EPUB Container</a> that are not
-					for use by EPUB Reading Systems. The primary case for this exemption is to allow data files to
-					travel with an EPUB Publication, whether for scripts to use in their constituent EPUB Content
-					Documents or for external applications to use (e.g., a scientific journal might include a data set
-					with instructions on how to extract it from the EPUB Container).</p>
+				<p>This exemption allows EPUB creators to include resources in the <a>EPUB container</a> that are not
+					for use by EPUB reading systems. The primary case for this exemption is to allow data files to
+					travel with an EPUB publication, whether for scripts to use in their constituent EPUB content
+					documents or for external applications to use (e.g., a scientific journal might include a data set
+					with instructions on how to extract it from the EPUB container).</p>
 
-				<p>It also allows EPUB Creators to use Foreign Resources in Foreign Content Documents without Reading
-					Systems or <a>EPUB Conformance Checkers</a> having to understand the fallback capabilities of those
-					resources (i.e., the requirement for a fallback for the Foreign Content Document covers any
-					rendering issues within it). As the resource is not referenced from an EPUB Content Document, it
+				<p>It also allows EPUB creators to use foreign resources in foreign content documents without reading
+					systems or <a>EPUB conformance checkers</a> having to understand the fallback capabilities of those
+					resources (i.e., the requirement for a fallback for the foreign content document covers any
+					rendering issues within it). As the resource is not referenced from an EPUB content document, it
 					automatically becomes exempt from fallbacks.</p>
 			</section>
 
@@ -1304,47 +1303,47 @@
 				<section id="sec-manifest-fallbacks">
 					<h5>Manifest fallbacks</h5>
 
-					<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create a <dfn class="export"
-							>manifest fallback chain</dfn> for a <a>Publication Resource</a>, allowing Reading Systems
+					<p>Manifest fallbacks are a feature of the <a>package document</a> that create a <dfn class="export"
+							>manifest fallback chain</dfn> for a <a>publication resource</a>, allowing reading systems
 						to select an alternative format they can render.</p>
 
 					<p>Fallback chains are created using the <a href="#attrdef-item-fallback"><code>fallback</code>
 							attribute</a> on manifest <a href="#sec-item-elem"><code>item</code> elements</a>. This
 						attribute references the ID [[XML]] of another manifest <code>item</code> that is a fallback for
-						the current <code>item</code>. The ordered list of all the references that a Reading System can
+						the current <code>item</code>. The ordered list of all the references that a reading system can
 						reach, starting from a given <code>item</code>'s <code>fallback</code> attribute, represents the
-						full fallback chain for that <code>item</code>. This chain also represents the EPUB Creator's
+						full fallback chain for that <code>item</code>. This chain also represents the EPUB creator's
 						preferred fallback order.</p>
 
 					<p>There are two cases for manifest fallbacks:</p>
 
 					<dl>
-						<dt id="spine-fallbacks">Spine Fallbacks</dt>
+						<dt id="spine-fallbacks">Spine fallbacks</dt>
 						<dd>
-							<p>EPUB Creators MUST specify a fallback chain for a <a>Foreign Content Document</a> to
-								ensure that Reading Systems can always render the <a>spine</a> item. In this case, the
-								chain MUST contain at least one <a>EPUB Content Document</a>.</p>
-							<p>EPUB Creators MAY provide fallbacks for EPUB Content Documents (e.g., to provide a <a
+							<p>EPUB creators MUST specify a fallback chain for a <a>foreign content document</a> to
+								ensure that reading systems can always render the <a>spine</a> item. In this case, the
+								chain MUST contain at least one <a>EPUB content document</a>.</p>
+							<p>EPUB creators MAY provide fallbacks for EPUB content documents (e.g., to provide a <a
 									href="#confreq-cd-scripted-flbk">fallback for scripted content</a>).</p>
-							<p>When a fallback chain includes more than one EPUB Content Document, EPUB Creators can use
+							<p>When a fallback chain includes more than one EPUB content document, EPUB creators can use
 								the <a href="#attrdef-properties"><code>properties</code> attribute</a> to differentiate
 								the purpose of each.</p>
 						</dd>
 
-						<dt id="content-fallbacks">Content Fallbacks</dt>
+						<dt id="content-fallbacks">Content fallbacks</dt>
 						<dd>
 							<div class="note">
 								<p>The original purpose for content fallbacks was to specify fallback images for the
-									[[HTML]] <a data-lt="img"><code>img</code> element</a>. As HTML
-									now has intrinsic fallback mechanism for images, the use of content fallbacks is
-									strongly discouraged. EPUB Creators should always use the intrinsic fallback
-									capabilities of [[HTML]] and [[SVG]] to provide fallback content.</p>
+									[[HTML]] <a data-lt="img"><code>img</code> element</a>. As HTML now has intrinsic
+									fallback mechanism for images, the use of content fallbacks is strongly discouraged.
+									EPUB creators should always use the intrinsic fallback capabilities of [[HTML]] and
+									[[SVG]] to provide fallback content.</p>
 							</div>
-							<p>EPUB Creators MUST provide a content fallback for <a>Foreign Resources</a> when the
+							<p>EPUB creators MUST provide a content fallback for <a>foreign resources</a> when the
 								elements that reference them do not have intrinsic fallback capabilities. In this case,
-								the fallback chain MUST contain at least one <a>Core Media Type Resource</a>.</p>
-							<p>EPUB Creators MAY also provide manifest fallbacks for <a>Core Media Type Resources</a>
-								(e.g., to allow Reading Systems to select from more than one image format).</p>
+								the fallback chain MUST contain at least one <a>core media type resource</a>.</p>
+							<p>EPUB creators MAY also provide manifest fallbacks for <a>core media type resources</a>
+								(e.g., to allow reading systems to select from more than one image format).</p>
 						</dd>
 					</dl>
 
@@ -1353,7 +1352,7 @@
 
 					<div class="note">
 						<p>As it is not possible to use manifest fallbacks for resources represented in <a
-								href="#sec-data-urls">data URLs</a>, EPUB Creators can only represent Foreign Resources
+								href="#sec-data-urls">data URLs</a>, EPUB creators can only represent foreign resources
 							as data URLs where an intrinsic fallback mechanism is available.</p>
 					</div>
 				</section>
@@ -1367,21 +1366,20 @@
 					<section id="sec-fallbacks-audio">
 						<h5>HTML <code>audio</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-media">EPUB Creators MUST NOT use embedded 
-							[[HTML]] <a>flow content</a> within the <a><code>audio</code></a> element as an intrinsic
-							fallback for Foreign Resources. 
-							Only child <a><code>source</code></a> elements [[HTML]] provide intrinsic fallback
-							capabilities.</p>
+						<p id="confreq-resources-cd-fallback-media">EPUB creators MUST NOT use embedded [[HTML]] <a>flow
+								content</a> within the <a><code>audio</code></a> element as an intrinsic fallback for
+							foreign resources. Only child <a><code>source</code></a> elements [[HTML]] provide intrinsic
+							fallback capabilities.</p>
 
-						<p>Only older Reading Systems that do not recognize the <code>audio</code> element (e.g., EPUB 2
-							Reading Systems) will render the embedded content. When Reading Systems support the
+						<p>Only older reading systems that do not recognize the <code>audio</code> element (e.g., EPUB 2
+							reading systems) will render the embedded content. When reading systems support the
 								<code>audio</code> element but not the available audio formats, they do not render the
 							embedded content for the user.</p>
 
 						<div class="note">
-							<p>As video resources are <a>Exempt Resources</a>, this requirement does not apply to the
-									<code>video</code> element. EPUB Creators may also include flow content in the
-									<code>video</code> element for Reading Systems that do not support the element,
+							<p>As video resources are <a>exempt resources</a>, this requirement does not apply to the
+									<code>video</code> element. EPUB creators may also include flow content in the
+									<code>video</code> element for reading systems that do not support the element,
 								however.</p>
 						</div>
 					</section>
@@ -1389,28 +1387,27 @@
 					<section id="sec-fallbacks-img">
 						<h5>HTML <code>img</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that EPUB Creators can
-							specify in the [[HTML]] <a data-lt="img"><code>img</code> element</a>,
-							the following fallback conditions apply to its use:</p>
+						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that EPUB creators can
+							specify in the [[HTML]] <a data-lt="img"><code>img</code> element</a>, the following
+							fallback conditions apply to its use:</p>
 
 						<ul>
 							<li>
-								<p>If it is the child of a <a data-lt="picture"><code>picture</code>
-										element</a>:</p>
+								<p>If it is the child of a <a data-lt="picture"><code>picture</code> element</a>:</p>
 								<ul>
-									<li>it MUST reference Core Media Type Resources from its <code>src</code> and
-											<code>srcset</code> attributes, when EPUB Creators specify those attributes;
+									<li>it MUST reference core media type resources from its <code>src</code> and
+											<code>srcset</code> attributes, when EPUB creators specify those attributes;
 										and</li>
-									<li>each sibling <a data-lt="source"><code>source</code> element</a> MUST reference a 
-										Core Media Type Resource from its <code>[^source/src^]</code> and 
-										<code>[^source/srcset^]</code> attributes unless it specifies the 
-										MIME media type [[RFC2046]] of a Foreign Resource in 
-										its <code>[^source/type^]</code> attribute.</li>
+									<li>each sibling <a data-lt="source"><code>source</code> element</a> MUST reference
+										a core media type resource from its <code>[^source/src^]</code> and
+											<code>[^source/srcset^]</code> attributes unless it specifies the MIME media
+										type [[RFC2046]] of a foreign resource in its <code>[^source/type^]</code>
+										attribute.</li>
 								</ul>
 							</li>
 
-							<li>Otherwise, it MAY reference Foreign Resources in its <code>[^img/src^]</code> and 
-								<code>[^img/srcset^]</code> attributes provided EPUB Creators define a <a
+							<li>Otherwise, it MAY reference foreign resources in its <code>[^img/src^]</code> and
+									<code>[^img/srcset^]</code> attributes provided EPUB creators define a <a
 									href="#sec-manifest-fallbacks">manifest fallback</a>.</li>
 						</ul>
 					</section>
@@ -1419,7 +1416,7 @@
 			<section id="sec-resource-locations">
 				<h4>Resource locations</h4>
 
-				<p>EPUB Creators MAY host the following types of Publication Resources outside the EPUB Container:</p>
+				<p>EPUB creators MAY host the following types of publication resources outside the EPUB container:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -1437,24 +1434,23 @@
 					</li>
 				</ul>
 
-				<p>EPUB Creators MUST store all other resources within the EPUB Container.</p>
+				<p>EPUB creators MUST store all other resources within the EPUB container.</p>
 
-				<p>Storing all resources inside the EPUB Container is strongly encouraged whenever possible as it allows
+				<p>Storing all resources inside the EPUB container is strongly encouraged whenever possible as it allows
 					users access to the entire presentation regardless of connectivity status.</p>
 
-				<p>These rules for locating Publication Resource apply regardless of whether the given resource is a
-						<a>Core Media Type Resource</a> or a <a>Foreign Resource</a>.</p>
+				<p>These rules for locating publication resource apply regardless of whether the given resource is a
+						<a>core media type resource</a> or a <a>foreign resource</a>.</p>
 
 				<div class="note">
 					<p>Refer to the <a href="#remote-resources"><code>remote-resources</code> property</a> for more
 						information on how to indicate that a <a>manifest</a>
-						<a href="#sec-item-elem"><code>item</code></a> references a <a>Remote Resource</a>.</p>
+						<a href="#sec-item-elem"><code>item</code></a> references a <a>remote resource</a>.</p>
 				</div>
 
-				<aside class="example" title="Referencing a Container Resource">
-					<p>In this example, the audio file referenced from the [[HTML]] <a
-							data-lt="audio"><code>audio</code> element</a> is located inside the
-							<a>EPUB Container</a>.</p>
+				<aside class="example" title="Referencing a container resource">
+					<p>In this example, the audio file referenced from the [[HTML]] <a data-lt="audio"
+								><code>audio</code> element</a> is located inside the <a>EPUB container</a>.</p>
 					<pre>&lt;html …>
    …
    &lt;body>
@@ -1467,9 +1463,9 @@
 &lt;/html></pre>
 				</aside>
 
-				<aside class="example" title="Referencing a Remote Resource">
-					<p>In this example, the audio file referenced from the [[HTML]] <a
-						data-lt="audio"><code>audio</code> element</a> is hosted on the web.</p>
+				<aside class="example" title="Referencing a remote resource">
+					<p>In this example, the audio file referenced from the [[HTML]] <a data-lt="audio"
+								><code>audio</code> element</a> is hosted on the web.</p>
 					<pre>&lt;html …>
    …
    &lt;body>
@@ -1487,12 +1483,12 @@
 				<h3>Data URLs</h3>
 
 				<p>The <a data-cite="rfc2397#"><code>data:</code> URL scheme</a> [[RFC2397]] is used to encode resources
-					directly into a URL string. The advantage of this scheme is that it allows EPUB Creators to embed a
+					directly into a URL string. The advantage of this scheme is that it allows EPUB creators to embed a
 					resource within another, avoiding the need for an external file.</p>
 
-				<p><a>EPUB Creators</a> MAY use data URLs in EPUB Publications provided their use does not result in a
-						<a>Top-level Content Document</a> or <a>top-level browsing context</a> [[HTML]].
-						This restriction applies to data URLs used in the following scenarios:</p>
+				<p><a>EPUB creators</a> MAY use data URLs in EPUB publications provided their use does not result in a
+						<a>top-level content document</a> or <a>top-level browsing context</a> [[HTML]]. This
+					restriction applies to data URLs used in the following scenarios:</p>
 
 				<ul>
 					<li>
@@ -1517,22 +1513,22 @@
 						allow their use evolve.</p>
 				</div>
 
-				<p>This restriction on their use is to prevent security issues and also to ensure that <a>Reading
-						Systems</a> can determine where to take a user next (i.e., because these resources are not be
+				<p>This restriction on their use is to prevent security issues and also to ensure that <a>reading
+						systems</a> can determine where to take a user next (i.e., because these resources are not be
 					listed in the spine).</p>
 
-				<p>Resources represented as data URLs are not Publication Resources so are exempt from the requirement
-					for EPUB Creators to list them in the <a>manifest</a>.</p>
+				<p>Resources represented as data URLs are not publication resources so are exempt from the requirement
+					for EPUB creators to list them in the <a>manifest</a>.</p>
 
-				<p>EPUB Creators MUST encode Data URLs as Core Media Type Resources or use them where they can provide a
-					fallback (i.e., Data URLs are subject to the <a href="#sec-foreign-resources">Foreign Resource
+				<p>EPUB creators MUST encode Data URLs as core media type resources or use them where they can provide a
+					fallback (i.e., Data URLs are subject to the <a href="#sec-foreign-resources">foreign resource
 						restrictions</a>).</p>
 			</section>
 
 			<section id="sec-xml-constraints">
 				<h3>XML conformance</h3>
 
-				<p>Any <a>Publication Resource</a> that is an XML-Based Media Type:</p>
+				<p>Any <a>publication resource</a> that is an XML-Based Media Type:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -1559,30 +1555,30 @@
 					</li>
 				</ul>
 
-				<p>The above constraints apply regardless of whether the given Publication Resource is a <a>Core Media
-						Type Resource</a> or a <a>Foreign Resource</a>.</p>
+				<p>The above constraints apply regardless of whether the given publication resource is a <a>core media
+						type resource</a> or a <a>foreign resource</a>.</p>
 
 				<div class="note">
-					<p>[[HTML]] and [[SVG]] are removing support for the XML <code>base</code> attribute [[XMLBase]]. EPUB Creators
-						should avoid using this feature.</p>
+					<p>[[HTML]] and [[SVG]] are removing support for the XML <code>base</code> attribute [[XMLBase]].
+						EPUB creators should avoid using this feature.</p>
 				</div>
 			</section>
 		</section>
 		<section id="sec-ocf">
-			<h2>Open container format</h2>
+			<h2>Open Container Format (OCF)</h2>
 
 			<section id="sec-container-abstract">
-				<h3>OCF Abstract Container</h3>
+				<h3>OCF abstract container</h3>
 
 				<section id="sec-container-abstract-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>The <a>OCF Abstract Container</a> file system model uses a single common <a>Root Directory</a>.
-						All <a>Container Resources</a> are located within the directory tree headed by the Root
-						Directory, but no specific file system structure for them is mandated by this specification.</p>
+					<p>The <a>OCF abstract container</a> file system model uses a single common <a>root directory</a>.
+						All <a>container resources</a> are located within the directory tree headed by the root
+						directory, but no specific file system structure for them is mandated by this specification.</p>
 
 					<p>The file system model also includes a mandatory directory named <code>META-INF</code> that is a
-						direct child of the Root Directory and stores the following special files:</p>
+						direct child of the root directory and stores the following special files:</p>
 
 					<dl class="variablelist">
 						<dt>
@@ -1590,7 +1586,7 @@
 							<code>[required]</code>
 						</dt>
 						<dd>
-							<p>Identifies the <a>Package Document(s)</a> that define the EPUB Publication.</p>
+							<p>Identifies the <a>package document(s)</a> that define the EPUB publication.</p>
 						</dd>
 
 						<dt>
@@ -1606,8 +1602,8 @@
 							<code>[optional]</code>
 						</dt>
 						<dd>
-							<p>Contains information about the encryption of <a>Publication Resources</a>. This file is
-								mandatory when EPUB Creators use <a href="#sec-font-obfuscation">font
+							<p>Contains information about the encryption of <a>publication resources</a>. This file is
+								mandatory when EPUB creators use <a href="#sec-font-obfuscation">font
 								obfuscation</a>.</p>
 						</dd>
 
@@ -1616,7 +1612,7 @@
 							<code>[optional]</code>
 						</dt>
 						<dd>
-							<p>Used to store metadata about the <a>OCF ZIP Container</a>.</p>
+							<p>Used to store metadata about the <a>OCF ZIP container</a>.</p>
 						</dd>
 
 						<dt>
@@ -1643,26 +1639,26 @@
 				<section id="sec-container-file-and-dir-structure">
 					<h4>File and directory structure</h4>
 
-					<p>The virtual file system for the <a>OCF Abstract Container</a> MUST have a single common <a>Root
-							Directory</a> for all the contents of the container.</p>
+					<p>The virtual file system for the <a>OCF abstract container</a> MUST have a single common <a>root
+							directory</a> for all the contents of the container.</p>
 
-					<p>The OCF Abstract Container MUST include a directory for configuration files named
-							<code>META-INF</code> that is a direct child of the container's Root Directory. Refer to <a
+					<p>The OCF abstract container MUST include a directory for configuration files named
+							<code>META-INF</code> that is a direct child of the container's root directory. Refer to <a
 							href="#sec-container-metainf"></a> for the requirements for the contents of this
 						directory.</p>
 
-					<p>The file name <code>mimetype</code> in the Root Directory is reserved for use by <a>OCF ZIP
-							Containers</a>, as explained in <a href="#sec-container-zip"></a>.</p>
+					<p>The file name <code>mimetype</code> in the root directory is reserved for use by <a>OCF ZIP
+							containers</a>, as explained in <a href="#sec-container-zip"></a>.</p>
 
-					<p>EPUB Creators MAY locate all other files within the OCF Abstract Container in any location
-						descendant from the Root Directory, provided they are not within the <code>META-INF</code>
-						directory. EPUB Creators MUST NOT reference files in the <code>META-INF</code> directory from an
-						EPUB Publication.</p>
+					<p>EPUB creators MAY locate all other files within the OCF abstract container in any location
+						descendant from the root directory, provided they are not within the <code>META-INF</code>
+						directory. EPUB creators MUST NOT reference files in the <code>META-INF</code> directory from an
+						EPUB publication.</p>
 
 					<div class="note">
-						<p>Some Reading Systems do not provide access to resources outside the directory where the
-							Package Document is stored. EPUB Creators should therefore place all resources at or below
-							the directory containing the Package Document to avoid interoperability issues.</p>
+						<p>Some reading systems do not provide access to resources outside the directory where the
+							package document is stored. EPUB creators should therefore place all resources at or below
+							the directory containing the package document to avoid interoperability issues.</p>
 
 						<p>This problem is more commonly encountered when <a data-cite="epub-multi-rend-11#container"
 								>creating multiple renditions</a> [[EPUB-MULTI-REND-11]] of the publication.</p>
@@ -1672,25 +1668,25 @@
 				<section id="sec-container-filenames">
 					<h4>File paths and file names</h4>
 
-					<p id="ocf-fn-cs">In the context of the Abstract Container, <a>File Paths</a> and <a>File Names</a>
-						are case sensitive.</p>
+					<p id="ocf-fn-cs">In the context of the OCF abstract container, <a>file paths</a> and <a>file
+							names</a> are case sensitive.</p>
 
-					<p>In addition, the following restrictions are designed to allow File Paths and File Names to be
+					<p>In addition, the following restrictions are designed to allow file paths and file names to be
 						used without modification on most operating systems:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="ocf-fn-encoding">File Names and Paths MUST be UTF-8 [[Unicode]] encoded.</p>
+							<p id="ocf-fn-encoding">file names and paths MUST be UTF-8 [[Unicode]] encoded.</p>
 						</li>
 						<li>
-							<p id="ocf-fn-length">File Names MUST NOT exceed 255 bytes.</p>
+							<p id="ocf-fn-length">file names MUST NOT exceed 255 bytes.</p>
 						</li>
 						<li>
-							<p id="ocf-pn-length">The File Paths for any directory or file within the OCF Abstract
-								Container MUST NOT exceed 65535 bytes.</p>
+							<p id="ocf-pn-length">The file paths for any directory or file within the OCF abstract
+								container MUST NOT exceed 65535 bytes.</p>
 						</li>
 						<li>
-							<p id="ocf-fn-chars">File Names MUST NOT use the following [[Unicode]] characters, as
+							<p id="ocf-fn-chars">file names MUST NOT use the following [[Unicode]] characters, as
 								commonly used operating systems may not support these characters consistently:</p>
 							<ul>
 								<li>
@@ -1768,15 +1764,15 @@
 							</ul>
 						</li>
 						<li>
-							<p id="ocf-fn-cn">All File Names within the same directory MUST be unique following Unicode
+							<p id="ocf-fn-cn">All file names within the same directory MUST be unique following Unicode
 								canonical normalization [[UAX15]] and then full case folding [[Unicode]]. (Refer to <a
 									data-cite="charmod-norm#CanonicalFoldNormalizationStep">Unicode Canonical Case Fold
 									Normalization Step</a> [[?CHARMOD-NORM]] for more information.)</p>
 						</li>
 					</ul>
 					<div class="note">
-						<p> If EPUB Creators dynamically integrate resources (i.e., where the naming is beyond their
-							control), they should be aware that automatic truncation of File Names to keep them within
+						<p> If EPUB creators dynamically integrate resources (i.e., where the naming is beyond their
+							control), they should be aware that automatic truncation of file names to keep them within
 							the 255 bytes limit can lead to corruption. This is due to the difference between bytes and
 							characters in multibyte encodings such as UTF-8; it is, therefore, important to avoid
 							mid-character truncation. See the section on <a
@@ -1785,7 +1781,7 @@
 					</div>
 
 					<div class="note">
-						<p>EPUB Creators should use an abundance of caution in their file naming when interoperability
+						<p>EPUB creators should use an abundance of caution in their file naming when interoperability
 							of content is key. The <a href="#ocf-fn-chars">list of restricted characters</a> is intended
 							to help avoid some known problem areas, but it does not ensure that all other Unicode
 							characters are supported. Although Unicode support is much better now than in earlier
@@ -1793,7 +1789,7 @@
 							that only support [[US-ASCII]]).</p>
 
 
-						<p>If EPUB Creators need to ensure compatibility with EPUB 2 Reading Systems that only accept
+						<p>If EPUB creators need to ensure compatibility with EPUB 2 reading systems that only accept
 							URIs [[RFC3986]], they should further consider restricting resource names to the ASCII
 							character set [[US-ASCII]].</p>
 					</div>
@@ -1802,17 +1798,17 @@
 				<section id="sec-file-names-to-path-names">
 					<h4>Deriving file paths</h4>
 
-					<p>To <strong>derive the File Path</strong>, given a file or directory <var>file</var> in the <a
-							href="#sec-container-abstract">OCF Abstract Container</a>, apply the following steps
+					<p>To <strong>derive the file path</strong>, given a file or directory <var>file</var> in the <a
+							href="#sec-container-abstract">OCF abstract container</a>, apply the following steps
 						(expressed using the terminology of [[INFRA]]):</p>
 
 					<ol class="algorithm">
 						<!-- <li>Let <var>file</var> be the directory or file to parse</li> -->
 						<li>Let <var>path</var> be an empty <a>list</a>.</li>
 						<li>Let <var>current</var> be <var>file</var>.</li>
-						<li>While <var>current</var> is not the <a>Root Directory</a>: <ol>
-								<li> [=list/prepend=] the <a>File Name</a> of
-										<var>current</var> to <var>path</var>;</li>
+						<li>While <var>current</var> is not the <a>root directory</a>: <ol>
+								<li> [=list/prepend=] the <a>file name</a> of <var>current</var> to
+									<var>path</var>;</li>
 								<li>set <var>current</var> to the parent directory of <var>current</var>.</li>
 							</ol>
 						</li>
@@ -1822,37 +1818,35 @@
 				</section>
 
 				<section id="sec-container-iri">
-					<h4>URLs in the OCF Abstract Container</h4>
+					<h4>URLs in the OCF abstract container</h4>
 
 					<p id="sec-container-iri-root"
 						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">The <a>container root
-							URL</a> is the <a>URL</a> [[URL]] of the <a>Root Directory</a>.
-						It is implementation-specific, but EPUB Creators MUST assume it has the following
-						properties:</p>
+							URL</a> is the <a>URL</a> [[URL]] of the <a>root directory</a>. It is
+						implementation-specific, but EPUB creators MUST assume it has the following properties:</p>
 
 					<ul id="sec-root-url-properties">
 						<li id="sec-container-iri-root-parse"
 							data-tests="#ocf-url_link-path-absolute,#ocf-url_parse-path-absolute">The result of <a
-								data-lt="url parser">parsing</a> "<code>/</code>" with the <a>container
-								root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the
-								<a>container root URL</a>.</li>
+								data-lt="url parser">parsing</a> "<code>/</code>" with the <a>container root URL</a> as
+								<a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root
+							URL</a>.</li>
 						<li id="sec-container-iri-step-parse"
 							data-tests="#ocf-url_link-leaking-relative,#ocf-url_parse-leaking-relative">The result of <a
-							data-lt="url parser">parsing</a> "<code>..</code>" with the <a>container
-								root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the
-								<a>container root URL</a>.</li>
+								data-lt="url parser">parsing</a> "<code>..</code>" with the <a>container root URL</a> as
+								<a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root
+							URL</a>.</li>
 					</ul>
 
-					<p>The <a>content URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result
-						of <a data-lt="url parser">parsing</a> the file's <a>File Path</a> with the
-							<a>container root URL</a> as 							
-							<a data-cite="url#concept-base-url"><var>base</var></a>.</p>
+					<p>The <a>content URL</a> of a file or directory in the <a>OCF abstract container</a> is the result
+						of <a data-lt="url parser">parsing</a> the file's <a>file path</a> with the <a>container root
+							URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 					<div class="note" id="note-cru-explanation">
-						<p> The <a>container root URL</a> is the URL assigned by the Reading System to the root of the
+						<p> The <a>container root URL</a> is the URL assigned by the reading system to the root of the
 							container. It typically depends on how the reading system internally implements the
 							container file system. </p>
-						<p> However, a Reading System cannot arbitrarily use any URL, but one that honors the
+						<p> However, a reading system cannot arbitrarily use any URL, but one that honors the
 							constraints defined above. These constraints ensure that any relative URL string found in
 							the EPUB will always be parsed to a URL of a resource within the container (which may or may
 							not exist). The primary reason for these constraints is to avoid potential run-time security
@@ -1863,50 +1857,49 @@
 								<code>file:///path/to.epub#path=/</code>, or <code>jar:file:/path/to.epub!/EPUB/</code>
 							do not (parsing the URL string "<code>..</code>" with these three examples as base would
 							return <code>https://localhost:12345/path/</code>, <code>file:///path/</code>, and a parsing
-							error, respectively). It is the responsibility of the Reading System to assign a URL to the
+							error, respectively). It is the responsibility of the reading system to assign a URL to the
 							root directory that complies with the properties defined above. </p>
 					</div>
 
 					<div class="note">
 						<p>
-							<a data-lt="url parser">Parsing</a> may replace some characters in the File
-							Path by their <a data-cite="url#percent-encode">percent encoded</a> alternative. For
-							example, <code>A/B/C/file&#160;name.xhtml</code> becomes
-								<code>A/B/C/file%20name.xhtml</code>. </p>
+							<a data-lt="url parser">Parsing</a> may replace some characters in the file path by their <a
+								data-cite="url#percent-encode">percent encoded</a> alternative. For example,
+								<code>A/B/C/file&#160;name.xhtml</code> becomes <code>A/B/C/file%20name.xhtml</code>.
+						</p>
 					</div>
 
-					<p> A string <var>url</var> is a 
-						<dfn class="export" id="dfn-valid-relative-container-url-with-fragment-string">valid-relative-ocf-URL-with-fragment string</dfn> 
-						if it is a <a>path-relative-scheme-less-url string</a>, optionally followed by <code>U+0023 (#)</code> and
-						a <a>url-fragment string</a>, and if the following steps return <var>true</var>: </p>
+					<p> A string <var>url</var> is a <dfn class="export"
+							id="dfn-valid-relative-container-url-with-fragment-string"
+							>valid-relative-ocf-URL-with-fragment string</dfn> if it is a
+							<a>path-relative-scheme-less-url string</a>, optionally followed by <code>U+0023 (#)</code>
+						and a <a>url-fragment string</a>, and if the following steps return <var>true</var>: </p>
 
 					<ol class="algorithm" id="algo-out-of-container">
-						<li> Set the <a>container root URL</a> to <code>https://a.example.org/A/</code>. 
-							<details
+						<li> Set the <a>container root URL</a> to <code>https://a.example.org/A/</code>. <details
 								class="explanation">
 								<summary>Explanation</summary>
 								<p> The goal of the algorithm is to detect whether <var>url</var> could be seen as
-									"leaking" outside the container. To do that, the standard 
-									<a data-lt="url parser">URL parsing algorithm</a> is used with an
-									artificial root URL; the detection of the "leak" is done by comparing the result of
-									the parsing with the presence of the first test path segment (<code>A</code>). (Note
-									that the artificial container root URL wilfully violates, for the purpose of this
-									algorithm, the <a href="#sec-root-url-properties">required properties</a> by using
-									that first test path segment.) </p>
+									"leaking" outside the container. To do that, the standard <a data-lt="url parser"
+										>URL parsing algorithm</a> is used with an artificial root URL; the detection of
+									the "leak" is done by comparing the result of the parsing with the presence of the
+									first test path segment (<code>A</code>). (Note that the artificial container root
+									URL wilfully violates, for the purpose of this algorithm, the <a
+										href="#sec-root-url-properties">required properties</a> by using that first test
+									path segment.) </p>
 							</details>
 						</li>
 
 						<li> Let <var>base</var> be the <a data-cite="url#concept-base-url">base URL</a> that must be
 							used to parse <var>url</var> as defined by the context (document or environment) where
-								<var>url</var> is used, and according to the <a>content URL</a> of the <a>Package
-								Document</a> (see <a href="#sec-parse-package-urls"></a>). 
-							<details class="explanation">
+								<var>url</var> is used, and according to the <a>content URL</a> of the <a>package
+								document</a> (see <a href="#sec-parse-package-urls"></a>). <details class="explanation">
 								<summary>Explanation</summary>
 								<p> In the case of a URL in the package document the <var>base</var> variable is set to
-									the <a>content URL</a> of the <a>Package Document</a>. In the case of a document
+									the <a>content URL</a> of the <a>package document</a>. In the case of a document
 									within the <code>META-INF</code> directory, the <var>base</var> variable is set to
 									the <a>container root URL</a> (see <a href="#sec-parsing-urls-metainf"></a>). In the
-									case of a URL in an XHTML Content Document, the base URL used for parsing is defined
+									case of a URL in an XHTML content document, the base URL used for parsing is defined
 									by the <a data-cite="html#resolving-urls">HTML standard</a>. Typically, it will be
 									the <a>content URL</a> of the content document (unless the <a
 										href="#sec-xhtml-deviations-base">discouraged</a>
@@ -1914,10 +1907,11 @@
 							</details>
 						</li>
 
-						<li> Let <var>testURLRecord</var> be the result of applying the <a>URL parser</a> to <var>url</var>, with
-								<var>base</var>. </li>
+						<li> Let <var>testURLRecord</var> be the result of applying the <a>URL parser</a> to
+								<var>url</var>, with <var>base</var>. </li>
 
-						<li> Let <var>testURLStringA</var> be the result of applying the <a>URL Serializer</a> to <var>testURLRecord</var>. </li>
+						<li> Let <var>testURLStringA</var> be the result of applying the <a>URL Serializer</a> to
+								<var>testURLRecord</var>. </li>
 
 						<li> Set the <a>container root URL</a> to <code>https://b.example.org/B/</code>. <details
 								class="explanation">
@@ -1931,13 +1925,14 @@
 
 						<li> Set <var>base</var> to be the <a data-cite="url#concept-base-url">base URL</a> that must be
 							used to parse <var>url</var> as defined by the context (document or environment) where
-								<var>url</var> is used, and according to the <a>content URL</a> of the <a>Package
-								Document</a> (see <a href="#sec-parse-package-urls"></a>). </li>
+								<var>url</var> is used, and according to the <a>content URL</a> of the <a>package
+								document</a> (see <a href="#sec-parse-package-urls"></a>). </li>
 
-						<li> Set <var>testURLRecord</var> to be the result of applying the <a>URL parser</a> 
-							to <var>url</var>, with <var>base</var>. </li>
+						<li> Set <var>testURLRecord</var> to be the result of applying the <a>URL parser</a> to
+								<var>url</var>, with <var>base</var>. </li>
 
-						<li> Let <var>testURLStringB</var> be the result of applying the <a>URL Serializer</a> to <var>testURLRecord</var>. </li>
+						<li> Let <var>testURLStringB</var> be the result of applying the <a>URL Serializer</a> to
+								<var>testURLRecord</var>. </li>
 
 						<li> If <var>testURLStringA</var> does not start with <code>https://a.example.org/</code> or
 								<var>testURLStringB</var> does not start with <code>https://b.example.org/</code>,
@@ -1952,8 +1947,7 @@
 
 						<li> If <var>testURLStringA</var> starts with <code>https://a.example.org/A/</code> and
 								<var>testURLStringB</var> starts with <code>https://b.example.org/B/</code>, return
-								<var>true</var>. 
-							<details class="explanation">
+								<var>true</var>. <details class="explanation">
 								<summary>Explanation</summary>
 								<p>The presence of the first test path segments (<code>A</code>, respectively
 										<code>B</code>) indicate that the URL doesn't leak outside the container.</p>
@@ -1963,11 +1957,13 @@
 						<li>Return <var>false</var>.</li>
 					</ol>
 
-					<p id="urls-in-ocf-constraints"> In the <a>OCF Abstract Container</a>, any URL string MUST be an
-						<a>absolute-url-with-fragment string</a> or a <a>valid-relative-ocf-URL-with-fragment string</a>.</p>
+					<p id="urls-in-ocf-constraints"> In the <a>OCF abstract container</a>, any URL string MUST be an
+							<a>absolute-url-with-fragment string</a> or a <a>valid-relative-ocf-URL-with-fragment
+							string</a>.</p>
 
-					<p>In addition, all <a>relative-URL-with-fragment strings</a> [[URL]] MUST, after <a data-lt="url parser">parsing</a>, be equal
-						to the <a>Content URL</a> of an existing file in the OCF Abstract Container.</p>
+					<p>In addition, all <a>relative-URL-with-fragment strings</a> [[URL]] MUST, after <a
+							data-lt="url parser">parsing</a>, be equal to the <a>content URL</a> of an existing file in
+						the OCF abstract container.</p>
 
 					<div class="note">
 						<p>These constraints on URL strings mean that:</p>
@@ -1975,21 +1971,21 @@
 						<ul>
 							<li>relative URL strings starting with a <code>/</code> (<code>U+002F</code>) (for example,
 									<code>/EPUB/content.xhtml</code>) are disallowed; </li>
-							<li>relative URL strings containing more <a>double-dot path segments</a> than 
-								needed to reach the target file (for example,
-									<code>EPUB/../../../../config.xml</code>) are disallowed; </li>
+							<li>relative URL strings containing more <a>double-dot path segments</a> than needed to
+								reach the target file (for example, <code>EPUB/../../../../config.xml</code>) are
+								disallowed; </li>
 							<li>any other absolute or relative URL string is allowed.</li>
 						</ul>
 
 						<p> Note that in any case, even the disallowed URL strings described above will not "leak"
-							outside the container after parsing (as explained in the 
-							<a href="#note-cru-explanation">first note</a> of this section). They are nevertheless disallowed for better
-							interoperability with non-conforming or legacy Reading Systems and toolchains. </p>
+							outside the container after parsing (as explained in the <a href="#note-cru-explanation"
+								>first note</a> of this section). They are nevertheless disallowed for better
+							interoperability with non-conforming or legacy reading systems and toolchains. </p>
 					</div>
 
 					<aside class="example" title="Referencing a file in the same directory">
 						<p>In this example, the file <code>image1.jpg</code> is in the same directory as the <a>XHTML
-								Content Document</a>.</p>
+								content document</a>.</p>
 
 						<pre>&lt;html …>
    …
@@ -2015,7 +2011,7 @@
 						</pre>
 
 						<p> A URL `../../../../EPUB/secret.xhtml` appearing in `content.xhtml` would be parsed by a
-							Reading System into a <a>content URL</a> with a path `EPUB/secret.xhtml`, following the
+							reading system into a <a>content URL</a> with a path `EPUB/secret.xhtml`, following the
 							constraints on the <a>container root URL</a>. However, as the URL could be perceived as one
 							of a resource outside the container, and create interoperability issues; it would be
 							reported as an error by a checker tool. </p>
@@ -2026,10 +2022,10 @@
 					<h4><code>META-INF</code> directory</h4>
 
 					<section id="sec-container-metainf-inc">
-						<h5>Inclusion in OCF Abstract Container</h5>
+						<h5>Inclusion in OCF abstract container</h5>
 
-						<p>All <a>OCF Abstract Containers</a> MUST include a directory called <code>META-INF</code> in
-							their <a>Root Directory</a>.</p>
+						<p>All <a>OCF abstract containers</a> MUST include a directory called <code>META-INF</code> in
+							their <a>root directory</a>.</p>
 
 						<p>This directory is reserved for configuration files, specifically those defined in <a
 								href="#sec-container-metainf-files"></a>.</p>
@@ -2039,10 +2035,10 @@
 						<h5>Parsing URLs in the <code>META-INF</code> directory</h5>
 
 						<p id="sec-container-metainf-url-parsing" data-tests="#ocf-url_relative">To parse a URL string
-								<var>url</var> used in files located in the <code>META-INF</code> directory 
-								the <a data-lt="url parser">URL Parser</a> MUST be applied to <var>url</var>,
-							with the <a>container root URL</a> as <a data-cite="url#concept-base-url"
-								><var>base</var></a>.</p>
+								<var>url</var> used in files located in the <code>META-INF</code> directory the <a
+								data-lt="url parser">URL Parser</a> MUST be applied to <var>url</var>, with the
+								<a>container root URL</a> as <a data-cite="url#concept-base-url"
+							><var>base</var></a>.</p>
 
 						<aside class="example" title="Resolving paths in the container file">
 							<p>If container file (<code>META-INF/container.xml</code>) has the following content:</p>
@@ -2057,7 +2053,7 @@
 &lt;/container></pre>
 
 							<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the root directory
-								for the OCF Abstract Container and not relative to the <code>META-INF</code>
+								for the OCF abstract container and not relative to the <code>META-INF</code>
 								directory.</p>
 						</aside>
 					</section>
@@ -2069,8 +2065,8 @@
 							<h6>Container file (<code>container.xml</code>)</h6>
 
 							<p>The REQUIRED <code>container.xml</code> file in the <code>META-INF</code> directory
-								identifies the <a>Package Documents</a> available in the <a>OCF Abstract
-								Container</a>.</p>
+								identifies the <a>package documents</a> available in the <a>OCF abstract
+								container</a>.</p>
 
 							<p>All [[XML]] elements defined in this section are in the
 									<code>urn:oasis:names:tc:opendocument:xmlns:container</code> namespace [[XML-NAMES]]
@@ -2129,8 +2125,8 @@
 							<section id="sec-container.xml-rootfiles-elem">
 								<h6>The <code>rootfiles</code> element</h6>
 
-								<p>The <code>rootfiles</code> element contains a list of <a>Package Documents</a>
-									available in the <a>EPUB Container</a>.</p>
+								<p>The <code>rootfiles</code> element contains a list of <a>package documents</a>
+									available in the <a>EPUB container</a>.</p>
 
 								<dl id="elemdef-rootfiles" class="elemdef">
 									<dt>Element Name:</dt>
@@ -2163,8 +2159,8 @@
 							<section id="sec-container.xml-rootfile-elem">
 								<h6>The <code>rootfile</code> element</h6>
 
-								<p>Each <code>rootfile</code> element identifies the location of one <a>Package
-										Document</a> in the <a>EPUB Container</a>.</p>
+								<p>Each <code>rootfile</code> element identifies the location of one <a>package
+										document</a> in the <a>EPUB container</a>.</p>
 
 								<dl id="elemdef-rootfile" class="elemdef">
 									<dt>Element Name:</dt>
@@ -2188,10 +2184,10 @@
 												<code>[required]</code>
 											</dt>
 											<dd>
-												<p>Identifies the location of a <a>Package Document</a>.</p>
-												<p>The value of the attribute MUST be a <a>path-relative-scheme-less-URL string</a> [[URL]]. 
-													The path is
-													relative to the <a>Root Directory</a>.</p>
+												<p>Identifies the location of a <a>package document</a>.</p>
+												<p>The value of the attribute MUST be a <a>path-relative-scheme-less-URL
+														string</a> [[URL]]. The path is relative to the <a>root
+														directory</a>.</p>
 											</dd>
 
 											<dt>
@@ -2199,7 +2195,7 @@
 												<code>[required]</code>
 											</dt>
 											<dd>
-												<p>Identifies the media type of the Package Document.</p>
+												<p>Identifies the media type of the package document.</p>
 												<p>The value of the attribute MUST be
 														"<code>application/oebps-package+xml</code>".</p>
 											</dd>
@@ -2212,13 +2208,13 @@
 									</dd>
 								</dl>
 
-								<p>If an EPUB Creator defines more than one <code>rootfile</code> element, each MUST
-									reference a Package Document that conforms to the same version of EPUB. Each Package
-									Document represents one rendering of the EPUB Publication.</p>
+								<p>If an EPUB creator defines more than one <code>rootfile</code> element, each MUST
+									reference a package document that conforms to the same version of EPUB. Each package
+									document represents one rendering of the EPUB publication.</p>
 
 								<div class="note">
-									<p>Although the EPUB Container provides the ability to reference more than one
-										Package Document, this specification does not define how to interpret, or select
+									<p>Although the EPUB container provides the ability to reference more than one
+										package document, this specification does not define how to interpret, or select
 										from, the available options. Refer to [[EPUB-MULTI-REND-11]] for more
 										information on how to bundle more than one rendering of the content.</p>
 								</div>
@@ -2228,7 +2224,7 @@
 								<h6>The <code>links</code> element</h6>
 
 								<p>The <code id="elemdef-container-links">links</code> element identifies resources
-									necessary for the processing of the <a>OCF ZIP Container</a>.</p>
+									necessary for the processing of the <a>OCF ZIP container</a>.</p>
 
 								<dl id="elemdef-links" class="elemdef">
 									<dt>Element Name:</dt>
@@ -2290,8 +2286,8 @@
 											<dd>
 												<p>Identifies the location of a resource.</p>
 												<p>The value of the <code>link</code> element <code>href</code>
-													attribute MUST be a <a>path-relative-scheme-less-URL string</a> [[URL]]. The path is
-													relative to the <a>Root Directory</a>.</p>
+													attribute MUST be a <a>path-relative-scheme-less-URL string</a>
+													[[URL]]. The path is relative to the <a>root directory</a>.</p>
 											</dd>
 
 											<dt>
@@ -2342,7 +2338,7 @@
 							<h6>Encryption file (<code>encryption.xml</code>)</h6>
 
 							<p>The OPTIONAL <code>encryption.xml</code> file in the <code>META-INF</code> directory
-								holds all encryption information on the contents of the container. If an EPUB Creator
+								holds all encryption information on the contents of the container. If an EPUB creator
 								encrypts any resources within the container, they MUST include an
 									<code>encryption.xml</code> file to provide information about the encryption
 								used.</p>
@@ -2404,25 +2400,25 @@
 								<p>OCF uses XML Encryption [[XMLENC-CORE1]] to provide a framework for encryption,
 									allowing a variety of algorithms to be used. XML Encryption specifies a process for
 									encrypting arbitrary data and representing the result in XML. Even though an <a>OCF
-										Abstract Container</a> may contain non-XML data, EPUB Creators can use XML
-									Encryption to encrypt all data in an OCF Abstract Container. OCF encryption supports
+										abstract container</a> may contain non-XML data, EPUB creators can use XML
+									Encryption to encrypt all data in an OCF abstract container. OCF encryption supports
 									only the encryption of entire files within the container, not parts of files. EPUB
-									Creators MUST NOT encrypt the <code>encryption.xml</code> file when present.</p>
+									creators MUST NOT encrypt the <code>encryption.xml</code> file when present.</p>
 
-								<p>Encrypted data replaces unencrypted data in an OCF Abstract Container. For example,
-									if an EPUB Creator encrypts an image named <code>photo.jpeg</code>, they should
+								<p>Encrypted data replaces unencrypted data in an OCF abstract container. For example,
+									if an EPUB creator encrypts an image named <code>photo.jpeg</code>, they should
 									replace the contents of the <code>photo.jpeg</code> resource with its encrypted
-									contents. Within the ZIP directory, EPUB Creators SHOULD store encrypted files
+									contents. Within the ZIP directory, EPUB creators SHOULD store encrypted files
 									rather than Deflate-compress them.</p>
 
 								<p id="encryption-obfuscation">Note that some situations require obfuscating the storage
-									of embedded fonts referenced by an <a>EPUB Publication</a> to make them more
+									of embedded fonts referenced by an <a>EPUB publication</a> to make them more
 									difficult to extract for unrestricted use. Although obfuscation is not encryption,
-									Reading Systems use the <code>encryption.xml</code> file in conjunction with the <a
+									reading systems use the <code>encryption.xml</code> file in conjunction with the <a
 										href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify fonts to
 									deobfuscate.</p>
 
-								<p id="encryption-restrictions">EPUB Creators MUST NOT encrypt the following files:</p>
+								<p id="encryption-restrictions">EPUB creators MUST NOT encrypt the following files:</p>
 
 								<ul class="nomark">
 									<li>
@@ -2448,13 +2444,13 @@
 									</li>
 									<li>
 										<a>
-											<code>Package Document</code>
+											<code>package document</code>
 										</a>
 									</li>
 								</ul>
-								<p>EPUB Creators MAY subsequently encrypt signed resources using the Decryption
-									Transform for XML Signature [[XMLENC-DECRYPT]]. This feature enables a Reading
-									System to distinguish data encrypted before signing from data encrypted after
+								<p>EPUB creators MAY subsequently encrypt signed resources using the Decryption
+									Transform for XML Signature [[XMLENC-DECRYPT]]. This feature enables a reading
+									system to distinguish data encrypted before signing from data encrypted after
 									signing.</p>
 
 								<aside class="example" title="An encrypted image">
@@ -2502,24 +2498,24 @@
 							<section id="sec-enc-compression">
 								<h6>Order of compression and encryption</h6>
 
-								<p>When stored in a ZIP container, EPUB Creators SHOULD compress streams of data with
-										<a>Non-Codec</a> content types before encrypting them. EPUB Creators MUST use
+								<p>When stored in a ZIP container, EPUB creators SHOULD compress streams of data with
+										<a>non-codec</a> content types before encrypting them. EPUB creators MUST use
 									Deflate compression. This practice ensures that file entries stored in the ZIP
 									container have a smaller size.</p>
 
-								<p>EPUB Creators SHOULD NOT compress streams of data with <a>Codec</a> content types
+								<p>EPUB creators SHOULD NOT compress streams of data with <a>codec</a> content types
 									before encrypting them. In such cases, additional compression introduces unnecessary
 									processing overhead at production time (especially with large resource files) and
 									impacts audio/video playback performance at consumption time. In some cases, the
 									combination of compression with some encryption schemes might even compromise the
-									ability of Reading Systems to handle partial content requests (e.g. HTTP byte
+									ability of reading systems to handle partial content requests (e.g. HTTP byte
 									ranges), due to the technical impossibility to determine the length of the full
 									resource ahead of media playback (e.g. HTTP Content-Length header).</p>
 
-								<p>When EPUB Creators compress streams of data before encrypting, they SHOULD provide
+								<p>When EPUB creators compress streams of data before encrypting, they SHOULD provide
 									additional <code>EncryptionProperties</code> metadata to specify the size of the
 									initial resource (i.e., before compression and encryption), as per the
-										<code>Compression</code> XML element defined below. When EPUB Creators do not
+										<code>Compression</code> XML element defined below. When EPUB creators do not
 									compress streams of data before encrypting, they MAY provide the additional
 										<code>EncryptionProperties</code> metadata to specify the size of the initial
 									resource (i.e., before encryption).</p>
@@ -2569,7 +2565,7 @@
 								</dl>
 
 								<aside class="example" title="A compressed video">
-									<p>In this example, the EPUB Creator has Deflate compressed the MP4 file. Its
+									<p>In this example, the EPUB creator has Deflate compressed the MP4 file. Its
 										original size was 3500000 bytes.</p>
 
 									<pre>&lt;encryption
@@ -2600,12 +2596,12 @@
 							<h6>Manifest file (<code>manifest.xml</code>)</h6>
 
 							<p>The OPTIONAL <code>manifest.xml</code> file in the <code>META-INF</code> directory
-								provides a manifest of files in the Container.</p>
+								provides a manifest of files in the container.</p>
 
 							<p>The OCF specification does not mandate a format for the manifest.</p>
 
-							<p>Note that <a>Package Documents</a> specify the only manifests used for processing <a>EPUB
-									Publications</a>. Reading Systems do not use this file.</p>
+							<p>Note that <a>package documents</a> specify the only manifests used for processing <a>EPUB
+									publications</a>. Reading systems do not use this file.</p>
 
 							<div class="note">This feature exists only for compatibility with [[ODF]].</div>
 						</section>
@@ -2616,7 +2612,7 @@
 							<p>The OPTIONAL <code>metadata.xml</code> file in the <code>META-INF</code> directory is
 								only for container-level metadata.</p>
 
-							<p>If EPUB Creators include a <code>metadata.xml</code> file, they SHOULD use only
+							<p>If EPUB creators include a <code>metadata.xml</code> file, they SHOULD use only
 								namespace-qualified elements [[XML-NAMES]] in it. The file SHOULD contain the root
 								element <code>metadata</code> in the namespace
 									<code>http://www.idpf.org/2013/metadata</code>, but this specification allows other
@@ -2632,15 +2628,15 @@
 
 							<p>This specification reserves the OPTIONAL <code>rights.xml</code> file in the
 									<code>META-INF</code> directory for digital rights management (DRM) information for
-								trusted exchange of EPUB Publications among rights holders, intermediaries, and
+								trusted exchange of EPUB publications among rights holders, intermediaries, and
 								users.</p>
 
-							<p>When EPUB Creators do not include a <code>rights.xml</code> file, no part of the
+							<p>When EPUB creators do not include a <code>rights.xml</code> file, no part of the
 								container is rights governed at the container level. Rights expressions might exist
-								within the EPUB Publications.</p>
+								within the EPUB publications.</p>
 
-							<p>If EPUB Creators do not include a <code>rights.xml</code> file, no part of the OCF
-								Abstract Container is rights governed.</p>
+							<p>If EPUB creators do not include a <code>rights.xml</code> file, no part of the OCF
+								abstract container is rights governed.</p>
 						</section>
 
 						<section id="sec-container-metainf-signatures.xml">
@@ -2648,7 +2644,7 @@
 
 							<div class="note">
 								<p>Adding a digital signature is not a guarantee that a malicious actor cannot tamper
-									with an EPUB Publication as Reading Systems do not have to check signatures.</p>
+									with an EPUB publication as reading systems do not have to check signatures.</p>
 							</div>
 
 							<p>The OPTIONAL <code>signatures.xml</code> file in the <code>META-INF</code> directory
@@ -2689,18 +2685,18 @@
 								</dl>
 
 								<p>The <code>signature</code> element contains child elements of type
-										<code>Signature</code>, as defined by [[XMLDSIG-CORE1]]. EPUB Creators can apply
-									signatures to an EPUB Publication as a whole or to its parts, and can specify the
+										<code>Signature</code>, as defined by [[XMLDSIG-CORE1]]. EPUB creators can apply
+									signatures to an EPUB publication as a whole or to its parts, and can specify the
 									signing of any kind of data (i.e., not just XML).</p>
 
 								<p class="note">An <a href="#app-schema-signatures">XML Schema</a> also informally
 									defines the content of the <code>signatures.xml</code> file.</p>
 
-								<p>When an EPUB Creator does not include a <code>signatures.xml</code> file, they are
+								<p>When an EPUB creator does not include a <code>signatures.xml</code> file, they are
 									not signing any part of the container at the container level. Digital signing might
-									exist within the <a>EPUB Publication</a>.</p>
+									exist within the <a>EPUB publication</a>.</p>
 
-								<p id="sig-container">When an EPUB Creator creates a data signature for the container,
+								<p id="sig-container">When an EPUB creator creates a data signature for the container,
 									they SHOULD add the signature as the last child <code>Signature</code> element of
 									the <code>signatures</code> element.</p>
 
@@ -2708,24 +2704,24 @@
 									<p>Each <code>Signature</code> in the <code>signatures.xml</code> file identifies by
 										URL [[URL]] the data to which the signature applies, using the [[XMLDSIG-CORE1]]
 											<code>Manifest</code> element and its <code>Reference</code> sub-elements.
-										EPUB Creator may sign individual container files separately or together.
+										EPUB creator may sign individual container files separately or together.
 										Separately signing each file creates a digest value for the resource that
-										Reading Systems can validate independently. This approach might make a Signature
-										element larger. If EPUB Creators sign files together, they can list the set of
+										reading systems can validate independently. This approach might make a Signature
+										element larger. If EPUB creators sign files together, they can list the set of
 										signed files in a single XML Signature <code>Manifest</code> element and
 										reference them by one or more <code>Signature</code> elements.</p>
 								</div>
 
-								<p id="sig-restrictions">EPUB Creators can sign any or all files in the container in
+								<p id="sig-restrictions">EPUB creators can sign any or all files in the container in
 									their entirety, except for the <code>signatures.xml</code> file since that file will
-									contain the computed signature information. Whether and how EPUB Creators sign the
+									contain the computed signature information. Whether and how EPUB creators sign the
 										<code>signatures.xml</code> file depends on their objective.</p>
 
-								<p>If the EPUB Creator wants to allow signatures to be added or removed from the
+								<p>If the EPUB creator wants to allow signatures to be added or removed from the
 									container without invalidating their signature, they SHOULD NOT sign the
 										<code>signatures.xml</code> file.</p>
 
-								<p>If the EPUB Creator wants any addition or removal of a signature to invalidate their
+								<p>If the EPUB creator wants any addition or removal of a signature to invalidate their
 									signature, they can use the Enveloped Signature transform defined in <a
 										data-cite="xmldsig-core#sec-EnvelopedSignature">Section 6.6.4</a> of
 									[[XMLDSIG-CORE1]] to sign the entire pre-existing signature file excluding the
@@ -2734,7 +2730,7 @@
 									package.</p>
 
 								<div class="note">
-									<p>If the EPUB Creator wants the removal of an existing signature to invalidate
+									<p>If the EPUB creator wants the removal of an existing signature to invalidate
 										their signature, but also wants to allow the addition of signatures, they could
 										use an XPath transform to sign just the existing signatures. The details of such
 										a transform are outside the scope of this specification, however.</p>
@@ -2821,20 +2817,20 @@
 				<section id="sec-container-zip-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>An <a>OCF ZIP Container</a> is a physical single-file manifestation of an <a>OCF Abstract
-							Container</a>. The Container allows:</p>
+					<p>An <a>OCF ZIP container</a> is a physical single-file manifestation of an <a>OCF abstract
+							container</a>. The container allows:</p>
 
 					<ul>
 						<li>
-							<p>the exchange of in-progress <a>EPUB Publication</a> between different individuals and/or
+							<p>the exchange of in-progress <a>EPUB publication</a> between different individuals and/or
 								different organizations;</p>
 						</li>
 						<li>
-							<p>the transfer of EPUB Publications from a publisher or conversion house to the
+							<p>the transfer of EPUB publications from a publisher or conversion house to the
 								distribution or sales channel; and</p>
 						</li>
 						<li>
-							<p>the delivery of EPUB Publications to <a>EPUB Reading Systems</a> or users.</p>
+							<p>the delivery of EPUB publications to <a>EPUB reading systems</a> or users.</p>
 						</li>
 					</ul>
 				</section>
@@ -2842,49 +2838,49 @@
 				<section id="sec-zip-container-zipreqs">
 					<h4>ZIP file requirements</h4>
 
-					<p>An <a>OCF ZIP Container</a> uses the ZIP format as specified by [[ZIP]], but with the following
+					<p>An <a>OCF ZIP container</a> uses the ZIP format as specified by [[ZIP]], but with the following
 						constraints and clarifications:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-zip-abstr">The contents of the OCF ZIP Container MUST be a conforming <a
-									href="#sec-container-abstract">OCF Abstract Container</a>.</p>
+							<p id="confreq-zip-abstr">The contents of the OCF ZIP container MUST be a conforming <a
+									href="#sec-container-abstract">OCF abstract container</a>.</p>
 						</li>
 						<li>
-							<p id="confreq-zip-mult">OCF ZIP Containers MUST NOT use the features in the ZIP application
+							<p id="confreq-zip-mult">OCF ZIP containers MUST NOT use the features in the ZIP application
 								note [[ZIP]] that allow ZIP files to be spanned across multiple storage media or be
 								split into multiple files.</p>
 						</li>
 						<li>
-							<p id="confreq-zip-comp">OCF ZIP Containers MUST include only stored (uncompressed) and
+							<p id="confreq-zip-comp">OCF ZIP containers MUST include only stored (uncompressed) and
 								Deflate-compressed ZIP entries within the ZIP archive.</p>
 						</li>
 						<li>
-							<p id="confreq-zip-64">OCF ZIP Containers MAY use the ZIP64 extensions defined as "Version
+							<p id="confreq-zip-64">OCF ZIP containers MAY use the ZIP64 extensions defined as "Version
 								1" in section V, subsection G of the application note [[ZIP]] and SHOULD use only those
 								extensions when the content requires them.</p>
 						</li>
 						<li>
-							<p id="confreq-zip-enc">OCF ZIP Containers MUST NOT use the encryption features defined by
+							<p id="confreq-zip-enc">OCF ZIP containers MUST NOT use the encryption features defined by
 								the ZIP format; instead, encryption MUST be done using the features described in <a
 									href="#sec-container-metainf-encryption.xml"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-zip-utf8">OCF ZIP Containers MUST encode File System Names using UTF-8
+							<p id="confreq-zip-utf8">OCF ZIP containers MUST encode File System Names using UTF-8
 								[[Unicode]].</p>
 						</li>
 					</ul>
-					<p>The following constraints apply to specific fields in the OCF ZIP Container archive:</p>
+					<p>The following constraints apply to specific fields in the OCF ZIP container archive:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-zip-fld-version">In the local file header table, EPUB Creators MUST set the
+							<p id="confreq-zip-fld-version">In the local file header table, EPUB creators MUST set the
 									<code>version needed to extract</code> fields to the values <code>10</code>,
 									<code>20</code> or <code>45</code> to match the maximum version level needed by the
 								given file (e.g., <code>20</code> for Deflate, <code>45</code> for ZIP64).</p>
 						</li>
 						<li>
-							<p id="confreq-zip-fld-comp">In the local file header table, EPUB Creators MUST set the
+							<p id="confreq-zip-fld-comp">In the local file header table, EPUB creators MUST set the
 									<code>compression</code> method field to the values <code>0</code> or
 								<code>8</code>.</p>
 						</li>
@@ -2894,8 +2890,8 @@
 				<section id="sec-zip-container-mime">
 					<h4>OCF ZIP container media type identification</h4>
 
-					<p>EPUB Creators MUST include the <code>mimetype</code> file as the first file in the <a>OCF ZIP
-							Container</a>. In addition:</p>
+					<p>EPUB creators MUST include the <code>mimetype</code> file as the first file in the <a>OCF ZIP
+							container</a>. In addition:</p>
 
 					<ul>
 						<li>The contents of the <code>mimetype</code> file MUST be the MIME media type [[RFC2046]]
@@ -2903,8 +2899,8 @@
 						<li>The <code>mimetype</code> file MUST NOT contain any leading or trailing padding or white
 							space.</li>
 						<li>The <code>mimetype</code> file MUST NOT begin with the Unicode byte order mark U+FEFF.</li>
-						<li>EPUB Creators MUST NOT compress or encrypt the <code>mimetype</code> file.</li>
-						<li>EPUB Creators MUST NOT include an extra field in its ZIP header.</li>
+						<li>EPUB creators MUST NOT compress or encrypt the <code>mimetype</code> file.</li>
+						<li>EPUB creators MUST NOT include an extra field in its ZIP header.</li>
 					</ul>
 
 					<div class="note">
@@ -2920,7 +2916,7 @@
 				<div class="caution">
 					<p>Better methods of protecting fonts exist. Both [[WOFF]] and [[WOFF2]] fonts, for example, allow
 						the embedding of licensing information and provide some protection through font table
-						compression. The use of remotely hosted fonts also allows for font subsetting. EPUB Creators are
+						compression. The use of remotely hosted fonts also allows for font subsetting. EPUB creators are
 						advised to use font obfuscation as defined in this section only when no other options are
 						available to them. See also the <a href="#fobfus-limitations">limitations of
 						obfuscation</a>.</p>
@@ -2929,27 +2925,27 @@
 				<section id="fobfus-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>Since an <a>OCF ZIP Container</a> is fundamentally a ZIP file, commonly available ZIP tools can
+					<p>Since an <a>OCF ZIP container</a> is fundamentally a ZIP file, commonly available ZIP tools can
 						be used to extract any unencrypted content stream from the package. Moreover, the nature of ZIP
 						files means that their contents might appear like any other native container on some systems
 						(e.g., a folder).</p>
 
 					<p>While this simplicity of ZIP files is quite useful, it also poses a problem when ease of
-						extraction of fonts is not a desired side-effect of not encrypting them. An <a>EPUB Creator</a>
+						extraction of fonts is not a desired side-effect of not encrypting them. An <a>EPUB creator</a>
 						who wishes to include a third-party font, for example, typically does not want that font
 						extracted and re-used by others. More critically, many commercial fonts allow embedding, but
-						embedding a font implies making it an integral part of the EPUB Publication, not just providing
+						embedding a font implies making it an integral part of the EPUB publication, not just providing
 						the original font file along with the content.</p>
 
 					<p>Since integrated ZIP support is so ubiquitous in modern operating systems, simply placing a font
 						in the ZIP archive is insufficient to signify that the font cannot be reused in other contexts.
 						This uncertainty can undermine the otherwise useful font embedding capability of EPUB
-						Publications.</p>
+						publications.</p>
 
 					<p>To discourage reuse of their fonts, some font vendors might only allow their use in EPUB
-						Publications if the fonts are bound in some way to the EPUB Publication. That is, if the font
+						publications if the fonts are bound in some way to the EPUB publication. That is, if the font
 						file cannot be installed directly for use on an operating system with the built-in tools of that
-						computing device, and it cannot be directly used by other EPUB Publications.</p>
+						computing device, and it cannot be directly used by other EPUB publications.</p>
 
 					<p>It is beyond the scope of this specification to provide a digital rights management or
 						enforcement system for fonts. This section instead defines a method of obfuscation that will
@@ -2963,7 +2959,7 @@
 					<p>This specification does not claim that obfuscation constitutes encryption, nor does it guarantee
 						that the resource will be secure from copyright infringement. The hope is only that this
 						algorithm will meet the requirements of vendors who require some assurance that their fonts
-						cannot be extracted simply by unzipping the OCF Container and copying the resource.</p>
+						cannot be extracted simply by unzipping the OCF container and copying the resource.</p>
 
 					<p>Obfuscation, like any protection scheme, cannot fully protect fonts from being accessed in their
 						deobfuscated state. The mechanism only provides an obstacle for those who are unaware of the
@@ -2972,37 +2968,37 @@
 
 					<ul>
 						<li>applying the deobfuscation algorithm to extract the raw font file;</li>
-						<li>accessing the deobfuscated font through a Reading System that must dedobfuscate it to render
-							the content (e.g., by accessing the resources through a browser-based Reading System);
+						<li>accessing the deobfuscated font through a reading system that must dedobfuscate it to render
+							the content (e.g., by accessing the resources through a browser-based reading system);
 							or</li>
 						<li>accessing the deobfuscated font through authoring tools that provide the visual rendering of
 							the content.</li>
 					</ul>
 
 					<p>As a result, whether this method of obfuscation satisfies the requirements of individual font
-						licenses remains a question for the licensor and licensee. EPUB Creators are responsible for
+						licenses remains a question for the licensor and licensee. EPUB creators are responsible for
 						ensuring their use of obfuscation meets font licensing requirements.</p>
 
-					<p>EPUB Creators should also be aware that obfuscation may lead to interoperability issues in
-						Reading Systems as Reading Systems are not required to deobfuscate fonts. As a result, the
-						visual presentation of their publications may differ from Reading System to Reading System.</p>
+					<p>EPUB creators should also be aware that obfuscation may lead to interoperability issues in
+						reading systems as reading systems are not required to deobfuscate fonts. As a result, the
+						visual presentation of their publications may differ from reading system to reading system.</p>
 
 					<p>Also note that the algorithm is restricted to obfuscating fonts. It is not intended as a
-						general-purpose mechanism for obfuscating any resource in the EPUB Container.</p>
+						general-purpose mechanism for obfuscating any resource in the EPUB container.</p>
 				</section>
 
 				<section id="obfus-keygen">
 					<h4>Obfuscation key</h4>
 
-					<p>EPUB Creators MUST derive the key used in the obfuscation algorithm from the <a>Unique
-							Identifier</a>.</p>
+					<p>EPUB creators MUST derive the key used in the obfuscation algorithm from the <a>unique
+							identifier</a>.</p>
 
 					<p>All white space characters, as defined in <a data-cite="xml#sec-common-syn">section 2.3 of the
 							XML 1.0 specification</a> [[XML]], MUST be removed from this identifier — specifically, the
 						Unicode code points <code>U+0020</code>, <code>U+0009</code>, <code>U+000D</code> and
 							<code>U+000A</code>.</p>
 
-					<p>EPUB Creators MUST generate a SHA-1 digest of the UTF-8 representation of the resulting string as
+					<p>EPUB creators MUST generate a SHA-1 digest of the UTF-8 representation of the resulting string as
 						specified by the Secure Hash Standard [[FIPS-180-4]]. They can then use this digest as the key
 						for the algorithm.</p>
 				</section>
@@ -3023,7 +3019,7 @@
 						the source. Once 1040 bytes are encoded in this way (or the end of the source is reached),
 						directly copy any remaining data in the source to the destination.</p>
 
-					<p>EPUB Creators MUST obfuscate fonts before compressing and adding them to the OCF Container. Note
+					<p>EPUB creators MUST obfuscate fonts before compressing and adding them to the OCF container. Note
 						that as obfuscation is not encryption, this requirement is not a violation of the one in <a
 							href="#sec-container-metainf-encryption.xml"></a> to compress fonts before encrypting
 						them.</p>
@@ -3075,19 +3071,19 @@
 					<h4>Specifying obfuscated fonts</h4>
 
 					<p>Although not technically encrypted data, all obfuscated fonts MUST have an entry in the <code
-							class="filename">encryption.xml</code> file accompanying the EPUB Publication (see <a
+							class="filename">encryption.xml</code> file accompanying the EPUB publication (see <a
 							href="#sec-container-metainf-encryption.xml"></a>).</p>
 
-					<p>EPUB Creators MUST specify an <code>EncryptedData</code> element for each obfuscated font. Each
+					<p>EPUB creators MUST specify an <code>EncryptedData</code> element for each obfuscated font. Each
 							<code>EncryptedData</code> element MUST contain a child <code>EncryptionMethod</code>
 						element whose <code>Algorithm</code> attribute has the value
 							<code>http://www.idpf.org/2008/embedding</code>. The presence of this attribute signals the
 						use of the algorithm described in this specification.</p>
 
-					<p>EPUB Creators MUST list the path to the obfuscated font in the <code>CipherReference</code> child
+					<p>EPUB creators MUST list the path to the obfuscated font in the <code>CipherReference</code> child
 						of the <code>CipherData</code> element. As the obfuscation algorithm is restricted to fonts, the
 							<code>URI</code> attribute of the <code>CipherReference</code> element MUST reference a <a
-							href="#cmt-grp-font">Font Core Media Type Resource</a>.</p>
+							href="#cmt-grp-font">Font core media type resource</a>.</p>
 
 					<aside class="example" title="An entry for an obfuscated font">
 						<pre>&lt;encryption 
@@ -3104,14 +3100,14 @@
 &lt;/encryption></pre>
 					</aside>
 
-					<p>To prevent trivial copying of the embedded font to other EPUB Publications, EPUB Creators MUST
+					<p>To prevent trivial copying of the embedded font to other EPUB publications, EPUB creators MUST
 						NOT provide the <a href="#obfus-keygen">obfuscation key</a> in the <code>encryption.xml</code>
 						file.</p>
 				</section>
 			</section>
 		</section>
 		<section id="sec-package-doc">
-			<h2>Package Document</h2>
+			<h2>Package document</h2>
 
 			<p>All [[XML]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
 				namespace [[XML-NAMES]] unless otherwise specified.</p>
@@ -3119,25 +3115,25 @@
 			<section id="sec-package-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>The <a>Package Document</a> is an XML document that consists of a set of elements that each
-					encapsulate information about a particular aspect of an <a>EPUB Publication</a>. These elements
+				<p>The <a>package document</a> is an XML document that consists of a set of elements that each
+					encapsulate information about a particular aspect of an <a>EPUB publication</a>. These elements
 					serve to centralize metadata, detail the individual resources, and provide the reading order and
 					other information necessary for its rendering.</p>
 
-				<p>The following list summarizes the information found in the Package Document:</p>
+				<p>The following list summarizes the information found in the package document:</p>
 
 				<ul>
 					<li>
 						<p><a href="#sec-pkg-metadata">Metadata</a> — mechanisms to include and/or reference information
-							about the EPUB Publication.</p>
+							about the EPUB publication.</p>
 					</li>
 					<li>
 						<p>A <a href="#sec-manifest-elem">manifest</a> — identifies via URL [[URL]], and describes via
-							MIME media type [[RFC4839]], the set of <a>Publication Resources</a>.</p>
+							MIME media type [[RFC4839]], the set of <a>publication resources</a>.</p>
 					</li>
 					<li>
 						<p>A <a href="#sec-spine-elem">spine</a> — an ordered sequence of ID references to top-level
-							resources in the manifest from which Reading Systems can reach or utilize all other
+							resources in the manifest from which reading systems can reach or utilize all other
 							resources in the set. The spine defines the default reading order.</p>
 					</li>
 					<li>
@@ -3146,30 +3142,30 @@
 					</li>
 					<li>
 						<p><a>Manifest fallback chains</a> — a mechanism that defines an ordered list of top-level
-							resources as content equivalents. A Reading System can then choose between the resources
+							resources as content equivalents. A reading system can then choose between the resources
 							based on which it is capable of rendering.</p>
 					</li>
 				</ul>
 
 				<div class="note">
-					<p>An EPUB Publication can reference more than one Package Document, allowing for alternative
+					<p>An EPUB publication can reference more than one package document, allowing for alternative
 						representations of the content. For more information, refer to <a
 							href="#sec-container-metainf-container.xml"></a></p>
 				</div>
 
 				<div class="note">
 					<p>Refer to <a href="#app-media-type-app-oebps-package"></a> for information about the file
-						properties of Package Documents.</p>
+						properties of package documents.</p>
 				</div>
 			</section>
 
 			<section id="sec-parse-package-urls">
-				<h3>Parsing URLs in the Package Document</h3>
+				<h3>Parsing URLs in the package document</h3>
 
 				<p id="pkg-parse-package-url" data-tests="#ocf-url_link-relative,#ocf-url_relative"> To parse a URL
-					string <var>url</var> used in the Package Document, the <a data-lt="url parser">URL
-						Parser</a> [[URL]] MUST be applied to <var>url</var>, with the <a>content URL</a> of the Package
-					Document as <var>base</var>.</p>
+					string <var>url</var> used in the package document, the <a data-lt="url parser">URL
+					Parser</a> [[URL]] MUST be applied to <var>url</var>, with the <a>content URL</a> of the package
+					document as <var>base</var>.</p>
 			</section>
 
 			<section id="sec-shared-attrs">
@@ -3195,8 +3191,8 @@
 							[[BIDI]].</li>
 					</ul>
 
-					<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading Systems will assume the
-						value <code>auto</code> when EPUB Creators omit the attribute or use an invalid value.</p>
+					<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading systems will assume the
+						value <code>auto</code> when EPUB creators omit the attribute or use an invalid value.</p>
 
 					<div class="note">
 						<p>The base direction specified in the <code>dir</code> attribute does not affect the ordering
@@ -3204,7 +3200,7 @@
 							placement of weak directional characters such as punctuation.</p>
 					</div>
 
-					<aside class="example" title="Setting the global base direction for Package Document text">
+					<aside class="example" title="Setting the global base direction for package document text">
 						<pre>&lt;package … dir="ltr">
    …
 &lt;/package></pre>
@@ -3226,9 +3222,8 @@
 				<section id="attrdef-href">
 					<h4>The <code>href</code> attribute</h4>
 
-					<p>A <a>valid URL string</a> [[URL]] that references a resource. If
-						the value is an <a>absolute-URL string</a>, it SHOULD NOT use the
-						"file" URI scheme [[rfc8089]].</p>
+					<p>A <a>valid URL string</a> [[URL]] that references a resource. If the value is an <a>absolute-URL
+							string</a>, it SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
 
 					<aside class="example" title="Linking a metadata record">
 						<pre>&lt;package …>
@@ -3310,7 +3305,7 @@
 					<p>Refer to each element's definition for the <a href="#sec-default-vocab">reserved vocabulary</a>
 						for the attribute.</p>
 
-					<aside class="example" title="Identifying the EPUB Navigation Document in the manifest">
+					<aside class="example" title="Identifying the EPUB navigation document in the manifest">
 						<pre>&lt;package …>
    …
    &lt;manifest>
@@ -3334,9 +3329,9 @@
 					<h4>The <code>refines</code> attribute</h4>
 
 					<p>Establishes an association between the current expression and the element or resource identified
-						by its value. EPUB Creators MUST use as the value a <a>path-relative-scheme-less-URL
-							string</a>, optionally followed by <code>U+0023 (#)</code> and a <a>URL-fragment string</a> that references the resource or
-						element they are describing.</p>
+						by its value. EPUB creators MUST use as the value a <a>path-relative-scheme-less-URL string</a>,
+						optionally followed by <code>U+0023 (#)</code> and a <a>URL-fragment string</a> that references
+						the resource or element they are describing.</p>
 
 					<aside class="example" title="Specifying that a creator is the illustrator">
 						<pre>&lt;package …>
@@ -3360,13 +3355,13 @@
 					<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata expressed. When
 						omitted, the element defines a <a href="#primary-expression">primary expression</a>.</p>
 
-					<p>When creating expressions about a <a>Publication Resource</a>, the <code>refines</code> attribute
+					<p>When creating expressions about a <a>publication resource</a>, the <code>refines</code> attribute
 						SHOULD specify a fragment identifier that references the ID of the resource's <a
 							href="#sec-item-elem">manifest entry</a>.</p>
 
 					<p>Refinement chains MUST NOT contain circular references or self-references.</p>
 
-					<aside class="example" title="Setting the duration of a Media Overlay Document">
+					<aside class="example" title="Setting the duration of a media overlay document">
 						<pre>&lt;package …>
    &lt;metadata …>
       …
@@ -3401,7 +3396,7 @@
 							Identification</a> of [[XML]]. The value of each <code>xml:lang</code> attribute MUST be a
 							<a data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
 
-					<aside class="example" title="Setting the global language for Package Document text">
+					<aside class="example" title="Setting the global language for package document text">
 						<pre>&lt;package … xml:lang="ja">
    …
 &lt;/package></pre>
@@ -3423,7 +3418,7 @@
 			<section id="sec-package-elem">
 				<h3>The <code>package</code> element</h3>
 
-				<p>The <code>package</code> element is the root element of the <a>Package Document</a>.</p>
+				<p>The <code>package</code> element is the root element of the <a>package document</a>.</p>
 
 				<dl id="elemdef-opf-package" class="elemdef">
 					<dt>Element Name:</dt>
@@ -3435,7 +3430,7 @@
 
 					<dt>Usage:</dt>
 					<dd>
-						<p>The <code>package</code> element is the root element of the Package Document.</p>
+						<p>The <code>package</code> element is the root element of the package document.</p>
 					</dd>
 
 					<dt>Attributes:</dt>
@@ -3551,7 +3546,7 @@
 				</dl>
 
 				<p id="attrdef-package-version">The <code>version</code> attribute specifies the EPUB specification
-					version to which the given EPUB Publication conforms. The attribute MUST have the value
+					version to which the given EPUB publication conforms. The attribute MUST have the value
 						"<code>3.0</code>" to indicate conformance with EPUB 3.</p>
 
 				<div class="note">
@@ -3660,12 +3655,12 @@
 						</dd>
 					</dl>
 
-					<p>The Package Document <code>metadata</code> element has two primary functions:</p>
+					<p>The package document <code>metadata</code> element has two primary functions:</p>
 
 					<ol>
 						<li>
-							<p>to provide a minimal set of meta information for Reading Systems to use to internally
-								catalogue an <a>EPUB Publication</a> and make it available to a user (e.g., to present
+							<p>to provide a minimal set of meta information for reading systems to use to internally
+								catalogue an <a>EPUB publication</a> and make it available to a user (e.g., to present
 								in a bookshelf).</p>
 						</li>
 						<li>
@@ -3674,14 +3669,14 @@
 						</li>
 					</ol>
 
-					<p>The Package Document does not provide complex metadata encoding capabilities. If EPUB Creators
+					<p>The package document does not provide complex metadata encoding capabilities. If EPUB creators
 						need to provide more detailed information, they can associate metadata records (e.g., that
 						conform to an international standard such as [[ONIX]] or are created for custom purposes) using
-						the <a href="#sec-link-elem"><code>link</code></a> element. This approach allows Reading Systems
+						the <a href="#sec-link-elem"><code>link</code></a> element. This approach allows reading systems
 						to process the metadata in its native form, avoiding the potential problems and information loss
-						caused by translating to use the minimal Package Document structure.</p>
+						caused by translating to use the minimal package document structure.</p>
 
-					<p id="core-metadata-reqs">In keeping with this philosophy, the Package Document only has the
+					<p id="core-metadata-reqs">In keeping with this philosophy, the package document only has the
 						following minimal metadata requirements: it MUST contain the [[DCTERMS]] <a
 							href="#sec-opf-dcidentifier"><code>dc:title</code></a>, <a href="#elemdef-opf-dcidentifier"
 								><code>dc:identifier</code></a>, and <a href="#elemdef-opf-dclanguage"
@@ -3689,7 +3684,7 @@
 							href="#last-modified-date"><code>dcterms:modified</code> property</a>. All other metadata is
 						OPTIONAL.</p>
 
-					<aside class="example" title="The minimal set of metadata required in the Package Document">
+					<aside class="example" title="The minimal set of metadata required in the package document">
 						<pre>&lt;package … unique-identifier="pub-id">
     …
     &lt;metadata …>
@@ -3715,7 +3710,7 @@
 
 					<p>The <a href="#sec-meta-elem"><code>meta</code> element</a> provides a generic mechanism for
 						including <a href="#sec-vocab-assoc">metadata properties from any vocabulary</a>. Although EPUB
-						Creators MAY use this mechanism for any metadata purposes, they will typically use it to include
+						creators MAY use this mechanism for any metadata purposes, they will typically use it to include
 						rendering metadata defined in EPUB specifications.</p>
 
 					<div class="note">
@@ -3727,9 +3722,8 @@
 					<h4>Metadata values</h4>
 
 					<p>The Dublin Core elements [[DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code> element</a>
-						have mandatory <a>child text content</a> [[DOM]].
-						This specification refers to this content as the <dfn>value</dfn> of the element in their
-						descriptions.</p>
+						have mandatory <a>child text content</a> [[DOM]]. This specification refers to this content as
+						the <dfn>value</dfn> of the element in their descriptions.</p>
 
 					<p>These elements MUST have non-empty values after <a
 							data-lt="strip leading and trailing ascii whitespace">leading and trailing ASCII
@@ -3738,7 +3732,7 @@
 
 					<p>Whitespace within these element values is not significant. Sequences of one or more whitespace
 						characters are <a data-lt="strip and collapse ascii whitespace">collapsed to a single
-							space</a> [[Infra]] during processing .</p>
+						space</a> [[Infra]] during processing .</p>
 				</section>
 
 				<section id="sec-opf-dcmes-required">
@@ -3795,8 +3789,8 @@
 							</dd>
 						</dl>
 
-						<p>The <a>EPUB Creator</a> MUST provide an identifier that is unique to one and only one <a>EPUB
-								Publication</a> &#8212; its <a>Unique Identifier</a> &#8212; in an
+						<p>The <a>EPUB creator</a> MUST provide an identifier that is unique to one and only one <a>EPUB
+								publication</a> &#8212; its <a>unique identifier</a> &#8212; in an
 								<code>dc:identifier</code> element. This <code>dc:identifier</code> element MUST specify
 							an <code>id</code> attribute whose value is referenced from the <a
 								href="#elemdef-opf-package"><code>package</code> element's</a>
@@ -3814,16 +3808,16 @@
 &lt;/package></pre>
 						</aside>
 
-						<p>Although not static, EPUB Creators should make changes to the Unique Identifier for an EPUB
-							Publication as infrequently as possible. Unique Identifiers should have maximal persistence
-							both for referencing and distribution purposes. EPUB Creators should not issue new
+						<p>Although not static, EPUB creators should make changes to the unique identifier for an EPUB
+							publication as infrequently as possible. Unique Identifiers should have maximal persistence
+							both for referencing and distribution purposes. EPUB creators should not issue new
 							identifiers when making minor revisions such as updating metadata, fixing errata, or making
 							similar minor changes.</p>
 
-						<p>EPUB Creators MAY specify additional identifiers. The identifiers should be fully qualified
+						<p>EPUB creators MAY specify additional identifiers. The identifiers should be fully qualified
 							URIs.</p>
 
-						<p>EPUB Creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
+						<p>EPUB creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
 								property</a> to indicate that the value of a <code>dc:identifier</code> element conforms
 							to an established system or an issuing authority granted it.</p>
 
@@ -3855,7 +3849,7 @@
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
 									><code>dc:title</code> element</a> [[DCTERMS]] represents an instance of a name for
-							the <a>EPUB Publication</a>.</p>
+							the <a>EPUB publication</a>.</p>
 
 						<dl id="elemdef-opf-dctitle" class="elemdef">
 							<dt>Element Name:</dt>
@@ -3915,7 +3909,7 @@
 						</dl>
 
 						<p id="title-order">The first <code>dc:title</code> element in document order is the main title
-							of the EPUB Publication (i.e., the primary one Reading Systems present to users).</p>
+							of the EPUB publication (i.e., the primary one reading systems present to users).</p>
 
 						<aside class="example" title="A basic title element">
 							<pre>&lt;metadata …>
@@ -3927,13 +3921,13 @@
 </pre>
 						</aside>
 
-						<p>EPUB Creators should use only a single <code>dc:title</code> element to ensure consistent
-							rendering of the title in Reading Systems.</p>
+						<p>EPUB creators should use only a single <code>dc:title</code> element to ensure consistent
+							rendering of the title in reading systems.</p>
 
 						<div class="note">
 							<p>Although it is possible to include more than one <code>dc:title</code> element for
-								multipart titles, Reading System support for additional <code>dc:title</code> elements
-								is inconsistent. Reading Systems may ignore the additional segments or combine them in
+								multipart titles, reading system support for additional <code>dc:title</code> elements
+								is inconsistent. Reading systems may ignore the additional segments or combine them in
 								unexpected ways.</p>
 
 							<p>For example, the following example shows a basic multipart title:</p>
@@ -3975,7 +3969,7 @@
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/language"
 									><code>dc:language</code> element</a> [[DCTERMS]] specifies the language of the
-							content of the <a>EPUB Publication</a>.</p>
+							content of the <a>EPUB publication</a>.</p>
 
 						<dl id="elemdef-opf-dclanguage" class="elemdef">
 							<dt>Element Name:</dt>
@@ -4017,7 +4011,7 @@
 						<p>The <a>value</a> of each <code>dc:language</code> element MUST be a <a
 								data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
 
-						<aside class="example" title="Specifying U.S. English as the language of the EPUB Publication">
+						<aside class="example" title="Specifying U.S. English as the language of the EPUB publication">
 							<pre>&lt;metadata …>
    …
    &lt;dc:language>
@@ -4027,13 +4021,13 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<p>Although EPUB Creators MAY specify additional <code>dc:language</code> elements for
-							multilingual Publications, Reading Systems will treat the first <code>dc:language</code>
-							element in document order as the primary language of the EPUB Publication.</p>
+						<p>Although EPUB creators MAY specify additional <code>dc:language</code> elements for
+							multilingual Publications, reading systems will treat the first <code>dc:language</code>
+							element in document order as the primary language of the EPUB publication.</p>
 
 						<div class="note">
-							<p><a>Publication Resources</a> do not inherit their language from the
-									<code>dc:language</code> element(s). EPUB Creators must set the language of a
+							<p><a>Publication resources</a> do not inherit their language from the
+									<code>dc:language</code> element(s). EPUB creators must set the language of a
 								resource using the intrinsic methods of the format.</p>
 						</div>
 					</section>
@@ -4130,7 +4124,7 @@
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/creator"
 									><code>dc:creator</code> element</a> [[DCTERMS]] represents the name of a person,
-							organization, etc. responsible for the creation of the content. EPUB Creators MAY <a
+							organization, etc. responsible for the creation of the content. EPUB creators MAY <a
 								href="#subexpression">associate</a> a <a href="#role"><code>role</code> property</a>
 							with the element to indicate the function the creator played.</p>
 
@@ -4156,10 +4150,10 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<p>The <code>dc:creator</code> element should contain the name of the creator as EPUB Creators
-							intend Reading Systems to display it to users.</p>
+						<p>The <code>dc:creator</code> element should contain the name of the creator as EPUB creators
+							intend reading systems to display it to users.</p>
 
-						<p>EPUB Creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
+						<p>EPUB creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
 							<a href="#subexpression">to associate</a> a normalized form of the creator's name, and the
 								<a href="#alternate-script"><code>alternate-script</code> property</a> to represent the
 							creator's name in another language or script.</p>
@@ -4186,7 +4180,7 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<p>If an EPUB Publication has more than one creator, EPUB Creators should specify each in a
+						<p>If an EPUB publication has more than one creator, EPUB creators should specify each in a
 							separate <code>dc:creator</code> element.</p>
 
 						<p>The document order of <code>dc:creator</code> elements in the <code>metadata</code> section
@@ -4210,7 +4204,7 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<p>EPUB Creators should represent secondary contributors using the <a
+						<p>EPUB creators should represent secondary contributors using the <a
 								href="#sec-opf-dccontributor"><code>dc:contributor</code> element</a>.</p>
 					</section>
 
@@ -4220,9 +4214,9 @@
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/date"
 									><code>dc:date</code> element</a> [[DCTERMS]] defines the publication date of the
-								<a>EPUB Publication</a>. The publication date is not the same as the <a
-								href="#last-modified-date">last modified date</a> (the last time the EPUB Creator
-							changed the EPUB Publication).</p>
+								<a>EPUB publication</a>. The publication date is not the same as the <a
+								href="#last-modified-date">last modified date</a> (the last time the EPUB creator
+							changed the EPUB publication).</p>
 
 						<p>It is RECOMMENDED that the date string conform to [[ISO8601]], particularly the subset
 							expressed in W3C Date and Time Formats [[DateTime]], as such strings are both human and
@@ -4238,10 +4232,10 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<p>EPUB Creators should express additional dates using the specialized date properties available
+						<p>EPUB creators should express additional dates using the specialized date properties available
 							in the [[DCTERMS]] vocabulary, or similar.</p>
 
-						<p>EPUB Publications MUST NOT contain more than one <code>dc:date</code> element.</p>
+						<p>EPUB publications MUST NOT contain more than one <code>dc:date</code> element.</p>
 					</section>
 
 					<section id="sec-opf-dcsubject">
@@ -4250,14 +4244,14 @@
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/subject"
 									><code>dc:subject</code> element</a> [[DCTERMS]] identifies the subject of the EPUB
-							Publication. EPUB Creators should set the <a>value</a> of the element to the human-readable
+							publication. EPUB creators should set the <a>value</a> of the element to the human-readable
 							heading or label, but may use a code value if the subject taxonomy does not provide a
 							separate descriptive label.</p>
 
-						<p>EPUB Creators MAY identify the system or scheme they drew the element's <a>value</a> from
+						<p>EPUB creators MAY identify the system or scheme they drew the element's <a>value</a> from
 							using the <a href="#authority"><code>authority</code> property</a>.</p>
 
-						<p>When a scheme is identified, EPUB Creators MUST <a href="#subexpression">associate</a> a
+						<p>When a scheme is identified, EPUB creators MUST <a href="#subexpression">associate</a> a
 							subject code using the <a href="#term"><code>term</code> property</a>.</p>
 
 						<aside class="example" title="Specifying a BISAC code and heading">
@@ -4309,15 +4303,15 @@
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/type"
 									><code>dc:type</code> element</a> [[DCTERMS]] is used to indicate that the EPUB
-							Publication is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
+							publication is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
 							format).</p>
 
-						<p>EPUB Creators MAY use any text string as a <a>value</a>.</p>
+						<p>EPUB creators MAY use any text string as a <a>value</a>.</p>
 
 						<div class="note">
 							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
 								Working Group maintained a <a href="http://www.idpf.org/epub/vocab/package/types"
-									>non-normative registry of specialized EPUB Publication types</a> for use with this
+									>non-normative registry of specialized EPUB publication types</a> for use with this
 								element. This Working Group no longer maintains the registry and does not anticipate
 								developing new specialized publication types.</p>
 						</div>
@@ -4410,11 +4404,11 @@
 						information.)</p>
 
 					<p id="meta-expr-types">This specification defines two types of metadata expressions that EPUB
-						Creators can define using the <code>meta</code> element:</p>
+						creators can define using the <code>meta</code> element:</p>
 
 					<ul>
 						<li id="primary-expression">A <em>primary expression</em> is one in which the expression defined
-							in the <code>meta</code> element establishes some aspect of the <a>EPUB Publication</a>. A
+							in the <code>meta</code> element establishes some aspect of the <a>EPUB publication</a>. A
 								<code>meta</code> element that omits a refines attribute defines a primary
 							expression.</li>
 						<li id="subexpression">A <em>subexpression</em> is one in which the expression defined in the
@@ -4424,7 +4418,7 @@
 							expression by defining the role of the person.</li>
 					</ul>
 
-					<p>EPUB Creators MAY use subexpressions to refine the meaning of other subexpressions, thereby
+					<p>EPUB creators MAY use subexpressions to refine the meaning of other subexpressions, thereby
 						creating chains of information.</p>
 
 					<p class="note">All the [[DCTERMS]] elements represent primary expressions, and permit refinement by
@@ -4434,7 +4428,7 @@
 							href="#sec-default-vocab">default vocabulary</a> for use with the <code>property</code>
 						attribute.</p>
 
-					<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+					<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
 						></a>.</p>
 
 					<aside class="example" title="Using properties with reserved prefixes">
@@ -4459,7 +4453,7 @@
 					</aside>
 
 					<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme the EPUB
-						Creator obtained the element's <a>value</a> from. The value of the attribute MUST be a <a
+						creator obtained the element's <a>value</a> from. The value of the attribute MUST be a <a
 							href="#sec-property-datatype"><var>property</var> data type value</a> that resolves to the
 						resource that defines the scheme.</p>
 
@@ -4488,7 +4482,7 @@
 						this property MUST be an [[XMLSCHEMA-2]] dateTime conformant date of the form:
 							<code>CCYY-MM-DDThh:mm:ssZ</code></p>
 
-					<p>EPUB Creators MUST express the last modification date in Coordinated Universal Time (UTC) and
+					<p>EPUB creators MUST express the last modification date in Coordinated Universal Time (UTC) and
 						MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>
 
 					<aside class="example" title="Expressing a last modification date">
@@ -4502,10 +4496,10 @@
 &lt;/metadata></pre>
 					</aside>
 
-					<p>EPUB Creators should update the last modified date whenever they make changes to the EPUB
-						Publication.</p>
+					<p>EPUB creators should update the last modified date whenever they make changes to the EPUB
+						publication.</p>
 
-					<p>EPUB Creators MAY specify additional modified properties in the Package Document metadata, but
+					<p>EPUB creators MAY specify additional modified properties in the package document metadata, but
 						they MUST have a different subject (i.e., they require a <code>refines</code> attribute that
 						references an element or resource).</p>
 
@@ -4513,14 +4507,14 @@
 						<p>The requirements for the last modification date are to ensure compatibility with earlier
 							versions of EPUB 3 that defined a <a
 								href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
-								>release identifier</a> [[EPUBPackages-32]] for EPUB Publications.</p>
+								>release identifier</a> [[EPUBPackages-32]] for EPUB publications.</p>
 					</div>
 				</section>
 
 				<section id="sec-link-elem">
 					<h4>The <code>link</code> element</h4>
 
-					<p>The <code>link</code> element associates resources with an <a>EPUB Publication</a>, such as
+					<p>The <code>link</code> element associates resources with an <a>EPUB publication</a>, such as
 						metadata records.</p>
 
 					<dl id="elemdef-opf-link" class="elemdef">
@@ -4606,10 +4600,10 @@
 					</dl>
 
 					<p>The <a href="#sec-metadata-elem"><code>metadata</code> element</a> MAY contain zero or more
-							<code>link</code> elements, each of which identifies the location of a <a>Linked
-							Resource</a> in its REQUIRED <code>href</code> attribute</p>
+							<code>link</code> elements, each of which identifies the location of a <a>linked
+							resource</a> in its REQUIRED <code>href</code> attribute</p>
 
-					<p id="linked-res-manifest">Linked Resources are <a>Publication Resources</a> only when they
+					<p id="linked-res-manifest">linked resources are <a>publication resources</a> only when they
 						are:</p>
 
 					<ul>
@@ -4617,24 +4611,24 @@
 							<p>referenced from the <a href="#sec-spine-elem">spine</a>; or</p>
 						</li>
 						<li>
-							<p>included or embedded in an EPUB Content Document (e.g., a metadata record serialized as
-								RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]] embedded in an 
-								[[HTML]] [^script^] element).</p>
+							<p>included or embedded in an EPUB content document (e.g., a metadata record serialized as
+								RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]] embedded in an [[HTML]] [^script^]
+								element).</p>
 						</li>
 					</ul>
 
-					<p>In all other cases (e.g., when linking to standalone [[?ONIX]] or [[?XMP]] records), the Linked
-						Resources are not Publication Resources (i.e., are not subject to <a
-							href="#sec-core-media-types">Core Media Type requirements</a>) and EPUB Creators MUST NOT
+					<p>In all other cases (e.g., when linking to standalone [[?ONIX]] or [[?XMP]] records), the linked
+						resources are not publication resources (i.e., are not subject to <a
+							href="#sec-core-media-types">core media type requirements</a>) and EPUB creators MUST NOT
 						list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
 
-					<aside class="example" title="Reference to a record embedded in an XHTML Content Document">
+					<aside class="example" title="Reference to a record embedded in an XHTML content document">
 						<p>In this example, the metadata record is embedded in a <code>script</code> element. Note that
 							the media type of the embedded record (i.e., <code>application/ld+json</code>) is obtained
 							from the <code>type</code> attribute on the <code>script</code> element; it is not specified
 							in the <code>link</code> element.</p>
 
-						<pre>Package Document:
+						<pre>Package document:
 
 &lt;package …>
    &lt;metadata …>
@@ -4666,22 +4660,22 @@ XHTML:
 &lt;/html></pre>
 					</aside>
 
-					<p id="linked-res-location">EPUB Creators MAY locate Linked Resources within the <a>EPUB
-							Container</a> or externally, but should consider that <a>Reading Systems</a> are not
-						required to retrieve resources outside the EPUB Container.</p>
+					<p id="linked-res-location">EPUB creators MAY locate linked resources within the <a>EPUB
+							container</a> or externally, but should consider that <a>reading systems</a> are not
+						required to retrieve resources outside the EPUB container.</p>
 
 					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
-							attribute</a> is OPTIONAL when a Linked Resource is located outside the EPUB Container, as
-						more than one media type could be served from the same URL [[URL]]. EPUB Creators MUST specify
-						the attribute for all Linked Resources within the EPUB Container.</p>
+							attribute</a> is OPTIONAL when a linked resource is located outside the EPUB container, as
+						more than one media type could be served from the same URL [[URL]]. EPUB creators MUST specify
+						the attribute for all linked resources within the EPUB container.</p>
 
 					<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of the
-						Linked Resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language
+						linked resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language
 							tag</a> [[BCP47]].</p>
 
 					<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated list of <a
-							href="#sec-property-datatype">property</a> values that establish the relationship the Linked
-						Resource has with the EPUB Publication.</p>
+							href="#sec-property-datatype">property</a> values that establish the relationship the linked
+						resource has with the EPUB publication.</p>
 
 					<aside class="example" title="Linking to a MARC XML record">
 						<pre>&lt;metadata …>
@@ -4695,9 +4689,9 @@ XHTML:
 					</aside>
 
 					<p>The value of the <code>media-type</code> attribute is not always sufficient to identify the type
-						of Linked Resource (e.g., many XML-based record formats use the media type
-							"<code>application/xml</code>"). To aid Reading Systems in the identification of such
-						generic resources, EPUB Creators MAY specify a semantic identifier in the
+						of linked resource (e.g., many XML-based record formats use the media type
+							"<code>application/xml</code>"). To aid reading systems in the identification of such
+						generic resources, EPUB creators MAY specify a semantic identifier in the
 							<code>properties</code> attribute.</p>
 
 					<aside class="example" title="Identifying a record type via a property">
@@ -4717,7 +4711,7 @@ XHTML:
 					<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a href="#sec-default-vocab"
 							>default vocabulary</a> for the <code>rel</code> and <code>properties</code> attributes.</p>
 
-					<p><a>EPUB Creators</a> MAY add relationships and properties from other vocabularies as defined in
+					<p><a>EPUB creators</a> MAY add relationships and properties from other vocabularies as defined in
 							<a href="#sec-vocab-assoc"></a>.</p>
 
 					<aside class="example" title="Declaring a new link relationship">
@@ -4742,11 +4736,11 @@ XHTML:
 </pre>
 					</aside>
 
-					<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB Creators MAY provide one or more <a
-							href="#record">linked metadata records</a> to enhance the information available to Reading
-						Systems, but Reading Systems may ignore these records.</p>
+					<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB creators MAY provide one or more <a
+							href="#record">linked metadata records</a> to enhance the information available to reading
+						systems, but reading systems may ignore these records.</p>
 
-					<p>When a Reading System <a data-cite="epub-rs-33#sec-linked-records">processes linked records</a>
+					<p>When a reading system <a data-cite="epub-rs-33#sec-linked-records">processes linked records</a>
 						[[EPUB-RS-33]], the document order of <code>link</code> elements is used to determine which has
 						the highest priority in the case of conflicts (i.e., first in document order has the highest
 						priority).</p>
@@ -4773,16 +4767,16 @@ XHTML:
 					</aside>
 
 					<div class="note">
-						<p>Due to the variety of metadata record formats and serializations that an EPUB Creator can
-							link to an EPUB Publication, and the complexity of comparing metadata properties between
-							them, this specification does not require Reading Systems to process linked records.</p>
+						<p>Due to the variety of metadata record formats and serializations that an EPUB creator can
+							link to an EPUB publication, and the complexity of comparing metadata properties between
+							them, this specification does not require reading systems to process linked records.</p>
 					</div>
 
-					<p>In addition to full records, EPUB Creators MAY also use the <code>link</code> element to identify
+					<p>In addition to full records, EPUB creators MAY also use the <code>link</code> element to identify
 						individual metadata properties available in an alternative format.</p>
 
 					<aside class="example" title="Link to a description">
-						<p>In this example, the description of the EPUB Publication is contained in an HTML
+						<p>In this example, the description of the EPUB publication is contained in an HTML
 							document.</p>
 
 						<pre>&lt;metadata …>
@@ -4803,7 +4797,7 @@ XHTML:
 				<section id="sec-manifest-elem">
 					<h4>The <code>manifest</code> element</h4>
 
-					<p>The <code>manifest</code> element provides an exhaustive list of <a>Publication Resources</a>
+					<p>The <code>manifest</code> element provides an exhaustive list of <a>publication resources</a>
 						used in the rendering of the content.</p>
 
 					<dl id="elemdef-opf-manifest" class="elemdef">
@@ -4842,17 +4836,17 @@ XHTML:
 						</dd>
 					</dl>
 
-					<p id="confreq-rendition-manifest">EPUB Creators MUST list all <a>Publication Resources</a> in the
-							<code>manifest</code>, regardless of whether they are <a>Container Resources</a> or
-							<a>Remote Resources</a>, using <a class="codelink" href="#sec-item-elem"><code>item</code>
+					<p id="confreq-rendition-manifest">EPUB creators MUST list all <a>publication resources</a> in the
+							<code>manifest</code>, regardless of whether they are <a>container resources</a> or
+							<a>remote resources</a>, using <a class="codelink" href="#sec-item-elem"><code>item</code>
 							elements</a>.</p>
 
-					<p>Note that the <code>manifest</code> is not self-referencing: EPUB Creators MUST NOT specify an
-							<code>item</code> element that refers to the Package Document itself.</p>
+					<p>Note that the <code>manifest</code> is not self-referencing: EPUB creators MUST NOT specify an
+							<code>item</code> element that refers to the package document itself.</p>
 
 					<div class="note">
 						<p>Failure to provide a complete manifest of resources may lead to rendering issues. Reading
-							Systems might not unzip such resources or could prevent access to them for security
+							systems might not unzip such resources or could prevent access to them for security
 							reasons.</p>
 					</div>
 				</section>
@@ -4860,7 +4854,7 @@ XHTML:
 				<section id="sec-item-elem">
 					<h4>The <code>item</code> element</h4>
 
-					<p>The <code>item</code> element represents a <a>Publication Resource</a>.</p>
+					<p>The <code>item</code> element represents a <a>publication resource</a>.</p>
 
 					<dl id="elemdef-package-item" class="elemdef">
 						<dt>Element Name:</dt>
@@ -4935,21 +4929,21 @@ XHTML:
 						</dd>
 					</dl>
 
-					<p>Each <code>item</code> element identifies a <a>Publication Resource</a> by the URL [[URL]] in its
+					<p>Each <code>item</code> element identifies a <a>publication resource</a> by the URL [[URL]] in its
 							<code>href</code> attribute. The value MUST be an <a data-lt="absolute-url string"
 							>absolute-</a> or <a data-lt="path-relative-scheme-less-url string"
-							>path-relative-scheme-less-URL</a> string [[URL]]. EPUB Creators MUST ensure each URL is
+							>path-relative-scheme-less-URL</a> string [[URL]]. EPUB creators MUST ensure each URL is
 						unique within the <code>manifest</code> scope after <a href="#sec-parse-package-urls"
 							>parsing</a>.</p>
 
-					<p id="attrdef-item-media-type">The Publication Resource identified by an <code>item</code> element
+					<p id="attrdef-item-media-type">The publication resource identified by an <code>item</code> element
 						MUST conform to the applicable specification(s) as inferred from the MIME media type provided in
-						the <a href="#attrdef-media-type"><code>media-type</code> attribute</a>. For <a>Core Media Type
-							Resources</a>, EPUB Creators MUST use the media type designated in <a
+						the <a href="#attrdef-media-type"><code>media-type</code> attribute</a>. For <a>core media type
+							resources</a>, EPUB creators MUST use the media type designated in <a
 							href="#sec-core-media-types"></a>.</p>
 
 					<p id="attrdef-item-fallback">The <code>fallback</code> attribute specifies the fallback for the
-						referenced Publication Resource. The <code>fallback</code> attribute's IDREF [[XML]] value MUST
+						referenced publication resource. The <code>fallback</code> attribute's IDREF [[XML]] value MUST
 						resolve to another <code>item</code> in the <code>manifest</code>.</p>
 
 					<p>The fallback for one <code>item</code> MAY specify a fallback to another <code>item</code>, and
@@ -4957,7 +4951,7 @@ XHTML:
 						additional requirements related to the use of fallback chains.</p>
 
 					<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF [[XML]]
-						that identifies the <a>Media Overlay Document</a> for the resource described by this
+						that identifies the <a>media overlay document</a> for the resource described by this
 							<code>item</code>. Refer to <a href="#sec-docs-package"></a> for more information.</p>
 
 					<div class="note">
@@ -4970,16 +4964,16 @@ XHTML:
 						<h6>Resource properties</h6>
 
 						<p>The <a href="#attrdef-properties"><code>properties</code> attribute</a> provides information
-							to <a>Reading Systems</a> about the content of a resource. This information enables
-							discovery of key resources, such as the cover image and <a>EPUB Navigation Document</a>. It
-							also allows Reading Systems to optimize rendering by indicating, for example, whether the
+							to <a>reading systems</a> about the content of a resource. This information enables
+							discovery of key resources, such as the cover image and <a>EPUB navigation document</a>. It
+							also allows reading systems to optimize rendering by indicating, for example, whether the
 							resource contains embedded scripting, MathML, or SVG.</p>
 
 						<p id="attrdef-item-properties">The <a href="#app-item-properties-vocab">Manifest Properties
 								Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
 								<code>properties</code> attribute.</p>
 
-						<p>EPUB Creators MUST set the following properties whenever a resource referenced by an
+						<p>EPUB creators MUST set the following properties whenever a resource referenced by an
 								<code>item</code> element matches their respective definitions:</p>
 
 						<ul>
@@ -4991,7 +4985,7 @@ XHTML:
 						</ul>
 
 						<aside class="example" id="example-item-properties-scripted-mathml"
-							title="Identifying a Scripted Content Document with embedded MathML">
+							title="Identifying a scripted content document with embedded MathML">
 							<pre class="synopsis">&lt;item
     properties="scripted mathml"
     id="c2"
@@ -5001,15 +4995,15 @@ XHTML:
 						</aside>
 
 						<p>These properties do not apply recursively to content included into a resource (e.g., via the
-							HTML <code>iframe</code> element). For example, if a non-scripted XHTML Content Document
+							HTML <code>iframe</code> element). For example, if a non-scripted XHTML content document
 							embeds a scripted Content Document, only the embedded document's manifest <code>item</code>
 							<code>properties</code> attribute will have the <code>scripted</code> value.</p>
 
-						<p>EPUB Creators MUST declare exactly one <code>item</code> as the EPUB Navigation Document
+						<p>EPUB creators MUST declare exactly one <code>item</code> as the EPUB navigation document
 							using the <a href="#sec-nav-prop"><code>nav</code> property</a>.</p>
 
 						<aside class="example" id="example-item-properties-nav"
-							title="Identifying the EPUB Navigation Document">
+							title="Identifying the EPUB navigation document">
 							<pre class="synopsis">&lt;item
     properties="nav"
     id="c1"
@@ -5017,7 +5011,7 @@ XHTML:
     media-type="application/xhtml+xml" /&gt;</pre>
 						</aside>
 
-						<p>If an EPUB Publication contains a cover image, it is recommended to set the <a
+						<p>If an EPUB publication contains a cover image, it is recommended to set the <a
 								href="#sec-cover-image"><code>cover-image</code> property</a>, but setting this property
 							is OPTIONAL.</p>
 
@@ -5030,7 +5024,7 @@ XHTML:
     media-type="image/svg+xml" /&gt;</pre>
 						</aside>
 
-						<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+						<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
 							></a>.</p>
 					</section>
 
@@ -5038,7 +5032,7 @@ XHTML:
 						<h6>Examples</h6>
 
 						<aside class="example" id="example-manifest-cmt"
-							title="A manifest with only Core Media Type Resources">
+							title="A manifest with only core media type resources">
 							<pre>&lt;package …>
    …
    &lt;manifest>
@@ -5102,10 +5096,10 @@ XHTML:
 						</aside>
 
 						<aside class="example" id="example-manifest-flbk"
-							title="Foreign Content Document in Spine with Fallback">
-							<p>The following example shows the <a>manifest fallback chain</a> allowing a <a>Foreign
-									Content Document</a> (JPEG) to be listed in the spine with fallback to an SVG
-								Content Document.</p>
+							title="Foreign content document in spine with fallback">
+							<p>The following example shows the <a>manifest fallback chain</a> allowing a <a>foreign
+									content document</a> (JPEG) to be listed in the spine with fallback to an SVG
+								content document.</p>
 
 							<pre>&lt;package …>
    …
@@ -5133,14 +5127,14 @@ XHTML:
 						</aside>
 
 						<aside class="example"
-							title="Embedded Core Media Type Resource with Link to View as Top-Level Content Document">
-							<p>The following example shows a JPEG embedded in an EPUB Content Document (via the
+							title="Embedded core media type resource with Link to View as top-level content document">
+							<p>The following example shows a JPEG embedded in an EPUB content document (via the
 									<code>img</code> tag) with a hyperlink that allows it to open as a separate page
 								(e.g., for easier zooming). Although embedding the image using the <code>img</code> tag
 								does not require it to be listed in the <a href="#sec-spine-elem">spine</a> or have a
-								fallback, adding the hyperlink causes the document to open as a <a>Top-Level Content
-									Document</a>. As its use in the spine makes it a <a>Foreign Content Document</a>,
-								the EPUB Creator must include a fallback to an EPUB Content Document.</p>
+								fallback, adding the hyperlink causes the document to open as a <a>top-level content
+									document</a>. As its use in the spine makes it a <a>foreign content document</a>,
+								the EPUB creator must include a fallback to an EPUB content document.</p>
 
 							<pre>XHTML:
 &lt;html …>
@@ -5158,7 +5152,7 @@ XHTML:
    &lt;/body>
 &lt;/html>
 
-Package Document:
+Package document:
 &lt;package …>
    …
    &lt;manifest>
@@ -5186,13 +5180,13 @@ Package Document:
 &lt;/package></pre>
 						</aside>
 
-						<aside class="example" title="Link to View Foreign Resource as Top-Level Content Document">
+						<aside class="example" title="Link to View foreign resource as top-level content document">
 							<p>The following example shows a link to the raw CSV data file. The data will open in the
-								Reading System as a <a>Top-Level Content Document</a> the EPUB Creator must list it in
-								the spine. As its use in the spine makes it a <a>Foreign Content Document</a>, the EPUB
-								Creator must also provide a fallback to an <a>EPUB Content Document</a>. Because there
+								reading system as a <a>top-level content document</a> the EPUB creator must list it in
+								the spine. As its use in the spine makes it a <a>foreign content document</a>, the EPUB
+								creator must also provide a fallback to an <a>EPUB content document</a>. Because there
 								is no guarantee users will be able to access the data in its raw form, instructions on
-								how to extract the file from the <a>EPUB Container</a> are also provided.</p>
+								how to extract the file from the <a>EPUB container</a> are also provided.</p>
 
 							<pre>XHTML:
 &lt;html …>
@@ -5213,7 +5207,7 @@ Package Document:
    &lt;/body>
 &lt;/html>
 
-Package Document:
+Package document:
 &lt;package …>
    …
    &lt;manifest>
@@ -5240,12 +5234,12 @@ Package Document:
 &lt;/package></pre>
 						</aside>
 
-						<aside class="example" title="Remote Resources that are Publication Resources">
+						<aside class="example" title="Remote resources that are publication resources">
 							<p>The following example shows a reference to a remote audio file. Because the
-									<code>audio</code> element embeds the audio in its EPUB Content Document, the file
-								is considered a Publication Resource. The EPUB Creator therefore must list the audio
-								file in the manifest and indicate that its host EPUB Content Document contains a
-									<a>Remote Resource</a>.</p>
+									<code>audio</code> element embeds the audio in its EPUB content document, the file
+								is considered a publication resource. The EPUB creator therefore must list the audio
+								file in the manifest and indicate that its host EPUB content document contains a
+									<a>remote resource</a>.</p>
 
 							<pre>XHTML:
 &lt;html …>
@@ -5259,7 +5253,7 @@ Package Document:
    &lt;/body>
 &lt;/html>
 
-Package Document:
+Package document:
 &lt;package …>
    …
    &lt;manifest>
@@ -5280,11 +5274,11 @@ Package Document:
 &lt;/package></pre>
 						</aside>
 
-						<aside class="example" title="External Resources that are not Publication Resources">
+						<aside class="example" title="External Resources that are not publication resources">
 							<p>The following example shows a hyperlink to an audio file hosted on the web. Reading
-								Systems will open such external content in a new browser window; it is not rendered
-								within the publication. In this case, the EPUB Creator does not list the file in the
-								manifest because it is not a Publication Resource.</p>
+								systems will open such external content in a new browser window; it is not rendered
+								within the publication. In this case, the EPUB creator does not list the file in the
+								manifest because it is not a publication resource.</p>
 
 							<pre>XHTML:
 &lt;html …>
@@ -5386,42 +5380,40 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p id="confreq-pub-resource">The <code>spine</code> MUST specify at least one <a>EPUB Content
-							Document</a> or <a>Foreign Content Document</a>.</p>
+					<p id="confreq-pub-resource">The <code>spine</code> MUST specify at least one <a>EPUB content
+							document</a> or <a>foreign content document</a>.</p>
 
-					<p id="spine-inclusion-req">EPUB Creators MUST list in the <code>spine</code> all EPUB and Foreign
-						Content Documents that are hyperlinked to from Publication Resources in the <code>spine</code>,
+					<p id="spine-inclusion-req">EPUB creators MUST list in the <code>spine</code> all EPUB and foreign
+						content documents that are hyperlinked to from publication resources in the <code>spine</code>,
 						where hyperlinking encompasses any linking mechanism that requires the user to navigate away
-						from the current resource. Common hyperlinking mechanisms include the [^a/href^]
-						attribute of the [[HTML]] <a data-lt="a"><code>a</code></a> and <a
-							data-lt="area"><code>area</code></a> elements and scripted links (e.g.,
-						using DOM Events and/or form elements). The requirement to list hyperlinked resources applies
-						recursively (i.e., EPUB Creators must list all EPUB and Foreign Content Documents hyperlinked to
-						from hyperlinked documents, and so on.).</p>
+						from the current resource. Common hyperlinking mechanisms include the [^a/href^] attribute of
+						the [[HTML]] <a data-lt="a"><code>a</code></a> and <a data-lt="area"><code>area</code></a>
+						elements and scripted links (e.g., using DOM Events and/or form elements). The requirement to
+						list hyperlinked resources applies recursively (i.e., EPUB creators must list all EPUB and
+						foreign content documents hyperlinked to from hyperlinked documents, and so on.).</p>
 
-					<p>EPUB Creators also MUST list in the <code>spine</code> all EPUB and Foreign Content Documents
-						hyperlinked to from the <a>EPUB Navigation Document</a>, regardless of whether EPUB Creators
+					<p>EPUB creators also MUST list in the <code>spine</code> all EPUB and foreign content documents
+						hyperlinked to from the <a>EPUB navigation document</a>, regardless of whether EPUB creators
 						include the Navigation Document in the <code>spine</code>.</p>
 
 					<div class="note">
-						<p>As hyperlinks to resources outside the EPUB Container are not Publication Resources, they are
+						<p>As hyperlinks to resources outside the EPUB container are not publication resources, they are
 							not subject to the requirement to include in the spine (e.g., web pages and web-hosted
 							resources).</p>
 
-						<p>Publication Resources used in the rendering of spine items (e.g., referenced from [[HTML]] 
-							<a>embedded content</a>) similarly do not have to be
-							included in the spine.</p>
+						<p>Publication resources used in the rendering of spine items (e.g., referenced from [[HTML]]
+								<a>embedded content</a>) similarly do not have to be included in the spine.</p>
 					</div>
 
 					<p id="attrdef-spine-page-progression-direction">The <code>page-progression-direction</code>
 						attribute sets the global direction in which the content flows. Allowed values are
 							<code>ltr</code> (left-to-right), <code>rtl</code> (right-to-left) and <code>default</code>.
-						When EPUB Creators specify the <code>default</code> value, they are expressing no preference and
-						the Reading System can choose the rendering direction.</p>
+						When EPUB creators specify the <code>default</code> value, they are expressing no preference and
+						the reading system can choose the rendering direction.</p>
 
 					<p>Although the <code>page-progression-direction</code> attribute sets the global flow direction,
 						individual Content Documents and parts of Content Documents MAY override this setting (e.g., via
-						the <code>writing-mode</code> CSS property). Reading Systems may also provide mechanisms to
+						the <code>writing-mode</code> CSS property). Reading systems may also provide mechanisms to
 						override the default direction (e.g., buttons or settings that allow the application of
 						alternate style sheets).</p>
 
@@ -5433,8 +5425,8 @@ No Entry</pre>
 				<section id="sec-itemref-elem">
 					<h4>The <code>itemref</code> element</h4>
 
-					<p>The <code>itemref</code> element identifies an <a>EPUB Content Document</a> or <a>Foreign Content
-							Document</a> in the default reading order.</p>
+					<p>The <code>itemref</code> element identifies an <a>EPUB content document</a> or <a>foreign content
+							document</a> in the default reading order.</p>
 
 					<dl id="elemdef-spine-itemref" class="elemdef">
 						<dt>Element Name:</dt>
@@ -5500,49 +5492,49 @@ No Entry</pre>
 						once. </p>
 
 					<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a) an
-							<a>EPUB Content Document</a> or b) a <a>Foreign Content Document</a> that includes an EPUB
-						Content Document in its <a>manifest fallback chain</a>.</p>
+							<a>EPUB content document</a> or b) a <a>foreign content document</a> that includes an EPUB
+						content document in its <a>manifest fallback chain</a>.</p>
 
 					<div class="note">
-						<p>Although EPUB Publications <a href="#confreq-nav">require an EPUB Navigation Document</a>, it
+						<p>Although EPUB publications <a href="#confreq-nav">require an EPUB navigation document</a>, it
 							is not mandatory to include it in the <code>spine</code>.</p>
 					</div>
 
 					<p id="attrdef-itemref-linear">The <code>linear</code> attribute indicates whether the referenced
 							<code>item</code> contains content that contributes to the primary reading order and that
-						Reading Systems must read sequentially ("<code>yes</code>"), or auxiliary content that enhances
-						or augments the primary content that Reading Systems can access out of sequence
+						reading systems must read sequentially ("<code>yes</code>"), or auxiliary content that enhances
+						or augments the primary content that reading systems can access out of sequence
 							("<code>no</code>"). Examples of auxiliary content include notes, descriptions, and answer
 						keys.</p>
 
-					<p>The <code>linear</code> attribute allows Reading Systems to distinguish content that a user
-						should access as part of the default reading order from supplementary content which a Reading
-						System might, for example, present in a popup window or omit from an aural rendering.</p>
+					<p>The <code>linear</code> attribute allows reading systems to distinguish content that a user
+						should access as part of the default reading order from supplementary content which a reading
+						system might, for example, present in a popup window or omit from an aural rendering.</p>
 
-					<p>Specifying that content is non-linear does not require Reading Systems to present it in a
-						specific way, however; it is only a hint to the purpose. Reading Systems may present non-linear
+					<p>Specifying that content is non-linear does not require reading systems to present it in a
+						specific way, however; it is only a hint to the purpose. Reading systems may present non-linear
 						content where it occurs in the spine, for example, or may skip it until users reach the end of
 						the spine.</p>
 
 					<div class="note">
-						<p>EPUB Creators should list non-linear content at the end of the spine except when it makes
+						<p>EPUB creators should list non-linear content at the end of the spine except when it makes
 							sense for users to encounter it between linear spine items.</p>
 					</div>
 
 					<p id="linear-itemrefs"> A linear <code>itemref</code> element is one whose <code>linear</code>
-						attribute value is explicitly set to "<code>yes</code>" or that omits the attribute — Reading
-						Systems will assume the value "<code>yes</code>" for <code>itemref</code> elements without the
+						attribute value is explicitly set to "<code>yes</code>" or that omits the attribute — reading
+						systems will assume the value "<code>yes</code>" for <code>itemref</code> elements without the
 						attribute. The spine MUST contain at least one linear <code>itemref</code> element. </p>
 
-					<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB Creators MUST provide a means
+					<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB creators MUST provide a means
 						of accessing all non-linear content (e.g., hyperlinks in the content or from the <a
-							href="#sec-nav">EPUB Navigation Document</a>).</p>
+							href="#sec-nav">EPUB navigation document</a>).</p>
 
 					<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine Properties
 							Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
 							<code>properties</code> attribute.</p>
 
-					<p>EPUB Creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
+					<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
 						></a>.</p>
 
 					<aside class="example" title="A basic spine">
@@ -5646,14 +5638,14 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p>The <code>collection</code> element allows EPUB Creators to assemble resources into logical
+					<p>The <code>collection</code> element allows EPUB creators to assemble resources into logical
 						groups for a variety of potential uses: enabling reassembly into a meaningful unit of content
-						split across multiple <a>EPUB Content Documents</a> (e.g., an index split across multiple
+						split across multiple <a>EPUB content documents</a> (e.g., an index split across multiple
 						documents), identifying resources for specialized purposes (e.g., preview content), or
 						collecting together resources that present additional information about the <a>EPUB
-							Publication</a>.</p>
+							publication</a>.</p>
 
-					<p id="attrdef-collection-role">EPUB Creators MUST identify the role of each <code>collection</code>
+					<p id="attrdef-collection-role">EPUB creators MUST identify the role of each <code>collection</code>
 						element in its <code>role</code> attribute, whose value MUST be one or more NMTOKENs
 						[[XMLSCHEMA-2]] and/or <a>absolute-URL-with-fragment strings</a> [[URL]].</p>
 
@@ -5707,7 +5699,7 @@ No Entry</pre>
 
 					<div class="note">
 						<p>The [[OPF-201]] <code>meta</code> element is retained in EPUB 3 primarily so that EPUB
-							Creators can identify the cover image for compatibility with EPUB 2 Reading Systems. In EPUB
+							creators can identify the cover image for compatibility with EPUB 2 reading systems. In EPUB
 							3, the cover image must be identified using the <a href="#sec-cover-image"
 									><code>cover-image</code> property</a> on the <a href="#sec-item-elem">manifest
 									<code>item</code></a> for the image.</p>
@@ -5720,7 +5712,7 @@ No Entry</pre>
 					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code>
 							element</a> [[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided
 						machine-processable navigation to key structures. The <a href="#sec-nav-landmarks">landmarks
-							nav</a> in the <a>EPUB Navigation Document</a> replaces this element.</p>
+							nav</a> in the <a>EPUB navigation document</a> replaces this element.</p>
 
 					<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
 								><code>guide</code> element definition</a> in [[OPF-201]] for more information.</p>
@@ -5731,7 +5723,7 @@ No Entry</pre>
 
 					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a>
 						[[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table of
-						contents. The <a href="#sec-nav">EPUB Navigation Document</a> replaces this document.</p>
+						contents. The <a href="#sec-nav">EPUB navigation document</a> replaces this document.</p>
 
 					<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
 							definition</a> in [[OPF-201]] for more information.</p>
@@ -5739,23 +5731,23 @@ No Entry</pre>
 			</section>
 		</section>
 		<section id="sec-contentdocs">
-			<h2>EPUB Content Documents</h2>
+			<h2>EPUB content documents</h2>
 
 			<section id="sec-xhtml">
-				<h3>XHTML Content Documents</h3>
+				<h3>XHTML content documents</h3>
 
 				<section id="sec-xhtml-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>This section defines a profile of [[HTML]] for creating XHTML Content Documents. An instance of
-						an XML document that conforms to this profile is a <a>Core Media Type Resource</a> and is
-						referred to in this specification as an <a>XHTML Content Document</a>.</p>
+					<p>This section defines a profile of [[HTML]] for creating XHTML content documents. An instance of
+						an XML document that conforms to this profile is a <a>core media type resource</a> and is
+						referred to in this specification as an <a>XHTML content document</a>.</p>
 				</section>
 
 				<section id="sec-xhtml-req">
 					<h4>XHTML requirements</h4>
 
-					<p>An XHTML Content Document:</p>
+					<p>An XHTML content document:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -5773,12 +5765,12 @@ No Entry</pre>
 								conformance constraints defined therein.</p>
 						</li>
 					</ul>
-					<p>Unless specified otherwise, XHTML Content Documents inherit all definitions of semantics,
+					<p>Unless specified otherwise, XHTML content documents inherit all definitions of semantics,
 						structure, and processing behaviors from the [[HTML]] specification.</p>
 
 					<div class="note">
-						<p>The recommendation that EPUB Publications follow the accessibility requirements in
-							[[EPUB-A11Y-11]] applies to XHTML Content Documents. See <a href="#confreq-a11y"
+						<p>The recommendation that EPUB publications follow the accessibility requirements in
+							[[EPUB-A11Y-11]] applies to XHTML content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -5786,7 +5778,7 @@ No Entry</pre>
 				<section id="sec-xhtml-extensions">
 					<h4>HTML extensions</h4>
 
-					<p>This section defines EPUB 3 <a>XHTML Content Document</a> extensions to the underlying [[HTML]]
+					<p>This section defines EPUB 3 <a>XHTML content document</a> extensions to the underlying [[HTML]]
 						document model.</p>
 
 					<div class="note">
@@ -5798,30 +5790,30 @@ No Entry</pre>
 					<section id="sec-xhtml-structural-semantics">
 						<h5>Structural semantics</h5>
 
-						<p>EPUB Creators MAY use the <a href="#sec-epub-type-attribute"><code>epub:type</code>
-								attribute</a> in <a>XHTML Content Documents</a> to express <a
+						<p>EPUB creators MAY use the <a href="#sec-epub-type-attribute"><code>epub:type</code>
+								attribute</a> in <a>XHTML content documents</a> to express <a
 								href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
-						<p>As the [[HTML]] <a data-lt="head"><code>head</code> element</a> contains
-							metadata for the document, structural semantics expressed on this element or any descendant
-							of it have no meaning.</p>
+						<p>As the [[HTML]] <a data-lt="head"><code>head</code> element</a> contains metadata for the
+							document, structural semantics expressed on this element or any descendant of it have no
+							meaning.</p>
 					</section>
 
 					<section id="sec-xhtml-rdfa">
 						<h5>RDFa</h5>
 
-						<p>The [[HTML-RDFA]] specification defines a set of attributes that EPUB Creators MAY use in
-								<a>XHTML Content Documents</a> to semantically enrich the content. The use of these
+						<p>The [[HTML-RDFA]] specification defines a set of attributes that EPUB creators MAY use in
+								<a>XHTML content documents</a> to semantically enrich the content. The use of these
 							attributes MUST conform to the requirements defined in [[HTML-RDFA]].</p>
 
 						<p>The [[HTML-RDFA]] specification defines changes to the [[HTML]] content model when authors
-							use RDFa attributes. This modified content model is valid in XHTML Content Documents.</p>
+							use RDFa attributes. This modified content model is valid in XHTML content documents.</p>
 
 						<div class="note">
 							<p>The listing of RDFa does not express a preference on the part of the Working Group, only
-								that these attributes represent an extension of the HTML grammar. EPUB Creators can also
+								that these attributes represent an extension of the HTML grammar. EPUB creators can also
 								specify <a data-cite="html#microdata">microdata attributes</a> [[HTML]] and <a
-									data-cite="json-ld11#">linked data</a> [[JSON-LD11]] in XHTML Content Documents as
+									data-cite="json-ld11#">linked data</a> [[JSON-LD11]] in XHTML content documents as
 								both are natively supported.</p>
 						</div>
 					</section>
@@ -5830,8 +5822,8 @@ No Entry</pre>
 						<h5>Content switching (deprecated)</h5>
 
 						<p>The <code>switch</code> element provides a simple mechanism through which <a>EPUB
-								Creators</a> can tailor the content displayed to users, one that is not dependent on the
-							scripting capabilities of the <a>EPUB Reading System</a>.</p>
+								creators</a> can tailor the content displayed to users, one that is not dependent on the
+							scripting capabilities of the <a>EPUB reading system</a>.</p>
 
 						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
 
@@ -5859,7 +5851,7 @@ No Entry</pre>
 					<section id="sec-xhtml-custom-attributes">
 						<h5>Custom attributes</h5>
 
-						<p><a>XHTML Content Documents</a> MAY contain custom attributes, which are <a
+						<p><a>XHTML content documents</a> MAY contain custom attributes, which are <a
 								data-cite="xml-names#NT-Prefix">prefixed</a> [[XML-NAMES]] attributes whose namespace
 							URL does not include either of the following strings in its <a>domain</a> [[URL]]:</p>
 
@@ -5868,13 +5860,13 @@ No Entry</pre>
 							<li><code>idpf.org</code></li>
 						</ul>
 						<p>When using custom attributes, the content MUST remain consumable by a user without any
-							information loss or other significant deterioration, regardless of the Reading System it is
+							information loss or other significant deterioration, regardless of the reading system it is
 							rendered on.</p>
 
 						<div class="note">
-							<p>Custom attributes are usually defined in a Reading System-specific manner and are not
-								intended for use by other Reading Systems. This specification should be extended to
-								provide extensions that multiple independent Reading Systems can use.</p>
+							<p>Custom attributes are usually defined in a reading system-specific manner and are not
+								intended for use by other reading systems. This specification should be extended to
+								provide extensions that multiple independent reading systems can use.</p>
 						</div>
 					</section>
 				</section>
@@ -5883,12 +5875,12 @@ No Entry</pre>
 					<h4>HTML deviations and constraints</h4>
 
 					<p>This section defines deviations from, and constraints on, the underlying [[HTML]] document model
-						applicable to EPUB 3 <a>XHTML Content Documents</a>.</p>
+						applicable to EPUB 3 <a>XHTML content documents</a>.</p>
 
 					<section id="sec-xhtml-mathml">
 						<h5>Embedded MathML</h5>
 
-						<p>XHTML Content Documents support embedded [[MATHML3]]. Occurrences of MathML markup MUST
+						<p>XHTML content documents support embedded [[MATHML3]]. Occurrences of MathML markup MUST
 							conform to the constraints expressed in the MathML specification [[MATHML3]], with the
 							following additional restrictions:</p>
 
@@ -5902,12 +5894,12 @@ No Entry</pre>
 
 							<dt id="math-cont">Content MathML</dt>
 							<dd>
-								<p id="confreq-mathml-annot-cont">EPUB Creators MAY include <a
+								<p id="confreq-mathml-annot-cont">EPUB creators MAY include <a
 										data-cite="mathml3/chapter4.html#">Content MathML</a> within MathML markup in
-									XHTML Content Documents, and, when present, MUST include it within an
+									XHTML content documents, and, when present, MUST include it within an
 										<code>annotation-xml</code> child element of a <code>semantics</code>
 									element.</p>
-								<p id="confreq-mathml-annot-cont-attrs">When EPUB Creators include Content MathML per
+								<p id="confreq-mathml-annot-cont-attrs">When EPUB creators include Content MathML per
 									the previous condition, they MUST set the given <code>annotation-xml</code>
 									element's <code>encoding</code> attribute to either of the functionally-equivalent
 									values <code>MathML-Content</code> or <code>application/mathml-content+xml</code>,
@@ -5915,12 +5907,12 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p>This subset eases the implementation burden on Reading Systems and promotes accessibility,
+						<p>This subset eases the implementation burden on reading systems and promotes accessibility,
 							while retaining compatibility with [[HTML]] user agents.</p>
 
 						<div class="note">
 							<p>The <a href="#mathml"><code>mathml</code> property</a> of the <a>manifest</a>
-								<code>item</code> element indicates that an XHTML Content Document contains embedded
+								<code>item</code> element indicates that an XHTML content document contains embedded
 								MathML.</p>
 						</div>
 					</section>
@@ -5928,19 +5920,19 @@ No Entry</pre>
 					<section id="sec-xhtml-svg">
 						<h5>Embedded SVG</h5>
 
-						<p><a>XHTML Content Documents</a> support the embedding of <a
+						<p><a>XHTML content documents</a> support the embedding of <a
 								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
 								fragments</a> [[SVG]] <em>by reference</em> (embedding via reference, for example, from
 							an <code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
-							direct inclusion of the <code>svg</code> element in the XHTML Content Document).</p>
+							direct inclusion of the <code>svg</code> element in the XHTML content document).</p>
 
-						<p>The content conformance constraints for SVG embedded in XHTML Content Documents are the same
-							as defined for <a>SVG Content Documents</a> in <a href="#sec-svg-restrictions"></a>.</p>
+						<p>The content conformance constraints for SVG embedded in XHTML content documents are the same
+							as defined for <a>SVG content documents</a> in <a href="#sec-svg-restrictions"></a>.</p>
 
 						<div class="note">
 							<p>The <a href="#svg"><code>svg</code> property</a> of the <a>manifest</a>
-								<a href="#sec-item-elem"><code>item</code> element</a> indicates that an XHTML Content
-								Document contains embedded SVG.</p>
+								<a href="#sec-item-elem"><code>item</code> element</a> indicates that an XHTML content
+								document contains embedded SVG.</p>
 						</div>
 					</section>
 
@@ -5950,48 +5942,47 @@ No Entry</pre>
 						<section id="sec-xhtml-deviations-base">
 							<h6>The <code>base</code> element</h6>
 
-							<p id="confreq-html-vocab-base"> The [[HTML]] <a data-lt="base"
-										><code>base</code> element</a> can be used to specify the 
-										<a>document base URL</a> for the purposes of parsing
-								URLs. When using it in an <a>EPUB Publication</a>, the interpretation of the
-									<code>base</code> element may inadvertently result in references to <a>Remote
-									Resources</a>. It may also cause Reading Systems to misinterpret the location of
+							<p id="confreq-html-vocab-base"> The [[HTML]] <a data-lt="base"><code>base</code>
+									element</a> can be used to specify the <a>document base URL</a> for the purposes of
+								parsing URLs. When using it in an <a>EPUB publication</a>, the interpretation of the
+									<code>base</code> element may inadvertently result in references to <a>remote
+									resources</a>. It may also cause reading systems to misinterpret the location of
 								hyperlinks (e.g., relative links to other documents in the publication might appear as
 								links to a web site if the <code>base</code> element specifies an absolute URL). To
-								avoid significant interoperability issues, EPUB Creators should not use the
+								avoid significant interoperability issues, EPUB creators should not use the
 									<code>base</code> element. </p>
 						</section>
 
 						<section id="sec-xhtml-deviations-rp">
 							<h6>The <code>rp</code> element</h6>
 
-							<p id="confreq-html-vocab-rp">The [[HTML]] <a data-lt="rp"
-										><code>rp</code> element</a> is intended to provide a fallback for older
-									<a>Reading Systems</a> that do not recognize ruby markup (i.e., a parenthesis
-								display around <code>ruby</code> markup). As EPUB 3 Reading Systems are ruby-aware, and
-								can provide fallbacks, EPUB Creators should not use <code>rp</code> elements.</p>
+							<p id="confreq-html-vocab-rp">The [[HTML]] <a data-lt="rp"><code>rp</code> element</a> is
+								intended to provide a fallback for older <a>reading systems</a> that do not recognize
+								ruby markup (i.e., a parenthesis display around <code>ruby</code> markup). As EPUB 3
+								reading systems are ruby-aware, and can provide fallbacks, EPUB creators should not use
+									<code>rp</code> elements.</p>
 						</section>
 
 						<section id="sec-xhtml-deviations-embed">
 							<h6>The <code>embed</code> element</h6>
 
-							<p id="confreq-html-vocab-embed">Since the [[HTML]] <a data-lt="embed"
-										><code>embed</code> element</a> element does not include intrinsic facilities to provide
-								fallback content for Reading Systems that do not support scripting, <a>EPUB Creators</a>
-								are discouraged from using the element when the referenced resource includes scripting.
-								The [[HTML]] <a data-lt="object"><code>object</code> element</a> is a
-								better alternative, as it includes intrinsic fallback capabilities.</p>
+							<p id="confreq-html-vocab-embed">Since the [[HTML]] <a data-lt="embed"><code>embed</code>
+									element</a> element does not include intrinsic facilities to provide fallback
+								content for reading systems that do not support scripting, <a>EPUB creators</a> are
+								discouraged from using the element when the referenced resource includes scripting. The
+								[[HTML]] <a data-lt="object"><code>object</code> element</a> is a better alternative, as
+								it includes intrinsic fallback capabilities.</p>
 						</section>
 					</section>
 				</section>
 			</section>
 
 			<section id="sec-svg">
-				<h3>SVG Content Documents</h3>
+				<h3>SVG content documents</h3>
 
 				<div class="caution">
-					<p><a>Reading Systems</a> may not support all the features of [[SVG]] or supported them across all
-						platforms that Reading Systems run on. When utilizing such features, <a>EPUB Creators</a> should
+					<p><a>Reading systems</a> may not support all the features of [[SVG]] or supported them across all
+						platforms that reading systems run on. When utilizing such features, <a>EPUB creators</a> should
 						consider the inherent risks on interoperability and document longevity.</p>
 				</div>
 
@@ -6001,27 +5992,27 @@ No Entry</pre>
 					<p>The Scalable Vector Graphics (SVG) specification [[SVG]] defines a format for representing
 						final-form vector graphics and text.</p>
 
-					<p>Although <a>EPUB Creators</a> typically use <a href="#sec-xhtml">XHTML Content Documents</a> as
-						the <a data-lt="Top-level Content Document">top-level</a> document type, the use of <a>SVG
-							Content Documents</a> is also permitted. EPUB Creators will typically only need SVGs for
+					<p>Although <a>EPUB creators</a> typically use <a href="#sec-xhtml">XHTML content documents</a> as
+						the <a data-lt="top-level content document">top-level</a> document type, the use of <a>SVG
+							content documents</a> is also permitted. EPUB creators will typically only need SVGs for
 						certain special cases, such as when final-form page images are the only suitable representation
 						of the content (e.g., for cover art or in the context of manga or comic books).</p>
 
 					<p>This section defines a profile for [[SVG]] documents. An instance of an XML document that
-						conforms to this profile is a <a>Core Media Type Resource</a> and is referred to in this
-						specification as an <a>SVG Content Document</a>.</p>
+						conforms to this profile is a <a>core media type resource</a> and is referred to in this
+						specification as an <a>SVG content document</a>.</p>
 
 					<div class="note">
-						<p>This section defines conformance requirements for <a>SVG Content Documents</a>. Refer to <a
+						<p>This section defines conformance requirements for <a>SVG content documents</a>. Refer to <a
 								href="#sec-xhtml-svg"></a> for the conformance requirements for SVG embedded in XHTML
-							Content Documents.</p>
+							content documents.</p>
 					</div>
 				</section>
 
 				<section id="sec-svg-req">
 					<h4>SVG requirements</h4>
 
-					<p>An SVG Content Document:</p>
+					<p>An SVG content document:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -6038,8 +6029,8 @@ No Entry</pre>
 						</li>
 					</ul>
 					<div class="note">
-						<p>The recommendation that EPUB Publications follow the accessibility requirements in
-							[[EPUB-A11Y-11]] applies to SVG Content Documents. See <a href="#confreq-a11y"
+						<p>The recommendation that EPUB publications follow the accessibility requirements in
+							[[EPUB-A11Y-11]] applies to SVG content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -6047,8 +6038,8 @@ No Entry</pre>
 				<section id="sec-svg-restrictions">
 					<h4>Restrictions on SVG</h4>
 
-					<p>This specification restricts the content model of <a>SVG Content Documents</a> and <a
-							href="#sec-xhtml-svg">SVG embedded in XHTML Content Documents</a> as follows:</p>
+					<p>This specification restricts the content model of <a>SVG content documents</a> and <a
+							href="#sec-xhtml-svg">SVG embedded in XHTML content documents</a> as follows:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -6057,15 +6048,15 @@ No Entry</pre>
 										><code>foreignObject</code></a> element:</p>
 							<ul class="conformance-list">
 								<li>
-									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[HTML]] 
-										<a>flow content</a> or exactly one [[HTML]] [^body^] element.</p>
+									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[HTML]] <a>flow
+											content</a> or exactly one [[HTML]] [^body^] element.</p>
 									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
 											<code>body</code> element is not permitted per the <a data-cite="html#svg-0"
 											>restrictions on SVG</a> defined in [[HTML]].</p>
 								</li>
 								<li>
 									<p id="confreq-svg-foreignObject-xhtml-frag">MUST contain a valid document fragment
-										that conforms to the XHTML Content Document model defined in <a
+										that conforms to the XHTML content document model defined in <a
 											href="#sec-xhtml-req"></a>.</p>
 								</li>
 							</ul>
@@ -6073,7 +6064,7 @@ No Entry</pre>
 						<li>
 							<p id="confreq-svg-title">The [[SVG]] <a
 									href="https://www.w3.org/TR/SVG/struct.html#TitleElement"><code>title</code></a>
-								element MUST contain only valid <a href="#sec-xhtml-req">XHTML Content Document Phrasing
+								element MUST contain only valid <a href="#sec-xhtml-req">XHTML content document Phrasing
 									content</a>.</p>
 						</li>
 					</ul>
@@ -6083,8 +6074,8 @@ No Entry</pre>
 			<section id="sec-common-resource-req">
 				<h3>Common resource requirements</h3>
 
-				<p>This section defines requirements for technologies usable in both XHTML and SVG Content
-					Documents.</p>
+				<p>This section defines requirements for technologies usable in both XHTML and SVG content
+					documents.</p>
 
 				<section id="sec-css">
 					<h3>Cascading Style Sheets (CSS)</h3>
@@ -6102,13 +6093,13 @@ No Entry</pre>
 							section, EPUB defers to the W3C to define CSS.</p>
 
 						<div class="note">
-							<p>Keep in mind that some <a>Reading Systems</a> will not support all desired features of
+							<p>Keep in mind that some <a>reading systems</a> will not support all desired features of
 								CSS. The following are known to be particularly problematic:</p>
 
 							<ul>
 								<li>
-									<p>Reading System-induced pagination can interact poorly with style sheets as
-										Reading Systems sometimes paginate using columns. This may result in incorrect
+									<p>Reading system-induced pagination can interact poorly with style sheets as
+										reading systems sometimes paginate using columns. This may result in incorrect
 										values for viewport sizes. Fixed and absolute positioning are particularly
 										problematic.</p>
 								</li>
@@ -6131,8 +6122,7 @@ No Entry</pre>
 									exceptions:</p>
 								<ul class="conformance-list">
 									<li>
-										<p id="confreq-css-props-exc-direction">It MUST NOT include the 											
-											<a
+										<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
 												data-cite="css-writing-modes-3#direction"><code>direction</code>
 												property</a> [[CSS-Writing-Modes-3]].</p>
 									</li>
@@ -6154,21 +6144,21 @@ No Entry</pre>
 						</ul>
 						<div class="note">
 							<p>This specification restricts the use of the <code>direction</code> and
-									<code>unicode-bidi</code> properties because Reading Systems may not implement, or
-								may switch off, CSS processing. EPUB Creators must use the following format-specific
+									<code>unicode-bidi</code> properties because reading systems may not implement, or
+								may switch off, CSS processing. EPUB creators must use the following format-specific
 								methods when they need control over these aspects of the rendering:</p>
 
 							<ul>
 								<li>
-									<p>the [^html-global/dir^] attribute [[HTML]]
-										and <a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
+									<p>the [^html-global/dir^] attribute [[HTML]] and <a
+											href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
 												><code>direction</code></a> attribute [[SVG]] for inline base
 										directionality.</p>
 								</li>
 								<li>
-									<p>the <a><code>bdo</code></a> element with the 
-										[^html-global/dir^] attribute [[HTML]]
-										and the <a href="https://www.w3.org/TR/SVG/styling.html#PresentationAttributes"
+									<p>the <a><code>bdo</code></a> element with the [^html-global/dir^]
+										attribute [[HTML]] and the <a
+											href="https://www.w3.org/TR/SVG/styling.html#PresentationAttributes"
 											>presentation attribute alternative</a> for <code>unicode-bidi</code>
 										[[SVG]] for bidirectionality.</p>
 								</li>
@@ -6187,13 +6177,13 @@ No Entry</pre>
 								href="#css-prefixes"></a>. </p>
 
 						<div class="caution">
-							<p><a>EPUB Creators</a> should use unprefixed properties and <a>Reading Systems</a> should
+							<p><a>EPUB creators</a> should use unprefixed properties and <a>reading systems</a> should
 								support current CSS specifications. This specification retains the widely used prefixed
 								properties from [[EPUBContentDocs-301]] but removes support for the less-used ones. EPUB
-								Creators should use CSS-native solutions for the removed properties whenever
+								creators should use CSS-native solutions for the removed properties whenever
 								available.</p>
 
-							<p>The Working Group recommends that EPUB Creators currently using these prefixed properties
+							<p>The Working Group recommends that EPUB creators currently using these prefixed properties
 								move to unprefixed versions as soon as support allows, as the Working Group does not
 								anticipate supporting them in the next major version of EPUB.</p>
 						</div>
@@ -6206,15 +6196,15 @@ No Entry</pre>
 					<section id="sec-scripted-support">
 						<h4>Script inclusion</h4>
 
-						<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in
-							the respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB Content
-							Document contains scripting, this specification refers to it as a <a>Scripted Content
-								Document</a>. This label also applies to <a>XHTML Content Documents</a> when they
+						<p><a>EPUB content documents</a> MAY contain scripting using the facilities defined for this in
+							the respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB content
+							document contains scripting, this specification refers to it as a <a>scripted content
+								document</a>. This label also applies to <a>XHTML content documents</a> when they
 							contain instances of [[HTML]] <a>forms</a>.</p>
 
 						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
-							<code>item</code> element is used to indicate that an EPUB Content Document is a <a>Scripted
-								Content Document</a>.</p>
+							<code>item</code> element is used to indicate that an EPUB content document is a <a>scripted
+								content document</a>.</p>
 
 						<p>When an [[HTML]] <code>script</code> element contains a <a data-cite="html#data-block">data
 								block</a> [[HTML]], it does not represent scripted content.</p>
@@ -6224,18 +6214,17 @@ No Entry</pre>
 								if a future update adds the concept.</p>
 						</div>
 
-						<p>EPUB Creators should note that Reading Systems are required to behave as though a unique 
-							<a>origin</a> [[URL]] has been assigned to each EPUB Publication. In
-							practice, this means that it is not possible for scripts to share data between EPUB
-							Publications.</p>
+						<p>EPUB creators should note that reading systems are required to behave as though a unique
+								<a>origin</a> [[URL]] has been assigned to each EPUB publication. In practice, this
+							means that it is not possible for scripts to share data between EPUB publications.</p>
 
 						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
-							rights and restrictions that a Reading System places on it (refer to <a
+							rights and restrictions that a reading system places on it (refer to <a
 								data-cite="epub-rs-33#sec-scripted-content">Scripting Conformance</a> [[?EPUB-RS-33]]
 							for more information).</p>
 
 						<div class="note">
-							<p>Reading Systems may render Scripted Content Documents in a manner that disables other
+							<p>Reading systems may render scripted content documents in a manner that disables other
 								EPUB capabilities and/or provides a different rendering and user experience (e.g., by
 								disabling pagination).</p>
 						</div>
@@ -6250,23 +6239,23 @@ No Entry</pre>
 							<li><a href="#sec-scripted-container-constrained">container constrained</a> &#8212; when the
 								execution of a script occurs within an <code>iframe</code>; and</li>
 							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a script
-								occurs directly within a <a>Top-level Content Document</a>.</li>
+								occurs directly within a <a>top-level content document</a>.</li>
 						</ul>
 
 						<div class="note">
-							<p>Scripts may execute in other contexts, but Reading System support for these contexts is
+							<p>Scripts may execute in other contexts, but reading system support for these contexts is
 								optional. For example, a scripted SVG document may be referenced from an [[HTML]] <a
 									data-lt="object"><code>object</code> element</a>.</p>
 							<p>Refer to the <a href="https://www.w3.org/TR/epub-rs-33#sec-scripted-content">processing
 									of scripts</a> [[EPUB-RS-33]] for more information.</p>
 						</div>
 
-						<p>Whether EPUB Creators embed the code directly in the <code>script</code> element or reference
+						<p>Whether EPUB creators embed the code directly in the <code>script</code> element or reference
 							it via the element's <code>src</code> attribute makes no difference to its executing
 							context.</p>
 
-						<p>Which context EPUB Creators use for their scripts affects both what actions the scripts can
-							perform and the likelihood of support in Reading Systems, as described in the following
+						<p>Which context EPUB creators use for their scripts affects both what actions the scripts can
+							perform and the likelihood of support in reading systems, as described in the following
 							subsections.</p>
 
 						<div class="note">
@@ -6279,35 +6268,34 @@ No Entry</pre>
 							<p>A <em>container-constrained script</em> is either of the following:</p>
 							<ul>
 								<li>
-									<p>An instance of the [[HTML]] [^script^] element contained in an <a>XHTML Content
-											Document</a> that is embedded in an XHTML Content Document using the
-										[[HTML]] <a data-lt="iframe"><code>iframe</code></a>
-										element.</p>
+									<p>An instance of the [[HTML]] [^script^] element contained in an <a>XHTML content
+											document</a> that is embedded in an XHTML content document using the
+										[[HTML]] <a data-lt="iframe"><code>iframe</code></a> element.</p>
 								</li>
 								<li>
 									<p>An instance of the [[SVG]] <a
 											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
-												><code>script</code></a> element contained in an <a>SVG Content
-											Document</a> that is embedded in a XHTML Content Document using the [[HTML]]
-											<a><code>iframe</code></a> element.</p>
+												><code>script</code></a> element contained in an <a>SVG content
+											document</a> that is embedded in a XHTML content document using the [[HTML]]
+												<a><code>iframe</code></a> element.</p>
 								</li>
 							</ul>
 
 							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
-								instructions for modifying the DOM of the EPUB Content Document that embeds it (i.e.,
+								instructions for modifying the DOM of the EPUB content document that embeds it (i.e.,
 								the one that contains the <code>iframe</code> element). It also MUST NOT contain
 								instructions for manipulating the size of its containing rectangle.</p>
 
-							<p>EPUB Creators should note that <a data-cite="epub-rs-33#sec-scripted-content">support for
-									container-constrained scripting in Reading Systems</a> is only recommended in
-								reflowable documents [[EPUB-RS-33]]. Furthermore, Reading System support in
+							<p>EPUB creators should note that <a data-cite="epub-rs-33#sec-scripted-content">support for
+									container-constrained scripting in reading systems</a> is only recommended in
+								reflowable documents [[EPUB-RS-33]]. Furthermore, reading system support in
 								fixed-layouts EPUBs is optional.</p>
 
-							<p>EPUB Creators should ensure container-constrained scripts degrade gracefully in Reading
-								Systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
+							<p>EPUB creators should ensure container-constrained scripts degrade gracefully in reading
+								systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
 
 							<div class="note">
-								<p>EPUB Creators choosing to restrict the usage of scripting to the
+								<p>EPUB creators choosing to restrict the usage of scripting to the
 									container-constrained model will ensure a more consistent user experience between
 									scripted and non-scripted content (e.g., consistent pagination behavior).</p>
 							</div>
@@ -6318,38 +6306,38 @@ No Entry</pre>
 
 							<p>A <em>spine-level script</em> is an instance of the [[HTML]] [^script^] or [[SVG]] <a
 									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
-								element contained in a <a>Top-level Content Document</a>.</p>
+								element contained in a <a>top-level content document</a>.</p>
 
-							<p>EPUB Creators should note that support for spine-level scripting in Reading Systems is
+							<p>EPUB creators should note that support for spine-level scripting in reading systems is
 								only recommended in <a data-cite="epub-rs-33#confreq-rs-scripted-fxl-support"
 									>fixed-layout documents</a> and <a
 									data-cite="epub-rs-33#confreq-rs-scripted-scrolled">reflowable documents set to
-									scroll</a> [[EPUB-RS-33]]. Furthermore, Reading System support in all other contexts
+									scroll</a> [[EPUB-RS-33]]. Furthermore, reading system support in all other contexts
 								is optional.</p>
 
-							<p id="confreq-cd-scripted-spine"><a>Top-level Content Documents</a> that include
+							<p id="confreq-cd-scripted-spine"><a>Top-level content documents</a> that include
 								spine-level scripting SHOULD remain consumable by the user without any information loss
 								or other significant deterioration when scripting is disabled or not available (e.g., by
 								employing progressive enhancement techniques or <a href="#sec-scripted-fallbacks"
-									>fallbacks</a>). Failing to account for non-scripted environments in Top-level
-								Content Documents can result in EPUB Publications being unreadable.</p>
+									>fallbacks</a>). Failing to account for non-scripted environments in top-level
+								content documents can result in EPUB publications being unreadable.</p>
 						</section>
 					</section>
 
 					<section id="sec-scripted-content-events" class="informative">
 						<h4>Event model</h4>
 
-						<p><a>EPUB Creators</a> should consider the wide variety of possible Reading System
-							implementations when adding scripting functionality to their EPUB Publications (e.g., not
+						<p><a>EPUB creators</a> should consider the wide variety of possible reading system
+							implementations when adding scripting functionality to their EPUB publications (e.g., not
 							all devices have physical keyboards, and in many cases a soft keyboard is activated only for
-							text input elements). Consequently, EPUB Creators should not rely on keyboard events alone;
+							text input elements). Consequently, EPUB creators should not rely on keyboard events alone;
 							they should always provide alternative ways to trigger a desired action.</p>
 					</section>
 
 					<section id="sec-scripted-a11y">
 						<h4>Scripting accessibility</h4>
 
-						<p id="confreq-cd-scripted-a11y">EPUB Content Documents that contain scripting SHOULD employ
+						<p id="confreq-cd-scripted-a11y">EPUB content documents that contain scripting SHOULD employ
 							relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable
 							by all users.</p>
 					</section>
@@ -6357,49 +6345,48 @@ No Entry</pre>
 					<section id="sec-scripted-fallbacks">
 						<h4 id="confreq-cd-scripted-flbk">Scripting fallbacks</h4>
 
-						<p id="confreq-cd-scripted-fallback">EPUB Content Documents that contain scripting MAY provide
+						<p id="confreq-cd-scripted-fallback">EPUB content documents that contain scripting MAY provide
 							fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
-							available for the [[HTML]] <a><code>object</code></a>
-							and <a><code>canvas</code></a> elements) or, when an
-							intrinsic fallback is not applicable, by using a <a href="#sec-manifest-fallbacks"
-								>manifest-level fallback</a>.</p>
+							available for the [[HTML]] <a><code>object</code></a> and <a><code>canvas</code></a>
+							elements) or, when an intrinsic fallback is not applicable, by using a <a
+								href="#sec-manifest-fallbacks">manifest-level fallback</a>.</p>
 
-						<p id="confreq-cd-scripted-foreign-resources">EPUB Creators MUST ensure that scripts only
-							generate <a href="#sec-core-media-types">Core Media Type Resources</a> or fragments
+						<p id="confreq-cd-scripted-foreign-resources">EPUB creators MUST ensure that scripts only
+							generate <a href="#sec-core-media-types">core media type resources</a> or fragments
 							thereof.</p>
 					</section>
 				</section>
 			</section>
 		</section>
 		<section id="sec-nav">
-			<h2>EPUB Navigation Document</h2>
+			<h2>EPUB navigation document</h2>
 
 			<section id="sec-nav-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>The EPUB Navigation Document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
-						Publication</a>. It allows <a>EPUB Creators</a> to include a human- and machine-readable global
+				<p>The EPUB navigation document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
+						publication</a>. It allows <a>EPUB creators</a> to include a human- and machine-readable global
 					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
 
-				<p>The EPUB Navigation Document is a special type of <a>XHTML Content Document</a> that defines the <a
-						href="#sec-nav-toc">table of contents</a> for <a>Reading Systems</a>. It may also include other
+				<p>The EPUB navigation document is a special type of <a>XHTML content document</a> that defines the <a
+						href="#sec-nav-toc">table of contents</a> for <a>reading systems</a>. It may also include other
 					specialized navigation elements, such as a <a href="#sec-nav-pagelist">page list</a> and a list of
 					key <a href="#sec-nav-landmarks">landmarks</a>. These navigation elements have <a
 						href="#sec-nav-def-model">additional restrictions</a> on their content to facilitate their
 					processing.</p>
 
-				<p>The EPUB Navigation Document is not exclusively for machine processing, however. There are no
-					restrictions on the structure or content of the EPUB Navigation Document outside of the specialized
-					navigation elements (i.e., EPUB Creators can mark the rest of the document up like any other XHTML
-					Content Document). As a result, it can also be part of the linear reading order, avoiding the need
-					for duplicate tables of contents. EPUB Creators can hide navigation elements that are only for
+				<p>The EPUB navigation document is not exclusively for machine processing, however. There are no
+					restrictions on the structure or content of the EPUB navigation document outside of the specialized
+					navigation elements (i.e., EPUB creators can mark the rest of the document up like any other XHTML
+					content document). As a result, it can also be part of the linear reading order, avoiding the need
+					for duplicate tables of contents. EPUB creators can hide navigation elements that are only for
 					machine processing (e.g., the page list) with the <a href="#sec-nav-doc-use-spine"
 							><code>hidden</code> attribute</a>.</p>
 
-				<p>Note that Reading Systems may strip scripting, styling, and HTML formatting as they generate
-					navigational interfaces from information found in the EPUB Navigation Document, and this may make
-					the result difficult to read. If EPUB Creators require such formatting and functionality, then they
-					should also include the EPUB Navigation Document in the <a>spine</a>. The use of progressive
+				<p>Note that reading systems may strip scripting, styling, and HTML formatting as they generate
+					navigational interfaces from information found in the EPUB navigation document, and this may make
+					the result difficult to read. If EPUB creators require such formatting and functionality, then they
+					should also include the EPUB navigation document in the <a>spine</a>. The use of progressive
 					enhancement techniques for scripting and styling of the navigation document will help ensure the
 					content will retain its integrity when rendered in a non-browser context.</p>
 			</section>
@@ -6408,7 +6395,7 @@ No Entry</pre>
 				<h3>The <code>nav</code> element: restrictions</h3>
 
 				<p>When a <code>nav</code> element carries the <a href="#sec-epub-type-attribute"><code>epub:type</code>
-						attribute</a> in an <a>EPUB Navigation Document</a>, this specification restricts the content
+						attribute</a> in an <a>EPUB navigation document</a>, this specification restricts the content
 					model of the element and its descendants as follows:</p>
 
 				<dl class="elemdef">
@@ -6471,8 +6458,7 @@ No Entry</pre>
 								</ul>
 							</dd>
 
-							<dt><a><code>span</code></a> and 
-								<a><code>a</code></a></dt>
+							<dt><a><code>span</code></a> and <a><code>a</code></a></dt>
 							<dd>
 								<p>In any order:</p>
 								<ul class="nomark">
@@ -6502,7 +6488,7 @@ No Entry</pre>
 						<p id="confreq-nav-a">Each list item of the ordered list represents a heading, structure, or
 							other item of interest. A child <code>a</code> element describes the target that the link
 							points to, while a <code>span</code> element serves as a heading for breaking down lists
-							into distinct groups (for example, an EPUB Creator could segment a large list of
+							into distinct groups (for example, an EPUB creator could segment a large list of
 							illustrations into several lists, one for each chapter).</p>
 					</li>
 					<li>
@@ -6514,9 +6500,9 @@ No Entry</pre>
 					</li>
 					<li>
 						<p id="confreq-nav-a-title">If an <code>a</code> or <code>span</code> element contains instances
-							of <a data-lt="embedded content">HTML embedded content</a> that do not provide
-							intrinsic text alternatives, the element MUST also contain a <code>title</code> attribute
-							with an alternate text rendering of the link label.</p>
+							of <a data-lt="embedded content">HTML embedded content</a> that do not provide intrinsic
+							text alternatives, the element MUST also contain a <code>title</code> attribute with an
+							alternate text rendering of the link label.</p>
 					</li>
 					<li>
 						<p id="confreq-nav-a-href">The URL [[URL]] reference provided in the <code>href</code> attribute
@@ -6526,12 +6512,12 @@ No Entry</pre>
 								<p id="confreq-nav-a-href-default">MUST, in the case of the <a href="#sec-nav-toc"
 											><code>toc nav</code></a>, <a href="#sec-nav-landmarks"><code>landmarks
 											nav</code></a> and <a href="#sec-nav-pagelist"><code>page-list
-										nav</code></a>, resolve to a <a>Top-level Content Document</a> or fragment
+										nav</code></a>, resolve to a <a>top-level content document</a> or fragment
 									therein.</p>
 							</li>
 							<li>
 								<p id="confreq-nav-a-href-other">MAY, for all other <code>nav</code> types, also
-									reference content outside the <a>EPUB Container</a> (e.g., web-hosted
+									reference content outside the <a>EPUB container</a> (e.g., web-hosted
 									resources).</p>
 							</li>
 						</ul>
@@ -6579,13 +6565,13 @@ No Entry</pre>
 &lt;/nav></pre>
 				</aside>
 
-				<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML Content Document, EPUB Creators MAY include
-					the EPUB Navigation Document in the <a href="#sec-spine-elem">spine</a>.</p>
+				<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML content document, EPUB creators MAY include
+					the EPUB navigation document in the <a href="#sec-spine-elem">spine</a>.</p>
 
 				<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
 					items within <code>nav</code> elements is equivalent to the <a
 						href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:</code>
-						<code>none</code> property</a> [[CSSSnapshot]]. <a>EPUB Creators</a> MAY specify alternative
+						<code>none</code> property</a> [[CSSSnapshot]]. <a>EPUB creators</a> MAY specify alternative
 					list styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
 							><code>spine</code></a>.</p>
 			</section>
@@ -6596,7 +6582,7 @@ No Entry</pre>
 				<section id="sec-nav-def-types-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>The <code>nav</code> elements defined in an EPUB Navigation Document are distinguished
+					<p>The <code>nav</code> elements defined in an EPUB navigation document are distinguished
 						semantically by the value of their <a href="#sec-epub-type-attribute"><code>epub:type</code>
 							attribute</a>.</p>
 
@@ -6611,8 +6597,8 @@ No Entry</pre>
 						<dd>
 							<p>Identifies the <code>nav</code> element that contains the table of contents. The
 									<code>toc</code>
-								<code>nav</code> is the only navigation aid that EPUB Creators must include in the EPUB
-								Navigation Document.</p>
+								<code>nav</code> is the only navigation aid that EPUB creators must include in the EPUB
+								navigation document.</p>
 						</dd>
 
 						<dt>
@@ -6635,9 +6621,9 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p>An EPUB Navigation Document may contain at most one navigation aid for each of these types.</p>
+					<p>An EPUB navigation document may contain at most one navigation aid for each of these types.</p>
 
-					<p>The EPUB Navigation Document may include additional navigation types. See <a
+					<p>The EPUB navigation document may include additional navigation types. See <a
 							href="#sec-nav-def-types-other"></a> for more information.</p>
 				</section>
 
@@ -6650,18 +6636,18 @@ No Entry</pre>
 						sections of the publication).</p>
 
 					<p>The <code>toc</code>
-						<code>nav</code> element MUST occur exactly once in an EPUB Navigation Document.</p>
+						<code>nav</code> element MUST occur exactly once in an EPUB navigation document.</p>
 
-					<p>EPUB Creators SHOULD order the references in the <code>toc</code>
+					<p>EPUB creators SHOULD order the references in the <code>toc</code>
 						<code>nav</code> element such that they reflect both:</p>
 
 					<ul>
 						<li>
-							<p>the order of the <a href="#confreq-nav-a-href">referenced EPUB Content Documents</a> in
+							<p>the order of the <a href="#confreq-nav-a-href">referenced EPUB content documents</a> in
 								the <a>spine</a>; and</p>
 						</li>
 						<li>
-							<p>the order of the targeted elements within their respective EPUB Content Documents.</p>
+							<p>the order of the targeted elements within their respective EPUB content documents.</p>
 						</li>
 					</ul>
 				</section>
@@ -6671,18 +6657,18 @@ No Entry</pre>
 
 					<p>The <code>page-list</code> element provides navigation to static page boundaries in the content.
 						These boundaries may correspond to a statically paginated source such as print or may be defined
-						exclusively for the <a>EPUB Publication</a>.</p>
+						exclusively for the <a>EPUB publication</a>.</p>
 
 					<p>The <code>page-list</code>
-						<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more than
+						<code>nav</code> element is OPTIONAL in EPUB navigation documents and MUST NOT occur more than
 						once.</p>
 
 					<p>The <code>page-list</code>
 						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
 						nested sublists).</p>
 
-					<p>EPUB Creators MAY identify the destinations of the <code>page-list</code> references in their
-						respective EPUB Content Documents using the <a data-cite="epub-ssv-11/#pagebreak"
+					<p>EPUB creators MAY identify the destinations of the <code>page-list</code> references in their
+						respective EPUB content documents using the <a data-cite="epub-ssv-11/#pagebreak"
 								><code>pagebreak</code> term</a> [[EPUB-SSV-11]].</p>
 				</section>
 
@@ -6691,11 +6677,11 @@ No Entry</pre>
 
 					<p>The <code>landmarks</code>
 						<code>nav</code> element identifies fundamental structural components in the content to enable
-						Reading Systems to provide the user efficient access to them (e.g., through a dedicated button
+						reading systems to provide the user efficient access to them (e.g., through a dedicated button
 						in the user interface).</p>
 
 					<p>The <code>landmarks</code>
-						<code>nav</code> element is OPTIONAL in EPUB Navigation Documents and MUST NOT occur more than
+						<code>nav</code> element is OPTIONAL in EPUB navigation documents and MUST NOT occur more than
 						once.</p>
 
 					<p>The <code>landmarks</code>
@@ -6741,18 +6727,18 @@ No Entry</pre>
 						<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code> value
 						that reference the same resource, or fragment thereof.</p>
 
-					<p>EPUB Creators should limit the number of items they define in the <code>landmarks</code>
-						<code>nav</code> to only items that a Reading System is likely to use in its user interface. The
+					<p>EPUB creators should limit the number of items they define in the <code>landmarks</code>
+						<code>nav</code> to only items that a reading system is likely to use in its user interface. The
 						element is not meant to repeat the table of contents.</p>
 
 					<p>The following landmarks are recommended to include when available:</p>
 
 					<ul>
 						<li><a data-cite="epub-ssv-11#bodymatter"><code>bodymatter</code></a> [[?EPUB-SSV-11]] &#8212;
-							Reading Systems often use this landmark to automatically jump users past the front matter
+							Reading systems often use this landmark to automatically jump users past the front matter
 							when they begin reading.</li>
 						<li><a data-cite="epub-ssv-11#toc-1"><code>toc</code></a> [[?EPUB-SSV-11]] &#8212; If the table
-							of contents is available in the spine, Reading Systems may use this landmark to take users
+							of contents is available in the spine, reading systems may use this landmark to take users
 							to the document containing it.</li>
 					</ul>
 
@@ -6760,18 +6746,18 @@ No Entry</pre>
 						<code>nav</code> are key reference sections such as indexes and glossaries.</p>
 
 					<p>Although the <code>landmarks</code>
-						<code>nav</code> is intended for Reading System use, EPUB Creators should still ensure that the
+						<code>nav</code> is intended for reading system use, EPUB creators should still ensure that the
 						labels for the <code>landmarks</code>
-						<code>nav</code> are human readable. Reading Systems may expose the links directly to users.</p>
+						<code>nav</code> are human readable. Reading systems may expose the links directly to users.</p>
 				</section>
 
 				<section id="sec-nav-def-types-other">
 					<h4>Other <code>nav</code> elements</h4>
 
-					<p>EPUB Navigation Documents MAY contain one or more <code>nav</code> elements in addition to the
+					<p>EPUB navigation documents MAY contain one or more <code>nav</code> elements in addition to the
 							<code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
 						<code>nav</code> elements defined in the preceding sections. If these <code>nav</code> elements
-						are intended for Reading System processing, they MUST have an <a href="#sec-epub-type-attribute"
+						are intended for reading system processing, they MUST have an <a href="#sec-epub-type-attribute"
 								><code>epub:type</code> attribute</a> and are subject to the content model restrictions
 						defined in <a href="#sec-nav-def-model"></a>.</p>
 
@@ -6780,7 +6766,7 @@ No Entry</pre>
 						contain link targets with homogeneous or heterogeneous semantics.</p>
 
 					<aside class="example" title="Adding a custom navigation element">
-						<p>In this example, the <code>lot</code> semantic indicates that the EPUB Creator is adding a
+						<p>In this example, the <code>lot</code> semantic indicates that the EPUB creator is adding a
 							"list of tables" navigation element.</p>
 
 						<pre>&lt;nav
@@ -6813,26 +6799,26 @@ No Entry</pre>
 			<section id="sec-nav-doc-use-spine" class="informative">
 				<h3>Using in the spine</h3>
 
-				<p>Although it is possible to reuse the EPUB Navigation Document in the <a>spine</a>, it is often the
+				<p>Although it is possible to reuse the EPUB navigation document in the <a>spine</a>, it is often the
 					case that not all of the navigation structures, or branches within them, are needed. <a>EPUB
-						Creators</a> will often want to hide the <a href="#sec-nav-pagelist">page list</a> and <a
+						creators</a> will often want to hide the <a href="#sec-nav-pagelist">page list</a> and <a
 						href="#sec-nav-landmarks">landmarks</a> navigation elements or trim the branches of the table of
 					contents for books that have many levels of subsections.</p>
 
 				<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
-						property</a> [[CSSSnapshot]] controls the visual rendering of EPUB Navigation Documents in
-					Reading Systems with <a>Viewports</a>, Reading Systems without Viewports may not support CSS. To
-					better ensure the proper rendering in these Reading Systems, EPUB Creators should use the [[HTML]]
-						[^html-global/hidden^] attribute to indicate which (if
-					any) portions of the navigation data are excluded from rendering in the content flow.</p>
+						property</a> [[CSSSnapshot]] controls the visual rendering of EPUB navigation documents in
+					reading systems with <a>viewports</a>, reading systems without viewports may not support CSS. To
+					better ensure the proper rendering in these reading systems, EPUB creators should use the [[HTML]]
+					[^html-global/hidden^] attribute to indicate which (if any) portions of the navigation data are
+					excluded from rendering in the content flow.</p>
 
-				<p>The <code>hidden</code> attribute has no effect on how Reading Systems render the navigation data
-					outside of the content flow (such as in dedicated navigation user interfaces provided by Reading
-					Systems).</p>
+				<p>The <code>hidden</code> attribute has no effect on how reading systems render the navigation data
+					outside of the content flow (such as in dedicated navigation user interfaces provided by reading
+					systems).</p>
 
 				<div class="note">
 					<p>The <code>hidden</code> attribute can be used together with the <code>display</code> property to
-						maximize interoperability across all Reading Systems.</p>
+						maximize interoperability across all reading systems.</p>
 				</div>
 
 				<aside class="example" title="Hiding a nav element in spine">
@@ -6903,10 +6889,10 @@ No Entry</pre>
 					upon. For example, although HTML with CSS provides powerful layout capabilities, those capabilities
 					are limited to the scope of the document being rendered.</p>
 
-				<p>This section defines properties that allow EPUB Creators to express package-level rendering
-					intentions (i.e., functionality that can only be implemented by the <a>EPUB Reading System</a>). If
-					a Reading System supports the desired rendering, these properties enable the user to be presented
-					the content as the EPUB Creator optimally designed it.</p>
+				<p>This section defines properties that allow EPUB creators to express package-level rendering
+					intentions (i.e., functionality that can only be implemented by the <a>EPUB reading system</a>). If
+					a reading system supports the desired rendering, these properties enable the user to be presented
+					the content as the EPUB creator optimally designed it.</p>
 			</section>
 
 			<section id="sec-fixed-layouts">
@@ -6923,19 +6909,19 @@ No Entry</pre>
 
 					<p>But this principle does not work for all types of documents. Sometimes content and design are so
 						intertwined it is not possible to separate them. Any change in appearance risks changing the
-						meaning or losing all meaning. <a>Fixed-Layout Documents</a> give <a>EPUB Creators</a> greater
+						meaning or losing all meaning. <a>fixed-layout documents</a> give <a>EPUB creators</a> greater
 						control over presentation when a reflowable EPUB is not suitable for the content.</p>
 
-					<p>EPUB Creators define fixed layouts using a <a href="#sec-fxl-package">set of Package Document
-							properties</a> to control the rendering in <a>Reading Systems</a>. In addition, they set <a
-							href="#sec-fxl-package">the dimensions of each Fixed-Layout Document</a> in its respective
-						EPUB Content Document.</p>
+					<p>EPUB creators define fixed layouts using a <a href="#sec-fxl-package">set of package document
+							properties</a> to control the rendering in <a>reading systems</a>. In addition, they set <a
+							href="#sec-fxl-package">the dimensions of each fixed-layout document</a> in its respective
+						EPUB content document.</p>
 
 					<div class="note" id="note-mechanisms">
 						<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
-							content is necessary, the EPUB Creator's choice of mechanism will depend on many factors
+							content is necessary, the EPUB creator's choice of mechanism will depend on many factors
 							including desired degree of precision, file size, accessibility, etc. This section does not
-							attempt to dictate the EPUB Creator's choice of mechanism.</p>
+							attempt to dictate the EPUB creator's choice of mechanism.</p>
 					</div>
 				</section>
 
@@ -6952,27 +6938,27 @@ No Entry</pre>
 								property</a> is specified on a <code>meta</code> element, it indicates that the
 							paginated or reflowable layout style applies globally (i.e., for all spine items).</p>
 
-						<p>EPUB Creators MUST use one of the following values with the <code>rendition:layout</code>
+						<p>EPUB creators MUST use one of the following values with the <code>rendition:layout</code>
 							property:</p>
 
 						<dl class="variablelist">
 							<dt id="def-layout-reflowable">reflowable</dt>
 							<dd>
-								<p>The content is not pre-paginated (i.e., Reading Systems apply dynamic pagination when
+								<p>The content is not pre-paginated (i.e., reading systems apply dynamic pagination when
 									rendering). Default value.</p>
 							</dd>
 
 							<dt id="def-layout-pre-paginated">pre-paginated</dt>
 							<dd>
-								<p>The content is pre-paginated (i.e., Reading Systems produce exactly one page per
+								<p>The content is pre-paginated (i.e., reading systems produce exactly one page per
 									spine <a href="#elemdef-spine-itemref"><code>itemref</code></a> when rendering).</p>
 							</dd>
 						</dl>
 
 						<div class="note" id="uaag">
-							<p>Reading Systems typically restrict or deny the application of user or user agent style
+							<p>Reading systems typically restrict or deny the application of user or user agent style
 								sheets to pre-paginated documents because dynamic style changes are likely to have
-								unintended consequence on the intrinsic properties of such documents. EPUB Creators
+								unintended consequence on the intrinsic properties of such documents. EPUB creators
 								should consider the negative impact on usability and accessibility that these
 								restrictions have when choosing to use pre-paginated instead of reflowable content.
 								Refer to <a data-cite="UAAG20#gl-text-config">Guideline 1.4 - Provide text
@@ -6983,11 +6969,11 @@ No Entry</pre>
 								<code>pre-paginated</code> for a spine item, its content dimensions MUST be set as
 							defined in <a href="#sec-fxl-content-dimensions"></a>.</p>
 
-						<p>EPUB Creators MUST NOT declare the <code>rendition:layout</code> property more than once.</p>
+						<p>EPUB creators MUST NOT declare the <code>rendition:layout</code> property more than once.</p>
 
 						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
 									><code>refines</code> attribute</a>. Refer to <a href="#layout-overrides"></a> for
-							setting the property for individual <a>EPUB Content Documents</a>.</p>
+							setting the property for individual <a>EPUB content documents</a>.</p>
 
 						<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
 							<p>In this example, the document's layout is set to <code>pre-paginated</code>, i.e., it is
@@ -6997,7 +6983,7 @@ No Entry</pre>
 								the content area set in the <code>viewport</code>
 								<code>meta</code> tag is static.</p>
 
-							<p>Package Document</p>
+							<p>Package document:</p>
 
 							<pre>&lt;package …>
    &lt;metadata …>
@@ -7044,7 +7030,7 @@ No Entry</pre>
 						<section id="layout-overrides">
 							<h6>Layout overrides</h6>
 
-							<p id="property-layout-local">EPUB Creators MAY specify the following properties locally on
+							<p id="property-layout-local">EPUB creators MAY specify the following properties locally on
 								spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
 									<a href="#property-layout-global">global value</a> for the given spine item:</p>
 
@@ -7056,14 +7042,14 @@ No Entry</pre>
 								<dd>Specifies that the given spine item is reflowable.</dd>
 							</dl>
 
-							<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
+							<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
 						</section>
 					</section>
 
 					<section id="orientation">
 						<h5>Orientation</h5>
 
-						<p>The <code>rendition:orientation</code> property specifies which orientation the EPUB Creator
+						<p>The <code>rendition:orientation</code> property specifies which orientation the EPUB creator
 							intends the content to be rendered in. </p>
 
 						<p id="property-orientation-global">When the <a href="#orientation"
@@ -7071,18 +7057,18 @@ No Entry</pre>
 							element, it indicates that the intended orientation applies globally (i.e., for all spine
 							items).</p>
 
-						<p>EPUB Creators MUST use one of the following values with the
+						<p>EPUB creators MUST use one of the following values with the
 								<code>rendition:orientation</code> property:</p>
 
 						<dl class="variablelist">
 							<dt>landscape</dt>
 							<dd>
-								<p>Reading Systems should render the content in landscape orientation.</p>
+								<p>Reading systems should render the content in landscape orientation.</p>
 							</dd>
 
 							<dt>portrait</dt>
 							<dd>
-								<p>Reading Systems should render the content in portrait orientation.</p>
+								<p>Reading systems should render the content in portrait orientation.</p>
 							</dd>
 
 							<dt>auto</dt>
@@ -7091,12 +7077,12 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p id="fxl-orientation-duplication" data-tests="#fxl-orientation-duplication">EPUB Creators MUST
+						<p id="fxl-orientation-duplication" data-tests="#fxl-orientation-duplication">EPUB creators MUST
 							NOT declare the <code>rendition:orientation</code> property more than once.</p>
 
 						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
 									><code>refines</code> attribute</a>. Refer to <a href="#orientation-overrides"></a>
-							for setting the property for individual <a>EPUB Content Documents</a>.</p>
+							for setting the property for individual <a>EPUB content documents</a>.</p>
 
 						<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
 							<p>In this example, items in the spine are to be rendered in landscape mode.</p>
@@ -7121,52 +7107,52 @@ No Entry</pre>
 						<section id="orientation-overrides">
 							<h6>Orientation overrides</h6>
 
-							<p id="property-orientation-local">EPUB Creators MAY specify the following properties
+							<p id="property-orientation-local">EPUB creators MAY specify the following properties
 								locally on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
 								override the <a href="#property-orientation-global">global value</a> for the given spine
 								item:</p>
 
 							<dl>
 								<dt id="orientation-auto">rendition:orientation-auto</dt>
-								<dd>Specifies that the Reading System determines the orientation to render the spine
+								<dd>Specifies that the reading system determines the orientation to render the spine
 									item in.</dd>
 
 								<dt id="orientation-landscape">rendition:orientation-landscape</dt>
-								<dd>Specifies that Reading Systems should render the given spine item in landscape
+								<dd>Specifies that reading systems should render the given spine item in landscape
 									orientation.</dd>
 
 								<dt id="orientation-portrait">rendition:orientation-portrait</dt>
-								<dd>Specifies that Reading Systems should render the given spine item in portrait
+								<dd>Specifies that reading systems should render the given spine item in portrait
 									orientation.</dd>
 							</dl>
 
-							<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
+							<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
 						</section>
 					</section>
 
 					<section id="spread">
 						<h5>Synthetic spreads</h5>
 
-						<p>The <code>rendition:spread</code> property specifies the intended Reading System synthetic
+						<p>The <code>rendition:spread</code> property specifies the intended reading system synthetic
 							spread behavior.</p>
 
 						<p id="property-spread-global">When the <code>rendition:spread</code> property is specified on a
-								<code>meta</code> element, it indicates that the intended <a>Synthetic Spread</a>
+								<code>meta</code> element, it indicates that the intended <a>synthetic spread</a>
 							behavior applies globally (i.e., for all spine items).</p>
 
-						<p>EPUB Creators MUST use one of the following values with the <code>rendition:spread</code>
+						<p>EPUB creators MUST use one of the following values with the <code>rendition:spread</code>
 							property:</p>
 
 						<dl class="variablelist">
 							<dt>none</dt>
 							<dd>
-								<p>Do not incorporate spine items in a Synthetic Spread. Reading Systems should display
+								<p>Do not incorporate spine items in a synthetic spread. Reading systems should display
 									the items in a single viewport positioned at the center of the screen.</p>
 							</dd>
 
 							<dt>landscape</dt>
 							<dd>
-								<p>Render a Synthetic Spread for spine items only when the device is in landscape
+								<p>Render a synthetic spread for spine items only when the device is in landscape
 									orientation.</p>
 							</dd>
 
@@ -7174,30 +7160,30 @@ No Entry</pre>
 							<dd>
 								<p>The use of spreads only in portrait orientation is <a href="#deprecated"
 										>deprecated</a>.</p>
-								<p>EPUB Creators should use the value "<code>both</code>" instead, as spreads that are
+								<p>EPUB creators should use the value "<code>both</code>" instead, as spreads that are
 									readable in portrait orientation are also readable in landscape.</p>
 							</dd>
 
 							<dt>both</dt>
 							<dd>
-								<p>Render a Synthetic Spread regardless of device orientation.</p>
+								<p>Render a synthetic spread regardless of device orientation.</p>
 							</dd>
 
 							<dt>auto</dt>
 							<dd>
-								<p>The EPUB Creator is not defining an explicit Synthetic Spread behavior. Default
+								<p>The EPUB creator is not defining an explicit synthetic spread behavior. Default
 									value.</p>
 							</dd>
 						</dl>
 
-						<p>EPUB Creators MUST NOT declare the <code>rendition:spread</code> property more than once.</p>
+						<p>EPUB creators MUST NOT declare the <code>rendition:spread</code> property more than once.</p>
 
 						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
 									><code>refines</code> attribute</a>. Refer to <a href="#spread-overrides"></a> for
-							setting the property for individual <a>EPUB Content Documents</a>.</p>
+							setting the property for individual <a>EPUB content documents</a>.</p>
 
 						<div class="note">
-							<p>When Synthetic Spreads are used in the context of HTML and SVG Content Documents, the
+							<p>When synthetic spreads are used in the context of HTML and SVG content documents, the
 								dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
 									<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"><code>viewBox</code>
 									attribute</a> represents the size of one page in the spread, respectively.</p>
@@ -7210,7 +7196,7 @@ No Entry</pre>
 						</div>
 
 						<aside class="example" id="spread-none-example"
-							title="A fixed-layout EPUB Publication without synthetic spread">
+							title="A fixed-layout EPUB publication without synthetic spread">
 							<pre>&lt;package …>
    &lt;metadata …>
       …
@@ -7270,7 +7256,7 @@ No Entry</pre>
 
 
 							<figure id="spread-landscape-figure">
-								<figcaption> Rendering of three fixed-Layout Documents, with synthetic spread in
+								<figcaption> Rendering of three fixed-layout documents, with synthetic spread in
 									landscape orientation only. <br /><span class="attribution">(Comics courtesy of <a
 											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
 											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
@@ -7341,8 +7327,8 @@ No Entry</pre>
 
 						<aside class="example" id="spread-both-with-intro-example"
 							title="Overriding the global spread behavior">
-							<p>In this example, the EPUB Creator overrides the global reflowable setting in the spine
-								for the introductory page. The intention is for Reading Systems to render it as a
+							<p>In this example, the EPUB creator overrides the global reflowable setting in the spine
+								for the introductory page. The intention is for reading systems to render it as a
 								reflowable document.</p>
 
 							<pre>&lt;package …>
@@ -7397,25 +7383,25 @@ No Entry</pre>
 						<section id="spread-overrides">
 							<h6>Synthetic spread overrides</h6>
 
-							<p id="property-spread-local">EPUB Creators MAY specify the following properties locally on
+							<p id="property-spread-local">EPUB creators MAY specify the following properties locally on
 								spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
 									<a href="#property-spread-global">global value</a> for the given spine item:</p>
 
 							<dl>
 								<dt id="spread-auto">rendition:spread-auto</dt>
-								<dd>Specifies the Reading System determines when to render a synthetic spread for the
+								<dd>Specifies the reading system determines when to render a synthetic spread for the
 									spine item. </dd>
 
 								<dt id="spread-both">rendition:spread-both</dt>
-								<dd>Specifies the Reading System should render a synthetic spread for the spine item in
+								<dd>Specifies the reading system should render a synthetic spread for the spine item in
 									both portrait and landscape orientations. </dd>
 
 								<dt id="spread-landscape">rendition:spread-landscape</dt>
-								<dd>Specifies the Reading System should render a synthetic spread for the spine item
+								<dd>Specifies the reading system should render a synthetic spread for the spine item
 									only when in landscape orientation.</dd>
 
 								<dt id="spread-none">rendition:spread-none</dt>
-								<dd>Specifies the Reading System should not render a synthetic spread for the spine
+								<dd>Specifies the reading system should not render a synthetic spread for the spine
 									item.</dd>
 
 								<dt id="spread-portrait">rendition:spread-portrait</dt>
@@ -7428,19 +7414,19 @@ No Entry</pre>
 									in [[EPUBPublications-301]] for more information.</dd>
 							</dl>
 
-							<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
+							<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
 						</section>
 					</section>
 
 					<section id="page-spread">
 						<h5>Spread placement</h5>
 
-						<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to populate
-							the spread by rendering the next <a>EPUB Content Document</a> in the next available
+						<p>When a reading system renders a <a>synthetic spread</a>, the default behavior is to populate
+							the spread by rendering the next <a>EPUB content document</a> in the next available
 							unpopulated viewport, where the next available viewport is determined by the given <a
 								href="#sec-spine-elem">page progression direction</a> or by local declarations within
-							Content Documents. An EPUB Creator MAY override this automatic population behavior and force
-							Reading Systems to place a document in a particular viewport by specifying one of the
+							Content Documents. An EPUB creator MAY override this automatic population behavior and force
+							reading systems to place a document in a particular viewport by specifying one of the
 							following properties on its spine <code>itemref</code> element:</p>
 
 						<dl>
@@ -7467,30 +7453,30 @@ No Entry</pre>
 
 						<p>The <code>rendition:page-spread-center</code>, <code>rendition:page-spread-left</code>, and
 								<code>rendition:page-spread-right</code> properties apply to both pre-paginated and
-							reflowable content. They only apply when the Reading System is creating Synthetic
-							Spreads.</p>
+							reflowable content. They only apply when the reading system is creating synthetic
+							spreads.</p>
 
-						<p>Although EPUB Creators often indicate to use a spread in certain device orientations, the
-							content itself does not represent true spreads (i.e., two consecutive pages that Reading
-							Systems must render side-by-side for readability, such as a two-page map). To indicate that
-							two consecutive pages represent a true spread, EPUB Creators SHOULD use the
+						<p>Although EPUB creators often indicate to use a spread in certain device orientations, the
+							content itself does not represent true spreads (i.e., two consecutive pages that reading
+							systems must render side-by-side for readability, such as a two-page map). To indicate that
+							two consecutive pages represent a true spread, EPUB creators SHOULD use the
 								<code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-							properties on the spine items for the two adjacent EPUB Content Documents, and omit the
+							properties on the spine items for the two adjacent EPUB content documents, and omit the
 							properties on spine items where one-up or two-up presentation is equally acceptable.</p>
 
-						<p>EPUB Creators MUST NOT declare more than one <code>page-spread-*</code> property on any given
+						<p>EPUB creators MUST NOT declare more than one <code>page-spread-*</code> property on any given
 							spine item.</p>
 
 						<div class="note" id="note-page-spread-aliases">
 							<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 								properties were created to allow the use of a single vocabulary for all fixed-layout
-								properties. EPUB Creators can use either property set, but older Reading Systems might
+								properties. EPUB creators can use either property set, but older reading systems might
 								only recognize the unprefixed versions.</p>
 
 							<p>The <code>rendition:page-spread-center</code> was created to make it easier for EPUB
-								Creators to understand the process of switching between two-page spreads and single
-								centered pages. EPUB Creators can use either <code>rendition:page-spread-center</code>
-								or <code>spread-none</code> to disable spread behavior in Reading Systems.</p>
+								creators to understand the process of switching between two-page spreads and single
+								centered pages. EPUB creators can use either <code>rendition:page-spread-center</code>
+								or <code>spread-none</code> to disable spread behavior in reading systems.</p>
 						</div>
 
 						<aside class="example" id="spread-page-spread-right-example"
@@ -7543,9 +7529,9 @@ No Entry</pre>
 						</aside>
 
 						<aside class="example" id="fxl-ex5" title="Placing individual spine items in a spread">
-							<p>In this example, the EPUB Creator intends the Reading System to create a two-page
+							<p>In this example, the EPUB creator intends the reading system to create a two-page
 								fixed-layout center plate using synthetic spreads in any device orientation. Note that
-								the EPUB Creator has left spread behavior for the other (reflowable) parts undefined,
+								the EPUB creator has left spread behavior for the other (reflowable) parts undefined,
 								since the global value of <code>rendition:spread</code> initializes to <code>auto</code>
 								by default.</p>
 
@@ -7592,8 +7578,8 @@ No Entry</pre>
 					<section id="viewport">
 						<h5>Viewport dimensions (deprecated)</h5>
 
-						<p>The <code>rendition:viewport</code> property allows <a>EPUB Creators</a> to express the CSS
-							initial containing block (ICB) [[CSS2]] for XHTML and SVG Content Documents whose
+						<p>The <code>rendition:viewport</code> property allows <a>EPUB creators</a> to express the CSS
+							initial containing block (ICB) [[CSS2]] for XHTML and SVG content documents whose
 								<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
 
 						<p>Use of the property is <a href="#deprecated">deprecated</a>.</p>
@@ -7608,16 +7594,16 @@ No Entry</pre>
 						<h4>Content document dimensions</h4>
 
 						<p>This section defines rules for the expression and interpretation of dimensional properties of
-								<a>Fixed-Layout Documents</a>.</p>
+								<a>fixed-layout documents</a>.</p>
 
-						<p id="confreg-fxl-icb">Fixed-Layout Documents specify their <a
+						<p id="confreg-fxl-icb">Fixed-layout documents specify their <a
 								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
 								containing block</a> [[CSS2]] in the manner applicable to their format:</p>
 
 						<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
 							<dt id="sec-fxl-icb-html" data-tests="#fxl-xhtml-icb">Expressing in XHTML</dt>
 							<dd>
-								<p>For XHTML <a>Fixed-Layout Documents</a>, the <a
+								<p>For XHTML <a>fixed-layout documents</a>, the <a
 										href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
 										containing block</a> [[CSS2]] dimensions MUST be expressed in a
 										<code>viewport</code>
@@ -7639,7 +7625,7 @@ No Entry</pre>
 
 							<dt id="sec-fxl-icb-svg">Expressing in SVG</dt>
 							<dd>
-								<p>For SVG <a>Fixed-Layout Documents</a>, the initial containing block [[CSS2]]
+								<p>For SVG <a>fixed-layout documents</a>, the initial containing block [[CSS2]]
 									dimensions MUST be expressed using the <a
 										href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
 											><code>viewBox</code> attribute</a> [[SVG]].</p>
@@ -7664,28 +7650,28 @@ No Entry</pre>
 			<section id="sec-reflowable-layouts">
 				<h3>Reflowable layouts</h3>
 
-				<p>Although control over the rendering of <a>EPUB Content Documents</a> to create <a
+				<p>Although control over the rendering of <a>EPUB content documents</a> to create <a
 						href="#sec-fixed-layouts">fixed layouts</a> is an obvious need not handled by other
 					technologies, there are also considerations for reflowable content that are unique to EPUB
-					Publications (e.g., how to handle the flow of content in the <a>Viewport</a>). This section defines
-					properties that allow <a>EPUB Creators</a> to control presentation aspects of reflowable
+					publications (e.g., how to handle the flow of content in the <a>viewport</a>). This section defines
+					properties that allow <a>EPUB creators</a> to control presentation aspects of reflowable
 					content.</p>
 
 				<section id="flow">
 					<h4>The <code>rendition:flow</code> property</h4>
 
-					<p>The <code>rendition:flow</code> property specifies the EPUB Creator preference for how Reading
-						Systems should handle content overflow. </p>
+					<p>The <code>rendition:flow</code> property specifies the EPUB creator preference for how reading
+						systems should handle content overflow. </p>
 
 					<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code> property</a> is
-						specified on a <code>meta</code> element, it indicates the EPUB Creator's global preference for
-						overflow content handling (i.e., for all spine items). EPUB Creators MAY indicate a preference
+						specified on a <code>meta</code> element, it indicates the EPUB creator's global preference for
+						overflow content handling (i.e., for all spine items). EPUB creators MAY indicate a preference
 						for dynamic pagination or scrolling. For scrolled content, it is also possible to specify
-						whether consecutive <a>EPUB Content Documents</a> are to be rendered as a continuous scrolling
+						whether consecutive <a>EPUB content documents</a> are to be rendered as a continuous scrolling
 						view or whether each is to be rendered separately (i.e., with a dynamic page break between
 						each).</p>
 
-					<p>EPUB Creators MUST use one of the following values with the <code>rendition:flow</code>
+					<p>EPUB creators MUST use one of the following values with the <code>rendition:flow</code>
 						property:</p>
 
 					<dl class="variablelist">
@@ -7697,11 +7683,11 @@ No Entry</pre>
 						<dt id="scrolled-continuous">scrolled-continuous</dt>
 						<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
 							<p>Render all Content Documents such that overflow content is scrollable, and the EPUB
-								Publication is presented as one continuous scroll from spine item to spine item (except
+								publication is presented as one continuous scroll from spine item to spine item (except
 								where <a href="#layout-property-flow-overrides">locally overridden</a>).</p>
-							<p>Note that EPUB Creators SHOULD NOT create publications in which different resources have
-								different block flow directions, as continuous scrolled rendition in EPUB Reading
-								Systems would be problematic.</p>
+							<p>Note that EPUB creators SHOULD NOT create publications in which different resources have
+								different block flow directions, as continuous scrolled rendition in EPUB reading
+								systems would be problematic.</p>
 						</dd>
 
 						<dt id="scrolled-doc">scrolled-doc</dt>
@@ -7712,25 +7698,25 @@ No Entry</pre>
 
 						<dt id="auto">auto</dt>
 						<dd>
-							<p>Render overflow content using the Reading System default method or a user preference,
+							<p>Render overflow content using the reading system default method or a user preference,
 								whichever is applicable. Default value.</p>
 						</dd>
 					</dl>
 
-					<p id="html-body-page-break-before">Note that when two reflowable EPUB Content Documents occur
+					<p id="html-body-page-break-before">Note that when two reflowable EPUB content documents occur
 						sequentially in the spine, the default rendering for their [[!HTML]] <a
 							data-cite="html#the-body-element"><code>body</code></a> elements is consistent with the <a
 							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
 								><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been set to
 							<code>always</code>. In addition to using the <code>rendition:flow</code> property, EPUB
-						Creators MAY override this behavior through an appropriate style sheet declaration, if the
-						Reading System supports such overrides.</p>
+						creators MAY override this behavior through an appropriate style sheet declaration, if the
+						reading system supports such overrides.</p>
 
-					<p>EPUB Creators MUST NOT declare the <code>rendition:flow</code> property more than once.</p>
+					<p>EPUB creators MUST NOT declare the <code>rendition:flow</code> property more than once.</p>
 
 					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
 							attribute</a>. Refer to <a href="#layout-property-flow-overrides"></a> for setting the
-						property for individual <a>EPUB Content Documents</a>.</p>
+						property for individual <a>EPUB content documents</a>.</p>
 
 					<figure id="fig-flow-paginated-single">
 						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
@@ -7803,33 +7789,33 @@ No Entry</pre>
 					<section id="layout-property-flow-overrides">
 						<h5>Spine overrides</h5>
 
-						<p id="layout-property-flow-local">EPUB Creators MAY specify the following properties locally on
+						<p id="layout-property-flow-local">EPUB creators MAY specify the following properties locally on
 							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
 								href="#property-flow-global">global value</a> for the given spine item:</p>
 
 						<dl>
 							<dt id="flow-auto">rendition:flow-auto</dt>
-							<dd>Indicates no preference for overflow content handling by the EPUB Creator.</dd>
+							<dd>Indicates no preference for overflow content handling by the EPUB creator.</dd>
 
 							<dt id="flow-paginated">rendition:flow-paginated</dt>
-							<dd>Indicates the EPUB Creator preference is to dynamically paginate content overflow.</dd>
+							<dd>Indicates the EPUB creator preference is to dynamically paginate content overflow.</dd>
 
 							<dt id="flow-scrolled-continuous">rendition:flow-scrolled-continuous</dt>
-							<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow
+							<dd>Indicates the EPUB creator preference is to provide a scrolled view for overflow
 								content, and that consecutive spine items with this property are to be rendered as a
 								continuous scroll.</dd>
 
 							<dt id="flow-scrolled-doc">rendition:flow-scrolled-doc</dt>
-							<dd>Indicates the EPUB Creator preference is to provide a scrolled view for overflow
+							<dd>Indicates the EPUB creator preference is to provide a scrolled view for overflow
 								content, and each spine item with this property is to be rendered as a separate
 								scrollable document.</dd>
 						</dl>
 
-						<p>EPUB Creators MUST NOT use more than one of these overrides on any given spine item.</p>
+						<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
 
 						<aside class="example" id="property-flow-ex1"
 							title="Overriding a global paginated flow declaration">
-							<p>In this example, the EPUB Creator's intent is to have a paginated EPUB Publication with a
+							<p>In this example, the EPUB creator's intent is to have a paginated EPUB publication with a
 								scrollable table of contents.</p>
 							<pre>&lt;package …>
 &lt;metadata …&gt;
@@ -7861,17 +7847,17 @@ No Entry</pre>
 					<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should be
 						centered horizontally in the viewport or spread.</p>
 
-					<p>The property MUST NOT be set globally for all EPUB Content Documents (i.e., in a <a
+					<p>The property MUST NOT be set globally for all EPUB content documents (i.e., in a <a
 							href="#sec-meta-elem"><code>meta</code> element</a> without a <a href="#attrdef-refines"
 								><code>refines</code> attribute</a>). It is only available as a spine override for
-						individual EPUB Content Documents via the <a href="#sec-itemref-elem"><code>itemref</code>
+						individual EPUB content documents via the <a href="#sec-itemref-elem"><code>itemref</code>
 							element's <code>properties</code> attribute</a>.</p>
 
 					<div class="note">
 						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title pages),
 							in the absence of reliable centering control within the content rendering. As support for
 							paged media evolves in CSS, however, this property is expected to be deprecated. EPUB
-							Creators are encouraged to use CSS solutions when effective.</p>
+							creators are encouraged to use CSS solutions when effective.</p>
 					</div>
 				</section>
 			</section>
@@ -7883,9 +7869,9 @@ No Entry</pre>
 				<h4>Introduction</h4>
 
 				<p>Mainstream ebooks, educational tools and ebooks formatted for persons with print disabilities are
-					some examples of works that contain synchronized audio narration. In EPUB 3, EPUB Creators can
-					create these types of books using Media Overlay Documents to describe the timing for the
-					pre-recorded audio narration and how it relates to the EPUB Content Document markup. The
+					some examples of works that contain synchronized audio narration. In EPUB 3, EPUB creators can
+					create these types of books using media overlay documents to describe the timing for the
+					pre-recorded audio narration and how it relates to the EPUB content document markup. The
 					specification defines the file format for Media Overlays as a subset of [[SMIL3]], a W3C
 					recommendation for representing synchronized multimedia information in XML.</p>
 
@@ -7895,9 +7881,9 @@ No Entry</pre>
 					something that traditional audio embedding techniques cannot offer. They are even useful for
 					purposes not traditionally considered accessibility concerns (e.g., for language learning).</p>
 
-				<p>The Media Overlays feature is transparent to <a>EPUB Reading Systems</a> that do not support the
-					feature. The inclusion of Media Overlays in an EPUB Publication has no impact on the ability of
-					Media Overlay-unaware Reading Systems to render the EPUB Publication as though the Media Overlays
+				<p>The Media Overlays feature is transparent to <a>EPUB reading systems</a> that do not support the
+					feature. The inclusion of Media Overlays in an EPUB publication has no impact on the ability of
+					Media Overlay-unaware reading systems to render the EPUB publication as though the Media Overlays
 					are not present.</p>
 
 				<p>Media Overlays in EPUB are not an equivalent to audiobooks, as audiobooks are primarily audio-based
@@ -7906,16 +7892,16 @@ No Entry</pre>
 
 				<p>Although future versions of this specification might incorporate support for video media (e.g.,
 					synchronized text/sign-language books), this version supports only synchronizing audio media with
-					the EPUB Content Document.</p>
+					the EPUB content document.</p>
 			</section>
 
 			<section id="sec-overlay-docs">
-				<h3>Media Overlay Documents</h3>
+				<h3>Media overlay documents</h3>
 
 				<section id="sec-overlay-req">
-					<h4>Media Overlay Document requirements</h4>
+					<h4>Media overlay document requirements</h4>
 
-					<p>A <a>Media Overlay Document</a>:</p>
+					<p>A <a>media overlay document</a>:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -7924,15 +7910,15 @@ No Entry</pre>
 								constraints expressed in <a href="#sec-overlays-def"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-mo-docprops-references">MAY refer to more than one EPUB Content Document, but
-								more than one Media Overlay Document MUST NOT reference the same EPUB Content
-								Document.</p>
+							<p id="confreq-mo-docprops-references">MAY refer to more than one EPUB content document, but
+								more than one media overlay document MUST NOT reference the same EPUB content
+								document.</p>
 						</li>
 					</ul>
 				</section>
 
 				<section id="sec-overlays-def">
-					<h3>Media Overlay Document definition</h3>
+					<h3>Media overlay document definition</h3>
 
 					<p>All elements [[XML]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
 						namespace [[XML-NAMES]] unless otherwise specified.</p>
@@ -7940,7 +7926,7 @@ No Entry</pre>
 					<section id="sec-smil-smil-elem">
 						<h5>The <code>smil</code> element</h5>
 
-						<p>The <code>smil</code> element is the root element of all Media Overlay Documents.</p>
+						<p>The <code>smil</code> element is the root element of all media overlay documents.</p>
 
 						<dl class="elemdef" id="elemdef-smil">
 							<dt>Element Name:</dt>
@@ -7952,7 +7938,7 @@ No Entry</pre>
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>The <code>smil</code> element is the root element of the Media Overlay Document.</p>
+								<p>The <code>smil</code> element is the root element of the media overlay document.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -8017,8 +8003,8 @@ No Entry</pre>
 					<section id="sec-smil-head-elem">
 						<h5>The <code>head</code> element</h5>
 
-						<p>The <code>head</code> element is the container for metadata in the Media Overlay
-							Document.</p>
+						<p>The <code>head</code> element is the container for metadata in the media overlay
+							document.</p>
 
 						<dl class="elemdef" id="elemdef-smil-head">
 							<dt>Element Name:</dt>
@@ -8050,14 +8036,14 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p>As this specification does not define any metadata properties that must occur in the Media
-							Overlay Document, the <code>head</code> element is OPTIONAL.</p>
+						<p>As this specification does not define any metadata properties that must occur in the media
+							overlay document, the <code>head</code> element is OPTIONAL.</p>
 					</section>
 
 					<section id="sec-smil-metadata-elem">
 						<h5>The <code>metadata</code> element</h5>
 
-						<p>The <code>metadata</code> element represents metadata for the Media Overlay Document. The
+						<p>The <code>metadata</code> element represents metadata for the media overlay document. The
 								<code>metadata</code> element is an extension point that allows the inclusion of
 							metadata from any metainformation structuring language.</p>
 
@@ -8085,7 +8071,7 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p>This specification does not require any metadata properties in the Media Overlay Document;
+						<p>This specification does not require any metadata properties in the media overlay document;
 							the <code>metadata</code> element is provided for custom metadata requirements.</p>
 					</section>
 
@@ -8093,7 +8079,7 @@ No Entry</pre>
 						<h5>The <code>body</code> element</h5>
 
 						<p>The <code>body</code> element is the starting point for the presentation contained in the
-							Media Overlay Document. It contains the main sequence of <code>par</code> and
+							media overlay document. It contains the main sequence of <code>par</code> and
 								<code>seq</code> elements.</p>
 
 						<dl class="elemdef" id="elemdef-smil-body">
@@ -8120,7 +8106,7 @@ No Entry</pre>
 									</dt>
 									<dd>
 										<p>An expression of the structural semantics of the corresponding element in the
-												<a>EPUB Content Document</a>.</p>
+												<a>EPUB content document</a>.</p>
 										<p>The value is a white space separated list of <a href="#sec-property-datatype"
 												>property</a> types. Refer to <a href="#sec-docs-structural-semantic"
 											></a> for more information.</p>
@@ -8140,10 +8126,10 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>Refers to the associated EPUB Content Document and, optionally, identifies a
+										<p>Refers to the associated EPUB content document and, optionally, identifies a
 											specific part of it.</p>
-										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally followed by
-												<code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
+										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally
+											followed by <code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
 									</dd>
 								</dl>
 							</dd>
@@ -8204,7 +8190,7 @@ No Entry</pre>
 									</dt>
 									<dd>
 										<p>An expression of the structural semantics of the corresponding element in the
-												<a>EPUB Content Document</a>.</p>
+												<a>EPUB content document</a>.</p>
 										<p>The value is a white space separated list of <a href="#sec-property-datatype"
 												>property</a> types. Refer to <a href="#sec-docs-structural-semantic"
 											></a> for more information.</p>
@@ -8224,10 +8210,10 @@ No Entry</pre>
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>Refers to the associated EPUB Content Document and, optionally, identifies a
+										<p>Refers to the associated EPUB content document and, optionally, identifies a
 											specific part of it.</p>
-										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally followed by
-												<code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
+										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally
+											followed by <code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
 										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
 											information.</p>
 									</dd>
@@ -8288,7 +8274,7 @@ No Entry</pre>
 									</dt>
 									<dd>
 										<p>An expression of the structural semantics of the corresponding element in the
-												<a>EPUB Content Document</a>.</p>
+												<a>EPUB content document</a>.</p>
 										<p>The value is a white space separated list of <a href="#sec-property-datatype"
 												>property</a> types. Refer to <a href="#sec-docs-structural-semantic"
 											></a> for more information.</p>
@@ -8333,9 +8319,9 @@ No Entry</pre>
 					<section id="sec-smil-text-elem">
 						<h5>The <code>text</code> element</h5>
 
-						<p> The <code>text</code> element references an element in an <a>EPUB Content Document</a>. A
+						<p> The <code>text</code> element references an element in an <a>EPUB content document</a>. A
 								<code>text</code> element typically refers to a textual element but can also refer to
-							other EPUB Content Document media elements (see <a href="#sec-embedded-media"></a>). In the
+							other EPUB content document media elements (see <a href="#sec-embedded-media"></a>). In the
 							absence of a sibling <code>audio</code> element textual content referred to by this element
 							may be rendered via <a href="#sec-tts">text-to-speech</a>. </p>
 
@@ -8361,10 +8347,10 @@ No Entry</pre>
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>Refers to the associated EPUB Content Document and, optionally, identifies a
+										<p>Refers to the associated EPUB content document and, optionally, identifies a
 											specific part of it.</p>
-										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally followed by
-												<code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
+										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally
+											followed by <code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
 									</dd>
 
 									<dt>
@@ -8387,8 +8373,8 @@ No Entry</pre>
 						<p class="note"> This specification places no restriction on the <code>src</code> attribute of a
 								<code>text</code> element. Authors should, however, refer to a content that can be
 							styled with CSS to make the <a href="#sec-docs-assoc-style">association with style
-								information</a> effective, i.e., <a>palpable
-								content</a> for XHTML or <a href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a
+								information</a> effective, i.e., <a>palpable content</a> for XHTML or <a
+								href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a
 								href="https://www.w3.org/TR/SVG11/shapes.html">basic shapes</a>, or <a
 								href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG. </p>
 					</section>
@@ -8430,10 +8416,9 @@ No Entry</pre>
 									</dt>
 									<dd>
 										<p>The <a data-lt="relative-url string">relative-</a> or <a
-												data-lt="absolute-url string">absolute-URL string</a> [[URL]]
-											reference to an audio file. The audio file MUST be one of the audio formats
-											listed in the <a href="#sec-core-media-types">Core Media Type Resources</a>
-											table.</p>
+												data-lt="absolute-url string">absolute-URL string</a> [[URL]] reference
+											to an audio file. The audio file MUST be one of the audio formats listed in
+											the <a href="#sec-core-media-types">core media type resources</a> table.</p>
 									</dd>
 
 									<dt id="attrdef-smil-clipBegin">
@@ -8479,12 +8464,12 @@ No Entry</pre>
 				<section id="sec-docs-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>EPUB Creators can represent a pre-recorded narration of a publication as a series of audio clips,
-						each corresponding to part of an <a>EPUB Content Document</a>. A single audio clip, for example,
+					<p>EPUB creators can represent a pre-recorded narration of a publication as a series of audio clips,
+						each corresponding to part of an <a>EPUB content document</a>. A single audio clip, for example,
 						typically represents a single phrase or paragraph, but infers no order relative to the other
 						clips or to the text of a document. Media Overlays solve this problem of synchronization by
 						tying the structured audio narration to its corresponding text (or other media) in the EPUB
-						Content Document using [[SMIL3]] markup. Media Overlays are, in fact, a simplified subset of
+						content document using [[SMIL3]] markup. Media Overlays are, in fact, a simplified subset of
 						SMIL 3.0 that define the playback sequence of these clips.</p>
 
 					<p>The SMIL elements primarily used for structuring Media Overlays are <a href="#elemdef-smil-body"
@@ -8494,17 +8479,17 @@ No Entry</pre>
 						SMIL elements.)</p>
 
 					<p>The <code>par</code> element is the basic building block of an Overlay and corresponds to a
-						phrase in the EPUB Content Document. The element provides two key pieces of information for
+						phrase in the EPUB content document. The element provides two key pieces of information for
 						synchronizing content: 1) the audio clip containing the narration for the phrase; and 2) a
-						pointer to the associated EPUB Content Document fragment. The <code>par</code> element uses two
+						pointer to the associated EPUB content document fragment. The <code>par</code> element uses two
 						media element children to represent this information: an <a href="#elemdef-smil-audio"
 								><code>audio</code></a> element and a <a href="#elemdef-smil-text"><code>text</code></a>
-						element. Because <code>par</code> elements' media object children are timed in parallel, Reading
-						Systems render the audio clip and EPUB Content Document fragment at the same time, resulting in
+						element. Because <code>par</code> elements' media object children are timed in parallel, reading
+						systems render the audio clip and EPUB content document fragment at the same time, resulting in
 						a synchronized presentation.</p>
 
 					<p>The <code>text</code> element <code>src</code> attribute references the associated phrase,
-						sentence, or other segment of the EPUB Content Document by its URL [[URL]] reference. The
+						sentence, or other segment of the EPUB content document by its URL [[URL]] reference. The
 							<code>audio</code> element <code>src</code> attribute similarly references the location of
 						the corresponding audio clip and adds the OPTIONAL <a href="#attrdef-smil-clipBegin"
 								><code>clipBegin</code></a> and <a href="#attrdef-smil-clipEnd"><code>clipEnd</code></a>
@@ -8520,12 +8505,12 @@ No Entry</pre>
        clipEnd="30s"/>
 &lt;/par></pre>
 					</aside>
-					<p>EPUB Creators place <code>par</code> elements together sequentially to form a series of phrases
-						or sentences. Not every element of the EPUB Content Document will have a corresponding
+					<p>EPUB creators place <code>par</code> elements together sequentially to form a series of phrases
+						or sentences. Not every element of the EPUB content document will have a corresponding
 							<code>par</code> element in the Media Overlay, only those relevant to the audio
 						narration.</p>
 
-					<aside class="example" title="A basic Media Overlay Document containing a sequence of phrases">
+					<aside class="example" title="A basic media overlay document containing a sequence of phrases">
 						<p>In this example, the <code>body</code> element acts as the main sequence for the whole
 							document.</p>
 
@@ -8560,29 +8545,29 @@ No Entry</pre>
    &lt;/body>
 &lt;/smil></pre>
 					</aside>
-					<p>EPUB Creators can also add <code>par</code> elements to <code>seq</code> elements to define more
+					<p>EPUB creators can also add <code>par</code> elements to <code>seq</code> elements to define more
 						complex structures such as parts and chapters (see <a href="#sec-media-overlays-structure"
 						></a>).</p>
 				</section>
 
 				<section id="sec-docs-relations">
-					<h4>Relationship to the EPUB Content Document</h4>
+					<h4>Relationship to the EPUB content document</h4>
 
 					<div class="note">
-						<p>In this section, the <a>EPUB Content Document</a> is assumed to be an <a>XHTML Content
-								Document</a>. While EPUB Creators may use Media Overlays with <a>SVG Content
-								Documents</a>, playback behavior might not be consistent and therefore interoperability
+						<p>In this section, the <a>EPUB content document</a> is assumed to be an <a>XHTML content
+								document</a>. While EPUB creators may use Media Overlays with <a>SVG content
+								documents</a>, playback behavior might not be consistent and therefore interoperability
 							is not guaranteed.</p>
 					</div>
 
 					<section id="sec-media-overlays-structure">
 						<h5>Overlay structure</h5>
 
-						<p>The <a href="#elemdef-smil-body"><code>body</code></a> of a Media Overlay Document consists
+						<p>The <a href="#elemdef-smil-body"><code>body</code></a> of a media overlay document consists
 							of two elements: the <a href="#elemdef-smil-par"><code>par</code> element</a> and the <a
 								href="#elemdef-smil-seq"><code>seq</code> element</a>. The ordering of these elements
-							represents how Reading Systems render the content in the corresponding EPUB Content
-							Documents during playback.</p>
+							represents how reading systems render the content in the corresponding EPUB content
+							documents during playback.</p>
 
 						<p>The <code>par</code> element represents a segment of content, such as a word, phrase,
 							sentence, table cell, list item, image, or other identifiable piece of content in the
@@ -8592,19 +8577,19 @@ No Entry</pre>
 
 						<p>The <code>seq</code> element represents sequences &#8212; sets of <code>seq</code> and/or
 								<code>par</code> elements that together represent a logical component of the content.
-							EPUB Creators can use it to represent nested containers such as sections, asides, headers,
-							tables, lists, and footnotes. It allows EPUB Creators to retain the structure inherent in
-							these containers in the Media Overlay Document.</p>
+							EPUB creators can use it to represent nested containers such as sections, asides, headers,
+							tables, lists, and footnotes. It allows EPUB creators to retain the structure inherent in
+							these containers in the media overlay document.</p>
 
 						<p>The <code>seq</code> element MUST contain an <a href="#attrdef-body-textref"
 									><code>epub:textref</code> attribute</a>. As <code>seq</code> elements do not
-							provide synchronization instructions, this attribute allows a Reading System to match the
+							provide synchronization instructions, this attribute allows a reading system to match the
 							fragment to a location in the text.</p>
 
 						<div class="note">
 							<p>The reason for grouping structures like sections, figures, tables, and footnotes in a
-									<code>seq</code> element is so that Reading Systems can identify their start and end
-								positions during playback. Reading Systems can then offer playback options tailored to
+									<code>seq</code> element is so that reading systems can identify their start and end
+								positions during playback. Reading systems can then offer playback options tailored to
 								the layout of the content, such as jumping past a long figure, turning off rendering of
 								page break announcements (see <a href="#sec-behaviors-skip-escape"></a>), or customizing
 								the reading mode to suit structures such as tables.</p>
@@ -8614,7 +8599,7 @@ No Entry</pre>
 							elements">
 							<p>This example shows a chapter with both a section header and a figure.</p>
 
-							<p>Media Overlay Document:</p>
+							<p>Media overlay document:</p>
 
 							<pre>&lt;smil
     xmlns="http://www.w3.org/ns/SMIL"
@@ -8704,13 +8689,13 @@ No Entry</pre>
    &lt;/body>
 &lt;/smil></pre>
 
-							<p>XHTML Content Document:</p>
+							<p>XHTML content document:</p>
 
 							<pre>&lt;html …>
    &lt;head>
       &lt;title>
          Media Overlays Example of
-         EPUB Content Document
+         EPUB content document
       &lt;/title>
    &lt;/head>
    &lt;body id="sec1">
@@ -8758,41 +8743,42 @@ No Entry</pre>
 
 						<p>Both the <code>epub:textref</code> attribute and the <a href="#elemdef-smil-text"
 									><code>text</code> element's</a>
-							<code>src</code> attribute may contain a <a>URL-fragment string</a> that references a specific part (e.g., an element via its ID) of the
-							associated <a>EPUB Content Document</a>.</p>
+							<code>src</code> attribute may contain a <a>URL-fragment string</a> that references a
+							specific part (e.g., an element via its ID) of the associated <a>EPUB content
+							document</a>.</p>
 
-						<p>For XHTML and SVG Content Documents, the URL-fragment string SHOULD be a reference to a
+						<p>For XHTML and SVG content documents, the URL-fragment string SHOULD be a reference to a
 							specific element via its ID, or an <a
 								href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
 								Identifier</a> [[SVG]], respectively.</p>
 
-						<p>EPUB Creators MAY use other fragment identifier schemes, but Reading Systems may not support
+						<p>EPUB creators MAY use other fragment identifier schemes, but reading systems may not support
 							such identifiers.</p>
 					</section>
 
 					<section id="sec-media-overlays-granularity" class="informative">
 						<h5>Overlay granularity</h5>
 
-						<p>The granularity level of the Media Overlay depends on how EPUB Creators mark up the EPUB
-							Content Document and the type of fragment identifier they use in the <a
+						<p>The granularity level of the Media Overlay depends on how EPUB creators mark up the EPUB
+							content document and the type of fragment identifier they use in the <a
 								href="#elemdef-smil-text"><code>text</code> elements'</a>
 							<code>src</code> attributes and the <a href="#elemdef-smil-seq"><code>seq</code></a>
 							elements' <code>epub:textref</code> attrbutes. For example, when referencing [[HTML]]
 							elements, if the finest level of markup is at the paragraph level, then that is the finest
 							possible level for Media Overlay synchronization. Likewise, if sub-paragraph markup is
-							available, such as [[HTML]] <a data-lt="span"><code>span</code> element</a>
-							representing phrases or sentences, then finer granularity is possible in the Media
-							Overlay. Finer granularity gives users more precise results for synchronized playback when
-							navigating by word or phrase and when searching the text but increases the file size of the
-							Media Overlay Documents. Fragment identifier schemes that do not rely on the presence of
-							elements could provide even finer granularity, where supported.</p>
+							available, such as [[HTML]] <a data-lt="span"><code>span</code> element</a> representing
+							phrases or sentences, then finer granularity is possible in the Media Overlay. Finer
+							granularity gives users more precise results for synchronized playback when navigating by
+							word or phrase and when searching the text but increases the file size of the media overlay
+							documents. Fragment identifier schemes that do not rely on the presence of elements could
+							provide even finer granularity, where supported.</p>
 					</section>
 
 					<section id="sec-embedded-media">
 						<h5>Embedded media</h5>
 
-						<p>Any <a>EPUB Content Document</a> associated with a Media Overlay MAY contain embedded media
-							such as video, audio, and images. EPUB Creators MAY use the Media Overlay <a
+						<p>Any <a>EPUB content document</a> associated with a Media Overlay MAY contain embedded media
+							such as video, audio, and images. EPUB creators MAY use the Media Overlay <a
 								href="#elemdef-smil-text"><code>text</code> element</a> in such instances to reference
 							the embedded media by its element's <code>id</code> attribute value.</p>
 
@@ -8800,15 +8786,15 @@ No Entry</pre>
 							<h6>Embedded audio and video</h6>
 
 							<p> When a <a href="#elemdef-smil-text"><code>text</code></a> element references embedded
-								audio or video, Reading Systems will initiate playback of the media in the absence of an
+								audio or video, reading systems will initiate playback of the media in the absence of an
 									<a href="#elemdef-smil-audio"><code>audio</code></a> element sibling. </p>
 
-							<p><a>EPUB Creators</a> SHOULD avoid using scripts to control playback of referenced
-								embedded EPUB Content Document media, as this might conflict with Media Overlays
+							<p><a>EPUB creators</a> SHOULD avoid using scripts to control playback of referenced
+								embedded EPUB content document media, as this might conflict with Media Overlays
 								playback behavior.</p>
 
-							<p>EPUB Creators should carefully examine any overlapping audio situations and deal with
-								them at the production stage, as Reading Systems handling of simultaneous volume levels
+							<p>EPUB creators should carefully examine any overlapping audio situations and deal with
+								them at the production stage, as reading systems handling of simultaneous volume levels
 								is optional.</p>
 						</section>
 
@@ -8817,10 +8803,10 @@ No Entry</pre>
 
 							<p>When a <code>text</code> element references an embedded image, the <a
 									href="#elemdef-smil-audio"><code>audio</code></a> sibling element is OPTIONAL. In
-								the absence of an <code>audio</code> element, Reading Systems will voice the image using
+								the absence of an <code>audio</code> element, reading systems will voice the image using
 									<a href="#sec-tts">Text-to-Speech rendering</a>.</p>
 
-							<p>EPUB Creators MUST ensure they provide fallback text for an image when an omitting an
+							<p>EPUB creators MUST ensure they provide fallback text for an image when an omitting an
 									<code>audio</code> element (e.g., using the [[HTML]] <code>alt</code>
 								attribute).</p>
 						</section>
@@ -8830,18 +8816,18 @@ No Entry</pre>
 						<h5>Text-to-speech rendering</h5>
 
 						<p>This specification allows the use of text-to-speech (TTS) &#8212; the rendering of the
-							textual content of an <a>EPUB Publication</a> as artificial human speech using a synthesized
+							textual content of an <a>EPUB publication</a> as artificial human speech using a synthesized
 							voice &#8212; in addition to pre-recorded audio clips.</p>
 
 						<p>When a Media Overlay <a href="#elemdef-smil-par"><code>par</code> element</a> omits its <a
 								href="#elemdef-smil-audio"><code>audio</code> element</a>, its <a
-								href="#elemdef-smil-text"><code>text</code> element</a> may be rendered in Reading
-							Systems via TTS. If the text fragment is not appropriate for TTS rendering (e.g., is not a
+								href="#elemdef-smil-text"><code>text</code> element</a> may be rendered in reading
+							systems via TTS. If the text fragment is not appropriate for TTS rendering (e.g., is not a
 							text element and/or has no text fallback), this may produce unexpected results.</p>
 
 						<div class="note">
 							<p>See <a data-cite="epub-tts-10#">EPUB 3 Text-to-Speech Support</a> [[EPUB-TTS-10]] for
-								more information about using TTS technologies in EPUB Publications.</p>
+								more information about using TTS technologies in EPUB publications.</p>
 						</div>
 					</section>
 				</section>
@@ -8849,13 +8835,13 @@ No Entry</pre>
 				<section id="sec-docs-structural-semantic">
 					<h4>Structural semantics in overlays</h4>
 
-					<p>To express <a href="#app-structural-semantics">structural semantics</a> in <a>Media Overlay
-							Documents</a>, EPUB Creators MAY specify the <a href="#attrdef-epub-type"
+					<p>To express <a href="#app-structural-semantics">structural semantics</a> in <a>media overlay
+							documents</a>, EPUB creators MAY specify the <a href="#attrdef-epub-type"
 								><code>epub:type</code> attribute</a> on <a href="#elemdef-smil-par"
 							><code>par</code></a>, <a href="#elemdef-smil-seq"><code>seq</code></a>, and <a
 							href="#elemdef-smil-body"><code>body</code></a> elements.</p>
 
-					<p>The <code>epub:type</code> attribute facilitates Reading System behavior appropriate for the
+					<p>The <code>epub:type</code> attribute facilitates reading system behavior appropriate for the
 						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
 							>skippability and escapability</a> and <a data-cite="epub-rs-33#note-table-reading-mode"
 							>table reading mode</a> [[?EPUB-RS-33]].</p>
@@ -8906,34 +8892,34 @@ No Entry</pre>
 				<section id="sec-docs-assoc-style">
 					<h4>Associating style information</h4>
 
-					<p>EPUB Creators MAY express visual rendering information for the currently playing <a>EPUB Content
-							Document</a> element in a CSS Style Sheet using author-defined classes.</p>
+					<p>EPUB creators MAY express visual rendering information for the currently playing <a>EPUB content
+							document</a> element in a CSS Style Sheet using author-defined classes.</p>
 
-					<p>When used, EPUB Creators MUST declare the class names in the Package Document using the <a
+					<p>When used, EPUB creators MUST declare the class names in the package document using the <a
 							href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 								><code>playback-active-class</code></a> properties.</p>
 
-					<p>EPUB Creators MUST define exactly one CSS class name in each property they define. Each property
+					<p>EPUB creators MUST define exactly one CSS class name in each property they define. Each property
 						MUST define a <a href="https://www.w3.org/TR/CSS2/syndata.html#characters">valid CSS class
 							name</a> not including any <a href="https://www.w3.org/TR/CSS2/selector.html">selectors</a>
 						[[CSS2]]. This specification <strong>does not</strong> reserve names for use with these
 						properties.</p>
 
-					<p>EPUB Creators MAY define any CSS properties for the specified CSS classes but must ensure that
-						each EPUB Content Document with an associated Media Overlay Document includes a CSS stylesheet
+					<p>EPUB creators MAY define any CSS properties for the specified CSS classes but must ensure that
+						each EPUB content document with an associated media overlay document includes a CSS stylesheet
 						(either embedded or linked) containing the class definitions. In the absence of such definitions
-						Reading Systems might provide their own styling, or no styling at all.</p>
+						reading systems might provide their own styling, or no styling at all.</p>
 
-					<p>EPUB Creators MUST NOT use the <code>active-class</code> and <code>playback-active-class</code>
+					<p>EPUB creators MUST NOT use the <code>active-class</code> and <code>playback-active-class</code>
 						properties in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a>
-						as they always apply to the entire <a>EPUB Publication</a>.</p>
+						as they always apply to the entire <a>EPUB publication</a>.</p>
 
 					<aside class="example" title="Associating style information with the
-						currently playing EPUB Content Document">
+						currently playing EPUB content document">
 
 						<p>The author-defined CSS class names are declared using the metadata properties <a
 								href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
-									><code>playback-active-class</code></a> in the Package Document:</p>
+									><code>playback-active-class</code></a> in the package document:</p>
 
 						<pre>&lt;package …>
    &lt;metadata …>
@@ -8965,7 +8951,7 @@ html.my-document-playing * {
 }
 </pre>
 
-						<p>The relevant EPUB Content Document excerpt:</p>
+						<p>The relevant EPUB content document excerpt:</p>
 
 						<pre>&lt;html>
    …
@@ -8984,17 +8970,17 @@ html.my-document-playing * {
    &lt;/body>
 &lt;/html></pre>
 
-						<p>In this example, the Reading System would apply the author-defined
-								<code>my-active-item</code> class to each text element in the EPUB Content Document as
-							it became active during playback. Conversely, Reading Systems would remove the class name
-							when the element is no longer active. The user would see each EPUB Content Document element
+						<p>In this example, the reading system would apply the author-defined
+								<code>my-active-item</code> class to each text element in the EPUB content document as
+							it became active during playback. Conversely, reading systems would remove the class name
+							when the element is no longer active. The user would see each EPUB content document element
 							styled with a yellow background for the duration of that element's playback.</p>
 
-						<p>The Reading System would also apply the author-defined <code>my-document-playing</code> class
-							to the document element of the EPUB Content Document when Media Overlays playback begins.
-							The Reading System would remove the class name when playback stops. In the case of an XHTML
-							Content Document, the Reading System would apply the class name to the <code>html</code>
-							element. In the case of an SVG Content Document, the Reading System would apply the class
+						<p>The reading system would also apply the author-defined <code>my-document-playing</code> class
+							to the document element of the EPUB content document when Media Overlays playback begins.
+							The reading system would remove the class name when playback stops. In the case of an XHTML
+							content document, the reading system would apply the class name to the <code>html</code>
+							element. In the case of an SVG content document, the reading system would apply the class
 							name to the <code>svg</code> element. The user would see all the inactive text elements turn
 							gray during Media Overlays playback. When playback stopped, the elements' colors would
 							return to their defaults.</p>
@@ -9008,20 +8994,20 @@ html.my-document-playing * {
 					<section id="sec-package-including">
 						<h5>Including media overlays</h5>
 
-						<p>If an <a>EPUB Content Document</a> is wholly or partially referenced by a Media Overlay, then
+						<p>If an <a>EPUB content document</a> is wholly or partially referenced by a Media Overlay, then
 							its <a>manifest</a>
 							<a href="#elemdef-package-item"><code>item</code> element</a> MUST specify a
 								<code>media-overlay</code> attribute. The attribute MUST reference the ID [[XML]] of the
-							manifest <code>item</code> for the corresponding Media Overlay Document.</p>
+							manifest <code>item</code> for the corresponding media overlay document.</p>
 
-						<p>EPUB Creators MUST only specify the <code>media-overlay</code> attribute on manifest
-								<code>item</code> elements that reference <a>EPUB Content Documents</a>.</p>
+						<p>EPUB creators MUST only specify the <code>media-overlay</code> attribute on manifest
+								<code>item</code> elements that reference <a>EPUB content documents</a>.</p>
 
-						<p>Manifest items for Media Overlay Documents MUST have the media type
+						<p>Manifest items for media overlay documents MUST have the media type
 								<code>application/smil+xml</code>.</p>
 
-						<aside class="example" title="Entries for an EPUB Content Document and its associated
-							Media Overlay in the Package Document manifest">
+						<aside class="example" title="Entries for an EPUB content document and its associated
+							Media Overlay in the package document manifest">
 							<pre>&lt;package …>
    …
    &lt;manifest>
@@ -9044,17 +9030,17 @@ html.my-document-playing * {
 					<section id="sec-mo-package-metadata">
 						<h5>Overlays package metadata</h5>
 
-						<p id="total-duration">EPUB Creators MUST specify the duration of the entire <a>EPUB
-								Publication</a> in the <a>Package Document</a> using a <a href="#elemdef-meta"
+						<p id="total-duration">EPUB creators MUST specify the duration of the entire <a>EPUB
+								publication</a> in the <a>package document</a> using a <a href="#elemdef-meta"
 									><code>meta</code> element</a> with the <a href="#duration"><code>duration</code>
 								property</a>.</p>
 
-						<p>In addition, EPUB Creators MUST provide the duration of each Media Overlay Document. EPUB
-							Creators MUST use the <a href="#attrdef-refines"><code>refines</code> attribute</a> to
+						<p>In addition, EPUB creators MUST provide the duration of each media overlay document. EPUB
+							creators MUST use the <a href="#attrdef-refines"><code>refines</code> attribute</a> to
 							associate each duration declaration to the corresponding <a>manifest</a>
 							<a href="#elemdef-package-item"><code>item</code></a>.</p>
 
-						<p>The sum of the durations for each Media Overlay Document SHOULD equal the <a
+						<p>The sum of the durations for each media overlay document SHOULD equal the <a
 								href="#total-duration">total duration</a> plus or minus one second.</p>
 
 						<div class="note">
@@ -9063,17 +9049,17 @@ html.my-document-playing * {
 								indicates a mismatch arising from other issues.</p>
 						</div>
 
-						<p><a>EPUB Creators</a> MAY also specify <a href="#narrator"><code>narrator</code></a>
-							information in the Package Document, as well as <a href="#sec-docs-assoc-style"
-								>author-defined CSS class names</a> to apply to the currently playing EPUB Content
-							Document element.</p>
+						<p><a>EPUB creators</a> MAY also specify <a href="#narrator"><code>narrator</code></a>
+							information in the package document, as well as <a href="#sec-docs-assoc-style"
+								>author-defined CSS class names</a> to apply to the currently playing EPUB content
+							document element.</p>
 
 						<div class="note">
 							<p>The <code>media:</code> prefix is <a href="#sec-metadata-reserved-prefixes">reserved</a>
 								for inclusion of these properties in package metadata.</p>
 						</div>
 
-						<aside class="example" title="Media Overlays metadata in the Package Document">
+						<aside class="example" title="Media Overlays metadata in the package document">
 							<pre>&lt;package …>
    &lt;metadata …>
       …
@@ -9130,11 +9116,11 @@ html.my-document-playing * {
 
 					<p>While reading, users may want to turn on or off certain features of the content, such as
 						footnotes, page numbers, or other types of secondary content. This feature is called
-						skippability. Reading Systems use the semantic information provided by Media Overlay elements'
+						skippability. Reading systems use the semantic information provided by Media Overlay elements'
 							<a href="#sec-docs-structural-semantic"><code>epub:type</code></a> attribute to determine
 						when to offer users the option of skippable features.</p>
 
-					<p>EPUB Creators MAY use the following semantics to enable skippability:</p>
+					<p>EPUB creators MAY use the following semantics to enable skippability:</p>
 
 					<ul>
 						<li>
@@ -9149,14 +9135,14 @@ html.my-document-playing * {
 					</ul>
 
 					<p>This list is non-exhaustive, however. It represents terms from the Structural Semantics
-						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems are most likely to offer the option of
+						Vocabulary [[?EPUB-SSV-11]] for which reading systems are most likely to offer the option of
 						skippability.</p>
 
 					<aside class="example" title="Media Overlay with a page break">
-						<p>In this example, a Reading System could offer the user the option of turning on and off the
+						<p>In this example, a reading system could offer the user the option of turning on and off the
 							page break/page number announcements, which are often cumbersome to listen to.</p>
 
-						<p>Media Overlay Document:</p>
+						<p>Media overlay document:</p>
 
 						<pre>&lt;smil
     xmlns="http://www.w3.org/ns/SMIL" 
@@ -9198,7 +9184,7 @@ html.my-document-playing * {
 &lt;/smil>
 </pre>
 
-						<p>EPUB Content Document:</p>
+						<p>EPUB content document:</p>
 
 						<pre>&lt;html … >
    …
@@ -9229,7 +9215,7 @@ html.my-document-playing * {
 						of items, but provides an exit from them (e.g., a user can listen to some of the content before
 						choosing to escape).</p>
 
-					<p>EPUB Creators MAY use the following semantics to enable escapability:</p>
+					<p>EPUB creators MAY use the following semantics to enable escapability:</p>
 
 					<ul>
 						<li>
@@ -9247,20 +9233,20 @@ html.my-document-playing * {
 					</ul>
 
 					<p>This list is non-exhaustive list, however. It represents terms from the Structural Semantics
-						Vocabulary [[?EPUB-SSV-11]] for which Reading Systems are most likely to offer the option of
+						Vocabulary [[?EPUB-SSV-11]] for which reading systems are most likely to offer the option of
 						escapability.</p>
 
 					<div class="note">
 						<p>Sometimes escapable structures may contain escapable structures. For example, tables are
 							composed of many rows and cells that users may want to separately escape from. Reading
-							System support for escaping from such structures is complex and not well supported at this
-							time. EPUB Creators should avoid identifying nested escapable structures until better
+							system support for escaping from such structures is complex and not well supported at this
+							time. EPUB creators should avoid identifying nested escapable structures until better
 							support is available.</p>
 					</div>
 
 					<aside class="example" title="Escapable structures">
-						<p>In this example, the Media Overlay Document for an EPUB Content Document contains a
-							paragraph, a table, and another paragraph. A Reading System that supported escapability
+						<p>In this example, the media overlay document for an EPUB content document contains a
+							paragraph, a table, and another paragraph. A reading system that supported escapability
 							would give the user the option to interrupt playback of the table to continue playing the
 							next paragraph.</p>
 
@@ -9382,29 +9368,29 @@ html.my-document-playing * {
 			<section id="sec-mo-nav-doc" class="informative">
 				<h3>Navigation document overlays</h3>
 
-				<p>As the <a>EPUB Navigation Document</a> is an <a>XHTML Content Document</a>, <a>EPUB Creators</a> may
-					associate an audio Media Overlay with it. Unlike traditional XHTML Content Documents, however,
-						<a>Reading Systems</a> must present the EPUB Navigation Document to users even when it is not
+				<p>As the <a>EPUB navigation document</a> is an <a>XHTML content document</a>, <a>EPUB creators</a> may
+					associate an audio Media Overlay with it. Unlike traditional XHTML content documents, however,
+						<a>reading systems</a> must present the EPUB navigation document to users even when it is not
 					included in the <a>spine</a> (see <a data-cite="epub-rs-33#sec-nav">Navigation Document
 						Processing</a> [[EPUB-RS-33]]). As a result, the method in which an associated Media Overlay
 					behaves can change depending on the context:</p>
 
 				<ul>
 					<li>
-						<p>When included in the spine, playback of the EPUB Navigation Document's Media Overlay obeys
-							the same conformance requirements as with any other XHTML Content Document.</p>
+						<p>When included in the spine, playback of the EPUB navigation document's Media Overlay obeys
+							the same conformance requirements as with any other XHTML content document.</p>
 					</li>
 					<li>
 						<p>When exposed in a presentation context that allows users to access and activate the links,
-							Reading Systems may implement additional presentation behaviors to expose audio feedback
+							reading systems may implement additional presentation behaviors to expose audio feedback
 							when user access navigation links.</p>
 					</li>
 				</ul>
 				<div class="note">
 					<p>Specific implementation details are beyond the scope of this specification. The <a
 							href="https://www.daisy.org/guidelines/epub/media-overlays-playback-requirements">DAISY
-							Media Overlays Playback Requirements</a> document describes best practices for EPUB Creators
-						and provides recommendations for Reading System developers.</p>
+							Media Overlays Playback Requirements</a> document describes best practices for EPUB creators
+						and provides recommendations for reading system developers.</p>
 				</div>
 			</section>
 		</section>
@@ -9416,20 +9402,20 @@ html.my-document-playing * {
 
 			<p>The requirements and practices for creating accessible web content have already been documented in the
 				W3C's <a href="https://www.w3.org/TR/wcag2/">Web Content Accessibility Guidelines (WCAG)</a> [[WCAG2]].
-				These guidelines also form the basis for defining accessibility in EPUB Publications.</p>
+				These guidelines also form the basis for defining accessibility in EPUB publications.</p>
 
 			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, <a
 					data-cite="epub-a11y-11#">EPUB Accessibility</a> [[EPUB-A11Y-11]], defines how to apply the standard
-				to <a>EPUB Publications</a>. It also adds EPUB-specific requirements and recommendations for metadata,
+				to <a>EPUB publications</a>. It also adds EPUB-specific requirements and recommendations for metadata,
 				pagination, and media overlays.</p>
 
-			<p>This specification recommends that EPUB Publications <a href="#confreq-a11y">conform to the accessibility
+			<p>This specification recommends that EPUB publications <a href="#confreq-a11y">conform to the accessibility
 					requirements</a> defined in [[EPUB-A11Y-11]]. A benefit of following this recommendation is that it
-				helps to ensure that EPUB Publications meet the accessibility requirements legislated in jurisdictions
+				helps to ensure that EPUB publications meet the accessibility requirements legislated in jurisdictions
 				around the world.</p>
 
-			<p><a>EPUB Creators</a>, however, should look beyond legal imperatives and treat accessibility as a
-				requirement for all their content. The more accessible that EPUB Publications are, the greater the
+			<p><a>EPUB creators</a>, however, should look beyond legal imperatives and treat accessibility as a
+				requirement for all their content. The more accessible that EPUB publications are, the greater the
 				potential audience for them.</p>
 
 			<div class="note">
@@ -9447,20 +9433,20 @@ html.my-document-playing * {
 			<section id="security-privacy-overview">
 				<h3>Overview</h3>
 
-				<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
+				<p>The particularity of an <a>EPUB publication</a> is its structure. The EPUB format provides a means of
 					representing, packaging, and encoding structured and semantically enhanced web content — including
 					HTML, CSS, SVG, JavaScript, and other resources — for distribution in a single-file container.</p>
 
 				<p>This means that EPUB 3's security and privacy issues are primarily linked to the features of those
 					formats, and closely mirror the threats presented by web content.</p>
 
-				<p>Although content risks are often equated with deliberately malicious authoring intent, EPUB Creators
+				<p>Although content risks are often equated with deliberately malicious authoring intent, EPUB creators
 					need to be aware that many practices followed with the best of intentions may expose users to
 					privacy and security issues. The rest of this section explores the risk model of EPUB 3 with the aim
-					of helping EPUB Creators recognize and mitigate these risks.</p>
+					of helping EPUB creators recognize and mitigate these risks.</p>
 
 				<div class="note">
-					<p>For the risks associated with Reading Systems, refer to the <a
+					<p>For the risks associated with reading systems, refer to the <a
 							data-cite="epub-rs-33#sec-security-privacy">security and privacy section</a> of
 						[[EPUB-RS-33]].</p>
 				</div>
@@ -9469,29 +9455,29 @@ html.my-document-playing * {
 			<section id="epub-threat-model">
 				<h3>Threat model</h3>
 
-				<p>EPUB Publications pose a variety of privacy and security threats to unsuspecting users. Many of these
+				<p>EPUB publications pose a variety of privacy and security threats to unsuspecting users. Many of these
 					threats intersect with web content, but EPUB also introduces its own unique methods of attack that
 					can be used to trick users into accessing malicious content or into providing sensitive information.
-					Some of the more important attack vectors that EPUB Creators and users need to be aware of
+					Some of the more important attack vectors that EPUB creators and users need to be aware of
 					include:</p>
 
 				<dl>
-					<dt>Embedding of Remote Resources</dt>
+					<dt>Embedding of remote resources</dt>
 					<dd>
-						<p>EPUB 3 allows some <a>Publication Resources</a> to be <a href="#sec-resource-locations"
+						<p>EPUB 3 allows some <a>publication resources</a> to be <a href="#sec-resource-locations"
 								>remotely hosted</a>, specifically resources whose sizes can negatively affect the
-							downloading and opening of the EPUB Publication (e.g., audio, video, and fonts). Although
+							downloading and opening of the EPUB publication (e.g., audio, video, and fonts). Although
 							helpful for users when used as intended, these exemptions can also be used to inject
 							malicious content into a publication.</p>
-						<p>This threat is not limited to accessing content created by a bad actor. If EPUB Creators
+						<p>This threat is not limited to accessing content created by a bad actor. If EPUB creators
 							embed content from untrustworthy sources (e.g., third party audio and video), there is
 							always the possibility that users may receive compromised resources.</p>
 						<p>Checking for malware and exploits at distribution time is not always reliable, either, as the
 							malicious content can be swapped in any time after publication, unlike resources that come
-							embedded in the EPUB Container.</p>
-						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB Creator
-							and specific to each Reading System implementation. Consequently, if the EPUB Creator hosts
-							Remote Resources on a web server they control, the server effectively cannot use security
+							embedded in the EPUB container.</p>
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB creator
+							and specific to each reading system implementation. Consequently, if the EPUB creator hosts
+							remote resources on a web server they control, the server effectively cannot use security
 							features that require specifying allowable origins, such as headers for <a
 								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
 								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
@@ -9502,24 +9488,24 @@ html.my-document-playing * {
 					<dt>Linking to external resources</dt>
 					<dd>
 						<p>Whether intentional or not, links to external web sites and resources expose users to
-							potential exploits that can compromise their Reading System or operating system. Although
+							potential exploits that can compromise their reading system or operating system. Although
 							external links will typically open in a web browser, and be subject to the browser security
 							model, this does not protect users from all exploits.</p>
-						<p>Even if the intentions of the EPUB Creator are not malicious, adding tracking information to
+						<p>Even if the intentions of the EPUB creator are not malicious, adding tracking information to
 							external links is problematic for user privacy as it can allow a user's activity to be
 							tracked without their consent.</p>
 						<p>Broken-link hijacking &#8212; when a domain expires and is bought by another party to exploit
-							the links to it &#8212; can also lead to users being taken to resources the EPUB Creator did
+							the links to it &#8212; can also lead to users being taken to resources the EPUB creator did
 							not intend.</p>
 					</dd>
 
 					<dt>Including malicious content</dt>
 					<dd>
-						<p>Resources embedded in the EPUB Container are not immune to malicious actors, especially when
-							EPUB Publications are obtained from untrusted sources. Resources may contain exploits or
+						<p>Resources embedded in the EPUB container are not immune to malicious actors, especially when
+							EPUB publications are obtained from untrusted sources. Resources may contain exploits or
 							forms may submit sensitive information to unintended parties.</p>
 						<p>The use of third-party content, such as games and quizzes, may also lead to security and
-							privacy issues if the EPUB Creator is not able to fully vet the content.</p>
+							privacy issues if the EPUB creator is not able to fully vet the content.</p>
 					</dd>
 
 					<dt>Allowing scripts network access</dt>
@@ -9530,17 +9516,17 @@ html.my-document-playing * {
 							<li>collecting information about the user and their activities, whether malicious or
 								not;</li>
 							<li>attempting to access the file system and local storage to harvest information;</li>
-							<li>phishing attempts (e.g., making an EPUB Content Document appear like a trusted web site
+							<li>phishing attempts (e.g., making an EPUB content document appear like a trusted web site
 								to get the user to submit login information); and</li>
-							<li>injecting malicious content from external sites into the EPUB Publication.</li>
+							<li>injecting malicious content from external sites into the EPUB publication.</li>
 						</ul>
 						<p>Network access may allow third-party content to exploit the user even if it was not the EPUB
-							Creator's intent.</p>
+							creator's intent.</p>
 					</dd>
 
 					<dt>Securing content with digital rights management</dt>
 					<dd>
-						<p>The encryption and decryption of EPUB Publications using digital rights management schemes
+						<p>The encryption and decryption of EPUB publications using digital rights management schemes
 							may allow personally identifiable information about the user, what vendors they use, and
 							their reading choices to be relayed to third parties.</p>
 					</dd>
@@ -9553,17 +9539,17 @@ html.my-document-playing * {
 				<dl>
 					<dt>Falsified publication information</dt>
 					<dd>
-						<p>The EPUB Publication may include false information about itself to trick users into believing
-							that it comes from a legitimate source. A malicious EPUB Creator might, for example, fake
+						<p>The EPUB publication may include false information about itself to trick users into believing
+							that it comes from a legitimate source. A malicious EPUB creator might, for example, fake
 							the title, authors, identifiers, and publisher for the work.</p>
 						<p>Although this misinformation itself does not present an immediate harm, it could lead users
-							to trust malicious forms, links, and other content within the EPUB Publication believing it
+							to trust malicious forms, links, and other content within the EPUB publication believing it
 							comes from a reliable source.</p>
 					</dd>
 
 					<dt>Spoofed platforms</dt>
 					<dd>
-						<p>Malicious EPUB Creators may also design their content to imitate or replicate a platform's
+						<p>Malicious EPUB creators may also design their content to imitate or replicate a platform's
 							experience to trick users into trusting their content.</p>
 					</dd>
 				</dl>
@@ -9590,8 +9576,8 @@ html.my-document-playing * {
 					</ul>
 
 					<p>The one potential exception is the <a data-cite="epub-rs-33#app-epubReadingSystem"
-								><code>epubReadingSystem</code> object</a> [[EPUB-RS-33]] that allows EPUB Creators to
-						query information about the current Reading System. EPUB Creators need to be mindful that they
+								><code>epubReadingSystem</code> object</a> [[EPUB-RS-33]] that allows EPUB creators to
+						query information about the current reading system. EPUB creators need to be mindful that they
 						only use the information exposed by this object to improve the rendering of their content (i.e.,
 						avoid using the information to profile the user and their environment).</p>
 				</section>
@@ -9600,17 +9586,17 @@ html.my-document-playing * {
 			<section id="security-privacy-recommendations">
 				<h3>Recommendations</h3>
 
-				<p>Although EPUB Creators cannot prevent every method of exploiting users, they are ultimately
+				<p>Although EPUB creators cannot prevent every method of exploiting users, they are ultimately
 					responsible for the secure construction of their content. That means that they should take
-					precautions to limit the exposure of their EPUB Publications to the types of <a
+					precautions to limit the exposure of their EPUB publications to the types of <a
 						href="#epub-threat-model">malicious exploits</a> described in the previous section.</p>
 
 				<p>Some practical steps include:</p>
 
 				<ul>
-					<li>Ensuring the use of stable links to <a>Remote Resources</a>.</li>
+					<li>Ensuring the use of stable links to <a>remote resources</a>.</li>
 					<li>Avoiding third-party resources, especially those hosted on servers outside the control of the
-						EPUB Creator.</li>
+						EPUB creator.</li>
 					<li>Avoiding links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
 					<li>Using secure connections to external sites and resources (i.e., using the HTTPS protocol).</li>
 					<li>Not using scripts to send or receive data over the network without the consent of the user.</li>
@@ -9622,14 +9608,14 @@ html.my-document-playing * {
 						implementations.</li>
 				</ul>
 
-				<p>EPUB Creators also need to consider the privacy rights of users and avoid situations where they are
-					intentionally collecting data. Ideally, EPUB Creators should not track their users, but this is not
+				<p>EPUB creators also need to consider the privacy rights of users and avoid situations where they are
+					intentionally collecting data. Ideally, EPUB creators should not track their users, but this is not
 					realistic for all types of publishing.</p>
 
-				<p>When tracking must occur, EPUB Creators should obtain the approval of the user to collect information
-					prior to opening the EPUB Publication (e.g., in educational course work). If this is not possible,
-					they should obtain permission when users access the EPUB Publication for the first time. EPUB
-					Creators should also allow users to opt out of tracking, when feasible, and provide users the
+				<p>When tracking must occur, EPUB creators should obtain the approval of the user to collect information
+					prior to opening the EPUB publication (e.g., in educational course work). If this is not possible,
+					they should obtain permission when users access the EPUB publication for the first time. EPUB
+					creators should also allow users to opt out of tracking, when feasible, and provide users the
 					ability to manage and delete any data that is collected about them.</p>
 
 				<p>Content authors also need to consider the inadvertent collection of information about users. Linking
@@ -9640,8 +9626,8 @@ html.my-document-playing * {
 					that do not utilize or transmit information about the user or their content to external parties to
 					perform encryption or decryption.</p>
 
-				<p>EPUB Creators who want to maximally limit the privacy and security issues in their EPUB Publications
-					should work to make the content as self-contained as possible. An EPUB Publication that comes with
+				<p>EPUB creators who want to maximally limit the privacy and security issues in their EPUB publications
+					should work to make the content as self-contained as possible. An EPUB publication that comes with
 					all its needed resources and has no dependencies on network access or links to external content not
 					only benefits users but reduces future maintenance and improves archivability.</p>
 			</section>
@@ -9649,9 +9635,9 @@ html.my-document-playing * {
 		<section id="app-overview-unsupported" class="appendix">
 			<h2>Unsupported features</h2>
 
-			<p>This specification contains certain features that are not yet fully supported in Reading Systems, that
+			<p>This specification contains certain features that are not yet fully supported in reading systems, that
 				the Working Group no longer recommends for use, or that are only retained for interoperability with EPUB
-				2 Reading Systems. This section defines the meanings of the designations attached to these features and
+				2 reading systems. This section defines the meanings of the designations attached to these features and
 				their support expectations.</p>
 
 			<section id="under-implemented">
@@ -9663,29 +9649,29 @@ html.my-document-playing * {
 						experience</a>.</p>
 
 				<p>These features are considered important to retain despite this limitation because they are known to
-					be implemented by EPUB Creators (i.e., their deprecation would invalidate existing content) and/or
+					be implemented by EPUB creators (i.e., their deprecation would invalidate existing content) and/or
 					they are integral to the content model on which EPUB is built.</p>
 
 				<p>If this specification designates a feature as under-implemented, the following hold true:</p>
 
 				<ul>
 					<li>
-						<p><a>EPUB Creators</a> MAY use the features as described.</p>
+						<p><a>EPUB creators</a> MAY use the features as described.</p>
 					</li>
 					<li>
-						<p><a>Reading Systems</a> SHOULD support the feature as described.</p>
+						<p><a>Reading systems</a> SHOULD support the feature as described.</p>
 					</li>
 				</ul>
 
 				<div class="note">
-					<p><a>EPUB Conformance Checkers</a> should alert EPUB Creators to the presence of under-implemented
-						features when encountered in EPUB Publications but must not treat their inclusion as a violation
+					<p><a>EPUB conformance checkers</a> should alert EPUB creators to the presence of under-implemented
+						features when encountered in EPUB publications but must not treat their inclusion as a violation
 						of the standard (i.e., not emit errors or warnings).</p>
 				</div>
 
 				<div class="caution">
 					<p>Whether under-implemented labels are removed or replaced by deprecation in a future version of
-						the standard cannot be determined at this time. EPUB Creators should strongly consider the
+						the standard cannot be determined at this time. EPUB creators should strongly consider the
 						interoperability problems that may arise both now and in the future when using these
 						features.</p>
 				</div>
@@ -9701,24 +9687,24 @@ html.my-document-playing * {
 				<h3>Deprecated features</h3>
 
 				<p>A <strong>deprecated</strong> feature is one the Working Group no longer recommends for use in this
-					version of the specification. Deprecated features typically have limited or no support in Reading
-					Systems and/or usage in EPUB Publications. If this specification designates a feature as deprecated,
+					version of the specification. Deprecated features typically have limited or no support in reading
+					systems and/or usage in EPUB publications. If this specification designates a feature as deprecated,
 					the following hold true:</p>
 
 				<ul>
 					<li>
-						<p><a>EPUB Creators</a> SHOULD NOT use the feature in their <a>EPUB Publications</a>.</p>
+						<p><a>EPUB creators</a> SHOULD NOT use the feature in their <a>EPUB publications</a>.</p>
 					</li>
 					<li>
-						<p><a>Reading Systems</a> MAY support the feature.</p>
+						<p><a>Reading systems</a> MAY support the feature.</p>
 						<p class="note">Developers should consider the unlikelihood of encountering content with
 							deprecated features before adding new support for them.</p>
 					</li>
 				</ul>
 
 				<div class="note">
-					<p><a>EPUB Conformance Checkers</a> should alert EPUB Creators to the presence of deprecated
-						features when encountered in EPUB Publications.</p>
+					<p><a>EPUB conformance checkers</a> should alert EPUB creators to the presence of deprecated
+						features when encountered in EPUB publications.</p>
 				</div>
 			</section>
 
@@ -9731,18 +9717,18 @@ html.my-document-playing * {
 
 				<ul>
 					<li>
-						<p><a>EPUB Creators</a> MAY include the legacy feature for compatibility purposes.</p>
+						<p><a>EPUB creators</a> MAY include the legacy feature for compatibility purposes.</p>
 					</li>
 					<li>
-						<p><a>Reading Systems</a> MUST NOT support the legacy feature in content that conforms to this
+						<p><a>Reading systems</a> MUST NOT support the legacy feature in content that conforms to this
 							version of EPUB.</p>
 					</li>
 				</ul>
 
 				<div class="note">
-					<p><a>EPUB Conformance Checkers</a> should not alert EPUB Creators about the presence of legacy
-						features in an <a>EPUB Publication</a>, as their inclusion is valid for backwards compatibility.
-						EPUB Conformance Checkers must alert EPUB Creators if a legacy feature does not conform to its
+					<p><a>EPUB conformance checkers</a> should not alert EPUB creators about the presence of legacy
+						features in an <a>EPUB publication</a>, as their inclusion is valid for backwards compatibility.
+						EPUB conformance checkers must alert EPUB creators if a legacy feature does not conform to its
 						definition or otherwise breaks a usage requirement.</p>
 				</div>
 			</section>
@@ -9754,7 +9740,7 @@ html.my-document-playing * {
 					<a data-cite="xml#dt-sysid">system identifiers</a> [[XML]] allowed in <a data-cite="xml#dt-doctype"
 					>document type declarations</a>. [[XML]]</p>
 
-			<p>EPUB Creators MAY use these external identifiers only in <a>Publication Resources</a> with the listed
+			<p>EPUB creators MAY use these external identifiers only in <a>publication resources</a> with the listed
 				media types specified in their <a href="#sec-manifest-elem">manifest</a> declarations. (Refer to <a
 					href="#sec-xml-constraints"></a> for more information.)</p>
 
@@ -9821,19 +9807,21 @@ html.my-document-playing * {
 
 				<p>Structural semantics add additional meaning about the specific structural purpose an element plays.
 					The <a href="#sec-epub-type-attribute"><code>epub:type</code> attribute</a> is used to express
-					domain-specific semantics in <a>EPUB Content Documents</a> and <a>Media Overlay Documents</a>, with
+					domain-specific semantics in <a>EPUB content documents</a> and <a>media overlay documents</a>, with
 					the structural information it carries complementing the underlying vocabulary.</p>
 
 				<p>The applied semantics refine the meaning of their containing elements without changing their nature
-					for assistive technologies, as happens when using the similar [^/role^] attribute [[HTML]]. The attribute does not enhance the accessibility of the content, in other words, only provides hints about the purpose.</p>
+					for assistive technologies, as happens when using the similar [^/role^] attribute [[HTML]]. The
+					attribute does not enhance the accessibility of the content, in other words, only provides hints
+					about the purpose.</p>
 
 				<p>Semantic metadata enriches content for use in publishing workflows and for author-defined purposes.
-					It also allows Reading Systems to learn more about the structure and content of a document (e.g., to
+					It also allows reading systems to learn more about the structure and content of a document (e.g., to
 					enable <a href="#sec-behaviors-skip-escape">skippability and escapability</a> in Media
 					Overlays).</p>
 
 				<p>This specification defines a method for adding structural semantics using <em>the attribute
-					axis</em>: instead of adding new elements, EPUB Creators can append the <code>epub:type</code>
+					axis</em>: instead of adding new elements, EPUB creators can append the <code>epub:type</code>
 					attribute to existing elements to add the desired semantics.</p>
 			</section>
 
@@ -9857,7 +9845,7 @@ html.my-document-playing * {
 
 					<dt>Usage:</dt>
 					<dd>
-						<p><a data-cite="html#global-attributes">Global attribute</a>. EPUB Creators MAY specify on all
+						<p><a data-cite="html#global-attributes">Global attribute</a>. EPUB creators MAY specify on all
 							elements.</p>
 					</dd>
 
@@ -9870,18 +9858,18 @@ html.my-document-playing * {
 				</dl>
 
 				<div class="caution">
-					<p>Although the <code>epub:type</code> attribute is similar in nature to the 
-						[^/role^] attribute [[HTML]], the attributes
-						serve different purposes. The values of the <code>epub:type</code> attribute do not enhance
-						access through assistive technologies like screen readers as they do not map to the
-						accessibility <abbr title="Application Programming Interfaces">APIs</abbr> used by these
-						technologies. This means that adding <code>epub:type</code> values to semantically neutral
-						elements like [[HTML]] <a><code>div</code></a> and <a><code>span</code></a> does not make them any more
+					<p>Although the <code>epub:type</code> attribute is similar in nature to the [^/role^]
+						attribute [[HTML]], the attributes serve different purposes. The values of the
+							<code>epub:type</code> attribute do not enhance access through assistive technologies like
+						screen readers as they do not map to the accessibility <abbr
+							title="Application Programming Interfaces">APIs</abbr> used by these technologies. This
+						means that adding <code>epub:type</code> values to semantically neutral elements like [[HTML]]
+								<a><code>div</code></a> and <a><code>span</code></a> does not make them any more
 						accessible to assistive technologies. Only ARIA roles influence how assistive technologies
 						understand such elements.</p>
 
 					<p>The <code>epub:type</code> attribute is consequently only intended for publishing semantics and
-						Reading System enhancements. Reading Systems may use <code>epub:type</code> values to provide
+						reading system enhancements. Reading systems may use <code>epub:type</code> values to provide
 						accessibility enhancements like built-in read aloud or Media Overlays functionality where
 						interaction with assistive technologies is not essential.</p>
 
@@ -9894,7 +9882,7 @@ html.my-document-playing * {
 					document instance.</p>
 
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
-					the EPUB 3 Structural Semantics Vocabulary [[?EPUB-SSV-11]]. EPUB Creators MAY include unprefixed
+					the EPUB 3 Structural Semantics Vocabulary [[?EPUB-SSV-11]]. EPUB creators MAY include unprefixed
 					terms that are not part of this vocabulary, but the preferred method for adding custom semantics is
 					to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a href="#sec-vocab-assoc"></a>
 					for more information.</p>
@@ -9965,25 +9953,25 @@ html.my-document-playing * {
 
 					<p>EPUB defines a formal method of referencing terms and properties defined in metadata and semantic
 						vocabularies using the <a href="#sec-property-datatype"><var>property</var> data type</a>. The
-							<code>epub:type</code> attribute uses this data type in <a>EPUB Content Documents</a> and
-							<a>Media Overlay Documents</a> to add <a href="#app-structural-semantics">structural
+							<code>epub:type</code> attribute uses this data type in <a>EPUB content documents</a> and
+							<a>media overlay documents</a> to add <a href="#app-structural-semantics">structural
 							semantics</a>, for example, while the <code>property</code> and <code>rel</code> attributes
-						use the data type to define properties and relationships in the <a>Package Document</a>.</p>
+						use the data type to define properties and relationships in the <a>package document</a>.</p>
 
 					<p>A <var>property</var> value is like a CURIE [[RDFA-CORE]] &#8212; it represents a URL [[URL]] in
 						compact form. The expression consists of a prefix and a reference, where the prefix — whether
 						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
-						vocabulary. When a Reading System converts the prefix to its URL representation and combines
+						vocabulary. When a reading system converts the prefix to its URL representation and combines
 						with the reference, the resulting URL normally resolves to a fragment within that vocabulary
 						that contains human- and/or machine-readable information about the term.</p>
 
 					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> data type
 						also defines a <a href="#sec-default-vocab">default vocabulary</a>. Terms and properties
-						referenced from the default vocabularies do not include a prefix as the mapping <a>Reading
-							Systems</a> use to map to a URL is predefined.</p>
+						referenced from the default vocabularies do not include a prefix as the mapping <a>reading
+							systems</a> use to map to a URL is predefined.</p>
 
 					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
-						terms and properties, EPUB Creators only need to declare a <a href="#sec-prefix-attr"
+						terms and properties, EPUB creators only need to declare a <a href="#sec-prefix-attr"
 						>prefix</a>. In another authoring convenience, this specification also <a
 							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
 						publishing vocabularies (i.e., their declaration is optional).</p>
@@ -10053,7 +10041,7 @@ html.my-document-playing * {
 								prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
 					</aside>
 
-					<p>When an EPUB Creator omits a prefix from a <var>property</var> value, the expressed reference
+					<p>When an EPUB creator omits a prefix from a <var>property</var> value, the expressed reference
 						represents a term from the <a href="#sec-default-vocab">default vocabulary</a> for that
 						attribute.</p>
 
@@ -10077,12 +10065,12 @@ html.my-document-playing * {
 				<section id="sec-default-vocab">
 					<h5>Default vocabularies</h5>
 
-					<p>A default vocabulary is one that EPUB Creators do not have to declare a <a
+					<p>A default vocabulary is one that EPUB creators do not have to declare a <a
 							href="#sec-prefix-attr">prefix</a> for in order to use its terms and properties where a <a
-							href="#sec-property-datatype"><var>property</var> value</a> is expected. EPUB Creators MUST
+							href="#sec-property-datatype"><var>property</var> value</a> is expected. EPUB creators MUST
 						NOT add a prefix to terms and properties from a default vocabulary.</p>
 
-					<p>EPUB Creators MUST NOT assign a prefix to the URLs associated with these vocabularies using the
+					<p>EPUB creators MUST NOT assign a prefix to the URLs associated with these vocabularies using the
 							<a href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
 
 					<div class="note">
@@ -10160,13 +10148,13 @@ html.my-document-playing * {
 						</tr>
 					</table>
 
-					<p>EPUB Creators MUST only specify the <code>prefix</code> attribute on the root element of the
+					<p>EPUB creators MUST only specify the <code>prefix</code> attribute on the root element of the
 						respective format.</p>
 
-					<p>The attribute is not namespaced when used in the <a>Package Document</a>.</p>
+					<p>The attribute is not namespaced when used in the <a>package document</a>.</p>
 
-					<aside class="example" title="Declaring prefixes in the Package Document">
-						<p>In this example, the EPUB Creator declares prefixes for the Friend of a Friend
+					<aside class="example" title="Declaring prefixes in the package document">
+						<p>In this example, the EPUB creator declares prefixes for the Friend of a Friend
 								(<code>foaf</code>) and DBPedia (<code>dbp</code>) vocabularies.</p>
 
 						<pre>&lt;package
@@ -10177,12 +10165,12 @@ html.my-document-playing * {
 &lt;/package></pre>
 					</aside>
 
-					<p>EPUB Creators MUST declare the attribute in the namespace
-							<code>http://www.idpf.org/2007/ops</code> in <a>EPUB Content Documents</a> and <a>Media
-							Overlay Documents</a>.</p>
+					<p>EPUB creators MUST declare the attribute in the namespace
+							<code>http://www.idpf.org/2007/ops</code> in <a>EPUB content documents</a> and <a>media
+							overlay documents</a>.</p>
 
-					<aside class="example" title="Declaring prefixes in an XHTML Content Document">
-						<p>In this example, the EPUB Creator declares a prefix for the Z39.98 Structural Semantics
+					<aside class="example" title="Declaring prefixes in an XHTML content document">
+						<p>In this example, the EPUB creator declares a prefix for the Z39.98 Structural Semantics
 							Vocabulary.</p>
 
 						<pre>&lt;html …
@@ -10194,11 +10182,11 @@ html.my-document-playing * {
 
 					<div class="note">
 						<p>Although the <code>prefix</code> attribute is modeled on the identically named
-								<code>prefix</code> attribute in [[RDFA-CORE]], EPUB Creators cannot use the attributes
-							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB Content
-							Documents is the RDFa attribute.</p>
+								<code>prefix</code> attribute in [[RDFA-CORE]], EPUB creators cannot use the attributes
+							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB content
+							documents is the RDFa attribute.</p>
 
-						<p>It is common for both attributes to appear in EPUB Content Documents that also specify RDFa
+						<p>It is common for both attributes to appear in EPUB content documents that also specify RDFa
 							expressions.</p>
 
 						<pre>&lt;html … prefix="…"
@@ -10210,43 +10198,43 @@ html.my-document-playing * {
 					<p>Note that for <a href="#sec-xhtml-svg">embedded SVG</a>, prefixes MUST be declared on the
 						[[HTML]] root <a><code>html</code></a> element.</p>
 
-					<p>To avoid conflicts, EPUB Creators MUST NOT use the <code>prefix</code> attribute to declare a
+					<p>To avoid conflicts, EPUB creators MUST NOT use the <code>prefix</code> attribute to declare a
 						prefix that maps to the <a href="#sec-default-vocab">default vocabulary</a>.</p>
 
-					<p>EPUB Creators MUST NOT declare the prefix '_' as this specification reserves this prefix for
+					<p>EPUB creators MUST NOT declare the prefix '_' as this specification reserves this prefix for
 						future compatibility with RDFa [[RDFA-CORE]] processing.</p>
 
-					<p>For future compatibility with alternative serializations of the Package Document, EPUB Creators
+					<p>For future compatibility with alternative serializations of the package document, EPUB creators
 						MUST NOT declare a prefix for the Dublin Core <em>/elements/1.1/</em> namespace [[DCTERMS]].
-							<a>EPUB Creators</a> MUST use only the [[DCTERMS]] elements <a href="#sec-pkg-metadata"
-							>allowed in the Package Document metadata</a>.</p>
+							<a>EPUB creators</a> MUST use only the [[DCTERMS]] elements <a href="#sec-pkg-metadata"
+							>allowed in the package document metadata</a>.</p>
 				</section>
 
 				<section id="sec-reserved-prefixes">
 					<h4>Reserved prefixes</h4>
 
 					<div class="caution">
-						<p>Although reserved prefixes are an authoring convenience, EPUB Creators should avoid relying
-							on them as they may cause interoperability issues. <a>EPUB Conformance Checkers</a> will
+						<p>Although reserved prefixes are an authoring convenience, EPUB creators should avoid relying
+							on them as they may cause interoperability issues. <a>EPUB conformance checkers</a> will
 							often reject new prefixes until their developers update the tools to the latest version of
-							the specification, for example. EPUB Creators should declare all prefixes they use to avoid
+							the specification, for example. EPUB creators should declare all prefixes they use to avoid
 							such issues.</p>
 					</div>
 
-					<p><a>EPUB Creators</a> MAY use reserved prefixes in attributes that expect a <a
+					<p><a>EPUB creators</a> MAY use reserved prefixes in attributes that expect a <a
 							href="#sec-property-datatype"><var>property</var> value</a> without declaring them in a <a
 							href="#sec-prefix-attr"><code>prefix</code> attribute</a>.</p>
 
 
-					<p>EPUB Creators SHOULD NOT override reserved prefixes in the <a href="#sec-prefix-attr"
+					<p>EPUB creators SHOULD NOT override reserved prefixes in the <a href="#sec-prefix-attr"
 								><code>prefix</code> attribute</a>.</p>
 
-					<p>The reserved prefixes an EPUB Creators can use depends on the context:</p>
+					<p>The reserved prefixes an EPUB creators can use depends on the context:</p>
 
 					<dl class="conformance-list">
-						<dt>Package Document</dt>
+						<dt>Package document</dt>
 						<dd id="sec-metadata-reserved-prefixes">
-							<p>EPUB Creators MAY use the following prefixes in <a>Package Document</a> attributes
+							<p>EPUB creators MAY use the following prefixes in <a>package document</a> attributes
 								without having to declare them.</p>
 							<table id="tbl-pkg-reserved-prefixes" class="prefix">
 								<thead>
@@ -10294,7 +10282,7 @@ html.my-document-playing * {
 
 						<dt id="sec-content-reserved-prefixes">Structural Semantics</dt>
 						<dd>
-							<p>EPUB Creators MAY use the following reserved prefixes in the <a
+							<p>EPUB creators MAY use the following reserved prefixes in the <a
 									href="#app-structural-semantics"><code>epub:type</code> attribute</a> without having
 								to declare them.</p>
 							<table id="tbl-reserved-prefixes" class="prefix">
@@ -10333,14 +10321,14 @@ html.my-document-playing * {
 
 					<dt>Applies To</dt>
 					<dd>
-						<p>Specifies which Publication Resource type(s) EPUB Creators MAY specify the property on.</p>
+						<p>Specifies which publication resource type(s) EPUB creators MAY specify the property on.</p>
 						<p>This field appears for properties used in the <a href="#attrdef-properties"
 									><code>properties</code> attribute</a>.</p>
 					</dd>
 
 					<dt>Cardinality</dt>
 					<dd>
-						<p>Specifies the number of times EPUB Creators MAY specify the property, whether globally or
+						<p>Specifies the number of times EPUB creators MAY specify the property, whether globally or
 							attached to another element or property.</p>
 						<p>Properties with a minimum cardinality of one MUST be specified.</p>
 					</dd>
@@ -10348,7 +10336,7 @@ html.my-document-playing * {
 					<dt>Description</dt>
 					<dd>
 						<p>Describes the purpose of the property and specifies any additional usage requirements that
-							EPUB Creators must follow.</p>
+							EPUB creators must follow.</p>
 					</dd>
 
 					<dt>Example</dt>
@@ -10358,7 +10346,7 @@ html.my-document-playing * {
 
 					<dt>Extends</dt>
 					<dd>
-						<p>Identifies what EPUB Creators MAY associate the property with.</p>
+						<p>Identifies what EPUB creators MAY associate the property with.</p>
 						<p>This field appears for properties that define <a href="#meta-expr-types">primary expressions
 								and subexpressions</a> and <a href="#attrdef-link-rel">relationships</a>.</p>
 					</dd>
@@ -10388,8 +10376,8 @@ html.my-document-playing * {
 			<p>This appendix describes the prefixed CSS properties supported by EPUB. </p>
 
 			<p class="note">The prefix definitions are no longer being synchronized with their CSS counterparts. In some
-				cases, the unprefixed versions of these properties now support additional values. Reading Systems may
-				not support the new syntax with the prefixed properties, so EPUB Creators are advised to use the
+				cases, the unprefixed versions of these properties now support additional values. Reading systems may
+				not support the new syntax with the prefixed properties, so EPUB creators are advised to use the
 				unprefixed versions for newer features.</p>
 
 			<section id="sec-css-prefixed-writing-modes">
@@ -10756,7 +10744,7 @@ html.my-document-playing * {
 			<section id="app-package-schema">
 				<h3>Package document schema</h3>
 
-				<p>A schema for Package Documents is available at <a
+				<p>A schema for package documents is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
 						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.</p>
 
@@ -10825,8 +10813,8 @@ html.my-document-playing * {
 			<section id="publication-resources-example">
 				<h3>Resources</h3>
 
-				<p>Consider the following extracts of a <a>Package Document</a> and an <a>XHTML Content
-					Document</a>:</p>
+				<p>Consider the following extracts of a <a>package document</a> and an <a>XHTML content
+					document</a>:</p>
 
 				<pre>&lt;package …>
     &lt;metadata …>
@@ -10916,38 +10904,38 @@ html.my-document-playing * {
 &lt;/html>					
 				</pre>
 
-				<p>The various resources in the <a>EPUB Publication</a> can be categorized as follows. (Refer to <a
+				<p>The various resources in the <a>EPUB publication</a> can be categorized as follows. (Refer to <a
 						href="#sec-publication-resources"></a> for more information about these categories.)</p>
 
 				<dl>
 					<dt><code>meta/data.xml</code></dt>
 					<dd>
 						<p>The resource is a metadata record, stored in the container. It is linked via a <a
-								href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It
-							is therefore a <a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in
+								href="#sec-link-elem"><code>link</code> element</a> in the package document metadata. It
+							is therefore a <a>linked resource</a> on the <a>manifest plane</a>, i.e., is not listed in
 							the <a>manifest</a>. It is not part on any other planes. </p>
 					</dd>
 
 					<dt><code>https://www.example.org/meta/data2.xml</code></dt>
 					<dd>
 						<p>The resource is a metadata record, stored remotely. It is linked via a <a
-								href="#sec-link-elem"><code>link</code> element</a> in the Package Document metadata. It
-							is therefore a <a>Linked Resource</a> on the <a>manifest plane</a>, i.e., is not listed in
+								href="#sec-link-elem"><code>link</code> element</a> in the package document metadata. It
+							is therefore a <a>linked resource</a> on the <a>manifest plane</a>, i.e., is not listed in
 							the <a>manifest</a>. It is not part on any other planes.</p>
 					</dd>
 
 					<dt><code>page.xhtml</code></dt>
 					<dd>
-						<p>The resource is an XHTML document. It is listed in the spine. It is a <a>Publication
-								Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, an <a>EPUB
-								Content Document</a> on the <a>spine plane</a>, and is not present on the <a>content
+						<p>The resource is an XHTML document. It is listed in the spine. It is a <a>publication
+								resource</a> on the <a>manifest plane</a>, a <a>container resource</a>, an <a>EPUB
+								content document</a> on the <a>spine plane</a>, and is not present on the <a>content
 								plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>nav.xhtml</code></dt>
 					<dd>
-						<p>The resource is the <a>EPUB Navigation Document</a>. It is not listed in the spine. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+						<p>The resource is the <a>EPUB navigation document</a>. It is not listed in the spine. It is a
+								<a>publication resource</a> on the <a>manifest plane</a>, a <a>container resource</a>,
 							and is not present on either the <a>spine plane</a> or the <a>content plane</a>. No fallback
 							is necessary.</p>
 					</dd>
@@ -10955,64 +10943,64 @@ html.my-document-playing * {
 					<dt><code>style.css</code></dt>
 					<dd>
 						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[HTML]]
-								<a data-lt="link"><code>link</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the
-								<a>content plane</a>. No fallback is necessary.</p>
+								<a data-lt="link"><code>link</code> element</a>. It is a <a>publication resource</a> on
+							the <a>manifest plane</a>, a <a>container resource</a>, is not present on the <a>spine
+								plane</a>, and is a <a>core media type resource</a> on the <a>content plane</a>. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.otf</code></dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
-							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a
-								<a>Container Resource</a>, is not present on the <a>spine plane</a>, and is a <a>Core
-								Media Type Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
+							CSS file. It is a <a>publication resource</a> on the <a>manifest plane</a>, is a
+								<a>container resource</a>, is not present on the <a>spine plane</a>, and is a <a>core
+								media type resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>https://www.example.org/fonts/font-file2.otf</code></dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
-							CSS file. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, is a <a>Remote
-								Resource</a>, is not present on the <a>spine plane</a>, and is a <a>Core Media Type
-								Resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
+							CSS file. It is a <a>publication resource</a> on the <a>manifest plane</a>, is a <a>remote
+								resource</a>, is not present on the <a>spine plane</a>, and is a <a>core media type
+								resource</a> on the <a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.cff</code></dt>
 					<dd>
 						<p>The resource is a font file in Compact Font Format. It is not listed in the spine but is
 							referenced from a CSS file. Its media type is not listed as a <a
-								href="#sec-core-media-types">core media type</a>. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine
-								plane</a>, and is an <a>Exempt Resource</a> on the <a>content plane</a>. No fallback is
+								href="#sec-core-media-types">core media type</a>. It is a <a>publication resource</a> on
+							the <a>manifest plane</a>, a <a>container resource</a>, is not present on the <a>spine
+								plane</a>, and is an <a>exempt resource</a> on the <a>content plane</a>. No fallback is
 							necessary.</p>
 					</dd>
 
 					<dt><code>speech/cmn.pls</code></dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
-							from an [[HTML]] <a data-lt="link"><code>link</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							not present on the <a>spine plane</a>, and is an <a>Exempt Resource</a> on the <a>content
-								plane</a>. No fallback is necessary.</p>
+							from an [[HTML]] <a data-lt="link"><code>link</code> element</a>. It is a <a>publication
+								resource</a> on the <a>manifest plane</a>, a <a>container resource</a>, not present on
+							the <a>spine plane</a>, and is an <a>exempt resource</a> on the <a>content plane</a>. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_1.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-lt="img"><code>img</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the
-								<a>content plane</a>. No fallback is necessary.</p>
+							[[HTML]] <a data-lt="img"><code>img</code> element</a>. It is a <a>publication resource</a>
+							on the <a>manifest plane</a>, a <a>container resource</a>, is not present on the <a>spine
+								plane</a>, and is a <a>core media type resource</a> on the <a>content plane</a>. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_2.png</code></dt>
 					<dd>
-						<p>The resource is a PNG image file. It is referenced via an [[HTML]] <a
-								data-lt="a"><code>a</code> element</a>. Because it is referenced from
-							a hyperlink, it <em>must</em> be listed in the spine. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, a <a>Container Resource</a>, a <a>Foreign Content Document</a> on
-							the <a>spine plane</a>, and a <a>Core Media Type Resource</a> on the <a>content plane</a>.
-							As a <a>Foreign Content Document</a> a fallback is required, which is provided via a <a
+						<p>The resource is a PNG image file. It is referenced via an [[HTML]] <a data-lt="a"
+									><code>a</code> element</a>. Because it is referenced from a hyperlink, it
+								<em>must</em> be listed in the spine. It is a <a>publication resource</a> on the
+								<a>manifest plane</a>, a <a>container resource</a>, a <a>foreign content document</a> on
+							the <a>spine plane</a>, and a <a>core media type resource</a> on the <a>content plane</a>.
+							As a <a>foreign content document</a> a fallback is required, which is provided via a <a
 								href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
@@ -11020,8 +11008,8 @@ html.my-document-playing * {
 					<dd>
 						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not
 							explicitly listed in the spine (but it "replaces" the existing spine item when needed). It
-							is a <a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							an EPUB Content Document on <a>spine plane</a>, and, because it is not "used" when rendering
+							is a <a>publication resource</a> on the <a>manifest plane</a>, a <a>container resource</a>,
+							an EPUB content document on <a>spine plane</a>, and, because it is not "used" when rendering
 							another Content Document, it is not present on the <a>content plane</a>. No fallback is
 							necessary.</p>
 					</dd>
@@ -11029,43 +11017,40 @@ html.my-document-playing * {
 					<dt><code>image/image_3.heic</code></dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
-							referenced from an [[HTML]] <a data-lt="source"><code>source</code>
-								element</a>. Its media type is not listed as a <a href="#sec-core-media-types">core
-								media type</a>. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a
-								<a>Container Resource</a>, is not present on the <a>spine plane</a>, and is a <a>Foreign
-								Resource</a> on the <a>content plane</a>. As a <a>Foreign Resource</a>, a fallback is
-							required, which is provided via the sibling [[HTML]] <a data-lt="img"
-									><code>img</code> element</a> in an [[HTML]] <a data-lt="picture"
-									><code>picture</code> element</a>.</p>
+							referenced from an [[HTML]] <a data-lt="source"><code>source</code> element</a>. Its media
+							type is not listed as a <a href="#sec-core-media-types">core media type</a>. It is a
+								<a>publication resource</a> on the <a>manifest plane</a>, a <a>container resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>foreign resource</a> on the <a>content
+								plane</a>. As a <a>foreign resource</a>, a fallback is required, which is provided via
+							the sibling [[HTML]] <a data-lt="img"><code>img</code> element</a> in an [[HTML]] <a
+								data-lt="picture"><code>picture</code> element</a>.</p>
 					</dd>
 
 					<dt><code>image/image_3.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-lt="img"><code>img</code> element</a> that is used as an
-							intrinsic fallback of the [[HTML]] <a data-lt="picture"
-									><code>picture</code> element</a>. It is a <a>Publication Resource</a> on the
-								<a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine
-								plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
-							fallback is necessary.</p>
+							[[HTML]] <a data-lt="img"><code>img</code> element</a> that is used as an intrinsic fallback
+							of the [[HTML]] <a data-lt="picture"><code>picture</code> element</a>. It is a
+								<a>publication resource</a> on the <a>manifest plane</a>, a <a>container resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>core media type resource</a> on the
+								<a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>widget.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-lt="iframe"><code>iframe</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on <a>spine plane</a>, and, because it is "used" when rendering another
-							Content Document, a <a>Core Media Type Resource</a> on the <a>content plane</a>. No fallback
-							is necessary.</p>
+							[[HTML]] <a data-lt="iframe"><code>iframe</code> element</a>. It is a <a>publication
+								resource</a> on the <a>manifest plane</a>, a <a>container resource</a>, is not present
+							on <a>spine plane</a>, and, because it is "used" when rendering another Content Document, a
+								<a>core media type resource</a> on the <a>content plane</a>. No fallback is
+							necessary.</p>
 					</dd>
 
 					<dt><code>https://www.example.org/some_content</code></dt>
 					<dd>
-						<p>The resource is referenced via an [[HTML]] <a data-lt="a"><code>a</code>
-								element</a> and is not stored in the <a>EPUB Container</a>. Reading Systems will
-							normally open this link via a separate browser instance. It is not on any planes defined by
-							this specification.</p>
+						<p>The resource is referenced via an [[HTML]] <a data-lt="a"><code>a</code> element</a> and is
+							not stored in the <a>EPUB container</a>. Reading systems will normally open this link via a
+							separate browser instance. It is not on any planes defined by this specification.</p>
 					</dd>
 				</dl>
 
@@ -11076,7 +11061,7 @@ html.my-document-playing * {
 			<section id="scripted-contexts-example">
 				<h3>Scripting contexts</h3>
 
-				<p>Consider the following example Package Document:</p>
+				<p>Consider the following example package document:</p>
 
 				<pre>&lt;package …>
     …
@@ -11107,7 +11092,7 @@ html.my-document-playing * {
     &lt;head>
         …
         &lt;script type="text/javascript">
-            alert("Reading System name: " + navigator.epubReadingSystem.name);
+            alert("Reading system name: " + navigator.epubReadingSystem.name);
         &lt;/script>
     &lt;/head>
     &lt;body>
@@ -11148,9 +11133,9 @@ html.my-document-playing * {
 				<h3>Packaged EPUB</h3>
 
 				<p>This example demonstrates the use of the OCF format to contain a signed and encrypted EPUB
-					Publication within an <a>OCF ZIP Container</a>.</p>
+					publication within an <a>OCF ZIP container</a>.</p>
 
-				<p>Ordered list of files in the OCF ZIP Container:</p>
+				<p>Ordered list of files in the OCF ZIP container:</p>
 
 				<pre>mimetype
 META-INF/container.xml
@@ -11467,10 +11452,10 @@ EPUB/images/cover.png</pre>
 				<h3>The <code>application/oebps-package+xml</code> media type</h3>
 
 				<p>This appendix registers the media type <code>application/oebps-package+xml</code> for the EPUB
-					Package Document. This registration supersedes [[RFC4839]].</p>
+					package document. This registration supersedes [[RFC4839]].</p>
 
-				<p>The Package Document is an XML file that describes an EPUB Publication. It identifies the resources
-					in the EPUB Publication and provides metadata information. The Package Document and its related
+				<p>The package document is an XML file that describes an EPUB publication. It identifies the resources
+					in the EPUB publication and provides metadata information. The package document and its related
 					specifications are maintained and defined by the <a href="https://www.w3.org">World Wide Web
 						Consortium</a> (W3C).</p>
 
@@ -11501,19 +11486,19 @@ EPUB/images/cover.png</pre>
 
 					<dt>Encoding considerations:</dt>
 					<dd>
-						<p>Package Documents are UTF-8 or UTF-16 encoded XML.</p>
+						<p>Package documents are UTF-8 or UTF-16 encoded XML.</p>
 					</dd>
 
 					<dt>Security considerations:</dt>
 					<dd>
-						<p>Package Documents contain well-formed XML conforming to the XML 1.0 specification.</p>
+						<p>Package documents contain well-formed XML conforming to the XML 1.0 specification.</p>
 						<p>Clearly, it is possible to author malicious files which, for example, contain malformed data.
 							Most XML parsers protect themselves from such attacks by rigorously enforcing
 							conformance.</p>
-						<p>All processors that read Package Documents should rigorously check the size and validity of
+						<p>All processors that read package documents should rigorously check the size and validity of
 							data retrieved.</p>
 						<p>There is no current provision in the EPUB 3 specification for encryption, signing, or
-							authentication within the Package Document format.</p>
+							authentication within the package document format.</p>
 					</dd>
 
 					<dt>Interoperability considerations:</dt>
@@ -11523,7 +11508,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Published specification:</dt>
 					<dd>
-						<p>This media type registration is for the EPUB Package Document, as described by the EPUB 3
+						<p>This media type registration is for the EPUB package document, as described by the EPUB 3
 							specification located at <a href="https://www.w3.org/TR/epub-33/"
 								>https://www.w3.org/TR/epub-33/</a>.</p>
 						<p>The EPUB 3 specification supersedes the Open Packaging Format 2.0.1 specification, which is
@@ -11588,8 +11573,8 @@ EPUB/images/cover.png</pre>
 				<p>This appendix registers the media type <code>application/epub+zip</code> for the EPUB Open Container
 					Format (OCF).</p>
 
-				<p>An <a>OCF ZIP Container</a>, or <a>EPUB Container</a>, file is a container technology based on the
-					[[ZIP]] archive format. It is used to encapsulate the EPUB Publication. OCF and its related
+				<p>An <a>OCF ZIP container</a>, or <a>EPUB container</a>, file is a container technology based on the
+					[[ZIP]] archive format. It is used to encapsulate the EPUB publication. OCF and its related
 					standards are maintained and defined by the <a href="https://www.w3.org">World Wide Web
 						Consortium</a> (W3C).</p>
 
@@ -11620,23 +11605,23 @@ EPUB/images/cover.png</pre>
 
 					<dt>Encoding considerations:</dt>
 					<dd>
-						<p>OCF ZIP Container files are binary files encoded in the <a class="media-type"
+						<p>OCF ZIP container files are binary files encoded in the <a class="media-type"
 								href="https://www.iana.org/assignments/media-types/application/zip">
 								<code>application/zip</code></a> media type.</p>
 					</dd>
 
 					<dt>Security considerations:</dt>
 					<dd>
-						<p>All processors that read OCF ZIP Container files should rigorously check the size and
+						<p>All processors that read OCF ZIP container files should rigorously check the size and
 							validity of data retrieved.</p>
-						<p>In addition, because of the various content types that can be embedded in OCF ZIP Container
+						<p>In addition, because of the various content types that can be embedded in OCF ZIP container
 							files, <code>application/epub+zip</code> may describe content that poses security
 							implications beyond those noted here. However, only in cases where the processor recognizes
 							and processes the additional content, or where further processing of that content is
 							dispatched to other processors, would security issues potentially arise. In such cases,
 							matters of security would fall outside the domain of this registration document.</p>
 						<p>Security considerations that apply to <code>application/zip</code> also apply to OCF ZIP
-							Container files.</p>
+							container files.</p>
 					</dd>
 
 					<dt>Interoperability considerations:</dt>
@@ -11673,7 +11658,7 @@ EPUB/images/cover.png</pre>
 
 							<dt>File extension(s):</dt>
 							<dd>
-								<p>OCF ZIP Container files are most often identified with the extension
+								<p>OCF ZIP container files are most often identified with the extension
 										<code>.epub</code>.</p>
 							</dd>
 
@@ -11713,7 +11698,7 @@ EPUB/images/cover.png</pre>
 
 			<p>Note that this change log only identifies substantive changes since <a
 					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> &#8212; those that affect the
-				conformance of <a>EPUB Publications</a> or are similarly noteworthy.</p>
+				conformance of <a>EPUB publications</a> or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+-label%3ASpec-RS+"
@@ -11724,15 +11709,15 @@ EPUB/images/cover.png</pre>
 					note referencing the old IDPF registry. See <a href="https://github.com/w3c/epub-specs/issues/2120"
 						>issue 2200</a>.</li>
 				<li>31-Mar-2022: Removed the restriction on deprecated MathML features and added a general caution that
-					any technology may make changes that can cause an EPUB Publication to become invalid. See <a
+					any technology may make changes that can cause an EPUB publication to become invalid. See <a
 						href="https://github.com/w3c/epub-specs/issues/2118">issue 2118</a>.</li>
 				<li>31-Mar-2022: Reformulated custom attributes as a content authoring feature and added a new section
 					on custom rendering properties. See <a href="https://github.com/w3c/epub-specs/issues/2134">issue
 						2134</a>.</li>
-				<li>25-Mar-2022: Fixed conflicting statements about the requirement for semantics in Media Overlay
-					Documents and clarified requirements for skippability and escapability. See <a
+				<li>25-Mar-2022: Fixed conflicting statements about the requirement for semantics in media overlay
+					documents and clarified requirements for skippability and escapability. See <a
 						href="https://github.com/w3c/epub-specs/issues/2066">issue 2066</a>.</li>
-				<li>22-Mar-2022: Removed the recommendation that Reading Systems recognize the built-in
+				<li>22-Mar-2022: Removed the recommendation that reading systems recognize the built-in
 					`collection-type` values and replaced with a note about enabling improved handling of related
 					content. See <a href="https://github.com/w3c/epub-specs/issues/2071">issue 2071</a>.</li>
 				<li>21-Mar-2022: Add a tolerance of one second for the sum of the individual Media Overlay Docuemnts
@@ -11743,13 +11728,13 @@ EPUB/images/cover.png</pre>
 				<li>17-Mar-2022: Removed dated requirements on the use of <code>epub:type</code> that suggest
 					equivalence with ARIA roles. See <a href="https://github.com/w3c/epub-specs/pull/2070">issue
 						2070</a>.</li>
-				<li>16-Mar-2022: Add new section on conformance checking and definition for EPUB Conformance Checker.
+				<li>16-Mar-2022: Add new section on conformance checking and definition for EPUB conformance checker.
 					See <a href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
 				<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to
 					"valid-relative-ocf-URL-with-fragment string". See <a
 						href="https://github.com/w3c/epub-specs/issues/2076">issue 2076</a>.</li>
 				<li>09-Mar-2022: Restore requirement that valid-relative-container-URL-with-fragment strings resolve to
-					resources in the OCF Abstract Container. See <a href="https://github.com/w3c/epub-specs/issues/2024"
+					resources in the OCF abstract container. See <a href="https://github.com/w3c/epub-specs/issues/2024"
 						>issue 2024</a>.</li>
 				<li>09-Mar-2022: Added NCX doctype to allowed external identifiers. See <a
 						href="https://github.com/w3c/epub-specs/issues/2045">issue 2045</a>.</li>
@@ -11766,7 +11751,7 @@ EPUB/images/cover.png</pre>
 					the element is indeed not present. See <a href="https://github.com/w3c/epub-specs/issues/1986">issue
 						1986</a>.</li>
 				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
-					model for EPUB Publications and additional recommendations for ensuring security and privacy. See <a
+					model for EPUB publications and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a
 						href="https://github.com/w3c/epub-specs/issues/1872">issue 1872</a>, <a
 						href="https://github.com/w3c/epub-specs/issues/1875">issue 1875</a> and <a
@@ -11799,7 +11784,7 @@ EPUB/images/cover.png</pre>
 				<li>10-Nov-2021: Proper definition of the content URL and handling of relative URLs. See <a
 						href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and <a
 						href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
-				<li>29-Oct-2021: Recommended that EPUB Creators not use path-absolute-URL strings for referencing
+				<li>29-Oct-2021: Recommended that EPUB creators not use path-absolute-URL strings for referencing
 					resources due to the lack of a consistent root. See <a
 						href="https://github.com/w3c/epub-specs/issues/1681">issue 1681</a>.</li>
 				<li>18-Oct-2021: Clarified the contexts from which remote resources may be referenced. See <a
@@ -11820,8 +11805,8 @@ EPUB/images/cover.png</pre>
 				<li>05-July-2021: Removed the section on private use area characters from the XHTML restrictions. The
 					issues are more complex than what is covered and not in scope of EPUB to define. See <a
 						href="https://github.com/w3c/epub-specs/issues/1732">issue 1732</a>.</li>
-				<li>28-June-2021: Added a note discouraging EPUB Creators from referencing resources outside the
-					directory containing the Package Document to avoid interoperability issues. See <a
+				<li>28-June-2021: Added a note discouraging EPUB creators from referencing resources outside the
+					directory containing the package document to avoid interoperability issues. See <a
 						href="https://github.com/w3c/epub-specs/issues/1687">issue 1687</a></li>
 				<li>23-June-2021: Added the <code>base</code> element to the list of discouraged XHTML constructs. See
 						<a href="https://github.com/w3c/epub-specs/issues/1699">issue 1699</a>.</li>
@@ -11834,7 +11819,7 @@ EPUB/images/cover.png</pre>
 				<li>31-May-2021: Require Unicode normalization and full case folding (in this order) for file name
 					uniqueness comparisons. See <a href="https://github.com/w3c/epub-specs/issues/1631">issue 1631</a>
 					and <a href="https://github.com/w3c/epub-specs/pull/1648">pull request 1648</a>.</li>
-				<li>31-May-2021: Confirmed that SVG Content Documents do not have to be valid to the SVG specification,
+				<li>31-May-2021: Confirmed that SVG content documents do not have to be valid to the SVG specification,
 					only meet the well-formedness and ID requirements currently referenced and the restrictions imposed
 					by this specification. See <a href="https://github.com/w3c/epub-specs/issues/1323">issue
 					1323</a>.</li>
@@ -11861,13 +11846,13 @@ EPUB/images/cover.png</pre>
 						1312</a>.</li>
 				<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 is the recommended
 					encoding. See <a href="https://github.com/w3c/epub-specs/issues/1628">issue 1628</a>.</li>
-				<li>19-Apr-2021: The use of custom attributes in EPUB Content Documents is no longer supported. See <a
+				<li>19-Apr-2021: The use of custom attributes in EPUB content documents is no longer supported. See <a
 						href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>
 				<li>13-Apr-2021: Require path names in OCF to also be UTF-8 encoded. See <a
 						href="https://github.com/w3c/epub-specs/issues/1630">issue 1630</a>.</li>
 				<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in <a href="#sec-css-req"
 					></a>. See <a href="https://github.com/w3c/epub-specs/issues/1613">issue 1614</a>.</li>
-				<li>09-Apr-2021: Added a new section dedicated to accessibility in EPUB Publications.</li>
+				<li>09-Apr-2021: Added a new section dedicated to accessibility in EPUB publications.</li>
 				<li>04-May-2021: Removed requirements around SVG <code>requiredExtensions</code> attribute. See <a
 						href="https://github.com/w3c/epub-specs/issues/1087">issue 1087</a>.</li>
 				<li>26-Mar-2021: Removed requirement for page list ordering to reflect the order of page breaks in the
@@ -11876,7 +11861,7 @@ EPUB/images/cover.png</pre>
 					multiple roles and allowed roles for <code>publisher</code>. See <a
 						href="https://github.com/w3c/epub-specs/issues/1129">issue 1129</a> and <a
 						href="https://github.com/w3c/epub-specs/issues/1583">issue 1583</a></li>
-				<li>23-Mar-2021: Clarified the requirements for the use of data URLs in EPUB Publications. See <a
+				<li>23-Mar-2021: Clarified the requirements for the use of data URLs in EPUB publications. See <a
 						href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a>.</li>
 				<li>17-Mar-2021: Include non characters at the end of the supplementary planes in list of characters not
 					allowed in file names. See <a href="https://github.com/w3c/epub-specs/issues/1538">issue
@@ -11885,14 +11870,14 @@ EPUB/images/cover.png</pre>
 					definitions for the <code>container.xml</code>, <code>encryption.xml</code> and
 						<code>signatures.xml</code> files. All schemas are considered non-normative. See <a
 						href="https://github.com/w3c/epub-specs/issues/1566">issue 1566</a>.</li>
-				<li>10-Mar-2021: Require that resources referenced from an EPUB Publication not be located in the
+				<li>10-Mar-2021: Require that resources referenced from an EPUB publication not be located in the
 						<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205"
 						>issue 1205</a>.</li>
 				<li>08-Mar-2021: The fix for <a href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a> on
-					20-Jan-2021 incorrectly mentioned EPUB Content Documents having durations. Corrected to Media
-					Overlay Documents.</li>
+					20-Jan-2021 incorrectly mentioned EPUB content documents having durations. Corrected to media
+					overlay documents.</li>
 				<li>08-Mar-2021: Added recommendation that <code>refines</code> attribute use fragment identifiers to
-					reference Publication Resources. See <a href="https://github.com/w3c/epub-specs/issues/1361">issue
+					reference publication resources. See <a href="https://github.com/w3c/epub-specs/issues/1361">issue
 						1361</a>.</li>
 				<li>08-Mar-2021: Change requirement that Media Overlay <code>par</code> and <code>seq</code> ordering
 					match the default reading order to guidance. See <a
@@ -11903,11 +11888,11 @@ EPUB/images/cover.png</pre>
 				<li>26-Feb-2021: Created a new section for describing general metadata value requirements, specifically
 					whitespace handling. See <a href="https://github.com/w3c/epub-specs/issues/1528">issue
 					1528</a>.</li>
-				<li>17-Feb-2020: File extension recommendations have been removed (affects the Package Document, XHTML
-					Content Documents, Media Overlay Documents). See <a
+				<li>17-Feb-2020: File extension recommendations have been removed (affects the package document, XHTML
+					content documents, media overlay documents). See <a
 						href="https://github.com/w3c/epub-specs/issues/1294">issue 1294</a>.</li>
 				<li>15-Feb-2021: Clarified that <code>nav</code> elements without an <code>epub:type</code> attribute
-					are not subject to the EPUB Navigation Document's content model restrictions. See <a
+					are not subject to the EPUB navigation document's content model restrictions. See <a
 						href="https://github.com/w3c/epub-specs/issues/976">issue 976</a>.</li>
 				<li>10-Feb-2021: A first draft of the <a href="#sec-security-privacy">security and privacy section</a>
 					has been added.</li>
@@ -11919,10 +11904,10 @@ EPUB/images/cover.png</pre>
 				<li>02-Feb-2021: Added the <code>hreflang</code> attribute to <code>link</code> elements to identify the
 					language of linked resources. See <a href="https://github.com/w3c/epub-specs/issues/1488">issue
 						1488</a>.</li>
-				<li>20-Jan-2021: Clarified that user-defined media overlay style classes must be declared in the Package
-					Document metadata. See <a href="https://github.com/w3c/epub-specs/issues/1319">issue 1319</a>.</li>
+				<li>20-Jan-2021: Clarified that user-defined media overlay style classes must be declared in the package
+					document metadata. See <a href="https://github.com/w3c/epub-specs/issues/1319">issue 1319</a>.</li>
 				<li>20-Jan-2021: Add recommendation that the sum of the media overlay durations for each Content
-					Document match the total duration specified for the EPUB Publication. See <a
+					Document match the total duration specified for the EPUB publication. See <a
 						href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>.</li>
 				<li>20-Jan-2021: Clarified that the <code>epub:type</code> attribute does not improve the accessibility
 					of publications. Added pointers to the <code>role</code> attribute and the DPUB-ARIA vocabulary for
@@ -11933,10 +11918,10 @@ EPUB/images/cover.png</pre>
 				<li>24-Dec-2020: The specification no longer refers to a release identifier, but the requirement to
 					include a last modification date remains for backwards compatibility. See <a
 						href="https://github.com/w3c/epub-specs/issues/1440">issue 1440</a>.</li>
-				<li>16-Dec-2020: Terminology and requirements related to "renditions" of an EPUB Publication have been
+				<li>16-Dec-2020: Terminology and requirements related to "renditions" of an EPUB publication have been
 					simplified to improve the readability of the specifications (i.e., to align with the generally
-					understood concept that an EPUB Publication has only a single rendering described by a single
-					Package Document). These changes do not affect the ability to include multiple renditions, which are
+					understood concept that an EPUB publication has only a single rendering described by a single
+					package document). These changes do not affect the ability to include multiple renditions, which are
 					now more fully covered in [[EPUB-MULTI-REND-11]]. See <a
 						href="https://github.com/w3c/epub-specs/issues/1436">issue 1436</a>.</li>
 				<li>14-Nov-2020: The term "semantic inflection" is no longer used to describe the process of adding
@@ -11944,7 +11929,7 @@ EPUB/images/cover.png</pre>
 					unnecessarily complex. The specification now simply refers to "expressing" or "adding" structural
 					semantics.</li>
 				<li>09-Nov-2020: The requirement that the ordering of the <code>toc nav</code> match the ordering of
-					EPUB Content Documents in the spine, and the elements within each file, has been reduced to a
+					EPUB content documents in the spine, and the elements within each file, has been reduced to a
 					recommendation. See <a href="https://github.com/w3c/epub-specs/issues/1283">issue 1283</a>.</li>
 				<li>06-Nov-2020: Clarified that HTML <code>script</code> elements that contain <a
 						href="#sec-scripted-context">data blocks are not instances of scripting</a>. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10540,7 +10540,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="sec-css-prefixed-text">
-				<h5>CSS Text Level 3</h5>
+				<h5>CSS text level 3</h5>
 
 				<p>This section describes the <code>-epub-</code> prefixed properties (and one prefixed value) for
 					[[CSS-Text-3]].</p>
@@ -10655,7 +10655,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="sec-css-prefixed-text-decoration">
-				<h5>CSS Text Decoration Level 3</h5>
+				<h5>CSS text decoration level 3</h5>
 
 				<p>This section describes the <code>-epub-</code> prefixed properties for [[CSS-Text-Decor-3]].</p>
 
@@ -10775,7 +10775,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="app-ocf-schema">
-				<h3>OCF Schemas</h3>
+				<h3>OCF schemas</h3>
 
 				<section id="app-schema-container">
 					<h4>Schema for <code>container.xml</code></h4>
@@ -11464,7 +11464,7 @@ EPUB/images/cover.png</pre>
 			<h2>Media type registrations</h2>
 
 			<section id="app-media-type-app-oebps-package">
-				<h3>The <code>application/oebps-package+xml</code> Media type</h3>
+				<h3>The <code>application/oebps-package+xml</code> media type</h3>
 
 				<p>This appendix registers the media type <code>application/oebps-package+xml</code> for the EPUB
 					Package Document. This registration supersedes [[RFC4839]].</p>
@@ -11583,7 +11583,7 @@ EPUB/images/cover.png</pre>
 			</section>
 
 			<section class="informative" id="app-media-type">
-				<h3>The <code>application/epub+zip</code> Media type</h3>
+				<h3>The <code>application/epub+zip</code> media type</h3>
 
 				<p>This appendix registers the media type <code>application/epub+zip</code> for the EPUB Open Container
 					Format (OCF).</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11812,7 +11812,7 @@ EPUB/images/cover.png</pre>
 						<a href="https://github.com/w3c/epub-specs/issues/1699">issue 1699</a>.</li>
 				<li>18-June-2021: Moved requirements for authoring SSML, PLS lexicons and CSS 3 Speech to the <a
 						href="https://www.w3.org/TR/epub-tts-10">EPUB 3 Text-to-Speech Enhancements</a> note. The
-					ability to use these technologies in EPUB 3 Publications remains unchanged. See <a
+					ability to use these technologies in EPUB 3 publications remains unchanged. See <a
 						href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
 				<li>16-June-2021: Absolute URLs with <code>file</code> scheme should not be used on manifest items. See
 						<a href="https://github.com/w3c/epub-specs/issues/1688">issue 1688</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5394,7 +5394,7 @@ No Entry</pre>
 
 					<p>EPUB creators also MUST list in the <code>spine</code> all EPUB and foreign content documents
 						hyperlinked to from the <a>EPUB navigation document</a>, regardless of whether EPUB creators
-						include the Navigation Document in the <code>spine</code>.</p>
+						include the EPUB navigation document in the <code>spine</code>.</p>
 
 					<div class="note">
 						<p>As hyperlinks to resources outside the EPUB container are not publication resources, they are
@@ -6220,7 +6220,7 @@ No Entry</pre>
 
 						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
 							rights and restrictions that a reading system places on it (refer to <a
-								data-cite="epub-rs-33#sec-scripted-content">Scripting Conformance</a> [[?EPUB-RS-33]]
+								data-cite="epub-rs-33#sec-scripted-content">Scripting conformance</a> [[?EPUB-RS-33]]
 							for more information).</p>
 
 						<div class="note">
@@ -9371,8 +9371,8 @@ html.my-document-playing * {
 				<p>As the <a>EPUB navigation document</a> is an <a>XHTML content document</a>, <a>EPUB creators</a> may
 					associate an audio Media Overlay with it. Unlike traditional XHTML content documents, however,
 						<a>reading systems</a> must present the EPUB navigation document to users even when it is not
-					included in the <a>spine</a> (see <a data-cite="epub-rs-33#sec-nav">Navigation Document
-						Processing</a> [[EPUB-RS-33]]). As a result, the method in which an associated Media Overlay
+					included in the <a>spine</a> (see <a data-cite="epub-rs-33#sec-nav">Navigation document
+						processing</a> [[EPUB-RS-33]]). As a result, the method in which an associated Media Overlay
 					behaves can change depending on the context:</p>
 
 				<ul>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11721,7 +11721,7 @@ EPUB/images/cover.png</pre>
 
 			<ul>
 				<li>6-Apr-2022: Removed the restrictions on the value of the <code>authority</code> property and added a
-					note referencing the old IDPF registry. See <a href="https://github.com/w3c/epub-specs/issues/2118"
+					note referencing the old IDPF registry. See <a href="https://github.com/w3c/epub-specs/issues/2120"
 						>issue 2200</a>.</li>
 				<li>31-Mar-2022: Removed the restriction on deprecated MathML features and added a general caution that
 					any technology may make changes that can cause an EPUB Publication to become invalid. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -193,7 +193,7 @@
 			</section>
 
 			<section id="sec-intro-relations" class="informative">
-				<h3>Relationship to Other Specifications</h3>
+				<h3>Relationship to other specifications</h3>
 
 				<div class="caution">
 					<p>The technologies EPUB 3 builds on are constantly evolving. Some, typically referred to as
@@ -678,7 +678,7 @@
 			</section>
 
 			<section id="sec-intro-shorthands" class="informative">
-				<h3>Authoring Shorthands</h3>
+				<h3>Authoring shorthands</h3>
 
 				<p>In <a>Package Document</a> metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
 						prefixes</a> are used without declaration.</p>
@@ -692,7 +692,7 @@
 			</section>
 		</section>
 		<section id="sec-epub-conf">
-			<h2>EPUB Publication Conformance</h2>
+			<h2>EPUB Publication conformance</h2>
 
 			<p>An EPUB Publication:</p>
 
@@ -727,7 +727,7 @@
 			<p>The rest of this specification covers specific conformance details.</p>
 
 			<section id="sec-conformance-checking" class="informative">
-				<h3>Conformance Checking</h3>
+				<h3>Conformance checking</h3>
 
 				<p>Due to the complexity of this specification and number of technologies used in <a>EPUB
 						Publications</a>, <a>EPUB Creators</a> are advised to use an <a>EPUB Conformance Checker</a> to
@@ -760,7 +760,7 @@
 			</section>
 		</section>
 		<section id="sec-publication-resources">
-			<h2>Publication Resources</h2>
+			<h2>Publication resources</h2>
 
 			<section id="sec-pub-res-intro" class="informative">
 				<h3>Introduction</h3>
@@ -801,7 +801,7 @@
 				</div>
 
 				<section id="sec-manifest-plane">
-					<h4>The Manifest Plane</h4>
+					<h4>The manifest plane</h4>
 
 					<p>To <dfn class="export">manifest plane</dfn> defines all the resources of an <a>EPUB
 							Publication</a>. It is analogous to the <a>Package Document</a>
@@ -848,7 +848,7 @@
 				</section>
 
 				<section id="sec-spine-plane">
-					<h4>The Spine Plane</h4>
+					<h4>The spine plane</h4>
 
 					<p>The <dfn class="export">spine plane</dfn> defines resources used in the default reading order
 						established by the <a>spine</a>, which includes both <a href="#attrdef-itemref-linear">linear
@@ -896,7 +896,7 @@
 				</section>
 
 				<section id="sec-content-plane">
-					<h4>The Content Plane</h4>
+					<h4>The content plane</h4>
 
 					<p>The <dfn class="export">content plane</dfn> classifies resources that are used when rendering
 							<a>EPUB Content Documents</a> and <a>Foreign Content Documents</a>. These types of resources
@@ -1294,10 +1294,10 @@
 
 
 			<section id="sec-resource-fallbacks">
-				<h4>Resource Fallbacks</h4>
+				<h4>Resource fallbacks</h4>
 
 				<section id="sec-manifest-fallbacks">
-					<h5>Manifest Fallbacks</h5>
+					<h5>Manifest fallbacks</h5>
 
 					<p>Manifest fallbacks are a feature of the <a>Package Document</a> that create a <dfn class="export"
 							>manifest fallback chain</dfn> for a <a>Publication Resource</a>, allowing Reading Systems
@@ -1354,13 +1354,13 @@
 				</section>
 
 				<section id="sec-intrinsic-fallbacks">
-					<h4>Intrinsic Fallbacks</h4>
+					<h4>Intrinsic fallbacks</h4>
 
 					<p>The following sections provide additional clarifications about the intrinsic fallback
 						requirements of specific elements.</p>
 
 					<section id="sec-fallbacks-audio">
-						<h5>HTML <code>audio</code> Fallbacks</h5>
+						<h5>HTML <code>audio</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-media">EPUB Creators MUST NOT use embedded [[HTML]] <a
 								data-cite="html#flow-content">flow content</a> within the <a
@@ -1383,7 +1383,7 @@
 					</section>
 
 					<section id="sec-fallbacks-img">
-						<h5>HTML <code>img</code> Fallbacks</h5>
+						<h5>HTML <code>img</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that EPUB Creators can
 							specify in the [[HTML]] <a data-cite="html#the-img-element"><code>img</code> element</a>,
@@ -1413,7 +1413,7 @@
 				</section>
 			</section>
 			<section id="sec-resource-locations">
-				<h4>Resource Locations</h4>
+				<h4>Resource locations</h4>
 
 				<p>EPUB Creators MAY host the following types of Publication Resources outside the EPUB Container:</p>
 
@@ -1528,7 +1528,7 @@
 			</section>
 
 			<section id="sec-xml-constraints">
-				<h3>XML Conformance</h3>
+				<h3>XML conformance</h3>
 
 				<p>Any <a>Publication Resource</a> that is an XML-Based Media Type:</p>
 
@@ -1567,7 +1567,7 @@
 			</section>
 		</section>
 		<section id="sec-ocf">
-			<h2>Open Container Format</h2>
+			<h2>Open container format</h2>
 
 			<section id="sec-container-abstract">
 				<h3>OCF Abstract Container</h3>
@@ -1639,7 +1639,7 @@
 				</section>
 
 				<section id="sec-container-file-and-dir-structure">
-					<h4>File and Directory Structure</h4>
+					<h4>File and directory structure</h4>
 
 					<p>The virtual file system for the <a>OCF Abstract Container</a> MUST have a single common <a>Root
 							Directory</a> for all the contents of the container.</p>
@@ -1668,7 +1668,7 @@
 				</section>
 
 				<section id="sec-container-filenames">
-					<h4>File Paths and File Names</h4>
+					<h4>File paths and file names</h4>
 
 					<p id="ocf-fn-cs">In the context of the Abstract Container, <a>File Paths</a> and <a>File Names</a>
 						are case sensitive.</p>
@@ -1798,7 +1798,7 @@
 				</section>
 
 				<section id="sec-file-names-to-path-names">
-					<h4>Deriving File Paths</h4>
+					<h4>Deriving file paths</h4>
 
 					<p>To <strong>derive the File Path</strong>, given a file or directory <var>file</var> in the <a
 							href="#sec-container-abstract">OCF Abstract Container</a>, apply the following steps
@@ -2026,7 +2026,7 @@
 				</section>
 
 				<section id="sec-container-metainf">
-					<h4><code>META-INF</code> Directory</h4>
+					<h4><code>META-INF</code> directory</h4>
 
 					<section id="sec-container-metainf-inc">
 						<h5>Inclusion in OCF Abstract Container</h5>
@@ -2039,7 +2039,7 @@
 					</section>
 
 					<section id="sec-parsing-urls-metainf">
-						<h5>Parsing URLs in the <code>META-INF</code> Directory</h5>
+						<h5>Parsing URLs in the <code>META-INF</code> directory</h5>
 
 						<p id="sec-container-metainf-url-parsing" data-tests="#ocf-url_relative">To parse a URL string
 								<var>url</var> used in files located in the <code>META-INF</code> directory the <a
@@ -2066,10 +2066,10 @@
 					</section>
 
 					<section id="sec-container-metainf-files">
-						<h5>Reserved Files</h5>
+						<h5>Reserved files</h5>
 
 						<section id="sec-container-metainf-container.xml">
-							<h6>Container File (<code>container.xml</code>)</h6>
+							<h6>Container file (<code>container.xml</code>)</h6>
 
 							<p>The REQUIRED <code>container.xml</code> file in the <code>META-INF</code> directory
 								identifies the <a>Package Documents</a> available in the <a>OCF Abstract
@@ -2087,7 +2087,7 @@
 								the content of this file.</p>
 
 							<section id="sec-container.xml-container-elem">
-								<h6>The <code>container</code> Element</h6>
+								<h6>The <code>container</code> element</h6>
 
 								<p>The <code>container</code> element is the root element of the
 										<code>container.xml</code> file.</p>
@@ -2130,7 +2130,7 @@
 							</section>
 
 							<section id="sec-container.xml-rootfiles-elem">
-								<h6>The <code>rootfiles</code> Element</h6>
+								<h6>The <code>rootfiles</code> element</h6>
 
 								<p>The <code>rootfiles</code> element contains a list of <a>Package Documents</a>
 									available in the <a>EPUB Container</a>.</p>
@@ -2164,7 +2164,7 @@
 							</section>
 
 							<section id="sec-container.xml-rootfile-elem">
-								<h6>The <code>rootfile</code> Element</h6>
+								<h6>The <code>rootfile</code> element</h6>
 
 								<p>Each <code>rootfile</code> element identifies the location of one <a>Package
 										Document</a> in the <a>EPUB Container</a>.</p>
@@ -2229,7 +2229,7 @@
 							</section>
 
 							<section id="sec-container.xml-links-elem">
-								<h6>The <code>links</code> Element</h6>
+								<h6>The <code>links</code> element</h6>
 
 								<p>The <code id="elemdef-container-links">links</code> element identifies resources
 									necessary for the processing of the <a>OCF ZIP Container</a>.</p>
@@ -2268,7 +2268,7 @@
 							</section>
 
 							<section id="sec-container.xml-link-elem">
-								<h6>The <code>link</code> Element</h6>
+								<h6>The <code>link</code> element</h6>
 
 								<dl id="elemdef-link" class="elemdef">
 									<dt>Element Name:</dt>
@@ -2345,7 +2345,7 @@
 						</section>
 
 						<section id="sec-container-metainf-encryption.xml">
-							<h6>Encryption File (<code>encryption.xml</code>)</h6>
+							<h6>Encryption file (<code>encryption.xml</code>)</h6>
 
 							<p>The OPTIONAL <code>encryption.xml</code> file in the <code>META-INF</code> directory
 								holds all encryption information on the contents of the container. If an EPUB Creator
@@ -2506,7 +2506,7 @@
 							</section>
 
 							<section id="sec-enc-compression">
-								<h6>Order of Compression and Encryption</h6>
+								<h6>Order of compression and encryption</h6>
 
 								<p>When stored in a ZIP container, EPUB Creators SHOULD compress streams of data with
 										<a>Non-Codec</a> content types before encrypting them. EPUB Creators MUST use
@@ -2603,7 +2603,7 @@
 						</section>
 
 						<section id="sec-container-metainf-manifest.xml">
-							<h6>Manifest File (<code>manifest.xml</code>)</h6>
+							<h6>Manifest file (<code>manifest.xml</code>)</h6>
 
 							<p>The OPTIONAL <code>manifest.xml</code> file in the <code>META-INF</code> directory
 								provides a manifest of files in the Container.</p>
@@ -2617,7 +2617,7 @@
 						</section>
 
 						<section id="sec-container-metainf-metadata.xml">
-							<h6>Metadata File (<code>metadata.xml</code>)</h6>
+							<h6>Metadata file (<code>metadata.xml</code>)</h6>
 
 							<p>The OPTIONAL <code>metadata.xml</code> file in the <code>META-INF</code> directory is
 								only for container-level metadata.</p>
@@ -2634,7 +2634,7 @@
 						</section>
 
 						<section id="sec-container-metainf-rights.xml">
-							<h6>Rights Management File (<code>rights.xml</code>)</h6>
+							<h6>Rights management file (<code>rights.xml</code>)</h6>
 
 							<p>This specification reserves the OPTIONAL <code>rights.xml</code> file in the
 									<code>META-INF</code> directory for digital rights management (DRM) information for
@@ -2650,7 +2650,7 @@
 						</section>
 
 						<section id="sec-container-metainf-signatures.xml">
-							<h6>Digital Signatures File (<code>signatures.xml</code>)</h6>
+							<h6>Digital signatures file (<code>signatures.xml</code>)</h6>
 
 							<div class="note">
 								<p>Adding a digital signature is not a guarantee that a malicious actor cannot tamper
@@ -2822,7 +2822,7 @@
 			</section>
 
 			<section id="sec-container-zip">
-				<h3>OCF ZIP Container</h3>
+				<h3>OCF ZIP container</h3>
 
 				<section id="sec-container-zip-intro" class="informative">
 					<h4>Introduction</h4>
@@ -2846,7 +2846,7 @@
 				</section>
 
 				<section id="sec-zip-container-zipreqs">
-					<h4>ZIP File Requirements</h4>
+					<h4>ZIP file requirements</h4>
 
 					<p>An <a>OCF ZIP Container</a> uses the ZIP format as specified by [[ZIP]], but with the following
 						constraints and clarifications:</p>
@@ -2898,7 +2898,7 @@
 				</section>
 
 				<section id="sec-zip-container-mime">
-					<h4>OCF ZIP Container Media Type Identification</h4>
+					<h4>OCF ZIP container media type identification</h4>
 
 					<p>EPUB Creators MUST include the <code>mimetype</code> file as the first file in the <a>OCF ZIP
 							Container</a>. In addition:</p>
@@ -2921,7 +2921,7 @@
 			</section>
 
 			<section id="sec-font-obfuscation">
-				<h3>Font Obfuscation</h3>
+				<h3>Font obfuscation</h3>
 
 				<div class="caution">
 					<p>Better methods of protecting fonts exist. Both [[WOFF]] and [[WOFF2]] fonts, for example, allow
@@ -2998,7 +2998,7 @@
 				</section>
 
 				<section id="obfus-keygen">
-					<h4>Obfuscation Key</h4>
+					<h4>Obfuscation key</h4>
 
 					<p>EPUB Creators MUST derive the key used in the obfuscation algorithm from the <a>Unique
 							Identifier</a>.</p>
@@ -3014,7 +3014,7 @@
 				</section>
 
 				<section id="obfus-algorithm">
-					<h4>Obfuscation Algorithm</h4>
+					<h4>Obfuscation algorithm</h4>
 
 					<p>The algorithm employed to obfuscate fonts consists of modifying the first 1040 bytes (~1KB) of
 						the font file. (In the unlikely event that the font file is less than 1040 bytes, this process
@@ -3078,7 +3078,7 @@
 				</section>
 
 				<section id="obfus-specifying">
-					<h4>Specifying Obfuscated Fonts</h4>
+					<h4>Specifying obfuscated fonts</h4>
 
 					<p>Although not technically encrypted data, all obfuscated fonts MUST have an entry in the <code
 							class="filename">encryption.xml</code> file accompanying the EPUB Publication (see <a
@@ -3179,13 +3179,13 @@
 			</section>
 
 			<section id="sec-shared-attrs">
-				<h3>Shared Attributes</h3>
+				<h3>Shared attributes</h3>
 
 				<p>This section provides definitions for shared attributes (i.e., attributes allowed on two or more
 					elements).</p>
 
 				<section id="attrdef-dir">
-					<h4>The <code>dir</code> Attribute</h4>
+					<h4>The <code>dir</code> attribute</h4>
 
 					<p
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
@@ -3230,7 +3230,7 @@
 
 
 				<section id="attrdef-href">
-					<h4>The <code>href</code> Attribute</h4>
+					<h4>The <code>href</code> attribute</h4>
 
 					<p>A <a data-cite="url#valid-url-string">valid URL string</a> [[URL]] that references a resource. If
 						the value is an <a data-cite="url#absolute-url-string">absolute URL</a>, it SHOULD NOT use the
@@ -3255,7 +3255,7 @@
 				</section>
 
 				<section id="attrdef-id">
-					<h4>The <code>id</code> Attribute</h4>
+					<h4>The <code>id</code> attribute</h4>
 
 					<p>The ID [[XML]] of the element, which MUST be unique within the document scope.</p>
 
@@ -3285,7 +3285,7 @@
 				</section>
 
 				<section id="attrdef-media-type">
-					<h4>The <code>media-type</code> Attribute</h4>
+					<h4>The <code>media-type</code> attribute</h4>
 
 					<p>A media type [[RFC2046]] that specifies the type and format of the referenced resource.</p>
 
@@ -3309,7 +3309,7 @@
 				</section>
 
 				<section id="attrdef-properties">
-					<h4>The <code>properties</code> Attribute</h4>
+					<h4>The <code>properties</code> attribute</h4>
 
 					<p>A space-separated list of <a href="#sec-property-datatype">property</a> values.</p>
 
@@ -3337,7 +3337,7 @@
 				</section>
 
 				<section id="attrdef-refines">
-					<h4>The <code>refines</code> Attribute</h4>
+					<h4>The <code>refines</code> attribute</h4>
 
 					<p>Establishes an association between the current expression and the element or resource identified
 						by its value. EPUB Creators MUST use as the value a <a
@@ -3402,7 +3402,7 @@
 				</section>
 
 				<section id="attrdef-xml-lang">
-					<h4>The <code>xml:lang</code> Attribute</h4>
+					<h4>The <code>xml:lang</code> attribute</h4>
 
 					<p>Specifies the language of the textual content and attribute values of the carrying element and
 						its descendants, as defined in section <a data-cite="xml#sec-lang-tag">2.12 Language
@@ -3429,7 +3429,7 @@
 			</section>
 
 			<section id="sec-package-elem">
-				<h3>The <code>package</code> Element</h3>
+				<h3>The <code>package</code> element</h3>
 
 				<p>The <code>package</code> element is the root element of the <a>Package Document</a>.</p>
 
@@ -3580,10 +3580,10 @@
 			</section>
 
 			<section id="sec-pkg-metadata">
-				<h3>Metadata Section</h3>
+				<h3>Metadata section</h3>
 
 				<section id="sec-metadata-elem">
-					<h4>The <code>metadata</code> Element</h4>
+					<h4>The <code>metadata</code> element</h4>
 
 					<p>The <code>metadata</code> element encapsulates meta information.</p>
 
@@ -3732,7 +3732,7 @@
 				</section>
 
 				<section id="sec-metadata-values">
-					<h4>Metadata Values</h4>
+					<h4>Metadata values</h4>
 
 					<p>The Dublin Core elements [[DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code> element</a>
 						have mandatory <a data-cite="dom#concept-child-text-content">child text content</a> [[DOM]].
@@ -3750,10 +3750,10 @@
 				</section>
 
 				<section id="sec-opf-dcmes-required">
-					<h4>Dublin Core Required Elements</h4>
+					<h4>Dublin Core required elements</h4>
 
 					<section id="sec-opf-dcidentifier">
-						<h5>The <code>dc:identifier</code> Element</h5>
+						<h5>The <code>dc:identifier</code> element</h5>
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
@@ -3858,7 +3858,7 @@
 					</section>
 
 					<section id="sec-opf-dctitle">
-						<h5>The <code>dc:title</code> Element</h5>
+						<h5>The <code>dc:title</code> element</h5>
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
@@ -3978,7 +3978,7 @@
 					</section>
 
 					<section id="sec-opf-dclanguage">
-						<h5>The <code>dc:language</code> Element</h5>
+						<h5>The <code>dc:language</code> element</h5>
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/language"
@@ -4048,10 +4048,10 @@
 				</section>
 
 				<section id="sec-opf-dcmes-optional">
-					<h4>Dublin Core Optional Elements</h4>
+					<h4>Dublin Core optional elements</h4>
 
 					<section id="sec-opf-dcmes-optional-def">
-						<h5>General Definition</h5>
+						<h5>General definition</h5>
 
 						<p>All [[DCTERMS]] elements except for <a href="#sec-opf-dcidentifier"
 									><code>dc:identifier</code></a>, <a href="#sec-opf-dclanguage"
@@ -4119,7 +4119,7 @@
 					</section>
 
 					<section id="sec-opf-dccontributor">
-						<h5>The <code>dc:contributor</code> Element</h5>
+						<h5>The <code>dc:contributor</code> element</h5>
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/contributor"
@@ -4133,7 +4133,7 @@
 					</section>
 
 					<section id="sec-opf-dccreator">
-						<h5>The <code>dc:creator</code> Element</h5>
+						<h5>The <code>dc:creator</code> element</h5>
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/creator"
@@ -4223,7 +4223,7 @@
 					</section>
 
 					<section id="sec-opf-dcdate">
-						<h5>The <code>dc:date</code> Element</h5>
+						<h5>The <code>dc:date</code> element</h5>
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/date"
@@ -4253,7 +4253,7 @@
 					</section>
 
 					<section id="sec-opf-dcsubject">
-						<h5>The <code>dc:subject</code> Element</h5>
+						<h5>The <code>dc:subject</code> element</h5>
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/subject"
@@ -4312,7 +4312,7 @@
 					</section>
 
 					<section id="sec-opf-dctype">
-						<h5>The <code>dc:type</code> Element</h5>
+						<h5>The <code>dc:type</code> element</h5>
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/type"
@@ -4333,7 +4333,7 @@
 				</section>
 
 				<section id="sec-meta-elem">
-					<h4>The <code>meta</code> Element</h4>
+					<h4>The <code>meta</code> element</h4>
 
 					<p>The <code>meta</code> element provides a generic means of including package metadata.</p>
 
@@ -4489,7 +4489,7 @@
 				</section>
 
 				<section id="sec-metadata-last-modified">
-					<h4>Last Modified Date</h4>
+					<h4>Last modified date</h4>
 
 					<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one [[DCTERMS]]
 							<code>modified</code> property containing the last modification date. The <a>value</a> of
@@ -4526,7 +4526,7 @@
 				</section>
 
 				<section id="sec-link-elem">
-					<h4>The <code>link</code> Element</h4>
+					<h4>The <code>link</code> element</h4>
 
 					<p>The <code>link</code> element associates resources with an <a>EPUB Publication</a>, such as
 						metadata records.</p>
@@ -4806,10 +4806,10 @@ XHTML:
 			</section>
 
 			<section id="sec-pkg-manifest">
-				<h3>Manifest Section</h3>
+				<h3>Manifest section</h3>
 
 				<section id="sec-manifest-elem">
-					<h4>The <code>manifest</code> Element</h4>
+					<h4>The <code>manifest</code> element</h4>
 
 					<p>The <code>manifest</code> element provides an exhaustive list of <a>Publication Resources</a>
 						used in the rendering of the content.</p>
@@ -4866,7 +4866,7 @@ XHTML:
 				</section>
 
 				<section id="sec-item-elem">
-					<h4>The <code>item</code> Element</h4>
+					<h4>The <code>item</code> element</h4>
 
 					<p>The <code>item</code> element represents a <a>Publication Resource</a>.</p>
 
@@ -4975,7 +4975,7 @@ XHTML:
 					</div>
 
 					<section id="sec-item-resource-properties">
-						<h6>Resource Properties</h6>
+						<h6>Resource properties</h6>
 
 						<p>The <a href="#attrdef-properties"><code>properties</code> attribute</a> provides information
 							to <a>Reading Systems</a> about the content of a resource. This information enables
@@ -5314,7 +5314,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-opf-bindings">
-					<h4>The <code>bindings</code> Element (Deprecated)</h4>
+					<h4>The <code>bindings</code> element (deprecated)</h4>
 
 					<p>The <code>bindings</code> element defines a set of custom handlers for media types not supported
 						by this specification.</p>
@@ -5329,10 +5329,10 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-pkg-spine">
-				<h3>Spine Section</h3>
+				<h3>Spine section</h3>
 
 				<section id="sec-spine-elem">
-					<h4>The <code>spine</code> Element</h4>
+					<h4>The <code>spine</code> element</h4>
 
 					<p>The <code>spine</code> element defines an ordered list of <a href="#sec-itemref-elem">manifest
 								<code>item</code> references</a> that represent the default reading order.</p>
@@ -5439,7 +5439,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-itemref-elem">
-					<h4>The <code>itemref</code> Element</h4>
+					<h4>The <code>itemref</code> element</h4>
 
 					<p>The <code>itemref</code> element identifies an <a>EPUB Content Document</a> or <a>Foreign Content
 							Document</a> in the default reading order.</p>
@@ -5589,7 +5589,7 @@ No Entry</pre>
 				<h3>Collections</h3>
 
 				<section id="sec-collection-elem">
-					<h4>The <code>collection</code> Element</h4>
+					<h4>The <code>collection</code> element</h4>
 
 					<p>The <code>collection</code> element defines a related group of resources.</p>
 
@@ -5686,7 +5686,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-defining-collection-types">
-					<h4>Defining Collection Types (Deprecated)</h4>
+					<h4>Defining collection types (deprecated)</h4>
 
 					<p>The creation of new <code>collection</code> element roles is now <a href="#deprecated"
 							>deprecated</a>.</p>
@@ -5700,10 +5700,10 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-pkg-legacy">
-				<h3>Legacy Content</h3>
+				<h3>Legacy content</h3>
 
 				<section id="sec-opf2-meta">
-					<h4>The <code>meta</code> Element</h4>
+					<h4>The <code>meta</code> element</h4>
 
 					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"><code>meta</code>
 							element</a> [[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided a
@@ -5724,7 +5724,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-opf2-guide">
-					<h4>The <code>guide</code> Element</h4>
+					<h4>The <code>guide</code> element</h4>
 
 					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code>
 							element</a> [[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided
@@ -5762,7 +5762,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-xhtml-req">
-					<h4>XHTML Requirements</h4>
+					<h4>XHTML requirements</h4>
 
 					<p>An XHTML Content Document:</p>
 
@@ -5793,7 +5793,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-xhtml-extensions">
-					<h4>HTML Extensions</h4>
+					<h4>HTML extensions</h4>
 
 					<p>This section defines EPUB 3 <a>XHTML Content Document</a> extensions to the underlying [[HTML]]
 						document model.</p>
@@ -5805,7 +5805,7 @@ No Entry</pre>
 					</div>
 
 					<section id="sec-xhtml-structural-semantics">
-						<h5>Structural Semantics</h5>
+						<h5>Structural semantics</h5>
 
 						<p>EPUB Creators MAY use the <a href="#sec-epub-type-attribute"><code>epub:type</code>
 								attribute</a> in <a>XHTML Content Documents</a> to express <a
@@ -5836,7 +5836,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-xhtml-content-switch">
-						<h5>Content Switching (Deprecated)</h5>
+						<h5>Content switching (deprecated)</h5>
 
 						<p>The <code>switch</code> element provides a simple mechanism through which <a>EPUB
 								Creators</a> can tailor the content displayed to users, one that is not dependent on the
@@ -5851,7 +5851,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-xhtml-epub-trigger">
-						<h5>The <code>epub:trigger</code> Element (Deprecated)</h5>
+						<h5>The <code>epub:trigger</code> element (deprecated)</h5>
 
 						<p>The <code>trigger</code> element enables the creation of markup-defined user interfaces for
 							controlling multimedia objects, such as audio and video playback, in both scripted and
@@ -5866,7 +5866,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-xhtml-custom-attributes">
-						<h5>Custom Attributes</h5>
+						<h5>Custom attributes</h5>
 
 						<p><a>XHTML Content Documents</a> MAY contain custom attributes, which are <a
 								data-cite="xml-names#NT-Prefix">prefixed</a> [[XML-NAMES]] attributes whose namespace
@@ -5890,7 +5890,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-xhtml-deviations">
-					<h4>HTML Deviations and Constraints</h4>
+					<h4>HTML deviations and constraints</h4>
 
 					<p>This section defines deviations from, and constraints on, the underlying [[HTML]] document model
 						applicable to EPUB 3 <a>XHTML Content Documents</a>.</p>
@@ -5955,10 +5955,10 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-xhtml-deviations-discouraged" class="informative">
-						<h5>Discouraged Constructs</h5>
+						<h5>Discouraged constructs</h5>
 
 						<section id="sec-xhtml-deviations-base">
-							<h6>The <code>base</code> Element</h6>
+							<h6>The <code>base</code> element</h6>
 
 							<p id="confreq-html-vocab-base"> The [[HTML]] <a data-cite="html#the-base-element"
 										><code>base</code> element</a> can be used to specify the <a
@@ -5973,7 +5973,7 @@ No Entry</pre>
 						</section>
 
 						<section id="sec-xhtml-deviations-rp">
-							<h6>The <code>rp</code> Element</h6>
+							<h6>The <code>rp</code> element</h6>
 
 							<p id="confreq-html-vocab-rp">The [[HTML]] <a data-cite="html#the-rp-element"
 										><code>rp</code></a> element is intended to provide a fallback for older
@@ -5983,7 +5983,7 @@ No Entry</pre>
 						</section>
 
 						<section id="sec-xhtml-deviations-embed">
-							<h6>The <code>embed</code> Element</h6>
+							<h6>The <code>embed</code> element</h6>
 
 							<p id="confreq-html-vocab-embed">Since the [[HTML]] <a data-cite="html#the-embed-element"
 										><code>embed</code></a> element does not include intrinsic facilities to provide
@@ -6029,7 +6029,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-svg-req">
-					<h4>SVG Requirements</h4>
+					<h4>SVG requirements</h4>
 
 					<p>An SVG Content Document:</p>
 
@@ -6092,7 +6092,7 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-common-resource-req">
-				<h3>Common Resource Requirements</h3>
+				<h3>Common resource requirements</h3>
 
 				<p>This section defines requirements for technologies usable in both XHTML and SVG Content
 					Documents.</p>
@@ -6132,7 +6132,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-css-req">
-						<h4>CSS Requirements</h4>
+						<h4>CSS requirements</h4>
 
 						<p>A CSS style sheet:</p>
 
@@ -6187,7 +6187,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-css-prefixed">
-						<h4>Prefixed Properties</h4>
+						<h4>Prefixed properties</h4>
 
 						<p>Earlier version of EPUB included prefixed CSS properties, as many CSS features related to
 							world languages were not yet mature. To ensure backwards compatibility for content authored
@@ -6214,7 +6214,7 @@ No Entry</pre>
 					<h3>Scripting</h3>
 
 					<section id="sec-scripted-support">
-						<h4>Script Inclusion</h4>
+						<h4>Script inclusion</h4>
 
 						<p><a>EPUB Content Documents</a> MAY contain scripting using the facilities defined for this in
 							the respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB Content
@@ -6252,7 +6252,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-scripted-context">
-						<h4>Scripting Contexts</h4>
+						<h4>Scripting contexts</h4>
 
 						<p>EPUB 3 defines two contexts for script execution:</p>
 
@@ -6285,7 +6285,7 @@ No Entry</pre>
 						</div>
 
 						<section id="sec-scripted-container-constrained">
-							<h5>Container-Constrained Scripts</h5>
+							<h5>Container-constrained scripts</h5>
 							<p>A <em>container-constrained script</em> is either of the following:</p>
 							<ul>
 								<li>
@@ -6325,7 +6325,7 @@ No Entry</pre>
 						</section>
 
 						<section id="sec-scripted-spine">
-							<h5>Spine-Level Scripts</h5>
+							<h5>Spine-level scripts</h5>
 
 							<p>A <em>spine-level script</em> is an instance of the [[HTML]] <a
 									data-cite="html#the-script-element"><code>script</code></a> or [[SVG]] <a
@@ -6349,7 +6349,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-scripted-content-events" class="informative">
-						<h4>Event Model</h4>
+						<h4>Event model</h4>
 
 						<p><a>EPUB Creators</a> should consider the wide variety of possible Reading System
 							implementations when adding scripting functionality to their EPUB Publications (e.g., not
@@ -6359,7 +6359,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-scripted-a11y">
-						<h4>Scripting Accessibility</h4>
+						<h4>Scripting accessibility</h4>
 
 						<p id="confreq-cd-scripted-a11y">EPUB Content Documents that contain scripting SHOULD employ
 							relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable
@@ -6367,7 +6367,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-scripted-fallbacks">
-						<h4 id="confreq-cd-scripted-flbk">Scripting Fallbacks</h4>
+						<h4 id="confreq-cd-scripted-flbk">Scripting fallbacks</h4>
 
 						<p id="confreq-cd-scripted-fallback">EPUB Content Documents that contain scripting MAY provide
 							fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
@@ -6417,7 +6417,7 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-nav-def-model">
-				<h3>The <code>nav</code> Element: Restrictions</h3>
+				<h3>The <code>nav</code> element: restrictions</h3>
 
 				<p>When a <code>nav</code> element carries the <a href="#sec-epub-type-attribute"><code>epub:type</code>
 						attribute</a> in an <a>EPUB Navigation Document</a>, this specification restricts the content
@@ -6611,7 +6611,7 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-nav-def-types">
-				<h3>The <code>nav</code> Element: Types</h3>
+				<h3>The <code>nav</code> element: types</h3>
 
 				<section id="sec-nav-def-types-intro" class="informative">
 					<h4>Introduction</h4>
@@ -6662,7 +6662,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-nav-toc">
-					<h4>The <code>toc nav</code> Element </h4>
+					<h4>The <code>toc nav</code> element </h4>
 
 					<p>The <code>toc</code>
 						<code>nav</code> element defines the primary navigational hierarchy. It conceptually corresponds
@@ -6687,7 +6687,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-nav-pagelist">
-					<h4>The <code>page-list nav</code> Element </h4>
+					<h4>The <code>page-list nav</code> element </h4>
 
 					<p>The <code>page-list</code> element provides navigation to static page boundaries in the content.
 						These boundaries may correspond to a statically paginated source such as print or may be defined
@@ -6707,7 +6707,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-nav-landmarks">
-					<h4>The <code>landmarks nav</code> Element</h4>
+					<h4>The <code>landmarks nav</code> element</h4>
 
 					<p>The <code>landmarks</code>
 						<code>nav</code> element identifies fundamental structural components in the content to enable
@@ -6786,7 +6786,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-nav-def-types-other">
-					<h4>Other <code>nav</code> Elements</h4>
+					<h4>Other <code>nav</code> elements</h4>
 
 					<p>EPUB Navigation Documents MAY contain one or more <code>nav</code> elements in addition to the
 							<code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
@@ -6831,7 +6831,7 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-nav-doc-use-spine" class="informative">
-				<h3>Using in the Spine</h3>
+				<h3>Using in the spine</h3>
 
 				<p>Although it is possible to reuse the EPUB Navigation Document in the <a>spine</a>, it is often the
 					case that not all of the navigation structures, or branches within them, are needed. <a>EPUB
@@ -6914,7 +6914,7 @@ No Entry</pre>
 			</section>
 		</section>
 		<section id="sec-rendering-control">
-			<h2>Layout Rendering Control</h2>
+			<h2>Layout rendering control</h2>
 
 			<section id="sec-general-rendering-intro" class="informative">
 				<h3>Introduction</h3>
@@ -6930,7 +6930,7 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-fixed-layouts">
-				<h3>Fixed Layouts</h3>
+				<h3>Fixed layouts</h3>
 
 				<section id="fxl-intro" class="informative">
 					<h4>Introduction</h4>
@@ -6960,7 +6960,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-fxl-package">
-					<h4>Fixed-Layout Package Settings</h4>
+					<h4>Fixed-layout package settings</h4>
 
 					<section id="layout">
 						<h5>Layout</h5>
@@ -7062,7 +7062,7 @@ No Entry</pre>
 						</aside>
 
 						<section id="layout-overrides">
-							<h6>Layout Overrides</h6>
+							<h6>Layout overrides</h6>
 
 							<p id="property-layout-local">EPUB Creators MAY specify the following properties locally on
 								spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
@@ -7139,7 +7139,7 @@ No Entry</pre>
 						</aside>
 
 						<section id="orientation-overrides">
-							<h6>Orientation Overrides</h6>
+							<h6>Orientation overrides</h6>
 
 							<p id="property-orientation-local">EPUB Creators MAY specify the following properties
 								locally on spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to
@@ -7165,7 +7165,7 @@ No Entry</pre>
 					</section>
 
 					<section id="spread">
-						<h5>Synthetic Spreads</h5>
+						<h5>Synthetic spreads</h5>
 
 						<p>The <code>rendition:spread</code> property specifies the intended Reading System synthetic
 							spread behavior.</p>
@@ -7415,7 +7415,7 @@ No Entry</pre>
 						</aside>
 
 						<section id="spread-overrides">
-							<h6>Synthetic Spread Overrides</h6>
+							<h6>Synthetic spread overrides</h6>
 
 							<p id="property-spread-local">EPUB Creators MAY specify the following properties locally on
 								spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the
@@ -7453,7 +7453,7 @@ No Entry</pre>
 					</section>
 
 					<section id="page-spread">
-						<h5>Spread Placement</h5>
+						<h5>Spread placement</h5>
 
 						<p>When a Reading System renders a <a>Synthetic Spread</a>, the default behavior is to populate
 							the spread by rendering the next <a>EPUB Content Document</a> in the next available
@@ -7610,7 +7610,7 @@ No Entry</pre>
 					</section>
 
 					<section id="viewport">
-						<h5>Viewport Dimensions (Deprecated)</h5>
+						<h5>Viewport dimensions (deprecated)</h5>
 
 						<p>The <code>rendition:viewport</code> property allows <a>EPUB Creators</a> to express the CSS
 							initial containing block (ICB) [[CSS2]] for XHTML and SVG Content Documents whose
@@ -7625,7 +7625,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-fxl-content-dimensions">
-						<h4>Content Document Dimensions</h4>
+						<h4>Content document dimensions</h4>
 
 						<p>This section defines rules for the expression and interpretation of dimensional properties of
 								<a>Fixed-Layout Documents</a>.</p>
@@ -7682,7 +7682,7 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-reflowable-layouts">
-				<h3>Reflowable Layouts</h3>
+				<h3>Reflowable layouts</h3>
 
 				<p>Although control over the rendering of <a>EPUB Content Documents</a> to create <a
 						href="#sec-fixed-layouts">fixed layouts</a> is an obvious need not handled by other
@@ -7692,7 +7692,7 @@ No Entry</pre>
 					content.</p>
 
 				<section id="flow">
-					<h4>The <code>rendition:flow</code> Property</h4>
+					<h4>The <code>rendition:flow</code> property</h4>
 
 					<p>The <code>rendition:flow</code> property specifies the EPUB Creator preference for how Reading
 						Systems should handle content overflow. </p>
@@ -7821,7 +7821,7 @@ No Entry</pre>
 					</details>
 
 					<section id="layout-property-flow-overrides">
-						<h5>Spine Overrides</h5>
+						<h5>Spine overrides</h5>
 
 						<p id="layout-property-flow-local">EPUB Creators MAY specify the following properties locally on
 							spine <a href="#elemdef-spine-itemref"><code>itemref</code> elements</a> to override the <a
@@ -7876,7 +7876,7 @@ No Entry</pre>
 				</section>
 
 				<section id="align-x-center">
-					<h4>The <code>rendition:align-x-center</code> Property</h4>
+					<h4>The <code>rendition:align-x-center</code> property</h4>
 
 					<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should be
 						centered horizontally in the viewport or spread.</p>
@@ -7897,7 +7897,7 @@ No Entry</pre>
 			</section>
 		</section>
 		<section id="sec-media-overlays">
-			<h2>Media Overlays</h2>
+			<h2>Media overlays</h2>
 
 			<section id="sec-overlays-introduction" class="informative">
 				<h4>Introduction</h4>
@@ -7933,7 +7933,7 @@ No Entry</pre>
 				<h3>Media Overlay Documents</h3>
 
 				<section id="sec-overlay-req">
-					<h4>Media Overlay Document Requirements</h4>
+					<h4>Media Overlay Document requirements</h4>
 
 					<p>A <a>Media Overlay Document</a>:</p>
 
@@ -7952,13 +7952,13 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-overlays-def">
-					<h3>Media Overlay Document Definition</h3>
+					<h3>Media Overlay Document definition</h3>
 
 					<p>All elements [[XML]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
 						namespace [[XML-NAMES]] unless otherwise specified.</p>
 
 					<section id="sec-smil-smil-elem">
-						<h5>The <code>smil</code> Element</h5>
+						<h5>The <code>smil</code> element</h5>
 
 						<p>The <code>smil</code> element is the root element of all Media Overlay Documents.</p>
 
@@ -8035,7 +8035,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-smil-head-elem">
-						<h5>The <code>head</code> Element</h5>
+						<h5>The <code>head</code> element</h5>
 
 						<p>The <code>head</code> element is the container for metadata in the Media Overlay
 							Document.</p>
@@ -8075,7 +8075,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-smil-metadata-elem">
-						<h5>The <code>metadata</code> Element</h5>
+						<h5>The <code>metadata</code> element</h5>
 
 						<p>The <code>metadata</code> element represents metadata for the Media Overlay Document. The
 								<code>metadata</code> element is an extension point that allows the inclusion of
@@ -8110,7 +8110,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-smil-body-elem">
-						<h5>The <code>body</code> Element</h5>
+						<h5>The <code>body</code> element</h5>
 
 						<p>The <code>body</code> element is the starting point for the presentation contained in the
 							Media Overlay Document. It contains the main sequence of <code>par</code> and
@@ -8197,7 +8197,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-smil-seq-elem">
-						<h5>The <code>seq</code> Element</h5>
+						<h5>The <code>seq</code> element</h5>
 
 						<p>The <code>seq</code> element is a sequential time container for media objects and/or child
 							time containers.</p>
@@ -8285,7 +8285,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-smil-par-elem">
-						<h5>The <code>par</code> Element</h5>
+						<h5>The <code>par</code> element</h5>
 						<p>The <code>par</code> element is a parallel time container for media objects.</p>
 
 						<dl class="elemdef" id="elemdef-smil-par">
@@ -8355,7 +8355,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-smil-text-elem">
-						<h5>The <code>text</code> Element</h5>
+						<h5>The <code>text</code> element</h5>
 
 						<p> The <code>text</code> element references an element in an <a>EPUB Content Document</a>. A
 								<code>text</code> element typically refers to a textual element but can also refer to
@@ -8421,7 +8421,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-smil-audio-elem">
-						<h5>The <code>audio</code> Element</h5>
+						<h5>The <code>audio</code> element</h5>
 
 						<p>The <code>audio</code> element represents a clip of audio media.</p>
 
@@ -8501,7 +8501,7 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-overlay-doc-create">
-				<h3>Creating Media Overlays</h3>
+				<h3>Creating media overlays</h3>
 
 				<section id="sec-docs-intro" class="informative">
 					<h4>Introduction</h4>
@@ -8603,7 +8603,7 @@ No Entry</pre>
 					</div>
 
 					<section id="sec-media-overlays-structure">
-						<h5>Overlay Structure</h5>
+						<h5>Overlay structure</h5>
 
 						<p>The <a href="#elemdef-smil-body"><code>body</code></a> of a Media Overlay Document consists
 							of two elements: the <a href="#elemdef-smil-par"><code>par</code> element</a> and the <a
@@ -8781,7 +8781,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-media-overlays-fragids">
-						<h5>Referencing Document Fragments</h5>
+						<h5>Referencing document fragments</h5>
 
 						<p>Both the <code>epub:textref</code> attribute and the <a href="#elemdef-smil-text"
 									><code>text</code> element's</a>
@@ -8799,7 +8799,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-media-overlays-granularity" class="informative">
-						<h5>Overlay Granularity</h5>
+						<h5>Overlay granularity</h5>
 
 						<p>The granularity level of the Media Overlay depends on how EPUB Creators mark up the EPUB
 							Content Document and the type of fragment identifier they use in the <a
@@ -8817,7 +8817,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-embedded-media">
-						<h5>Embedded Media</h5>
+						<h5>Embedded media</h5>
 
 						<p>Any <a>EPUB Content Document</a> associated with a Media Overlay MAY contain embedded media
 							such as video, audio, and images. EPUB Creators MAY use the Media Overlay <a
@@ -8825,7 +8825,7 @@ No Entry</pre>
 							the embedded media by its element's <code>id</code> attribute value.</p>
 
 						<section id="sec-emb-audio-video">
-							<h6>Embedded Audio and Video</h6>
+							<h6>Embedded audio and video</h6>
 
 							<p> When a <a href="#elemdef-smil-text"><code>text</code></a> element references embedded
 								audio or video, Reading Systems will initiate playback of the media in the absence of an
@@ -8841,7 +8841,7 @@ No Entry</pre>
 						</section>
 
 						<section id="sec-emb-img">
-							<h6>Embedded Images</h6>
+							<h6>Embedded images</h6>
 
 							<p>When a <code>text</code> element references an embedded image, the <a
 									href="#elemdef-smil-audio"><code>audio</code></a> sibling element is OPTIONAL. In
@@ -8855,7 +8855,7 @@ No Entry</pre>
 					</section>
 
 					<section id="sec-tts">
-						<h5>Text-to-Speech Rendering</h5>
+						<h5>Text-to-speech rendering</h5>
 
 						<p>This specification allows the use of text-to-speech (TTS) &#8212; the rendering of the
 							textual content of an <a>EPUB Publication</a> as artificial human speech using a synthesized
@@ -8875,7 +8875,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-docs-structural-semantic">
-					<h4>Structural Semantics in Overlays</h4>
+					<h4>Structural semantics in overlays</h4>
 
 					<p>To express <a href="#app-structural-semantics">structural semantics</a> in <a>Media Overlay
 							Documents</a>, EPUB Creators MAY specify the <a href="#attrdef-epub-type"
@@ -8932,7 +8932,7 @@ No Entry</pre>
 				</section>
 
 				<section id="sec-docs-assoc-style">
-					<h4>Associating Style Information</h4>
+					<h4>Associating style information</h4>
 
 					<p>EPUB Creators MAY express visual rendering information for the currently playing <a>EPUB Content
 							Document</a> element in a CSS Style Sheet using author-defined classes.</p>
@@ -9031,10 +9031,10 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-docs-package">
-					<h4>Media Overlays Packaging</h4>
+					<h4>Media overlays packaging</h4>
 
 					<section id="sec-package-including">
-						<h5>Including Media Overlays</h5>
+						<h5>Including media overlays</h5>
 
 						<p>If an <a>EPUB Content Document</a> is wholly or partially referenced by a Media Overlay, then
 							its <a>manifest</a>
@@ -9070,7 +9070,7 @@ html.my-document-playing * {
 					</section>
 
 					<section id="sec-mo-package-metadata">
-						<h5>Overlays Package Metadata</h5>
+						<h5>Overlays package metadata</h5>
 
 						<p id="total-duration">EPUB Creators MUST specify the duration of the entire <a>EPUB
 								Publication</a> in the <a>Package Document</a> using a <a href="#elemdef-meta"
@@ -9151,7 +9151,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="sec-behaviors-skip-escape">
-				<h3>Skippability and Escapability</h3>
+				<h3>Skippability and escapability</h3>
 
 				<section id="sec-skippability">
 					<h4>Skippability</h4>
@@ -9408,7 +9408,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="sec-mo-nav-doc" class="informative">
-				<h3>Navigation Document Overlays</h3>
+				<h3>Navigation document overlays</h3>
 
 				<p>As the <a>EPUB Navigation Document</a> is an <a>XHTML Content Document</a>, <a>EPUB Creators</a> may
 					associate an audio Media Overlay with it. Unlike traditional XHTML Content Documents, however,
@@ -9470,7 +9470,7 @@ html.my-document-playing * {
 			</div>
 		</section>
 		<section id="sec-security-privacy" class="informative">
-			<h2>Security and Privacy</h2>
+			<h2>Security and privacy</h2>
 
 			<section id="security-privacy-overview">
 				<h3>Overview</h3>
@@ -9495,7 +9495,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="epub-threat-model">
-				<h3>Threat Model</h3>
+				<h3>Threat model</h3>
 
 				<p>EPUB Publications pose a variety of privacy and security threats to unsuspecting users. Many of these
 					threats intersect with web content, but EPUB also introduces its own unique methods of attack that
@@ -9597,7 +9597,7 @@ html.my-document-playing * {
 				</dl>
 
 				<section id="privacy-security-epub-features">
-					<h4>EPUB-Specific Features</h4>
+					<h4>EPUB-specific features</h4>
 
 					<p>EPUB 3 tries to avoid extending the underlying technologies it builds on, but it has introduced
 						some new features. The restricted scope of these features limits the threats they might pose,
@@ -9675,7 +9675,7 @@ html.my-document-playing * {
 			</section>
 		</section>
 		<section id="app-overview-unsupported" class="appendix">
-			<h2>Unsupported Features</h2>
+			<h2>Unsupported features</h2>
 
 			<p>This specification contains certain features that are not yet fully supported in Reading Systems, that
 				the Working Group no longer recommends for use, or that are only retained for interoperability with EPUB
@@ -9683,7 +9683,7 @@ html.my-document-playing * {
 				their support expectations.</p>
 
 			<section id="under-implemented">
-				<h3>Under-implemented Features</h3>
+				<h3>Under-implemented features</h3>
 
 				<p>A <strong>under-implemented</strong> feature is a feature introduced prior to EPUB 3.3 for which the
 					Working Group has not been able to establish enough <a
@@ -9726,7 +9726,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="deprecated">
-				<h3>Deprecated Features</h3>
+				<h3>Deprecated features</h3>
 
 				<p>A <strong>deprecated</strong> feature is one the Working Group no longer recommends for use in this
 					version of the specification. Deprecated features typically have limited or no support in Reading
@@ -9751,7 +9751,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="legacy">
-				<h3>Legacy Features</h3>
+				<h3>Legacy features</h3>
 
 				<p>A <strong>legacy</strong> feature is one that the Working Group has retained only for authoring
 					content that is compatible with versions of EPUB prior to 3.0. If this specification designates a
@@ -9776,7 +9776,7 @@ html.my-document-playing * {
 			</section>
 		</section>
 		<section id="app-identifiers-allowed" class="appendix">
-			<h2>Allowed External Identifiers</h2>
+			<h2>Allowed external identifiers</h2>
 
 			<p>The following table lists the <a aria-label="public identifiers" data-cite="xml#dt-pubid">public </a> and
 					<a data-cite="xml#dt-sysid">system identifiers</a> [[XML]] allowed in <a data-cite="xml#dt-doctype"
@@ -9842,7 +9842,7 @@ html.my-document-playing * {
 			</table>
 		</section>
 		<section id="app-structural-semantics" class="appendix">
-			<h2>Expressing Structural Semantics</h2>
+			<h2>Expressing structural semantics</h2>
 
 			<section id="sec-structural-semantics-intro" class="informative">
 				<h3>Introduction</h3>
@@ -9868,7 +9868,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="sec-epub-type-attribute">
-				<h3>The <code>epub:type</code> Attribute</h3>
+				<h3>The <code>epub:type</code> attribute</h3>
 
 				<dl class="elemdef" id="attrdef-epub-type">
 					<dt>Attribute Name:</dt>
@@ -9989,7 +9989,7 @@ html.my-document-playing * {
 				terms from vocabularies. It also defines EPUB-specific vocabularies for use with the attributes.</p>
 
 			<section id="sec-vocab-assoc">
-				<h3>Vocabulary Association Mechanisms</h3>
+				<h3>Vocabulary association mechanisms</h3>
 
 				<section id="sec-vocab-assoc-intro" class="informative">
 					<h4>Introduction</h4>
@@ -10024,7 +10024,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-property-datatype">
-					<h4>The <var>property</var> Data Type</h4>
+					<h4>The <var>property</var> data type</h4>
 
 					<p>The <var>property</var> data type is a compact means of expressing a URL [[URL]] and consists of
 						an OPTIONAL prefix separated from a reference by a colon.</p>
@@ -10107,7 +10107,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-default-vocab">
-					<h5>Default Vocabularies</h5>
+					<h5>Default vocabularies</h5>
 
 					<p>A default vocabulary is one that EPUB Creators do not have to declare a <a
 							href="#sec-prefix-attr">prefix</a> for in order to use its terms and properties where a <a
@@ -10125,7 +10125,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-prefix-attr">
-					<h4>The <code>prefix</code> Attribute</h4>
+					<h4>The <code>prefix</code> attribute</h4>
 
 					<p>The <code>prefix</code> attribute defines prefix mappings for use in <a
 							href="#sec-property-datatype"><var>property</var> values</a>.</p>
@@ -10255,7 +10255,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-reserved-prefixes">
-					<h4>Reserved Prefixes</h4>
+					<h4>Reserved prefixes</h4>
 
 					<div class="caution">
 						<p>Although reserved prefixes are an authoring convenience, EPUB Creators should avoid relying
@@ -10353,7 +10353,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="sec-property-field-definitions">
-				<h3>Property Field Definitions</h3>
+				<h3>Property field definitions</h3>
 
 				<p>The fields in the vocabulary definition tables have the following implicit requirements:</p>
 
@@ -10415,7 +10415,7 @@ html.my-document-playing * {
 			<div data-include="vocab/overlays.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
 		</section>
 		<section id="css-prefixes" class="appendix">
-			<h2>Prefixed CSS Properties</h2>
+			<h2>Prefixed CSS properties</h2>
 
 			<p>This appendix describes the prefixed CSS properties supported by EPUB. </p>
 
@@ -10425,12 +10425,12 @@ html.my-document-playing * {
 				unprefixed versions for newer features.</p>
 
 			<section id="sec-css-prefixed-writing-modes">
-				<h5>CSS Writing Modes</h5>
+				<h5>CSS writing modes</h5>
 
 				<p>This section describes the <code>-epub-</code> prefixed properties for [[CSS-Writing-Modes-3]].</p>
 
 				<section id="sec-css-prefixed-writing-modes-text-orientation" data-tests="#css-epub-text-orientation">
-					<h6>The <code>-epub-text-orientation</code> Property</h6>
+					<h6>The <code>-epub-text-orientation</code> property</h6>
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-writing-modes-3#propdef-text-orientation"><code>text-orientation</code>
@@ -10479,7 +10479,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-css-prefixed-writing-modes-writing-mode" data-tests="#css-epub-writing-mode">
-					<h6>The <code>-epub-writing-mode</code> Property</h6>
+					<h6>The <code>-epub-writing-mode</code> property</h6>
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-writing-modes-3#propdef-writing-mode"><code>writing-mode</code> property</a>
@@ -10501,7 +10501,7 @@ html.my-document-playing * {
 
 				<section id="sec-css-prefixed-writing-modes-text-combine" data-tests="#css-epub-text-combine-horizontal">
 					<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>
-						Properties</h6>
+						properties</h6>
 
 					<p>These properties are prefixed versions of the <a
 							data-cite="css-writing-modes-3#text-combine-upright"><code>text-combine-upright</code>
@@ -10578,7 +10578,7 @@ html.my-document-playing * {
 					[[CSS-Text-3]].</p>
 
 				<section id="sec-css-prefixed-text-epub-hyphens" data-tests="#css-epub-hyphens">
-					<h6>The <code>-epub-hyphens</code> Property</h6>
+					<h6>The <code>-epub-hyphens</code> property</h6>
 
 					<p>This property is a prefixed version of the <a data-cite="css-text-3#hyphens-property"
 								><code>hyphens</code> property</a> [[CSS-Text-3]].</p>
@@ -10602,7 +10602,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-css-prefixed-text-epub-line-break" data-tests="#css-epub-line-break">
-					<h6>The <code>-epub-line-break</code> Property</h6>
+					<h6>The <code>-epub-line-break</code> property</h6>
 
 					<p>This property is a prefixed version of the <a data-cite="css-text-3#line-break-property"
 								><code>line-break</code> property</a> [[CSS-Text-3]].</p>
@@ -10622,7 +10622,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-css-prefixed-text-epub-text-align-last" data-tests="#css-epub-text-align-last">
-					<h6>The <code>-epub-text-align-last</code> Property</h6>
+					<h6>The <code>-epub-text-align-last</code> property</h6>
 
 					<p>This property is a prefixed version of the <a data-cite="css-text-3#text-align-last-property"
 								><code>text-align-last</code> property</a> [[CSS-Text-3]].</p>
@@ -10642,7 +10642,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-css-prefixed-text-epub-word-break" data-tests="#css-epub-word-break">
-					<h6>The <code>-epub-word-break</code> Property</h6>
+					<h6>The <code>-epub-word-break</code> property</h6>
 
 					<p>This property is a prefixed version of the <a data-cite="css-text-3#word-break-property"
 								><code>word-break</code> property</a> [[CSS-Text-3]].</p>
@@ -10662,7 +10662,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-css-prefixed-text-text-transform" data-tests="#css-epub-text-transform">
-					<h6>The <code>text-transform</code> Property</h6>
+					<h6>The <code>text-transform</code> property</h6>
 
 					<p>This property is a prefixed value for the <a data-cite="css-text-3#text-transform-property"
 								><code>text-transform</code> property</a> [[CSS-Text-3]].</p>
@@ -10713,7 +10713,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-css-prefixed-text-epub-text-emphasis-position" data-tests="#css-epub-text-emphasis">
-					<h6>The <code>-epub-text-emphasis-position</code> Property</h6>
+					<h6>The <code>-epub-text-emphasis-position</code> property</h6>
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-text-decor-3#text-emphasis-position-property"
@@ -10734,7 +10734,7 @@ html.my-document-playing * {
 				</section>
 
 				<section id="sec-css-prefixed-text-epub-text-emphasis-style" data-tests="#css-epub-text-emphasis">
-					<h6>The <code>-epub-text-emphasis-style</code> Property</h6>
+					<h6>The <code>-epub-text-emphasis-style</code> property</h6>
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-text-decor-3#text-emphasis-style-property"><code>text-emphasis-style</code>
@@ -10757,7 +10757,7 @@ html.my-document-playing * {
 
 				<section id="sec-css-prefixed-text-epub-text-underline-position"
 					data-tests="#css-epub-text-underline-position">
-					<h6>The <code>-epub-text-underline-position</code> Property</h6>
+					<h6>The <code>-epub-text-underline-position</code> property</h6>
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-text-decor-3#text-underline-position-property"
@@ -10786,7 +10786,7 @@ html.my-document-playing * {
 			<h2>Schemas</h2>
 
 			<section id="app-package-schema">
-				<h3>Package Document Schema</h3>
+				<h3>Package document schema</h3>
 
 				<p>A schema for Package Documents is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
@@ -10836,7 +10836,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="app-schema-overlays">
-				<h3>Media Overlays Schema</h3>
+				<h3>Media overlays schema</h3>
 
 				<p>A schema for Media Overlays is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl"
@@ -10852,7 +10852,7 @@ html.my-document-playing * {
 			</section>
 		</section>
 		<section id="app-examples" class="appendix informative">
-			<h2>Detailed Examples</h2>
+			<h2>Detailed examples</h2>
 
 			<section id="publication-resources-example">
 				<h3>Resources</h3>
@@ -11106,7 +11106,7 @@ html.my-document-playing * {
 			</section>
 
 			<section id="scripted-contexts-example">
-				<h3>Scripting Contexts</h3>
+				<h3>Scripting contexts</h3>
 
 				<p>Consider the following example Package Document:</p>
 
@@ -11451,7 +11451,7 @@ EPUB/images/cover.png</pre>
 			</section>
 
 			<section id="clock-examples">
-				<h3>Clock Values</h3>
+				<h3>Clock values</h3>
 
 				<p>The following are examples of allowed clock values:</p>
 
@@ -11493,10 +11493,10 @@ EPUB/images/cover.png</pre>
 			</section>
 		</section>
 		<section id="app-media-types" class="appendix informative">
-			<h2>Media Type Registrations</h2>
+			<h2>Media type registrations</h2>
 
 			<section id="app-media-type-app-oebps-package">
-				<h3>The <code>application/oebps-package+xml</code> Media Type</h3>
+				<h3>The <code>application/oebps-package+xml</code> Media type</h3>
 
 				<p>This appendix registers the media type <code>application/oebps-package+xml</code> for the EPUB
 					Package Document. This registration supersedes [[RFC4839]].</p>
@@ -11615,7 +11615,7 @@ EPUB/images/cover.png</pre>
 			</section>
 
 			<section class="informative" id="app-media-type">
-				<h3>The <code>application/epub+zip</code> Media Type</h3>
+				<h3>The <code>application/epub+zip</code> Media type</h3>
 
 				<p>This appendix registers the media type <code>application/epub+zip</code> for the EPUB Open Container
 					Format (OCF).</p>
@@ -11741,7 +11741,7 @@ EPUB/images/cover.png</pre>
 			</section>
 		</section>
 		<section id="change-log" class="appendix informative">
-			<h2>Change Log</h2>
+			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
 					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> &#8212; those that affect the

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -486,8 +486,8 @@
 						<div class="note">
 							<p>Foreign resource and <a>foreign content document</a> are not interchangeable terms. The
 								types of resources considered foreign when used in the spine is greater than the types
-								of resources considered foreign when used in <a href="#sec-contentdocs">Content
-									Documents</a>.</p>
+								of resources considered foreign when used in <a href="#sec-contentdocs">EPUB content
+									documents</a>.</p>
 						</div>
 					</dd>
 
@@ -4996,7 +4996,7 @@ XHTML:
 
 						<p>These properties do not apply recursively to content included into a resource (e.g., via the
 							HTML <code>iframe</code> element). For example, if a non-scripted XHTML content document
-							embeds a scripted Content Document, only the embedded document's manifest <code>item</code>
+							embeds a scripted content document, only the embedded document's manifest <code>item</code>
 							<code>properties</code> attribute will have the <code>scripted</code> value.</p>
 
 						<p>EPUB creators MUST declare exactly one <code>item</code> as the EPUB navigation document
@@ -5412,10 +5412,10 @@ No Entry</pre>
 						the reading system can choose the rendering direction.</p>
 
 					<p>Although the <code>page-progression-direction</code> attribute sets the global flow direction,
-						individual Content Documents and parts of Content Documents MAY override this setting (e.g., via
-						the <code>writing-mode</code> CSS property). Reading systems may also provide mechanisms to
-						override the default direction (e.g., buttons or settings that allow the application of
-						alternate style sheets).</p>
+						individual EPUB content documents and parts of EPUB content documents MAY override this setting
+						(e.g., via the <code>writing-mode</code> CSS property). Reading systems may also provide
+						mechanisms to override the default direction (e.g., buttons or settings that allow the
+						application of alternate style sheets).</p>
 
 					<p>The <a href="#legacy">legacy</a>
 						<code>toc</code> attribute takes an IDREF [[XML]] that identifies the manifest item that
@@ -7425,8 +7425,8 @@ No Entry</pre>
 							the spread by rendering the next <a>EPUB content document</a> in the next available
 							unpopulated viewport, where the next available viewport is determined by the given <a
 								href="#sec-spine-elem">page progression direction</a> or by local declarations within
-							Content Documents. An EPUB creator MAY override this automatic population behavior and force
-							reading systems to place a document in a particular viewport by specifying one of the
+							EPUB content documents. An EPUB creator MAY override this automatic population behavior and
+							force reading systems to place a document in a particular viewport by specifying one of the
 							following properties on its spine <code>itemref</code> element:</p>
 
 						<dl>
@@ -7682,7 +7682,7 @@ No Entry</pre>
 
 						<dt id="scrolled-continuous">scrolled-continuous</dt>
 						<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
-							<p>Render all Content Documents such that overflow content is scrollable, and the EPUB
+							<p>Render all EPUB content documents such that overflow content is scrollable, and the EPUB
 								publication is presented as one continuous scroll from spine item to spine item (except
 								where <a href="#layout-property-flow-overrides">locally overridden</a>).</p>
 							<p>Note that EPUB creators SHOULD NOT create publications in which different resources have
@@ -7692,8 +7692,8 @@ No Entry</pre>
 
 						<dt id="scrolled-doc">scrolled-doc</dt>
 						<dd id="scrolled-doc-dd" data-tests="#pkg-flow-scrolled-doc">
-							<p>Render all Content Documents such that overflow content is scrollable, and each spine
-								item is presented as a separate scrollable document.</p>
+							<p>Render all EPUB content documents such that overflow content is scrollable, and each
+								spine item is presented as a separate scrollable document.</p>
 						</dd>
 
 						<dt id="auto">auto</dt>
@@ -11010,7 +11010,7 @@ html.my-document-playing * {
 							explicitly listed in the spine (but it "replaces" the existing spine item when needed). It
 							is a <a>publication resource</a> on the <a>manifest plane</a>, a <a>container resource</a>,
 							an EPUB content document on <a>spine plane</a>, and, because it is not "used" when rendering
-							another Content Document, it is not present on the <a>content plane</a>. No fallback is
+							another EPUB content document, it is not present on the <a>content plane</a>. No fallback is
 							necessary.</p>
 					</dd>
 
@@ -11041,8 +11041,8 @@ html.my-document-playing * {
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
 							[[HTML]] <a data-lt="iframe"><code>iframe</code> element</a>. It is a <a>publication
 								resource</a> on the <a>manifest plane</a>, a <a>container resource</a>, is not present
-							on <a>spine plane</a>, and, because it is "used" when rendering another Content Document, a
-								<a>core media type resource</a> on the <a>content plane</a>. No fallback is
+							on <a>spine plane</a>, and, because it is "used" when rendering another EPUB content
+							document, a <a>core media type resource</a> on the <a>content plane</a>. No fallback is
 							necessary.</p>
 					</dd>
 
@@ -11906,8 +11906,8 @@ EPUB/images/cover.png</pre>
 						1488</a>.</li>
 				<li>20-Jan-2021: Clarified that user-defined media overlay style classes must be declared in the package
 					document metadata. See <a href="https://github.com/w3c/epub-specs/issues/1319">issue 1319</a>.</li>
-				<li>20-Jan-2021: Add recommendation that the sum of the media overlay durations for each Content
-					Document match the total duration specified for the EPUB publication. See <a
+				<li>20-Jan-2021: Add recommendation that the sum of the media overlay durations for each EPUB content
+					document match the total duration specified for the EPUB publication. See <a
 						href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>.</li>
 				<li>20-Jan-2021: Clarified that the <code>epub:type</code> attribute does not improve the accessibility
 					of publications. Added pointers to the <code>role</code> attribute and the DPUB-ARIA vocabulary for

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -1,5 +1,5 @@
 <section id="app-item-properties-vocab" class="vocab">
-	<h3>Manifest Properties Vocabulary</h3>
+	<h3>Manifest properties vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the manifest <a href="#sec-item-elem"><code>item</code>
 			element's</a>

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -20,7 +20,7 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>The <code>cover-image</code> property identifies the described Publication Resource as
+					<td>The <code>cover-image</code> property identifies the described publication resource as
 						the cover image for the Publication.</td>
 				</tr>
 				<tr>
@@ -48,13 +48,13 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>The <code>mathml</code> property indicates that the described Publication Resource
+					<td>The <code>mathml</code> property indicates that the described publication resource
 						contains one or more instances of MathML markup.</td>
 				</tr>
 				<tr>
 					<th>Applies to:</th>
 					<td>
-						<a>EPUB Content Documents</a>
+						<a>EPUB content documents</a>
 					</td>
 				</tr>
 				<tr>
@@ -78,12 +78,12 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>The <code>nav</code> property indicates that the described Publication Resource
-						constitutes the <a>EPUB Navigation Document</a> of the <a>EPUB Publication</a>.</td>
+					<td>The <code>nav</code> property indicates that the described publication resource
+						constitutes the <a>EPUB navigation document</a> of the <a>EPUB publication</a>.</td>
 				</tr>
 				<tr>
 					<th>Applies to:</th>
-					<td>The <a>EPUB Navigation Document</a>
+					<td>The <a>EPUB navigation document</a>
 					</td>
 				</tr>
 				<tr>
@@ -108,17 +108,16 @@
 				<tr>
 					<th>Description:</th>
 					<td>
-						<p>The <code>remote-resources</code> property indicates that the described Publication
-							Resource contains one or more internal references to other Publication Resources
-							that are located outside of the <a>EPUB Container</a>.</p>
+						<p>The <code>remote-resources</code> property indicates that the described publication resource contains one or more internal references to other publication resources
+							that are located outside of the <a>EPUB container</a>.</p>
 						<p>Refer to <a href="#sec-resource-locations"></a> for more information.</p>
 					</td>
 				</tr>
 				<tr>
 					<th>Applies to:</th>
-					<td>All Publication Resources with the capability of internal referencing (e.g., <a>XHTML
-							Content Documents</a>, <a>SVG Content Documents</a>, CSS Style Sheets and <a>Media
-							Overlay Documents</a>).</td>
+					<td>All publication resources with the capability of internal referencing
+						(e.g., <a>XHTML content documents</a>, <a>SVG content documents</a>, 
+						CSS style sheets and <a>media overlay documents</a>).</td>
 				</tr>
 				<tr>
 					<th>Cardinality:</th>
@@ -141,14 +140,14 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>The <code>scripted</code> property indicates that the described Publication Resource is
-						a <a>Scripted Content Document</a> (i.e., contains scripted content and/or HTML form
+					<td>The <code>scripted</code> property indicates that the described publication resource is
+						a <a>scripted content document</a> (i.e., contains scripted content and/or HTML form
 						elements).</td>
 				</tr>
 				<tr>
 					<th>Applies to:</th>
 					<td>
-						<a>EPUB Content Documents</a>
+						<a>EPUB content documents</a>
 					</td>
 				</tr>
 				<tr>
@@ -173,7 +172,7 @@
 				<tr>
 					<th>Description:</th>
 					<td>
-						<p>The <code>svg</code> property indicates that the described Publication Resource
+						<p>The <code>svg</code> property indicates that the described publication resource
 							embeds one or more instances of SVG markup.</p>
 						<p>This property MUST be set when SVG markup is included directly in the resource and
 							MAY be set when the SVG is referenced from the resource (e.g., from an [[HTML]]
@@ -182,8 +181,7 @@
 				</tr>
 				<tr>
 					<th>Applies to:</th>
-					<td><a>XHTML Content Documents</a>; the value is implied for <a>SVG Content
-						Documents</a>.</td>
+					<td><a>XHTML content documents</a>; the value is implied for <a>SVG content documents</a>.</td>
 				</tr>
 				<tr>
 					<th>Cardinality:</th>
@@ -207,14 +205,14 @@
 				<tr>
 					<th>Description:</th>
 					<td>
-						<p>The <code>switch</code> property indicates that the described Publication Resource
+						<p>The <code>switch</code> property indicates that the described publication resource
 							contains one or more instances of the <a href="#sec-xhtml-content-switch"
 									>deprecated <code>epub:switch</code> element</a>.</p>
 					</td>
 				</tr>
 				<tr>
 					<th>Applies to:</th>
-					<td><a>XHTML Content Documents</a>.</td>
+					<td><a>XHTML content documents</a>.</td>
 				</tr>
 				<tr>
 					<th>Cardinality:</th>

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -1,6 +1,6 @@
 
 <section id="app-itemref-properties-vocab" class="vocab">
-	<h3>Spine Properties Vocabulary</h3>
+	<h3>Spine properties vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the spine <a href="#sec-itemref-elem"
 				><code>itemref</code> element's</a>

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -22,7 +22,7 @@
 				<tr>
 					<th>Description:</th>
 					<td>The <code>page-spread-left</code> property indicates that the first page of the
-						associated <code>item</code> element's <a>EPUB Content Document</a> represents the
+						associated <code>item</code> element's <a>EPUB content document</a> represents the
 						left-hand side of a two-page spread.</td>
 				</tr>
 			</tbody>
@@ -41,7 +41,7 @@
 				<tr>
 					<th>Description:</th>
 					<td>The <code>page-spread-right</code> property indicates that the first page of the
-						associated <code>item</code> element's <a>EPUB Content Document</a>
+						associated <code>item</code> element's <a>EPUB content document</a>
 						represents the right-hand side of a two-page spread.</td>
 				</tr>
 			</tbody>

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -30,7 +30,7 @@
 						<th>Description:</th>
 						<td>The <code>acquire</code> keyword is used with <a
 								href="http://www.idpf.org/epub/previews">EPUB Previews</a> to identify where the
-							full version of the <a>EPUB Publication</a> can be acquired.</td>
+							full version of the <a>EPUB publication</a> can be acquired.</td>
 					</tr>
 					<tr>
 						<th>Cardinality:</th>
@@ -40,7 +40,7 @@
 					</tr>
 					<tr>
 						<th>Extends:</th>
-						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
+						<td>Only applies to the EPUB publication or collection. MUST NOT be used when the <a
 								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
 					</tr>
 					<tr>
@@ -71,14 +71,14 @@
 										<code>alternate</code> keyword</a> for links. It differs as follows:</p>
 							<ul>
 								<li>It cannot be paired with other keywords.</li>
-								<li>If an alternate link is included in the Package Document metadata, it
-									identifies an alternate representation of the Package Document in the format
+								<li>If an alternate link is included in the package document metadata, it
+									identifies an alternate representation of the package document in the format
 									specified in the <code>media-type</code> attribute.</li>
 								<li>If an alternate link is included in a <a href="#sec-collection-elem"
 											><code>collection</code> element's</a> metadata, it identifies an
 									alternate representation of the <code>collection</code> in the format
 									specified in the <code>media-type</code> attribute.</li>
-								<li>Reading Systems do not have to generate hyperlinks for alternate links.</li>
+								<li>Reading systems do not have to generate hyperlinks for alternate links.</li>
 							</ul>
 						</td>
 					</tr>
@@ -90,7 +90,7 @@
 					</tr>
 					<tr>
 						<th>Extends:</th>
-						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
+						<td>Only applies to the EPUB publication or collection. MUST NOT be used when the <a
 								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
 					</tr>
 					<tr>
@@ -172,7 +172,7 @@
 					</tr>
 					<tr>
 						<th>Extends:</th>
-						<td>Only applies to the EPUB Publication or collection. MUST NOT be used when the <a
+						<td>Only applies to the EPUB publication or collection. MUST NOT be used when the <a
 								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
 					</tr>
 					<tr>

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -1,6 +1,6 @@
 
 <section id="app-link-vocab" class="vocab">
-	<h3>Metadata Link Vocabulary</h3>
+	<h3>Metadata link vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the metadata <a href="#sec-link-elem"
 				><code>link</code> element's</a>
@@ -10,7 +10,7 @@
 		<code>http://idpf.org/epub/vocab/package/link/#</code>.</p>
 	
 	<section id="sec-link-rel">
-		<h4>Link Relationships</h4>
+		<h4>Link relationships</h4>
 		
 		<p>The following values can be used in the <code>link</code> element <a href="#attrdef-link-rel"
 					><code>rel</code> attribute</a> to establish the relationship of the resource referenced in
@@ -228,7 +228,7 @@
 			</table>
 		</section>
 		<section id="sec-xml-signature">
-			<h5>xml-signature (Deprecated)</h5>
+			<h5>xml-signature (deprecated)</h5>
 			
 			<p id="xml-signature">Use of the <code>xml-signature</code> keyword is <a href="#deprecated">deprecated</a>.
 				It is not replaced by another linking method.</p>
@@ -238,7 +238,7 @@
 				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
 		</section>
 		<section id="sec-xmp-record">
-			<h5>xmp-record (Deprecated)</h5>
+			<h5>xmp-record (deprecated)</h5>
 			
 			<p id="xmp-record">Use of the <code>xmp-record</code> keyword is <a href="#deprecated">deprecated</a>. It
 				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
@@ -251,7 +251,7 @@
 		</section>
 	</section>
 	<section id="sec-link-properties">
-		<h4>Link Properties</h4>
+		<h4>Link properties</h4>
 		<p>The following values can be used in the <a href="#sec-link-elem"><code>link</code> element's</a>
 			<code>properties</code> attribute to establish the type of record a referenced resource represents.
 			These values are provided for record formats that cannot be uniquely identified by their media

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -104,7 +104,7 @@
 			</table>
 		</section>
 		<section id="sec-marc21xml-record">
-			<h5>marc21xml-record (Deprecated)</h5>
+			<h5>marc21xml-record (deprecated)</h5>
 			
 			<p id="marc2xml-record">Use of the <code>marc21xml-record</code> keyword is <a href="#deprecated">deprecated</a>.
 				It is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
@@ -116,7 +116,7 @@
 				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
 		</section>
 		<section id="sec-mods-record">
-			<h5>mods-record (Deprecated)</h5>
+			<h5>mods-record (deprecated)</h5>
 			
 			<p id="mods-record">Use of the <code>mods-record</code> keyword is <a href="#deprecated">deprecated</a>. It
 				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
@@ -128,7 +128,7 @@
 				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
 		</section>
 		<section id="sec-onix-record">
-			<h5>onix-record (Deprecated)</h5>
+			<h5>onix-record (deprecated)</h5>
 			
 			<p id="onix-record">Use of the <code>onix-record</code> keyword is <a href="#deprecated">deprecated</a>. It
 				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -1,5 +1,5 @@
 <section id="app-meta-property-vocab" class="vocab">
-	<h3>Meta Properties Vocabulary</h3>
+	<h3>Meta properties vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the <a href="#sec-meta-elem"><code>meta</code>
 			element's</a>
@@ -513,7 +513,7 @@
 		</aside>
 	</section>
 	<section id="sec-meta-auth">
-		<h5>meta-auth (Deprecated)</h5>
+		<h5>meta-auth (deprecated)</h5>
 		<p id="meta-auth">Use of this property is <a href="#deprecated">deprecated</a>.</p>
 		
 		<p>Refer to the <a 

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -144,19 +144,19 @@
 					<th>Description:</th>
 					<td>
 						<p>The <code>belongs-to-collection</code> property identifies the name of a collection
-							to which the EPUB Publication belongs. An EPUB Publication MAY belong to one or more
+							to which the EPUB publication belongs. An EPUB publication MAY belong to one or more
 							collections.</p>
 						<p>It is also possible to chain these properties using the <a href="#attrdef-refines"
 									><code>refines</code> attribute</a> to indicate that one collection is
 							itself a member of another collection.</p>
-						<p>To allow Reading Systems to organize collections and avoid naming collisions (e.g.,
+						<p>To allow reading systems to organize collections and avoid naming collisions (e.g.,
 							unrelated collections might share a similar name, or different editions of a
 							collection could be released), an identifier SHOULD be provided that uniquely
 							identifies the instance of the collection. The <code>dcterms:identifier</code>
 							property must carry this identifier.</p>
 						<p>The collection MAY more precisely define its nature by attaching a <a
 								href="#collection-type"><code>collection-type</code></a> property.</p>
-						<p>The position of the EPUB Publication within the collection MAY be provided by
+						<p>The position of the EPUB publication within the collection MAY be provided by
 							attaching a <a href="#group-position"><code>group-position</code> property</a>.</p>
 					</td>
 				</tr>
@@ -174,7 +174,7 @@
 				</tr>
 				<tr>
 					<th>Extends:</th>
-					<td>Applies to the EPUB Publication and can refine other instances of itself.</td>
+					<td>Applies to the EPUB publication and can refine other instances of itself.</td>
 				</tr>
 			</tbody>
 		</table>
@@ -233,8 +233,8 @@
 							</dd>
 						</dl>
 						<div class="note">
-							<p>Although Reading Systems are not required to support these values, specifying them
-								provides the option to group related EPUB Publications in more meaningful ways.</p>
+							<p>Although reading systems are not required to support these values, specifying them
+								provides the option to group related EPUB publications in more meaningful ways.</p>
 						</div>
 					</td>
 				</tr>
@@ -382,13 +382,13 @@
 					<th>Description:</th>
 					<td>
 						<p>The <code>group-position</code> property indicates the numeric position in which the
-							EPUB Publication is ordered relative to other works belonging to the same group
-							(whether all EPUB Publications or not).</p>
+							EPUB publication is ordered relative to other works belonging to the same group
+							(whether all EPUB publications or not).</p>
 						<p>The <code>group-position</code> property can be attached to any metadata property
 							that establishes the group but is typically associated with the <a
 								href="#belongs-to-collection"><code>belongs-to-collection</code>
 							property</a>.</p>
-						<p>An EPUB Publication can belong to more than one group.</p>
+						<p>An EPUB publication can belong to more than one group.</p>
 					</td>
 				</tr>
 				<tr>
@@ -534,8 +534,7 @@
 					<th>Description:</th>
 					<td>
 						<p>The <code>role</code> property describes the role of a <code>creator</code>,
-								<code>contributor</code> or <code>publisher</code> in the creation of an EPUB
-							Publication.</p>
+								<code>contributor</code> or <code>publisher</code> in the creation of an EPUB publication.</p>
 						<p>When the <code>role</code> value is drawn from a code list or other formal
 							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
 							be attached to identify its source.</p>
@@ -634,7 +633,7 @@
 					<th>Description:</th>
 					<td>
 						<p>The <code>source-of</code> property indicates a unique aspect of an adapted source
-							resource that has been retained in the <a>EPUB Publication</a>. </p>
+							resource that has been retained in the <a>EPUB publication</a>. </p>
 						<p>This specification defines the <code>pagination</code> value to indicate that the
 							referenced <code>dc:source</code> element is the source of the <a
 								href="http://www.idpf.org/epub/vocab/structure/#pagebreak"
@@ -774,7 +773,7 @@
 								<code>title</code>.</p>
 						<p>When the <code>title-type</code> value is drawn from a code list or other formal
 							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
-							be attached to identify its source. When a scheme is not specified, Reading Systems
+							be attached to identify its source. When a scheme is not specified, reading systems
 								<span class="rfc2119">should</span> recognize the following title type values:
 								<code>main</code>, <code>subtitle</code>, <code class="value">short</code>,
 								<code>collection</code>, <code class="value">edition</code> and
@@ -916,7 +915,7 @@
 	</section>
 	<section id="sec-property-examples">
 		<h5>Examples</h5>
-		<aside class="example" title="A typical set of refines metadata in an EPUB Publication">
+		<aside class="example" title="A typical set of refines metadata in an EPUB publication">
 			<pre>&lt;metadata …>
 
    &lt;dc:identifier id="pub-id">

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -9,7 +9,7 @@
 		<code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>
 	
 	<p>The prefix "<code>media:</code>" is <a href="#sec-metadata-reserved-prefixes">reserved for use</a> with
-		properties in this vocabulary and does not have to be declared in the Package Document.</p>
+		properties in this vocabulary and does not have to be declared in the package document.</p>
 	
 	<section id="sec-active-class">
 		<h4>active-class</h4>
@@ -23,7 +23,7 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>Author-defined CSS class name to apply to the currently playing EPUB Content Document
+					<td>Author-defined CSS class name to apply to the currently playing EPUB content document
 						element.</td>
 				</tr>
 				<tr>
@@ -74,7 +74,7 @@
 				</tr>
 				<tr>
 					<th>Cardinality:</th>
-					<td>Exactly one for the <a>EPUB Publication</a> and for each Media Overlay.</td>
+					<td>Exactly one for the <a>EPUB publication</a> and for each Media Overlay.</td>
 				</tr>
 				<tr>
 					<th>Example:</th>
@@ -134,7 +134,7 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>Author-defined CSS class name to apply to the EPUB Content Document's document element
+					<td>Author-defined CSS class name to apply to the EPUB content document's document element
 						when playback is active.</td>
 				</tr>
 				<tr>

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -1,5 +1,5 @@
 <section id="app-overlays-vocab" class="vocab">
-	<h3>Media Overlays Vocabulary</h3>
+	<h3>Media overlays vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the <a href="#sec-meta-elem"><code>meta</code>
 			element's</a>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -6,7 +6,7 @@
 	
 	<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved for
 		use</a> with the package rendering properties and does not have to be declared in the
-		Package Document.</p>
+		package document.</p>
 	
 	<div class="note">
 		<p>Unlike the other vocabularies in this appendix, the properties in the Package Rendering Vocabulary
@@ -103,17 +103,15 @@
 	<section id="sec-rendering-custom-properties">
 		<h4>Custom rendering properties</h4>
 		
-		<p>Reading System developers may introduce functionality not defined in this specification to address Reading
-			System-specific issues rendering <a>EPUB Content Documents</a>.</p>
+		<p>Reading system developers may introduce functionality not defined in this specification to address reading system-specific issues rendering <a>EPUB content documents</a>.</p>
 		
-		<p>To facilitate this experimentation, EPUB Creators MAY include custom properties and spine overrides for
-			use in the <a>Package Document</a> provided they do not use the <code>rendition:</code>
+		<p>To facilitate this experimentation, EPUB creators MAY include custom properties and spine overrides for
+			use in the <a>package document</a> provided they do not use the <code>rendition:</code>
 			prefix.</p>
 		
 		<div class="note">
-			<p>Custom properties should only address rendering issues specific to a particular Reading
-				System. This specification should be extended to provide extensions that multiple
-				independent Reading Systems can use.</p>
+			<p>Custom properties should only address rendering issues specific to a particular reading system. This specification should be extended to provide extensions that multiple
+				independent reading systems can use.</p>
 		</div>
 	</section>
 </section>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -1,5 +1,5 @@
 <section id="app-rendering-vocab">
-	<h3>Package Rendering Vocabulary</h3>
+	<h3>Package rendering vocabulary</h3>
 	
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 		<code>http://www.idpf.org/vocab/rendition/#</code>.</p>
@@ -101,7 +101,7 @@
 	</table>
 	
 	<section id="sec-rendering-custom-properties">
-		<h4>Custom Rendering Properties</h4>
+		<h4>Custom rendering properties</h4>
 		
 		<p>Reading System developers may introduce functionality not defined in this specification to address Reading
 			System-specific issues rendering <a>EPUB Content Documents</a>.</p>

--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -150,7 +150,7 @@
 								<p>Making the information available via more than one sensory channel</p>
 							</blockquote>
 
-							<p>Out of scope: requirement for Reading Systems and Distributors.</p>
+							<p>Out of scope: requirement for reading systems and Distributors.</p>
 						</section>
 
 						<section id="annex-I-section-III-b-ii">
@@ -160,7 +160,7 @@
 								<p>Presenting the information in an understandable way</p>
 							</blockquote>
 
-							<p>Out of scope: requirement for Reading Systems and Distributors.</p>
+							<p>Out of scope: requirement for reading systems and Distributors.</p>
 						</section>
 
 						<section id="annex-I-section-III-b-iii">
@@ -170,7 +170,7 @@
 								<p>Presenting the information to users in ways they can perceive</p>
 							</blockquote>
 
-							<p>Out of scope: requirement for Reading Systems and Distributors.</p>
+							<p>Out of scope: requirement for reading systems and Distributors.</p>
 						</section>
 
 						<section id="annex-I-section-III-b-iv">
@@ -229,7 +229,7 @@
 									robust</p>
 							</blockquote>
 
-							<p>Out of scope: requirement for Reading Systems and Distributors.</p>
+							<p>Out of scope: requirement for reading systems and Distributors.</p>
 						</section>
 					</section>
 
@@ -242,7 +242,7 @@
 								making them perceivable, operable, understandable and robust</p>
 						</blockquote>
 
-						<p>Out of scope: requirement for Reading Systems and Distributors.</p>
+						<p>Out of scope: requirement for reading systems and Distributors.</p>
 					</section>
 
 					<section id="annex-I-section-III-d">
@@ -255,7 +255,7 @@
 								communication</p>
 						</blockquote>
 
-						<p>Out of scope: requirement for Reading Systems and Distributors.</p>
+						<p>Out of scope: requirement for reading systems and Distributors.</p>
 					</section>
 				</section>
 

--- a/epub33/epub-aria-authoring/index.html
+++ b/epub33/epub-aria-authoring/index.html
@@ -104,7 +104,7 @@
 			<h2>Guidelines</h2>
 
 			<section id="sec-mappings">
-				<h3>Mapping Types to Roles</h3>
+				<h3>Mapping types to roles</h3>
 
 				<p>ARIA roles are more restricted in where you can use them than EPUB's structural semantics. Although
 					there are elements that accept any role, you need to take care to ensure that roles are only used
@@ -1104,7 +1104,7 @@
 			</section>
 
 			<section id="sec-overload">
-				<h3>Do Not Overload Roles</h3>
+				<h3>Do not overload roles</h3>
 
 				<p>Only use <strong>one digital publishing role</strong> per <a
 						href="https://www.w3.org/TR/wai-aria/#host_general_role"><code>role</code> attribute</a>
@@ -1130,7 +1130,7 @@
 			</section>
 
 			<section id="sec-repetition">
-				<h3>Avoid Unnecessary Repetition</h3>
+				<h3>Avoid unnecessary repetition</h3>
 
 				<p>Do not reapply a semantic just because your content has been chunked into separate files.</p>
 
@@ -1141,7 +1141,7 @@
 			</section>
 
 			<section id="sec-hd">
-				<h3>Supply Labels</h3>
+				<h3>Supply labels</h3>
 
 				<p>If a landmark role (e.g., <a href="https://www.w3.org/TR/dpub-aria/#doc-chapter"
 							><code>doc-chapter</code></a>, <a href="https://www.w3.org/TR/dpub-aria/#doc-part"
@@ -1177,7 +1177,7 @@
 			</section>
 
 			<section id="sec-body">
-				<h3>Do Not Override the <code>body</code> Element</h3>
+				<h3>Do not override the <code>body</code> element</h3>
 
 				<p>The <a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code>
 						attribute</a> [[EPUB-3]] may be used to inflect sectioning semantics on the [[HTML]] <a
@@ -1193,7 +1193,7 @@
 			</section>
 
 			<section id="sec-lists">
-				<h3>List Roles are for Lists</h3>
+				<h3>List roles are for lists</h3>
 
 				<p>Assigning a role to an element overrides its default nature, so use care when applying roles to lists
 					and list items.</p>
@@ -1239,7 +1239,7 @@
 			</section>
 
 			<section id="sec-covers">
-				<h3>Cover Role is for Images</h3>
+				<h3>Cover role is for images</h3>
 
 				<p>Although the <a href="https://www.w3.org/TR/DPUB-ARIA/#doc-cover"><code>doc-cover</code> role</a>
 					[[DPUB-ARIA]] seems like it should be the same as the <a

--- a/epub33/epub-aria-authoring/index.html
+++ b/epub33/epub-aria-authoring/index.html
@@ -126,7 +126,7 @@
 					<thead>
 						<tr>
 							<th>[[EPUB-SSV-11]]</th>
-							<th>[[EPUB-3]] Manifest</th>
+							<th>[[EPUB-3]] manifest</th>
 							<th>[[DPUB-ARIA]]</th>
 							<th>[[WAI-ARIA]]</th>
 							<th>Elements Allowed On<a href="#role-general" role="doc-noteref" aria-label="note"
@@ -1243,10 +1243,10 @@
 
 				<p>Although the <a href="https://www.w3.org/TR/DPUB-ARIA/#doc-cover"><code>doc-cover</code> role</a>
 					[[DPUB-ARIA]] seems like it should be the same as the <a
-						href="https://www.w3.org/TR/epub-ssv/#cover"><code>cover</code> semantic</a> [[EPUB-SSV-11]], it is
-					actually related to the <a href="https://www.w3.org/TR/epub/#cover-image"><code>cover-image</code>
-						semantic</a> [[EPUB-3]] used to identify cover images in the EPUB package document. The role is
-					used to identify an image that represents the cover.</p>
+						href="https://www.w3.org/TR/epub-ssv/#cover"><code>cover</code> semantic</a> [[EPUB-SSV-11]], it
+					is actually related to the <a href="https://www.w3.org/TR/epub/#cover-image"
+							><code>cover-image</code> semantic</a> [[EPUB-3]] used to identify cover images in the EPUB
+					package document. The role is used to identify an image that represents the cover.</p>
 
 				<aside class="example">
 					<pre>&lt;img

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -145,7 +145,7 @@
 				</li>
 			</ul>
 
-			<p>In the case of both <a>Standard EPUB CFIs</a> and <a>Intra-Publication EPUB CFI</a>, this specification
+			<p>In the case of both <a>standard EPUB CFIs</a> and <a>intra-publication EPUB CFI</a>, this specification
 				conforms with the guidelines expressed by W3C in <a
 					href="https://www.w3.org/TR/fragid-best-practices/#structures">Section 6. Best Practices for Fragid
 					Structures</a> [[FRAGID-BEST-PRACTICES]].</p>
@@ -169,14 +169,14 @@
 
 				<dl class="termlist">
 					<dt>
-						<dfn id="dfn-standard-epub-cfi">Standard EPUB CFI</dfn>
+						<dfn id="dfn-standard-epub-cfi">standard EPUB CFI</dfn>
 					</dt>
 					<dd>
 						<p>A publication-level EPUB CFI links into an EPUB publication. The path preceding the EPUB CFI
 							references the location of the EPUB publication.</p>
 					</dd>
 					<dt>
-						<dfn id="gloss-intra-publication-epub-cfi">Intra-Publication EPUB CFI</dfn>
+						<dfn id="gloss-intra-publication-epub-cfi">intra-publication EPUB CFI</dfn>
 					</dt>
 					<dd>
 						<p>An intra-publication EPUB CFI allows one EPUB content document to reference another within
@@ -841,14 +841,14 @@
 							content without relying on character offsets at the start/end boundaries.</p>
 					</div>
 
-					<p>For a <a>Standard EPUB CFI</a>, the leading step in the CFI MUST start with a slash
+					<p>For a <a>standard EPUB CFI</a>, the leading step in the CFI MUST start with a slash
 							(<code>/</code>) followed by an even number that references the <code>spine</code> child
 						element of the package document's root <code>package</code> element. The package document
 						traversed by the CFI MUST be the one specified as the Default Rendition in the EPUB
 						publication's <code>META-INF/container.xml</code> file (i.e., the package document referenced by
 						the first <code>rootfile</code> element in <code>container.xml</code>).</p>
 
-					<p>For an <a>Intra-Publication EPUB CFI</a>, the first step MUST start with a slash followed by a
+					<p>For an <a>intra-publication EPUB CFI</a>, the first step MUST start with a slash followed by a
 						node number that references a position in package document starting from the root
 							<code>package</code> element.</p>
 				</section>

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -89,23 +89,23 @@
 				standardized method for referencing arbitrary content within an EPUB® Publication through the use of
 				fragment identifiers. </p>
 
-			<p>The web has proven that the concept of hyperlinking is tremendously powerful, but EPUB Publications have
+			<p>The web has proven that the concept of hyperlinking is tremendously powerful, but EPUB publications have
 				been denied much of the benefit that hyperlinking makes possible because of the lack of a standardized
 				scheme to link into them. Although proprietary schemes have been developed and implemented for
-				individual Reading Systems, without a commonly-understood syntax there has been no way to achieve
+				individual reading systems, without a commonly-understood syntax there has been no way to achieve
 				cross-platform interoperability. The functionality that can see significant benefit from breaking down
 				this barrier, however, is varied: from reading location maintenance to annotation attachment to
 				navigation, the ability to point into any Publication opens a whole new dimension not previously
 				available to developers and Authors. </p>
 
 			<p>This specification attempts to rectify this situation by defining an arbitrary structural reference that
-				can uniquely identify any location, or simple range of locations, in an EPUB Publication: the EPUB CFI.
+				can uniquely identify any location, or simple range of locations, in an EPUB publication: the EPUB CFI.
 				The following considerations have strongly influenced the design and scope of this scheme:</p>
 
 			<ul>
 				<li>
 					<p>The mechanism used to reference content should be interoperable: references to a reading position
-						created by one Reading System should be usable by another.</p>
+						created by one reading system should be usable by another.</p>
 				</li>
 				<li>
 					<p>Document references to EPUB content should be enabled in the same way that existing hyperlinks
@@ -172,16 +172,16 @@
 						<dfn id="dfn-standard-epub-cfi">Standard EPUB CFI</dfn>
 					</dt>
 					<dd>
-						<p>A publication-level EPUB CFI links into an EPUB Publication. The path preceding the EPUB CFI
-							references the location of the EPUB Publication.</p>
+						<p>A publication-level EPUB CFI links into an EPUB publication. The path preceding the EPUB CFI
+							references the location of the EPUB publication.</p>
 					</dd>
 					<dt>
 						<dfn id="gloss-intra-publication-epub-cfi">Intra-Publication EPUB CFI</dfn>
 					</dt>
 					<dd>
 						<p>An intra-publication EPUB CFI allows one Content Document to reference another within the
-							same Rendition of an EPUB Publication. The path preceding the EPUB CFI references the
-							current Rendition's Package Document.</p>
+							same Rendition of an EPUB publication. The path preceding the EPUB CFI references the
+							current Rendition's package document.</p>
 						<p>Refer to <a href="#sec-intra-cfis">Intra-Publication CFIs</a> for more information. </p>
 					</dd>
 				</dl>
@@ -202,7 +202,7 @@
 					given ID.</p>
 
 				<p>A Canonical Fragment Identifier (CFI) is a similar construct to these, but expresses a location
-					within an EPUB Publication. For example:</p>
+					within an EPUB publication. For example:</p>
 
 				<aside class="example">
 					<pre>book.epub#epubcfi(/6/4[chap01ref]!/4[body01]/10[para05]/3:10)</pre>
@@ -210,10 +210,10 @@
 
 				<p>The function-like string immediately following the hash (<code>epubcfi(…)</code>) indicates that this
 					fragment identifier conforms to the scheme defined by this specification, and the value contained in
-					the parentheses is the syntax used to reference the location within the specified EPUB Publication
+					the parentheses is the syntax used to reference the location within the specified EPUB publication
 						(<code>book.epub</code>). Using the processing rules defined in <a href="#sec-path-res">Path
-						Resolution</a>, any Reading System can parse this syntax, open the corresponding Content
-					Document in the EPUB Publication and load the specified location for the user.</p>
+						Resolution</a>, any reading system can parse this syntax, open the corresponding Content
+					Document in the EPUB publication and load the specified location for the user.</p>
 
 				<p>A complete definition of the EPUB CFI syntax is provided in the next section.</p>
 
@@ -611,7 +611,7 @@
 				<p>Substrings in brackets are extensible assertions that improve the robustness of traversing paths and
 					migrating them from one revision of the document to another. These assertions preserve additional
 					information about traversed elements of the document, which makes it possible to recover intended
-					location even after some modifications are made to the EPUB Publication.</p>
+					location even after some modifications are made to the EPUB publication.</p>
 
 				<p>Although the <strong>value</strong> definition in the syntax above allows any a sequence of
 					characters, a circumflex (<code>^</code>) MUST be used to escape the following characters to ensure
@@ -712,7 +712,7 @@
 					<li>
 						<p>(X)HTML context:</p>
 						<p> IRI references are designed to be used in the various types of documents that EPUB
-							Publications comprise. XML and (X)HTML represent yet another insertion context that requires
+							publications comprise. XML and (X)HTML represent yet another insertion context that requires
 							specific character escaping rules. For example, double quote characters or angle brackets
 							conflict with significant delimiters in the markup syntax, and MUST therefore be escaped
 							using the <code>&amp;xxx;</code> special sequence (character reference).</p>
@@ -777,8 +777,8 @@
 			<section id="sec-path-res">
 				<h2>Path resolution</h2>
 
-				<p>The process of resolving an EPUB CFI to a location within an EPUB Publication begins with the root
-						<code>package</code> element of the Package Document. Each step in the CFI is then processed one
+				<p>The process of resolving an EPUB CFI to a location within an EPUB publication begins with the root
+						<code>package</code> element of the package document. Each step in the CFI is then processed one
 					by one, left to right, applying the rules defined in the following subsections.</p>
 
 				<div class="note">
@@ -821,7 +821,7 @@
 								element's content. Similarly, <code>n+2</code> is a valid index that refers to a
 								non-existing element which virtually follows the last potentially-empty chunk of
 								character data, where <code>n</code> is the even index of the last child element, or 0
-								if there are no child elements. CFI processors (e.g., Reading Systems) MUST be capable
+								if there are no child elements. CFI processors (e.g., reading systems) MUST be capable
 								of consuming (e.g., parsing and interpreting) CFI expressions containing references to
 								the 0 and <code>n+2</code> "virtual" elements, even when the first (or last,
 								respectively) chunk of character data is empty. Conversely, the *production* of such CFI
@@ -843,13 +843,13 @@
 
 					<p>For a <a>Standard EPUB CFI</a>, the leading step in the CFI MUST start with a slash
 							(<code>/</code>) followed by an even number that references the <code>spine</code> child
-						element of the Package Document's root <code>package</code> element. The Package Document
+						element of the package document's root <code>package</code> element. The package document
 						traversed by the CFI MUST be the one specified as the Default Rendition in the EPUB
-						Publication's <code>META-INF/container.xml</code> file (i.e., the Package Document referenced by
+						publication's <code>META-INF/container.xml</code> file (i.e., the package document referenced by
 						the first <code>rootfile</code> element in <code>container.xml</code>).</p>
 
 					<p>For an <a>Intra-Publication EPUB CFI</a>, the first step MUST start with a slash followed by a
-						node number that references a position in Package Document starting from the root
+						node number that references a position in package document starting from the root
 							<code>package</code> element.</p>
 				</section>
 				<section id="sec-path-xmlid">
@@ -859,7 +859,7 @@
 						MUST include that ID in square brackets (i.e., after the slash (<code>/</code>) and even number
 						that identifies the element).</p>
 
-					<p>Specification of identifiers adds robustness to the CFI scheme: a Reading System can determine
+					<p>Specification of identifiers adds robustness to the CFI scheme: a reading system can determine
 						that the location referenced by the CFI is not the original intended location, and can use the
 						identifier to compute the set of steps that reach the desired destination in the content (see <a
 							href="#sec-target-correction">Intended Target Location Correction</a>). The cost of this
@@ -879,7 +879,7 @@
 
 					<ul>
 						<li>
-							<p>For <code>itemref</code> in the Package Document <code>spine</code>, the reference is
+							<p>For <code>itemref</code> in the package document <code>spine</code>, the reference is
 								defined by the <code>href</code> attribute of the corresponding <code>item</code>
 								element in the <code>manifest</code> (i.e., that the <code>itemref</code>'s
 									<code>idref</code> attribute references).</p>
@@ -943,13 +943,13 @@
 								>String API</a> [[ECMA-262]]</p>
 					</div>
 
-					<p>A character offset MAY follow a <code>/N</code> step. For XHTML Content Documents, <code>N</code>
+					<p>A character offset MAY follow a <code>/N</code> step. For XHTML content documents, <code>N</code>
 						would be an even number when referencing the <code>alt</code> text of an <code>img</code>
 						element, and <code>N</code> would be odd when referencing XML character data within
 						elements.</p>
 
 					<p>CFI expressions that terminate with an odd numbered <code>/N</code> step SHOULD include an
-						explicit character offset. However, CFI processors (e.g., Reading Systems) MUST be capable of
+						explicit character offset. However, CFI processors (e.g., reading systems) MUST be capable of
 						consuming (i.e., parse + interpret / render) such CFI expressions, by assuming the implicit
 							<code>/N:0</code> character offset.</p>
 				</section>
@@ -1016,7 +1016,7 @@
 						collapsed (i.e., a non-empty sequence of contiguous white space characters is always replaced
 						with a single space character).</p>
 
-					<p>A Reading System can determine that the location referenced by the CFI is not the original
+					<p>A reading system can determine that the location referenced by the CFI is not the original
 						intended location (due to non-matching text), and can use the preceding/trailing text to compute
 						the set of steps that reach the desired destination in the content (see <a
 							href="#sec-target-correction">Intended Target Location Correction</a>). The cost of this
@@ -1074,7 +1074,7 @@
 				<section id="sec-path-examples" class="informative">
 					<h3>Examples</h3>
 
-					<p>Given the following Package Document:</p>
+					<p>Given the following package document:</p>
 
 					<aside class="example">
 						<pre>&lt;?xml version="1.0"?&gt;
@@ -1126,7 +1126,7 @@
 </pre>
 					</aside>
 
-					<p>and the XHTML Content Document <code>chapter01.xhtml</code>:</p>
+					<p>and the XHTML content document <code>chapter01.xhtml</code>:</p>
 
 					<aside class="example">
 						<pre>&lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
@@ -1160,7 +1160,7 @@
 							<code>para05</code>. When producing CFIs for text locations, unless the text is defined by
 						an <code>img</code> element's <code>alt</code> tag, one SHOULD always start with the reference
 						to the (possibly-empty) chunk of XML character data that corresponds to the location and then
-						trace the ancestor and reference chain to the Package Document root.</p>
+						trace the ancestor and reference chain to the package document root.</p>
 
 					<p>The following examples show how EPUB CFIs can be constructed to reference additional content
 						locations.</p>
@@ -1190,7 +1190,7 @@
 				<h2>Sorting rules</h2>
 
 				<p>In order to sort or compute relative locations of multiple EPUB CFIs referencing the same EPUB
-					Publication, the following rules MUST be applied:</p>
+					publication, the following rules MUST be applied:</p>
 
 				<ol>
 					<li>
@@ -1230,10 +1230,10 @@
 				<h2>Intra-publication CFIs</h2>
 
 				<p>An EPUB CFI can be used to reference content inside the container. This kind of referencing can be
-					achieved by specifying a reference to the Package Document followed by a CFI, which MUST be resolved
+					achieved by specifying a reference to the package document followed by a CFI, which MUST be resolved
 					starting from the root <code>package</code> element.</p>
 
-				<p>For example, using the Package Document in the <a href="#sec-path-examples">previous example</a>, a
+				<p>For example, using the package document in the <a href="#sec-path-examples">previous example</a>, a
 					reference to the last location in <code>chapter01.xhtml</code> might be written as follows:</p>
 
 				<aside class="example">
@@ -1295,16 +1295,16 @@
 			<section id="sec-target-correction">
 				<h2>Intended target location correction</h2>
 
-				<p>As an EPUB Publication can be updated, corrected or otherwise altered over time, it is useful to be
+				<p>As an EPUB publication can be updated, corrected or otherwise altered over time, it is useful to be
 					able to derive an EPUB CFI for the modified document from one that targeted a previous version. This
 					specification provides two mechanisms to detect and adapt to content changes that impact CFIs: IDs
 					[[XML]] and <a href="#sec-path-text-location">text location assertions</a>.</p>
 
-				<p>When a Reading System is processing a CFI, it SHOULD check the correctness of any encountered
-					assertions. For example, given the path <code>/6/4[chap01ref]!…</code>, the Reading System SHOULD
+				<p>When a reading system is processing a CFI, it SHOULD check the correctness of any encountered
+					assertions. For example, given the path <code>/6/4[chap01ref]!…</code>, the reading system SHOULD
 					verify that the element has the ID matching <code>chap01ref</code> when processing element
 						<code>4</code> (for this example, an <code>itemref</code> in the <code>spine</code>). If not,
-					the Reading System SHOULD locate the ID <code>chap01ref</code> within the document and correct the
+					the reading system SHOULD locate the ID <code>chap01ref</code> within the document and correct the
 					CFI (e.g., if a new <code>itemref</code> was inserted before the <code>chap01ref</code>
 					<code>itemref</code>, the desired element number would now be <code>6</code> and the corrected CFI
 					would be <code>/6/6[chap01ref]!…</code>). Likewise, text location assertions SHOULD be used to check
@@ -1313,13 +1313,13 @@
 
 				<p>If one of the assertions fails during processing, and a corrected CFI can not be derived (the ID is
 					not found in the document, or text matches could not be found), the CFI MUST be considered an
-					invalid reference. In cases where a Reading System cannot check for correctness (e.g.,
-					document-resident XML IDs are not available at CFI processing time), a Reading System MUST ignore
+					invalid reference. In cases where a reading system cannot check for correctness (e.g.,
+					document-resident XML IDs are not available at CFI processing time), a reading system MUST ignore
 					the CFI assertions.</p>
 
 				<p>This notion of correcting CFIs can lead to circumstances where two different CFIs point to the same
 					location (i.e., the "stale" CFI, pre-correction, and the corrected CFI). The corrected CFI SHOULD be
-					used where possible. A Reading System and any surrounding content management system SHOULD attempt
+					used where possible. A reading system and any surrounding content management system SHOULD attempt
 					to replace stale CFIs with their corrected versions where possible.</p>
 
 				<div class="note">
@@ -1334,7 +1334,7 @@
 			<h1>Extending EPUB CFIs</h1>
 
 			<p>The provision for extensions (CSV parameter lists, prefixed by a parameter name, and separated by
-				semicolons) allow Reading Systems to apply new or experimental heuristics to assist, for example, in
+				semicolons) allow reading systems to apply new or experimental heuristics to assist, for example, in
 				migrating EPUB CFI fragments to updated documents.</p>
 
 			<p>It is RECOMMENDED that any vendor-specific parameter names start with <code>vnd.</code> followed by the

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -179,8 +179,8 @@
 						<dfn id="gloss-intra-publication-epub-cfi">Intra-Publication EPUB CFI</dfn>
 					</dt>
 					<dd>
-						<p>An intra-publication EPUB CFI allows one Content Document to reference another within the
-							same Rendition of an EPUB publication. The path preceding the EPUB CFI references the
+						<p>An intra-publication EPUB CFI allows one EPUB content document to reference another within
+							the same Rendition of an EPUB publication. The path preceding the EPUB CFI references the
 							current Rendition's package document.</p>
 						<p>Refer to <a href="#sec-intra-cfis">Intra-Publication CFIs</a> for more information. </p>
 					</dd>
@@ -212,8 +212,8 @@
 					fragment identifier conforms to the scheme defined by this specification, and the value contained in
 					the parentheses is the syntax used to reference the location within the specified EPUB publication
 						(<code>book.epub</code>). Using the processing rules defined in <a href="#sec-path-res">Path
-						Resolution</a>, any reading system can parse this syntax, open the corresponding Content
-					Document in the EPUB publication and load the specified location for the user.</p>
+						Resolution</a>, any reading system can parse this syntax, open the corresponding EPUB content
+					document in the EPUB publication and load the specified location for the user.</p>
 
 				<p>A complete definition of the EPUB CFI syntax is provided in the next section.</p>
 

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -190,7 +190,7 @@
 			<section id="conformance"></section>
 		</section>
 		<section id="sec-epubcfi-def">
-			<h1>EPUB CFI Definition</h1>
+			<h1>EPUB CFI definition</h1>
 
 			<section id="sec-epubcfi-intro" class="informative">
 				<h2>Introduction</h2>
@@ -574,7 +574,7 @@
 				</table>
 
 				<aside id="unicode-chars">
-					<h3>Unicode Characters</h3>
+					<h3>Unicode characters</h3>
 
 					<p>The definition of allowed Unicode characters is the same as [[XML]]. This excludes the surrogate
 						blocks, FFFE, and FFFF:</p>
@@ -661,7 +661,7 @@
 				</ul>
 			</section>
 			<section id="sec-epubcfi-escaping">
-				<h2>Character Escaping</h2>
+				<h2>Character escaping</h2>
 
 				<p> As described in <a href="#sec-epubcfi-syntax">Syntax</a>, the EPUB CFI grammar contains characters
 					that have a special purpose as delimiters within a fragment identifier expression. These characters
@@ -772,10 +772,10 @@
 			</section>
 		</section>
 		<section id="sec-epubcfi-processing">
-			<h1>EPUB CFI Processing</h1>
+			<h1>EPUB CFI processing</h1>
 
 			<section id="sec-path-res">
-				<h2>Path Resolution</h2>
+				<h2>Path resolution</h2>
 
 				<p>The process of resolving an EPUB CFI to a location within an EPUB Publication begins with the root
 						<code>package</code> element of the Package Document. Each step in the CFI is then processed one
@@ -787,7 +787,7 @@
 				</div>
 
 				<section id="sec-path-child-ref">
-					<h3>Step Reference to Child Element or Character Data (<code>/</code>)</h3>
+					<h3>Step reference to child element or character data (<code>/</code>)</h3>
 
 					<p>A step with a slash (<code>/</code>) followed by a positive integer refers to either a child
 						element or a chunk of character data, as per the rules defined herein:</p>
@@ -853,7 +853,7 @@
 							<code>package</code> element.</p>
 				</section>
 				<section id="sec-path-xmlid">
-					<h3>XML ID Assertion (<code>[</code>)</h3>
+					<h3>XML ID assertion (<code>[</code>)</h3>
 
 					<p>When an EPUB CFI references an element that contains an ID [[XML]], the corresponding path step
 						MUST include that ID in square brackets (i.e., after the slash (<code>/</code>) and even number
@@ -867,7 +867,7 @@
 						logically stripping all bracketed substrings (see <a href="#sec-sorting">Sorting Rules</a>).</p>
 				</section>
 				<section id="sec-path-indirection">
-					<h3>Step Indirection (<code>!</code>)</h3>
+					<h3>Step indirection (<code>!</code>)</h3>
 
 					<p>If a step, or a sequence of steps, points to an element that references another document, the
 						exclamation mark (<code>!</code>) MUST be used whenever that step is immediately followed by an
@@ -912,7 +912,7 @@
 					</div>
 				</section>
 				<section id="sec-path-terminating-char">
-					<h3>Character Offset (<code>:</code>)</h3>
+					<h3>Character offset (<code>:</code>)</h3>
 
 					<p>A path terminating with a leading colon (<code>:</code>) followed by an integer refers to a
 						character offset. The given character offset MAY apply to an element only if this element is the
@@ -954,13 +954,13 @@
 							<code>/N:0</code> character offset.</p>
 				</section>
 				<section id="sec-path-terminating-temporal">
-					<h3>Temporal Offset (<code>~</code>)</h3>
+					<h3>Temporal offset (<code>~</code>)</h3>
 
 					<p>A path terminating with a leading tilde (<code>~</code>) followed by a number indicates a
 						temporal position for audio or video measured in seconds.</p>
 				</section>
 				<section id="sec-path-terminating-spatial">
-					<h3>Spatial Offset (<code>@</code>)</h3>
+					<h3>Spatial offset (<code>@</code>)</h3>
 
 					<p>A path terminating with a leading at sign (<code>@</code>) followed by two colon-separated
 						numbers indicates a 2D spatial position within an image or video. The two numbers represent
@@ -969,14 +969,14 @@
 						(i.e., the upper left is <code>0:0</code> and the lower right is <code>100:100</code>).</p>
 				</section>
 				<section id="sec-path-terminating-tempspatial">
-					<h3>Temporal-Spatial Offset (<code>~</code> + <code>@</code>)</h3>
+					<h3>Temporal-spatial offset (<code>~</code> + <code>@</code>)</h3>
 
 					<p>A temporal and a spatial position MAY be used together. In this case, the temporal specification
 						MUST precede the spatial one syntactically (e.g., <code>~23.5@5.75:97.6</code> refers to a point
 						23.5 seconds into a video in the lower left of the frame).</p>
 				</section>
 				<section id="sec-path-text-location">
-					<h3>Text Location Assertion (<code>[</code>)</h3>
+					<h3>Text location assertion (<code>[</code>)</h3>
 
 					<p>An EPUB CFI MAY specify a substring that is expected to precede and/or follow the encountered
 						point, but such assertions MUST occur only after a <a href="#sec-path-terminating-char"
@@ -1024,7 +1024,7 @@
 						logically stripping all bracketed substrings (see <a href="#sec-sorting">Sorting Rules</a>).</p>
 				</section>
 				<section id="sec-path-side-bias">
-					<h3>Side Bias (<code>[</code> + <code>;s=</code>)</h3>
+					<h3>Side bias (<code>[</code> + <code>;s=</code>)</h3>
 
 					<p>In some situations, it is important to preserve which side of a location a reference points to.
 						For example, when resolving a location in a dynamically paginated environment, it would make a
@@ -1187,7 +1187,7 @@
 				</section>
 			</section>
 			<section id="sec-sorting">
-				<h2>Sorting Rules</h2>
+				<h2>Sorting rules</h2>
 
 				<p>In order to sort or compute relative locations of multiple EPUB CFIs referencing the same EPUB
 					Publication, the following rules MUST be applied:</p>
@@ -1227,7 +1227,7 @@
 				</ol>
 			</section>
 			<section id="sec-intra-cfis">
-				<h2>Intra-Publication CFIs</h2>
+				<h2>Intra-publication CFIs</h2>
 
 				<p>An EPUB CFI can be used to reference content inside the container. This kind of referencing can be
 					achieved by specifying a reference to the Package Document followed by a CFI, which MUST be resolved
@@ -1241,7 +1241,7 @@
 				</aside>
 			</section>
 			<section id="sec-ranges">
-				<h2>Simple Ranges</h2>
+				<h2>Simple ranges</h2>
 
 				<p>EPUB CFIs allow the expression of simple ranges extending from a start location to an end location. A
 					range MUST be expressed as a triple of <em>parent</em> path (<code>P</code>), <em>start</em> subpath
@@ -1293,7 +1293,7 @@
 					location.</p>
 			</section>
 			<section id="sec-target-correction">
-				<h2>Intended Target Location Correction</h2>
+				<h2>Intended target location correction</h2>
 
 				<p>As an EPUB Publication can be updated, corrected or otherwise altered over time, it is useful to be
 					able to derive an EPUB CFI for the modified document from one that targeted a previous version. This

--- a/epub33/explainers/EPUB-33-security-privacy.md
+++ b/epub33/explainers/EPUB-33-security-privacy.md
@@ -6,7 +6,7 @@ Written by Dave Cramer (invited expert) and the EPUB 3 Working Group, April 29, 
 
 * [EPUB 3.3 Overview](https://w3c.github.io/epub-specs/epub33/overview/), a non-normative overview of EPUB 3.3
 * [EPUB 3.3 Core](https://w3c.github.io/epub-specs/epub33/core/), the specification of the file format
-* [EPUB 3.3 Reading Systems](https://w3c.github.io/epub-specs/epub33/rs/), the specification for user agents, known as EPUB Reading Systems. 
+* [EPUB 3.3 Reading Systems](https://w3c.github.io/epub-specs/epub33/rs/), the specification for user agents, known as EPUB reading systems. 
 * [EPUB Accessibility 1.1](https://w3c.github.io/epub-specs/epub33/a11y/), the specification for accessibility. 
 * [EPUB Accessibility Techniques 1.1](https://w3c.github.io/epub-specs/epub33/a11y-tech/), an informative document on accessibility techniques. 
 * [EPUB Multiple-Rendition Publications 1.1](https://w3c.github.io/epub-specs/epub33/multi-rend/), a non-normative description of a largely-unimplemented feature allowing multiple EPUB publications to be packaged in the same container. 
@@ -14,7 +14,7 @@ Written by Dave Cramer (invited expert) and the EPUB 3 Working Group, April 29, 
 
 ## Introduction
 
-EPUB files are presented to end users by EPUB Reading Systems, which can be constructed as web applications but are more likely to be native apps using browser rendering engines. The EPUB specifications define the file format in great detail, but generally give user agents wide latitude, subject mostly to the requirements of the embedded technologies, such as HTML, SVG, XML, and CSS. 
+EPUB files are presented to end users by EPUB reading systems, which can be constructed as web applications but are more likely to be native apps using browser rendering engines. The EPUB specifications define the file format in great detail, but generally give user agents wide latitude, subject mostly to the requirements of the embedded technologies, such as HTML, SVG, XML, and CSS. 
 
 This makes it hard to think about security issues. Most of the security implications around EPUB depend on the architectural details and the business model of the reading system, rather than the specifications themselves. 
 
@@ -24,7 +24,7 @@ It’s hard to even reason about how HTML’s security issues affect EPUB. If I 
 
 ### 1. What information might this feature expose to web sites or other parties, and for what purposes is that exposure necessary?
 
-EPUB Reading Systems typically collect information on the reading habits of their users. In some cases this information is necessary to provide a good user experience; in other cases the information is collected for other users—the reading system company or the publisher of the book. 
+EPUB reading systems typically collect information on the reading habits of their users. In some cases this information is necessary to provide a good user experience; in other cases the information is collected for other users—the reading system company or the publisher of the book. 
 
 1. Tracking reading position. You really do want the reading system to remember that you just started chapter 5. 
 2. Remembering highlights, notes, bookmarks. 
@@ -100,4 +100,4 @@ No.
 
 ### 17. What should this questionnaire have asked?
 
-I am somewhat concerned about a feature of app platform web views that could lead to user confusion. In testing, if an EPUB reading system opens an EPUB that contains a non-HTML content document, the Reading System will often offer to the user the opportunity to download the file. This is a spec violation, but I’ve seen this behaviour in multiple user agents. It seems to be browser-level issue: request a `.dmg` file, for example, and you get a download dialogue. 
+I am somewhat concerned about a feature of app platform web views that could lead to user confusion. In testing, if an EPUB reading system opens an EPUB that contains a non-HTML content document, the reading system will often offer to the user the opportunity to download the file. This is a spec violation, but I’ve seen this behaviour in multiple user agents. It seems to be browser-level issue: request a `.dmg` file, for example, and you get a download dialogue. 

--- a/epub33/explainers/EPUB33-explainer.md
+++ b/epub33/explainers/EPUB33-explainer.md
@@ -29,7 +29,7 @@ EPUB 3.3 includes the following specifications:
 
 * [EPUB 3.3 Overview](https://w3c.github.io/epub-specs/epub33/overview/), a non-normative overview of EPUB 3.3
 * [EPUB 3.3 Core](https://w3c.github.io/epub-specs/epub33/core/), the specification of the file format
-* [EPUB 3.3 Reading Systems](https://w3c.github.io/epub-specs/epub33/rs/), the specification for user agents, known as EPUB Reading Systems. 
+* [EPUB 3.3 Reading Systems](https://w3c.github.io/epub-specs/epub33/rs/), the specification for user agents, known as EPUB reading systems. 
 * [EPUB Accessibility 1.1](https://w3c.github.io/epub-specs/epub33/a11y/)
 * [EPUB Accessibility Techniques 1.1](https://w3c.github.io/epub-specs/epub33/a11y-tech/)
 
@@ -117,7 +117,7 @@ The package file is the heart of any EPUB, and includes publication metadata, a 
 
 EPUB uses the XML serialization of HTML5. There have been many attempts to allow the HTML serialization, but they failed because much of the existing supply chain depends on XML-based tools to process EPUBs, and there has not been implementor interest. 
 
-Scripting is poorly supported in existing EPUB Reading Systems. Since EPUBs are not generally presented to end users via the web, and since most EPUBs are sold by retailers rather than publishers, the idea of an origin is less useful as the basis for a security model. 
+Scripting is poorly supported in existing EPUB reading systems. Since EPUBs are not generally presented to end users via the web, and since most EPUBs are sold by retailers rather than publishers, the idea of an origin is less useful as the basis for a security model. 
 
 
 

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -68,7 +68,7 @@ The main motivation behind creating fixed layout publications is the need to pre
 
 This note serves to help content authors and publishers try to address some of the common accessibility issues found in fixed layout content, including navigation, reading order, and text alternatives. This document is a companion to [[EPUB-A11Y-11]], specifically for fixed layout publications. All recommendations made in [[EPUB-A11Y-11]], [[EPUB-33]], and [[EPUB-RS-33]] are applied and extended here.
 
-### The Limits of Fixed Layout Accessibility {#limits}
+### The Limits of fixed layout accessibility {#limits}
 
 Fixed Layout publications present some unique challenges for accessibility. The requirements laid out in [[EPUB-A11Y-11]] recommend [[WCAG2]] AA, but for many use cases in fixed layout, that might not be possible without fundamental changes to the content.
 
@@ -106,7 +106,7 @@ In a multi-column document, the linear presentation of the content flows from th
 
 [Example from Understanding Success Criterion 1.3.2: Meaningful Sequence](https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence)
 
-### The Stacking Order Problem {#reading-order-stacking}
+### The stacking order problem {#reading-order-stacking}
 
 The default reading order for Text to Speech (TTS) is determined by the order of the elements in the XHTML page (DOM). Popular page layout programs like Adobe InDesign and Apple Pages export the page content in the order of the stacking order of objects on the page rather than their page position. The topmost objects sits above other objects and so is written last in the HTML.
 
@@ -128,7 +128,7 @@ The design above would be rendered in reverse reading order.
 </body>
 ```
 
-### Altering the Reading Order {#reading-order-changing}
+### Altering the reading order {#reading-order-changing}
 
 > If a blind user, who reads the page with a screen reader that follows the source order, is working with a sighted user who reads the page in visual order, they may be confused when they encounter information in different orders. A user with low vision who uses a screen magnifier in combination with a screen reader may be confused when the reading order appears to skip around on the screen. A keyboard user may have trouble predicting where focus will go next when the source order does not match the visual order.
 
@@ -158,7 +158,7 @@ The recommended best practice solution is to adjust the order of the elements in
 </body>
 ```
 
-### Removing items from the Reading Order {#reading-order-removing}
+### Removing items from the reading order {#reading-order-removing}
 
 There may be cases when text appears on the page but is unnecessary, duplicated or otherwise confusing for it to be added to the reading order. e.g. page numbers, section or chapter headings which are already part of the publication’s structure or text used for visual effects.
 
@@ -172,13 +172,13 @@ There may be cases when text appears on the page but is unnecessary, duplicated 
 </div>
 ```
 
-### Reading Order across the ‘fold’ {#reading-order-spreads}
+### Reading order across the ‘fold’ {#reading-order-spreads}
 
 Fixed-layout documents can be presented as ‘synthetic spreads’ when a left and right page are presented together as a spread. As each page of the fixed-layout document is a separate XHTML document it is expected that reading order moves through there document from left to right (when using left to right page progression) but is not possible for the reading order to move from the left to the right and then back to the left page again.
 
 If the text must be read in this way, the only solution to maintain the correct reading order is to convert the double page spread in to a single landscape page that contains the entire content of the spread and for the EPUB to be rendered as single pages.
 
-## Images in Fixed Layout {#images}
+## Images in fixed layout {#images}
 
 ### Overview
     
@@ -192,7 +192,7 @@ One challenge with fixed layouts is finding ways to describe the image and provi
 
 Image descriptions and alternative text do have limits in their ability to translate image content to text, those limitations include the ability to adequately map the flow of action on a page to text, or translation of visual effects to textual equivalents. Work continues in this area to improve this experience, and we will note gaps in the sections below.
 
-### Alternative Text and Image Descriptions
+### Alternative text and image descriptions
 
 Describing images within a fixed layout book will somewhat depend on the type of book these images are within.  For example describing a childrens picture book will be quite different than if this is a fixed layout graphic novel such as a comic book.
 
@@ -253,7 +253,7 @@ Support for scripting in XHTML content documents in EPUB is generally much bette
 
 Unlike reflowable publications, the CSS `background-image` property can be used with fixed layouts to set the background image for a page. It is best to limit this practice to backgrounds that are purely presentational as much as possible, however, as it complicates the ability to provide a description that any user will be able to reach (i.e., it often involves hiding the description only for assistive technologies).
 
-### Complex Image Descriptions
+### Complex image descriptions
 
 Depending on the complexity of the image this may require complex description with one of the following formats:
 
@@ -269,7 +269,7 @@ If there are a group of images in sequence, you only have to describe details in
 
 Not all details are needed in writing alternative text for images, and what you do describe relies heavily on context. For example, if the image is described in the surrounding text, you only need to briefly describe it in the alt-text. For more information on when, and how to describe you can go to the DIAGRAM centre, or AccessibilePublishing.ca. See resources for links.    
 
-### Useful Resources for describing images
+### Useful resources for describing images
 
 * [W3C - Resources on Alternative Text for Images](https://www.w3.org/WAI/alt/)
 * [Image Description Guidelines](http://diagramcenter.org/table-of-contents-2.html)
@@ -288,14 +288,14 @@ Effective navigation of fixed-layout EPUB can be as important for accessibility 
 
 [EPUB Packages 3.2 - 5. EPUB Navigation Document](https://www.w3.org/publishing/epub3/epub-packages.html#sec-package-nav)
 
-#### Table of Contents {#epub-toc}
+#### Table of contents {#epub-toc}
 
 Longer and more complex visual publications often have a table of contents spanning several EPUB pages, and must have an additional table of contents for the navigation.
 
 A navigation document is a requirement of EPUB; it is recommended to add additional levels of content and structure to the table of contents for accessibility.
 See [EPUB Navigation Document Definition 5.4 - 5.4.2.2 EPUB toc nav Element](https://www.w3.org/publishing/epub3/epub-packages.html#sec-nav-toc)
 
-#### Page Lists {#epub-pagelist}
+#### Page lists {#epub-pagelist}
 
 Because each page of a fixed layout EPUB is a separate HTML document, a page list can be generated relatively easily and will be created automatically from commonly used fixed-layout creation applications.
 
@@ -311,7 +311,7 @@ The navigation of fixed layout EPUB can be further increased by adding section m
 
 See [EPUB Navigation Document Definition 5.4 - 5.4.2.4 EPUB landmarks nav Element](https://www.w3.org/publishing/epub3/epub-packages.html#sec-nav-landmarks)
 
-### XHTML Page Titles {#xhtml-titles}
+### XHTML page titles {#xhtml-titles}
 
 The title of each XHTML page may be displayed to the end reader. As such it should be a meaningful description of the page contents or a page number.
 
@@ -353,7 +353,7 @@ Example:
 <p class="Paragraph">There are three primary considerations for how much depth of field – the amount of the scene in focus in the resulting photograph. The size of your aperture, the focal length of your lens, and the distance from your subject all have an impact on how much you’ll get in focus in a single frame.</p>
 ```
 
-### Region-Based Navigation
+### Region-based navigation
 
 Within a page it may be possible to add the navigation to ‘regions of interest’ within that page. Especially useful for splitting up a larger visual partook or layout for reading on smaller screens.
 
@@ -367,30 +367,30 @@ EPUB Region-Based Navigation is currently only supported by a few reading system
  
 The legibility, or readability, of fixed layout content is an important contributing factor to its accessibility, particularly for users with low vision, cognitive, or learning disabilities. As text in a fixed layout document is unalterable, it is important to consider best practices in putting together clear, legible documents. Content creators are reminded that ebooks can be read on a number of different screen sizes and devices, many that will be smaller than the printed version of the page. Designs for fixed layout content should take into account these smaller screen sizes and their impact on legibility and layout. This section will focus on what to consider when constructing more legible fixed layout publications.
 
-### Font Selection
+### Font selection
 
 There is no single font that meets the legibility needs of all users, but considering certain font characteristics to increase legibility is possible. When planning font selections in fixed layout publications, consider the following: 
 * Font sizing 
 * Font weight
 * Font face
 
-#### Font Sizing 
+#### Font sizing 
 
 There is no font size guideline in [[WCAG2]], however the standard default font size in most desktop and mobile browsers is 16pt for body text (I.e. in a `<p>` element). This size is sufficient for most content, and headings should be based off of it by using `em` or `rem` sizing in [[CSS]]. If content contains a great deal of text, it is also recommended to consider a larger body font size like 18pt to ensure readability. 
 
 Content creators should also ensure font size patterns are consistent throughout the content, to assist users in differentiating and contextualizing the content. 
 
-#### Font Weight
+#### Font weight
 
 Depending on the chosen font, it might be necessary to consider the weight of the font to make it more legible. A font weight of `400` is considered `normal` or `regular`, but depending on the font face, may be too light. A font that is too light can disappear into the background of a page, especially if factors like clarity or contrast are not considered. A font weight of `700` is considered `bold`, and would be more readable, but overusing a bold typeface can present its own issues for legibility. 
 
-#### Font Face
+#### Font face
 
 Selecting a font face for your content can depend on a number of factors. When choosing a font for fixed layout content it’s important for content creators to consider readability because a user will not be able to alter the font face to suit their needs or preferences. 
 
 One of the most important factors for the readability of fonts relates to character differentiation. Character differentiation in a font is a strong indicator of readability, specifically for characters that have similar shapes in a font face. In the Latin alphabet, letters like `I` and `l`, `b` and `d`, or `a` `o` and `e` can look very similar to one another depending on the style of the font. The same issue is possible in fonts for other alphabets, particularly when glyphs are similar in appearance or use similar elements. 
 
-### Color Contrast 
+### Color contrast 
 
 [[WCAG2]] specifies that the color contrast should meet certain ratios depending on its size and weight. 
 
@@ -400,7 +400,7 @@ Large scale text, text that is over 18pt (or 14pt bold) must have a contrast of 
 
 It is recommended text be placed on a solid background or one that is significantly muted in order to increase the legibility of the text. 
 
-### Text Layout
+### Text layout
 
 The layout of text in a fixed-layout publication is also important when considering legibility. As outlined in the [Reading Order](#reading-order) section, the order of content on the page, and the order in code should match. When laying out a page in a fixed layout document, consider the order the reader should follow, how to indicate that order visually, and any complications to the order (i.e. asides, definitions, images, etc). 
 
@@ -433,7 +433,7 @@ Depending on the complexity of the image this may require complex description wi
 Using hidden descriptions should be considered very carefully, as hiding the description as demonstrated in example 4 will hide it from everything except assistive technologies. People with learning or cognitive disabilities would not benefit from this technique. 
  </aside>
 
-### ARIA Roles for Tables {#tables-aria}
+### ARIA roles for tables {#tables-aria}
 
 Provide an extended description for a table using either [aria-describedby or aria-details](https://www.w3.org/TR/WCAG20-TECHS/ARIA15.html).
 
@@ -441,7 +441,7 @@ The advantage of aria-details over aria-describedby is that it allows users acce
 
 The aria-describedby attribute's big drawback is that it turns the description into one long text string that users have to listen to. There's no way to navigate the columns and rows or have headers read out, so it's likely going to be very difficult for users to make sense of except for very simple and very small tables.
 
-## Package Metadata 
+## Package metadata 
 
 The [package metadata](https://www.w3.org/TR/epub-33/#sec-fxl-package) used in the EPUB is the primary method for a reading system to determine whether content is fixed layout or reflowable. In addition to identifying the pagination mode with <code>rendition:layout</code>, package metadata can also allow the content creator to have some control over other display characteristics.
 
@@ -468,7 +468,7 @@ It is recommended that content creators do not set a specific <code>orientation<
 
 Books with accessible elements require metadata to indicate how they are accessible, and if they present and hazards to the reader.
 
-### Accessibility Features {#a11y-metadata-features}
+### Accessibility features {#a11y-metadata-features}
     
 The schema.org property `accessibilityFeature` is used to define all accessibility features within this book.
     
@@ -490,7 +490,7 @@ A few values that could apply to a Fixed Layout book might be:
 </pre>
 </aside>
     
-### Access Mode {#a11y-metadata-access-mode}
+### Access mode {#a11y-metadata-access-mode}
 
 The schema.org property `accessMode` is used to define the ways in which this book can be consumed be that `visual`, `textual`, `auditory`, or `tactile`.
 
@@ -513,7 +513,7 @@ A Fixed Layout book which contains both text and images would have two separate 
 </pre>
 </aside>    
     
-### Access Mode Sufficient {#a11y-metadata-access-mode-sufficient}
+### Access mode sufficient {#a11y-metadata-access-mode-sufficient}
  
 The schema.org property `accessModeSufficient` is used to define the combinations in which this book can be consumed be that `visual`, `textual`, `auditory`, or `tactile`.
     
@@ -541,7 +541,7 @@ If a Fixed Layout book has all images fully described then having `accessModeSuf
 &lt;/meta&gt;</pre>
 </aside>
 
-### Accessibility Hazards {#a11y-metadata-hazards}
+### Accessibility hazards {#a11y-metadata-hazards}
 
 The schema.org property `accessibilityHazard` defines any hazards within the book.
     
@@ -555,7 +555,7 @@ If there are no hazards within the book one can simply have `none` or can call o
 &lt;/meta&gt;</pre>
 </aside>
     
-### Accessibility Summary {#a11y-metadata-accessibility-summary}
+### Accessibility summary {#a11y-metadata-accessibility-summary}
 
 The schema.org property `accessibilitySummary` is a human readable statement on how accessible or inaccessible this book is.
 

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -94,7 +94,7 @@ In addition, there may be additional text and image objects on the fixed-layout 
  * Section or chapter headings
  * Other purely decorative objects
 
-### The Page Position Problem {#reading-order-position}
+### The page position problem {#reading-order-position}
 
 For complex designs, the position of objects on the fixed-layout page is not a reliable indicator of their reading order.
 
@@ -340,7 +340,7 @@ The reading order within the page can be complex. See the [reading order](#readi
 Alongside the main content of the publication, auxiliary content that enhances or augments the primary content and can be accessed out of sequence. Examples of auxiliary content include: notes, descriptions and answers to quizzes.
 See https://www.w3.org/publishing/epub3/epub-packages.html#attrdef-itemref-linear
 
-### Structural Hierarchy
+### Structural hierarchy
 
 The use of heading tags ensures users do not have to rely on visual styling to understand and navigate the document outline. The structural hierarchy is already being considered at the design stage of visual page layout. By adding this information into the styles on the page and the tags used on export, we pull can this structure into EPUB.
 Example:

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -78,7 +78,7 @@ We want to recognize these challenges for content creators, and in this document
 
 ## Reading Order {#reading-order}
 
-> A key concept of EPUB is that an EPUB Publication consists of multiple resources that can be completely navigated and consumed by a person or program in some specific order. - 1.2.1 Reading Order [[EPUB-OVERVIEW-33]]
+> A key concept of EPUB is that an EPUB publication consists of multiple resources that can be completely navigated and consumed by a person or program in some specific order. - 1.2.1 Reading Order [[EPUB-OVERVIEW-33]]
 
 Whereas many reflowable publications have an obvious reading order, or logical progression through their content, fixed-layout publications are often more complex in their design and layout and may consist of multiple readable objects on the same page.
 
@@ -282,24 +282,24 @@ Not all details are needed in writing alternative text for images, and what you 
 
 Effective navigation of fixed-layout EPUB can be as important for accessibility as it is for reflowable EPUB. Many of the EPUB accessibility features found in reflowable EPUB can still be used in fixed layout. 
 
-### EPUB Navigation Document {#epub-nav}
+### EPUB navigation document {#epub-nav}
 
-> The EPUB Navigation Document is a mandatory component of an EPUB Package. It allows Authors to include a human- and machine-readable global navigation layer, thereby ensuring increased usability and accessibility for the user.
+> The EPUB navigation document is a mandatory component of an EPUB Package. It allows Authors to include a human- and machine-readable global navigation layer, thereby ensuring increased usability and accessibility for the user.
 
-[EPUB Packages 3.2 - 5. EPUB Navigation Document](https://www.w3.org/publishing/epub3/epub-packages.html#sec-package-nav)
+[EPUB Packages 3.2 - 5. EPUB navigation document](https://www.w3.org/publishing/epub3/epub-packages.html#sec-package-nav)
 
 #### Table of contents {#epub-toc}
 
 Longer and more complex visual publications often have a table of contents spanning several EPUB pages, and must have an additional table of contents for the navigation.
 
 A navigation document is a requirement of EPUB; it is recommended to add additional levels of content and structure to the table of contents for accessibility.
-See [EPUB Navigation Document Definition 5.4 - 5.4.2.2 EPUB toc nav Element](https://www.w3.org/publishing/epub3/epub-packages.html#sec-nav-toc)
+See [EPUB navigation document Definition 5.4 - 5.4.2.2 EPUB toc nav Element](https://www.w3.org/publishing/epub3/epub-packages.html#sec-nav-toc)
 
 #### Page lists {#epub-pagelist}
 
 Because each page of a fixed layout EPUB is a separate HTML document, a page list can be generated relatively easily and will be created automatically from commonly used fixed-layout creation applications.
 
-See [EPUB Navigation Document Definition 5.4 - 5.4.2.3 EPUB page-list nav Element](https://www.w3.org/publishing/epub3/epub-packages.html#sec-nav-toc)
+See [EPUB navigation document Definition 5.4 - 5.4.2.3 EPUB page-list nav Element](https://www.w3.org/publishing/epub3/epub-packages.html#sec-nav-toc)
 
 <aside class="ednote">
 There was previously an accessibility requirement in DAISY ACE for a dc:source to be present for any EPUBs that have a page list added. As fixed-layout EPUBS can be created as original works, they have a page list but no other source which caused a serious EPUB violation error in ACE. This has been resolved.
@@ -309,7 +309,7 @@ There was previously an accessibility requirement in DAISY ACE for a dc:source t
 
 The navigation of fixed layout EPUB can be further increased by adding section markers and landmarks to identify major sections of the publication. e.g. cover image, table of contents, and the start of the main body matter. 
 
-See [EPUB Navigation Document Definition 5.4 - 5.4.2.4 EPUB landmarks nav Element](https://www.w3.org/publishing/epub3/epub-packages.html#sec-nav-landmarks)
+See [EPUB navigation document Definition 5.4 - 5.4.2.4 EPUB landmarks nav Element](https://www.w3.org/publishing/epub3/epub-packages.html#sec-nav-landmarks)
 
 ### XHTML page titles {#xhtml-titles}
 
@@ -323,15 +323,15 @@ The title of each XHTML page may be displayed to the end reader. As such it shou
 
 As the fixed-layout EPUB standard did not exist before EPUB3 there is no requirement for the older and superseded NCX document, the earlier method to indicate navigation in  EPUB 2.
 
-### EPUB Package Document {#epub-package}
+### EPUB package document {#epub-package}
 
-> The Package Document is an XML document that consists of a set of elements that each encapsulate information about a particular aspect of the EPUB Package. These elements serve to centralize metadata, detail the individual resources that compose the Package and provide the reading order and other information necessary to render the Rendition.
+> The package document is an XML document that consists of a set of elements that each encapsulate information about a particular aspect of the EPUB Package. These elements serve to centralize metadata, detail the individual resources that compose the Package and provide the reading order and other information necessary to render the Rendition.
 
-From [Package Document Definition 3.4](https://www.w3.org/publishing/epub3/epub-packages.html#sec-package-content-conf)
+From [Package document definition 3.4](https://www.w3.org/publishing/epub3/epub-packages.html#sec-package-content-conf)
 
 ### Reading order
 
-Each page of a fixed-layout EPUB is an individual XHTML page. Pages are presented sequentially in the order that they are listed in the Spine element of the Package Document.
+Each page of a fixed-layout EPUB is an individual XHTML page. Pages are presented sequentially in the order that they are listed in the spine element of the package document.
 
 The reading order within the page can be complex. See the [reading order](#reading-order) section for more information on pages. 
 

--- a/epub33/locators/index.html
+++ b/epub33/locators/index.html
@@ -68,7 +68,7 @@ This specification does not define solutions for other problems related to locat
 * *Page-list*: a navigation element including linked mapping to the print page locations in an EPUB file, as defined in [EPUB 3.3 core](https://w3c.github.io/epub-specs/epub33/core/#sec-nav-pagelist). Also called a position list.
 * *Screen display*: a variable-size section of the publication that appears on a screen at a certain time, during navigation, often changes with font, screen size, etc.
 
-## Use Cases
+## Use cases
 
 * Susan, a teacher, asks her students to go to a certain location in an EPUB file that contains no publisher-provided page list. The students are using different types of reading systems, nevertheless all are able to reach the same location.
 * Ali is a student preparing a bibliography for an essay assignment. Several of his resources are EPUBs, and he wants to reference them accurately, including precise citations.
@@ -79,22 +79,22 @@ This specification does not define solutions for other problems related to locat
 * Caris is writing and embedding an index for an ebook and needs labels for locator links. The publisher has not provided a page list as this is a digital-only edition. She needs a consistent locator scheme for generating the locations in the index, so generates one using a standard algorithm.
 * Namjoon is scrolling vertically through a webtoon chapter when he needs to return to work and closes the app. Upon reopening the app, he is able to resume reading on the exact panel he finished at without having to scroll to find it.  
 
-## Recommendations and Possible Solutions 
+## Recommendations and possible solutions 
 
 First, we recommend publishers provide virtual page-lists or position lists in the navigation documents of their ebooks. Page-lists (also called position lists) can include line numbers, section numbers, page numbers, etc. We encourage publishers to provide specific lists. 
 
 In lieu of a publisher-provided page-list or position list, the following algorithm is recommended for creating such a list:
 
-### The Algorithm
+### The algorithm
 The algorithm must be near-perfectly repeatable and therefore consistent between different reading systems, but it is not necessarily of high quality relative to an authored page-list — it is best-effort, prioritizing consistency over pleasant page sizes.
 
 The reading system or EPUB implementation should, in memory or persistently, calculate one page number for every 1,000 unicode code points of uncompressed visible-to-the-reader text (number TBD, requires experimental implementation and tuning to "feel" right). 
 
-### Format and Persistence
+### Format and persistence
 
 The reading system should treat the result of the algorithm as if it were an authored page-list, but whether it is actually a page-list, and whether the results are written back to the reading system's copy of the book, are implementation details. (Not all reading systems are capable of writing back to the EPUB.)
 
-### User Experience
+### User experience
 
 We should talk a bit about recommendations for page navigation. For example, typing strings into a box is not a good experience. By comparison, browsing from page to page (say with a slider/scroller) makes non sequential page "numbers" bearable.
 
@@ -102,15 +102,15 @@ Laurent says that authored page-lists sometimes have visual indications in the b
 
 Possibly the user can choose what kind of page numbers they want: authored page numbers, calculated page numbers, no page numbers at all.
 
-## Internationalization Considerations 
+## Internationalization considerations 
 
 Page sizes are likely to vary widely between different languages. This is acceptable as page numbers do not need to correspond between translated versions of a book. A publisher who wants page content to correspond across languages can use an explicit page-list (but this is unlikely to correspond to all versions of the print book).
 
-## Accessibility Considerations
+## Accessibility considerations
 
 The solution should follow the best practice recommendations for authored page numbers in EPUB (see Daisy knowledge base). For the user, there should be no difference between the authored and calculated page number. Calculated page numbers must appear in the reading system accessibility tree.
 
-## Locator Affordances 
+## Locator affordances 
 
 Ensuring that ebooks have consistent locating schemes, either in a provided page list or programmatically, creates an opportunity for a number of possible affordances. 
 
@@ -122,7 +122,7 @@ Possible affordances include:
 * Accurate position sharing between ebook readers 
 * Accuracy of length of book on item detail pages
 
-## Other Considerations (Notes for the Algorithm)
+## Other considerations (notes for the algorithm)
 
 If using bytes, compressed vs uncompressed
 
@@ -136,7 +136,7 @@ If a title is ingested by a distributor, and they insert virtual page breaks in 
 
 Implementing page-list or a similar locating scheme where the content creator uses strings to declare page/location ID can present implementation challenges. If a location ID can be a string, it theoretically can be anything, which could complicate the implementation of a search or enter page number function in a reading system. However, it is also known that content creators do occasionally use a mix of numbers and letters (i.e. using roman numerals to denote an introduction) in publications, so finding an alternative to using strings could be challenging. 
 
-## Page List vs Position List
+## Page list vs position list
 
 We inherit the definition of a page list from EPUB, among other things we could mention that:
 

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -383,7 +383,7 @@
 							publications that do not conform to this specification can include different metadata. EPUB
 							publications that are not valid to the content model restrictions in this section are not
 							valid multiple-rendition publications as defined by this specification, but might still be
-							valid EPUB 3 Publications.</p>
+							valid EPUB 3 publications.</p>
 						<p>EPUB creators are strongly encouraged to migrate to the content model defined in this
 							specification, even if not producing multiple-rendition publications, to ensure consistent
 							processing.</p>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -1257,7 +1257,7 @@
 			</section>
 
 			<section id="schema-container">
-				<h3>Container.xml Schema</h3>
+				<h3>Container.xml schema</h3>
 				<p>The schema for including rendition selection attributes in the <code class="markup"
 						>container.xml</code> file, as described in <a href="#rendition-selection"></a>, is available at
 						<a
@@ -1266,7 +1266,7 @@
 			</section>
 
 			<section id="schema-mapping-doc">
-				<h3>Mapping Document Schema</h3>
+				<h3>Mapping document schema</h3>
 				<p>The schema for Mapping Documents, as described in <a href="#rendition-mapping"></a>, is available at
 						<a
 						href="https://github.com/w3c/epubcheck/blob/main/src/main/resources/com/adobe/epubcheck/schema/30/multiple-renditions/mapping.rnc"

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -249,7 +249,7 @@
 			<section id="conformance"></section>
 		</section>
 		<section id="container">
-			<h2>Specifying Multiple Renditions</h2>
+			<h2>Specifying multiple renditions</h2>
 
 			<p>Each Rendition of an <a>EPUB Publication</a> MUST meet the <a data-cite="epub-33#sec-epub-conf"
 					>requirements for EPUB Publications</a> [[EPUB-33]].</p>
@@ -308,10 +308,10 @@
 			</div>
 		</section>
 		<section id="sec-metadata">
-			<h2>Expressing Metadata</h2>
+			<h2>Expressing metadata</h2>
 
 			<section id="rendition-metadata">
-				<h3>Rendition Metadata</h3>
+				<h3>Rendition metadata</h3>
 
 				<p>Metadata expressed at the Rendition level MAY change from instance to instance. For example,
 					Renditions in different languages will have different primary languages and language-specific
@@ -320,10 +320,10 @@
 			</section>
 
 			<section id="pub-metadata">
-				<h3>Publication Metadata</h3>
+				<h3>Publication metadata</h3>
 
 				<section id="pub-metadata-file">
-					<h3>The <code>metadata.xml</code> File</h3>
+					<h3>The <code>metadata.xml</code> file</h3>
 
 					<p>To ensure consistency of metadata at the Publication and <a>Rendition</a> levels, this
 						specification defines the content model of the root <code>metadata</code> element in the <a
@@ -386,7 +386,7 @@
 					</div>
 
 					<section id="pub-metadata-obfuscation">
-						<h4>Resource Obfuscation</h4>
+						<h4>Resource obfuscation</h4>
 
 						<p>The <a data-cite="epub-33#obfus-algorithm">resource obfuscation algorithm</a> [[EPUB-33]]
 							depends on creating an <a data-cite="epub-33#obfus-keygen">obfuscation key</a> [[EPUB-33]]
@@ -405,7 +405,7 @@
 				</section>
 
 				<section id="vocab-assoc">
-					<h3>Vocabulary Association Mechanisms</h3>
+					<h3>Vocabulary association mechanisms</h3>
 
 					<p>This specification inherits the mechanisms for associating vocabularies defined in <a
 							data-cite="epub-33#sec-vocab-assoc">Vocabulary Association Mechanisms</a> [[EPUB-33]] as
@@ -419,7 +419,7 @@
 			</section>
 		</section>
 		<section id="rendition-selection">
-			<h2>Rendition Selection</h2>
+			<h2>Rendition selection</h2>
 
 			<section id="rendition-selection-intro">
 				<h3 class="informative">Introduction</h3>
@@ -443,7 +443,7 @@
 			</section>
 
 			<section id="rendition-selection-pub-confomance">
-				<h3>Content Conformance</h3>
+				<h3>Content conformance</h3>
 
 				<p>A Container Document:</p>
 
@@ -463,14 +463,14 @@
 			</section>
 
 			<section id="rendition-selection-rs-conformance">
-				<h3>Reading System Conformance</h3>
+				<h3>Reading System conformance</h3>
 
 				<p>An EPUB Reading System SHOULD determine the Rendition to present to a user as defined in <a
 						href="#rendition-selection-proc-model"></a>.</p>
 			</section>
 
 			<section id="rendition-selection-attr">
-				<h3>Rendition Selection Attributes</h3>
+				<h3>Rendition selection attributes</h3>
 
 				<div class="note">
 					<p>The use of the rendition selection attributes in the <a
@@ -844,7 +844,7 @@
 			</section>
 
 			<section id="rendition-selection-proc-model">
-				<h3>Processing Model</h3>
+				<h3>Processing model</h3>
 
 				<p>This section describes the method by which Reading Systems locate the optimal <a>Rendition</a> to
 					present to a user.</p>
@@ -899,7 +899,7 @@
 			</section>
 		</section>
 		<section id="rendition-mapping">
-			<h2>Rendition Mapping</h2>
+			<h2>Rendition mapping</h2>
 
 			<section id="rendition-mapping-intro" class="informative">
 				<h3>Introduction</h3>
@@ -929,7 +929,7 @@
 			</section>
 
 			<section id="rendition-mapping-pub-conformance">
-				<h3>Content Conformance</h3>
+				<h3>Content conformance</h3>
 
 				<p>An EPUB Publication MAY include an EPUB Rendition Mapping Document.</p>
 
@@ -948,7 +948,7 @@
 			</section>
 
 			<section id="rendition-mapping-rs-conformance">
-				<h3>Reading System Conformance</h3>
+				<h3>Reading System conformance</h3>
 
 				<p>Reading Systems SHOULD support the use of Rendition Mapping Documents to switch between content. </p>
 
@@ -961,7 +961,7 @@
 			</section>
 
 			<section id="rendition-mapping-doc-def">
-				<h3>EPUB Rendition Mapping Document Definition</h3>
+				<h3>EPUB rendition mapping document definition</h3>
 
 				<div class="note">
 					<p>The content of this file is also defined informally through an XML schema. See <a
@@ -969,7 +969,7 @@
 				</div>
 
 				<section id="rendition-mapping-doc-xhtml">
-					<h4>XHTML Content Document: Restrictions</h4>
+					<h4>XHTML Content Document: restrictions</h4>
 
 					<p>The Rendition Mapping Document is a compliant XHTML Content Document, but with the following
 						restrictions on the [[HTML]] content model:</p>
@@ -994,7 +994,7 @@
 				</section>
 
 				<section id="rendition-mapping-doc-nav">
-					<h4>The nav Element: Modifications and Restrictions</h4>
+					<h4>The nav element: modifications and restrictions</h4>
 
 					<p>This specification restricts the content model of <code>nav</code> elements and their descendants
 						in the Rendition Mapping Document as follows:</p>
@@ -1022,7 +1022,7 @@
 				</section>
 
 				<section id="rendition-mappings">
-					<h4>Rendition Mappings</h4>
+					<h4>Rendition mappings</h4>
 
 					<p>Each <code>ul</code> element in the Rendition Mapping Document <code class="markup"
 							>resource-map</code>
@@ -1149,7 +1149,7 @@
 				</section>
 
 				<section id="rendition-mapping-container-id">
-					<h4>Container Identification</h4>
+					<h4>Container identification</h4>
 
 					<p>The location of the Rendition Mapping Document is identified in the Container Document using a <a
 							data-cite="epub-33#sec-container.xml-link-elem"><code>link</code> element</a> [[EPUB-33]],
@@ -1192,7 +1192,7 @@
 			</section>
 
 			<section id="rendition-mapping-proc-model" class="informative">
-				<h3>Processing Model</h3>
+				<h3>Processing model</h3>
 
 				<p>This section provides a non-normative model by which the Rendition Mapping Document could be
 					processed by a Reading System. It does not address how or when a Reading System should switch
@@ -1270,7 +1270,7 @@
 			</section>
 		</section>
 		<section id="change-log" class="appendix informative">
-			<h2>Change Log</h2>
+			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
 					href="http://idpf.org/epub/renditions/multiple/">EPUB Multiple-Rendition Publications 1.0</a>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -75,7 +75,7 @@
 	<body>
 		<section id="abstract">
 			<p>This specification, EPUB Multiple-Rendition Publications, defines the creation and rendering of EPUB®
-				Publications consisting of more than one Rendition.</p>
+				Publications consisting of more than one rendition.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="toc"></section>
@@ -85,112 +85,112 @@
 			<section id="overview" class="informative">
 				<h3>Overview</h3>
 
-				<p>The need to include more than one <a>Rendition</a> of an <a>EPUB Publication</a> has grown as
-						<a>Reading Systems</a> have evolved and become more sophisticated. While some measure of content
+				<p>The need to include more than one <a>rendition</a> of an <a>EPUB publication</a> has grown as
+						<a>reading systems</a> have evolved and become more sophisticated. While some measure of content
 					adaptation has always been possible at the style sheet level, it is both limited in what it can
-					accomplish and limited to content rendering. Existing fallback mechanisms within the <a>Package
-						Document</a> similarly only ensure that resources can be rendered.</p>
+					accomplish and limited to content rendering. Existing fallback mechanisms within the <a>package
+						document</a> similarly only ensure that resources can be rendered.</p>
 
 				<p>Adaptation is not just about optimizing styling and positioning content for screen considerations,
-					such as dimensions and color or Reading System orientation, but often involves changing the content
-					itself. The resources and markup required to render a fixed-layout Rendition of an EPUB Publication
+					such as dimensions and color or reading system orientation, but often involves changing the content
+					itself. The resources and markup required to render a fixed-layout rendition of an EPUB publication
 					may overlap with a reflowable version of the same, but the two are never exactly the same.
 					Adaptation also involves adapting the prose of a work. In an increasingly interconnected world,
 					including multiple translations of a work rather than bundling them all separately as
-					single-language EPUB Publications is often a necessity. And adaptation is also about the ability to
-					move from the same spot in one Rendition to the equivalent spot in another as changes in the reading
+					single-language EPUB publications is often a necessity. And adaptation is also about the ability to
+					move from the same spot in one rendition to the equivalent spot in another as changes in the reading
 					environment occur.</p>
 
-				<p>This specification defines how a Reading System selects from multiple <a>EPUB Creator</a>-provided
-					Renditions of the content to best match the current device characteristics and user preferences
+				<p>This specification defines how a reading system selects from multiple <a>EPUB creator</a>-provided
+					renditions of the content to best match the current device characteristics and user preferences
 					&#8212; it does not define methods for modifying content on the fly. As changes occur to device
-					orientation or the user's preferred reading modality, for example, the Reading System will be able
-					to check for a better Rendition and seamlessly present it using the functionality defined
+					orientation or the user's preferred reading modality, for example, the reading system will be able
+					to check for a better rendition and seamlessly present it using the functionality defined
 					herein.</p>
 
 				<p>The specification addresses each of the major requirements in the discovery of, selection of, and
-					mapping between, multiple Renditions of an EPUB Publication. In particular:</p>
+					mapping between, multiple renditions of an EPUB publication. In particular:</p>
 
 				<ul>
-					<li>the establishment of a unique identifier common to all the Renditions in the
+					<li>the establishment of a unique identifier common to all the renditions in the
 							<code>META-INF/metadata.xml</code> file;</li>
-					<li>the selection of Renditions through a set of attributes that can be attached to
-							<code>rootfile</code> elements in the <a>Container Document</a>;</li>
-					<li>the optional ability to move from a point in one Rendition to the same location in another by
+					<li>the selection of renditions through a set of attributes that can be attached to
+							<code>rootfile</code> elements in the <a>container document</a>;</li>
+					<li>the optional ability to move from a point in one rendition to the same location in another by
 						means of a mapping document.</li>
 				</ul>
 
-				<p>Taken together, these features enable the creation of advanced Multiple-Rendition Publications that
-					Reading Systems can adapt to changing user needs.</p>
+				<p>Taken together, these features enable the creation of advanced multiple-rendition publications that
+					reading systems can adapt to changing user needs.</p>
 			</section>
 
 			<section id="background" class="informative">
 				<h3>Background</h3>
 
-				<p>The notion of including multiple renditions of an <a>EPUB Publication</a> has existed for as long as
+				<p>The notion of including multiple renditions of an <a>EPUB publication</a> has existed for as long as
 					the EPUB standard, but the specification has never fully addressed what these renditions are for and
-					how to access them. As a result, the EPUB 3 specification generally equates an EPUB Publication with
-					a single rendering of the content. Moreover, most <a>EPUB Creators</a> and <a>Reading System</a>
-					developers equate an EPUB Publication with a single <a>Package Document</a> referenced from the
+					how to access them. As a result, the EPUB 3 specification generally equates an EPUB publication with
+					a single rendering of the content. Moreover, most <a>EPUB creators</a> and <a>reading system</a>
+					developers equate an EPUB publication with a single <a>package document</a> referenced from the
 					first <code>rootfile</code> element in the <code>container.xml</code> file [[EPUB-33]].</p>
 
-				<p>In practice, however, the <code>container.xml</code> file does not restrict EPUB Creators to listing
-					only a single Package Document. In EPUB 2, for example, <a>EPUB Creators</a> could add additional
-						<code>rootfile</code> elements referencing any other format they desired (e.g., another Package
-					Document, a PDF file, or even a Word Document). In EPUB 3, <code>rootfile</code> elements were
-					restricted to referencing only Package Documents of the same version of the standard.</p>
+				<p>In practice, however, the <code>container.xml</code> file does not restrict EPUB creators to listing
+					only a single package document. In EPUB 2, for example, <a>EPUB creators</a> could add additional
+						<code>rootfile</code> elements referencing any other format they desired (e.g., another package
+					document, a PDF file, or even a Word Document). In EPUB 3, <code>rootfile</code> elements were
+					restricted to referencing only package documents of the same version of the standard.</p>
 
 				<p>This specification moves beyond merely allowing multiple renderings to define a more complete
-					framework for identifying and selecting from among them. Each Package Document referenced from a
-						<code>rootfile</code> element is defined to be one <a>Rendition</a> of the EPUB Publication,
-					with the first Package Document representing the <a>Default Rendition</a> (i.e., the one that all
-					Reading Systems have to process).</p>
+					framework for identifying and selecting from among them. Each package document referenced from a
+						<code>rootfile</code> element is defined to be one <a>rendition</a> of the EPUB publication,
+					with the first package document representing the <a>default rendition</a> (i.e., the one that all
+					reading systems have to process).</p>
 
 				<p>Although this model is intended to work as seamlessly as possible with existing the EPUB ecosystem,
-					the authoring of multiple Renditions requires some compromises to maintain compatibility (e.g., some
-					duplication of metadata will be necessary for Reading Systems that do not handle multiple
+					the authoring of multiple renditions requires some compromises to maintain compatibility (e.g., some
+					duplication of metadata will be necessary for reading systems that do not handle multiple
 					renditions).</p>
 			</section>
 
 			<section id="rel-epub3">
 				<h4>Relationship to EPUB 3</h4>
 
-				<p>The method defined in this specification for including multiple <a>Renditions</a> within an <a>EPUB
-						Container</a> is not required for all <a>EPUB Publications</a>. Multiple Renditions MAY be
-					included in a Container without adhering to this specification, as the ability to create
-					multiple-Rendition Containers pre-dates this specification.</p>
+				<p>The method defined in this specification for including multiple <a>renditions</a> within an <a>EPUB
+						container</a> is not required for all <a>EPUB publications</a>. Multiple renditions MAY be
+					included in a container without adhering to this specification, as the ability to create
+					multiple-rendition containers pre-dates this specification.</p>
 
-				<p>It is strongly RECOMMENDED, however, that all future needs for multiple Renditions in a Container
+				<p>It is strongly RECOMMENDED, however, that all future needs for multiple renditions in a container
 					follow this specification. Existing implementations that utilize other methods for selecting from
-					multiple Renditions are also encouraged to consider migrating to use this specification to improve
-					the overall interoperability of Multiple-Rendition Publications.</p>
+					multiple renditions are also encouraged to consider migrating to use this specification to improve
+					the overall interoperability of multiple-rendition publications.</p>
 
-				<p>Some of the <a href="#rendition-selection-attr">Rendition selection attributes</a> defined in this
-					specification share common names with Package Document elements and properties [[EPUB-33]] as they
+				<p>Some of the <a href="#rendition-selection-attr">rendition selection attributes</a> defined in this
+					specification share common names with package document elements and properties [[EPUB-33]] as they
 					are designed to reflect that information for selection purposes.</p>
 
-				<p>Despite this commonality, this specification does not enforce equivalence between the Rendition
+				<p>Despite this commonality, this specification does not enforce equivalence between the rendition
 					selection properties expressed on a <code>rootfile</code> element [[EPUB-33]] and the metadata
-					expressed in the corresponding Package Document, as direct equivalence is not always possible.</p>
+					expressed in the corresponding package document, as direct equivalence is not always possible.</p>
 
-				<p>For example, a multilingual EPUB Publication will define more than one <a
+				<p>For example, a multilingual EPUB publication will define more than one <a
 						data-cite="epub-33#sec-opf-dclanguage">DCMES <code>language</code> element</a> [[EPUB-33]]
-					&#8212; one for each language &#8212; but for Rendition selection only the primary language is
-					defined. Likewise, the language defined in the Package Document could include a specific region
-					code, but for selection purposes the EPUB Creator might identify only the language code.</p>
+					&#8212; one for each language &#8212; but for rendition selection only the primary language is
+					defined. Likewise, the language defined in the package document could include a specific region
+					code, but for selection purposes the EPUB creator might identify only the language code.</p>
 
 				<p>The reason for common metadata in both locations is to simplify the selection process: including
-					attributes avoids the requirement to parse each referenced Package Document and allows for
+					attributes avoids the requirement to parse each referenced package document and allows for
 					expressions of primacy that are not possible at the package level. It also avoids collisions and
 					ambiguities between metadata being used for different purposes (selection versus rendering).</p>
 
 				<p>The selection properties defined in the <a data-cite="epub-33#sec-container-metainf-container.xml"
 							><code>container.xml</code> file</a> [[EPUB-33]] have no rendering behaviors attached to
-					them, either. For example, indicating that a Rendition is fixed layout in the <a href="#layout-attr"
+					them, either. For example, indicating that a rendition is fixed layout in the <a href="#layout-attr"
 							><code>rendition:layout</code> attribute</a> does not trigger fixed layout rendering
-					behaviors within the specified Rendition.</p>
+					behaviors within the specified rendition.</p>
 
-				<p>A Reading System renders a Rendition according to the metadata expressed in the Package Document
+				<p>A reading system renders a rendition according to the metadata expressed in the package document
 					only.</p>
 			</section>
 
@@ -200,52 +200,52 @@
 				<p>The following terms used in this document are defined in [[EPUB-33]]:</p>
 
 				<ul>
-					<li><a>EPUB Container</a></li>
-					<li><a>EPUB Content Document</a></li>
-					<li><a>EPUB Creator</a></li>
-					<li><a>EPUB Publication</a></li>
-					<li><a>EPUB Reading System</a></li>
-					<li><a>Package Document</a></li>
-					<li><a>Root Directory</a></li>
-					<li><a>Top-Level Content Document</a></li>
-					<li><a>Unique Identifier</a></li>
-					<li><a>XHTML Content Document</a></li>
+					<li><a>EPUB container</a></li>
+					<li><a>EPUB content document</a></li>
+					<li><a>EPUB creator</a></li>
+					<li><a>EPUB publication</a></li>
+					<li><a>EPUB reading system</a></li>
+					<li><a>package document</a></li>
+					<li><a>root directory</a></li>
+					<li><a>top-level content document</a></li>
+					<li><a>unique identifier</a></li>
+					<li><a>XHTML content document</a></li>
 				</ul>
 
 				<p>In addition, this document defines the following terms:</p>
 
 				<dl>
-					<dt><dfn>Container Document</dfn></dt>
+					<dt><dfn>container document</dfn></dt>
 					<dd>
 						<p>The <a data-cite="epub-33#sec-container-metainf-container.xml"><code>container.xml</code>
 								file</a> located in the child <a data-cite="epub-33#sec-container-metainf"
-									><code>META-INF</code> directory</a> of the EPUB Container Root Directory
-							[[EPUB-33]]. Each <a>Rendition</a> in the Container is identified by a <code>rootfile</code>
+									><code>META-INF</code> directory</a> of the EPUB container root directory
+							[[EPUB-33]]. Each <a>rendition</a> in the container is identified by a <code>rootfile</code>
 							element [[EPUB-33]].</p>
 					</dd>
 
-					<dt><dfn>Default Rendition</dfn></dt>
+					<dt><dfn>default rendition</dfn></dt>
 					<dd>
-						<p>The <a>Rendition</a> listed in the first <code>rootfile</code> element in the <a
+						<p>The <a>rendition</a> listed in the first <code>rootfile</code> element in the <a
 								data-cite="epub-33#sec-container-metainf-container.xml"><code>container.xml</code>
 								file</a> [[EPUB-33]].</p>
 					</dd>
 
-					<dt><dfn>Multiple-Rendition Publication</dfn></dt>
+					<dt><dfn>multiple-rendition publication</dfn></dt>
 					<dd>
-						<p>An EPUB Publication that consists of two or more <a>Renditions</a> of the content.</p>
+						<p>An EPUB publication that consists of two or more <a>renditions</a> of the content.</p>
 					</dd>
 
-					<dt><dfn>Rendition</dfn></dt>
+					<dt><dfn>rendition</dfn></dt>
 					<dd>
-						<p>One rendering of the content of an EPUB Publication, as expressed by a Package Document.</p>
+						<p>One rendering of the content of an EPUB publication, as expressed by a package document.</p>
 					</dd>
 
-					<dt><dfn>Rendition Mapping Document</dfn></dt>
+					<dt><dfn>rendition mapping document</dfn></dt>
 					<dd>
-						<p>A specialization of the XHTML Content Document, containing machine-readable mappings between
-							equivalent content in different <a>Renditions</a>, conforming to the constraints expressed
-							in <a href="#rendition-mapping">Rendition Mapping</a>.</p>
+						<p>A specialization of the XHTML content document, containing machine-readable mappings between
+							equivalent content in different <a>renditions</a>, conforming to the constraints expressed
+							in <a href="#rendition-mapping">rendition mapping</a>.</p>
 					</dd>
 				</dl>
 			</section>
@@ -255,14 +255,14 @@
 		<section id="container">
 			<h2>Specifying multiple renditions</h2>
 
-			<p>Each Rendition of an <a>EPUB Publication</a> MUST meet the <a data-cite="epub-33#sec-epub-conf"
-					>requirements for EPUB Publications</a> [[EPUB-33]].</p>
+			<p>Each rendition of an <a>EPUB publication</a> MUST meet the <a data-cite="epub-33#sec-epub-conf"
+					>requirements for EPUB publications</a> [[EPUB-33]].</p>
 
-			<p>The Package Document for each Rendition MUST be listed in the <code>container.xml</code> file
-				[[EPUB-33]], where the first Package Document listed represents the <a>Default Rendition</a>.</p>
+			<p>The package document for each rendition MUST be listed in the <code>container.xml</code> file
+				[[EPUB-33]], where the first package document listed represents the <a>default rendition</a>.</p>
 
 			<aside class="example">
-				<p>The following example shows SVG and XHTML Renditions bundled in the same container:</p>
+				<p>The following example shows SVG and XHTML renditions bundled in the same container:</p>
 
 				<pre id="sep-dir">&lt;?xml version="1.0"?&gt;
 &lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
@@ -275,16 +275,16 @@
 &lt;/container&gt;</pre>
 			</aside>
 
-			<p>Each Rendition of the EPUB Publication SHOULD only list the <a>Publication Resources</a> necessary for
-				its rendering in its Package Document <a>manifest</a> [[EPUB-33]]. Renditions MAY reference the same
-				Publication Resources.</p>
+			<p>Each rendition of the EPUB publication SHOULD only list the <a>publication resources</a> necessary for
+				its rendering in its package document <a>manifest</a> [[EPUB-33]]. renditions MAY reference the same
+				publication resources.</p>
 
 			<div class="note">
-				<p>Renditions may not be able to access resources stored in sibling directories on all Reading Systems
-					(i.e., some Reading Systems do not provide access outside the directory a Rendition's Package
-					Document is stored in).</p>
+				<p>Renditions may not be able to access resources stored in sibling directories on all reading systems
+					(i.e., some reading systems do not provide access outside the directory a rendition's package
+					document is stored in).</p>
 
-				<p>For example, given the following directory structure (all resources except the Package Documents
+				<p>For example, given the following directory structure (all resources except the package documents
 					omitted for clarity):</p>
 
 				<pre>/META-INF
@@ -297,8 +297,8 @@
 				<p>Resources in the "<code>Rendition1</code>" directory may not be able to access resources in either
 						"<code>Rendition2</code>" or "<code>Shared</code>".</p>
 
-				<p>To share resources between Renditions, it is recommended that the Package Documents be located in a
-					common directory and the resources for each Rendition stored in separate subdirectories.</p>
+				<p>To share resources between renditions, it is recommended that the package documents be located in a
+					common directory and the resources for each rendition stored in separate subdirectories.</p>
 
 				<p>Restructuring the previous example as follows would allow shared access to all resources:</p>
 
@@ -317,10 +317,10 @@
 			<section id="rendition-metadata">
 				<h3>Rendition metadata</h3>
 
-				<p>Metadata expressed at the Rendition level MAY change from instance to instance. For example,
-					Renditions in different languages will have different primary languages and language-specific
+				<p>Metadata expressed at the rendition level MAY change from instance to instance. For example,
+					renditions in different languages will have different primary languages and language-specific
 					metadata such as titles will be expressed differently. Similarly, bundled fixed-layout and
-					reflowbale Renditions will express different rendering metadata.</p>
+					reflowable renditions will express different rendering metadata.</p>
 			</section>
 
 			<section id="pub-metadata">
@@ -329,17 +329,17 @@
 				<section id="pub-metadata-file">
 					<h3>The <code>metadata.xml</code> file</h3>
 
-					<p>To ensure consistency of metadata at the Publication and <a>Rendition</a> levels, this
+					<p>To ensure consistency of metadata at the Publication and <a>rendition</a> levels, this
 						specification defines the content model of the root <code>metadata</code> element in the <a
 							data-cite="epub-33#sec-container-metainf-metadata.xml"><code>metadata.xml</code> file</a>
-						[[EPUB-33]] to be the same as the Package Document <a data-cite="epub-33#elemdef-opf-metadata"
+						[[EPUB-33]] to be the same as the package document <a data-cite="epub-33#elemdef-opf-metadata"
 								><code>metadata</code> element</a> [[EPUB-33]], with the following differences in syntax
 						and semantics:</p>
 
 					<ul>
 						<li>A <code>dc:identifier</code> element [[DCTERMS]] MUST contain the <a
 								data-cite="epub-33#sec-opf-dcidentifier">unique identifier</a> [[EPUB-33]] for the EPUB
-							Publication.</li>
+							publication.</li>
 						<li>A <code>meta</code> element [[EPUB-33]] MUST contain the last modified date, expressed using
 							the <code>dcterms:modified</code> property [[DCTERMS]]. The value of the property MUST
 							conform to the pattern and rules defined in <a
@@ -365,27 +365,27 @@
 					</div>
 
 					<p>This specification does not define a model for the inheritance of metadata from the Publication
-						level to the <a>Rendition</a> level, as EPUB processing only requires that the <a>Default
-							Rendition</a> be recognized by Reading Systems (i.e., reliance on inheritance could result
-						in Reading Systems not locating necessary metadata).</p>
+						level to the <a>rendition</a> level, as EPUB processing only requires that the <a>default
+							rendition</a> be recognized by reading systems (i.e., reliance on inheritance could result
+						in reading systems not locating necessary metadata).</p>
 
 					<div class="note">
-						<p>EPUB Creators are strongly encouraged to include a complete set of Publication metadata in
-							the Default Rendition to ensure cross-compatibility, even when making use of this file.</p>
-						<p>Titles, languages and other metadata is often not applicable from one Rendition to another,
+						<p>EPUB creators are strongly encouraged to include a complete set of Publication metadata in
+							the default rendition to ensure cross-compatibility, even when making use of this file.</p>
+						<p>Titles, languages and other metadata is often not applicable from one rendition to another,
 							further complicating the sharing of metadata. No assumption can be made that metadata in the
-								<code>metadata.xml</code> file is applicable to any given Rendition, whether the
-							metadata is expressed in the Rendition or not.</p>
+								<code>metadata.xml</code> file is applicable to any given rendition, whether the
+							metadata is expressed in the rendition or not.</p>
 					</div>
 
 					<div class="note">
 						<p>As [[EPUB-33]] does not define a content model for the <code>metadata.xml</code> file, EPUB
-							Publications that do not conform to this specification can include different metadata. EPUB
-							Publications that are not valid to the content model restrictions in this section are not
-							valid Multiple-Rendition Publications as defined by this specification, but might still be
+							publications that do not conform to this specification can include different metadata. EPUB
+							publications that are not valid to the content model restrictions in this section are not
+							valid multiple-rendition publications as defined by this specification, but might still be
 							valid EPUB 3 Publications.</p>
-						<p>EPUB Creators are strongly encouraged to migrate to the content model defined in this
-							specification, even if not producing Multiple-Rendition Publications, to ensure consistent
+						<p>EPUB creators are strongly encouraged to migrate to the content model defined in this
+							specification, even if not producing multiple-rendition publications, to ensure consistent
 							processing.</p>
 					</div>
 
@@ -394,17 +394,17 @@
 
 						<p>The <a data-cite="epub-33#obfus-algorithm">resource obfuscation algorithm</a> [[EPUB-33]]
 							depends on creating an <a data-cite="epub-33#obfus-keygen">obfuscation key</a> [[EPUB-33]]
-							from the <a>Unique Identifier</a> for the EPUB Publication.</p>
+							from the <a>unique identifier</a> for the EPUB publication.</p>
 
 						<p>For compatibility reasons, and due to the complexities of being able to share resources
-							across Renditions, this specification does not change this requirement but applies it to all
-							obfuscated resources in the EPUB Container.</p>
+							across renditions, this specification does not change this requirement but applies it to all
+							obfuscated resources in the EPUB container.</p>
 
-						<p>Consequently, EPUB Creators MUST use the Unique Identifier of the <a>Default Rendition</a> as
-							the obfuscation key for all resources in a <a>Multiple-Rendition Publication</a>.</p>
+						<p>Consequently, EPUB creators MUST use the unique identifier of the <a>default rendition</a> as
+							the obfuscation key for all resources in a <a>multiple-rendition publication</a>.</p>
 
-						<p>Similarly, <a>Reading Systems</a> MUST use this Unique Identifier of the Default Rendition to
-							de-obfuscate all resources in a Multiple-Rendition Publication.</p>
+						<p>Similarly, <a>reading systems</a> MUST use this unique identifier of the default rendition to
+							de-obfuscate all resources in a multiple-rendition publication.</p>
 					</section>
 				</section>
 
@@ -413,7 +413,7 @@
 
 					<p>This specification inherits the mechanisms for associating vocabularies defined in <a
 							data-cite="epub-33#sec-vocab-assoc">Vocabulary Association Mechanisms</a> [[EPUB-33]] as
-						they relate to the Package Document metadata, with only the following modification: the
+						they relate to the package document metadata, with only the following modification: the
 							<code>prefix</code> attribute MAY be attached only to the root <code>metadata</code>
 						element.</p>
 
@@ -428,48 +428,48 @@
 			<section id="rendition-selection-intro">
 				<h3 class="informative">Introduction</h3>
 
-				<p>Although each EPUB Publication represents a single work, it is possible to optimize the rendering of
+				<p>Although each EPUB publication represents a single work, it is possible to optimize the rendering of
 					that work in any number of different ways. An issue of a magazine, for example, could include a
 					fixed layout version (print replica) for rendering on tablet-sized screens with a reflowable version
 					for smaller cellphone screens where the fixed layout would be scaled to illegibility (or
 					automatically reflowed in unwanted ways if fixed layouts are not supported).</p>
 
-				<p>The EPUB Container allows multiple <a>Renditions</a> of the content to be included in an EPUB
-					Publication, but does not specify how Reading Systems are to determine the unique properties of the
-					Renditions listed in the Container Document, or select between them.</p>
+				<p>The EPUB container allows multiple <a>renditions</a> of the content to be included in an EPUB
+					publication, but does not specify how reading systems are to determine the unique properties of the
+					renditions listed in the container document, or select between them.</p>
 
 				<p>This section redresses this problem by defining both a set of rendition selection attributes that can
 					be attached to <a data-cite="epub-33#sec-container-metainf-container.xml"><code>rootfile</code>
-						elements</a> [[EPUB-33]] in the Container Document and a processing model that allows EPUB
-					Creators to specify which Rendition is the best representation depending on various conditions.
-					Reading Systems can then select the appropriate representation from the list of Renditions to match
+						elements</a> [[EPUB-33]] in the container document and a processing model that allows EPUB
+					creators to specify which rendition is the best representation depending on various conditions.
+					Reading systems can then select the appropriate representation from the list of renditions to match
 					the current configuration and user preferences.</p>
 			</section>
 
 			<section id="rendition-selection-pub-confomance">
 				<h3>Content conformance</h3>
 
-				<p>A Container Document:</p>
+				<p>A container document:</p>
 
 				<ul class="conformancelist">
 					<li id="confreq-container">MUST be valid to the definition and requirements for the
 							<code>container.xml</code> file specified in <a
-							data-cite="epub-33#sec-container-metainf-container.xml">Container –
+							data-cite="epub-33#sec-container-metainf-container.xml">container –
 							META-INF/container.xml</a> [[EPUB-33]].</li>
 					<li id="confreq-selection-attr">MAY include any of the selection attributes defined in <a
-							href="#rendition-selection-attr">Rendition Selection Attributes</a>.</li>
+							href="#rendition-selection-attr">Rendition selection attributes</a>.</li>
 					<li id="confreq-selection-default">MAY Include selection attributes on the <a
 							data-cite="epub-33#sec-container.xml-rootfiles-elem"><code>rootfile</code> element</a>
-						[[EPUB-33]] for the <a>Default Rendition</a></li>
+						[[EPUB-33]] for the <a>default rendition</a></li>
 					<li id="confreq-selection-min">SHOULD include at least one selection attribute ‒ in addition to the
 						OPTIONAL label ‒ on each subsequent <code>rootfile</code> element.</li>
 				</ul>
 			</section>
 
 			<section id="rendition-selection-rs-conformance">
-				<h3>Reading System conformance</h3>
+				<h3>reading system conformance</h3>
 
-				<p>An EPUB Reading System SHOULD determine the Rendition to present to a user as defined in <a
+				<p>An EPUB reading system SHOULD determine the rendition to present to a user as defined in <a
 						href="#rendition-selection-proc-model"></a>.</p>
 			</section>
 
@@ -486,8 +486,8 @@
 				<section id="media-attr">
 					<h4>The <code>rendition:media</code> attribute</h4>
 
-					<p>The <code>rendition:media</code> attribute identifies the media features of a Reading System the
-						given <a>Rendition</a> is best suitable for rendering on.</p>
+					<p>The <code>rendition:media</code> attribute identifies the media features of a reading system the
+						given <a>rendition</a> is best suitable for rendering on.</p>
 
 					<div class="elem-synopsis" id="attrdef-media">
 						<dl>
@@ -511,7 +511,7 @@
 								<span class="term">Usage</span>
 							</dt>
 							<dd>
-								<p>MAY be specified on Container Document <code>rootfile</code> elements
+								<p>MAY be specified on container document <code>rootfile</code> elements
 									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
@@ -525,14 +525,14 @@
 					</div>
 
 					<p>As per [[MediaQueries]], the media query in this attribute MUST evaluate to true in order for the
-						given Rendition to be selected for rendering. Media queries that evaluate to "not all” per <a
+						given rendition to be selected for rendering. Media queries that evaluate to "not all” per <a
 							data-cite="mediaqueries#error-handling">3.1 Error Handling</a> [[MediaQueries]] SHOULD be
-						treated as false for the purposes of Rendition selection (i.e., the given Rendition is not a
+						treated as false for the purposes of rendition selection (i.e., the given rendition is not a
 						valid match).</p>
 
 					<aside class="example">
-						<p>The following example shows two Renditions of The Sandman bundled in the same container, one
-							optimized for screens 1920 pixels or wider. The Default Rendition will be used for screen
+						<p>The following example shows two renditions of The Sandman bundled in the same container, one
+							optimized for screens 1920 pixels or wider. The default rendition will be used for screen
 							sizes smaller than 1920 pixels by default.</p>
 
 						<pre>&lt;container xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
@@ -552,7 +552,7 @@
 				<section id="layout-attr">
 					<h4>The <code>rendition:layout</code> attribute</h4>
 
-					<p>The <code>rendition:layout</code> attribute indicates whether the given <a>Rendition</a> is
+					<p>The <code>rendition:layout</code> attribute indicates whether the given <a>rendition</a> is
 						reflowable or pre-paginated.</p>
 
 					<div class="elem-synopsis" id="attrdef-layout">
@@ -577,7 +577,7 @@
 								<span class="term">Usage</span>
 							</dt>
 							<dd>
-								<p>MAY be specified on Container Document <code>rootfile</code> elements
+								<p>MAY be specified on container document <code>rootfile</code> elements
 									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
@@ -592,16 +592,16 @@
 
 					<p>When specified, the value of this attribute MUST match the <a
 							data-cite="epub-33#property-layout-global">global rendition:layout setting</a> [[EPUB-33]]
-						for the referenced Rendition.</p>
+						for the referenced rendition.</p>
 
-					<p>If a user layout preference is defined in the Reading System, the attribute evaluates to true if
+					<p>If a user layout preference is defined in the reading system, the attribute evaluates to true if
 						the preference matches the specified value, otherwise it evaluates to false. If no user
-						preference is defined, the Reading System SHOULD ignore the attribute when selecting from the
-						available Renditions.</p>
+						preference is defined, the reading system SHOULD ignore the attribute when selecting from the
+						available renditions.</p>
 
 					<aside class="example">
-						<p>The following example shows two Renditions of a magazine bundled in the same container. Note
-							that it is not necessary to state that the Default Rendition is reflowable, since Renditions
+						<p>The following example shows two renditions of a magazine bundled in the same container. Note
+							that it is not necessary to state that the default rendition is reflowable, since renditions
 							are reflowable by default.</p>
 						<pre>&lt;container xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
            xmlns:rendition="http://www.idpf.org/2013/rendition"
@@ -620,7 +620,7 @@
 				<section id="language-attr">
 					<h4>The <code>rendition:language</code> attribute</h4>
 
-					<p>The <code>rendition:language</code> attribute indicates that the given <a>Rendition</a> is
+					<p>The <code>rendition:language</code> attribute indicates that the given <a>rendition</a> is
 						optimized for the specified language. </p>
 
 					<div class="elem-synopsis" id="attrdef-language">
@@ -645,7 +645,7 @@
 								<span class="term">Usage</span>
 							</dt>
 							<dd>
-								<p>MAY be specified on Container Document <code>rootfile</code> elements
+								<p>MAY be specified on container document <code>rootfile</code> elements
 									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
@@ -658,19 +658,19 @@
 					</div>
 
 					<p>The <code>rendition:language</code> attribute more precisely identifies the primary language of a
-						Rendition than does the inclusion of <code>dc:language</code> elements in the Rendition's
-						Package Document, as the presence of <code>dc:language</code> elements only indicates that the
+						rendition than does the inclusion of <code>dc:language</code> elements in the rendition's
+						package document, as the presence of <code>dc:language</code> elements only indicates that the
 						specified languages are prominently used in the prose.</p>
 
-					<p>If a user language preference is defined in the Reading System, the attribute evaluates to true
+					<p>If a user language preference is defined in the reading system, the attribute evaluates to true
 						if the preference matches the specified value, otherwise it evaluates to false. Several matching
 						schemes are defined in Section 3 of [[RFC4647]]. Reading systems can use the most appropriate
-						matching scheme. If no user preference is defined, the Reading System SHOULD ignore the
-						attribute when selecting from the available Renditions.</p>
+						matching scheme. If no user preference is defined, the reading system SHOULD ignore the
+						attribute when selecting from the available renditions.</p>
 
 					<aside class="example">
-						<p>The following example shows a multilingual EPUB Publication, with English, French and Spanish
-							Renditions of the content.</p>
+						<p>The following example shows a multilingual EPUB publication, with English, French and Spanish
+							renditions of the content.</p>
 
 						<pre>&lt;container xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
            xmlns:rendition="http://www.idpf.org/2013/rendition"
@@ -694,7 +694,7 @@
 					<h4>The <code>rendition:accessMode</code> attribute</h4>
 
 					<p>The <code>rendition:accessMode</code> attribute identifies the way in which intellectual content
-						is communicated in a <a>Rendition</a>, and is based on the [[ISO24751-3]] "Access Mode"
+						is communicated in a <a>rendition</a>, and is based on the [[ISO24751-3]] "Access Mode"
 						property.</p>
 
 					<div class="elem-synopsis" id="attrdef-accessMode">
@@ -719,7 +719,7 @@
 								<span class="term">Usage</span>
 							</dt>
 							<dd>
-								<p>MAY be specified on Container Document <code>rootfile</code> elements
+								<p>MAY be specified on container document <code>rootfile</code> elements
 									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
@@ -733,24 +733,24 @@
 					</div>
 
 					<p>The <code>rendition:accessMode</code> attribute defines the primary access mode(s) for a given
-						Rendition. For example, although a textual work may include images, audio and video, its primary
+						rendition. For example, although a textual work may include images, audio and video, its primary
 						means of conveying information is the text. Likewise, a visual work might include alternative
 						text and/or descriptions, but these adaptations are not listed as a textual mode for the
-						Rendition for the purpose of selection.</p>
+						rendition for the purpose of selection.</p>
 
 					<p>The way in which information is encoded also needs to be considered when designating an access
 						mode. If a work has text components, or is completely textual in nature, but that content is
 						burned into an image format, the access mode is visual (e.g., character dialogue in a JPEG page
 						of a comic or a scan of a document).</p>
 
-					<p>A Rendition MAY include more than one primary access mode. For example, the textual version might
+					<p>A rendition MAY include more than one primary access mode. For example, the textual version might
 						also embed the auditory version using media overlays. In such cases, the attribute should list
 						each primary access mode that is available.</p>
 
-					<p>If a user access mode preference is defined in the Reading System, the attribute evaluates to
+					<p>If a user access mode preference is defined in the reading system, the attribute evaluates to
 						true if that preference matches any of the access modes defined in it, otherwise it evaluates to
-						false. If no user preference is defined, the Reading System SHOULD ignore the attribute when
-						selecting from the available Renditions.</p>
+						false. If no user preference is defined, the reading system SHOULD ignore the attribute when
+						selecting from the available renditions.</p>
 
 					<p>The <a href="#label-attr"><code>rendition:label</code> attribute</a> can be use to inform users
 						about the nature of the content, particularly where such information is not available, or not
@@ -759,7 +759,7 @@
 						text-to-speech rendering, not general use.</p>
 
 					<aside class="example">
-						<p>The following example shows an EPUB Publication with an image-based Rendition and a
+						<p>The following example shows an EPUB publication with an image-based rendition and a
 							text-based serialization available.</p>
 
 						<pre>&lt;container xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
@@ -805,7 +805,7 @@
 								<span class="term">Usage</span>
 							</dt>
 							<dd>
-								<p>MAY be specified on Container Document <code>rootfile</code> elements
+								<p>MAY be specified on container document <code>rootfile</code> elements
 									[[EPUB-33]].</p>
 							</dd>
 							<dt class="varlistentry">
@@ -817,15 +817,15 @@
 						</dl>
 					</div>
 
-					<p>The <code>rendition:label</code> attribute provides a name for the given <a>Rendition</a> (e.g.,
-						for manual Rendition selection).</p>
+					<p>The <code>rendition:label</code> attribute provides a name for the given <a>rendition</a> (e.g.,
+						for manual rendition selection).</p>
 
 					<p>The language of the <code>rendition:label</code> attribute MAY be expressed in an
 							<code>xml:lang</code> attribute.</p>
 
 					<aside class="example">
 						<p>The following example shows the <code>rendition:label</code> attribute being used to provide
-							a human-readable name for a Rendition.</p>
+							a human-readable name for a rendition.</p>
 
 						<pre>&lt;container xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
            xmlns:rendition="http://www.idpf.org/2013/rendition"
@@ -843,22 +843,22 @@
 					</aside>
 
 					<p>The <code>rendition:label</code> attribute is not a selection attribute for the purposes of
-						evaluating which Rendition to render.</p>
+						evaluating which rendition to render.</p>
 				</section>
 			</section>
 
 			<section id="rendition-selection-proc-model">
 				<h3>Processing model</h3>
 
-				<p>This section describes the method by which Reading Systems locate the optimal <a>Rendition</a> to
+				<p>This section describes the method by which reading systems locate the optimal <a>rendition</a> to
 					present to a user.</p>
 
-				<p>Rendition selection SHOULD occur on initial rendering, and Reading Systems SHOULD re-evaluate the
+				<p>rendition selection SHOULD occur on initial rendering, and reading systems SHOULD re-evaluate the
 					selection in response to changes in the user environment (e.g., change in device orientation or
 					viewport size).</p>
 
-				<p>When a change condition is triggered, the Reading System SHOULD evaluate the <code>rootfile</code>
-					elements [[EPUB-33]] in the Container Document as follows, starting with the last
+				<p>When a change condition is triggered, the reading system SHOULD evaluate the <code>rootfile</code>
+					elements [[EPUB-33]] in the container document as follows, starting with the last
 						<code>rootfile</code> entry:</p>
 
 				<ul>
@@ -867,7 +867,7 @@
 						true:</li>
 				</ul>
 				<ul>
-					<li>If all conditions evaluate to true, select the given Rendition and exit the selection
+					<li>If all conditions evaluate to true, select the given rendition and exit the selection
 						process.</li>
 					<li>If any condition is false, move to the preceding <code>rootfile</code> element and continue the
 						evaluation process.</li>
@@ -877,27 +877,27 @@
 							>rootfile</code> element and continue the evaluation process.</li>
 				</ul>
 
-				<p>If the Default Rendition is reached, select that Rendition and exit the process.</p>
+				<p>If the default rendition is reached, select that rendition and exit the process.</p>
 
 				<div class="note">
 					<p>This processing model does not require that the selection process occur on a user's device, or
-						that all Renditions be provided in the Container. Rendition selection could occur on the server
-						side of a cloud-based delivery system, for example, and only a single best-match Rendition sent
+						that all renditions be provided in the container. rendition selection could occur on the server
+						side of a cloud-based delivery system, for example, and only a single best-match rendition sent
 						to the device.</p>
 				</div>
 
 				<div class="note">
-					<p>Since EPUB 2 Reading Systems, and EPUB 3 Reading Systems that do not support multiple-Rendition
-						selection, will render the Default Rendition, EPUB Creators need to consider which Rendition
-						will have the greatest compatibility across Reading Systems and ensure it is listed first.</p>
+					<p>Since EPUB 2 reading systems, and EPUB 3 reading systems that do not support multiple-rendition
+						selection, will render the default rendition, EPUB creators need to consider which rendition
+						will have the greatest compatibility across reading systems and ensure it is listed first.</p>
 				</div>
 
-				<p>A Reading System MAY provide the user the option to manually select any of the Renditions in the
-					Container. It SHOULD use the <a href="#label-attr"><code>rendition:label</code> attribute</a>
+				<p>A reading system MAY provide the user the option to manually select any of the renditions in the
+					container. It SHOULD use the <a href="#label-attr"><code>rendition:label</code> attribute</a>
 					attribute value to present the option, when available.</p>
 
-				<p>As EPUB did not previously define a Rendition selection model, custom selection models might be
-					encountered in some EPUB Publications. When recognized, these selection models SHOULD be utilized.
+				<p>As EPUB did not previously define a rendition selection model, custom selection models might be
+					encountered in some EPUB publications. When recognized, these selection models SHOULD be utilized.
 					If both rendition selection attributes conformant to this specification and custom attributes are
 					defined, the latter SHOULD be ignored.</p>
 			</section>
@@ -908,59 +908,59 @@
 			<section id="rendition-mapping-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>The Rendition Mapping Document identifies related content locations across the <a>Renditions</a> in a
-					Multiple-Rendition Publication, allowing Reading Systems to switch between Renditions while keeping
+				<p>The rendition mapping document identifies related content locations across the <a>renditions</a> in a
+					multiple-rendition publication, allowing reading systems to switch between renditions while keeping
 					the user's place.</p>
 
-				<p>The Rendition Mapping Document is represented as XHTML, and uses <a><code>nav</code></a> elements with
-					unordered lists to group the mappings. There is no display component to the Rendition Mapping
-					Document; it is designed to enable automated switching. The lack of a rendering context means that
+				<p>The rendition mapping document is represented as XHTML, and uses <a><code>nav</code></a> elements
+					with unordered lists to group the mappings. There is no display component to the rendition mapping
+					document; it is designed to enable automated switching. The lack of a rendering context means that
 					the XHTML content model for this document is very restrictive, allowing only a single
-						<a><code>nav</code></a> element in the [^body^], to ease both authoring and processing.</p>
+							<a><code>nav</code></a> element in the [^body^], to ease both authoring and processing.</p>
 
-				<p>To enable the mapping of content locations between Renditions, the Rendition Mapping Document's
+				<p>To enable the mapping of content locations between renditions, the rendition mapping document's
 						<code>nav</code> element consists of a series of one or more unordered lists, each of which
-					represents a common point across all the Renditions (e.g., a chapter, a page or a component within a
+					represents a common point across all the renditions (e.g., a chapter, a page or a component within a
 					page). The list items in each unordered list represent the set of equivalent link destinations
-					across the available Renditions for that content (e.g., one link might point to a document
-					representing one page of a fixed layout Rendition, while the equivalent link to a reflowable
-					Rendition might point to the corresponding page break indicator within the XHTML Content Document
+					across the available renditions for that content (e.g., one link might point to a document
+					representing one page of a fixed layout rendition, while the equivalent link to a reflowable
+					rendition might point to the corresponding page break indicator within the XHTML content document
 					containing the page).</p>
 
-				<p>Knowing the position of the user in the current Rendition, when a change in context occurs, or is
-					triggered by the user, the Reading System can inspect the sibling list items to determine the EPUB
-					Content Document to load that best meets the new conditions.</p>
+				<p>Knowing the position of the user in the current rendition, when a change in context occurs, or is
+					triggered by the user, the reading system can inspect the sibling list items to determine the EPUB
+					content document to load that best meets the new conditions.</p>
 			</section>
 
 			<section id="rendition-mapping-pub-conformance">
 				<h3>Content conformance</h3>
 
-				<p>An EPUB Publication MAY include an EPUB Rendition Mapping Document.</p>
+				<p>An EPUB publication MAY include an EPUB rendition mapping document.</p>
 
-				<p>A conformant EPUB Rendition Mapping Document:</p>
+				<p>A conformant EPUB rendition mapping document:</p>
 
 				<ul class="conformancelist">
-					<li id="confreq-map-xhtml">MUST conform to all content conformance constraints for XHTML Content
-						Documents as defined in <a data-cite="epub-33#sec-xhtml-req">XHTML Requirements</a>
+					<li id="confreq-map-xhtml">MUST conform to all content conformance constraints for XHTML content
+						documents as defined in <a data-cite="epub-33#sec-xhtml-req">XHTML Requirements</a>
 						[[EPUB-33]].</li>
 					<li id="confreq-map-content-model">MUST conform to all content conformance constraints specific for
-						EPUB Rendition Mapping Documents expressed in <a href="#rendition-mapping-doc-def">EPUB
-							Rendition Mapping Document Definition</a>.</li>
-					<li id="confreq-map-unlisted">MUST NOT be listed in the Package Document manifest of any of the EPUB
-						Publication's Renditions.</li>
+						EPUB rendition mapping documents expressed in <a href="#rendition-mapping-doc-def">EPUB
+							rendition mapping document definition</a>.</li>
+					<li id="confreq-map-unlisted">MUST NOT be listed in the package document manifest of any of the EPUB
+						publication's renditions.</li>
 				</ul>
 			</section>
 
 			<section id="rendition-mapping-rs-conformance">
-				<h3>Reading System conformance</h3>
+				<h3>reading system conformance</h3>
 
-				<p>Reading Systems SHOULD support the use of Rendition Mapping Documents to switch between content. </p>
+				<p>Reading systems SHOULD support the use of rendition mapping documents to switch between content. </p>
 
-				<p>A Reading System that supports mapping:</p>
+				<p>A reading system that supports mapping:</p>
 
 				<ul class="conformancelist">
-					<li id="confreq-rs-remap">MUST, when a change in Renditions occurs, locate the current position in
-						the Rendition Mapping Document and load the matching position in the new Rendition.</li>
+					<li id="confreq-rs-remap">MUST, when a change in renditions occurs, locate the current position in
+						the rendition mapping document and load the matching position in the new rendition.</li>
 				</ul>
 			</section>
 
@@ -973,9 +973,9 @@
 				</div>
 
 				<section id="rendition-mapping-doc-xhtml">
-					<h4>XHTML Content Document: restrictions</h4>
+					<h4>XHTML content document: restrictions</h4>
 
-					<p>The Rendition Mapping Document is a compliant XHTML Content Document, but with the following
+					<p>The rendition mapping document is a compliant XHTML content document, but with the following
 						restrictions on the [[HTML]] content model:</p>
 
 					<ul>
@@ -988,7 +988,7 @@
 								>content</code> attributes MAY be attached to the <code>meta</code> elements.</li>
 						<li>The <code>head</code> MUST include a <code>meta</code> element whose <code>name</code>
 							attribute has the value "<code>epub.multiple.renditions.version</code>" and whose
-								<code>content</code> attribute has the value "<code>1.0</code>". Reading Systems MAY
+								<code>content</code> attribute has the value "<code>1.0</code>". Reading systems MAY
 							ignore all other <code>meta</code> elements.</li>
 						<li>The <code>body</code> element MUST include exactly one <code>nav</code> element child whose
 								<code>epub:type</code> attribute specifies the value "<code>resource-map</code>", and
@@ -1001,12 +1001,12 @@
 					<h4>The nav element: modifications and restrictions</h4>
 
 					<p>This specification restricts the content model of <code>nav</code> elements and their descendants
-						in the Rendition Mapping Document as follows:</p>
+						in the rendition mapping document as follows:</p>
 
 					<ul>
 						<li>Each <code>nav</code> element MUST identify its nature in an <code>epub:type</code>
 							attribute.</li>
-						<li>The Rendition Mapping Documents uses unordered lists (<code>ul</code>) in place of ordered
+						<li>The rendition mapping documents uses unordered lists (<code>ul</code>) in place of ordered
 							lists (<code>ol</code>).</li>
 						<li>The <code>nav</code> element MAY contain one or more <code>ul</code> element.</li>
 						<li>Each list item (<code>li</code>) MUST contain exactly one <code>a</code> element (i.e.,
@@ -1028,47 +1028,47 @@
 				<section id="rendition-mappings">
 					<h4>Rendition mappings</h4>
 
-					<p>Each <code>ul</code> element in the Rendition Mapping Document <code class="markup"
+					<p>Each <code>ul</code> element in the rendition mapping document <code class="markup"
 							>resource-map</code>
 						<code>nav</code> element identifies a content location, listing in its child <code>li</code>
-						elements where that location is found in each of the available Renditions. Consequently, each
-							<code>ul</code> element MUST contain an <code>li</code> for each Rendition.</p>
+						elements where that location is found in each of the available renditions. Consequently, each
+							<code>ul</code> element MUST contain an <code>li</code> for each rendition.</p>
 
 					<div class="note">
 						<p>In order to allow a broad variety of use cases, this specification does not impose any
 							particular level of mapping granularity. For example, some publications aimed at language
 							learners may define sentence-level synchronisation points, whereas other types of
-							publications may only map major sections across Renditions.</p>
+							publications may only map major sections across renditions.</p>
 					</div>
 
-					<p>Each list item in the unordered list MUST identify an EPUB Content Document, or a fragment
-						therein, for one of the Renditions ‒ defined in a child <code>a</code> element. Each of these
-						links MUST reference a <a data-cite="epub-33#sec-itemref-elem">linear Top-level Content
-							Document</a> [[EPUB-33]].</p>
+					<p>Each list item in the unordered list MUST identify an EPUB content document, or a fragment
+						therein, for one of the renditions ‒ defined in a child <code>a</code> element. Each of these
+						links MUST reference a <a data-cite="epub-33#sec-itemref-elem">linear Top-level content
+							document</a> [[EPUB-33]].</p>
 
-					<p>Each <code>a</code> element MUST specify which Rendition it refers to either 1) by including an
+					<p>Each <code>a</code> element MUST specify which rendition it refers to either 1) by including an
 							<a href="http://www.idpf.org/epub/linking/cfi/#sec-intra-cfis">Intra-Publication CFI</a>
 						[[EPUBCFI-11]] in its <code>href</code> attribute, or 2) by providing the relative path to the
-						Package Document for the Rendition as the value of an <code>epub:rendition</code> attribute.</p>
+						package document for the rendition as the value of an <code>epub:rendition</code> attribute.</p>
 
-					<p>If the <code>epub:rendition</code> attribute is used to specify the target Rendition, any
+					<p>If the <code>epub:rendition</code> attribute is used to specify the target rendition, any
 						fragment identifier scheme MAY be used within the URL value of the <code>href</code> attribute
 						of <code>a</code> elements (e.g., unique identifier, or W3C Media Fragment).</p>
 
 					<div class="note">
 						<p>The use of [[EPUBCFI-11]] expressions is strongly encouraged over other fragment identifier
-							schemes (particularly in the context of reflowable XHTML Content Documents), as they allow
-							Reading Systems to ingest Rendition Mappings without any prior pre-processing. Conversely,
-							the use of unique identifiers forces Reading Systems to load the targeted Content Documents
+							schemes (particularly in the context of reflowable XHTML content documents), as they allow
+							reading systems to ingest rendition mappings without any prior pre-processing. Conversely,
+							the use of unique identifiers forces reading systems to load the targeted Content Documents
 							and process their DOM in order to sort/compare the link destinations (in relation to
 							document order). This additional processing has performance implications, and implementation
 							costs in terms of caching, incremental updating, etc.</p>
 					</div>
 
 					<aside class="example">
-						<p>The following example shows a Rendition Mapping Document for a magazine with 3 Renditions:
-							text, portrait and landscape. ‘article 1' is on pages 5 and 6 of the fixed layout Renditions
-							and the landscape Rendition uses spreads (non-synthetic).</p>
+						<p>The following example shows a rendition mapping document for a magazine with 3 renditions:
+							text, portrait and landscape. ‘article 1' is on pages 5 and 6 of the fixed layout renditions
+							and the landscape rendition uses spreads (non-synthetic).</p>
 
 						<pre>&lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
     &lt;head&gt;
@@ -1112,8 +1112,8 @@
 					</aside>
 
 					<aside class="example">
-						<p>The following example shows a multilingual EPUB Publication with each language in a separate
-							Rendition.</p>
+						<p>The following example shows a multilingual EPUB publication with each language in a separate
+							rendition.</p>
 
 						<pre>&lt;html xmlns="http://www.w3.org/1999/xhtml"&gt;
     &lt;head&gt;
@@ -1155,23 +1155,23 @@
 				<section id="rendition-mapping-container-id">
 					<h4>Container identification</h4>
 
-					<p>The location of the Rendition Mapping Document is identified in the Container Document using a <a
+					<p>The location of the rendition mapping document is identified in the container document using a <a
 							data-cite="epub-33#sec-container.xml-link-elem"><code>link</code> element</a> [[EPUB-33]],
 						where:</p>
 
 					<ul>
-						<li>the <code>href</code> attribute MUST reference the location of the Rendition Mapping
-							Document relative to the root of the EPUB Container;</li>
+						<li>the <code>href</code> attribute MUST reference the location of the rendition mapping
+							document relative to the root of the EPUB container;</li>
 						<li>the <code>rel</code> attribute MUST specify the value "<code>mapping</code>";</li>
 						<li>the <code>media-type</code> attribute MUST specify the value
 								"<code>application/xhtml+xml</code>".</li>
 					</ul>
 
-					<p>The Container Document MUST NOT reference more than one mapping document.</p>
+					<p>The container document MUST NOT reference more than one mapping document.</p>
 
 					<aside class="example">
 						<p>The following example shows the <code>container.xml</code> file for a multilingual EPUB
-							Publication. The location of the Rendition Mapping Document is included in the
+							publication. The location of the rendition mapping document is included in the
 								<code>link</code> element.</p>
 
 						<pre>&lt;container xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
@@ -1198,47 +1198,47 @@
 			<section id="rendition-mapping-proc-model" class="informative">
 				<h3>Processing model</h3>
 
-				<p>This section provides a non-normative model by which the Rendition Mapping Document could be
-					processed by a Reading System. It does not address how or when a Reading System should switch
-					Renditions. </p>
+				<p>This section provides a non-normative model by which the rendition mapping document could be
+					processed by a reading system. It does not address how or when a reading system should switch
+					renditions. </p>
 
-				<p>The desired outcome of the Rendition Mapping Document's mapping capabilities is to display content in
-					the new Rendition that is equivalent to their location in the current Rendition, so that a user
-					maintains their place during reading. To accomplish this goal, a compliant Reading System could
-					follow these steps to reset the current Rendition when a change condition is triggered:</p>
+				<p>The desired outcome of the rendition mapping document's mapping capabilities is to display content in
+					the new rendition that is equivalent to their location in the current rendition, so that a user
+					maintains their place during reading. To accomplish this goal, a compliant reading system could
+					follow these steps to reset the current rendition when a change condition is triggered:</p>
 
 				<ul>
 					<li>
-						<p>First, it would ascertain the position range in the current Rendition:</p>
+						<p>First, it would ascertain the position range in the current rendition:</p>
 						<ul>
-							<li>For a fixed format Rendition, this will most likely be the rectangle for the current
+							<li>For a fixed format rendition, this will most likely be the rectangle for the current
 								viewport.<br /></li>
-							<li>For a reflowable Rendition, this will most likely be the range of text currently shown
+							<li>For a reflowable rendition, this will most likely be the range of text currently shown
 								on the screen.<br /></li>
 						</ul>
 					</li>
 				</ul>
 				<ul>
-					<li>Next, it would determine which Rendition to navigate to, as defined in <a
+					<li>Next, it would determine which rendition to navigate to, as defined in <a
 							href="#rendition-selection-proc-model"></a>.</li>
 					<li>
-						<p>Finally, the Reading System would parse the <code>ul</code> elements to find ones that
+						<p>Finally, the reading system would parse the <code>ul</code> elements to find ones that
 							contain <code>li</code> elements with child <code>a</code> elements that both specify the
 							same rendition and intersect the current range:</p>
 						<ul>
-							<li>If there is one and only one such <code>ul</code> element, the Reading System would
+							<li>If there is one and only one such <code>ul</code> element, the reading system would
 								navigate to the beginning of the range in the new rendition. </li>
-							<li>If there is more than one such <code>ul</code> element, then the Reading System behavior
-								is undefined. The Reading System might prompt the user to select between the new
+							<li>If there is more than one such <code>ul</code> element, then the reading system behavior
+								is undefined. The reading system might prompt the user to select between the new
 								locations, or might choose between them using its own heuristics.<br /></li>
-							<li>If no matching <code>ul</code> elements are found, the Reading System will have to
-								determine the location to navigate to in the new Rendition as if there was no Rendition
-								Mapping Document.</li>
+							<li>If no matching <code>ul</code> elements are found, the reading system will have to
+								determine the location to navigate to in the new rendition as if there was no rendition
+								mapping document.</li>
 						</ul>
 					</li>
 				</ul>
 
-				<p>Note that what happens during navigation is largely a user experience issue, so a Reading System
+				<p>Note that what happens during navigation is largely a user experience issue, so a reading system
 					might choose to consider additional information than above to try to achieve a better outcome.</p>
 			</section>
 		</section>
@@ -1278,7 +1278,7 @@
 
 			<p>Note that this change log only identifies substantive changes since <a
 					href="http://idpf.org/epub/renditions/multiple/">EPUB Multiple-Rendition Publications 1.0</a>
-				&#8212; those that affect the conformance of <a>EPUB Publications</a> or are similarly noteworthy.</p>
+				&#8212; those that affect the conformance of <a>EPUB publications</a> or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AMultipleRenditions11"
@@ -1288,7 +1288,7 @@
 				<li>19-Mar-2021: Require the use of the unique identifier in the <code>metadata.xml</code> file for
 					obfuscating resources and recommend it be the same as the identifier in the default rendition. See
 						<a href="https://github.com/w3c/publ-epub-revision/issues/1443">issue 1443</a>.</li>
-				<li>19-Mar-2021: Added note clarifying that Package Documents need to be in a common directory to share
+				<li>19-Mar-2021: Added note clarifying that package documents need to be in a common directory to share
 					resources. See <a href="https://github.com/w3c/publ-epub-revision/issues/619">issue 619</a>.</li>
 				<li>19-Mar-2021: Fixed incorrect reference to <code>link</code> element being a child of the
 						<code>container</code> element. See <a
@@ -1297,9 +1297,9 @@
 					requirement to include a unique identifier and last modification date in the
 						<code>metadata.xml</code> file remain for backwards compatibility. See <a
 						href="https://github.com/w3c/publ-epub-revision/issues/1440">issue 1440</a>.</li>
-				<li>16-Dec-2020: Terminology and requirements related to renditions of an EPUB Publication have been
+				<li>16-Dec-2020: Terminology and requirements related to renditions of an EPUB publication have been
 					moved to this specification to simplify readability of both this and the [[EPUB-33]] specification.
-					These changes do not affect the ability to include multiple renditions in an EPUB Publication. See
+					These changes do not affect the ability to include multiple renditions in an EPUB publication. See
 						<a href="https://github.com/w3c/publ-epub-revision/issues/1436">issue 1436</a>.</li>
 			</ul>
 		</section>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -1059,10 +1059,10 @@
 						<p>The use of [[EPUBCFI-11]] expressions is strongly encouraged over other fragment identifier
 							schemes (particularly in the context of reflowable XHTML content documents), as they allow
 							reading systems to ingest rendition mappings without any prior pre-processing. Conversely,
-							the use of unique identifiers forces reading systems to load the targeted Content Documents
-							and process their DOM in order to sort/compare the link destinations (in relation to
-							document order). This additional processing has performance implications, and implementation
-							costs in terms of caching, incremental updating, etc.</p>
+							the use of unique identifiers forces reading systems to load the targeted EPUB content
+							documents and process their DOM in order to sort/compare the link destinations (in relation
+							to document order). This additional processing has performance implications, and
+							implementation costs in terms of caching, incremental updating, etc.</p>
 					</div>
 
 					<aside class="example">

--- a/epub33/overview/biblio.js
+++ b/epub33/overview/biblio.js
@@ -64,7 +64,7 @@ var biblio = {
 		"William McCoy",
 		"Elika J. Etimad",
 		"Matt Garrish"],
-		"title": "EPUB Content Documents 3.0",
+		"title": "EPUB content documents 3.0",
 		"href": "http://idpf.org/epub/30/spec/epub30-contentdocs-20111011.html",
 		"date": "11 October 2011",
 		"publisher": "IDPF"
@@ -75,7 +75,7 @@ var biblio = {
 		"William McCoy",
 		"Elika J. Etimad",
 		"Matt Garrish"],
-		"title": "EPUB Content Documents 3.0.1",
+		"title": "EPUB content documents 3.0.1",
 		"href": "http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
 		"date": "26 June 2014",
 		"publisher": "IDPF"
@@ -87,7 +87,7 @@ var biblio = {
 		"Dave Cramer",
 		"Elika J. Etimad",
 		"Matt Garrish"],
-		"title": "EPUB Content Documents 3.1",
+		"title": "EPUB content documents 3.1",
 		"href": "http://idpf.org/epub/31/spec/epub-contentdocs-20170105.html",
 		"date": "05 January 2017",
 		"publisher": "IDPF"
@@ -96,7 +96,7 @@ var biblio = {
 		"authors":[
 		"Dave Cramer",
 		"Matt Garrish"],
-		"title": "EPUB Content Documents 3.2",
+		"title": "EPUB content documents 3.2",
 		"href": "https://www.w3.org/publishing/epub32/epub-contentdocs.html",
 		"date": "08 May 2019",
 		"publisher": "EPUB 3 Community Group"
@@ -161,7 +161,7 @@ var biblio = {
 		"Markus Gylling",
 		"William McCoy",
 		"Matt Garrish"],
-		"title": "EPUB Publications 3.0",
+		"title": "EPUB publications 3.0",
 		"href": "http://idpf.org/epub/30/spec/epub30-publications-20111011.html",
 		"date": "11 October 2011",
 		"publisher": "IDPF"
@@ -171,7 +171,7 @@ var biblio = {
 		"Markus Gylling",
 		"William McCoy",
 		"Matt Garrish"],
-		"title": "EPUB Publications 3.0.1",
+		"title": "EPUB publications 3.0.1",
 		"href": "http://idpf.org/epub/301/spec/epub-publications-20140626.html",
 		"date": "26 June 2014",
 		"publisher": "IDPF"

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -222,26 +222,26 @@
 
 					<p>Each EPUB publication contains a special XHTML content document called the <a>EPUB navigation
 							document</a>, which uses the [[HTML]] <a><code>nav</code></a> element to define human- and
-						machine-readable navigation information. All reading systems make use of the Navigation Document
-						to present a table of contents to their users.</p>
+						machine-readable navigation information. All reading systems make use of the EPUB navigation
+						document to present a table of contents to their users.</p>
 
-					<p>The Navigation Document contains baseline accessibility and navigation support, and features to
-						enhance navigation for all users. Prime among these are support for internationalization (for
-						example, as an XHTML document itself, the Navigation Document natively supports <a
+					<p>The EPUB navigation document contains baseline accessibility and navigation support, and features
+						to enhance navigation for all users. Prime among these are support for internationalization (for
+						example, as an XHTML document itself, the EPUB navigation document natively supports <a
 							data-lt="ruby">ruby annotations</a>) and support for embedded grammars (MathML and SVG can
 						be included within navigation links).</p>
 
 					<p>Note that EPUB reading systems are not <em>required</em> to use these advanced XHTML features,
 						such as ruby annotations, when generating a reading system specific table of contents. However,
-						EPUB creators may also include the Navigation Document in the <a
+						EPUB creators may also include the EPUB navigation document in the <a
 							data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]] to make use of the richer
 						markup.</p>
 
-					<p>Navigation Documents also provide a flexible means of tailoring the navigation display using CSS
-						and the <a data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a>
+					<p>EPUB navigation documents also provide a flexible means of tailoring the navigation display using
+						CSS and the <a data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a>
 						[[EPUB-33]] while not impacting access to information for accessible reading systems.</p>
 
-					<p>The structure and semantics of Navigation Documents are defined in the dedicated <a
+					<p>The structure and semantics of EPUB navigation documents are defined in the dedicated <a
 							data-cite="epub-33#sec-nav">section</a> of [[EPUB-33]].</p>
 				</section>
 			</section>
@@ -533,8 +533,8 @@
 				<p>As noted in <a href="#sec-nav-nav-doc"></a> above, the navigation features represent a universal and
 					flexible navigation system.</p>
 
-				<p>The Navigation Document can also be reused in the body of an EPUB publication by including it in the
-						<a data-cite="epub-33#sec-spine-elem"><code>spine</code></a>. To avoid the situation in highly
+				<p>The EPUB navigation document can also be reused in the body of an EPUB publication by including it in
+					the <a data-cite="epub-33#sec-spine-elem"><code>spine</code></a>. To avoid the situation in highly
 					structured documents where it might not be desirable to display the complete table of contents to
 					users in the body of the publication, the display level can be modified using the <a
 						data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a> [[EPUB-33]]. This

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -154,7 +154,7 @@
 			</details>
 
 			<section id="sec-package-file">
-				<h2>Package Document</h2>
+				<h2>Package document</h2>
 
 				<p>Every EPUB Publication is represented by a <a>Package Document</a>. The Package Document specifies
 					all the resources required to render that representation of the content. The Package Document also
@@ -188,7 +188,7 @@
 				<h2>Navigation</h2>
 
 				<section id="sec-nav-order">
-					<h3>Reading Order</h3>
+					<h3>Reading order</h3>
 
 					<p>A key concept of EPUB is that an EPUB Publication consists of multiple resources that can be
 						completely navigated and consumed by a person or program <em>in some specific order</em>.</p>
@@ -214,7 +214,7 @@
 				</section>
 
 				<section id="sec-nav-nav-doc">
-					<h3>Navigation Document</h3>
+					<h3>Navigation document</h3>
 
 					<p>Each EPUB Publication contains a special XHTML Content Document called the <a>EPUB Navigation
 							Document</a>, which uses the [[HTML]] <a data-cite="html#the-nav-element"
@@ -267,7 +267,7 @@
 			</section>
 
 			<section id="sec-content-docs">
-				<h2>Content Documents</h2>
+				<h2>Content documents</h2>
 
 				<p>Each EPUB Publication contains one or more <a>EPUB Content Documents</a>, as defined in the dedicated
 						<a data-cite="epub-33#sec-contentdocs">section</a> of [[EPUB-33]]. These are XHTML or SVG
@@ -278,7 +278,7 @@
 			</section>
 
 			<section id="sec-fxl">
-				<h2>Fixed Layouts</h2>
+				<h2>Fixed layouts</h2>
 
 				<p>Although EPUB's history is steeped in enabling reflowable content, not all publications lend
 					themselves easily to reflowing. Page-precise layouts are required to meaningfully represent
@@ -441,7 +441,7 @@
 			</section>
 		</section>
 		<section id="sec-gls">
-			<h1>Global Language Support</h1>
+			<h1>Global language support</h1>
 
 
 			<p> EPUB 3 leverages the features in XHTML, SVG, CSS, or MathML for global language support, and it also
@@ -549,7 +549,7 @@
 			</section>
 
 			<section id="sec-access-semantic-markup">
-				<h2>Semantic Markup</h2>
+				<h2>Semantic markup</h2>
 
 				<p>[[HTML]] supports a number of elements that make markup more semantically meaningful (e.g., <a
 						data-cite="html#the-section-element"><code>section</code></a>, <a
@@ -569,7 +569,7 @@
 			</section>
 
 			<section id="sec-access-layout">
-				<h2>Dynamic Layouts</h2>
+				<h2>Dynamic layouts</h2>
 
 				<p>At its core, EPUB is designed for dynamic layout: content is typically intended to be formatted on
 					the fly rather than being typeset in a paginated manner in advance. This core capability is useful
@@ -589,7 +589,7 @@
 			</section>
 
 			<section id="sec-access-overlays">
-				<h2>Aural Renditions and Media Overlays</h2>
+				<h2>Aural renditions and media overlays</h2>
 
 				<p>Aural renderings of content are important for accessibility and are a desirable feature for many
 					users. A baseline to facilitate aural rendering is to utilize semantic HTML designed for dynamic
@@ -632,7 +632,7 @@
 			</section>
 		</section>
 		<section id="sec-revision-history" class="appendix">
-			<h2>EPUB Revision History</h2>
+			<h2>EPUB revision history</h2>
 
 			<section id="epub2">
 				<h3>OEB, OCF and EPUB 2: 1999—2010</h3>

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -98,14 +98,14 @@
 				<dt>Recommendation-track Documents:</dt>
 				<dd>
 					<ul>
-						<li>EPUB 3.3 [[EPUB-33]]: defines the authoring format and requirements for EPUB Publications,
-							comprising features such as the <a href="#sec-package-file">Package</a> and <a
-								href="#sec-nav-nav-doc">Navigation</a> Documents, <a href="#sec-content-docs">EPUB
-								Content Documents</a>, <a href="#sec-fxl">Fixed Layout</a>, <a
-								href="#para-media-overlay">Media Overlays</a>, and the <a href="#sec-container"
-								>Container Format</a>. </li>
+						<li>EPUB 3.3 [[EPUB-33]]: defines the authoring format and requirements for EPUB publications,
+							comprising features such as the <a href="#sec-package-file">package</a> and <a
+								href="#sec-nav-nav-doc">navigation</a> Documents, <a href="#sec-content-docs">EPUB
+								content documents</a>, <a href="#sec-fxl">fixed layouts</a>, <a
+								href="#para-media-overlay">media overlays</a>, and the <a href="#sec-container"
+								>container format</a>. </li>
 						<li>EPUB Reading Systems 3.3 [[EPUB-RS-33]]: defines the conformance requirements for EPUB 3
-							Reading Systems — the user agents that render EPUB 3 Publications. </li>
+							reading systems — the user agents that render EPUB 3 Publications. </li>
 						<li>EPUB Accessibility 1.1 [[EPUB-A11Y-11]]: specifies content conformance requirements for
 							verifying the accessibility of EPUB 3 Publications. </li>
 					</ul>
@@ -119,9 +119,9 @@
 								Accessibility Act</a> related to ebooks are met by the EPUB standard.</li>
 						<li>EPUB Accessibility Techniques 1.1 [[EPUB-A11Y-TECH-11]]: provides guidance on how to meet
 							the EPUB Accessibility 1.1 [[EPUB-A11Y-11]] discovery and accessibility requirements for
-							EPUB Publications. </li>
+							EPUB publications. </li>
 						<li>EPUB Multiple-Rendition Publications 1.1 [[EPUB-MULTI-REND-11]]: defines the creation and
-							rendering of EPUB Publications consisting of more than one Rendition. </li>
+							rendering of EPUB publications consisting of more than one Rendition. </li>
 						<li>EPUB 3 Structural Semantics Vocabulary 1.1 [[EPUB-SSV-11]]: defines a set of properties
 							relating to the description of structural semantics of written works.</li>
 						<li>EPUB 3 Text-to-Speech Enhancements 1.0 [[EPUB-TTS-10]]: describes authoring features and
@@ -133,7 +133,7 @@
 
 			<div class="note"> The recommendation-track documents include detailed change logs on the substantive
 				changes since the previous official releases. See the change log for <a data-cite="epub-33#change-log"
-					>EPUB 3.3</a>, <a data-cite="epub-rs-33#change-log">EPUB Reading Systems 3.3</a>, and <a
+					>EPUB 3.3</a>, <a data-cite="epub-rs-33#change-log">EPUB reading systems 3.3</a>, and <a
 					data-cite="epub-a11y-11#change-log">EPUB Accessibility 1.1</a>, respectively. </div>
 
 		</section>
@@ -141,50 +141,50 @@
 			<h1>Features</h1>
 
 			<p>This section covers the major features of EPUB, including important components and topics that apply to
-				the process of authoring <a>EPUB Publications</a> as a whole.</p>
+				the process of authoring <a>EPUB publications</a> as a whole.</p>
 
 			<figure id="fig-epub-structure">
 				<figcaption> The following example visually represents the structure of an EPUB publication. </figcaption>
 				<img src="images/epub.svg" width="600" aria-details="fig-epub-structure-diagram"
-					alt="Visual structure of the main constituents of an EPUB Publication" />
+					alt="Visual structure of the main constituents of an EPUB publication" />
 			</figure>
 
 			<details id="fig-epub-structure-diagram" class="desc">
 				<summary style="font-weight: normal; font-style: italic">Image description</summary>
-				<p> 'EPUB (OCF) Container' as the outer most component which encapsulates the 'EPUB Publication'
-					containing two documents 'Publication Document' and 'Navigation Document' along with a inner
-					component labelled 'Publication Resources' which contains multiple 'Content Documents' (XHTML, SVG),
-					and multiple 'Other resources' (CSS, png, mp3, mov, ...). </p>
+				<p> 'EPUB (OCF) container' as the outer most component which encapsulates the 'EPUB publication'
+					containing two documents 'Publication Document' and 'EPUB navigation document' along with a inner
+					component labelled 'publication resources' which contains multiple 'EPUB content documents' (XHTML,
+					SVG), and multiple 'Other resources' (CSS, png, mp3, mov, ...). </p>
 			</details>
 
 			<section id="sec-package-file">
 				<h2>Package document</h2>
 
-				<p>Every EPUB Publication is represented by a <a>Package Document</a>. The Package Document specifies
-					all the resources required to render that representation of the content. The Package Document also
+				<p>Every EPUB publication is represented by a <a>package document</a>. The package document specifies
+					all the resources required to render that representation of the content. The package document also
 					defines a reading order for linear consumption, and associates metadata and navigation
 					information.</p>
 
-				<p>The Package Document defines a layer on top of the traditional structuring of a typical web site to
+				<p>The package document defines a layer on top of the traditional structuring of a typical web site to
 					facilitate the authoring of digital publications. A web site, for example, embeds references to its
 					resources within its content, which, while a simple and flexible means of identifying resources,
 					makes it difficult to enumerate all the resources required to render it. In addition, there is no
 					standard way for a web site to define that a sequence of pages make up a larger publication, which
 					is precisely what EPUB's <a data-cite="epub-33#sec-spine-elem"><code>spine</code> element</a>
 					[[EPUB-33]] does (i.e., it provides an external declarative means to explicitly specify navigation
-					through a collection of documents). Finally, the Package Document defines a standard way to
+					through a collection of documents). Finally, the package document defines a standard way to
 					represent metadata globally applicable to a collection of pages.</p>
 
-				<p>The Package Document also includes a <a data-cite="epub-33#sec-collection-elem"
+				<p>The package document also includes a <a data-cite="epub-33#sec-collection-elem"
 							><code>collection</code> element</a> [[EPUB-33]], which allows grouping of logically related
-						<a>Publication Resources</a>. This element exists to enable the development of specialized
+						<a>publication resources</a>. This element exists to enable the development of specialized
 					content identification, processing, and rendering features such as the ability to define embedded
-					preview content or assemble an index or dictionary from its constituent XHTML Content Documents.</p>
+					preview content or assemble an index or dictionary from its constituent XHTML content documents.</p>
 
 				<p class="note"> The <code>collection</code> element is not currently used in any specifications that
 					are actively maintained by the EPUB 3 Working Group. </p>
 
-				<p>The Package Document is specified in the dedicated <a data-cite="epub-33#sec-package-doc">section</a>
+				<p>The package document is specified in the dedicated <a data-cite="epub-33#sec-package-doc">section</a>
 					of [[EPUB-33]].</p>
 			</section>
 
@@ -194,7 +194,7 @@
 				<section id="sec-nav-order">
 					<h3>Reading order</h3>
 
-					<p>A key concept of EPUB is that an EPUB Publication consists of multiple resources that can be
+					<p>A key concept of EPUB is that an EPUB publication consists of multiple resources that can be
 						completely navigated and consumed by a person or program <em>in some specific order</em>.</p>
 
 					<p>Many types of publication have an obvious reading order, or logical progression through their
@@ -204,15 +204,15 @@
 						have at least one logical ordering of all their top-level content items, whether by date, topic,
 						location, or some other criteria (e.g., a cookbook is typically arranged by recipe type).</p>
 
-					<p>Each EPUB Publication defines at least one such logical ordering of all its top-level content in
-						the <a data-cite="epub-33#sec-spine-elem">spine</a> of the <a href="#sec-package-file">Package
-							Document</a> [[EPUB-33]]. Each one also defines a declarative table of contents in the <a
-							href="#sec-nav-nav-doc">EPUB Navigation Document</a> [[EPUB-33]]. EPUB Publications make
+					<p>Each EPUB publication defines at least one such logical ordering of all its top-level content in
+						the <a data-cite="epub-33#sec-spine-elem">spine</a> of the <a href="#sec-package-file">package
+							document</a> [[EPUB-33]]. Each one also defines a declarative table of contents in the <a
+							href="#sec-nav-nav-doc">EPUB navigation document</a> [[EPUB-33]]. EPUB publications make
 						these data structures available in a machine-readable way <em>external</em> to the content,
 						simplifying their discovery and use.</p>
 
-					<p>EPUB Publications are not limited to the linear ordering of their contents, nor do they preclude
-						linking in arbitrary ways — just like the web, EPUB Publications are built on hypertext — but
+					<p>EPUB publications are not limited to the linear ordering of their contents, nor do they preclude
+						linking in arbitrary ways — just like the web, EPUB publications are built on hypertext — but
 						the basic consumption and navigation can be reliably accomplished in a way that is not true for
 						a set of HTML pages.</p>
 				</section>
@@ -220,65 +220,62 @@
 				<section id="sec-nav-nav-doc">
 					<h3>Navigation document</h3>
 
-					<p>Each EPUB Publication contains a special XHTML Content Document called the <a>EPUB Navigation
-							Document</a>, which uses the [[HTML]] <a><code>nav</code></a>
-							element to define human- and machine-readable navigation information.
-						All Reading Systems make use of the Navigation Document to present a table of contents to their
-						users.</p>
+					<p>Each EPUB publication contains a special XHTML content document called the <a>EPUB navigation
+							document</a>, which uses the [[HTML]] <a><code>nav</code></a> element to define human- and
+						machine-readable navigation information. All reading systems make use of the Navigation Document
+						to present a table of contents to their users.</p>
 
 					<p>The Navigation Document contains baseline accessibility and navigation support, and features to
 						enhance navigation for all users. Prime among these are support for internationalization (for
-						example, as an XHTML document itself, the Navigation Document natively supports 
-						<a data-lt="ruby">ruby annotations</a>) and support for embedded grammars
-						(MathML and SVG can be included within navigation links).</p>
+						example, as an XHTML document itself, the Navigation Document natively supports <a
+							data-lt="ruby">ruby annotations</a>) and support for embedded grammars (MathML and SVG can
+						be included within navigation links).</p>
 
-					<p>Note that EPUB Reading Systems are not <em>required</em> to use these advanced XHTML features,
-						such as ruby annotations, when generating a Reading System specific table of contents. However,
-						EPUB Creators may also include the Navigation Document in the <a
+					<p>Note that EPUB reading systems are not <em>required</em> to use these advanced XHTML features,
+						such as ruby annotations, when generating a reading system specific table of contents. However,
+						EPUB creators may also include the Navigation Document in the <a
 							data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]] to make use of the richer
 						markup.</p>
 
 					<p>Navigation Documents also provide a flexible means of tailoring the navigation display using CSS
 						and the <a data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a>
-						[[EPUB-33]] while not impacting access to information for accessible Reading Systems.</p>
+						[[EPUB-33]] while not impacting access to information for accessible reading systems.</p>
 
 					<p>The structure and semantics of Navigation Documents are defined in the dedicated <a
 							data-cite="epub-33#sec-nav">section</a> of [[EPUB-33]].</p>
-
 				</section>
-
 			</section>
 
 			<section id="sec-metadata">
 				<h2>Metadata</h2>
 
-				<p>EPUB Publications provide a rich array of options for adding metadata. Each Package Document includes
+				<p>EPUB publications provide a rich array of options for adding metadata. Each package document includes
 					a dedicated <a data-cite="epub-33#sec-pkg-metadata"><code>metadata</code> section</a> [[EPUB-33]]
-					for general information about the EPUB Publication, allowing titles, authors, identifiers, and other
-					information about the EPUB Publication to be easily accessed. It also provides the means to attach
+					for general information about the EPUB publication, allowing titles, authors, identifiers, and other
+					information about the EPUB publication to be easily accessed. It also provides the means to attach
 					complete bibliographic records using the <a data-cite="epub-33#sec-link-elem"><code>link</code>
 						element</a> [[EPUB-33]].</p>
 
-				<p>The Package Document also allows a <a>Unique Identifier</a> to be established for the EPUB
-					Publication using the <a data-cite="epub-33#attrdef-package-unique-identifier"
+				<p>The package document also allows a <a>Unique Identifier</a> to be established for the EPUB
+					publication using the <a data-cite="epub-33#attrdef-package-unique-identifier"
 							><code>unique-identifier</code> attribute</a> [[EPUB-33]].</p>
 
-				<p>XHTML Content Documents also include the means of annotating document markup with rich metadata,
+				<p>XHTML content documents also include the means of annotating document markup with rich metadata,
 					making them more semantically meaningful and useful both for processing and accessibility purposes.
-					Both RDFa [[RDFA-IN-HTML]] and Microdata [[Microdata]] attributes can be used in XHTML Content
-					Documents for that purpose. </p>
+					Both RDFa [[RDFA-IN-HTML]] and Microdata [[Microdata]] attributes can be used in XHTML content
+					documents for that purpose. </p>
 
 			</section>
 
 			<section id="sec-content-docs">
 				<h2>Content documents</h2>
 
-				<p>Each EPUB Publication contains one or more <a>EPUB Content Documents</a>, as defined in the dedicated
+				<p>Each EPUB publication contains one or more <a>EPUB content documents</a>, as defined in the dedicated
 						<a data-cite="epub-33#sec-contentdocs">section</a> of [[EPUB-33]]. These are XHTML or SVG
 					documents that describe the readable content and reference associated media resources (e.g., images,
 					audio, and video clips).</p>
 
-				<p><a>XHTML Content Documents</a> are defined by a profile of [[HTML]].</p>
+				<p><a>XHTML content documents</a> are defined by a profile of [[HTML]].</p>
 			</section>
 
 			<section id="sec-fxl">
@@ -289,17 +286,17 @@
 					children's books, comics and manga, magazines, and many other content forms.</p>
 
 				<p>EPUB 3 includes metadata that allows the creation of <a data-cite="epub-33#sec-fixed-layouts"
-						>fixed-layout XHTML Content Documents</a> [[EPUB-33]], in addition to existing capabilities for
+						>fixed-layout XHTML content documents</a> [[EPUB-33]], in addition to existing capabilities for
 					fixed layouts in SVG. This metadata enables the control of the <a
 						data-cite="epub-33#sec-fxl-content-dimensions">page dimensions</a> [[EPUB-33]], creating a
 					canvas on which elements can be absolutely positioned.</p>
 
 				<p>The metadata does not just flag whether content is to be fixed or reflowed, but also allows EPUB
-					Creators to specify the desired <a data-cite="epub-33#orientation">orientation of
+					creators to specify the desired <a data-cite="epub-33#orientation">orientation of
 					pages</a> [[EPUB-33]], when to <a data-cite="epub-33#spread">create synthetic
 					spreads</a> [[EPUB-33]], and <a data-cite="epub-33#page-spread">how to position
 					pages</a> [[EPUB-33]] within those spreads, providing a broad range of control over the presentation
-					of EPUB Publications.</p>
+					of EPUB publications.</p>
 
 				<p>The <a data-cite="epub-33#sec-fixed-layouts">structure and semantics of EPUB Documents with Fixed
 						Layouts</a> are defined in [[EPUB-33]].</p>
@@ -315,15 +312,15 @@
 					on the needs of web applications, and many popular web sites now have layouts with less
 					flexibility.</p>
 
-				<p>EPUB Publications, however, are designed to maximize accessibility for the visually impaired, and
-					Reading Systems typically perform text line layout and pagination on the fly, adapting to the size
+				<p>EPUB publications, however, are designed to maximize accessibility for the visually impaired, and
+					reading systems typically perform text line layout and pagination on the fly, adapting to the size
 					of the display area, the user's preferred font size, and other environmental factors. This behavior
 					is not guaranteed in EPUB; images, vector graphics, video, and other non-reflowable content might be
-					included, and some Reading Systems might not paginate on the fly, or at all. Nevertheless,
+					included, and some reading systems might not paginate on the fly, or at all. Nevertheless,
 					supporting dynamic adaptive layout and accessibility has been a primary design consideration
 					throughout the evolution of the EPUB standard.</p>
 
-				<p>EPUB Content Documents can reference CSS Style Sheets, allowing EPUB Creators to define the desired
+				<p>EPUB content documents can reference CSS Style Sheets, allowing EPUB creators to define the desired
 					rendering properties. EPUB 3 follows support for CSS as defined in the [[CSSSnapshot]].</p>
 
 				<p>EPUB 3 also supports CSS styles that enable both horizontal and vertical layout and both
@@ -333,14 +330,14 @@
 			<section id="sec-multimedia">
 				<h2>Multimedia</h2>
 
-				<p>EPUB 3 supports audio and video embedded in <a>XHTML Content Documents</a> via the [[HTML]] <a><code>audio</code></a> 
-					and <a><code>video</code></a> elements, inheriting all the
+				<p>EPUB 3 supports audio and video embedded in <a>XHTML content documents</a> via the [[HTML]]
+							<a><code>audio</code></a> and <a><code>video</code></a> elements, inheriting all the
 					functionality and features these elements provide. For more information on audio and video formats,
 					refer to the section on <a data-cite="epub-33#sec-core-media-types">core media
 					types</a> [[EPUB-33]].</p>
 
-				<p id="para-media-overlay">Another key multimedia feature in EPUB 3 is the inclusion of <a>Media Overlay
-						Documents</a> [[EPUB-33]]. When pre-recorded narration is available for an EPUB Publication,
+				<p id="para-media-overlay">Another key multimedia feature in EPUB 3 is the inclusion of <a>media overlay
+						documents</a> [[EPUB-33]]. When pre-recorded narration is available for an EPUB publication,
 					Media Overlays provide the ability to synchronize that audio with the text of a Content Document
 					(see also <a href="#sec-access-overlays"></a>).</p>
 
@@ -355,7 +352,7 @@
 
 				<p>EPUB 3 supports two closely related font formats — OpenType [[OpenType]] and WOFF [[WOFF]]
 					[[WOFF2]] — to accommodate both traditional publishing workflows and emerging web-based workflows.
-					Word processing programs used to create EPUB Publications are likely to have access only to a
+					Word processing programs used to create EPUB publications are likely to have access only to a
 					collection of installed OpenType fonts, for example, whereas web-archival EPUB generators will
 					likely only have access to WOFF resources (which cannot be converted to OpenType without
 					undesirable, and potentially unlicensed, stripping of WOFF metadata).</p>
@@ -376,20 +373,20 @@
 					the section on <a data-cite="epub-33#sec-scripted-content">Scripting</a> [[EPUB-33]] for more
 					information).</p>
 
-				<p>It is important to note, however, that EPUB 3 does not require scripting support in Reading Systems,
+				<p>It is important to note, however, that EPUB 3 does not require scripting support in reading systems,
 					and scripting might be disabled for security reasons.</p>
 
-				<p>EPUB Creators need to be aware that scripting in an EPUB Publication can create security
+				<p>EPUB creators need to be aware that scripting in an EPUB publication can create security
 					considerations that are different from scripting within a web browser. For example, typical
 					same-origin policies are not applicable to content that has been downloaded to a user's local
 					system. Therefore, it is strongly encouraged that scripting be limited to container constrained
 					contexts, as further described in the section on <a
-						data-cite="epub-33#sec-scripted-container-constrained">Container-Constrained
-					Scripts</a> [[EPUB-33]].</p>
+						data-cite="epub-33#sec-scripted-container-constrained">container-constrained
+					scripts</a> [[EPUB-33]].</p>
 
 				<p>In other words, consider limiting scripting to cases where it is essential to the user experience,
-					since it greatly increases the likelihood that content will not be portable across all Reading
-					Systems and creates barriers to accessibility and content reusability.</p>
+					since it greatly increases the likelihood that content will not be portable across all reading
+					systems and creates barriers to accessibility and content reusability.</p>
 
 			</section>
 
@@ -403,21 +400,21 @@
 					<dt>Pronunciation Lexicons</dt>
 					<dd>
 						<p>The inclusion of generic pronunciation lexicons using the W3C PLS format
-							[[PRONUNCIATION-LEXICON]] enables EPUB Creators to provide pronunciation rules that apply to
-							the entire EPUB Publication. Refer to <a data-cite="epub-tts-10#pls">Pronunciation
+							[[PRONUNCIATION-LEXICON]] enables EPUB creators to provide pronunciation rules that apply to
+							the entire EPUB publication. Refer to <a data-cite="epub-tts-10#pls">Pronunciation
 								Lexicons</a> [[EPUB-TTS-10]] for more information.</p>
 					</dd>
 					<dt>Inline SSML Phonemes</dt>
 					<dd>
-						<p> The incorporation of SSML phonemes functionality [[SSML]] directly into a <a>EPUB Content
-								Document</a> enables fine-grained pronunciation control, taking precedence over default
+						<p> The incorporation of SSML phonemes functionality [[SSML]] directly into a <a>EPUB content
+								document</a> enables fine-grained pronunciation control, taking precedence over default
 							pronunciation rules and/or referenced pronunciation lexicons (as provided by the PLS format
 							mentioned above). Refer to <a data-cite="epub-tts-10#ssml">SSML Attributes</a>
 							[[EPUB-TTS-10]] for more information.</p>
 					</dd>
 				</dl>
 
-				<p>Note that EPUB Creators may also rely on CSS Speech [[CSS-SPEECH-1]] properties in their style sheet
+				<p>Note that EPUB creators may also rely on CSS Speech [[CSS-SPEECH-1]] properties in their style sheet
 					definitions.</p>
 
 				<p>The authoring features for improving the voicing of EPUB 3 publication are described in the separate
@@ -428,17 +425,17 @@
 			<section id="sec-container">
 				<h2>Container</h2>
 
-				<p>An EPUB Publication is transported and interchanged as a single file (a "portable document") that
-					contains the Package Documents, all Content Documents, and all other required resources for
+				<p>An EPUB publication is transported and interchanged as a single file (a "portable document") that
+					contains the package documents, all Content Documents, and all other required resources for
 					processing the Publication. The single-file container format for EPUB is based on the widely adopted
-					ZIP format, and an XML document that identifies the location of the Package Document for the
+					ZIP format, and an XML document that identifies the location of the package document for the
 					Publication in the ZIP archive is located at a pre-defined location within the archive.</p>
 
-				<p>This approach provides a clear contract between any creator of an EPUB Publication and any system
-					which consumes such EPUB Publications, as well as a reliable representation that is independent of
+				<p>This approach provides a clear contract between any creator of an EPUB publication and any system
+					which consumes such EPUB publications, as well as a reliable representation that is independent of
 					network transport or file system specifics.</p>
 
-				<p>An EPUB Publication's representation as a container file is specified in the dedicated <a
+				<p>An EPUB publication's representation as a container file is specified in the dedicated <a
 						data-cite="epub-33#sec-ocf">section</a> of [[EPUB-33]].</p>
 
 			</section>
@@ -457,12 +454,12 @@
 				<h2>Metadata</h2>
 
 				<p>EPUB 3 supports alternate representations of all text metadata items in the package metadata section
-					to improve global distribution of EPUB Publications. The <a data-cite="epub-33#alternate-script"
+					to improve global distribution of EPUB publications. The <a data-cite="epub-33#alternate-script"
 							><code>alternate-script</code> property</a> [[EPUB-33]] can be combined with the
 						<code>xml:lang</code> attribute to include and identify alternate script renderings of
 					language-specific metadata.</p>
 
-				<p>Using this property, a Japanese EPUB Publication could, for example, include an alternate
+				<p>Using this property, a Japanese EPUB publication could, for example, include an alternate
 					Roman-script representation of the author's name and/or one or more representations of the title in
 					a Romance language.</p>
 
@@ -479,17 +476,17 @@
 			<!-- <section id="sec-gls-fonts">
 				<h2>Fonts</h2>
 
-				<p>EPUB 3 does not require that Reading Systems come with a set of built-in system fonts. As occurs in
+				<p>EPUB 3 does not require that reading systems come with a set of built-in system fonts. As occurs in
 					web contexts, users in a particular locale might have installed fonts that omit characters required
-					for other locales and Reading Systems might utilize intrinsic fonts or font engines that do not
-					utilize operating system installed fonts. As a result, the text content of an EPUB Publication might
-					not natively render as intended on all Reading Systems.</p>
+					for other locales and reading systems might utilize intrinsic fonts or font engines that do not
+					utilize operating system installed fonts. As a result, the text content of an EPUB publication might
+					not natively render as intended on all reading systems.</p>
 
 				<p>To address this problem, EPUB 3 supports the embedding of fonts to facilitate the rendering of text
 					content, and this practice is advised to ensure content is rendered as intended. See also <a
 						href="#sec-fonts"></a> in the Features section for more information.</p>
 
-				<p>Support for embedded fonts also ensures that characters and glyphs unique to an EPUB Publication can
+				<p>Support for embedded fonts also ensures that characters and glyphs unique to an EPUB publication can
 					be embedded for proper display.</p>
 
 			</section> -->
@@ -498,7 +495,7 @@
 				<h2>Text-to-speech</h2>
 
 				<p>EPUB 3's support for PLS documents and SSML attributes increases the pronunciation control that EPUB
-					Creators have over the rendering of any natural language in text-to-speech-enabled Reading Systems.
+					creators have over the rendering of any natural language in text-to-speech-enabled reading systems.
 					Refer to <a href="#sec-tts"></a> in the Features section for more information on these
 					capabilities.</p>
 
@@ -518,17 +515,17 @@
 
 			<p>A major goal of EPUB is to facilitate content accessibility, and a variety of features in EPUB 3 support
 				this requirement. This section reviews these features, detailing some established best practices for
-				ensuring that EPUB Publications are accessible where applicable.</p>
+				ensuring that EPUB publications are accessible where applicable.</p>
 
 			<p>EPUB 3 also includes an Accessibility specification [[EPUB-A11Y-11]] that leverages the extensive work
 				done to make web content accessible in [[WCAG21]]. The specification defines requirements to produce
-				EPUB Publications that can be accessed by a wide range of users. It is accompanied by a techniques
+				EPUB publications that can be accessed by a wide range of users. It is accompanied by a techniques
 				document [[EPUB-A11Y-TECH-11]] that outlines best practices for meeting these requirements.</p>
 
 			<p>It is important to note that while accessibility is important in its own right, accessible content is
-				also more valuable content: an accessible EPUB Publication will be adaptable to more devices and be
+				also more valuable content: an accessible EPUB publication will be adaptable to more devices and be
 				easier to reuse, in whole or in part, via human and automated workflows. The EPUB Working Group strongly
-				recommends that EPUB Creators ensure that they generate accessible content.</p>
+				recommends that EPUB creators ensure that they generate accessible content.</p>
 
 			<section id="sec-access-nav">
 				<h2>Navigation</h2>
@@ -536,36 +533,35 @@
 				<p>As noted in <a href="#sec-nav-nav-doc"></a> above, the navigation features represent a universal and
 					flexible navigation system.</p>
 
-				<p>The Navigation Document can also be reused in the body of an EPUB Publication by including it in the
+				<p>The Navigation Document can also be reused in the body of an EPUB publication by including it in the
 						<a data-cite="epub-33#sec-spine-elem"><code>spine</code></a>. To avoid the situation in highly
 					structured documents where it might not be desirable to display the complete table of contents to
 					users in the body of the publication, the display level can be modified using the <a
 						data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a> [[EPUB-33]]. This
-					attribute is ignored by Reading Systems when they render the table of contents outside the <a
+					attribute is ignored by reading systems when they render the table of contents outside the <a
 						data-cite="epub-33#sec-spine-elem"><code>spine</code></a> (e.g., in their own specialized
 					views), which avoids minimizing the information that is available.</p>
 
-				<p>EPUB Creators are also encouraged to supply additional <a><code>nav</code></a> elements if their 
-					EPUB Publications contain non-structural points of
-					interest, such as figures, tables, etc., to further enhance access to the content.</p>
+				<p>EPUB creators are also encouraged to supply additional <a><code>nav</code></a> elements if their EPUB
+					publications contain non-structural points of interest, such as figures, tables, etc., to further
+					enhance access to the content.</p>
 
 			</section>
 
 			<section id="sec-access-semantic-markup">
 				<h2>Semantic markup</h2>
 
-				<p>[[HTML]] supports a number of elements that make markup more semantically meaningful (e.g., 
-					<a><code>section</code></a>, <a><code>nav</code></a>, and <a><code>aside</code></a>). 
-					EPUB Creators are encouraged to use these elements, in conjunction
-					with best practices for authoring well-structured web content, when creating EPUB XHTML Content
-					Documents. These additions allow content to be better grouped and defined, both to represent the
-					structure of documents and to facilitate their logical navigation. XHTML Content Documents also
-					natively support the inclusion of ARIA role and state attributes and events, including the dedicated
-					[[DPUB-ARIA-1.0]] roles, enhancing the ability of Assistive Technologies to interact with the
-					content.</p>
+				<p>[[HTML]] supports a number of elements that make markup more semantically meaningful (e.g.,
+							<a><code>section</code></a>, <a><code>nav</code></a>, and <a><code>aside</code></a>). EPUB
+					creators are encouraged to use these elements, in conjunction with best practices for authoring
+					well-structured web content, when creating EPUB XHTML content documents. These additions allow
+					content to be better grouped and defined, both to represent the structure of documents and to
+					facilitate their logical navigation. XHTML content documents also natively support the inclusion of
+					ARIA role and state attributes and events, including the dedicated [[DPUB-ARIA-1.0]] roles,
+					enhancing the ability of Assistive Technologies to interact with the content.</p>
 
 				<p>EPUB 3 also includes the <code>epub:type</code> attribute, which allows the inclusion of additional
-					information to any element in an EPUB Content Document to express its purpose and meaning within the
+					information to any element in an EPUB content document to express its purpose and meaning within the
 					work. Refer to the section on <a data-cite="epub-33#app-structural-semantics">Expressing Structural
 						Semantics</a> [EPUB-33] for more information.</p>
 			</section>
@@ -580,9 +576,9 @@
 
 				<p>While it is possible to incorporate more highly formatted content in EPUB — for example via bitmap
 					images or SVG graphics, or even use of CSS explicit positioning and/or table elements to achieve
-					particular visual layouts — EPUB Creators are strongly discouraged from utilizing such techniques.
-					These techniques are not reliable in EPUB since many Reading Systems render content in a paginated
-					manner rather than creating a single scrolling <a>Viewport</a> and since each Reading System might
+					particular visual layouts — EPUB creators are strongly discouraged from utilizing such techniques.
+					These techniques are not reliable in EPUB since many reading systems render content in a paginated
+					manner rather than creating a single scrolling <a>viewport</a> and since each reading system might
 					define its own pagination algorithm. In general, it is preferable to achieve visual richness by
 					using CSS Style Sheets without absolute sizing or positioning.</p>
 
@@ -596,10 +592,10 @@
 				<p>Aural renderings of content are important for accessibility and are a desirable feature for many
 					users. A baseline to facilitate aural rendering is to utilize semantic HTML designed for dynamic
 					layout. Refer to <a href="#sec-tts"></a> for more information on how to use the native facilities
-					that XHTML Content Documents include.</p>
+					that XHTML content documents include.</p>
 
 				<p><a data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[EPUB-33]] provide the ability to
-					synchronize the text and audio content of an EPUB Publication. Beyond benefiting accessibility,
+					synchronize the text and audio content of an EPUB publication. Beyond benefiting accessibility,
 					overlays have other applications, e.g., synchronizing text and audio as a tool for learning to
 					read.</p>
 			</section>
@@ -612,11 +608,11 @@
 					renderings can be made available in these cases.</p>
 
 				<p>Publication- and content-level fallbacks are defined in the section on <a
-						data-cite="epub-33#sec-foreign-resources">Foreign Resources</a> [[EPUB-33]]. These fallback
-					mechanisms enable the inclusion of Foreign Resources in an EPUB Publication and ensure compatibility
-					of EPUB 3 content across Reading Systems with varying capabilities (e.g., they allow the inclusion
-					of multiple video formats, and the inclusion of XHTML fallbacks to SVG Content Documents for EPUB 2
-					Reading Systems).</p>
+						data-cite="epub-33#sec-foreign-resources">foreign resources</a> [[EPUB-33]]. These fallback
+					mechanisms enable the inclusion of foreign resources in an EPUB publication and ensure compatibility
+					of EPUB 3 content across reading systems with varying capabilities (e.g., they allow the inclusion
+					of multiple video formats, and the inclusion of XHTML fallbacks to SVG content documents for EPUB 2
+					reading systems).</p>
 			</section> -->
 
 			<section id="sec-access-scripting">
@@ -628,7 +624,7 @@
 						data-cite="epub-33#sec-scripted-content">can provide fallbacks</a> [[EPUB-33]] to further
 					facilitate access to their contents, the documents have to be accessible without them.</p>
 
-				<p>EPUB Creators should always implement best practices for accessible scripting in web documents, such
+				<p>EPUB creators should always implement best practices for accessible scripting in web documents, such
 					as provided in [[WAI-ARIA]], and reserve the use of scripting for situations in which interactivity
 					is critical to the user experience.</p>
 			</section>
@@ -661,9 +657,9 @@
 					more closely with HTML, and in the process bringing new, native multimedia features, sophisticated
 					CSS layout rendering and font embedding, scripted interactivity, enhanced global language support,
 					and improved accessibility. A new specification for EPUB Media Overlays was also introduced,
-					allowing for text and audio synchronization in EPUB Publications. To better align the specification
-					names with the standard, the Open Package Format specification was renamed EPUB Publications and the
-					Open Publication Format specification was renamed EPUB Content Documents. The EPUB 3.0
+					allowing for text and audio synchronization in EPUB publications. To better align the specification
+					names with the standard, the Open Package Format specification was renamed EPUB publications and the
+					Open Publication Format specification was renamed EPUB content documents. The EPUB 3.0
 					specifications were approved in October 2011. See [[EPUBPublications-30]] [[EPUBContentDocs-30]]
 					[[OCF-30]] [[EPUBMediaOverlays-30]] [[EPUBChanges-30]].</p>
 			</section>
@@ -671,7 +667,7 @@
 			<section id="epub301">
 				<h3>EPUB 3.0.1: 2014</h3>
 				<p>The EPUB 3.0.1 revision was undertaken in 2013-14. Although introducing mostly minor fixes and
-					updates, it did see the integration of Fixed Layout Documents, which give EPUB Creators greater
+					updates, it did see the integration of Fixed Layout Documents, which give EPUB creators greater
 					control over presentation when a reflowable EPUB is not suitable for the content.
 					See [[EPUBPublications-301]] [[EPUBContentDocs-301]] [[OCF-301]] [[EPUBMediaOverlays-301]]
 					[[EPUBChanges-301]].</p>
@@ -685,7 +681,7 @@
 					is always valid to use; a revision of EPUB is not needed). The use of CSS was also clarified, and
 					the use of EPUB-specific properties reduced.</p>
 				<p>Many EPUB-specific features were also removed from the standard, in particular content switching,
-					triggers, and bindings. This change necessitated a new Package Document version number.
+					triggers, and bindings. This change necessitated a new package document version number.
 					See [[EPUB-31]] [[EPUBPackages-31]] [[EPUBContentDocs-31]] [[OCF-31]] [[EPUBMediaOverlays-31]]
 					[[EPUBChanges-31]]</p>
 			</section>
@@ -693,11 +689,11 @@
 			<section id="epub32">
 				<h3>EPUB 3.2: 2018</h3>
 				<p>The work on EPUB 3.2 was undertaken shortly after EPUB 3.1 to restore compatibility of content to
-					EPUB 3. The change of version number introduced in EPUB 3.1 meant that EPUB Creators, vendors and
-					Reading System developers would have to produce, distribute and consume two versions of EPUB
+					EPUB 3. The change of version number introduced in EPUB 3.1 meant that EPUB creators, vendors and
+					reading system developers would have to produce, distribute and consume two versions of EPUB
 					content, but the costs of this change outweighed the benefits of the new version. EPUB 3.2 instead
 					keeps all the best parts of EPUB 3.1 but deprecates elements instead of removing them so that a new
-					version number is not necessary in the Package Document. See [[EPUB-32]] [[EPUBPackages-32]]
+					version number is not necessary in the package document. See [[EPUB-32]] [[EPUBPackages-32]]
 					[[EPUBContentDocs-32]] [[OCF-32]] [[EPUBMediaOverlays-32]] [[EPUBChanges-32]]</p>
 			</section>
 
@@ -714,9 +710,9 @@
 						href="https://www.w3.org//publishing/groups/epub-wg/">W3C EPUB 3 Working Group</a>, this
 					restructuring led to the separation of Recommendations and Working Group Notes (see also <a
 						href="#sec-documents">the detailed list of documents</a> ). Features specified in the
-					Recommendations are thoroughly tested, are widely implemented in Reading Systems, and they can be
+					Recommendations are thoroughly tested, are widely implemented in reading systems, and they can be
 					considered as interoperable. On the other hand, features specified in Working Group Notes, although
-					they may have some authoring uptakes, still lack support in Reading Systems; as a result, these
+					they may have some authoring uptakes, still lack support in reading systems; as a result, these
 					technologies should not yet be considered stable and interoperable.</p>
 
 				<p>The separate <a data-cite="epub-33#change-log">section</a> in [[EPUB-33]] provides a more detailed

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -426,7 +426,7 @@
 				<h2>Container</h2>
 
 				<p>An EPUB publication is transported and interchanged as a single file (a "portable document") that
-					contains the package documents, all Content Documents, and all other required resources for
+					contains the package documents, all EPUB content documents, and all other required resources for
 					processing the Publication. The single-file container format for EPUB is based on the widely adopted
 					ZIP format, and an XML document that identifies the location of the package document for the
 					Publication in the ZIP archive is located at a pre-defined location within the archive.</p>
@@ -468,7 +468,7 @@
 					that combine Latin and Arabic or Hebrew characters). </p>
 
 				<p>Finally, the <code>page-progression-direction</code> attribute allows the content flow direction to
-					be globally specified for all Content Documents to facilitate rendering (see the <a
+					be globally specified for all EPUB content documents to facilitate rendering (see the <a
 						data-cite="epub-33#attrdef-spine-page-progression-direction">page-progression-direction</a>
 					[[EPUB-33]]).</p>
 			</section>

--- a/epub33/reports/a11y-properties-use.md
+++ b/epub33/reports/a11y-properties-use.md
@@ -14,8 +14,8 @@ target communities. This metadata falls into two categories:
 of publications; and
 2. EPUB-defined metadata properties for reporting aspects of conformance
 
-Usage of these properties means that they are regularly included in the Package Document
-metadata for their EPUB Publications (as appropriate for each title).
+Usage of these properties means that they are regularly included in the package document
+metadata for their EPUB publications (as appropriate for each title).
 
 ## Publisher Implementations
 

--- a/epub33/reports/epub-properties-use.md
+++ b/epub33/reports/epub-properties-use.md
@@ -13,8 +13,8 @@ target communities. This metadata falls into two categories:
 1. metadata for expressing information about the publication in the package document; and
 2. metadata for expressing preferred rendering of the content
 
-Usage of these properties means that they are regularly included in the Package Document
-metadata for their EPUB Publications (as appropriate for each title).
+Usage of these properties means that they are regularly included in the package document
+metadata for their EPUB publications (as appropriate for each title).
 
 ## Publisher Implementations
 
@@ -102,7 +102,7 @@ Manifest properties are expressed in the
         <tr>
             <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-meta-auth"><s>meta-auth</s></a></td>
             <td>
-            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
@@ -178,21 +178,21 @@ Link relationships are expressed in the
         <tr>
             <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-marc21xml-record"><s>marc21xml-record</s></a></td>
             <td>
-            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
             <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-mods-record"><s>mods-record</s></a></td>
             <td>
-            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
             <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-onix-record"><s>onix-record</s></a></td>
             <td>
-            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
@@ -215,14 +215,14 @@ Link relationships are expressed in the
         <tr>
             <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xml-signature"><s>xml-signature</s></a></td>
             <td>
-            	<p>This property deprecated and is no longer recommended for use in EPUB Publications.
+            	<p>This property deprecated and is no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
             <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xmp-record"><s>xmp-record</s></a></td>
             <td>
-            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
@@ -422,7 +422,7 @@ and as overrides in the
         <tr>
             <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-portrait"><s>rendition:spread-portrait</s></a></td>
             <td>
-            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
@@ -453,7 +453,7 @@ and as overrides in the
         <tr>
             <td><a href="https://w3c.github.io/epub-specs/epub33/core/#viewport"><s>rendition:viewport</s></a></td>
             <td>
-            	<p>This property is deprecated and no longer recommended for use in EPUB Publications.
+            	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
@@ -536,7 +536,7 @@ Manifest properties are expressed in the
     </tbody>
 </table>
 
-### Spine Properties Vocabulary
+### Spine properties vocabulary
 
 The following table lists publishers who have stated that they are currently using
 the [spine properties](https://w3c.github.io/epub-specs/epub33/core/#app-itemref-properties-vocab)

--- a/epub33/reports/exit_criteria.html
+++ b/epub33/reports/exit_criteria.html
@@ -51,7 +51,7 @@
     <section>
         <h1 id="introduction">Introduction</h1>
         <p>
-          At the core, an EPUB 3.3 publication consists of a number of <a href="https://w3c.github.io/epub-specs/epub33/core/#dfn-publication-resource">Publications Resources</a> that are in XHTML, SVG, CSS, or various media formats. Beyond these Publication Resources the EPUB publication includes some EPUB-specific files (e.g, a <a href="https://w3c.github.io/epub-specs/epub33/core/#dfn-package-document">Package Document</a>) whose formats are defined by the EPUB 3.3 standard family. Accordingly, an EPUB 3.3 Reading System has to:
+          At the core, an EPUB 3.3 publication consists of a number of <a href="https://w3c.github.io/epub-specs/epub33/core/#dfn-publication-resource">Publications Resources</a> that are in XHTML, SVG, CSS, or various media formats. Beyond these publication resources the EPUB publication includes some EPUB-specific files (e.g, a <a href="https://w3c.github.io/epub-specs/epub33/core/#dfn-package-document">package document</a>) whose formats are defined by the EPUB 3.3 standard family. Accordingly, an EPUB 3.3 reading system has to:
         </p>
 
         <ul>
@@ -60,15 +60,15 @@
         </ul>
 
         <p>
-          What this also means is that the validity and conformance of an EPUB 3.3 publication, as well as a Reading System implementation, <em>includes</em> the requirement of valid and conformant Publication Resources, and the conformant rendering thereof.
+          What this also means is that the validity and conformance of an EPUB 3.3 publication, as well as a reading system implementation, <em>includes</em> the requirement of valid and conformant publication resources, and the conformant rendering thereof.
         </p>
 
         <p>
-          Comprehensive testing would require to include the union of all HTML, SVG, or CSS tests both on the content side as well as the implementation side <em>as well as</em> testing the unique, EPUB 3.3 specific features. The industry standard checking tools, like <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> or <a href="https://daisy.github.io/ace/">ACE, by Daisy</a> indeed include standard, and externally developed, HTML, CSS, or accessibility checkers, which would check the validity or conformance of the Publication Resources. Similarly, today’s Reading Systems do not develop an HTML renderer themselves; they, rather, rely on external tools (typically a webview implementation) that can be assumed to conform to the relevant W3C specifications.
+          Comprehensive testing would require to include the union of all HTML, SVG, or CSS tests both on the content side as well as the implementation side <em>as well as</em> testing the unique, EPUB 3.3 specific features. The industry standard checking tools, like <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> or <a href="https://daisy.github.io/ace/">ACE, by Daisy</a> indeed include standard, and externally developed, HTML, CSS, or accessibility checkers, which would check the validity or conformance of the publication resources. Similarly, today’s reading systems do not develop an HTML renderer themselves; they, rather, rely on external tools (typically a webview implementation) that can be assumed to conform to the relevant W3C specifications.
         </p>
 
         <p>
-          However, taking into account these additional test would be quite unnecessary for the purpose of testing the EPUB 3.3 specification (which is the main purpose of a <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation</a>). As a consequence, the <em><strong>testing strategy of EPUB 3.3 concentrates on the unique EPUB 3.3 features only</strong></em>, and considers the Publication Resources, as well as the Reading Systems, to conform to the relevant Open Web Platform  specifications.
+          However, taking into account these additional test would be quite unnecessary for the purpose of testing the EPUB 3.3 specification (which is the main purpose of a <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation</a>). As a consequence, the <em><strong>testing strategy of EPUB 3.3 concentrates on the unique EPUB 3.3 features only</strong></em>, and considers the publication resources, as well as the reading systems, to conform to the relevant Open Web Platform  specifications.
         </p>
     </section>
 
@@ -118,7 +118,7 @@
                 </li>
                 <li>
                     <p>
-                      Structural constraints on a the EPUB-specific files of the publication; examples include the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-ocf">structure of the container format (OCF)</a> or of the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-package-doc">Package Document</a>.
+                      Structural constraints on a the EPUB-specific files of the publication; examples include the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-ocf">structure of the container format (OCF)</a> or of the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-package-doc">package document</a>.
                     </p>
                 </li>
                 <li>
@@ -158,7 +158,7 @@
         <section>
             <h2 id="epub-accessibility-1.1">EPUB Accessibility 1.1</h2>
             <p>
-              The goals of the <a href="https://w3c.github.io/epub-specs/epub33/a11y/">EPUB Accessibility 1.1</a> document is to define accessibility conformance of EPUB Publications beyond the accessibility requirements defined by WCAG for Publication Resources. The normative features of this specification can be divided, roughly, into the following categories:
+              The goals of the <a href="https://w3c.github.io/epub-specs/epub33/a11y/">EPUB Accessibility 1.1</a> document is to define accessibility conformance of EPUB publications beyond the accessibility requirements defined by WCAG for publication resources. The normative features of this specification can be divided, roughly, into the following categories:
             </p>
             <ol>
                 <li>
@@ -181,7 +181,7 @@
                         </p> 
                           
                         <p>
-                          Note that these conformance levels rely on each Publication Resource to be conform to WCAG 2.0 AA, when applicable; there are only a few EPUB specific features like page numbering. An EPUB Accessibility 1.1 Usage Report <span class="todo">to be done!!</span> shows that conformance table.
+                          Note that these conformance levels rely on each publication resource to conform to WCAG 2.0 AA, when applicable; there are only a few EPUB specific features like page numbering. An EPUB Accessibility 1.1 Usage Report <span class="todo">to be done!!</span> shows that conformance table.
                         </p>
                     </li>
                     <li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -948,7 +948,7 @@
 			</section>
 		</section>
 		<section id="sec-contentdocs">
-			<h2>Content Document processing</h2>
+			<h2>EPUB content document processing</h2>
 
 			<p>The definition of <a data-cite="epub-33#sec-contentdocs">EPUB content documents</a> [[EPUB-33]] includes
 				various authoring restrictions to optimize the cross-compatibility of content (e.g., <a
@@ -1317,8 +1317,8 @@
 								causing unexpected behavior);</p>
 						</li>
 						<li>
-							<p>an attack of one Content Document against another (e.g., stealing data that originated in
-								a different document);</p>
+							<p>an attack of one EPUB content document against another (e.g., stealing data that
+								originated in a different document);</p>
 						</li>
 						<li>
 							<p>an attack of an unencrypted script against an encrypted portion of a document (e.g., an
@@ -1657,7 +1657,7 @@
 
 						<dt id="scrolled-continuous">scrolled-continuous</dt>
 						<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
-							<p>The reading system SHOULD render all Content Documents such that overflow content is
+							<p>The reading system SHOULD render all EPUB content documents such that overflow content is
 								scrollable, and SHOULD present the EPUB publication as one continuous scroll from spine
 								item to spine item (except where <a data-cite="epub-33#layout-property-flow-overrides"
 									>locally overridden</a> [[EPUB-33]]).</p>
@@ -1665,7 +1665,7 @@
 
 						<dt id="scrolled-doc">scrolled-doc</dt>
 						<dd id="scrolled-doc-dd" data-tests="#pkg-flow-scrolled-doc">
-							<p>The reading system SHOULD render all Content Documents such that users can scroll
+							<p>The reading system SHOULD render all EPUB content documents such that users can scroll
 								overflow content, and SHOULD present each spine item as a separate scrollable
 								document.</p>
 						</dd>
@@ -2649,7 +2649,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
 				<li>19-Feb-2021: Updated the <a href="#sec-scripted-content-security">scripting security
 						considerations</a> so that the text recommends assigning a unique origin to each EPUB
-					publication for security rather than domain isolation at the Content Document level. See <a
+					publication for security rather than domain isolation at the EPUB content document level. See <a
 						href="https://github.com/w3c/epub-specs/issues/1156">issue 1156</a>.</li>
 				<li>15-Feb-2021: Clarified the requirements for presenting nav elements in the navigation document. The
 					toc nav is now the only required element, the page-list nav is recommended when present, and all

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -75,7 +75,7 @@
 						"William McCoy",
 						"Elika J. Etimad",
 						"Matt Garrish"],
-						"title": "EPUB Content Documents 3.0.1",
+						"title": "EPUB content documents 3.0.1",
 						"href": "http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
 						"date": "26 June 2014",
 						"publisher": "IDPF"
@@ -122,8 +122,8 @@
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
 				web content — including HTML, CSS, SVG and other resources — for distribution in a single-file
 				container.</p>
-			<p>This specification defines the conformance requirements for EPUB 3 Reading Systems — the user agents that
-				render EPUB Publications.</p>
+			<p>This specification defines the conformance requirements for EPUB 3 reading systems — the user agents that
+				render EPUB publications.</p>
 		</section>
 		<section id="sotd"></section>
 		<section id="sec-introduction">
@@ -133,26 +133,26 @@
 				<h3>Overview</h3>
 
 				<p>The EPUB 3 standard is separated into two distinct concerns: the authoring of <a>EPUB
-						Publications</a> is defined in the <a data-cite="epub-33#">core specification</a> [[EPUB-33]],
-					while this specification details the rendering requirements for them in EPUB Reading Systems.</p>
+						publications</a> is defined in the <a data-cite="epub-33#">core specification</a> [[EPUB-33]],
+					while this specification details the rendering requirements for them in EPUB reading systems.</p>
 
-				<p>An EPUB Reading System can take many forms. It might have a visual display area for rendering the
+				<p>An EPUB reading system can take many forms. It might have a visual display area for rendering the
 					content to users, for example, or it might only provide audio playback of the content. Therefore,
-					there is no single set of rules that applies to all Reading Systems. Rather, this specification
-					breaks down the rendering requirements based on a Reading System's capabilities and the features it
+					there is no single set of rules that applies to all reading systems. Rather, this specification
+					breaks down the rendering requirements based on a reading system's capabilities and the features it
 					supports.</p>
 
 				<p>Moreover, this specification allows for a great deal of flexibility for developers to create unique
 					user interfaces, and requirements for things like metadata processing are intentionally minimal to
 					allow for such flexibility.</p>
 
-				<p>So, although this specification identifies the formal requirements for Reading Systems, it is not
+				<p>So, although this specification identifies the formal requirements for reading systems, it is not
 					possible to understand this document in isolation. Developers should also familiarize themselves
-					with the full content structure of an EPUB Publication in order to understand the complete range of
+					with the full content structure of an EPUB publication in order to understand the complete range of
 					information that is available.</p>
 
 				<div class="note">
-					<p>A conforming Reading System is not necessarily a single dedicated program or device but might
+					<p>A conforming reading system is not necessarily a single dedicated program or device but might
 						exist as a distributed system.</p>
 				</div>
 			</section>
@@ -170,10 +170,10 @@
 						<dfn class="export" id="dfn-content-display-area">Content Display Area</dfn>
 					</dt>
 					<dd>
-						<p>The area within the <a>Viewport</a> dedicated to the display of <a>EPUB Content
-							Documents</a>. The Content Display Area excludes any borders, margins, headers, footers, or
-							other decoration a <a>EPUB Reading System</a> might inject into the Viewport.</p>
-						<p>In the case of <a>synthetic spreads</a>, the Viewport contains two Content Display Areas.</p>
+						<p>The area within the <a>viewport</a> dedicated to the display of <a>EPUB content
+							documents</a>. The Content Display Area excludes any borders, margins, headers, footers, or
+							other decoration a <a>EPUB reading system</a> might inject into the viewport.</p>
+						<p>In the case of <a>synthetic spreads</a>, the viewport contains two Content Display Areas.</p>
 					</dd>
 				</dl>
 			</section>
@@ -190,13 +190,13 @@
 						it. That standard, in turn, references various technologies that continue to evolve, such as
 						MathML, SVG, CSS, and JavaScript.</p>
 
-					<p>Reading System developers must keep track of the changes to HTML, and the technologies it
+					<p>Reading system developers must keep track of the changes to HTML, and the technologies it
 						references, to ensure they keep their systems up to date.</p>
 
-					<p>This specification does not require EPUB Reading Systems to support scripting, HTML forms or the
-						HTML DOM. Reading Systems conformant with this specification are only expected to be able to
-						process a conforming <a>EPUB Content Document</a>. As <a href="#sec-scripted-content">support
-							for scripting and HTML forms</a> is not compulsory, a conformant Reading System might not be
+					<p>This specification does not require EPUB reading systems to support scripting, HTML forms or the
+						HTML DOM. Reading systems conformant with this specification are only expected to be able to
+						process a conforming <a>EPUB content document</a>. As <a href="#sec-scripted-content">support
+							for scripting and HTML forms</a> is not compulsory, a conformant reading system might not be
 						a fully conformant HTML user agent.</p>
 				</section>
 
@@ -209,50 +209,50 @@
 						specification is the authoritative reference.</p>
 
 					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. Reading
-						System developers must keep track of changes to the SVG standard to ensure that they keep their
+						system developers must keep track of changes to the SVG standard to ensure that they keep their
 						systems up to date.</p>
 				</section>
 			</section>
 		</section>
 		<section id="sec-pub-resources">
-			<h3>Publication Resource processing</h3>
+			<h3>Publication resource processing</h3>
 
-			<p id="confreq-rs-epub-pub-res" class="support" data-tests="#cnt-xhtml-support">Reading Systems MUST process
-					<a data-cite="epub-33#sec-publication-resources">Publication Resources</a> [[EPUB-33]].</p>
+			<p id="confreq-rs-epub-pub-res" class="support" data-tests="#cnt-xhtml-support">Reading systems MUST process
+					<a data-cite="epub-33#sec-publication-resources">publication resources</a> [[EPUB-33]].</p>
 
 			<section id="sec-epub-rs-conf-cmt">
 				<h4>Core Media types</h4>
-				
+
 				<p id="confreq-rs-epub3-images"
-					data-tests="#pub-cmt-gif,#pub-cmt-jpg,#pub-cmt-png,#pub-cmt-svg,#pub-cmt-webp">If a Reading System
-					has a <a>Viewport</a>, it MUST support the <a data-cite="epub-33#cmt-grp-image">image Core Media
-						Type Resources</a> [[EPUB-33]].</p>
-				
+					data-tests="#pub-cmt-gif,#pub-cmt-jpg,#pub-cmt-png,#pub-cmt-svg,#pub-cmt-webp">If a reading system
+					has a <a>viewport</a>, it MUST support the <a data-cite="epub-33#cmt-grp-image">image core media
+						type resources</a> [[EPUB-33]].</p>
+
 				<p id="confreq-rs-epub3-mp3-aac" data-tests="#pub-cmt-mp3,#pub-cmt-mp4,#pub-cmt-opus">If it has the
 					capability to render prerecorded audio, it MUST support the <a data-cite="epub-33#cmt-grp-audio"
-						>audio Core Media Type Resources</a> [[EPUB-33]].</p>
-				
-				<p class="note" id="note-video-codecs">It is recommended that Reading Systems support at least one of
+						>audio core media type resources</a> [[EPUB-33]].</p>
+
+				<p class="note" id="note-video-codecs">It is recommended that reading systems support at least one of
 					the H.264 [[H264]] and VP8 [[RFC6386]] video codecs, but this is not a conformance requirement
-					&#8212; a Reading System may support any video codec, or none at all. Reading System developers
+					&#8212; a reading system may support any video codec, or none at all. Reading system developers
 					should take into consideration factors such as breadth of adoption, playback quality, and technology
 					royalties when deciding which video formats to support.</p>
 			</section>
-			
+
 			<section id="sec-epub-rs-conf-foreign-res">
-				<h4>Foreign Resources</h4>
+				<h4>Foreign resources</h4>
 
 				<p id="confreq-rs-foreign"
 					data-tests="#pub-foreign_image,#pub-foreign_xml-spine,#pub-foreign_xml-suffix-spine,#pub-foreign_bad-fallback,#pub-foreign_json-spine"
-					>Reading Systems MAY support an arbitrary set of <a>Foreign Resource</a> types, and if a Foreign
-					Resource is not supported, MUST process fallbacks as defined in <a
-						data-cite="epub-33#sec-foreign-restrictions">Foreign Resources</a> [[EPUB-33]].</p>
+					>Reading systems MAY support an arbitrary set of <a>foreign resource</a> types, and if a foreign
+					resource is not supported, MUST process fallbacks as defined in <a
+						data-cite="epub-33#sec-foreign-restrictions">foreign resources</a> [[EPUB-33]].</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-remote-res">
 				<h4>Resource locations</h4>
 
-				<p id="confreq-rs-remote">Reading Systems SHOULD support <a>Remote Resources</a>, as defined in <a
+				<p id="confreq-rs-remote">Reading systems SHOULD support <a>remote resources</a>, as defined in <a
 						data-cite="epub-33#sec-resource-locations">Resource Locations</a> [[EPUB-33]].</p>
 			</section>
 
@@ -260,17 +260,18 @@
 				<h4>Data URLs</h4>
 
 				<p id="confreq-rs-data-urls"
-					data-tests="#pub-data-urls_browsing-context,#pub-data-urls_top-level-content">Reading Systems MUST
-					prevent data URLs [[RFC2397]] from opening in <a>top-level browsing contexts</a> [[HTML]], except when initiated through a Reading System
-					affordance such as a context menu. If a Reading System does not use a top-level browsing context for
-						<a>Top-level Content Documents</a>, for example if the Top-level Content Document is an SVG, it
-					MUST also prevent data URLs from opening as though they are Top-level Content Documents.</p>
+					data-tests="#pub-data-urls_browsing-context,#pub-data-urls_top-level-content">Reading systems MUST
+					prevent data URLs [[RFC2397]] from opening in <a>top-level browsing contexts</a> [[HTML]], except
+					when initiated through a reading system affordance such as a context menu. If a reading system does
+					not use a top-level browsing context for <a>top-level content documents</a>, for example if the
+					top-level content document is an SVG, it MUST also prevent data URLs from opening as though they are
+					top-level content documents.</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-xml">
 				<h4>XML processing</h4>
 
-				<p>A Reading System MUST be both of the following:</p>
+				<p>A reading system MUST be both of the following:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -286,46 +287,46 @@
 				</ul>
 
 				<p id="confreq-rs-xml-extid" data-tests="#pub-xml-external-id">In addition, when processing XML
-					documents, a Reading System MUST NOT resolve <a data-cite="xml#NT-ExternalID">external
+					documents, a reading system MUST NOT resolve <a data-cite="xml#NT-ExternalID">external
 						identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[XML]].</p>
 			</section>
 
 			<section id="sec-epub-rs-i18n">
 				<h2>Internationalization</h2>
 
-				<p>A Reading System MUST process, for all <a data-cite="epub-33#dfn-publication-resource">Publication
-						Resources</a>, the attributes that set the language for the documents' contents, when
+				<p>A reading system MUST process, for all <a data-cite="epub-33#dfn-publication-resource">publication
+						resources</a>, the attributes that set the language for the documents' contents, when
 					applicable. This includes:</p>
 
 				<ul>
 					<li>the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a> [[XML]] for all XML
-						documents (e.g., the <a>Package Document</a>, <a>XHTML Content Documents</a>, <a>SVG Content
-							Documents</a>, and <a>Media Overlay Documents</a>).</li>
+						documents (e.g., the <a>package document</a>, <a>XHTML content documents</a>, <a>SVG content
+							documents</a>, and <a>media overlay documents</a>).</li>
 
-					<li>the <code>lang</code> attribute for XHTML Content Documents and SVG Content Documents. (Refer to
+					<li>the <code>lang</code> attribute for XHTML content documents and SVG content documents. (Refer to
 						respective "The 'lang' and 'xml:lang' attributes" sections in [[HTML]] and [[SVG]] for more
 						information.)</li>
 				</ul>
 
-				<p>Similarly, a Reading System MUST process, for all <a data-cite="epub-33#dfn-publication-resource"
-						>Publication Resources</a> [[EPUB-33]], the attributes that set the base direction for the
+				<p>Similarly, a reading system MUST process, for all <a data-cite="epub-33#dfn-publication-resource"
+						>publication resources</a> [[EPUB-33]], the attributes that set the base direction for the
 					documents' contents, when applicable. This includes:</p>
 
 				<ul>
 					<li id="confreq-rs-pkg-dir-intro"
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
-						>the <a data-cite="epub-33#attrdef-dir"><code>dir</code></a>  attribute [[EPUB-33]] for the
-							<a>Package Document</a>. (See also <a href="#sec-pkg-doc-base-dir"></a> for further
+						>the <a data-cite="epub-33#attrdef-dir"><code>dir</code></a> attribute [[EPUB-33]] for the
+							<a>package document</a>. (See also <a href="#sec-pkg-doc-base-dir"></a> for further
 						details.)</li>
-					<li>the [[HTML]] [^html-global/dir^] attribute for XHTML Content Documents.</li>
+					<li>the [[HTML]] [^html-global/dir^] attribute for XHTML content documents.</li>
 					<li>the [[SVG]] <a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
-								><code>direction</code></a> attribute for SVG Content Documents.</li>
+								><code>direction</code></a> attribute for SVG content documents.</li>
 				</ul>
 
 				<p id="confreq-rs-pkg-lang-no-content"
 					data-tests="#pgk-lang_pkg_non_content_dir,#pgk-lang_pkg_non_content">In the absence of this
-					information in a <a>Publication Resource</a>, Reading Systems MUST NOT assume either the language or
-					the base direction of that resource from information expressed in the Package Document (i.e., in <a
+					information in a <a>publication resource</a>, reading systems MUST NOT assume either the language or
+					the base direction of that resource from information expressed in the package document (i.e., in <a
 						data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
 						data-cite="epub-33#attrdef-dir"><code>dir</code></a> attributes, in <a
 						data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attributes</a> on <a
@@ -338,39 +339,39 @@
 			<section id="sec-epub-rs-network-access">
 				<h3>Network access</h3>
 
-				<p>Reading Systems MAY support network access to <a href="#sec-epub-rs-conf-remote-res">retrieve Remote
-						Resources</a> and to allow <a>Scripted Content Documents</a> to <a
+				<p>Reading systems MAY support network access to <a href="#sec-epub-rs-conf-remote-res">retrieve remote
+						resources</a> and to allow <a>scripted content documents</a> to <a
 						href="#confreq-rs-scripted-limit">communicate with web-hosted APIs and retrieve
 					resources</a>.</p>
 
-				<p>Providing network access, however, increases both the security risks to the Reading Systems and the
-					security and privacy risks to users. These risks are often unique to Reading Systems and the
-					platforms they run on &#8212; the browser cores that most Reading Systems are built on do not offer
+				<p>Providing network access, however, increases both the security risks to the reading systems and the
+					security and privacy risks to users. These risks are often unique to reading systems and the
+					platforms they run on &#8212; the browser cores that most reading systems are built on do not offer
 					the same security and privacy controls as web browsers themselves. Consequently, developers need to
-					use extra caution when allowing network access, and more thoroughly test that their Reading Systems
+					use extra caution when allowing network access, and more thoroughly test that their reading systems
 					are not vulnerable to attacks. More information about these risks is provided in <a
 						href="#sec-security-privacy"></a>.</p>
 
-				<p>If Reading System developers allow network access, it is strongly RECOMMENDED both that they:</p>
+				<p>If reading system developers allow network access, it is strongly RECOMMENDED both that they:</p>
 
 				<ul>
 					<li>notify users when network activity occurs; and</li>
-					<li>let users block access to the network (e.g., disable network access for the Reading System
-						globally or for a particular EPUB Publication).</li>
+					<li>let users block access to the network (e.g., disable network access for the reading system
+						globally or for a particular EPUB publication).</li>
 				</ul>
 			</section>
 
 			<section id="sec-epub-rs-external-links">
 				<h3>External links</h3>
 
-				<p data-tests="#pub-external-links">Reading Systems SHOULD open links that resolve outside the <a>EPUB
-						Publication</a> in a new browser instance to ensure that the browser's security and privacy
+				<p data-tests="#pub-external-links">Reading systems SHOULD open links that resolve outside the <a>EPUB
+						publication</a> in a new browser instance to ensure that the browser's security and privacy
 					controls are available to users.</p>
 
-				<p>Although links to external web sites and resources are commonly found in <a>EPUB Content
-						Documents</a>, these are not the only sources. For example, if a Reading System provides access
-					to <a data-cite="epub-33#sec-link-elem">linked records</a> [[EPUB-33]] in the <a>Package
-						Document</a> metadata, it should similarly open the links in a new browser instance.</p>
+				<p>Although links to external web sites and resources are commonly found in <a>EPUB content
+						documents</a>, these are not the only sources. For example, if a reading system provides access
+					to <a data-cite="epub-33#sec-link-elem">linked records</a> [[EPUB-33]] in the <a>package
+						document</a> metadata, it should similarly open the links in a new browser instance.</p>
 
 				<div class="note">
 					<p>For more information about security and privacy issues with external links, see <a
@@ -379,54 +380,54 @@
 			</section>
 		</section>
 		<section id="sec-ocf">
-			<h2>Open Container Format processing</h2>
+			<h2>Open Container Format (OCF) processing</h2>
 
-			<p id="confreq-rs-epub3-ocf" class="support" data-tests="#ocf-package_arbitrary">Reading Systems MUST
-				process the <a data-cite="epub-33#sec-ocf">EPUB Container</a> [[EPUB-33]].</p>
+			<p id="confreq-rs-epub3-ocf" class="support" data-tests="#ocf-package_arbitrary">Reading systems MUST
+				process the <a data-cite="epub-33#sec-ocf">EPUB container</a> [[EPUB-33]].</p>
 
 			<div class="note">
-				<p>An application that processes EPUB Containers does not have to be a full-fledged Reading System
+				<p>An application that processes EPUB containers does not have to be a full-fledged reading system
 					(e.g., an application might only extract the content of a container or check the validity of the
 					packaged content). In these cases, developers of such applications can ignore the rendering
-					requirements for Reading Systems defined in this section.</p>
+					requirements for reading systems defined in this section.</p>
 			</div>
 
 			<section id="sec-container-abstract">
-				<h3>OCF Abstract Container</h3>
+				<h3>OCF abstract container</h3>
 
 				<section id="sec-container-iri">
 					<h4>URL of the root directory</h4>
 
 					<p id="sec-container-iri-root"
-						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">Reading Systems MUST
-						assign a URL [[URL]] to the <a>Root Directory</a> of the <a>OCF Abstract Container</a>. This URL
+						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">Reading systems MUST
+						assign a URL [[URL]] to the <a>root directory</a> of the <a>OCF abstract container</a>. This URL
 						is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a> [[EPUB-33]].
 						It is implementation specific, but the implementation MUST have the following properties:</p>
 
 					<ul>
 						<li id="sec-container-iri-root-parse"
 							data-tests="#ocf-url_link-path-absolute,#ocf-url_parse-path-absolute">The result of <a
-								data-lt="url parser">parsing</a> [[URL]] "<code>/</code>" with the
-								<a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is
-							the <a>container root URL</a>.</li>
+								data-lt="url parser">parsing</a> [[URL]] "<code>/</code>" with the <a>container root
+								URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container
+								root URL</a>.</li>
 						<li id="sec-container-iri-step-parse"
 							data-tests="#ocf-url_link-leaking-relative,#ocf-url_parse-leaking-relative">The result of <a
-							data-lt="url parser">parsing</a> [[URL]] "<code>..</code>" with the
-								<a>container root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is
-							the <a>container root URL</a>.</li>
+								data-lt="url parser">parsing</a> [[URL]] "<code>..</code>" with the <a>container root
+								URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container
+								root URL</a>.</li>
 
-						<li id="sec-container-iri-origin" data-tests="#ocf-url_origin">The <a>origin</a> of the 
-							<a>container root URL</a> is unique for each user-specific instance
-							of an <a>EPUB Publication</a> in a Reading System.</li>
+						<li id="sec-container-iri-origin" data-tests="#ocf-url_origin">The <a>origin</a> of the
+								<a>container root URL</a> is unique for each user-specific instance of an <a>EPUB
+								publication</a> in a reading system.</li>
 					</ul>
 
-					<p class="note">The unicity of the <a>origin</a> per each user-specific
-						instance of an EPUB Publication in a Reading System means that if two different users acquire a
-						copy of the same EPUB Publication, the origins will be different for the two users on those
-						copies even if the same Reading System is used.</p>
+					<p class="note">The unicity of the <a>origin</a> per each user-specific instance of an EPUB
+						publication in a reading system means that if two different users acquire a copy of the same
+						EPUB publication, the origins will be different for the two users on those copies even if the
+						same reading system is used.</p>
 
 					<div class="note">
-						<p>The properties of the <a>container root URL</a> are such that a conforming Reading System
+						<p>The properties of the <a>container root URL</a> are such that a conforming reading system
 							will parse any relative URL string to a <a>content URL</a>. In other words, relative links
 							do not "leak" outside the container content, which is an important feature for security.</p>
 
@@ -467,7 +468,7 @@
 							</thead>
 							<tbody>
 								<tr>
-									<td>Root Directory</td>
+									<td>Root directory</td>
 									<td>
 										<var>empty string</var>
 									</td>
@@ -476,7 +477,7 @@
 									</td>
 								</tr>
 								<tr>
-									<td>Package Document</td>
+									<td>Package document</td>
 									<td>
 										<code>EPUB/package.opf</code>
 									</td>
@@ -485,7 +486,7 @@
 									</td>
 								</tr>
 								<tr>
-									<td>Content Document</td>
+									<td>EPUB content document</td>
 									<td>
 										<code>HTML/file name.xhtml</code>
 									</td>
@@ -501,7 +502,7 @@
 								<tr>
 									<td style="font-weight: bold; text-align: center;">URL string<br />(found for
 										example in the package document)</td>
-									<td style="font-weight: bold; text-align: center;">Content URL</td>
+									<td style="font-weight: bold; text-align: center;">content URL</td>
 								</tr>
 							</thead>
 							<tbody>
@@ -533,8 +534,8 @@
 						</table>
 
 						<p>Note that the last two links are <a data-cite="epub-33#urls-in-ocf-constraints"
-								>disallowed</a> in an EPUB Publications to ensure better interoperability with
-							non-conforming or legacy Reading Systems and toolchains.</p>
+								>disallowed</a> in an EPUB publications to ensure better interoperability with
+							non-conforming or legacy reading systems and toolchains.</p>
 					</div>
 
 					<div class="note">
@@ -544,7 +545,7 @@
 					</div>
 
 					<div class="note">
-						<p>Unlike most language specifications, Reading Systems must use the <a>container root URL</a>
+						<p>Unlike most language specifications, reading systems must use the <a>container root URL</a>
 							as the <a data-cite="url#concept-base-url">base URL</a> [[URL]] for all files within the
 								<code>META-INF</code> directory. See also the section on <a
 								data-cite="epub-33#sec-parsing-urls-metainf">Parsing URLs in the <code>META-INF</code>
@@ -555,14 +556,14 @@
 				<section id="sec-container-filenames">
 					<h4>File names</h4>
 
-					<p>Although EPUB Creators are required to follow various <a
-							data-cite="epub-33#sec-container-filenames">File Name and File Path restrictions</a>
-						[[EPUB-33]] for maximum interoperability, Reading Systems SHOULD attempt to process File Names
-						and Paths that do not adhere to these requirements. Invalid File Names and Paths may only be
+					<p>Although EPUB creators are required to follow various <a
+							data-cite="epub-33#sec-container-filenames">File name and file path restrictions</a>
+						[[EPUB-33]] for maximum interoperability, reading systems SHOULD attempt to process file names
+						and paths that do not adhere to these requirements. Invalid file names and paths may only be
 						problematic on some operating systems.</p>
 
-					<p>This specification does not specify how a Reading System that is unable to represent OCF File
-						Names and Paths would handle this incompatibility.</p>
+					<p>This specification does not specify how a reading system that is unable to represent OCF file
+						names and paths would handle this incompatibility.</p>
 				</section>
 
 				<section id="sec-container-metainf">
@@ -572,34 +573,34 @@
 						<dt id="sec-container-metainf-container.xml">Container File (<code>container.xml</code>)</dt>
 						<dd>
 							<p id="container-default-rendition"
-								data-tests="#ocf-package_arbitrary,#ocf-package_multiple">A Reading System MUST, by
-								default, use the <a>Package Document</a> referenced the from first <a
+								data-tests="#ocf-package_arbitrary,#ocf-package_multiple">A reading system MUST, by
+								default, use the <a>package document</a> referenced the from first <a
 									data-cite="epub-33#sec-container.xml-rootfile-elem"><code>rootfile</code>
-									element</a> [[EPUB-33]] to render the <a>EPUB Publication</a>. If the Reading System
+									element</a> [[EPUB-33]] to render the <a>EPUB publication</a>. If the reading system
 								recognizes a means of selecting from the other available options, it MAY choose a more
-								appropriate Package Document.</p>
+								appropriate package document.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-metadata.xml">Metadata File (<code>metadata.xml</code>)</dt>
 						<dd>
-							<p>Reading Systems SHOULD ignore <a data-cite="epub-33#sec-container-metainf-metadata.xml"
+							<p>Reading systems SHOULD ignore <a data-cite="epub-33#sec-container-metainf-metadata.xml"
 										><code>metadata.xml</code> files</a> [[EPUB-33]] with unrecognized root
 								elements.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-manifest.xml">Manifest File (<code>manifest.xml</code>)</dt>
 						<dd>
-							<p>Reading Systems MUST NOT use ancillary manifest information contained in the ZIP archive
+							<p>Reading systems MUST NOT use ancillary manifest information contained in the ZIP archive
 								or in the <a data-cite="epub-33#sec-container-metainf-manifest.xml"
 										><code>manifest.xml</code> file</a> [[EPUB-33]] for processing an <a>EPUB
-									Publication</a>.</p>
+									publication</a>.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-signature.xml">Signature File (<code>signature.xml</code>)</dt>
 						<dd>
 							<p>Before computing the digest used to validate the signature in the <a
 									data-cite="epub-33#sec-container-metainf-signature.xml"><code>signature.xml</code>
-									file</a> [[EPUB-33]], Reading Systems MUST decrypt any data encrypted after signing
+									file</a> [[EPUB-33]], reading systems MUST decrypt any data encrypted after signing
 								&#8212; data encrypted before signing MUST NOT be decrypted.</p>
 							<p>Refer to Decryption Transform for XML Signature [[XMLENC-DECRYPT]] for more information
 								about identifying data encrypted after signing.</p>
@@ -607,7 +608,7 @@
 
 						<dt id="sec-container-metainf-inc">Other Files</dt>
 						<dd>
-							<p>Reading Systems MUST NOT fail when encountering configuration files in the <code
+							<p>Reading systems MUST NOT fail when encountering configuration files in the <code
 									class="filename">META-INF</code> directory not listed in <a
 									data-cite="epub-33#sec-container-metainf-files">Reserved Files</a> [[EPUB-33]].</p>
 						</dd>
@@ -618,39 +619,39 @@
 			<section id="sec-container-zip">
 				<h3>OCF ZIP container</h3>
 
-				<p>A Reading System:</p>
+				<p>A reading system:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-zip-mult">MUST treat any OCF Containers that specify the [[ZIP]] file is split
+						<p id="confreq-zip-mult">MUST treat any OCF containers that specify the [[ZIP]] file is split
 							across multiple storage media as in error.</p>
 					</li>
 					<li>
-						<p id="confreq-zip-comp">MUST treat any OCF Containers that use compression techniques other
+						<p id="confreq-zip-comp">MUST treat any OCF containers that use compression techniques other
 							than Deflate [[RFC1951]] as in error.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-64">MUST support the ZIP64 extensions defined as "Version 1" [[ZIP]].</p>
 					</li>
 					<li>
-						<p id="confreq-zip-enc">MUST treat OCF ZIP Containers that use [[ZIP]] encryption features as in
+						<p id="confreq-zip-enc">MUST treat OCF ZIP containers that use [[ZIP]] encryption features as in
 							error.</p>
 					</li>
 					<li>
-						<p id="confreq-zip-rootdir">MAY generate a physical directory for the <a>Root Directory</a> of
-							the OCF Abstract Container if it unzips the contents.</p>
+						<p id="confreq-zip-rootdir">MAY generate a physical directory for the <a>root directory</a> of
+							the OCF abstract container if it unzips the contents.</p>
 					</li>
 					<li>
-						<p id="confreq-zip-preserve">does not have to preserve information from an OCF ZIP Container
-							through load and save operations outside the context of the OCF Abstract Container. In
-							particular, a Reading System does not have to preserve CRC values, comment fields or fields
+						<p id="confreq-zip-preserve">does not have to preserve information from an OCF ZIP container
+							through load and save operations outside the context of the OCF abstract container. In
+							particular, a reading system does not have to preserve CRC values, comment fields or fields
 							that hold file system information corresponding to a particular operating system (e.g., <em
 								class="firstterm">External file attributes</em> and <em class="firstterm">Extra
 								field</em>).</p>
 					</li>
 				</ul>
 
-				<p>With respect to specific fields in the OCF ZIP Container archive, the Reading System:</p>
+				<p>With respect to specific fields in the OCF ZIP container archive, the reading system:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -664,7 +665,7 @@
 							error.</p>
 					</li>
 					<li>
-						<p id="confreq-zip-fld-er">MUST treat OCF ZIP Containers with an <code>Archive decryption
+						<p id="confreq-zip-fld-er">MUST treat OCF ZIP containers with an <code>Archive decryption
 								header</code> or an <code>Archive extra data record</code> [[ZIP]] as being in
 							error.</p>
 					</li>
@@ -674,17 +675,17 @@
 			<section id="sec-container-fobfus">
 				<h3>Font obfuscation</h3>
 
-				<p id="confreq-ocf-fobfus">Reading Systems SHOULD support deobfuscation of fonts as defined in <a
+				<p id="confreq-ocf-fobfus">Reading systems SHOULD support deobfuscation of fonts as defined in <a
 						data-cite="epub-33#sec-font-obfuscation">Font Obfuscation</a> [[EPUB-33]].</p>
 
-				<p>To restore the original data, Reading Systems should simply reverse the process: the source file
+				<p>To restore the original data, reading systems should simply reverse the process: the source file
 					becomes the obfuscated data, and the destination file contains the raw data.</p>
 
 				<div class="note">
 					<p>EPUB 3 allowed font obfuscation prior to EPUB 3.0.1, but did not specify the order of obfuscation
-						and compression. As a result, Reading Systems might encounter invalid fonts after decompression
+						and compression. As a result, reading systems might encounter invalid fonts after decompression
 						and deobfuscation. In such instances, deobfuscating the data before inflating it may return a
-						valid font. Reading Systems do not have to support this method of retrieval, but developers
+						valid font. Reading systems do not have to support this method of retrieval, but developers
 						should consider it when supporting EPUB 3 content generally.</p>
 				</div>
 			</section>
@@ -692,8 +693,8 @@
 		<section id="sec-package-doc">
 			<h2>Package document processing</h2>
 
-			<p id="confreq-rs-epub-pub" class="support">Reading Systems MUST process the <a
-					data-cite="epub-33#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
+			<p id="confreq-rs-epub-pub" class="support">Reading systems MUST process the <a
+					data-cite="epub-33#sec-package-doc">package document</a> [[EPUB-33]].</p>
 
 			<section id="sec-pkg-doc-base-dir">
 				<h4>Base direction</h4>
@@ -701,13 +702,13 @@
 				<p id="confreq-rs-pkg-dir"
 					data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
 					>If the <a data-cite="epub-33#attrdef-dir"><code>dir</code> attribute</a> [[EPUB-33]] is set and
-					indicates a base direction of <code>ltr</code> or <code>rtl</code>, Reading Systems MUST override
+					indicates a base direction of <code>ltr</code> or <code>rtl</code>, reading systems MUST override
 					the bidi algorithm per <a data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a>
 					defined in [[BIDI]], setting the paragraph embedding level to 0 if the base direction is
 						<code>ltr</code>, or 1 if the base direction is <code>rtl</code>.</p>
 
 				<p id="confreq-rs-pkg-dir-auto" data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Otherwise
-					the base direction is <code>auto</code>, in which case Reading Systems MUST determine the text's
+					the base direction is <code>auto</code>, in which case reading systems MUST determine the text's
 					direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a>
 					of [[BIDI]].</p>
 			</section>
@@ -715,9 +716,9 @@
 			<section id="sec-pkg-doc-pub-identifiers">
 				<h3>Unique identifier</h3>
 
-				<p id="confreq-rs-pkg-unique-id" data-tests="#pkg-unique-id">Reading Systems SHOULD NOT depend on the <a
+				<p id="confreq-rs-pkg-unique-id" data-tests="#pkg-unique-id">Reading systems SHOULD NOT depend on the <a
 						data-cite="epub-33#dfn-unique-identifier">Unique Identifier</a> being unique to one and only one
-					EPUB Publication. Determining whether two EPUB Publications with the same Unique Identifier
+					EPUB publication. Determining whether two EPUB publications with the same Unique Identifier
 					represent different versions of the same publication, or different publications, may require
 					inspecting other metadata, such as their last modification dates, titles, and authors.</p>
 			</section>
@@ -728,8 +729,8 @@
 				<dl class="conformance-list">
 					<dt id="conf-meta-ws">White Space</dt>
 					<dd>
-						<p id="confreq-rs-pkg-whitespace" data-tests="#pkg-meta-whitespace">Reading Systems MUST 
-							<a>strip and collapse ASCII whitespace</a> [[Infra]] from Dublin Core [[DCTERMS]] and <a
+						<p id="confreq-rs-pkg-whitespace" data-tests="#pkg-meta-whitespace">Reading systems MUST
+								<a>strip and collapse ASCII whitespace</a> [[Infra]] from Dublin Core [[DCTERMS]] and <a
 								data-cite="epub-33#sec-meta-elem"><code>meta</code></a> element <a
 								data-cite="epub-33#dfn-value">values</a> [[EPUB-33]] before processing.</p>
 					</dd>
@@ -738,16 +739,16 @@
 					<dd>
 						<p>To determine whether the value of a <a data-cite="epub-33#sec-opf-dcidentifier"
 									><code>dc:identifier</code> element</a> [[EPUB-33]] conforms to an established
-							system or has been granted by an issuing authority, Reading Systems SHOULD check for an <a
+							system or has been granted by an issuing authority, reading systems SHOULD check for an <a
 								data-cite="epub-33#identifier-type"><code>identifier-type</code> property</a>
 							[[EPUB-33]].</p>
 					</dd>
 
 					<dt id="dc-title">The <code>dc:title</code> element</dt>
 					<dd>
-						<p id="title-order" data-tests="#pkg-title-order">Reading Systems MUST recognize the first <a
+						<p id="title-order" data-tests="#pkg-title-order">Reading systems MUST recognize the first <a
 								data-cite="epub-33#sec-opf-dctitle"><code>dc:title</code> element</a> [[EPUB-33]] in
-							document order as the main title of the EPUB Publication and present it to users before
+							document order as the main title of the EPUB publication and present it to users before
 							other title elements.</p>
 						<p>This specification does not define how to process additional <code>dc:title</code>
 							elements.</p>
@@ -755,71 +756,71 @@
 
 					<dt id="sec-opf-dclanguage">The <code>dc:language</code> element</dt>
 					<dd>
-						<p>The language(s) of the <a>EPUB Publication</a> specified in <a
+						<p>The language(s) of the <a>EPUB publication</a> specified in <a
 								data-cite="epub-33#sec-opf-dclanguage"><code>dc:language</code> elements</a> are
 							informational. Some uses of this information include:</p>
 						<ul>
-							<li>exposing it to the user through the Reading System user interface</li>
+							<li>exposing it to the user through the reading system user interface</li>
 							<li>using it to enhance functionality in a bookshelf (e.g., sorting by language)</li>
 							<li>using it to optimize the reading interface (e.g., to preload text-to-speech
 								languages)</li>
 						</ul>
 						<p>See <a href="#sec-epub-rs-i18n"></a> for more details on how to determine the language of a
-								<a>Publication Resource</a>.</p>
+								<a>publication resource</a>.</p>
 					</dd>
 
 					<dt id="dc-creator">The <code>dc:creator</code> element</dt>
 					<dd>
 						<p id="confreq-rs-pkg-creator-order" data-tests="#pkg-creator-order">When determining display
-							priority, Reading Systems MUST use the document order of <a
+							priority, reading systems MUST use the document order of <a
 								data-cite="epub-33#sec-opf-dccreator"><code>dc:creator</code> elements</a> [[EPUB-33]]
 							in the <code>metadata</code> section, where the first <code>creator</code> element
-							encountered is the primary creator. If a Reading System exposes creator metadata to the
+							encountered is the primary creator. If a reading system exposes creator metadata to the
 							user, it SHOULD include all the creators listed in the <code>metadata</code> section
 							whenever possible (e.g., when not constrained by display considerations).</p>
 					</dd>
 
 					<dt id="meta">The <code>meta</code> element</dt>
 					<dd>
-						<p>Reading Systems SHOULD ignore all <a data-cite="epub-33#sec-meta-elem"><code>meta</code>
+						<p>Reading systems SHOULD ignore all <a data-cite="epub-33#sec-meta-elem"><code>meta</code>
 								elements</a> whose <a data-cite="epub-33#attrdef-meta-property"><code>property</code>
 								attributes</a> [[EPUB-33]] define expressions they do not recognize. <span
-								id="confreq-rs-pkg-meta-unknown" data-tests="#pkg-meta-unknown">A Reading System MUST
+								id="confreq-rs-pkg-meta-unknown" data-tests="#pkg-meta-unknown">A reading system MUST
 								NOT fail when encountering unknown expressions.</span></p>
 						<p>If the <code>property</code> attribute's value does not include a <a
-								data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], Reading Systems MUST
+								data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], reading systems MUST
 							use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to <a
 								href="#sec-property-datatype">expand the value</a>.</p>
-						<p>If a Reading System does not recognize the <a data-cite="epub-33#attrdef-scheme"
+						<p>If a reading system does not recognize the <a data-cite="epub-33#attrdef-scheme"
 									><code>scheme</code> attribute</a> [[EPUB-33]] value, it SHOULD treat the value of
 							the element as a string.</p>
 					</dd>
 
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
 					<dd>
-						<p>Retrieval and support of linked resources is OPTIONAL.</p>
+						<p>Retrieval and support of <a>linked resources</a> is OPTIONAL.</p>
 						<p>The language identified in an <a data-cite="epub-33#attrdef-hreflang"><code>hreflang</code>
-								attribute</a> is purely advisory. Upon fetching the resource, a Reading System MUST use
+								attribute</a> is purely advisory. Upon fetching the resource, a reading system MUST use
 							the language information associated with the resource to determine its language, not the
 							metadata included in the link to the resource.</p>
 						<p id="sec-linked-records" data-tests="#pkg-linked-records">In the case of a <a
-								data-cite="epub-33#record">linked metadata record</a> [[EPUB-33]], Reading Systems MUST
-							NOT skip processing the metadata expressed in the Package Document (i.e., use only the
-							information expressed in the record). Reading Systems MAY compile metadata from multiple
+								data-cite="epub-33#record">linked metadata record</a> [[EPUB-33]], reading systems MUST
+							NOT skip processing the metadata expressed in the package document (i.e., use only the
+							information expressed in the record). Reading systems MAY compile metadata from multiple
 							linked records.</p>
-						<p>When resolving discrepancies and conflicts between metadata expressed in the Package Document
-							and in linked metadata records, Reading Systems MUST use the document order of <a
+						<p>When resolving discrepancies and conflicts between metadata expressed in the package document
+							and in linked metadata records, reading systems MUST use the document order of <a
 								data-cite="epub-33#sec-link-elem"><code>link</code> elements</a> [[EPUB-33]] in the
-							Package Document to establish precedence (i.e., metadata in the first linked record has the
-							highest precedence and metadata in the Package Document the lowest, regardless of whether
+							package document to establish precedence (i.e., metadata in the first linked record has the
+							highest precedence and metadata in the package document the lowest, regardless of whether
 							the <code>link</code> elements occur before, within, or after the package metadata
 							elements).</p>
-						<p>Reading Systems MUST ignore any instructions contained in linked resources related to the
-							layout and rendering of the EPUB Publication.</p>
+						<p>Reading systems MUST ignore any instructions contained in linked resources related to the
+							layout and rendering of the EPUB publication.</p>
 						<p>If any of the <a data-cite="epub-33#attrdef-link-rel"><code>rel</code></a> or <a
 								data-cite="epub-33#attrdef-properties"><code>properties</code></a> [[EPUB-33]]
 							attributes' values do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a>,
-							Reading Systems MUST use the prefix URL
+							reading systems MUST use the prefix URL
 								"<code>http://idpf.org/epub/vocab/package/link/#</code>" to <a
 								href="#sec-property-datatype">expand the values</a>.</p>
 					</dd>
@@ -829,35 +830,35 @@
 			<section id="sec-pkg-doc-manifest">
 				<h3>Manifest</h3>
 
-				<p id="confreq-rs-pkg-manifest-unknown" data-tests="#pkg-manifest-unknown">Reading Systems MUST ignore
+				<p id="confreq-rs-pkg-manifest-unknown" data-tests="#pkg-manifest-unknown">Reading systems MUST ignore
 					values of the <a data-cite="epub-33#sec-item-resource-properties"><code>properties</code>
 						attribute</a> [[EPUB-33]] they do not recognize.</p>
 
-				<p id="confreq-rendition-rs-manifest" data-tests="#pkg-manifest-unlisted-resource">Reading Systems
-					SHOULD NOT use <a>Linked Resources</a> in the rendering of an EPUB Publication due to the inherent
+				<p id="confreq-rendition-rs-manifest" data-tests="#pkg-manifest-unlisted-resource">Reading systems
+					SHOULD NOT use <a>linked resources</a> in the rendering of an EPUB publication due to the inherent
 					limitations and risks involved (e.g., lack of information about the resource and how to process it,
 					security risks from remotely-hosted sources, lack of fallbacks, etc.).</p>
 
-				<p>A Reading System that does not support the MIME media type [[RFC2046]] of a given Publication
-					Resource MUST traverse the <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a>
-					[[EPUB-33]] until it identifies a supported Publication Resource to use in place of the unsupported
-					resource. If the Reading System supports multiple Publication Resources in the fallback chain, it
+				<p>A reading system that does not support the MIME media type [[RFC2046]] of a given publication
+					resource MUST traverse the <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a>
+					[[EPUB-33]] until it identifies a supported publication resource to use in place of the unsupported
+					resource. If the reading system supports multiple publication resources in the fallback chain, it
 					MAY select the resource to use based on the resource's <a
 						data-cite="epub-33#attrdef-item-properties"><code>properties</code> attribute</a> [[EPUB-33]]
-					values, otherwise it SHOULD honor the EPUB Creator's preferred fallback order. If a Reading System
+					values, otherwise it SHOULD honor the EPUB creator's preferred fallback order. If a reading system
 					does not support any resource in the fallback chain, it MUST alert the reader that it could not
 					display the content.</p>
 
 				<p>When <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallbacks</a> [[EPUB-33]] are provided
-					for <a>Top-level Content Documents</a>, Reading Systems MAY choose from the available options to
+					for <a>top-level content documents</a>, reading systems MAY choose from the available options to
 					find the optimal version to render in a given context (e.g., by inspecting the properties attribute
 					for each).</p>
 
-				<p>A Reading System MUST terminate the fallback chain at the first reference to a manifest item it has
+				<p>A reading system MUST terminate the fallback chain at the first reference to a manifest item it has
 					already encountered.</p>
 
 				<p>If any of the <code>properties</code> attribute's values do not include a <a
-						data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], Reading Systems MUST use the
+						data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], reading systems MUST use the
 					prefix URL "<code>http://idpf.org/epub/vocab/package/item/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 			</section>
@@ -865,8 +866,8 @@
 			<section id="sec-pkg-doc-spine">
 				<h3>Spine</h3>
 
-				<p id="confreq-rs-spine-order" data-tests="#pkg-spine-order">Reading Systems MUST provide a means of
-					rendering the EPUB Publication in the order defined in the <a data-cite="epub-33#sec-spine-elem"
+				<p id="confreq-rs-spine-order" data-tests="#pkg-spine-order">Reading systems MUST provide a means of
+					rendering the EPUB publication in the order defined in the <a data-cite="epub-33#sec-spine-elem"
 							><code>spine</code> element</a> [[EPUB-33]], which includes:</p>
 				<ul>
 					<li>recognizing the first <a data-cite="epub-33#attrdef-itemref-linear">primary (linear)
@@ -876,45 +877,45 @@
 				</ul>
 
 				<p id="confreq-rendition-rs-spine-nonlinear">When a user traverses the default reading order defined in
-					the <code>spine</code> element, a Reading System MAY automatically skip <a
+					the <code>spine</code> element, a reading system MAY automatically skip <a
 						data-cite="epub-33#attrdef-itemref-linear">non-linear <code>itemref</code> elements</a>
 					[[EPUB-33]]. <span id="confreq-rs-spine-nonlinear-activation"
 						data-tests="#pkg-spine-nonlinear-activation">When a user activates a hyperlink to a non-linear
-						resource, however, Reading Systems MUST render the referenced resource or a designated
-						fallback.</span> Reading Systems MAY also provide the option for users to skip non-linear
+						resource, however, reading systems MUST render the referenced resource or a designated
+						fallback.</span> Reading systems MAY also provide the option for users to skip non-linear
 					content by default or not.</p>
 
 				<p id="confreq-rs-spine-progression-default" data-tests="#pkg-spine-progression-default">If the EPUB
-					Creator has not specified the <a data-cite="epub-33#attrdef-spine-page-progression-direction"
-							><code>page-progression-direction</code> attribute</a> [[EPUB-33]], the Reading System MUST
+					creator has not specified the <a data-cite="epub-33#attrdef-spine-page-progression-direction"
+							><code>page-progression-direction</code> attribute</a> [[EPUB-33]], the reading system MUST
 					assume the value of <code>default</code>. When <code>page-progression-direction</code> value is
-						<code>default</code>, the Reading System can choose the rendering direction.</p>
+						<code>default</code>, the reading system can choose the rendering direction.</p>
 
 				<p id="confreq-rs-spine-progression-pre-paginated" data-tests="#pkg-spine-progression-pre-paginated">If
 					the <code>page-progression-direction</code> attribute has a value other than <code>default</code>,
-					the Reading System MUST ignore any directionality computed from <a href="#layout"
+					the reading system MUST ignore any directionality computed from <a href="#layout"
 							><code>pre-paginated</code></a>
-					<a>XHTML Content Documents</a>.</p>
+					<a>XHTML content documents</a>.</p>
 
 				<p>If any values of the <a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a>
-					do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], Reading Systems
+					do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], reading systems
 					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 
-				<p id="confreq-rs-pkg-spine-unknown" data-tests="#pkg-spine-unknown">Reading Systems MUST ignore all
+				<p id="confreq-rs-pkg-spine-unknown" data-tests="#pkg-spine-unknown">Reading systems MUST ignore all
 					values expressed in spine <code>itemref</code>
 					<code>properties</code> attributes that they do not recognize.</p>
 
 				<p>
 					<span id="confreq-rs-pkg-duplicate-item-rendering" data-tests="#pkg-spine-duplicate-item-rendering">
-						Reading Systems MUST NOT skip spine references to duplicate manifest items when rendering the
+						Reading systems MUST NOT skip spine references to duplicate manifest items when rendering the
 						linear reading order.</span>
-					<span id="confreq-rs-pkg-duplicate-item-ui" data-tests="#pkg-spine-duplicate-item-ui">The Reading
-						System MUST treat these as distinct items for user interface (UI) purposes (for example, each
+					<span id="confreq-rs-pkg-duplicate-item-ui" data-tests="#pkg-spine-duplicate-item-ui">The reading
+						system MUST treat these as distinct items for user interface (UI) purposes (for example, each
 						occurrence could be independently bookmarked or annotated).</span>
 					<span id="confreq-rs-pkg-duplicate-item-hyperlink" data-tests="#pkg-spine-duplicate-item-hyperlink"
-						>When a Reading System follows a hyperlink to a resource referenced multiple times in the spine,
-						the Reading System MUST navigate to the first occurrence of the document in the linear reading
+						>When a reading system follows a hyperlink to a resource referenced multiple times in the spine,
+						the reading system MUST navigate to the first occurrence of the document in the linear reading
 						order.</span>
 				</p>
 
@@ -923,8 +924,8 @@
 
 					<p>When a spine <a data-cite="epub-33#sec-itemref-elem"><code>itemref</code> element's</a>
 						<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a <a
-							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[EPUB-33]], Reading
-						Systems MUST follow the requirements for the override's global value to display that spine
+							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[EPUB-33]], reading
+						systems MUST follow the requirements for the override's global value to display that spine
 						item.</p>
 
 					<p>For example, a spine item that contains the <a data-cite="epub-33#layout-overrides"
@@ -933,7 +934,7 @@
 							value</a>.</p>
 
 					<p>If more than one override for the same property is specified in a <code>properties</code>
-						attribute, Reading Systems MUST use only the first value.</p>
+						attribute, reading systems MUST use only the first value.</p>
 				</section>
 			</section>
 
@@ -941,28 +942,28 @@
 				<h3>Collections</h3>
 
 				<p>In the context of this specification, support for <a data-cite="epub-33#sec-collection-elem"
-						>collections</a> [[EPUB-33]] in Reading Systems is OPTIONAL. <span
-						id="confreq-rs-pkg-collections-unknown" data-tests="#pkg-collections-unknown">Reading Systems
+						>collections</a> [[EPUB-33]] in reading systems is OPTIONAL. <span
+						id="confreq-rs-pkg-collections-unknown" data-tests="#pkg-collections-unknown">Reading systems
 						MUST ignore <code>collection</code> elements that define unrecognized roles.</span></p>
 			</section>
 		</section>
 		<section id="sec-contentdocs">
 			<h2>Content Document processing</h2>
 
-			<p>The definition of <a data-cite="epub-33#sec-contentdocs">EPUB Content Documents</a> [[EPUB-33]] includes
+			<p>The definition of <a data-cite="epub-33#sec-contentdocs">EPUB content documents</a> [[EPUB-33]] includes
 				various authoring restrictions to optimize the cross-compatibility of content (e.g., <a
 					data-cite="epub-33#sec-css-req">prohibiting CSS for setting language and direction</a>
-				[[?EPUB-33]]). Unless stated otherwise in this specification, Reading Systems MAY support these
+				[[?EPUB-33]]). Unless stated otherwise in this specification, reading systems MAY support these
 				restricted features.</p>
 
 			<section id="sec-xhtml">
-				<h3>XHTML Content Documents</h3>
+				<h3>XHTML content documents</h3>
 
-				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="#cnt-xhtml-support">Reading Systems MUST
-					process <a data-cite="epub-33#sec-xhtml">XHTML Content Documents</a> [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="#cnt-xhtml-support">Reading systems MUST
+					process <a data-cite="epub-33#sec-xhtml">XHTML content documents</a> [[EPUB-33]].</p>
 
-				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, Reading
-					Systems MUST process XHTML Content Documents using semantics defined by the [[HTML]] specification
+				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, reading
+					systems MUST process XHTML content documents using semantics defined by the [[HTML]] specification
 					and honor any applicable user agent conformance constraints expressed therein.</p>
 
 				<section id="sec-xhtml-extensions">
@@ -971,7 +972,7 @@
 					<section id="sec-xhtml-aria">
 						<h5>ARIA</h5>
 
-						<p id="confreq-html-rs-a11y">Reading Systems SHOULD recognize embedded ARIA markup and support
+						<p id="confreq-html-rs-a11y">Reading systems SHOULD recognize embedded ARIA markup and support
 							exposure of any given ARIA roles, states and properties to platform accessibility APIs
 							[[WAI-ARIA]].</p>
 					</section>
@@ -980,22 +981,21 @@
 						<h5>Structural semantics</h5>
 
 						<p id="confreq-rs-epubtype-head">In addition to the requirements in <a
-								href="#sec-structural-semantics"></a>, a Reading System MUST ignore semantics expressed
-							on the [[HTML]] <a><code>head</code></a> element or its
-							descendants.</p>
+								href="#sec-structural-semantics"></a>, a reading system MUST ignore semantics expressed
+							on the [[HTML]] <a><code>head</code></a> element or its descendants.</p>
 					</section>
 
 					<section id="sec-xhtml-rdfa">
 						<h5>RDFa</h5>
 
-						<p>Reading System support for the <a data-cite="rdfa-core#s_model">attribute processing
+						<p>Reading system support for the <a data-cite="rdfa-core#s_model">attribute processing
 								model</a> [[RDFA-CORE]] is OPTIONAL.</p>
 					</section>
 
 					<section id="sec-xhtml-microdata">
 						<h5>Microdata</h5>
 
-						<p>Reading System support for the <a data-cite="microdata#encoding-microdata">attribute
+						<p>Reading system support for the <a data-cite="microdata#encoding-microdata">attribute
 								processing model</a> is OPTIONAL, as is the <a data-cite="microdata#json">conversion to
 								JSON</a> [[Microdata]].</p>
 					</section>
@@ -1019,7 +1019,7 @@
 					<section id="sec-xhtml-custom-attributes">
 						<h5>Custom attributes</h5>
 
-						<p>Reading Systems MAY support custom attributes provided the attributes do not modify the
+						<p>Reading systems MAY support custom attributes provided the attributes do not modify the
 							requirements of this specification.</p>
 					</section>
 				</section>
@@ -1030,8 +1030,8 @@
 					<section id="sec-xhtml-mathml">
 						<h3>MathML</h3>
 
-						<p>To support MathML [[MathML3]] embedded in <a>XHTML Content Documents</a>, a Reading
-							System:</p>
+						<p>To support MathML [[MathML3]] embedded in <a>XHTML content documents</a>, a reading
+							system:</p>
 
 						<ul class="conformance-list">
 							<li>
@@ -1042,7 +1042,7 @@
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-render" data-tests="#cnt-mathml-support">MUST, if it has a
-										<a>Viewport</a>, support visual rendering of Presentation MathML.</p>
+										<a>viewport</a>, support visual rendering of Presentation MathML.</p>
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
@@ -1052,35 +1052,35 @@
 							</li>
 						</ul>
 
-						<p class="note">Reading Systems may choose to use third-party libraries such as <a
+						<p class="note">Reading systems may choose to use third-party libraries such as <a
 								href="https://www.mathjax.org/">MathJax</a> to provide MathML rendering.</p>
 					</section>
 
 					<section id="sec-xhtml-svg">
 						<h5>Embedded SVG</h5>
 
-						<p id="confreq-svg-rs-embed" data-tests="#cnt-svg-embedded">Reading Systems MUST process SVG
-							embedded in <a>XHTML Content Documents</a> as defined in <a href="#sec-svg"></a>.</p>
+						<p id="confreq-svg-rs-embed" data-tests="#cnt-svg-embedded">Reading systems MUST process SVG
+							embedded in <a>XHTML content documents</a> as defined in <a href="#sec-svg"></a>.</p>
 
 						<section id="sec-xhtml-svg-css">
 							<h6>Embedded SVG and CSS</h6>
 
 							<p id="confreq-svg-rs-css-embed-ref" data-tests="#cnt-svg-css-reference">For the purposes of
-								styling SVG embedded in <a>XHTML Content Documents</a>
-								<em>by reference</em>, Reading Systems MUST NOT apply CSS style rules of the containing
+								styling SVG embedded in <a>XHTML content documents</a>
+								<em>by reference</em>, reading systems MUST NOT apply CSS style rules of the containing
 								document to the referenced SVG document.</p>
 
 							<p id="confreq-svg-rs-css-embed-inc" data-tests="#cnt-svg-css-inclusion">For the purposes of
-								styling SVG embedded in XHTML Content Documents <em>by inclusion</em>, Reading Systems
+								styling SVG embedded in XHTML content documents <em>by inclusion</em>, reading systems
 								MUST apply applicable CSS rules of the containing document to the included SVG
 								elements.</p>
 
 							<div class="note">
 								<p>SVG included <em>by reference</em> is processed as a separate document, and can
-									include its own CSS style rules just like an <a>SVG Content Document</a> would. Note
-									that this is consistent with situations where an [[HTML]] <a
-										data-lt="object"><code>object</code> element</a> references
-									an external [[HTML]] element.</p>
+									include its own CSS style rules just like an <a>SVG content document</a> would. Note
+									that this is consistent with situations where an [[HTML]] <a data-lt="object"
+											><code>object</code> element</a> references an external [[HTML]]
+									element.</p>
 							</div>
 						</section>
 					</section>
@@ -1088,24 +1088,24 @@
 					<section id="sec-xhtml-forms">
 						<h5>Form submission</h5>
 
-						<p>Reading System support for the submission of [[HTML]] forms is OPTIONAL. A Reading System
+						<p>Reading system support for the submission of [[HTML]] forms is OPTIONAL. A reading system
 							might, for example, prevent form submissions by limiting access to networking.</p>
 					</section>
 				</section>
 			</section>
 
 			<section id="sec-svg">
-				<h3>SVG Content Documents</h3>
+				<h3>SVG content documents</h3>
 
-				<p id="confreq-rs-epub3-svg" class="support" data-tests="#cnt-svg-support">Reading Systems MUST process
-						<a data-cite="epub-33#sec-svg">SVG Content Documents</a> [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-svg" class="support" data-tests="#cnt-svg-support">Reading systems MUST process
+						<a data-cite="epub-33#sec-svg">SVG content documents</a> [[EPUB-33]].</p>
 
-				<p>To process SVG Content Documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML Content
-						Documents</a>, a Reading System:</p>
+				<p>To process SVG content documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML content
+						documents</a>, a reading system:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-svg-rs-behavior">MUST process SVG Content Documents using semantics defined by
+						<p id="confreq-svg-rs-behavior">MUST process SVG content documents using semantics defined by
 							the [[SVG]] specification, and honor any applicable user agent conformance constraints
 							expressed therein, unless explicitly defined by this specification as overridden.</p>
 					</li>
@@ -1114,11 +1114,11 @@
 								href="#sec-scripted-content"></a>.</p>
 					</li>
 					<li>
-						<p id="confreq-svg-rs-css">MUST, if it has a <a>Viewport</a>, support the visual rendering of
+						<p id="confreq-svg-rs-css">MUST, if it has a <a>viewport</a>, support the visual rendering of
 							SVG using CSS as defined in <a href="https://www.w3.org/TR/SVG/styling.html#">Styling</a>
 							[[SVG]] and it SHOULD support all properties defined in the <a
 								href="https://www.w3.org/TR/SVG/propidx.html#">Property Index</a> [[SVG]]. In the case
-							of embedded SVG, a Reading System MUST also conform to the constraints defined in <a
+							of embedded SVG, a reading system MUST also conform to the constraints defined in <a
 								href="#sec-xhtml-svg-css"></a>.</p>
 					</li>
 				</ul>
@@ -1127,11 +1127,11 @@
 			<section id="sec-css">
 				<h3>Cascading Style Sheets (CSS)</h3>
 
-				<p id="confreq-rs-epub3-css" class="support">If a Reading System has a <a>Viewport</a>, it MUST support
-					the <a data-cite="epub-33#sec-css">visual rendering of XHTML Content Documents via CSS</a>
+				<p id="confreq-rs-epub3-css" class="support">If a reading system has a <a>viewport</a>, it MUST support
+					the <a data-cite="epub-33#sec-css">visual rendering of XHTML content documents via CSS</a>
 					[[EPUB-33]].</p>
 
-				<p>To support CSS, a Reading System:</p>
+				<p>To support CSS, a reading system:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -1155,91 +1155,91 @@
 								Style Sheets — Prefixed Properties</a> [[EPUB-33]].</p>
 					</li>
 					<li>
-						<p id="confreq-css-creator-styles">SHOULD apply <a>EPUB Creator</a> style sheets as written to
-								<a>EPUB Content Documents</a>.</p>
+						<p id="confreq-css-creator-styles">SHOULD apply <a>EPUB creator</a> style sheets as written to
+								<a>EPUB content documents</a>.</p>
 					</li>
 					<li>
-						<p id="confreq-css-overrides">SHOULD NOT override the EPUB Creator's style sheets, but SHOULD do
+						<p id="confreq-css-overrides">SHOULD NOT override the EPUB creator's style sheets, but SHOULD do
 							so in a way that preserves the Cascade when necessary: through a user agent style sheet, the
 								<a data-cite="DOM-Level-2-Style/css.html#CSS-OverrideAndComputed"
 									><code>getOverrideStyle</code></a> method [[DOM-Level-2-Style]], or [[HTML]]
-									[^html-global/style^] attributes.</p>
+							[^html-global/style^] attributes.</p>
 					</li>
 					<li>
-						<p id="confreq-css-user-styles">It MAY override parts of the EPUB Creator's style sheet because
+						<p id="confreq-css-user-styles">It MAY override parts of the EPUB creator's style sheet because
 							of user interaction.</p>
 					</li>
 				</ul>
 
-				<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above, a Reading
-					System's user agent style sheet SHOULD support the [[HTML]] <a data-cite="html#rendering">suggested
+				<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above, a reading
+					system's user agent style sheet SHOULD support the [[HTML]] <a data-cite="html#rendering">suggested
 						default rendering</a>.</p>
 
-				<p>Reading System developers should implement CSS support at the level of major browsers and publicly
-					document their user agent style sheets and how they interact with EPUB Creator's style sheets.</p>
+				<p>Reading system developers should implement CSS support at the level of major browsers and publicly
+					document their user agent style sheets and how they interact with EPUB creator's style sheets.</p>
 			</section>
 
 			<section id="sec-scripted-content">
 				<h3>Scripting</h3>
 
 				<p id="confreq-rs-scripted" class="support"
-					data-test="#scr-support,#scr-support_iframe,#scr-support_svg">Reading Systems SHOULD support <a
+					data-test="#scr-support,#scr-support_iframe,#scr-support_svg">Reading systems SHOULD support <a
 						data-cite="epub-33#sec-scripted-content">scripting</a> [[EPUB-33]].</p>
 
-				<p>Reading System support for scripting depends on its usage context:</p>
+				<p>Reading system support for scripting depends on its usage context:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-rs-scripted-reflow-support">Reading Systems SHOULD support <a
+						<p id="confreq-rs-scripted-reflow-support">Reading systems SHOULD support <a
 								data-cite="epub-33#sec-scripted-container-constrained">container-constrained
-								scripting</a> [[EPUB-33]] in reflowable EPUB Content Documents.</p>
+								scripting</a> [[EPUB-33]] in reflowable EPUB content documents.</p>
 					</li>
 					<li>
-						<p id="confreq-rs-scripted-fxl-support">Reading Systems SHOULD support <a
+						<p id="confreq-rs-scripted-fxl-support">Reading systems SHOULD support <a
 								data-cite="epub-33#sec-scripted-spine">spine-level scripting</a> [[EPUB-33]] in <a
 								data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a> [[EPUB-33]].</p>
 					</li>
 					<li>
-						<p id="confreq-rs-scripted-scrolled">Reading Systems SHOULD support spine-level scripting in
-							reflowable EPUB Content Documents that use the <a data-cite="epub-33#flow-scrolled-doc"
+						<p id="confreq-rs-scripted-scrolled">Reading systems SHOULD support spine-level scripting in
+							reflowable EPUB content documents that use the <a data-cite="epub-33#flow-scrolled-doc"
 									>"<code>scrolled-doc</code>"</a> or <a data-cite="epub-33#flow-scrolled-continuous"
 									>"<code>scrolled-continuous</code>"</a> [[EPUB-33]] presentation modes defined by <a
 								href="#flow">the <code>rendition:flow</code> property</a>. Similarly, if it supports
-							spine-level scripting in reflowable EPUB Content Documents, it MUST implement the
+							spine-level scripting in reflowable EPUB content documents, it MUST implement the
 								"<code>scrolled-doc</code>" presentation mode and SHOULD implement the
 								"<code>scrolled-continuous</code>" presentation mode.</p>
 					</li>
 					<li>
-						<p id="confreq-rs-scripted-optional-support">Reading Systems MAY support scripting in other
+						<p id="confreq-rs-scripted-optional-support">Reading systems MAY support scripting in other
 							contexts, but this specification does not address such scripting. As a result, the use of
-							scripting in these contexts may not be consistent across Reading Systems.</p>
+							scripting in these contexts may not be consistent across reading systems.</p>
 					</li>
 				</ul>
 
-				<p>If a Reading System supports scripting:</p>
+				<p>If a reading system supports scripting:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-rs-scripted-ua">It MAY render <a>Scripted Content Documents</a> as an
+						<p id="confreq-rs-scripted-ua">It MAY render <a>scripted content documents</a> as an
 							interactive, scripted user agent according to [[HTML]].</p>
 					</li>
 
 					<li>
 						<p id="confreq-rs-scripted-origin">
 							<span id="confreq-rs-scripted-origin-shared" data-tests="#scr-support_origin">It MUST assign
-								a unique <a>origin</a> [[URL]], shared by all <a
-									data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> of the EPUB
-								Publication.</span>
-							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin">That <a>origin</a> [[URL]] MUST be <em>unique</em> for each
-								user-specific instance of an EPUB Publication in a Reading System.</span>
+								a unique <a>origin</a> [[URL]], shared by all <a data-cite="epub-33#sec-scripted-spine"
+									>spine-level scripts</a> of the EPUB publication.</span>
+							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin">That
+								<a>origin</a> [[URL]] MUST be <em>unique</em> for each user-specific instance of an EPUB
+								publication in a reading system.</span>
 						</p>
 					</li>
 
 					<li>
 						<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to modify
-							the [[DOM]] of the host EPUB Content Document or other contents in the EPUB Publication and
+							the [[DOM]] of the host EPUB content document or other contents in the EPUB publication and
 							MUST NOT allow it to manipulate the size of its containing rectangle. (Note: Even if a
-							script is not container-constrained, the Reading System MAY impose restrictions on
+							script is not container-constrained, the reading system MAY impose restrictions on
 							modifications (see also the <a href="#feature-dom-manipulation">dom-manipulation
 							feature</a>).)</p>
 					</li>
@@ -1263,33 +1263,33 @@
 					risk". If, in the final version of this document, the object becomes non-normative, then each "MUST"
 					statement in the last bullet item would become a "MAY".</p>
 
-				<p id="confreq-rs-scripted-flbk">If a Reading System does not support scripting, it MUST process
+				<p id="confreq-rs-scripted-flbk">If a reading system does not support scripting, it MUST process
 					fallbacks for scripted content as defined in <a data-cite="epub-33#confreq-cd-scripted-flbk"
-						>Fallbacks for Scripted Content Documents</a> [[EPUB-33]].</p>
+						>Fallbacks for scripted content documents</a> [[EPUB-33]].</p>
 
 				<section id="sec-local-storage">
 					<h4>Local storage</h4>
 
 					<p>Scripts may save persistent data through <a data-cite="html#dom-document-cookie">cookies</a> and
-							<a data-cite="html#webstorage">web storage</a> [[HTML]], but Reading Systems MAY block such
-						attempts. Reading Systems that allow users to store data MUST ensure they do not make that data
+							<a data-cite="html#webstorage">web storage</a> [[HTML]], but reading systems MAY block such
+						attempts. Reading systems that allow users to store data MUST ensure they do not make that data
 						available to other unrelated documents (e.g., ones that could be spoofed). In particular,
 						checking for a matching document identifier (or similar metadata) is not a valid method to
 						control access to persistent data.</p>
 
-					<p>Reading Systems that allow <a data-cite="html#dom-localstorage">local storage</a> [[HTML]] SHOULD
+					<p>Reading systems that allow <a data-cite="html#dom-localstorage">local storage</a> [[HTML]] SHOULD
 						provide methods for users to inspect or delete that data.</p>
 				</section>
 
 				<section id="sec-scripted-content-events">
 					<h4>Event model</h4>
 
-					<p>Reading Systems SHOULD follow the DOM Event model as per [[HTML]] and pass UI events to the
+					<p>Reading systems SHOULD follow the DOM Event model as per [[HTML]] and pass UI events to the
 						scripting environment before performing any default action associated with these events.</p>
 
-					<p>Reading System developers must ensure that scripts cannot disable critical functionality (such as
+					<p>Reading system developers must ensure that scripts cannot disable critical functionality (such as
 						navigation) to constrain the extent to which a <a href="#sec-scripted-content-security"
-							>potentially malicious</a> script could impact their Reading Systems. As a result, although
+							>potentially malicious</a> script could impact their reading systems. As a result, although
 						the scripting environment should be able to cancel the default action of any event, some events
 						either might not be passed through or might not be cancelable.</p>
 				</section>
@@ -1297,13 +1297,13 @@
 				<section id="sec-scripted-content-security" class="informative">
 					<h3>Security considerations</h3>
 
-					<p>Reading System developers who also support scripting must be aware of the security issues that
-						arise when Reading Systems execute scripted content. As the underlying scripting model employed
-						by Reading Systems and browsers is the same, developers must take into consideration the same
+					<p>Reading system developers who also support scripting must be aware of the security issues that
+						arise when reading systems execute scripted content. As the underlying scripting model employed
+						by reading systems and browsers is the same, developers must take into consideration the same
 						kinds of issues encountered in web contexts.</p>
 
-					<p>Each Reading System must establish if it can trust the scripts in a particular document. Reading
-						Systems should treat all scripts as untrusted (and potentially malicious), and developers should
+					<p>Each reading system must establish if it can trust the scripts in a particular document. Reading
+						systems should treat all scripts as untrusted (and potentially malicious), and developers should
 						examine all vectors of attack and protect against them. In particular, developers should
 						consider the following:</p>
 
@@ -1313,7 +1313,7 @@
 								drive);</p>
 						</li>
 						<li>
-							<p>an attack against the Reading System itself (e.g., stealing a list of a user's books or
+							<p>an attack against the reading system itself (e.g., stealing a list of a user's books or
 								causing unexpected behavior);</p>
 						</li>
 						<li>
@@ -1330,39 +1330,38 @@
 						</li>
 					</ul>
 
-					<p>To limit the possible damage of untrusted scripts, this specification recommends that Reading
-						Systems establish a unique <a>origin</a> [[URL]] allocated to each
-							<a>EPUB Publication</a> (see <a href="#sec-container-iri"></a>). Assigning a unique origin
-						ensures that <a data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> [[EPUB-33]] are
-						isolated from other EPUB Publications, and limits access to <a
-							data-cite="html#dom-document-cookie">cookies</a> [[HTML]], <a data-cite="html#webstorage"
-							>web storage</a> [[HTML]], etc.</p>
+					<p>To limit the possible damage of untrusted scripts, this specification recommends that reading
+						systems establish a unique <a>origin</a> [[URL]] allocated to each <a>EPUB publication</a> (see
+							<a href="#sec-container-iri"></a>). Assigning a unique origin ensures that <a
+							data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> [[EPUB-33]] are isolated from
+						other EPUB publications, and limits access to <a data-cite="html#dom-document-cookie"
+							>cookies</a> [[HTML]], <a data-cite="html#webstorage">web storage</a> [[HTML]], etc.</p>
 
 					<p>Examples of web APIs that are tied to the concept of "origin" include web storage [[HTML]] and
-						IndexedDB [[INDEXEDDB]], which EPUB Content Documents can interact with via scripting. Reading
-						Systems that allow users to add/remove publications from a managed library (their "bookshelf")
+						IndexedDB [[INDEXEDDB]], which EPUB content documents can interact with via scripting. Reading
+						systems that allow users to add/remove publications from a managed library (their "bookshelf")
 						may maintain the publication's unique origin when the publication is removed and subsequently
-						re-imported into the content library. Conversely, Reading Systems may create a new unique origin
+						re-imported into the content library. Conversely, reading systems may create a new unique origin
 						for every newly added publication.</p>
 
 					<p>This specification also recommends that <a data-cite="epub-33#sec-scripted-container-constrained"
 							>container-constrained scripts</a> [[EPUB-33]] not be allowed to modify the DOM of the host
-						EPUB Content Document and/or manipulate the containing rectangle (see <a
+						EPUB content document and/or manipulate the containing rectangle (see <a
 							href="#sec-scripted-content"></a>).</p>
 
 					<p>Note that compliance with these recommendations does not guarantee protection from the possible
 						attacks listed above; developers must examine each potential vulnerability within the context of
-						their Reading System.</p>
+						their reading system.</p>
 				</section>
 			</section>
 		</section>
 		<section id="sec-nav">
 			<h3>Navigation document processing</h3>
 
-			<p id="sec-nav-rs-conf" class="support" data-tests="#nav-spine_in-spine">Reading Systems MUST process <a
-					data-cite="epub-33#sec-nav">EPUB Navigation Documents</a> [[EPUB-33]].</p>
+			<p id="sec-nav-rs-conf" class="support" data-tests="#nav-spine_in-spine">Reading systems MUST process <a
+					data-cite="epub-33#sec-nav">EPUB navigation documents</a> [[EPUB-33]].</p>
 
-			<p>To process the EPUB Navigation Document, a Reading System:</p>
+			<p>To process the EPUB navigation document, a reading system:</p>
 
 			<ul class="conformance-list">
 				<li>
@@ -1387,8 +1386,8 @@
 				</li>
 				<li>
 					<p id="confreq-nav-activation" data-tests="#nav-activation">MUST relocate the current reading
-						position to the destination identified by an activated link when the link is to a <a>Publication
-							Resource</a>.</p>
+						position to the destination identified by an activated link when the link is to a <a>publication
+							resource</a>.</p>
 				</li>
 				<li>
 					<p id="confreq-nav-ol-style" data-tests="#nav-spine_in-spine-no-list-style">MUST NOT show list item
@@ -1399,8 +1398,8 @@
 				</li>
 			</ul>
 
-			<p id="confreq-nav-spine" data-tests="#nav-spine_in-spine,#nav-spine_not-in-spine">Reading Systems MUST
-				honor the above requirements irrespective of whether the EPUB Navigation Document is part of the <a
+			<p id="confreq-nav-spine" data-tests="#nav-spine_in-spine,#nav-spine_not-in-spine">Reading systems MUST
+				honor the above requirements irrespective of whether the EPUB navigation document is part of the <a
 					data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]].</p>
 		</section>
 		<section id="sec-rendering-control">
@@ -1409,8 +1408,8 @@
 			<section id="sec-fixed-layouts">
 				<h3>Fixed-layout documents</h3>
 
-				<p id="confreq-rs-epub3-fxl" class="support">Reading Systems MUST support the rendering of <a
-						data-cite="epub-33#sec-fixed-layouts">Fixed-Layout Documents</a> [[EPUB-33]].</p>
+				<p id="confreq-rs-epub3-fxl" class="support">Reading systems MUST support the rendering of <a
+						data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a> [[EPUB-33]].</p>
 
 				<section id="sec-fxl-props">
 					<h4>Fixed-layout properties</h4>
@@ -1418,16 +1417,16 @@
 					<section id="layout">
 						<h5>The <code>rendition:layout</code> property</h5>
 
-						<p>The default value <code>reflowable</code> MUST be assumed by EPUB Reading Systems as the
+						<p>The default value <code>reflowable</code> MUST be assumed by EPUB reading systems as the
 							global value if no <a data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a>
 							carrying the <a data-cite="epub-33#layout"><code>rendition:layout</code> property</a> occurs
-							in the <a data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a>
+							in the <a data-cite="epub-33#elemdef-opf-metadata">package document metadata</a>
 							[[EPUB-33]].</p>
 
 						<p id="layout-pre-paginated" data-tests="#fxl-layout-pre-paginated-spreads">When the
-								<code>rendition:layout</code> property is set to <code>pre-paginated</code>, Reading
-							Systems MUST NOT include space between the adjacent content slots when rendering
-								<a>Synthetic Spreads</a>.</p>
+								<code>rendition:layout</code> property is set to <code>pre-paginated</code>, reading
+							systems MUST NOT include space between the adjacent content slots when rendering
+								<a>synthetic spreads</a>.</p>
 
 						<p>The <code>rendition:layout</code> property values have the following processing
 							requirements:</p>
@@ -1435,11 +1434,11 @@
 						<dl class="variablelist">
 							<dt id="def-layout-reflowable">reflowable</dt>
 							<dd>
-								<p>Reading Systems MAY apply dynamic pagination when rendering.</p>
+								<p>Reading systems MAY apply dynamic pagination when rendering.</p>
 							</dd>
 							<dt id="def-layout-pre-paginated" data-tests="#fxl-layout-pre-paginated">pre-paginated</dt>
 							<dd>
-								<p>Reading Systems MUST produce exactly one page per spine <a
+								<p>Reading systems MUST produce exactly one page per spine <a
 										data-cite="epub-33#elemdef-spine-itemref"><code>itemref</code></a> [[EPUB-33]]
 									when rendering.</p>
 							</dd>
@@ -1448,7 +1447,7 @@
 						<p>When a spine <code>itemref</code> element's <a data-cite="epub-33#attrdef-properties"
 									><code>properties</code> attribute</a> contains an <a
 								data-cite="epub-33#layout-overrides">override of the global rendition:layout
-								property</a> [[EPUB-33]], Reading Systems MUST follow the requirements for the
+								property</a> [[EPUB-33]], reading systems MUST follow the requirements for the
 							override's global value when displaying that spine item (e.g., a spine item that specifies
 								<code>layout-prepaginated</code> is rendered following the requirements of the global
 								<code>pre-paginated</code> value).</p>
@@ -1458,10 +1457,10 @@
 						<h5>The <code>rendition:orientation</code> property</h5>
 
 						<p id="fxl-orientation-default" data-tests="#fxl-orientation-default">The default value
-								<code>auto</code> MUST be assumed by EPUB Reading Systems as the global value if no <a
+								<code>auto</code> MUST be assumed by EPUB reading systems as the global value if no <a
 								data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
 								data-cite="epub-33#orientation"><code>rendition:orientation</code> property</a> occurs
-							in the <a data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a>
+							in the <a data-cite="epub-33#elemdef-opf-metadata">package document metadata</a>
 							[[EPUB-33]].</p>
 
 						<p>The <code>rendition:orientation</code> property values have the following processing
@@ -1470,18 +1469,18 @@
 						<dl class="variablelist">
 							<dt id="def-orientation-auto">auto</dt>
 							<dd>
-								<p>The Reading System determines the orientation in which to render the content.</p>
+								<p>The reading system determines the orientation in which to render the content.</p>
 							</dd>
 
 							<dt id="def-orientation-landscape" data-tests="#fxl-orientation-landscape">landscape</dt>
 							<dd>
-								<p>Reading Systems that support multiple orientations SHOULD render the content in
+								<p>Reading systems that support multiple orientations SHOULD render the content in
 									landscape orientation.</p>
 							</dd>
 
 							<dt id="def-orientation-portrait">portrait</dt>
 							<dd>
-								<p>Reading Systems that support multiple orientations SHOULD render the content in
+								<p>Reading systems that support multiple orientations SHOULD render the content in
 									portrait orientation.</p>
 							</dd>
 						</dl>
@@ -1493,10 +1492,10 @@
 						<h5>The <code>rendition:spread</code> property</h5>
 
 						<p id="fxl-spread-default" data-tests="#fxl-spread-default">The default value <code>auto</code>
-							MUST be assumed by EPUB Reading Systems as the global value if no <a
+							MUST be assumed by EPUB reading systems as the global value if no <a
 								data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
 								data-cite="epub-33#spread"><code>rendition:spread</code> property</a> occurs in the <a
-								data-cite="epub-33#elemdef-opf-metadata">Package Document metadata</a> [[EPUB-33]].</p>
+								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[EPUB-33]].</p>
 
 						<p>The <code>rendition:spread</code> property values have the following processing
 							requirements:</p>
@@ -1504,28 +1503,28 @@
 						<dl class="variablelist">
 							<dt id="def-spread-none" data-tests="#fxl-spread-none">none</dt>
 							<dd>
-								<p>Reading Systems MUST NOT incorporate spine items in a <a>Synthetic Spread</a>.
-									Reading Systems SHOULD create a single <a>Viewport</a> positioned at the center of
+								<p>Reading systems MUST NOT incorporate spine items in a <a>synthetic spread</a>.
+									Reading systems SHOULD create a single <a>viewport</a> positioned at the center of
 									the screen.</p>
 							</dd>
 							<dt id="def-spread-landscape" data-tests="#fxl-spread-landscape">landscape</dt>
 							<dd>
-								<p>Reading Systems SHOULD render a Synthetic Spread for spine items only when the device
+								<p>Reading systems SHOULD render a synthetic spread for spine items only when the device
 									is in landscape orientation.</p>
 							</dd>
 							<dt id="def-spread-portrait">portrait (deprecated)</dt>
 							<dd>
-								<p>Reading Systems SHOULD treat the value "<code>portrait</code>" as a synonym of
+								<p>Reading systems SHOULD treat the value "<code>portrait</code>" as a synonym of
 										"<code>both</code>" and create spreads regardless of orientation.</p>
 							</dd>
 							<dt id="def-spread-both" data-tests="#fxl-spread-both">both</dt>
 							<dd>
-								<p>Reading Systems SHOULD render a Synthetic Spread regardless of device
+								<p>Reading systems SHOULD render a synthetic spread regardless of device
 									orientation.</p>
 							</dd>
 							<dt id="def-spread-auto" data-tests="#fxl-spread-auto">auto</dt>
 							<dd>
-								<p>Reading Systems MAY use Synthetic Spreads in specific or all device orientations as
+								<p>Reading systems MAY use synthetic spreads in specific or all device orientations as
 									part of a <a>Content Display Area</a> utilization optimization process.</p>
 							</dd>
 						</dl>
@@ -1541,7 +1540,7 @@
 									id="page-spread-right"><code>rendition:page-spread-right</code></span> property</a>
 							[[EPUB-33]] that it SHOULD be rendered in the right-hand slot.</p>
 
-						<p>Reading Systems that support the <a href="#def-spread-none"><code>spread-none</code>
+						<p>Reading systems that support the <a href="#def-spread-none"><code>spread-none</code>
 								property</a> MUST recognize the <a data-cite="epub-33#fxl-page-spread-center"><span
 									id="page-spread-center"><code>rendition:page-spread-center</code></span>
 								property</a> as an alias for it, otherwise they MUST ignore the
@@ -1549,13 +1548,13 @@
 
 						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 							properties apply to both pre-paginated and reflowable content, and they only apply when the
-							Reading System is creating Synthetic Spreads.</p>
+							reading system is creating synthetic spreads.</p>
 
 						<p>The <code id="page-break-precedence">rendition:page-spread-*</code> properties MUST take
 							precedence over whatever value of the <a
 								href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
 									><code>page-break-before</code> property</a> [[CSSSnapshot]] has been set for an
-								<a>XHTML Content Document</a>.</p>
+								<a>XHTML content document</a>.</p>
 
 						<p id="page-layout-both" data-tests="#page-layout-both">When a <a href="#def-layout-reflowable"
 								>reflowable</a> spine item follows a <a href="#def-layout-pre-paginated"
@@ -1574,7 +1573,7 @@
 							pre-paginated spine item has a <code>rendition:page-spread-*</code> specification, it MUST
 							be honored (e.g., by inserting a blank page).</p>
 
-						<p id="fxl-page-spread-combined" data-tests="#fxl-page-spread-combined">When a Reading System
+						<p id="fxl-page-spread-combined" data-tests="#fxl-page-spread-combined">When a reading system
 							encounters two spine items that represent a true spread (i.e., two adjacent spine items with
 							the <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 							properties), it SHOULD create the spread with no space between the adjacent pages.</p>
@@ -1587,24 +1586,24 @@
 					<dl>
 						<dt>XHTML</dt>
 						<dd>
-							<p>Reading Systems MUST use the width and height expressions as defined in <a
+							<p>Reading systems MUST use the width and height expressions as defined in <a
 									data-cite="epub-33#sec-fxl-icb-html">Expressing in HTML</a> [[EPUB-33]] to render
-									<a>XHTML Content Documents</a>.</p>
-							<p id="confreq-fxl-rs-xhtml-icb" data-tests="#fxl-xhtml-icb">Reading Systems MUST clip XHTML
+									<a>XHTML content documents</a>.</p>
+							<p id="confreq-fxl-rs-xhtml-icb" data-tests="#fxl-xhtml-icb">Reading systems MUST clip XHTML
 								content to the initial containing block (ICB) dimensions declared in the
 									<code>viewport</code>
 								<code>meta</code> tag — content positioned outside of the initial containing block will
-								not be visible. When the ICB aspect ratio does not match the aspect ratio of the Reading
-								System <a>Content Display Area</a>, Reading Systems MAY position the ICB inside the area
+								not be visible. When the ICB aspect ratio does not match the aspect ratio of the reading
+								system <a>Content Display Area</a>, reading systems MAY position the ICB inside the area
 								to accommodate the user interface; in other words, added letter-boxing space MAY appear
 								on either side (or both) of the content.</p>
 						</dd>
 
 						<dt>SVG</dt>
 						<dd>
-							<p id="confreq-fxl-rs-svg">Reading Systems MUST use the dimensions as defined in <a
+							<p id="confreq-fxl-rs-svg">Reading systems MUST use the dimensions as defined in <a
 									data-cite="epub-33#sec-fxl-icb-svg">Expressing the ICB in SVG</a> [[EPUB-33]] to
-								render <a>SVG Content Documents</a>.</p>
+								render <a>SVG content documents</a>.</p>
 						</dd>
 					</dl>
 				</section>
@@ -1612,20 +1611,20 @@
 				<section id="sec-fxl-viewport">
 					<h4>Viewport rendering</h4>
 
-					<p>When rendering <a>Fixed-Layout Documents</a>, the default intent is that the <a>Content Display
-							Area</a> SHOULD occupy as much of the available <a>Viewport</a> area as possible. Reading
-						Systems SHOULD NOT inject additional content such as border, margins, headers, or footers into
-						the Viewport.</p>
+					<p>When rendering <a>fixed-layout documents</a>, the default intent is that the <a>Content Display
+							Area</a> SHOULD occupy as much of the available <a>viewport</a> area as possible. Reading
+						systems SHOULD NOT inject additional content such as border, margins, headers, or footers into
+						the viewport.</p>
 
 					<div class="note">
 						<p>This specification does not define how the <a
 								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-								containing block</a> [[CSS2]] is placed within the Reading System <a>Content Display
+								containing block</a> [[CSS2]] is placed within the reading system <a>Content Display
 								Area</a>.</p>
 					</div>
 
 					<div class="note">
-						<p>The exposure of Reading System control widgets to the user is implementation-specific and not
+						<p>The exposure of reading system control widgets to the user is implementation-specific and not
 							included in the above behavioral expectations.</p>
 					</div>
 				</section>
@@ -1634,58 +1633,58 @@
 			<section id="sec-reflowable-layouts">
 				<h3>Reflowable layouts</h3>
 
-				<p id="confreq-rs-epub3-presentational-meta" class="support">Reading Systems SHOULD process the <a
+				<p id="confreq-rs-epub3-presentational-meta" class="support">Reading systems SHOULD process the <a
 						data-cite="epub-33#sec-rendering-general">general package rendering properties</a>
 					[[EPUB-33]].</p>
 
 				<section id="flow">
 					<h4>The <code>rendition:flow</code> property</h4>
 
-					<p>If a Reading System supports the specified rendering, it SHOULD use that method to handle
+					<p>If a reading system supports the specified rendering, it SHOULD use that method to handle
 						overflow content, but MAY provide the option for users to override the requested rendering.</p>
 
 					<p>The default global value is <code>auto</code> if no <code>meta</code> element carrying this
 						property occurs in the <a data-cite="epub-33#elemdef-opf-metadata"><code>metadata</code>
-							section</a> [[EPUB-33]]. Reading Systems MAY support only this default value.</p>
+							section</a> [[EPUB-33]]. Reading systems MAY support only this default value.</p>
 
 					<p>The <code>rendition:flow</code> property values have the following processing requirements:</p>
 
 					<dl class="variablelist">
 						<dt id="paginated">paginated</dt>
 						<dd id="paginated-dd" data-tests="#pkg-flow-paginated">
-							<p>The Reading System SHOULD dynamically paginate all overflow content.</p>
+							<p>The reading system SHOULD dynamically paginate all overflow content.</p>
 						</dd>
 
 						<dt id="scrolled-continuous">scrolled-continuous</dt>
 						<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
-							<p>The Reading System SHOULD render all Content Documents such that overflow content is
-								scrollable, and SHOULD present the EPUB Publication as one continuous scroll from spine
+							<p>The reading system SHOULD render all Content Documents such that overflow content is
+								scrollable, and SHOULD present the EPUB publication as one continuous scroll from spine
 								item to spine item (except where <a data-cite="epub-33#layout-property-flow-overrides"
 									>locally overridden</a> [[EPUB-33]]).</p>
 						</dd>
 
 						<dt id="scrolled-doc">scrolled-doc</dt>
 						<dd id="scrolled-doc-dd" data-tests="#pkg-flow-scrolled-doc">
-							<p>The Reading System SHOULD render all Content Documents such that users can scroll
+							<p>The reading system SHOULD render all Content Documents such that users can scroll
 								overflow content, and SHOULD present each spine item as a separate scrollable
 								document.</p>
 						</dd>
 
 						<dt id="auto">auto</dt>
 						<dd>
-							<p>The Reading System MAY render overflow content using its default method or a user
+							<p>The reading system MAY render overflow content using its default method or a user
 								preference, whichever is applicable.</p>
 						</dd>
 					</dl>
 
 					<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction MUST be
-						defined relative to the block flow direction of the root element of the XHTML Content Document
+						defined relative to the block flow direction of the root element of the XHTML content document
 						referenced by the <a data-cite="epub-33#elemdef-spine-itemref"><code>itemref</code> element</a>
 						[[EPUB-33]]. The scroll direction MUST be vertical if the block flow direction is downward
 						(top-to-bottom). It MUST be horizontal if the block flow direction of the root element is
 						rightward (left-to-right) or leftward (right-to-left).</p>
 
-					<p>Reading Systems MUST ignore the <code>rendition:flow</code> property and its overrides when
+					<p>Reading systems MUST ignore the <code>rendition:flow</code> property and its overrides when
 						processing <a href="https://www.w3.org/TR/epub-33/#def-layout-pre-paginated">pre-paginated spine
 							items</a> [[EPUB-33]].</p>
 				</section>
@@ -1694,15 +1693,15 @@
 					<h4>The <code>rendition:align-x-center</code> property</h4>
 
 					<p>When the <a href="#align-x-center"><code>rendition:align-x-center</code> property</a> is set on a
-						spine item, Reading Systems SHOULD render the content centered horizontally within the
-							<a>Viewport</a> or spread, as applicable. This property does not affect the rendering of the
+						spine item, reading systems SHOULD render the content centered horizontally within the
+							<a>viewport</a> or spread, as applicable. This property does not affect the rendering of the
 						spine item, only the placement of the resulting content box.</p>
 
-					<p>For reflowable content, Reading Systems that support this property MUST center each virtual
+					<p>For reflowable content, reading systems that support this property MUST center each virtual
 						page.</p>
 
-					<p>This specification does not define a default rendering behavior when Reading Systems do not
-						support this property or EPUB Creators do not specify it. Reading Systems MAY render spine items
+					<p>This specification does not define a default rendering behavior when reading systems do not
+						support this property or EPUB creators do not specify it. Reading systems MAY render spine items
 						by their own design.</p>
 				</section>
 			</section>
@@ -1710,7 +1709,7 @@
 			<section id="sec-custom-properties">
 				<h3>Custom properties</h3>
 
-				<p>Reading Systems MAY support custom properties provided they do not introduce expressions that
+				<p>Reading systems MAY support custom properties provided they do not introduce expressions that
 					conflict behaviorally with the properties defined in the <a
 						href="https://www.w3.org/TR/epub-33/#app-rendering-vocab">Package Rendering Vocabulary</a>
 					[[EPUB-33]].</p>
@@ -1719,10 +1718,10 @@
 		<section id="sec-media-overlays">
 			<h2>Media overlays processing</h2>
 
-			<p id="confreq-rs-epub3-mo" class="support">Reading Systems with the capability to render prerecorded audio
+			<p id="confreq-rs-epub3-mo" class="support">Reading systems with the capability to render prerecorded audio
 				SHOULD support <a data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[EPUB-33]].</p>
 
-			<p>If a Reading System does not support Media Overlays, it MUST ignore both:</p>
+			<p>If a reading system does not support Media Overlays, it MUST ignore both:</p>
 
 			<ul>
 				<li>the <a data-cite="epub-33#attrdef-item-media-overlay"><code>media-overlay</code> attribute</a> on
@@ -1735,19 +1734,19 @@
 			<section id="sec-behaviors-loading">
 				<h4>Loading the media overlay</h4>
 
-				<p>When a Reading System loads a <a>Package Document</a>, it MUST refer to the <a>manifest</a>
+				<p>When a reading system loads a <a>package document</a>, it MUST refer to the <a>manifest</a>
 					<a data-cite="epub-33#elemdef-package-item"><code>item</code> elements'</a> [[EPUB-33]]
 						<code>media-overlay</code> attributes to discover the corresponding Media Overlays for <a>EPUB
-						Content Documents</a>.</p>
+						content documents</a>.</p>
 
-				<p id="confreq-rs-xhtml-svg">Reading Systems MUST support playback for <a>XHTML Content Documents</a>,
-					and MAY support <a>SVG Content Documents</a>.</p>
+				<p id="confreq-rs-xhtml-svg">Reading systems MUST support playback for <a>XHTML content documents</a>,
+					and MAY support <a>SVG content documents</a>.</p>
 
-				<p>Playback MUST start at the Media Overlay element which corresponds to the desired EPUB Content
-					Document starting point. Note that the start of an EPUB Content Document MAY correspond to an
-					element at the start or in the middle of a Media Overlay. When the Media Overlay Document finishes
-					playing, the Reading System SHOULD load the next EPUB Content Document (as specified in the Package
-					Document <a>spine</a>) and also load its corresponding Media Overlay Document, provided that one is
+				<p>Playback MUST start at the Media Overlay element which corresponds to the desired EPUB content
+					document starting point. Note that the start of an EPUB content document MAY correspond to an
+					element at the start or in the middle of a Media Overlay. When the media overlay document finishes
+					playing, the reading system SHOULD load the next EPUB content document (as specified in the package
+					document <a>spine</a>) and also load its corresponding media overlay document, provided that one is
 					given.</p>
 			</section>
 
@@ -1759,21 +1758,21 @@
 
 					<p id="mol-timing-sync"
 						data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio"
-						>Reading Systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
+						>Reading systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
 								><code>body</code> element</a> [[EPUB-33]] in a sequence. A <a
 							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[EPUB-33]] children
 						MUST be rendered in sequence, and playback completes when the last child finishes playing.
-						Reading System MUST render a <a data-cite="epub-33#elemdef-smil-par"><code>par</code>
+						Reading system MUST render a <a data-cite="epub-33#elemdef-smil-par"><code>par</code>
 							element's</a> [[EPUB-33]] children in parallel (with each starting at the same time), and
-						playback completes when all the children finish playing. Reading System playback of the Media
-						Overlay Document completes when the <code>body</code> element's last child finishes playing.</p>
+						playback completes when all the children finish playing. Reading system playback of the media
+						overlay document completes when the <code>body</code> element's last child finishes playing.</p>
 				</section>
 
 				<section id="sec-rsconf-rendering-audio">
 					<h5>Rendering audio</h5>
 
 					<p>When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
-							element</a>, Reading Systems MUST play the audio resource referenced by the <code>src</code>
+							element</a>, reading systems MUST play the audio resource referenced by the <code>src</code>
 						attribute, starting at the clip offset time given by the <a
 							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> and ending
 						at the clip offset time given by the <a data-cite="epub-33#attrdef-smil-clipEnd"
@@ -1783,16 +1782,16 @@
 
 					<ul>
 						<li id="mol-audio-no-clipbegin" data-tests="#mol-audio-no-clipbegin">
-							<p>If the EPUB Creator has not specified a <code>clipBegin</code> attribute, Reading Systems
+							<p>If the EPUB creator has not specified a <code>clipBegin</code> attribute, reading systems
 								MUST assume the value "<code>0</code>".</p>
 						</li>
 						<li id="mol-audio-no-clipend" data-tests="#mol-audio-no-clipend">
-							<p>If the EPUB Creator has not specified a <code>clipEnd</code> attribute, Reading Systems
+							<p>If the EPUB creator has not specified a <code>clipEnd</code> attribute, reading systems
 								MUST assume the value to be the full duration of the physical media.</p>
 						</li>
 						<li id="mol-audio-exceeding-clipend" data-tests="#mol-audio-exceeding-clipend">
 							<p>If the value of <code>clipEnd</code> exceeds the full duration of the physical media,
-								Reading Systems MUST assume its value to be the full duration of the physical media.</p>
+								reading systems MUST assume its value to be the full duration of the physical media.</p>
 						</li>
 					</ul>
 
@@ -1803,64 +1802,64 @@
 				</section>
 
 				<section id="sec-rsconf-rendering-text">
-					<h5>Rendering EPUB Content Document elements</h5>
+					<h5>Rendering EPUB content document elements</h5>
 
 					<p>When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-text"><code>text</code>
-							element</a> [[EPUB-33]] whose <code>src</code> attribute contains a <a>URL-fragment string</a> 
-							referencing a specific part of
-						an EPUB Content Document, Reading Systems SHOULD ensure the referenced portion is visible in the
-							<a>Viewport</a>. In addition to [[HTML]] element ID references and <a
-							href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
-							Identifiers</a> [[SVG]], Reading Systems MAY support other fragment identifier schemes.</p>
+							element</a> [[EPUB-33]] whose <code>src</code> attribute contains a <a>URL-fragment
+							string</a> referencing a specific part of an EPUB content document, reading systems SHOULD
+						ensure the referenced portion is visible in the <a>viewport</a>. In addition to [[HTML]] element
+						ID references and <a href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG
+							Fragment Identifiers</a> [[SVG]], reading systems MAY support other fragment identifier
+						schemes.</p>
 
 					<p id="mol-rendering-with-styling"
 						data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">During
-						Media Overlays playback, Reading Systems with a Viewport SHOULD add the class names given by the
+						Media Overlays playback, reading systems with a viewport SHOULD add the class names given by the
 						metadata properties <a data-cite="epub-33#active-class"><code>active-class</code></a> and <a
 							data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a> [[EPUB-33]]
-						to the appropriate elements, when specified, in the EPUB Content Document. Conversely, the class
+						to the appropriate elements, when specified, in the EPUB content document. Conversely, the class
 						names SHOULD be removed when the playback state changes, as described in <a
 							data-cite="epub-33#sec-docs-assoc-style">Associating Style Information</a> [[EPUB-33]].</p>
 
 					<p>The <code>active-class</code> and <code>playback-active-class</code> metadata properties are
-						OPTIONAL, and if omitted, Reading System behavior is implementation-specific.</p>
+						OPTIONAL, and if omitted, reading system behavior is implementation-specific.</p>
 
-					<p>Reading System behavior when a <a data-cite="epub-33#sec-media-overlays-fragids">fragment
+					<p>Reading system behavior when a <a data-cite="epub-33#sec-media-overlays-fragids">fragment
 							identifier</a> [[EPUB-33]] does not reference an element is also
 						implementation-specific.</p>
 				</section>
 			</section>
 
 			<section id="sec-behaviors-interaction">
-				<h4>Interacting with the EPUB Content Document</h4>
+				<h4>Interacting with the EPUB content document</h4>
 
 				<section id="sec-rsconf-navigation">
 					<h5>Navigation</h5>
 
-					<p>Because the Media Overlay is closely linked to the <a>EPUB Content Document</a>, it is very easy
-						for Reading Systems to locate a position in the EPUB Content Document based on the current
+					<p>Because the Media Overlay is closely linked to the <a>EPUB content document</a>, it is very easy
+						for reading systems to locate a position in the EPUB content document based on the current
 						position in the Media Overlay playback. If the user pauses synchronized playback and navigates
-						to a different part of the <a>EPUB Publication</a>, synchronized playback MUST resume at that
-						point. For example, if a specific page number in the EPUB Content Document is the desired
+						to a different part of the <a>EPUB publication</a>, synchronized playback MUST resume at that
+						point. For example, if a specific page number in the EPUB content document is the desired
 						location, then this same point is located in the Media Overlay and playback started there.</p>
 
 					<p>This same approach allows for synchronizing the Media Overlay playback with user selection of a
-						navigation point in the <a>EPUB Navigation Document</a>. The Reading System loads the Media
+						navigation point in the <a>EPUB navigation document</a>. The reading system loads the Media
 						Overlay for that file and finds the correct point for starting playback based on the ID of the
 						navigation point target.</p>
 
 					<div class="note">
-						<p>EPUB Creators may associate a Media Overlay Document directly with an <a>EPUB Navigation
-								Document</a>t in order to provide synchronized playback of its contents, regardless of
-							whether the <a>XHTML Content Document</a> in which it resides is included in the
-								<a>spine</a>. See <a data-cite="epub-33#sec-mo-nav-doc">EPUB Navigation Document</a>
+						<p>EPUB creators may associate a media overlay document directly with an <a>EPUB navigation
+								document</a>t in order to provide synchronized playback of its contents, regardless of
+							whether the <a>XHTML content document</a> in which it resides is included in the
+								<a>spine</a>. See <a data-cite="epub-33#sec-mo-nav-doc">EPUB navigation document</a>
 							[[EPUB-33]] for more information.</p>
 					</div>
 
 					<div class="note" id="note-table-reading-mode">
-						<p>EPUB Creators may associate Media Overlay Document elements with EPUB Content Document
-							structures such as tables. Reading Systems should ensure that Media Overlay playback remains
-							synchronized with user navigation of table rows and cells. The Reading System might also
+						<p>EPUB creators may associate media overlay document elements with EPUB content document
+							structures such as tables. Reading systems should ensure that Media Overlay playback remains
+							synchronized with user navigation of table rows and cells. The reading system might also
 							play the corresponding table header preceding the contents of the cell.</p>
 					</div>
 				</section>
@@ -1868,16 +1867,16 @@
 				<section id="sec-embedded-media">
 					<h5>Embedded audio and video</h5>
 
-					<p>An <a>EPUB Content Document</a> with which a Media Overlay is associated MAY itself contain
+					<p>An <a>EPUB content document</a> with which a Media Overlay is associated MAY itself contain
 						embedded video and audio media. The Media Overlay elements MAY point to these elements. Unlike
 						text and images, video and audio media have an intrinsic duration. <span id="mol-embed-override"
-							data-tests="#mol-embed,#mol-embed_fxl">Consequently, when a Reading System renders the
+							data-tests="#mol-embed,#mol-embed_fxl">Consequently, when a reading system renders the
 							synchronization described by a Media Overlay, it MUST override the default playback behavior
-							of audio and video media embedded within the associated EPUB Content Document.</span></p>
+							of audio and video media embedded within the associated EPUB content document.</span></p>
 
-					<p>Note that the rules below apply only to <em>referenced</em> [[HTML]] <a><code>video</code></a> or 
-						<a><code>audio</code></a> elements within the associated
-						EPUB Content Document. That is to say, the rules apply to only those elements pointed to by <a
+					<p>Note that the rules below apply only to <em>referenced</em> [[HTML]] <a><code>video</code></a> or
+								<a><code>audio</code></a> elements within the associated EPUB content document. That is
+						to say, the rules apply to only those elements pointed to by <a
 							data-cite="epub-33#elemdef-smil-text"><code>text</code> elements</a> [[EPUB-33]] within the
 						Media Overlay (i.e., via the <code>src</code> attribute). These rules do not apply to embedded
 						media not referenced by Media Overlay elements.</p>
@@ -1885,11 +1884,11 @@
 					<ul>
 						<li>
 							<p id="mol-embed-deactivate-playback" data-tests="#mol-embed_deactivate_playback">Reading
-								Systems MUST deactivate the public playback interface for all referenced audio and video
-								media embedded within an EPUB Content Document (typically: play/pause control, time
+								systems MUST deactivate the public playback interface for all referenced audio and video
+								media embedded within an EPUB content document (typically: play/pause control, time
 								slider, volume level, etc.). This behavior avoids interference between the scheduled
 								playback sequence defined by the Media Overlay, and the arbitrary playback behavior due
-								to user interaction or script execution. As a result, when the Reading System is in
+								to user interaction or script execution. As a result, when the reading system is in
 								playback mode, it SHOULD:</p>
 							<ul>
 								<li>
@@ -1897,27 +1896,26 @@
 										default behavior defined by the [[HTML]] [^audio/controls^] attribute.</p>
 								</li>
 								<li>
-									<p>Prevent scripts embedded within the EPUB Content Document from invoking the
+									<p>Prevent scripts embedded within the EPUB content document from invoking the
 										JavaScript audio/video playback API (i.e., authored as part of the default
 										behavior).</p>
 								</li>
 							</ul>
 						</li>
 						<li id="mol-embed-init-to-stop" data-tests="#mol-embed,#mol-embed_fxl">
-							<p>Reading Systems MUST initialize all referenced audio and video media embedded within an
-								EPUB Content Document to their "stopped" state, and ready them to play from the
+							<p>Reading systems MUST initialize all referenced audio and video media embedded within an
+								EPUB content document to their "stopped" state, and ready them to play from the
 								zero-position within their content stream (possibly displaying the image specified using
-								the [[HTML]] [^video/poster^] attribute.
-								This requirement overrides the default behavior defined by the [[HTML]] 
-								[^video/autoplay^] attribute.</p>
+								the [[HTML]] [^video/poster^] attribute. This requirement overrides the default behavior
+								defined by the [[HTML]] [^video/autoplay^] attribute.</p>
 						</li>
 						<li>
-							<p>When an EPUB Content Document element becomes active, the CSS Style Sheet visual
+							<p>When an EPUB content document element becomes active, the CSS Style Sheet visual
 								highlighting rules apply regardless of the content type referred to by that element's
 									<code>src</code> attribute (e.g., the CSS class name defined by the <a
 									data-cite="epub-33#active-class"><code>active-class</code> metadata property</a>
 								[[EPUB-33]] SHOULD be applied to visible video and audio player controls within the host
-								EPUB Content Document).</p>
+								EPUB content document).</p>
 						</li>
 						<li>
 							<p id="mol-embed-start-and-stop" data-tests="#mol-embed,#mol-embed_fxl">In addition to the
@@ -1930,7 +1928,7 @@
 									<p>When a Media Overlay <code>text</code> element has no <a
 											data-cite="epub-33#elemdef-smil-audio"><code>audio</code></a> [[EPUB-33]]
 										sibling within its <a data-cite="epub-33#elemdef-smil-par"><code>par</code></a>
-										[[EPUB-33]] parent container, the referenced EPUB Content Document audio or
+										[[EPUB-33]] parent container, the referenced EPUB content document audio or
 										video media MUST play until it ends, at which point the <code>text</code>
 										element's lifespan terminates. In this case, the implicit duration of the
 											<code>text</code> element (and by inference, of the parent <code>par</code>
@@ -1938,8 +1936,8 @@
 								</li>
 								<li>
 									<p>When a Media Overlay <code>text</code> element has an <code>audio</code> sibling
-										within its <code>par</code> parent container, Reading Systems MUST constrain the
-										playback duration of the referenced EPUB Content Document audio or video media
+										within its <code>par</code> parent container, reading systems MUST constrain the
+										playback duration of the referenced EPUB content document audio or video media
 										by the duration of the <code>audio</code> sibling. In this case, the actual
 										duration of the parent <code>par</code> container is that of the child audio
 										clip, regardless of the duration of the video or audio media pointed to by the
@@ -1951,13 +1949,13 @@
 										of the Media Overlay <code>audio</code> element implicitly carrying the behavior
 										of the [[SMIL3]] <a data-cite="smil3/smil-timing.html#adef-endsync"
 												><code>endsync</code></a> attribute.</p>
-									<p>Furthermore, Reading Systems SHOULD expose user controls for the volume levels of
+									<p>Furthermore, reading systems SHOULD expose user controls for the volume levels of
 										each independent audio track (i.e., from the <code>audio</code> element of the
 										Media Overlay, and from the embedded audio or video media within the EPUB
-										Content Document), so that users can adjust the audio output to match their
+										content document), so that users can adjust the audio output to match their
 										requirements. Note that having overlapping audio tracks is typically an
 										authoring-time concern: content producers usually add a layer of audio
-										information over a video track for description purposes. Reading Systems
+										information over a video track for description purposes. Reading systems
 										handling of simultaneous volume levels in any specific way is OPTIONAL.</p>
 								</li>
 							</ul>
@@ -1977,24 +1975,24 @@
 					<p id="mol-tts" data-tests="#mol-tts_multi,#mol-tts_single">When a Media Overlay <a
 							data-cite="epub-33#elemdef-smil-text"><code>text</code> element</a> [[EPUB-33]] with no <a
 							data-cite="epub-33#elemdef-smil-audio"><code>audio</code></a> [[EPUB-33]] sibling element
-						references text within the target <a>EPUB Content Document</a>, Reading Systems capable of
+						references text within the target <a>EPUB content document</a>, reading systems capable of
 						text-to-speech (TTS) playback SHOULD render the referenced text using TTS.</p>
 
-					<p>Reading Systems SHOULD use the speech-related information provided in the target EPUB Content
-						Document to play the audio stream as part of the Media Overlay rendering.</p>
+					<p>Reading systems SHOULD use the speech-related information provided in the target EPUB content
+						document to play the audio stream as part of the Media Overlay rendering.</p>
 
 					<div class="note">
 						<p>See <a data-cite="epub-tts-10#">EPUB 3 Text-to-Speech Support</a> [[EPUB-TTS-10]] for more
-							information about supporting TTS technologies in EPUB Publications.</p>
+							information about supporting TTS technologies in EPUB publications.</p>
 					</div>
 
 					<p>The Media Overlay <code>text</code> element's lifespan corresponds to the rendering time of the
 						associated speech synthesis. The implicit duration of the <code>text</code> element (and by
 						inference, of the parent <code>par</code> element) is therefore determined by the execution of
 						the Text-to-Speech engine, and cannot be known at authoring time (factors like speech rate,
-						pauses and other prosody parameters influence the audio output). This also means that Reading
-						Systems should treat the <a data-cite="epub-33#duration"><code>duration</code></a> property
-						values set in the Package Document as approximative when making use of them.</p>
+						pauses and other prosody parameters influence the audio output). This also means that reading
+						systems should treat the <a data-cite="epub-33#duration"><code>duration</code></a> property
+						values set in the package document as approximative when making use of them.</p>
 				</section>
 			</section>
 
@@ -2004,11 +2002,11 @@
 				<section id="sec-skippability">
 					<h5>Skippability</h5>
 
-					<p>Reading Systems SHOULD use the semantic information provided by Media Overlay elements' <a
+					<p>Reading systems SHOULD use the semantic information provided by Media Overlay elements' <a
 							href="#sec-structural-semantics"><code>epub:type</code> attribute</a> to offer users the
 						option of skipping content.</p>
 
-					<p>When skipping of content is enabled, Reading Systems MUST suppress playback of any
+					<p>When skipping of content is enabled, reading systems MUST suppress playback of any
 							<code>par</code> and <code>seq</code> elements whose <code>epub:type</code> attribute
 						contains a semantic that matches a skippable structure.</p>
 				</section>
@@ -2016,7 +2014,7 @@
 				<section id="sec-escapability">
 					<h5>Escapability</h5>
 
-					<p>Reading Systems SHOULD allow escaping of nested structures. Reading Systems MUST determine the
+					<p>Reading systems SHOULD allow escaping of nested structures. Reading systems MUST determine the
 						start of nested structures by the value of the <a href="#sec-structural-semantics"
 								><code>epub:type</code> attribute</a> and SHOULD offer users the option to skip playback
 						of that structure and resume with whatever content comes after it.</p>
@@ -2026,11 +2024,11 @@
 		<section id="sec-structural-semantics">
 			<h2>Processing structural semantics</h2>
 
-			<p id="confreq-rs-epub-epub-type" class="support">Reading Systems MAY support <a
-					data-cite="epub-33#app-structural-semantics">structural semantics</a> [[EPUB-33]] in <a>EPUB Content
-					Documents</a>.</p>
+			<p id="confreq-rs-epub-epub-type" class="support">Reading systems MAY support <a
+					data-cite="epub-33#app-structural-semantics">structural semantics</a> [[EPUB-33]] in <a>EPUB content
+					documents</a>.</p>
 
-			<p>When processing the <code>epub:type</code> attribute, a Reading System:</p>
+			<p>When processing the <code>epub:type</code> attribute, a reading system:</p>
 
 			<ul class="conformance-list">
 				<li>
@@ -2049,40 +2047,40 @@
 				</li>
 			</ul>
 
-			<p id="confreq-rs-epubtype-prec">When the Reading System behavior associated with a given
+			<p id="confreq-rs-epubtype-prec">When the Reading system behavior associated with a given
 					<code>epub:type</code> value conflicts with an element's native behavior, the behavior associated
 				with the element MUST be given precedence.</p>
 		</section>
 		<section id="sec-vocab-assoc">
 			<h2>Vocabulary association mechanisms</h2>
 
-			<p id="confreq-res-epub-vocab-assoc" class="support">Reading Systems MUST support <a
+			<p id="confreq-res-epub-vocab-assoc" class="support">Reading systems MUST support <a
 					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[EPUB-33]].</p>
 
 			<dl class="conformance-list">
 				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
 				<dd>
-					<p>Reading Systems MUST resolve all <a data-cite="epub-33#sec-reserved-prefixes">reserved
-							prefixes</a> [[EPUB-33]] used in Package Documents using their predefined URLs unless the
-						EPUB Creator declares a local <a href="#sec-prefix-attr">prefix</a>. Reading Systems MUST use
+					<p>Reading systems MUST resolve all <a data-cite="epub-33#sec-reserved-prefixes">reserved
+							prefixes</a> [[EPUB-33]] used in package documents using their predefined URLs unless the
+						EPUB creator declares a local <a href="#sec-prefix-attr">prefix</a>. Reading systems MUST use
 						the URLs defined for locally overridden prefixes (using the <code>prefix</code> attribute) when
 						encountered.</p>
-					<p>As changes to the reserved prefixes and updates to Reading Systems are not always going happen in
-						synchrony, Reading Systems MUST NOT fail when encountering unrecognized prefixes (i.e., not
+					<p>As changes to the reserved prefixes and updates to reading systems are not always going happen in
+						synchrony, reading systems MUST NOT fail when encountering unrecognized prefixes (i.e., not
 						reserved and not declared using the <code>prefix</code> attribute).</p>
 				</dd>
 
 				<dt id="sec-prefix-attr">The <code>prefix</code> attribute</dt>
 				<dd>
 					<p>If the <code>prefix</code> attribute includes a declaration for a <a
-							href="#sec-metadata-reserved-prefixes">predefined prefix</a>, Reading Systems MUST use the
+							href="#sec-metadata-reserved-prefixes">predefined prefix</a>, reading systems MUST use the
 						URL mapping defined in the <code>prefix</code> attribute, regardless of whether of it maps to
 						the same URL as the predefined prefix.</p>
 				</dd>
 
 				<dt id="sec-property-datatype">Expanding <code>property</code> Data Types</dt>
 				<dd>
-					<p>Reading Systems MUST expand <a data-cite="epub-33#sec-property-datatype"><code>property</code>
+					<p>Reading systems MUST expand <a data-cite="epub-33#sec-property-datatype"><code>property</code>
 							values</a> [[EPUB-33]] as follows:</p>
 					<ul>
 						<li>
@@ -2092,52 +2090,52 @@
 						</li>
 						<li>
 							<p>If the property consists of a prefix and reference, concatenate the URL defined for the
-								prefix to the reference. If the EPUB Creator has not defined a matching prefix, and it
+								prefix to the reference. If the EPUB creator has not defined a matching prefix, and it
 								is not a <a data-cite="epub-33#sec-reserved-prefixes">reserved prefix</a> [[EPUB-33]],
-								the property is invalid and Reading Systems MUST ignore it.</p>
+								the property is invalid and reading systems MUST ignore it.</p>
 						</li>
 						<li>
 							<p>If the property consists only of a prefix (i.e., there is no reference after the colon),
-								the property is invalid and Reading Systems MUST ignore it.</p>
+								the property is invalid and reading systems MUST ignore it.</p>
 						</li>
 					</ul>
-					<p>The result MUST be a <a>valid URL string</a> [[URL]]. If the
-						process results in an invalid URL, Reading Systems MUST ignore the property.</p>
-					<p>Reading Systems do not have to <a data-lt="url parser">parse the resulting URL</a>
-						[[URL]] or attempt to dereference the resource.</p>
+					<p>The result MUST be a <a>valid URL string</a> [[URL]]. If the process results in an invalid URL,
+						reading systems MUST ignore the property.</p>
+					<p>Reading systems do not have to <a data-lt="url parser">parse the resulting URL</a> [[URL]] or
+						attempt to dereference the resource.</p>
 				</dd>
 			</dl>
 		</section>
 		<section id="sec-epub-rs-conf-backward">
 			<h3>Backward compatibility</h3>
 
-			<p id="confreq-rs-backward-epub" data-tests="#pkg-version-backward">Reading Systems MUST attempt to process
-				an <a>EPUB Publication</a> whose <a>Package Document</a>
+			<p id="confreq-rs-backward-epub" data-tests="#pkg-version-backward">Reading systems MUST attempt to process
+				an <a>EPUB publication</a> whose <a>package document</a>
 				<a data-cite="epub-33#attrdef-package-version"><code>version</code> attribute</a> [[EPUB-33]] is less
 				than "<code>3.0</code>".</p>
 
-			<p id="confreq-rs-backward-conf">EPUB Publications with older version numbers will not always render exactly
-				as intended unless processed according to their respective specifications. Reading Systems SHOULD
-				support such EPUB Publications as defined by those specifications.</p>
+			<p id="confreq-rs-backward-conf">EPUB publications with older version numbers will not always render exactly
+				as intended unless processed according to their respective specifications. Reading systems SHOULD
+				support such EPUB publications as defined by those specifications.</p>
 		</section>
 		<section id="sec-epub-rs-conf-forward">
 			<h3>Forward compatibility</h3>
 
-			<p id="confreq-rs-forward-epubn">Reading Systems SHOULD attempt to process an <a>EPUB Publication</a> whose
-					<a>Package Document</a>
+			<p id="confreq-rs-forward-epubn">Reading systems SHOULD attempt to process an <a>EPUB publication</a> whose
+					<a>package document</a>
 				<a data-cite="epub-33#attrdef-package-version"><code>version</code> attribute</a> [[EPUB-33]] is greater
 				than "<code>3.0</code>".</p>
 		</section>
 		<section id="sec-accessibility" class="informative">
 			<h2>Accessibility</h2>
 
-			<p>Although the primary focus of this specification is on how to process and render <a>EPUB Publications</a>
-				it does not mandate specific user interfaces that all Reading Systems must offer. This does not mean
-				that there are not common accessibility issues that all Reading Systems developers should be aware of,
+			<p>Although the primary focus of this specification is on how to process and render <a>EPUB publications</a>
+				it does not mandate specific user interfaces that all reading systems must offer. This does not mean
+				that there are not common accessibility issues that all reading systems developers should be aware of,
 				or seek to avoid in their applications.</p>
 
 			<p>The W3C's User Agent Accessibility Guidelines [[UAAG20]] provides many useful practices developers should
-				apply to improve their Reading Systems as many browser accessibility issues have parallels in
+				apply to improve their reading systems as many browser accessibility issues have parallels in
 				EPUB-specific user agents.</p>
 
 			<p>The following list outlines some additional EPUB-specific areas where a lack of accessibility impacts the
@@ -2152,20 +2150,20 @@
 					and buttons to load features such as the table of contents) are exposed to assistive technologies
 					and that their actions do not rely on specific modalities (e.g., they only operate through touch or
 					a mouse).</li>
-				<li>Search &#8212; Search access to the full text content of all EPUB Content Documents is necessary to
+				<li>Search &#8212; Search access to the full text content of all EPUB content documents is necessary to
 					ensure users can locate information easily.</li>
 				<li>Display Control &#8212; Provide methods for users to tailor the styling of the content to their
 					preferences (e.g., to change and increase fonts, increase line and word spacing, and apply alternate
 					contrasts).</li>
 				<li>Zoom &#8212; Allow users to zoom the content to better size it to their needs, especially for
-						<a>Fixed-Layout Documents</a>.</li>
+						<a>fixed-layout documents</a>.</li>
 				<li>Reading Control &#8212; Ensure that the ability to read from page-to-page and document-to-document
 					does not depend on physical interaction (i.e., users of assistive technologies can read the content
 					without getting trapped at the end of pages or documents).</li>
 				<li>API Integration &#8212; Ensure that the accessibility tree, including support for roles, states and
 					properties [[WAI-ARIA-11]], is exposed to the underlying operating system's accessibility API so
 					that users can fully interact with the content when using assistive technologies.</li>
-				<li>Document Object Model (DOM) &#8212; Provide access to the [[DOM]] of EPUB Content Documents so that
+				<li>Document Object Model (DOM) &#8212; Provide access to the [[DOM]] of EPUB content documents so that
 					users can investigate the semantics and structure expressed in the source.</li>
 				<li>Table of Contents &#8212; Ensure that users can access the link text, including <a
 						data-cite="epub-33#confreq-nav-a-title">text alternatives for visual content</a>. Activating the
@@ -2181,20 +2179,20 @@
 			<section id="security-privacy-overview">
 				<h3>Overview</h3>
 
-				<p>The particularity of an <a>EPUB Publication</a> is its structure. The EPUB format provides a means of
+				<p>The particularity of an <a>EPUB publication</a> is its structure. The EPUB format provides a means of
 					representing, packaging, and encoding structured and semantically enhanced web content — including
 					HTML, CSS, SVG, and other resources — for distribution in a single-file container.</p>
 
-				<p>For Reading Systems, this means that the security and privacy issues are primarily based on the
+				<p>For reading systems, this means that the security and privacy issues are primarily based on the
 					features of those formats, and closely mirror the threats presented by web content generally.</p>
 
-				<p>Reading System developers also have a dual responsibility of both ensuring the security and privacy
+				<p>Reading system developers also have a dual responsibility of both ensuring the security and privacy
 					of their applications and helping limit the threats to users from the content that renders within
 					them. The rest of this section explores the risk model of EPUB 3 with the aim of helping developers
 					recognize and mitigate these risks.</p>
 
 				<div class="note">
-					<p>For the risks associated with the authoring of EPUB Publications, refer to the <a
+					<p>For the risks associated with the authoring of EPUB publications, refer to the <a
 							data-cite="epub-33#sec-security-privacy">security and privacy section</a> of
 						[[EPUB-33]].</p>
 				</div>
@@ -2204,16 +2202,16 @@
 				<h3>Threat model</h3>
 
 				<p>The greatest threats to users come from the <a data-cite="epub-33#epub-threat-model">content they
-						read</a> [[EPUB-33]], and the first line of defense against these attacks is the Reading Systems
-					they use. Users expect that Reading Systems act as safeguards against malicious content and are
-					often unaware that EPUB Publications are susceptible to the same security risks as web sites.</p>
+						read</a> [[EPUB-33]], and the first line of defense against these attacks is the reading systems
+					they use. Users expect that reading systems act as safeguards against malicious content and are
+					often unaware that EPUB publications are susceptible to the same security risks as web sites.</p>
 
-				<p>But although Reading Systems are relied on to provide security and privacy, they can also pose
+				<p>But although reading systems are relied on to provide security and privacy, they can also pose
 					unintended threats to users depending on how information is handled. Tracking user information to
-					optimize experiences is a common need, for example, but done without user permission and Reading
-					Systems can run afoul of legal privacy requirements.</p>
+					optimize experiences is a common need, for example, but done without user permission and reading
+					systems can run afoul of legal privacy requirements.</p>
 
-				<p>This section outlines some of the key threats that Reading System developers must take into
+				<p>This section outlines some of the key threats that reading system developers must take into
 					consideration, with further details and recommendations in the following sections.</p>
 
 				<dl>
@@ -2228,21 +2226,21 @@
 
 					<dt>Malicious content</dt>
 					<dd>
-						<p>EPUB Publications may contain resources designed to exploit security flaws in Reading Systems
+						<p>EPUB publications may contain resources designed to exploit security flaws in reading systems
 							or the operating systems they run on.</p>
 					</dd>
 
 					<dt>Remote resources</dt>
 					<dd>
-						<p><a>Remote resources</a> present the same risks as any EPUB Publication loaded from an
-							untrusted source. Even if the publisher of the EPUB Publication is trusted, Remote Resources
+						<p><a>Remote resources</a> present the same risks as any EPUB publication loaded from an
+							untrusted source. Even if the publisher of the EPUB publication is trusted, remote resources
 							may be compromised.</p>
-						<p>Calls to Remote Resources can also be used to track information about users (e.g., through
-							server logs). Reading Systems should limit the information they expose through HTTP requests
+						<p>Calls to remote resources can also be used to track information about users (e.g., through
+							server logs). Reading systems should limit the information they expose through HTTP requests
 							to only what is essential to obtain the resource.</p>
-						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB Creator
-							and specific to each Reading System implementation. Consequently, if the EPUB Creator hosts
-							Remote Resources on a web server they control, the server effectively cannot use security
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB creator
+							and specific to each reading system implementation. Consequently, if the EPUB creator hosts
+							remote resources on a web server they control, the server effectively cannot use security
 							features that require specifying allowable origins, such as headers for <a
 								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
 								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
@@ -2252,10 +2250,10 @@
 
 					<dt>External links</dt>
 					<dd>
-						<p>Like Remote Resources, external links may be used to trick unwitting users into opening
-							malicious resources on the web designed to exploit the Reading System or operating
+						<p>Like remote resources, external links may be used to trick unwitting users into opening
+							malicious resources on the web designed to exploit the reading system or operating
 							system.</p>
-						<p>Likewise, Reading Systems should also avoid exposing potentially identifying information
+						<p>Likewise, reading systems should also avoid exposing potentially identifying information
 							about users through the traversal of links (e.g., not using tracking identifiers or exposing
 							unnecessary information about the user's environment).</p>
 					</dd>
@@ -2279,7 +2277,7 @@
 				</dl>
 
 				<p>Additionally, the security considerations that apply to [[XML]] and [[ZIP]] files also apply to the
-						<a data-cite="epub-33#sec-package-doc">Package Document</a> and the <a
+						<a data-cite="epub-33#sec-package-doc">package document</a> and the <a
 						data-cite="epub-33#sec-ocf">Open Container Format</a>, respectively. See the "Security
 					Consideration" sections of the Media Type registrations for the <a
 						data-cite="epub-33#app-media-type-app-oebps-package"
@@ -2290,22 +2288,22 @@
 			<section id="security-privacy-recommendations">
 				<h3>Recommendations</h3>
 
-				<p>The strongest measure that Reading System developers can take for privacy is to specify the data they
-					intend to collect and use about the user and/or their reading behavior and seek the consent of
-					users to obtain it. They should also allow personalization and control over this information.</p>
+				<p>The strongest measure that reading system developers can take for privacy is to specify the data they
+					intend to collect and use about the user and/or their reading behavior and seek the consent of users
+					to obtain it. They should also allow personalization and control over this information.</p>
 
-				<p>If a Reading System allows users to store persistent data, especially personally identifiable
+				<p>If a reading system allows users to store persistent data, especially personally identifiable
 					information, it must treat that data as sensitive.</p>
 
 				<p>It is understood that the collection of some user data may be required for the sale, delivery, and
-					operation of an EPUB Publication, particularly on platforms where the sale of an EPUB Publication
-					and the method of reading it are connected. In these cases, it is recommended that the Reading
-					System or retailer be clear about the data being collected, how it is used, and allow for user
+					operation of an EPUB publication, particularly on platforms where the sale of an EPUB publication
+					and the method of reading it are connected. In these cases, it is recommended that the reading
+					system or retailer be clear about the data being collected, how it is used, and allow for user
 					opt-outs where possible. Anonymization of data is strongly recommended for the privacy and the
-					security of the user and Reading System.</p>
+					security of the user and reading system.</p>
 
-				<p>It is also understood that user data may be required or helpful for some Reading System affordances.
-					In these cases, anonymization is strongly recommended. It is also recommended that Reading Systems
+				<p>It is also understood that user data may be required or helpful for some reading system affordances.
+					In these cases, anonymization is strongly recommended. It is also recommended that reading systems
 					inform users of what data is needed, what it is to be used for, and to provide methods to
 					opt-out.</p>
 
@@ -2319,9 +2317,9 @@
 		<section id="app-epubReadingSystem">
 			<h2><dfn class="export">epubReadingSystem</dfn> object</h2>
 
-			<p class="note">Reading Systems act as the core rendering engines of EPUB Publications and provide a
+			<p class="note">Reading systems act as the core rendering engines of EPUB publications and provide a
 				scripting environment based on the [[DOM]] specification. So, although this interface definition uses
-				the [[WEBIDL]] notation for implementation by Reading Systems, web browsers generally do not have to
+				the [[WEBIDL]] notation for implementation by reading systems, web browsers generally do not have to
 				implement these objects.</p>
 
 			<section id="app-ers-idl">
@@ -2342,38 +2340,40 @@ partial interface Navigator {
 
 				<div class="note">
 					<p>This specification does not define an <code>epubReadingSystem</code> property extension for the
-						{{WorkerNavigator}} object [[HTML]]. Reading Systems therefore do not have to expose the <code>epubReadingSystem</code>
-						object in the scripting context of Workers, and EPUB Creators cannot rely on its presence.</p>
+						{{WorkerNavigator}} object [[HTML]]. Reading systems therefore do not have to expose the
+							<code>epubReadingSystem</code> object in the scripting context of Workers, and EPUB creators
+						cannot rely on its presence.</p>
 				</div>
 			</section>
 
 			<section id="app-ers-desc">
 				<h3>Description</h3>
 
-				<p>The <code><dfn class="export">Navigator.epubReadingSystem</dfn></code> object provides an interface through which a
-						<a>Scripted Content Document</a> can query information about a user's Reading System.</p>
+				<p>The <code><dfn class="export">Navigator.epubReadingSystem</dfn></code> object provides an interface
+					through which a <a>scripted content document</a> can query information about a user's reading
+					system.</p>
 
-				<p>The object exposes <a href="#app-ers-properties">properties</a> of the Reading System (its name and
+				<p>The object exposes <a href="#app-ers-properties">properties</a> of the reading system (its name and
 					version), and provides the <a href="#app-ers-hasFeature"><code>hasFeature</code> method</a> which
 					can be invoked to determine the features it supports.</p>
 
-				<aside class="example" title="JavaScript function to display the name of the current Reading System">
-					<pre>alert("Reading System name: " + navigator.epubReadingSystem.name);</pre>
+				<aside class="example" title="JavaScript function to display the name of the current reading system">
+					<pre>alert("Reading system name: " + navigator.epubReadingSystem.name);</pre>
 				</aside>
 
 				<p id="scripting-req-readingsystem"
 					data-tests="#scr-readingsystem-support,#scr-readingsystem-support_svg,#scr-readingsystem-support_iframe,#scr-readingsystem-support_iframe_svg"
-					>Reading Systems MUST expose the <code>epubReadingSystem</code> object on the <code>navigator</code>
-					object of all loaded Scripted Content Documents, including any nested <a
+					>Reading systems MUST expose the <code>epubReadingSystem</code> object on the <code>navigator</code>
+					object of all loaded scripted content documents, including any nested <a
 						data-cite="epub-33#sec-scripted-container-constrained">container-constrained scripting
-						contexts</a> [[EPUB-33]]. Reading Systems MUST ensure that the <code>epubReadingSystem</code>
+						contexts</a> [[EPUB-33]]. Reading systems MUST ensure that the <code>epubReadingSystem</code>
 					object is available no later than when the <a data-cite="html#the-end"><code>DOMContentLoaded</code>
 						event is triggered</a> [[HTML]].</p>
 
 				<div class="note">
 					<p>Reading systems implementations may create cloned instances of the <code>epubReadingSystem</code>
-						object in Scripted Content Documents for technical feasibility reasons. In such cases, the
-						Reading System must ensure they consistently maintain the object's state — as reflected by the
+						object in scripted content documents for technical feasibility reasons. In such cases, the
+						reading system must ensure they consistently maintain the object's state — as reflected by the
 						values of its properties and methods — across all copied instances.</p>
 				</div>
 			</section>
@@ -2383,7 +2383,7 @@ partial interface Navigator {
 
 				<p id="scripting-req-readingsystem-properties"
 					data-tests="#scr-readingsystem-support,#scr-readingsystem-support_svg,#scr-readingsystem-support_iframe,#scr-readingsystem-support_iframe_svg"
-					>The Reading System MUST make the following properties available for retrieving information about
+					>The reading system MUST make the following properties available for retrieving information about
 					it.</p>
 
 				<table data-dfn-for="EpubReadingSystem">
@@ -2400,7 +2400,7 @@ partial interface Navigator {
 									<dfn>name</dfn>
 								</code>
 							</td>
-							<td>Returns a <code>String</code> value representing the name of the Reading System (e.g.,
+							<td>Returns a <code>String</code> value representing the name of the reading system (e.g.,
 									"<code>iBooks</code>", "<code>Kindle</code>").</td>
 						</tr>
 						<tr>
@@ -2409,7 +2409,7 @@ partial interface Navigator {
 									<dfn>version</dfn>
 								</code>
 							</td>
-							<td>Returns a <code>String</code> value representing the version of the Reading System
+							<td>Returns a <code>String</code> value representing the version of the reading system
 								(e.g., "<code>1.0</code>", "<code>2.1.1</code>").</td>
 						</tr>
 					</tbody>
@@ -2430,16 +2430,16 @@ partial interface Navigator {
 						<h5>Description</h5>
 
 						<p data-dfn-for="EpubReadingSystem">The <code><dfn>hasFeature</dfn></code> method returns a
-							boolean value indicating whether the Reading System supports any version of the specified
-							feature, or <code>undefined</code> if the Reading System does not recognize the specified
+							boolean value indicating whether the reading system supports any version of the specified
+							feature, or <code>undefined</code> if the reading system does not recognize the specified
 							feature.</p>
 
-						<p>The optional <code>version</code> parameter allows EPUB Creators to query custom features
+						<p>The optional <code>version</code> parameter allows EPUB creators to query custom features
 							that could change in incompatible ways over time. The return value indicates support only
 							for the specified version of the feature.</p>
 
 						<p><a href="#app-ers-hasFeature-features">Features defined in this specification</a> are
-							versionless. If a Reading System supports a feature defined in this specification, it MUST
+							versionless. If a reading system supports a feature defined in this specification, it MUST
 							ignore any supplied <code>version</code> parameter and return a <code>true</code> value.</p>
 
 						<aside class="example"
@@ -2457,9 +2457,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 
 
 						<p id="scripting-req-readingsystem-features" data-tests="#scr-readingsystem-features">The
-							following table lists the set of features that Reading Systems that support the
+							following table lists the set of features that reading systems that support the
 								<code>epubReadingSystem</code> object MUST recognize. When the features are queried from
-							the <code>hasFeature</code> method, Reading Systems MUST return a boolean value indicating
+							the <code>hasFeature</code> method, reading systems MUST return a boolean value indicating
 							their support.</p>
 
 
@@ -2491,38 +2491,38 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 									<td id="feature-touch-events">
 										<code>touch-events</code>
 									</td>
-									<td>The device supports touch events, and the Reading System passes touch events to
+									<td>The device supports touch events, and the reading system passes touch events to
 										the content.</td>
 								</tr>
 								<tr>
 									<td id="feature-mouse-events">
 										<code>mouse-events</code>
 									</td>
-									<td>The device supports mouse events, and the Reading System passes mouse events to
+									<td>The device supports mouse events, and the reading system passes mouse events to
 										the content.</td>
 								</tr>
 								<tr>
 									<td id="feature-keyboard-events">
 										<code>keyboard-events</code>
 									</td>
-									<td>The device supports keyboard events, and the Reading System passes keyboard
+									<td>The device supports keyboard events, and the reading system passes keyboard
 										events to the content.</td>
 								</tr>
 								<tr>
 									<td id="feature-spine-scripting">
 										<code>spine-scripting</code>
 									</td>
-									<td>Indicates whether the Reading System supports <a
+									<td>Indicates whether the reading system supports <a
 											data-cite="epub-33#sec-scripted-spine">spine-level scripting</a> [[EPUB-33]]
 										(e.g., so a <a data-cite="epub-33#sec-scripted-container-constrained"
 											>container-constrained script</a> [[EPUB-33]] can determine whether any
-										actions that depend on scripting support in a <a>Top-level Content Document</a>
+										actions that depend on scripting support in a <a>top-level content document</a>
 										have any chance of success before attempting them).</td>
 								</tr>
 							</tbody>
 						</table>
 
-						<p>Reading System developers MAY add additional features, but future versions of this
+						<p>Reading system developers MAY add additional features, but future versions of this
 							specification could append to this list in ways that might conflict or be incompatible with
 							any such custom additions.</p>
 					</section>
@@ -2534,7 +2534,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 
 			<p>Note that this change log only identifies substantive Changes since <a
 					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> &#8212; those that affect the
-				conformance of Reading Systems or are similarly noteworthy.</p>
+				conformance of reading systems or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+label%3ASpec-RS+"
@@ -2542,7 +2542,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 
 			<ul>
 				<li>31-Mar-2022: Moved custom attribute authoring requirements to the authoring specification. Added
-					Reading System handling of custom properties. See <a
+					reading system handling of custom properties. See <a
 						href="https://github.com/w3c/epub-specs/issues/2134">issue 2134</a>.</li>
 				<li>17-Mar-2022: Added requirement to suppress playback of skippable elements in Media Overlays
 					Documents. See <a href="https://github.com/w3c/epub-specs/issues/2066">issue 2066</a>.</li>
@@ -2553,7 +2553,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					opening external links, and managing local storage to normative recommendations. See <a
 						href="https://github.com/w3c/epub-specs/issues/1957">issue 1957</a>.</li>
 				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
-					model for Reading Systems and additional recommendations for ensuring security and privacy. See <a
+					model for reading systems and additional recommendations for ensuring security and privacy. See <a
 						href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a
 						href="https://github.com/w3c/epub-specs/issues/1872">issue 1872</a>, <a
 						href="https://github.com/w3c/epub-specs/issues/1875">issue 1875</a> and <a
@@ -2566,10 +2566,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						1936</a>.</li>
 				<li>08-Dec-2021: <code>page-spread-center</code> is now an alias for <code>spread-none</code>. See <a
 						href="https://github.com/w3c/epub-specs/issues/1929">issue 1929</a>.</li>
-				<li>10-Nov-2021: Proper definition of the Content URL and handling of relative URLs. See <a
+				<li>10-Nov-2021: Proper definition of the content URL and handling of relative URLs. See <a
 						href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and <a
 						href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a>.</li>
-				<li>01-Nov-2021: Added a statement on the Reading System behavior when item references are repeated in
+				<li>01-Nov-2021: Added a statement on the reading system behavior when item references are repeated in
 					the spine. See <a href="https://github.com/w3c/epub-specs/issues/1686">issue 1686</a>.</li>
 				<li>25-Oct-2021: Clarify that reading systems must render non-linear resources when they are hyperlinked
 					to by a user. See <a href="https://github.com/w3c/epub-specs/issues/1864">issue 1864</a>.</li>
@@ -2586,22 +2586,22 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<li>18-June-2021: Moved requirements for supporting SSML, PLS lexicons and CSS 3 Speech to the <a
 						href="https://www.w3.org/TR/epub-tts-10">EPUB 3 Text-to-Speech Support</a> note. See <a
 						href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
-				<li>20-May-2021: Providing a shared and unique origin for scripts is a requirements for Reading Systems
+				<li>20-May-2021: Providing a shared and unique origin for scripts is a requirements for reading systems
 					that support scripting. See <a href="https://github.com/w3c/epub-specs/issues/1659">issue
 					1659</a>.</li>
 				<li>20-May-2021: Removed requirement for reading systems to be conformant xml:base processors. See <a
 						href="https://github.com/w3c/epub-specs/pull/1678">pull request 1678</a>.</li>
-				<li>12-May-2021: Added additional requirement that Reading Systems ignore property values that expand to
+				<li>12-May-2021: Added additional requirement that reading systems ignore property values that expand to
 					invalid URL strings and property values with empty references. See <a
 						href="https://github.com/w3c/epub-specs/issues/1673">issue 1673</a>.</li>
 				<li>12-May-2021: Changed all references to URIs/IRIs to URLs and references to RFCs 3986 and 3987 to the
 					URL standard. See <a href="https://github.com/w3c/epub-specs/issues/808">issue 808</a>.</li>
 
-				<li>06-May-2021: Recommend that Reading Systems support references to HTML target elements and SVG
+				<li>06-May-2021: Recommend that reading systems support references to HTML target elements and SVG
 					fragment identifiers in <code>textref</code> attributes and the <code>text</code> element's
 						<code>src</code> attribute. Support for other fragment identifier schemes is optional. See <a
 						href="https://github.com/w3c/epub-specs/issues/1586">issue 1586</a>.</li>
-				<li>23-Apr-2021: Clarified that Reading Systems should attempt to process invalid file and path names.
+				<li>23-Apr-2021: Clarified that reading systems should attempt to process invalid file and path names.
 					See <a href="https://github.com/w3c/epub-specs/issues/1629">issue 1629</a></li>
 				<li>16-Apr-2021: Removed the section on custom attributes. See <a
 						href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-04-15-epub#resolution2"
@@ -2617,10 +2617,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					the defunct appendix in the Accessibility specification. See <a
 						href="https://github.com/w3c/epub-specs/issues/1608">issue 1608</a>.</li>
 				<li>09-Apr-2021: Added section clarifying all the conformance requirements on establishing the primary
-					language and base direction of Publication Resources. See <a
+					language and base direction of publication resources. See <a
 						href="https://github.com/w3c/epub-specs/pull/1613">pull request 1613</a>.</li>
-				<li>01-Apr-2021: Added section clarifying how absolute URLs are created from relative in the Package
-					Document. See <a href="https://github.com/w3c/epub-specs/pull/1468">pull request 1468</a>.</li>
+				<li>01-Apr-2021: Added section clarifying how absolute URLs are created from relative in the package
+					document. See <a href="https://github.com/w3c/epub-specs/pull/1468">pull request 1468</a>.</li>
 				<li>30-Mar-2021: Restructured the document to remove the rendundant conformance sections and
 					requirements that were only used as locators when this specification was combined with the authoring
 					requirements. See <a href="https://github.com/w3c/epub-specs/pull/1597">pull request 1597</a> and <a
@@ -2630,7 +2630,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<li>23-Mar-2021: Changed "suppressing" of non-linear content to "skipping" when traversing the spine to
 					clarify that the intention is not to remove all access to such content. See <a
 						href="https://github.com/w3c/epub-specs/issues/1480">issue 1480</a>.</li>
-				<li>10-Mar-2021: Changed restriction against using resources not listed in the Package Document to a
+				<li>10-Mar-2021: Changed restriction against using resources not listed in the package document to a
 					recommendation not to use. See <a href="https://github.com/w3c/epub-specs/issues/810">issue
 					810</a>.</li>
 				<li>09-March-2021: the statement on unique identifiers has been set to non-normative, following the
@@ -2649,7 +2649,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
 				<li>19-Feb-2021: Updated the <a href="#sec-scripted-content-security">scripting security
 						considerations</a> so that the text recommends assigning a unique origin to each EPUB
-					Publication for security rather than domain isolation at the Content Document level. See <a
+					publication for security rather than domain isolation at the Content Document level. See <a
 						href="https://github.com/w3c/epub-specs/issues/1156">issue 1156</a>.</li>
 				<li>15-Feb-2021: Clarified the requirements for presenting nav elements in the navigation document. The
 					toc nav is now the only required element, the page-list nav is recommended when present, and all

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -167,13 +167,13 @@
 
 				<dl>
 					<dt>
-						<dfn class="export" id="dfn-content-display-area">Content Display Area</dfn>
+						<dfn class="export" id="dfn-content-display-area">content display area</dfn>
 					</dt>
 					<dd>
 						<p>The area within the <a>viewport</a> dedicated to the display of <a>EPUB content
-							documents</a>. The Content Display Area excludes any borders, margins, headers, footers, or
+							documents</a>. The content display area excludes any borders, margins, headers, footers, or
 							other decoration a <a>EPUB reading system</a> might inject into the viewport.</p>
-						<p>In the case of <a>synthetic spreads</a>, the viewport contains two Content Display Areas.</p>
+						<p>In the case of <a>synthetic spreads</a>, the viewport contains two content display areas.</p>
 					</dd>
 				</dl>
 			</section>
@@ -253,7 +253,7 @@
 				<h4>Resource locations</h4>
 
 				<p id="confreq-rs-remote">Reading systems SHOULD support <a>remote resources</a>, as defined in <a
-						data-cite="epub-33#sec-resource-locations">Resource Locations</a> [[EPUB-33]].</p>
+						data-cite="epub-33#sec-resource-locations">Resource locations</a> [[EPUB-33]].</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-data-urls">
@@ -549,7 +549,7 @@
 							as the <a data-cite="url#concept-base-url">base URL</a> [[URL]] for all files within the
 								<code>META-INF</code> directory. See also the section on <a
 								data-cite="epub-33#sec-parsing-urls-metainf">Parsing URLs in the <code>META-INF</code>
-								Directory</a> in [[!EPUB-33]].</p>
+								directory</a> in [[!EPUB-33]].</p>
 					</div>
 				</section>
 
@@ -610,7 +610,7 @@
 						<dd>
 							<p>Reading systems MUST NOT fail when encountering configuration files in the <code
 									class="filename">META-INF</code> directory not listed in <a
-									data-cite="epub-33#sec-container-metainf-files">Reserved Files</a> [[EPUB-33]].</p>
+									data-cite="epub-33#sec-container-metainf-files">Reserved files</a> [[EPUB-33]].</p>
 						</dd>
 					</dl>
 				</section>
@@ -676,7 +676,7 @@
 				<h3>Font obfuscation</h3>
 
 				<p id="confreq-ocf-fobfus">Reading systems SHOULD support deobfuscation of fonts as defined in <a
-						data-cite="epub-33#sec-font-obfuscation">Font Obfuscation</a> [[EPUB-33]].</p>
+						data-cite="epub-33#sec-font-obfuscation">Font obfuscation</a> [[EPUB-33]].</p>
 
 				<p>To restore the original data, reading systems should simply reverse the process: the source file
 					becomes the obfuscated data, and the destination file contains the raw data.</p>
@@ -1152,7 +1152,7 @@
 						<p id="confreq-css-rs-prefixed"
 							data-tests="#css-epub-hyphens, #css-epub-line-break, #css-epub-text-align-last, #css-epub-text-combine-horizontal, #css-epub-text-emphasis, #css-epub-text-orientation, #css-epub-text-transform, #css-epub-text-underline-position, #css-epub-word-break, #css-epub-writing-mode"
 							>MUST support all prefixed properties defined in <a data-cite="epub-33#sec-css-prefixed">CSS
-								Style Sheets — Prefixed Properties</a> [[EPUB-33]].</p>
+								Style Sheets — Prefixed properties</a> [[EPUB-33]].</p>
 					</li>
 					<li>
 						<p id="confreq-css-creator-styles">SHOULD apply <a>EPUB creator</a> style sheets as written to
@@ -1525,7 +1525,7 @@
 							<dt id="def-spread-auto" data-tests="#fxl-spread-auto">auto</dt>
 							<dd>
 								<p>Reading systems MAY use synthetic spreads in specific or all device orientations as
-									part of a <a>Content Display Area</a> utilization optimization process.</p>
+									part of a <a>content display area</a> utilization optimization process.</p>
 							</dd>
 						</dl>
 					</section>
@@ -1594,7 +1594,7 @@
 									<code>viewport</code>
 								<code>meta</code> tag — content positioned outside of the initial containing block will
 								not be visible. When the ICB aspect ratio does not match the aspect ratio of the reading
-								system <a>Content Display Area</a>, reading systems MAY position the ICB inside the area
+								system <a>content display area</a>, reading systems MAY position the ICB inside the area
 								to accommodate the user interface; in other words, added letter-boxing space MAY appear
 								on either side (or both) of the content.</p>
 						</dd>
@@ -1611,16 +1611,16 @@
 				<section id="sec-fxl-viewport">
 					<h4>Viewport rendering</h4>
 
-					<p>When rendering <a>fixed-layout documents</a>, the default intent is that the <a>Content Display
-							Area</a> SHOULD occupy as much of the available <a>viewport</a> area as possible. Reading
+					<p>When rendering <a>fixed-layout documents</a>, the default intent is that the <a>content display
+							area</a> SHOULD occupy as much of the available <a>viewport</a> area as possible. Reading
 						systems SHOULD NOT inject additional content such as border, margins, headers, or footers into
 						the viewport.</p>
 
 					<div class="note">
 						<p>This specification does not define how the <a
 								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-								containing block</a> [[CSS2]] is placed within the reading system <a>Content Display
-								Area</a>.</p>
+								containing block</a> [[CSS2]] is placed within the reading system <a>content display
+								area</a>.</p>
 					</div>
 
 					<div class="note">
@@ -1711,7 +1711,7 @@
 
 				<p>Reading systems MAY support custom properties provided they do not introduce expressions that
 					conflict behaviorally with the properties defined in the <a
-						href="https://www.w3.org/TR/epub-33/#app-rendering-vocab">Package Rendering Vocabulary</a>
+						href="https://www.w3.org/TR/epub-33/#app-rendering-vocab">Package rendering vocabulary</a>
 					[[EPUB-33]].</p>
 			</section>
 		</section>
@@ -1819,7 +1819,7 @@
 							data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a> [[EPUB-33]]
 						to the appropriate elements, when specified, in the EPUB content document. Conversely, the class
 						names SHOULD be removed when the playback state changes, as described in <a
-							data-cite="epub-33#sec-docs-assoc-style">Associating Style Information</a> [[EPUB-33]].</p>
+							data-cite="epub-33#sec-docs-assoc-style">Associating style information</a> [[EPUB-33]].</p>
 
 					<p>The <code>active-class</code> and <code>playback-active-class</code> metadata properties are
 						OPTIONAL, and if omitted, reading system behavior is implementation-specific.</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -181,7 +181,7 @@
 			<section id="conformance"></section>
 
 			<section id="sec-intro-relations" class="informative">
-				<h3>Relationship to Other Specifications</h3>
+				<h3>Relationship to other specifications</h3>
 
 				<section id="rel">
 					<h4>Relationship to HTML</h4>
@@ -215,13 +215,13 @@
 			</section>
 		</section>
 		<section id="sec-pub-resources">
-			<h3>Publication Resource Processing</h3>
+			<h3>Publication Resource processing</h3>
 
 			<p id="confreq-rs-epub-pub-res" class="support" data-tests="#cnt-xhtml-support">Reading Systems MUST process
 					<a data-cite="epub-33#sec-publication-resources">Publication Resources</a> [[EPUB-33]].</p>
 
 			<section id="sec-epub-rs-conf-cmt">
-				<h4>Core Media Types</h4>
+				<h4>Core Media types</h4>
 				
 				<p id="confreq-rs-epub3-images"
 					data-tests="#pub-cmt-gif,#pub-cmt-jpg,#pub-cmt-png,#pub-cmt-svg,#pub-cmt-webp">If a Reading System
@@ -250,7 +250,7 @@
 			</section>
 
 			<section id="sec-epub-rs-conf-remote-res">
-				<h4>Resource Locations</h4>
+				<h4>Resource locations</h4>
 
 				<p id="confreq-rs-remote">Reading Systems SHOULD support <a>Remote Resources</a>, as defined in <a
 						data-cite="epub-33#sec-resource-locations">Resource Locations</a> [[EPUB-33]].</p>
@@ -268,7 +268,7 @@
 			</section>
 
 			<section id="sec-epub-rs-conf-xml">
-				<h4>XML Processing</h4>
+				<h4>XML processing</h4>
 
 				<p>A Reading System MUST be both of the following:</p>
 
@@ -336,7 +336,7 @@
 			</section>
 
 			<section id="sec-epub-rs-network-access">
-				<h3>Network Access</h3>
+				<h3>Network access</h3>
 
 				<p>Reading Systems MAY support network access to <a href="#sec-epub-rs-conf-remote-res">retrieve Remote
 						Resources</a> and to allow <a>Scripted Content Documents</a> to <a
@@ -361,7 +361,7 @@
 			</section>
 
 			<section id="sec-epub-rs-external-links">
-				<h3>External Links</h3>
+				<h3>External links</h3>
 
 				<p data-tests="#pub-external-links">Reading Systems SHOULD open links that resolve outside the <a>EPUB
 						Publication</a> in a new browser instance to ensure that the browser's security and privacy
@@ -379,7 +379,7 @@
 			</section>
 		</section>
 		<section id="sec-ocf">
-			<h2>Open Container Format Processing</h2>
+			<h2>Open Container Format processing</h2>
 
 			<p id="confreq-rs-epub3-ocf" class="support" data-tests="#ocf-package_arbitrary">Reading Systems MUST
 				process the <a data-cite="epub-33#sec-ocf">EPUB Container</a> [[EPUB-33]].</p>
@@ -395,7 +395,7 @@
 				<h3>OCF Abstract Container</h3>
 
 				<section id="sec-container-iri">
-					<h4>URL of the Root Directory</h4>
+					<h4>URL of the root directory</h4>
 
 					<p id="sec-container-iri-root"
 						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">Reading Systems MUST
@@ -553,7 +553,7 @@
 				</section>
 
 				<section id="sec-container-filenames">
-					<h4>File Names</h4>
+					<h4>File names</h4>
 
 					<p>Although EPUB Creators are required to follow various <a
 							data-cite="epub-33#sec-container-filenames">File Name and File Path restrictions</a>
@@ -566,7 +566,7 @@
 				</section>
 
 				<section id="sec-container-metainf">
-					<h4><code>META-INF</code> Directory</h4>
+					<h4><code>META-INF</code> directory</h4>
 
 					<dl class="conformance-list">
 						<dt id="sec-container-metainf-container.xml">Container File (<code>container.xml</code>)</dt>
@@ -616,7 +616,7 @@
 			</section>
 
 			<section id="sec-container-zip">
-				<h3>OCF ZIP Container</h3>
+				<h3>OCF ZIP container</h3>
 
 				<p>A Reading System:</p>
 
@@ -672,7 +672,7 @@
 			</section>
 
 			<section id="sec-container-fobfus">
-				<h3>Font Obfuscation</h3>
+				<h3>Font obfuscation</h3>
 
 				<p id="confreq-ocf-fobfus">Reading Systems SHOULD support deobfuscation of fonts as defined in <a
 						data-cite="epub-33#sec-font-obfuscation">Font Obfuscation</a> [[EPUB-33]].</p>
@@ -690,13 +690,13 @@
 			</section>
 		</section>
 		<section id="sec-package-doc">
-			<h2>Package Document Processing</h2>
+			<h2>Package document processing</h2>
 
 			<p id="confreq-rs-epub-pub" class="support">Reading Systems MUST process the <a
 					data-cite="epub-33#sec-package-doc">Package Document</a> [[EPUB-33]].</p>
 
 			<section id="sec-pkg-doc-base-dir">
-				<h4>Base Direction</h4>
+				<h4>Base direction</h4>
 
 				<p id="confreq-rs-pkg-dir"
 					data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
@@ -713,7 +713,7 @@
 			</section>
 
 			<section id="sec-pkg-doc-pub-identifiers">
-				<h3>Unique Identifier</h3>
+				<h3>Unique identifier</h3>
 
 				<p id="confreq-rs-pkg-unique-id" data-tests="#pkg-unique-id">Reading Systems SHOULD NOT depend on the <a
 						data-cite="epub-33#dfn-unique-identifier">Unique Identifier</a> being unique to one and only one
@@ -919,7 +919,7 @@
 				</p>
 
 				<section id="spine-overrides">
-					<h4>Spine Overrides</h4>
+					<h4>Spine overrides</h4>
 
 					<p>When a spine <a data-cite="epub-33#sec-itemref-elem"><code>itemref</code> element's</a>
 						<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a <a
@@ -947,7 +947,7 @@
 			</section>
 		</section>
 		<section id="sec-contentdocs">
-			<h2>Content Document Processing</h2>
+			<h2>Content Document processing</h2>
 
 			<p>The definition of <a data-cite="epub-33#sec-contentdocs">EPUB Content Documents</a> [[EPUB-33]] includes
 				various authoring restrictions to optimize the cross-compatibility of content (e.g., <a
@@ -966,7 +966,7 @@
 					and honor any applicable user agent conformance constraints expressed therein.</p>
 
 				<section id="sec-xhtml-extensions">
-					<h4>HTML Extensions</h4>
+					<h4>HTML extensions</h4>
 
 					<section id="sec-xhtml-aria">
 						<h5>ARIA</h5>
@@ -977,7 +977,7 @@
 					</section>
 
 					<section id="sec-xhtml-structural-semantics">
-						<h5>Structural Semantics</h5>
+						<h5>Structural semantics</h5>
 
 						<p id="confreq-rs-epubtype-head">In addition to the requirements in <a
 								href="#sec-structural-semantics"></a>, a Reading System MUST ignore semantics expressed
@@ -1001,7 +1001,7 @@
 					</section>
 
 					<section id="sec-xhtml-content-switch">
-						<h5>Content Switching (Deprecated)</h5>
+						<h5>Content switching (deprecated)</h5>
 
 						<p>Use of the <code>switch</code> element is <a data-cite="epub-33#deprecated">deprecated</a>
 							[[EPUB-33]]. Refer to its definition in [[EPUBContentDocs-301]] for implementation
@@ -1009,7 +1009,7 @@
 					</section>
 
 					<section id="sec-xhtml-epub-trigger">
-						<h5>The <code>epub:trigger</code> Element (Deprecated)</h5>
+						<h5>The <code>epub:trigger</code> element (deprecated)</h5>
 
 						<p>Use of the <code>trigger</code> element is <a data-cite="epub-33#deprecated">deprecated</a>
 							[[EPUB-33]]. Refer to its definition in [[EPUBContentDocs-301]] for implementation
@@ -1017,7 +1017,7 @@
 					</section>
 
 					<section id="sec-xhtml-custom-attributes">
-						<h5>Custom Attributes</h5>
+						<h5>Custom attributes</h5>
 
 						<p>Reading Systems MAY support custom attributes provided the attributes do not modify the
 							requirements of this specification.</p>
@@ -1025,7 +1025,7 @@
 				</section>
 
 				<section id="sec-xhtml-deviations">
-					<h4>HTML Deviations and Constraints</h4>
+					<h4>HTML deviations and constraints</h4>
 
 					<section id="sec-xhtml-mathml">
 						<h3>MathML</h3>
@@ -1086,7 +1086,7 @@
 					</section>
 
 					<section id="sec-xhtml-forms">
-						<h5>Form Submission</h5>
+						<h5>Form submission</h5>
 
 						<p>Reading System support for the submission of [[HTML]] forms is OPTIONAL. A Reading System
 							might, for example, prevent form submissions by limiting access to networking.</p>
@@ -1832,7 +1832,7 @@
 			</section>
 
 			<section id="sec-behaviors-interaction">
-				<h4>Interacting with the EPUB Content document</h4>
+				<h4>Interacting with the EPUB Content Document</h4>
 
 				<section id="sec-rsconf-navigation">
 					<h5>Navigation</h5>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1268,7 +1268,7 @@
 						>Fallbacks for Scripted Content Documents</a> [[EPUB-33]].</p>
 
 				<section id="sec-local-storage">
-					<h4>Local Storage</h4>
+					<h4>Local storage</h4>
 
 					<p>Scripts may save persistent data through <a data-cite="html#dom-document-cookie">cookies</a> and
 							<a data-cite="html#webstorage">web storage</a> [[HTML]], but Reading Systems MAY block such
@@ -1282,7 +1282,7 @@
 				</section>
 
 				<section id="sec-scripted-content-events">
-					<h4>Event Model</h4>
+					<h4>Event model</h4>
 
 					<p>Reading Systems SHOULD follow the DOM Event model as per [[HTML]] and pass UI events to the
 						scripting environment before performing any default action associated with these events.</p>
@@ -1295,7 +1295,7 @@
 				</section>
 
 				<section id="sec-scripted-content-security" class="informative">
-					<h3>Security Considerations</h3>
+					<h3>Security considerations</h3>
 
 					<p>Reading System developers who also support scripting must be aware of the security issues that
 						arise when Reading Systems execute scripted content. As the underlying scripting model employed
@@ -1357,7 +1357,7 @@
 			</section>
 		</section>
 		<section id="sec-nav">
-			<h3>Navigation Document Processing</h3>
+			<h3>Navigation document processing</h3>
 
 			<p id="sec-nav-rs-conf" class="support" data-tests="#nav-spine_in-spine">Reading Systems MUST process <a
 					data-cite="epub-33#sec-nav">EPUB Navigation Documents</a> [[EPUB-33]].</p>
@@ -1404,19 +1404,19 @@
 					data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]].</p>
 		</section>
 		<section id="sec-rendering-control">
-			<h2>Layout Rendering Control Processing</h2>
+			<h2>Layout rendering control processing</h2>
 
 			<section id="sec-fixed-layouts">
-				<h3>Fixed-Layout Documents</h3>
+				<h3>Fixed-layout documents</h3>
 
 				<p id="confreq-rs-epub3-fxl" class="support">Reading Systems MUST support the rendering of <a
 						data-cite="epub-33#sec-fixed-layouts">Fixed-Layout Documents</a> [[EPUB-33]].</p>
 
 				<section id="sec-fxl-props">
-					<h4>Fixed-Layout Properties</h4>
+					<h4>Fixed-layout properties</h4>
 
 					<section id="layout">
-						<h5>The <code>rendition:layout</code> Property</h5>
+						<h5>The <code>rendition:layout</code> property</h5>
 
 						<p>The default value <code>reflowable</code> MUST be assumed by EPUB Reading Systems as the
 							global value if no <a data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a>
@@ -1455,7 +1455,7 @@
 					</section>
 
 					<section id="orientation">
-						<h5>The <code>rendition:orientation</code> Property</h5>
+						<h5>The <code>rendition:orientation</code> property</h5>
 
 						<p id="fxl-orientation-default" data-tests="#fxl-orientation-default">The default value
 								<code>auto</code> MUST be assumed by EPUB Reading Systems as the global value if no <a
@@ -1490,7 +1490,7 @@
 					</section>
 
 					<section id="spread">
-						<h5>The <code>rendition:spread</code> Property</h5>
+						<h5>The <code>rendition:spread</code> property</h5>
 
 						<p id="fxl-spread-default" data-tests="#fxl-spread-default">The default value <code>auto</code>
 							MUST be assumed by EPUB Reading Systems as the global value if no <a
@@ -1532,7 +1532,7 @@
 					</section>
 
 					<section id="page-spread">
-						<h4>The <code>rendition:page-spread-*</code> Properties</h4>
+						<h4>The <code>rendition:page-spread-*</code> properties</h4>
 
 						<p>The <a data-cite="epub-33#fxl-page-spread-left"><span id="page-spread-left"
 									data-tests="#fxl-page-spread-left"><code>rendition:page-spread-left</code></span>
@@ -1582,7 +1582,7 @@
 				</section>
 
 				<section id="sec-fxl-dimensions">
-					<h4>Initial Containing Block Dimensions</h4>
+					<h4>Initial containing block dimensions</h4>
 
 					<dl>
 						<dt>XHTML</dt>
@@ -1610,7 +1610,7 @@
 				</section>
 
 				<section id="sec-fxl-viewport">
-					<h4>Viewport Rendering</h4>
+					<h4>Viewport rendering</h4>
 
 					<p>When rendering <a>Fixed-Layout Documents</a>, the default intent is that the <a>Content Display
 							Area</a> SHOULD occupy as much of the available <a>Viewport</a> area as possible. Reading
@@ -1632,14 +1632,14 @@
 			</section>
 
 			<section id="sec-reflowable-layouts">
-				<h3>Reflowable Layouts</h3>
+				<h3>Reflowable layouts</h3>
 
 				<p id="confreq-rs-epub3-presentational-meta" class="support">Reading Systems SHOULD process the <a
 						data-cite="epub-33#sec-rendering-general">general package rendering properties</a>
 					[[EPUB-33]].</p>
 
 				<section id="flow">
-					<h4>The <code>rendition:flow</code> Property</h4>
+					<h4>The <code>rendition:flow</code> property</h4>
 
 					<p>If a Reading System supports the specified rendering, it SHOULD use that method to handle
 						overflow content, but MAY provide the option for users to override the requested rendering.</p>
@@ -1691,7 +1691,7 @@
 				</section>
 
 				<section id="align-x-center">
-					<h4>The <code>rendition:align-x-center</code> Property</h4>
+					<h4>The <code>rendition:align-x-center</code> property</h4>
 
 					<p>When the <a href="#align-x-center"><code>rendition:align-x-center</code> property</a> is set on a
 						spine item, Reading Systems SHOULD render the content centered horizontally within the
@@ -1708,7 +1708,7 @@
 			</section>
 
 			<section id="sec-custom-properties">
-				<h3>Custom Properties</h3>
+				<h3>Custom properties</h3>
 
 				<p>Reading Systems MAY support custom properties provided they do not introduce expressions that
 					conflict behaviorally with the properties defined in the <a
@@ -1717,7 +1717,7 @@
 			</section>
 		</section>
 		<section id="sec-media-overlays">
-			<h2>Media Overlays Processing</h2>
+			<h2>Media overlays processing</h2>
 
 			<p id="confreq-rs-epub3-mo" class="support">Reading Systems with the capability to render prerecorded audio
 				SHOULD support <a data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[EPUB-33]].</p>
@@ -1733,7 +1733,7 @@
 			</ul>
 
 			<section id="sec-behaviors-loading">
-				<h4>Loading the Media Overlay</h4>
+				<h4>Loading the media overlay</h4>
 
 				<p>When a Reading System loads a <a>Package Document</a>, it MUST refer to the <a>manifest</a>
 					<a data-cite="epub-33#elemdef-package-item"><code>item</code> elements'</a> [[EPUB-33]]
@@ -1752,10 +1752,10 @@
 			</section>
 
 			<section id="sec-behaviors-playback">
-				<h4>Basic Playback</h4>
+				<h4>Basic playback</h4>
 
 				<section id="sec-rsconf-timing-synch">
-					<h3>Timing and Synchronization</h3>
+					<h3>Timing and synchronization</h3>
 
 					<p id="mol-timing-sync"
 						data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio"
@@ -1770,7 +1770,7 @@
 				</section>
 
 				<section id="sec-rsconf-rendering-audio">
-					<h5>Rendering Audio</h5>
+					<h5>Rendering audio</h5>
 
 					<p>When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-audio"><code>audio</code>
 							element</a>, Reading Systems MUST play the audio resource referenced by the <code>src</code>
@@ -1803,7 +1803,7 @@
 				</section>
 
 				<section id="sec-rsconf-rendering-text">
-					<h5>Rendering EPUB Content Document Elements</h5>
+					<h5>Rendering EPUB Content Document elements</h5>
 
 					<p>When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-text"><code>text</code>
 							element</a> [[EPUB-33]] whose <code>src</code> attribute contains a <a
@@ -1832,7 +1832,7 @@
 			</section>
 
 			<section id="sec-behaviors-interaction">
-				<h4>Interacting with the EPUB Content Document</h4>
+				<h4>Interacting with the EPUB Content document</h4>
 
 				<section id="sec-rsconf-navigation">
 					<h5>Navigation</h5>
@@ -1866,7 +1866,7 @@
 				</section>
 
 				<section id="sec-embedded-media">
-					<h5>Embedded Audio and Video</h5>
+					<h5>Embedded audio and video</h5>
 
 					<p>An <a>EPUB Content Document</a> with which a Media Overlay is associated MAY itself contain
 						embedded video and audio media. The Media Overlay elements MAY point to these elements. Unlike
@@ -1974,7 +1974,7 @@
 				</section>
 
 				<section id="sec-text-to-speech">
-					<h5>Text-to-Speech</h5>
+					<h5>Text-to-speech</h5>
 
 					<p id="mol-tts" data-tests="#mol-tts_multi,#mol-tts_single">When a Media Overlay <a
 							data-cite="epub-33#elemdef-smil-text"><code>text</code> element</a> [[EPUB-33]] with no <a
@@ -2001,7 +2001,7 @@
 			</section>
 
 			<section id="sec-behaviors-skip-escape">
-				<h4>Skippability and Escapability</h4>
+				<h4>Skippability and escapability</h4>
 
 				<section id="sec-skippability">
 					<h5>Skippability</h5>
@@ -2026,7 +2026,7 @@
 			</section>
 		</section>
 		<section id="sec-structural-semantics">
-			<h2>Processing Structural Semantics</h2>
+			<h2>Processing structural semantics</h2>
 
 			<p id="confreq-rs-epub-epub-type" class="support">Reading Systems MAY support <a
 					data-cite="epub-33#app-structural-semantics">structural semantics</a> [[EPUB-33]] in <a>EPUB Content
@@ -2056,7 +2056,7 @@
 				with the element MUST be given precedence.</p>
 		</section>
 		<section id="sec-vocab-assoc">
-			<h2>Vocabulary Association Mechanisms</h2>
+			<h2>Vocabulary association mechanisms</h2>
 
 			<p id="confreq-res-epub-vocab-assoc" class="support">Reading Systems MUST support <a
 					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[EPUB-33]].</p>
@@ -2111,7 +2111,7 @@
 			</dl>
 		</section>
 		<section id="sec-epub-rs-conf-backward">
-			<h3>Backward Compatibility</h3>
+			<h3>Backward compatibility</h3>
 
 			<p id="confreq-rs-backward-epub" data-tests="#pkg-version-backward">Reading Systems MUST attempt to process
 				an <a>EPUB Publication</a> whose <a>Package Document</a>
@@ -2123,7 +2123,7 @@
 				support such EPUB Publications as defined by those specifications.</p>
 		</section>
 		<section id="sec-epub-rs-conf-forward">
-			<h3>Forward Compatibility</h3>
+			<h3>Forward compatibility</h3>
 
 			<p id="confreq-rs-forward-epubn">Reading Systems SHOULD attempt to process an <a>EPUB Publication</a> whose
 					<a>Package Document</a>
@@ -2178,7 +2178,7 @@
 				to aid in evaluating these issues and more.</p>
 		</section>
 		<section id="sec-security-privacy" class="informative">
-			<h2>Security and Privacy</h2>
+			<h2>Security and privacy</h2>
 
 			<section id="security-privacy-overview">
 				<h3>Overview</h3>
@@ -2203,7 +2203,7 @@
 			</section>
 
 			<section id="epub-threat-model">
-				<h3>Threat Model</h3>
+				<h3>Threat model</h3>
 
 				<p>The greatest threats to users come from the <a data-cite="epub-33#epub-threat-model">content they
 						read</a> [[EPUB-33]], and the first line of defence against these attacks is the Reading Systems
@@ -2319,7 +2319,7 @@
 			</section>
 		</section>
 		<section id="app-epubReadingSystem">
-			<h2><dfn class="export">epubReadingSystem</dfn> Object</h2>
+			<h2><dfn class="export">epubReadingSystem</dfn> object</h2>
 
 			<p class="note">Reading Systems act as the core rendering engines of EPUB Publications and provide a
 				scripting environment based on the [[DOM]] specification. So, although this interface definition uses
@@ -2327,7 +2327,7 @@
 				implement these objects.</p>
 
 			<section id="app-ers-idl">
-				<h3>Interface Definition</h3>
+				<h3>Interface definition</h3>
 
 				<p>This specification extends the {{Navigator}} object [[HTML]] as follows.</p>
 
@@ -2532,7 +2532,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 			</section>
 		</section>
 		<section id="change-log" class="appendix informative">
-			<h2>Change Log</h2>
+			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive Changes since <a
 					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> &#8212; those that affect the

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -122,7 +122,7 @@
 				values, i.e., a vocabulary, that can be used for that purpose.</p>
 
 			<section id="structure-vocab">
-				<h3>About this Vocabulary</h3>
+				<h3>About this vocabulary</h3>
 
 				<p>While the EPUB Structural Semantics vocabulary is generally host language agnostic, it has been
 					constructed primarily to enable semantic inflection of elements in the HTML vocabulary.</p>
@@ -148,7 +148,7 @@
 			</section>
 		</section>
 		<section id="sec-partitions">
-			<h2>Document Partitions</h2>
+			<h2>Document partitions</h2>
 
 			<dl>
 				<dt id="backmatter">backmatter</dt>
@@ -209,7 +209,7 @@
 			</dl>
 		</section>
 		<section id="sec-divisions">
-			<h2>Document Divisions</h2>
+			<h2>Document divisions</h2>
 
 			<dl>
 				<dt id="chapter">chapter</dt>
@@ -288,7 +288,7 @@
 			</dl>
 		</section>
 		<section id="sec-sections">
-			<h2>Document Sections and Components</h2>
+			<h2>Document sections and components</h2>
 
 			<p>Sections and components that typically occur in the publication bodymatter.</p>
 
@@ -477,7 +477,7 @@
 			</dl>
 		</section>
 		<section id="sec-navigation">
-			<h2>Document Navigation</h2>
+			<h2>Document navigation</h2>
 
 			<dl>
 				<dt id="landmarks">landmarks</dt>
@@ -577,7 +577,7 @@
 			</dl>
 		</section>
 		<section id="sec-document-references">
-			<h2>Document Reference Sections</h2>
+			<h2>Document reference sections</h2>
 
 			<dl>
 				<dt id="appendix">appendix</dt>
@@ -1690,7 +1690,7 @@
 			</section>
 		</section>
 		<section id="sec-preliminary">
-			<h2>Preliminary Sections and Components</h2>
+			<h2>Preliminary sections and components</h2>
 
 			<p>Preliminary sections and components, typically occurring in the publication frontmatter.</p>
 
@@ -1863,7 +1863,7 @@
 			</dl>
 		</section>
 		<section id="sec-complementary">
-			<h2>Complementary Content</h2>
+			<h2>Complementary content</h2>
 
 			<dl>
 				<dt id="case-study">case-study<span class="status draft"> [draft]</span></dt>
@@ -2063,7 +2063,7 @@
 			</dl>
 		</section>
 		<section id="sec-titles">
-			<h2>Titles and Headings</h2>
+			<h2>Titles and headings</h2>
 
 			<dl>
 				<dt id="bridgehead">bridgehead</dt>
@@ -2232,7 +2232,7 @@
 			</dl>
 		</section>
 		<section id="sec-educational">
-			<h2>Educational Content</h2>
+			<h2>Educational content</h2>
 
 			<section id="learning-obj">
 				<h3 id="h_learning-obj">Learning objectives</h3>
@@ -2620,7 +2620,7 @@
 			</dl>
 		</section>
 		<section id="notes">
-			<h2>Notes and Annotations</h2>
+			<h2>Notes and annotations</h2>
 
 			<dl>
 				<dt id="annotation">annotation<span class="status deprecated"> [deprecated]</span></dt>
@@ -2980,7 +2980,7 @@
 			</dl>
 		</section>
 		<section id="document-text">
-			<h2>Document Text</h2>
+			<h2>Document text</h2>
 
 			<p>Terms for describing components at the phrasing level.</p>
 

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -106,22 +106,22 @@
 
 			<p>Structural semantics add additional meaning about the specific structural purpose an HTML (or SVG)
 				element plays. The <a data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code>
-				attribute</a> [[EPUB-33]] is used to express domain-specific semantics in <a>EPUB Content Documents</a>
-				and <a>Media Overlay Documents</a> [[EPUB-33]], with the structural information it carries complementing
+				attribute</a> [[EPUB-33]] is used to express domain-specific semantics in <a>EPUB content documents</a>
+				and <a>media overlay documents</a> [[EPUB-33]], with the structural information it carries complementing
 				the underlying vocabulary.</p>
 
 			<p>The applied semantics refine the meaning of their containing elements without changing their nature for
-				assistive technologies, as happens when using the similar [^/role^] attribute [[HTML]]. 
-				The attribute does not enhance the accessibility of
-				the content, in other words, only provides hints about the purpose.</p>
+				assistive technologies, as happens when using the similar [^/role^] attribute [[HTML]]. The attribute
+				does not enhance the accessibility of the content, in other words, only provides hints about the
+				purpose.</p>
 
 			<p>Semantic metadata enriches content for use in publishing workflows and for author-defined purposes. It
-				also allows Reading Systems to learn more about the structure and content of a document (e.g., to enable
+				also allows reading systems to learn more about the structure and content of a document (e.g., to enable
 					<a data-cite="epub-33#sec-behaviors-skip-escape">skippability and escapability</a> in Media
 				Overlays).</p>
 
 			<p>The [[EPUB-33]] specification defines a method for adding structural semantics using <em>the attribute
-					axis</em>: instead of adding new elements, EPUB Creators can append the <code>epub:type</code>
+					axis</em>: instead of adding new elements, EPUB creators can append the <code>epub:type</code>
 				attribute to existing elements to add the desired semantics. This document defines a set of property
 				values, i.e., a vocabulary, that can be used for that purpose.</p>
 
@@ -132,7 +132,7 @@
 					constructed primarily to enable semantic inflection of elements in the HTML vocabulary.</p>
 
 				<p>The <i>HTML usage context</i> fields indicate contexts in HTML documents where the given property is
-					considered relevant. EPUB Creators may use the properties on HTML markup elements not specifically
+					considered relevant. EPUB creators may use the properties on HTML markup elements not specifically
 					listed, but must ensure that the semantics they express represent a subset of the carrying element's
 					semantics and do not attach an existing element's meaning to a semantically neutral element.</p>
 
@@ -142,13 +142,13 @@
 					attribute is used. Refer to [[HTML-ARIA]] for more information about where the roles are
 					allowed.</p>
 
-				<p>When processing HTML documents, Reading Systems may ignore such non-compliant properties, unless
+				<p>When processing HTML documents, reading systems may ignore such non-compliant properties, unless
 					their usage context is explicitly overridden or extended by the host specification.</p>
 
 				<p>The <i>Usage details</i> field, when present, identifies a specification that defines or utilizes the
 					designated property. Authors are only required to follow these usage details if they are creating
 					content that conforms to the specified specification, or if the rules apply to all EPUB
-					Publications. In all other cases, the properties may be used however needed.</p>
+					publications. In all other cases, the properties may be used however needed.</p>
 			</section>
 		</section>
 		<section id="sec-partitions">
@@ -1193,8 +1193,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>dl</a>, <a>sectioning
-								content</a>
+							<a>dl</a>, <a>sectioning content</a>
 						</p>
 					</dd>
 					<dd>
@@ -1224,8 +1223,9 @@
 					</dd>
 					<dd>
 						<p>
-							<span class="subproplabel">HTML usage context: </span>The glossdef property is implied on 
-							<a>dd</a> elements within a <a>dl</a> element marked with the <a href="#glossary" >glossary</a> property.</p>
+							<span class="subproplabel">HTML usage context: </span>The glossdef property is implied on
+								<a>dd</a> elements within a <a>dl</a> element marked with the <a href="#glossary"
+								>glossary</a> property.</p>
 					</dd>
 					<dd>
 						<p>
@@ -1249,7 +1249,8 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>The glossterm property is implied on
-							<a>dd</a> elements within a <a>dl</a> element marked with the <a href="#glossary" >glossary</a> property.</p>
+								<a>dd</a> elements within a <a>dl</a> element marked with the <a href="#glossary"
+								>glossary</a> property.</p>
 					</dd>
 					<dd>
 						<p>
@@ -1272,8 +1273,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>sectioning content</a>, <a
-								data-cite="html#the-body-element">body</a>
+							<a>sectioning content</a>, <a data-cite="html#the-body-element">body</a>
 						</p>
 					</dd>
 					<dd>
@@ -1330,8 +1330,8 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>li</a>; this property is implied when parent ul is of
-							type index-entry-list (implicit or explicit)</p>
+							<a>li</a>; this property is implied when parent ul is of type index-entry-list (implicit or
+							explicit)</p>
 					</dd>
 					<dd>
 						<p>
@@ -1358,8 +1358,8 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>ul</a>; this property is implied when the ul has an
-							ancestor of index except within index-headnotes</p>
+							<a>ul</a>; this property is implied when the ul has an ancestor of index except within
+							index-headnotes</p>
 					</dd>
 					<dd>
 						<p>
@@ -1409,8 +1409,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>sectioning content</a>, <a
-								data-cite="html#the-header-element">header</a>
+							<a>sectioning content</a>, <a data-cite="html#the-header-element">header</a>
 						</p>
 					</dd>
 					<dd>
@@ -1436,8 +1435,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>sectioning content</a>, <a
-								>dl</a>
+							<a>sectioning content</a>, <a>dl</a>
 						</p>
 					</dd>
 					<dd>
@@ -1466,8 +1464,8 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>a</a>; this property is implied when parent context is
-							index-locator-list or index-locator-range</p>
+							<a>a</a>; this property is implied when parent context is index-locator-list or
+							index-locator-range</p>
 					</dd>
 					<dd>
 						<p>
@@ -1547,8 +1545,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>phrasing content</a>; typically <a
-								>span</a>
+							<a>phrasing content</a>; typically <a>span</a>
 						</p>
 					</dd>
 					<dd>
@@ -1680,8 +1677,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 				<dd>
@@ -1698,8 +1694,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 
@@ -1710,8 +1705,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 
@@ -1723,8 +1717,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 				<dd>
@@ -1742,8 +1735,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a
-							>aside</a>, <a data-cite="html#grouping-content">grouping content</a>
+						<a>section</a>, <a>aside</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 				<dd>
@@ -1760,8 +1752,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 
@@ -1772,8 +1763,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 
@@ -1784,8 +1774,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 
@@ -1797,8 +1786,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 
@@ -1809,8 +1797,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 
@@ -1821,8 +1808,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 
@@ -1833,8 +1819,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 			</dl>
@@ -1878,8 +1863,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>aside</a>, <a>phrasing
-							content</a>
+						<a>aside</a>, <a>phrasing content</a>
 					</p>
 				</dd>
 				<dd>
@@ -1906,8 +1890,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>aside</a>, <a>phrasing
-							content</a>
+						<a>aside</a>, <a>phrasing content</a>
 					</p>
 				</dd>
 				<dd>
@@ -1927,8 +1910,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 				<dd>
@@ -2007,8 +1989,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>aside</a>, <a>phrasing
-							content</a>
+						<a>aside</a>, <a>phrasing content</a>
 					</p>
 				</dd>
 				<dd>
@@ -2025,8 +2006,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>section</a>, <a data-cite="html#grouping-content"
-							>grouping content</a>
+						<a>section</a>, <a data-cite="html#grouping-content">grouping content</a>
 					</p>
 				</dd>
 				<dd>
@@ -2051,9 +2031,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>flow content</a>, typically <a
-							>p</a>, <a>div</a> or <a
-							>span</a>
+						<a>flow content</a>, typically <a>p</a>, <a>div</a> or <a>span</a>
 					</p>
 				</dd>
 
@@ -2072,8 +2050,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>heading content</a>. This property should only appear once
-						within the document scope.</p>
+						<a>heading content</a>. This property should only appear once within the document scope.</p>
 				</dd>
 
 				<dt id="fulltitle">fulltitle</dt>
@@ -2101,8 +2078,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>heading content</a>. This property should only appear once
-						within the document scope.</p>
+						<a>heading content</a>. This property should only appear once within the document scope.</p>
 				</dd>
 
 				<dt id="halftitle">halftitle</dt>
@@ -2120,8 +2096,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>heading content</a>. This property should only appear once
-						within the document scope.</p>
+						<a>heading content</a>. This property should only appear once within the document scope.</p>
 				</dd>
 
 				<dt id="label">label<span class="status draft"> [draft]</span></dt>
@@ -2140,9 +2115,8 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>Phrasing content</a> descendants of <a
-							data-cite="html#heading-content">heading content</a>, <a
-							>li</a> and <a data-cite="html#the-figcaption-element">figcaption</a>
+						<a>Phrasing content</a> descendants of <a data-cite="html#heading-content">heading content</a>,
+							<a>li</a> and <a data-cite="html#the-figcaption-element">figcaption</a>
 					</p>
 				</dd>
 
@@ -2161,9 +2135,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>Phrasing content</a> descendants of <a
-							>heading content</a>, <a 
-							>li</a> and <a>figcaption</a>
+						<a>Phrasing content</a> descendants of <a>heading content</a>, <a>li</a> and <a>figcaption</a>
 					</p>
 				</dd>
 
@@ -2182,10 +2154,8 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>heading content</a>, <a
-							>phrasing content</a> descendants of <a>heading
-						content</a>, <a data-lt="p">paragraphs</a>, <a
-							data-lt="div">divs</a>
+						<a>heading content</a>, <a>phrasing content</a> descendants of <a>heading content</a>, <a
+							data-lt="p">paragraphs</a>, <a data-lt="div">divs</a>
 					</p>
 				</dd>
 				<dd>
@@ -2202,9 +2172,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>heading content</a>, <a
-							>phrasing content</a> descendants of <a>heading
-						content</a>.</p>
+						<a>heading content</a>, <a>phrasing content</a> descendants of <a>heading content</a>.</p>
 				</dd>
 			</dl>
 		</section>
@@ -2223,8 +2191,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>flow content</a>, <a
-								>phrasing content</a>
+							<a>flow content</a>, <a>phrasing content</a>
 						</p>
 					</dd>
 
@@ -2235,8 +2202,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>sectioning content</a>, <a
-								data-cite="html#grouping-content">grouping content</a>
+							<a>sectioning content</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 
@@ -2259,8 +2225,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>sectioning content</a>, <a
-								data-cite="html#grouping-content">grouping content</a>
+							<a>sectioning content</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 
@@ -2282,8 +2247,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>sectioning content</a>, <a
-								data-cite="html#grouping-content">grouping content</a>
+							<a>sectioning content</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 
@@ -2306,8 +2270,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>sectioning content</a>, <a
-								data-cite="html#grouping-content">grouping content</a>
+							<a>sectioning content</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 				</dl>
@@ -2324,8 +2287,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>aside</a>, <a data-cite="html#grouping-content"
-								>grouping content</a>
+							<a>aside</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 
@@ -2336,8 +2298,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>sectioning content</a>, <a
-								data-cite="html#grouping-content">grouping content</a>
+							<a>sectioning content</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 
@@ -2371,8 +2332,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a data-cite="html#grouping-content">grouping content</a>, <a
-								>phrasing content</a>
+							<a data-cite="html#grouping-content">grouping content</a>, <a>phrasing content</a>
 						</p>
 					</dd>
 
@@ -2385,8 +2345,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>aside</a>, <a data-cite="html#grouping-content"
-								>grouping content</a>
+							<a>aside</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 
@@ -2397,8 +2356,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>aside</a>, <a data-cite="html#grouping-content"
-								>grouping content</a>
+							<a>aside</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 
@@ -2410,8 +2368,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>aside</a>, <a data-cite="html#grouping-content"
-								>grouping content</a>
+							<a>aside</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 
@@ -2424,8 +2381,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>aside</a>, <a data-cite="html#grouping-content"
-								>grouping content</a>
+							<a>aside</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 
@@ -2444,8 +2400,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>aside</a>, <a data-cite="html#grouping-content"
-								>grouping content</a>
+							<a>aside</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 
@@ -2467,8 +2422,7 @@
 					</dd>
 					<dd>
 						<p>
-							<span class="subproplabel">HTML usage context: </span>lists or <a
-								>sectioning content</a>
+							<span class="subproplabel">HTML usage context: </span>lists or <a>sectioning content</a>
 						</p>
 					</dd>
 					<dd>
@@ -2496,8 +2450,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">HTML usage context: </span>
-							<a>aside</a>, <a data-cite="html#grouping-content"
-								>grouping content</a>
+							<a>aside</a>, <a data-cite="html#grouping-content">grouping content</a>
 						</p>
 					</dd>
 				</dl>
@@ -2614,8 +2567,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a>aside</a>, <a>phrasing
-							content</a>
+						<a>aside</a>, <a>phrasing content</a>
 					</p>
 				</dd>
 				<dd>
@@ -2831,7 +2783,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a >a</a>
+						<a>a</a>
 					</p>
 				</dd>
 				<dd>
@@ -2910,7 +2862,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a >a</a>
+						<a>a</a>
 					</p>
 				</dd>
 				<dd>
@@ -2944,7 +2896,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a >a</a>
+						<a>a</a>
 					</p>
 				</dd>
 				<dd>
@@ -3049,15 +3001,15 @@
 						publications (i.e., where no statically paginated equivalent exists). These markers provide
 						consistent navigation regardless of differences in font and screen size that can otherwise
 						affect the dynamic pagination of the content.</p>
-					<p>EPUB Creators must ensure the name of the page break is an end user-consumable page number that
+					<p>EPUB creators must ensure the name of the page break is an end user-consumable page number that
 						identifies the page that is beginning.</p>
 				</dd>
 				<dd>
 					<p>
 						<span class="subproplabel">HTML usage context: </span>
-						<a data-lt="phrasing content">phrasing</a> and <a data-lt="flow content">flow</a>
-						content, where the value of the carrying elements title attribute takes precedence over element
-						content for the purposes of representing the pagebreak value</p>
+						<a data-lt="phrasing content">phrasing</a> and <a data-lt="flow content">flow</a> content, where
+						the value of the carrying elements title attribute takes precedence over element content for the
+						purposes of representing the pagebreak value</p>
 				</dd>
 				<dd>
 					<p>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -143,7 +143,7 @@
 			<section id="conformance"></section>
 		</section>
 		<section id="ssml">
-			<h2>SSML Attributes</h2>
+			<h2>SSML attributes</h2>
 
 			<section id="ssml-intro" class="informative">
 				<h3>Introduction</h3>
@@ -332,7 +332,7 @@
 			</section>
 		</section>
 		<section id="pls">
-			<h2>Pronunciation Lexicons</h2>
+			<h2>Pronunciation lexicons</h2>
 
 			<section id="pls-intro" class="informative">
 				<h3>Introduction</h3>
@@ -354,7 +354,7 @@
 			</section>
 
 			<section id="pls-lexicon-conformance">
-				<h3>Lexicon Conformance</h3>
+				<h3>Lexicon conformance</h3>
 
 				<p>A pronunciation lexicon:</p>
 
@@ -392,7 +392,7 @@
 			</section>
 
 			<section id="pls-publication-requirements">
-				<h3>Associating with EPUB Content Documents</h3>
+				<h3>Associating with EPUB content documents</h3>
 
 				<p id="confreq-cd-pls-xht">EPUB Creators MAY associate zero or more pronunciation lexicons
 					[[PRONUNCIATION-LEXICON]] with an <a>EPUB Content Document</a>.</p>
@@ -428,7 +428,7 @@
 			</section>
 		</section>
 		<section id="css-speech">
-			<h2>CSS Speech</h2>
+			<h2>CSS speech</h2>
 
 			<p>The CSS Speech [[CSS-SPEECH-1]] module defines properties that allow EPUB Creators to declaratively
 				control the aural rendering of <a>EPUB Content Documents</a>. It includes properties for specifying the
@@ -447,7 +447,7 @@
 			</aside>
 		</section>
 		<section id="reading-system-support">
-			<h2>Reading System Support</h2>
+			<h2>Reading System support</h2>
 
 			<section id="reading-system-intro">
 				<h3>Introduction</h3>
@@ -555,7 +555,7 @@
 			</section>
 		</section>
 		<section id="change-log" class="appendix informative">
-			<h2>Change Log</h2>
+			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
 					href="https://www.w3.org/publishing/epub/epub-contentdocs.html">EPUB Content Documents 3.2</a>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -37,7 +37,7 @@
 						"William McCoy",
 						"Elika J. Etimad",
 						"Matt Garrish"],
-						"title": "EPUB Content Documents 3.0",
+						"title": "EPUB content documents 3.0",
 						"href": "http://idpf.org/epub/30/spec/epub30-contentdocs-20111011.html",
 						"date": "11 October 2011",
 						"publisher": "IDPF"
@@ -81,17 +81,17 @@
 
 				<p>SSML and pronunciation lexicons provide enhanced speech rendering. Lexicons are like dictionaries of
 					common terms a TTS engine can use, while SSML provides the ability to add individual voicing for
-					specific phrases. <a>EPUB Creators</a> can use these technologies together or separately depending
+					specific phrases. <a>EPUB creators</a> can use these technologies together or separately depending
 					on the complexity of the text. Despite these advantages, the technologies have not been adapted for
 					easy use within the XHTML and SVG formats that EPUB relies on. This document proposes an approach to
-					enable their authoring and rendering in EPUB Content Documents.</p>
+					enable their authoring and rendering in EPUB content documents.</p>
 
 				<p>This document also covers the use of CSS Speech for improved aural rendering in EPUB. CSS Speech
 					covers a different domain than SSML and pronunciation lexicons. Instead of controlling the specific
-					voicing of words and phrases, these properties allow EPUB Creators to aspects of the aural playback
+					voicing of words and phrases, these properties allow EPUB creators to aspects of the aural playback
 					itself &#8212; what text to render, at what volume, with what preferred voice, etc.</p>
 
-				<p>This document covers the use of these technologies for rendering by <a>EPUB Reading Systems</a>.
+				<p>This document covers the use of these technologies for rendering by <a>EPUB reading systems</a>.
 					Although it is anticipated that general assistive technologies such as screen readers could take
 					advantage of the technologies, use by them is out of scope.</p>
 			</section>
@@ -101,17 +101,17 @@
 
 				<p>The EPUB Working Group of the International Digital Publishing Forum (IDPF) first defined a means of
 					integrating the Synthetic Speech Markup Language [[SSML]] and pronunciation lexicons
-					[[PRONUNCIATION-LEXICON]] in EPUB 3.0 [[EPUBContentDocs-30]] so that <a>EPUB Creators</a> could
-					improve the rendering quality of text-to-speech (TTS) playback in <a>Reading Systems</a>. The
-					ability to include cascading style sheets [[CSS2]] also allowed EPUB Creators to access the
+					[[PRONUNCIATION-LEXICON]] in EPUB 3.0 [[EPUBContentDocs-30]] so that <a>EPUB creators</a> could
+					improve the rendering quality of text-to-speech (TTS) playback in <a>reading systems</a>. The
+					ability to include cascading style sheets [[CSS2]] also allowed EPUB creators to access the
 					in-development speech properties of the CSS Speech module [[CSS-Speech-1]].</p>
 
-				<p>Although there has been some authoring uptake of these technologies, support in Reading Systems has
+				<p>Although there has been some authoring uptake of these technologies, support in reading systems has
 					yet to materialize to a level where these technologies are considered stable. Consequently, these
 					technologies are now published as a W3C Working Group Note.</p>
 
-				<p>EPUB Creators can continue to use these technologies in their publications, as the move to a Note
-					does not change their validity or affect backward compatibility. Developers of Reading Systems that
+				<p>EPUB creators can continue to use these technologies in their publications, as the move to a Note
+					does not change their validity or affect backward compatibility. Developers of reading systems that
 					support TTS playback are also strongly encouraged to implement support. The Working Group will look
 					at standardizing any of the technologies that meet support requirements in future revisions of EPUB
 					3.</p>
@@ -138,7 +138,7 @@
 				<dl>
 					<dt><dfn>Text-to-Speech</dfn></dt>
 					<dd>
-						<p>The rendering of the textual content of an <a>EPUB Publication</a> by a <a>Reading System</a>
+						<p>The rendering of the textual content of an <a>EPUB publication</a> by a <a>reading system</a>
 							as artificial human speech using a synthesized voice.</p>
 					</dd>
 				</dl>
@@ -159,9 +159,9 @@
 
 				<p>This specification recasts the [[SSML]] <a data-cite="speech-synthesis11#S3.1.10"
 							><code>phoneme</code> element</a> as two attributes — <code>ssml:ph</code> and
-						<code>ssml:alphabet</code> — and makes them available within <a>EPUB Content Documents</a>.</p>
+						<code>ssml:alphabet</code> — and makes them available within <a>EPUB content documents</a>.</p>
 
-				<p>The attributes allow EPUB Creators to specify the proper phonetic pronunciation for uncommon terms
+				<p>The attributes allow EPUB creators to specify the proper phonetic pronunciation for uncommon terms
 					that a TTS engine is likely to mispronounce, as well as to disambiguate heteronyms.</p>
 			</section>
 
@@ -186,10 +186,10 @@
 					</dd>
 					<dt>Usage</dt>
 					<dd>
-						<p>EPUB Creators MAY specify on any element in EPUB Content Documents with which they can
+						<p>EPUB creators MAY specify on any element in EPUB content documents with which they can
 							logically associate a phonetic equivalent (i.e., that has descendant text content that a
 							Text-to-Speech engine would otherwise render).</p>
-						<p>EPUB Creators MUST NOT specify the attribute on a descendant of an element that already
+						<p>EPUB creators MUST NOT specify the attribute on a descendant of an element that already
 							carries this attribute.</p>
 					</dd>
 					<dt>Value</dt>
@@ -209,10 +209,10 @@
 					pronunciation must therefore logically match the element's textual data in its entirety (i.e., not
 					just an isolated part of its content).</p>
 
-				<p id="ssml-ph-text">EPUB Creators SHOULD NOT use the <code>ssml:ph</code> attribute on elements without
+				<p id="ssml-ph-text">EPUB creators SHOULD NOT use the <code>ssml:ph</code> attribute on elements without
 					text content that a Text-to-Speech engine would normally render (e.g., on empty <code>div</code> or
 						<code>span</code> elements). The attribute is not intended to add additional voicing only for
-					TTS playback, and Reading Systems are expected to ignore the attribute if it does not replace text
+					TTS playback, and reading systems are expected to ignore the attribute if it does not replace text
 					they would normally render.</p>
 
 				<div class="note">
@@ -224,8 +224,8 @@
 						[[WAI-ARIA]]).</p>
 				</div>
 
-				<p id="ssml-ph-empty">Similarly, EPUB Creators SHOULD NOT add empty <code>ssml:ph</code> attributes to
-					try and suppress the rendering of text. Reading Systems are expected to ignore empty attributes.
+				<p id="ssml-ph-empty">Similarly, EPUB creators SHOULD NOT add empty <code>ssml:ph</code> attributes to
+					try and suppress the rendering of text. Reading systems are expected to ignore empty attributes.
 					(See the <a href="https://www.w3.org/TR/wai-aria/#aria-hidden"><code>aria-hidden</code>
 						attribute</a> [[?WAI-ARIA]] for specifying that content is only for visual rendering.)</p>
 
@@ -275,7 +275,7 @@
 					</dd>
 					<dt>Usage</dt>
 					<dd>
-						<p>EPUB Creators MAY specify on any element in an EPUB Content Document that can contain
+						<p>EPUB creators MAY specify on any element in an EPUB content document that can contain
 							descendant text content.</p>
 					</dd>
 					<dt>Value</dt>
@@ -295,9 +295,9 @@
 					with the element on which the <code>ssml:ph</code> attribute appears, followed by the nearest
 					ancestor element.</p>
 
-				<p>EPUB Creators SHOULD ensure that an alphabet is defined in scope for all phonemes expressed in <a
+				<p>EPUB creators SHOULD ensure that an alphabet is defined in scope for all phonemes expressed in <a
 						href="#ssml-ph-attribute"><code>ssml:ph</code> attributes</a>. Interoperability of playback
-					cannot be guaranteed in the absence of a declaration &#8212; Reading Systems may apply a default
+					cannot be guaranteed in the absence of a declaration &#8212; reading systems may apply a default
 					alphabet, for example, or may not voice the phoneme.</p>
 
 				<aside class="example">
@@ -329,8 +329,8 @@
 				<div class="note">
 					<p>Although the [[SSML]] specification refers to a registry of alphabets, one has not been
 						published. As the charter of the W3C Voice Browser Working Group has expired, the Working Group
-						does not anticipate the publication of such a registry. EPUB Creators therefore should reference
-						Reading System support documentation to determine what alphabet values they support. Some common
+						does not anticipate the publication of such a registry. EPUB creators therefore should reference
+						reading system support documentation to determine what alphabet values they support. Some common
 						alphabets include x-JEITA (also x-JEITA-IT-4002 and x-JEITA-IT-4006) and x-sampa.</p>
 				</div>
 			</section>
@@ -345,15 +345,15 @@
 					semantics for XML-based pronunciation lexicons to be used by Automatic Speech Recognition and
 						<a>Text-to-Speech</a> (TTS) engines.</p>
 
-				<p>Pronunciation lexicons allow EPUB Creators to define a single global phonetic pronunciation that
-					Reading Systems can use for all instances of a term instead of having to tag every instance using
+				<p>Pronunciation lexicons allow EPUB creators to define a single global phonetic pronunciation that
+					reading systems can use for all instances of a term instead of having to tag every instance using
 					the SSML attributes. It is a much more efficient way of defining pronunciations for words with only
 					a single pronunciation, or where a particular pronunciation is predominant.</p>
 
-				<p>EPUB Creators can use the [[HTML]] <a data-cite="html#the-link-element"><code>link</code> element</a>
+				<p>EPUB creators can use the [[HTML]] <a data-cite="html#the-link-element"><code>link</code> element</a>
 					and [[SVG]] <a href="https://www.w3.org/TR/SVG/struct.html#HTMLMetadataElements"><code>link</code>
-						element</a> to associate one or more lexicons with their respective <a>EPUB Content Document</a>
-					type. When Reading Systems process the documents, they can identify the linked lexicons and use them
+						element</a> to associate one or more lexicons with their respective <a>EPUB content document</a>
+					type. When reading systems process the documents, they can identify the linked lexicons and use them
 					to initiate text-to-speech playback.</p>
 			</section>
 
@@ -398,27 +398,27 @@
 			<section id="pls-publication-requirements">
 				<h3>Associating with EPUB content documents</h3>
 
-				<p id="confreq-cd-pls-xht">EPUB Creators MAY associate zero or more pronunciation lexicons
-					[[PRONUNCIATION-LEXICON]] with an <a>EPUB Content Document</a>.</p>
+				<p id="confreq-cd-pls-xht">EPUB creators MAY associate zero or more pronunciation lexicons
+					[[PRONUNCIATION-LEXICON]] with an <a>EPUB content document</a>.</p>
 
-				<p id="confreq-cd-pls-assoc">To associate a pronunciation lexicon with an <a>XHTML Content Document</a>,
-					EPUB Creators MUST use the [[HTML]] <a data-cite="html#the-link-element"><code>link</code></a>
-					element. Similarly, to associate a pronunciation lexicon with an <a>SVG Content Document</a>, EPUB
-					Creators MUST use the [[SVG]] <a href="https://www.w3.org/TR/SVG/struct.html#HTMLMetadataElements"
+				<p id="confreq-cd-pls-assoc">To associate a pronunciation lexicon with an <a>XHTML content document</a>,
+					EPUB creators MUST use the [[HTML]] <a data-cite="html#the-link-element"><code>link</code></a>
+					element. Similarly, to associate a pronunciation lexicon with an <a>SVG content document</a>, EPUB
+					creators MUST use the [[SVG]] <a href="https://www.w3.org/TR/SVG/struct.html#HTMLMetadataElements"
 							><code>link</code> element</a>.</p>
 
-				<p>For both types of EPUB Content Document, the <code>link</code> element MUST have its <code>rel</code>
+				<p>For both types of EPUB content document, the <code>link</code> element MUST have its <code>rel</code>
 					attribute set to "<code>pronunciation</code>" and its <code>type</code> attribute set to the media
 					type "<code>application/pls+xml</code>".</p>
 
-				<p id="confreq-cd-pls-assoc-lang">EPUB Creators SHOULD specify the <code>link</code> element
+				<p id="confreq-cd-pls-assoc-lang">EPUB creators SHOULD specify the <code>link</code> element
 						<code>hreflang</code> attribute on each <code>link</code>, and its value MUST match <a
 						data-cite="pronunciation-lexicon#S4.1">the language for which the pronunciation lexicon is
 						relevant</a> [[PRONUNCIATION-LEXICON]] when specified.</p>
 
 				<aside class="example">
 					<p>The following example shows two pronunciation lexicons (one for Mandarin and one for Mongolian)
-						associated with an XHTML Content Document.</p>
+						associated with an XHTML content document.</p>
 					<pre>
 &lt;html … &gt;    
     &lt;head&gt;
@@ -434,12 +434,12 @@
 		<section id="css-speech">
 			<h2>CSS speech</h2>
 
-			<p>The CSS Speech [[CSS-SPEECH-1]] module defines properties that allow EPUB Creators to declaratively
-				control the aural rendering of <a>EPUB Content Documents</a>. It includes properties for specifying the
+			<p>The CSS Speech [[CSS-SPEECH-1]] module defines properties that allow EPUB creators to declaratively
+				control the aural rendering of <a>EPUB content documents</a>. It includes properties for specifying the
 				preferred <a>Text-to-Speech</a> voice, the volume level, and pauses and cues to perform when
 				encountering elements.</p>
 
-			<p>As EPUB Content Documents support the use of cascading style sheets [[CSS2]], EPUB Creators MAY use CSS
+			<p>As EPUB content documents support the use of cascading style sheets [[CSS2]], EPUB creators MAY use CSS
 				Speech [[CSS-SPEECH-1]] properties in their style sheet definitions.</p>
 
 			<aside class="example">
@@ -451,20 +451,20 @@
 			</aside>
 		</section>
 		<section id="reading-system-support">
-			<h2>Reading System support</h2>
+			<h2>reading system support</h2>
 
 			<section id="reading-system-intro">
 				<h3>Introduction</h3>
 
-				<p><a>Reading Systems</a> may implement <a>Text-to-Speech</a> playback in different ways depending on
+				<p><a>Reading systems</a> may implement <a>Text-to-Speech</a> playback in different ways depending on
 					the type of engine they use &#8212; one might only feed the text content of the document to the
 					engine, for example, while another could support full markup. This document tries to provide
 					flexibility in its requirements to allow for these differences. The only requirement is that the
 					correct rendering behavior result.</p>
 
-				<p>Although this document frames the enhancements in the context of a Reading System with built-in
+				<p>Although this document frames the enhancements in the context of a reading system with built-in
 					Text-to-Speech rendering capabilities, it is anticipated that any application or assistive
-					technology that can access the markup of an EPUB Publication will be able to use these features to
+					technology that can access the markup of an EPUB publication will be able to use these features to
 					provide improved voice rendering. Ensuring the technologies works with these applications is outside
 					the scope of this work, however.</p>
 			</section>
@@ -472,14 +472,14 @@
 			<section id="reading-system-conformance">
 				<h3>Conformance</h3>
 
-				<p><a>Reading Systems</a> with <a>Text-to-Speech</a> (TTS) capabilities SHOULD support <a href="#ssml"
+				<p><a>Reading systems</a> with <a>Text-to-Speech</a> (TTS) capabilities SHOULD support <a href="#ssml"
 						>SSML attributes</a>, <a href="#pls">pronunciation lexicons</a> and <a href="#css-speech">CSS
 						Speech</a> as follows:</p>
 
 				<dl>
 					<dt>SSML</dt>
 					<dd>
-						<p>Reading Systems that support SSML:</p>
+						<p>Reading systems that support SSML:</p>
 						<ul class="conformance-list">
 							<li>
 								<p id="confreq-ssml-ph">MUST process the <code>ssml:ph</code> attribute per the
@@ -514,31 +514,31 @@
 
 					<dt>Pronunciation Lexicons</dt>
 					<dd>
-						<p>Reading Systems that support pronunciation lexicons:</p>
+						<p>Reading systems that support pronunciation lexicons:</p>
 						<ul class="conformance-list">
 							<li>
 								<p id="confreq-pls-rs-proc">MUST process all linked pronunciation lexicons in an EPUB
-									Content Document as defined in [[PRONUNCIATION-LEXICON]].</p>
+									content document as defined in [[PRONUNCIATION-LEXICON]].</p>
 							</li>
 							<li>
 								<p id="confreq-pls-rs-scope">MUST apply the supplied lexemes to all text nodes in the
-									EPUB Content Document whose language matches <a
+									EPUB content document whose language matches <a
 										data-cite="pronunciation-lexicon#S4.1">the language for which the pronunciation
 										lexicon is relevant</a> [[PRONUNCIATION-LEXICON]]. [[BCP47]] defines the
 									algorithm for matching language tags.</p>
 							</li>
 						</ul>
 						<div class="note">
-							<p>It is not required that the Reading System use a Text-to-Speech engine that supports
+							<p>It is not required that the reading system use a Text-to-Speech engine that supports
 								pronunciation lexicons so long as the lexemes are processed and applied correctly. A
-								Reading System might, for example, transform the lexicon into an alternative dictionary
+								reading system might, for example, transform the lexicon into an alternative dictionary
 								format its TTS engine supports.</p>
 						</div>
 					</dd>
 
 					<dt>SSML and Pronunciation Lexicons</dt>
 					<dd>
-						<p>Reading Systems that support SSML and pronunciation lexicons:</p>
+						<p>Reading systems that support SSML and pronunciation lexicons:</p>
 						<ul>
 							<li>
 								<p>MUST let any pronunciation instructions provided via the <a href="#ssml-ph-attribute"
@@ -552,7 +552,7 @@
 
 					<dt>CSS Speech</dt>
 					<dd>
-						<p>This document adds no additional requirements for Reading System support to those defined in
+						<p>This document adds no additional requirements for reading system support to those defined in
 							[[CSS-SPEECH-1]].</p>
 					</dd>
 				</dl>
@@ -562,7 +562,7 @@
 			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
-					href="https://www.w3.org/publishing/epub/epub-contentdocs.html">EPUB Content Documents 3.2</a>
+					href="https://www.w3.org/publishing/epub/epub-contentdocs.html">EPUB content documents 3.2</a>
 				&#8212; those that affect conformance or are similarly noteworthy.</p>
 
 			<p>For a list of all issues addressed during the revision, refer to the <a
@@ -575,7 +575,7 @@
 					vocalization. See <a href="https://github.com/w3c/epub-specs/issues/1706">issue 1706</a>.</li>
 				<li>25-June-2021: Clarified application of pronunciation lexicons. See <a
 						href="https://github.com/w3c/epub-specs/issues/1705">issue 1705</a>.</li>
-				<li>22-June-2021: Added that SSML and PLS can also be used with SVG Content Documents. See <a
+				<li>22-June-2021: Added that SSML and PLS can also be used with SVG content documents. See <a
 						href="https://github.com/w3c/epub-specs/issues/1710">issue 1710</a>.</li>
 			</ul>
 		</section>


### PR DESCRIPTION
This is to fix: #2179

Two notes

- I have not touched the A11y documents to avoid merge conflicts
- I was not sure what to do with section titles that contained an official EPUB term. For the time being I did _not_ turned them into lower case; I guess this is something to settle together with the more general issue #2135


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2248.html" title="Last updated on Apr 15, 2022, 11:28 AM UTC (1655769)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2248/a229169...1655769.html" title="Last updated on Apr 15, 2022, 11:28 AM UTC (1655769)">Diff</a>