### PR TITLE
Add change log entry to core spec for #2221

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -80,8 +80,7 @@
 		<style>
 			pre {
 				white-space: break-spaces !important;
-			}
-		</style>
+			}</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -313,17 +312,17 @@
 						<dfn class="export" id="dfn-container-root-url">Container Root URL</dfn>
 					</dt>
 					<dd>
-						<p>The <a>URL</a> [[URL]] of the <a>Root Directory</a> representing
-							the <a>OCF Abstract Container</a>. It is implementation specific, but EPUB Creators must
-							assume it has properties defined in <a href="#sec-container-iri"></a>.</p>
+						<p>The <a>URL</a> [[URL]] of the <a>Root Directory</a> representing the <a>OCF Abstract
+								Container</a>. It is implementation specific, but EPUB Creators must assume it has
+							properties defined in <a href="#sec-container-iri"></a>.</p>
 					</dd>
 
 					<dt>
 						<dfn class="export" id="dfn-content-url">Content URL</dfn>
 					</dt>
 					<dd>
-						<p> The <a>URL</a> of a file or directory in the <a>OCF Abstract
-								Container</a>, defined in <a href="#sec-container-iri"></a>. </p>
+						<p> The <a>URL</a> of a file or directory in the <a>OCF Abstract Container</a>, defined in <a
+								href="#sec-container-iri"></a>. </p>
 					</dd>
 
 					<dt>
@@ -575,8 +574,8 @@
 						</ul>
 						<div class="note">
 							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
-									<code>href</code> attribute of an [[HTML]] <a data-lt="a"
-										><code>a</code> element</a>) are not Publication Resources.</p>
+									<code>href</code> attribute of an [[HTML]] <a data-lt="a"><code>a</code>
+								element</a>) are not Publication Resources.</p>
 						</div>
 					</dd>
 
@@ -926,9 +925,9 @@
 						one of two ways: using the capabilities of the host format or via manifest fallbacks.</p>
 
 					<p>The preferred method is to use the fallback capabilities of the host format. Many HTML elements,
-						for example, have intrinsic fallback capabilities. One example is the <a
-							data-lt="picture"><code>picture</code> element</a> [[HTML]], which allows EPUB
-						Creators to specify multiple alternative image formats.</p>
+						for example, have intrinsic fallback capabilities. One example is the <a data-lt="picture"
+								><code>picture</code> element</a> [[HTML]], which allows EPUB Creators to specify
+						multiple alternative image formats.</p>
 
 					<p>If an intrinsic fallback method is not available, it is also possible to use manifest fallbacks,
 						but this method, as <a href="#caution-fallbacks">cautioned against</a> in the previous section,
@@ -1235,23 +1234,23 @@
 
 					<dt id="exempt-links">Linked resources</dt>
 					<dd id="confreq-resources-cd-fallback-link">
-						<p>Any resource referenced from the [[HTML]] <a data-lt="link"
-									><code>link</code> element</a> that is not already a Core Media Type Resource (e.g.,
-							CSS style sheets) is an Exempt Resource.</p>
+						<p>Any resource referenced from the [[HTML]] <a data-lt="link"><code>link</code> element</a>
+							that is not already a Core Media Type Resource (e.g., CSS style sheets) is an Exempt
+							Resource.</p>
 					</dd>
 
 					<dt id="exempt-track" class="tbl-group">Tracks</dt>
 					<dd id="confreq-resources-cd-fallback-track">
 						<p>All audio and video tracks (e.g., [[?WebVTT]] captions, subtitles and descriptions)
-							referenced from the [[HTML]] <a data-lt="track"><code>track</code> element</a>
-							are Exempt Resources.</p>
+							referenced from the [[HTML]] <a data-lt="track"><code>track</code> element</a> are Exempt
+							Resources.</p>
 					</dd>
 
 					<dt id="exempt-video" class="tbl-group">Video</dt>
 					<dd id="confreq-resources-cd-fallback-video">
-						<p>All video codecs referenced from the [[HTML]] <a data-lt="video"
-									><code>video</code></a> — including any child <a data-lt="source"
-									><code>source</code></a> elements — are Exempt Resources.</p>
+						<p>All video codecs referenced from the [[HTML]] <a data-lt="video"><code>video</code></a>
+							— including any child <a data-lt="source"><code>source</code></a> elements — are Exempt
+							Resources.</p>
 						<div class="note">
 							<p>Although Reading Systems are encouraged to support at least one of the H.264 [[?H264]]
 								and VP8 [[?RFC6386]] video codecs, support for video codecs is not a conformance
@@ -1276,10 +1275,10 @@
 								<strong><em>and</em></strong></p>
 					</li>
 					<li>
-						<p>it is not embedded directly in EPUB Content Documents (e.g., via
-							[[?HTML]] <a>embedded content</a>  and [[?SVG]] <a
-								href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"><code>image</code></a> and
-								<a href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
+						<p>it is not embedded directly in EPUB Content Documents (e.g., via [[?HTML]] <a>embedded
+								content</a> and [[?SVG]] <a href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"
+									><code>image</code></a> and <a
+								href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
 									><code>foreignObject</code></a> elements).</p>
 					</li>
 				</ul>
@@ -1335,10 +1334,10 @@
 						<dd>
 							<div class="note">
 								<p>The original purpose for content fallbacks was to specify fallback images for the
-									[[HTML]] <a data-lt="img"><code>img</code> element</a>. As HTML
-									now has intrinsic fallback mechanism for images, the use of content fallbacks is
-									strongly discouraged. EPUB Creators should always use the intrinsic fallback
-									capabilities of [[HTML]] and [[SVG]] to provide fallback content.</p>
+									[[HTML]] <a data-lt="img"><code>img</code> element</a>. As HTML now has intrinsic
+									fallback mechanism for images, the use of content fallbacks is strongly discouraged.
+									EPUB Creators should always use the intrinsic fallback capabilities of [[HTML]] and
+									[[SVG]] to provide fallback content.</p>
 							</div>
 							<p>EPUB Creators MUST provide a content fallback for <a>Foreign Resources</a> when the
 								elements that reference them do not have intrinsic fallback capabilities. In this case,
@@ -1367,11 +1366,10 @@
 					<section id="sec-fallbacks-audio">
 						<h5>HTML <code>audio</code> Fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-media">EPUB Creators MUST NOT use embedded 
-							[[HTML]] <a>flow content</a> within the <a><code>audio</code></a> element as an intrinsic
-							fallback for Foreign Resources. 
-							Only child <a><code>source</code></a> elements [[HTML]] provide intrinsic fallback
-							capabilities.</p>
+						<p id="confreq-resources-cd-fallback-media">EPUB Creators MUST NOT use embedded [[HTML]] <a>flow
+								content</a> within the <a><code>audio</code></a> element as an intrinsic fallback for
+							Foreign Resources. Only child <a><code>source</code></a> elements [[HTML]] provide intrinsic
+							fallback capabilities.</p>
 
 						<p>Only older Reading Systems that do not recognize the <code>audio</code> element (e.g., EPUB 2
 							Reading Systems) will render the embedded content. When Reading Systems support the
@@ -1390,27 +1388,26 @@
 						<h5>HTML <code>img</code> Fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that EPUB Creators can
-							specify in the [[HTML]] <a data-lt="img"><code>img</code> element</a>,
-							the following fallback conditions apply to its use:</p>
+							specify in the [[HTML]] <a data-lt="img"><code>img</code> element</a>, the following
+							fallback conditions apply to its use:</p>
 
 						<ul>
 							<li>
-								<p>If it is the child of a <a data-lt="picture"><code>picture</code>
-										element</a>:</p>
+								<p>If it is the child of a <a data-lt="picture"><code>picture</code> element</a>:</p>
 								<ul>
 									<li>it MUST reference Core Media Type Resources from its <code>src</code> and
 											<code>srcset</code> attributes, when EPUB Creators specify those attributes;
 										and</li>
-									<li>each sibling <a data-lt="source"><code>source</code> element</a> MUST reference a 
-										Core Media Type Resource from its <code>[^source/src^]</code> and 
-										<code>[^source/srcset^]</code> attributes unless it specifies the 
-										MIME media type [[RFC2046]] of a Foreign Resource in 
-										its <code>[^source/type^]</code> attribute.</li>
+									<li>each sibling <a data-lt="source"><code>source</code> element</a> MUST reference
+										a Core Media Type Resource from its <code>[^source/src^]</code> and
+											<code>[^source/srcset^]</code> attributes unless it specifies the MIME media
+										type [[RFC2046]] of a Foreign Resource in its <code>[^source/type^]</code>
+										attribute.</li>
 								</ul>
 							</li>
 
-							<li>Otherwise, it MAY reference Foreign Resources in its <code>[^img/src^]</code> and 
-								<code>[^img/srcset^]</code> attributes provided EPUB Creators define a <a
+							<li>Otherwise, it MAY reference Foreign Resources in its <code>[^img/src^]</code> and
+									<code>[^img/srcset^]</code> attributes provided EPUB Creators define a <a
 									href="#sec-manifest-fallbacks">manifest fallback</a>.</li>
 						</ul>
 					</section>
@@ -1452,9 +1449,8 @@
 				</div>
 
 				<aside class="example" title="Referencing a Container Resource">
-					<p>In this example, the audio file referenced from the [[HTML]] <a
-							data-lt="audio"><code>audio</code> element</a> is located inside the
-							<a>EPUB Container</a>.</p>
+					<p>In this example, the audio file referenced from the [[HTML]] <a data-lt="audio"
+								><code>audio</code> element</a> is located inside the <a>EPUB Container</a>.</p>
 					<pre>&lt;html …>
    …
    &lt;body>
@@ -1468,8 +1464,8 @@
 				</aside>
 
 				<aside class="example" title="Referencing a Remote Resource">
-					<p>In this example, the audio file referenced from the [[HTML]] <a
-						data-lt="audio"><code>audio</code> element</a> is hosted on the web.</p>
+					<p>In this example, the audio file referenced from the [[HTML]] <a data-lt="audio"
+								><code>audio</code> element</a> is hosted on the web.</p>
 					<pre>&lt;html …>
    …
    &lt;body>
@@ -1491,8 +1487,8 @@
 					resource within another, avoiding the need for an external file.</p>
 
 				<p><a>EPUB Creators</a> MAY use data URLs in EPUB Publications provided their use does not result in a
-						<a>Top-level Content Document</a> or <a>top-level browsing context</a> [[HTML]].
-						This restriction applies to data URLs used in the following scenarios:</p>
+						<a>Top-level Content Document</a> or <a>top-level browsing context</a> [[HTML]]. This
+					restriction applies to data URLs used in the following scenarios:</p>
 
 				<ul>
 					<li>
@@ -1563,8 +1559,8 @@
 						Type Resource</a> or a <a>Foreign Resource</a>.</p>
 
 				<div class="note">
-					<p>[[HTML]] and [[SVG]] are removing support for the XML <code>base</code> attribute [[XMLBase]]. EPUB Creators
-						should avoid using this feature.</p>
+					<p>[[HTML]] and [[SVG]] are removing support for the XML <code>base</code> attribute [[XMLBase]].
+						EPUB Creators should avoid using this feature.</p>
 				</div>
 			</section>
 		</section>
@@ -1811,8 +1807,8 @@
 						<li>Let <var>path</var> be an empty <a>list</a>.</li>
 						<li>Let <var>current</var> be <var>file</var>.</li>
 						<li>While <var>current</var> is not the <a>Root Directory</a>: <ol>
-								<li> [=list/prepend=] the <a>File Name</a> of
-										<var>current</var> to <var>path</var>;</li>
+								<li> [=list/prepend=] the <a>File Name</a> of <var>current</var> to
+									<var>path</var>;</li>
 								<li>set <var>current</var> to the parent directory of <var>current</var>.</li>
 							</ol>
 						</li>
@@ -1826,27 +1822,25 @@
 
 					<p id="sec-container-iri-root"
 						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">The <a>container root
-							URL</a> is the <a>URL</a> [[URL]] of the <a>Root Directory</a>.
-						It is implementation-specific, but EPUB Creators MUST assume it has the following
-						properties:</p>
+							URL</a> is the <a>URL</a> [[URL]] of the <a>Root Directory</a>. It is
+						implementation-specific, but EPUB Creators MUST assume it has the following properties:</p>
 
 					<ul id="sec-root-url-properties">
 						<li id="sec-container-iri-root-parse"
 							data-tests="#ocf-url_link-path-absolute,#ocf-url_parse-path-absolute">The result of <a
-								data-lt="url parser">parsing</a> "<code>/</code>" with the <a>container
-								root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the
-								<a>container root URL</a>.</li>
+								data-lt="url parser">parsing</a> "<code>/</code>" with the <a>container root URL</a> as
+								<a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root
+							URL</a>.</li>
 						<li id="sec-container-iri-step-parse"
 							data-tests="#ocf-url_link-leaking-relative,#ocf-url_parse-leaking-relative">The result of <a
-							data-lt="url parser">parsing</a> "<code>..</code>" with the <a>container
-								root URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the
-								<a>container root URL</a>.</li>
+								data-lt="url parser">parsing</a> "<code>..</code>" with the <a>container root URL</a> as
+								<a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root
+							URL</a>.</li>
 					</ul>
 
 					<p>The <a>content URL</a> of a file or directory in the <a>OCF Abstract Container</a> is the result
-						of <a data-lt="url parser">parsing</a> the file's <a>File Path</a> with the
-							<a>container root URL</a> as 							
-							<a data-cite="url#concept-base-url"><var>base</var></a>.</p>
+						of <a data-lt="url parser">parsing</a> the file's <a>File Path</a> with the <a>container root
+							URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 					<div class="note" id="note-cru-explanation">
 						<p> The <a>container root URL</a> is the URL assigned by the Reading System to the root of the
@@ -1869,38 +1863,37 @@
 
 					<div class="note">
 						<p>
-							<a data-lt="url parser">Parsing</a> may replace some characters in the File
-							Path by their <a data-cite="url#percent-encode">percent encoded</a> alternative. For
-							example, <code>A/B/C/file&#160;name.xhtml</code> becomes
-								<code>A/B/C/file%20name.xhtml</code>. </p>
+							<a data-lt="url parser">Parsing</a> may replace some characters in the File Path by their <a
+								data-cite="url#percent-encode">percent encoded</a> alternative. For example,
+								<code>A/B/C/file&#160;name.xhtml</code> becomes <code>A/B/C/file%20name.xhtml</code>.
+						</p>
 					</div>
 
-					<p> A string <var>url</var> is a 
-						<dfn class="export" id="dfn-valid-relative-container-url-with-fragment-string">valid-relative-ocf-URL-with-fragment string</dfn> 
-						if it is a <a>path-relative-scheme-less-url string</a>, optionally followed by <code>U+0023 (#)</code> and
-						a <a>url-fragment string</a>, and if the following steps return <var>true</var>: </p>
+					<p> A string <var>url</var> is a <dfn class="export"
+							id="dfn-valid-relative-container-url-with-fragment-string"
+							>valid-relative-ocf-URL-with-fragment string</dfn> if it is a
+							<a>path-relative-scheme-less-url string</a>, optionally followed by <code>U+0023 (#)</code>
+						and a <a>url-fragment string</a>, and if the following steps return <var>true</var>: </p>
 
 					<ol class="algorithm" id="algo-out-of-container">
-						<li> Set the <a>container root URL</a> to <code>https://a.example.org/A/</code>. 
-							<details
+						<li> Set the <a>container root URL</a> to <code>https://a.example.org/A/</code>. <details
 								class="explanation">
 								<summary>Explanation</summary>
 								<p> The goal of the algorithm is to detect whether <var>url</var> could be seen as
-									"leaking" outside the container. To do that, the standard 
-									<a data-lt="url parser">URL parsing algorithm</a> is used with an
-									artificial root URL; the detection of the "leak" is done by comparing the result of
-									the parsing with the presence of the first test path segment (<code>A</code>). (Note
-									that the artificial container root URL wilfully violates, for the purpose of this
-									algorithm, the <a href="#sec-root-url-properties">required properties</a> by using
-									that first test path segment.) </p>
+									"leaking" outside the container. To do that, the standard <a data-lt="url parser"
+										>URL parsing algorithm</a> is used with an artificial root URL; the detection of
+									the "leak" is done by comparing the result of the parsing with the presence of the
+									first test path segment (<code>A</code>). (Note that the artificial container root
+									URL wilfully violates, for the purpose of this algorithm, the <a
+										href="#sec-root-url-properties">required properties</a> by using that first test
+									path segment.) </p>
 							</details>
 						</li>
 
 						<li> Let <var>base</var> be the <a data-cite="url#concept-base-url">base URL</a> that must be
 							used to parse <var>url</var> as defined by the context (document or environment) where
 								<var>url</var> is used, and according to the <a>content URL</a> of the <a>Package
-								Document</a> (see <a href="#sec-parse-package-urls"></a>). 
-							<details class="explanation">
+								Document</a> (see <a href="#sec-parse-package-urls"></a>). <details class="explanation">
 								<summary>Explanation</summary>
 								<p> In the case of a URL in the package document the <var>base</var> variable is set to
 									the <a>content URL</a> of the <a>Package Document</a>. In the case of a document
@@ -1914,10 +1907,11 @@
 							</details>
 						</li>
 
-						<li> Let <var>testURLRecord</var> be the result of applying the <a>URL parser</a> to <var>url</var>, with
-								<var>base</var>. </li>
+						<li> Let <var>testURLRecord</var> be the result of applying the <a>URL parser</a> to
+								<var>url</var>, with <var>base</var>. </li>
 
-						<li> Let <var>testURLStringA</var> be the result of applying the <a>URL Serializer</a> to <var>testURLRecord</var>. </li>
+						<li> Let <var>testURLStringA</var> be the result of applying the <a>URL Serializer</a> to
+								<var>testURLRecord</var>. </li>
 
 						<li> Set the <a>container root URL</a> to <code>https://b.example.org/B/</code>. <details
 								class="explanation">
@@ -1934,10 +1928,11 @@
 								<var>url</var> is used, and according to the <a>content URL</a> of the <a>Package
 								Document</a> (see <a href="#sec-parse-package-urls"></a>). </li>
 
-						<li> Set <var>testURLRecord</var> to be the result of applying the <a>URL parser</a> 
-							to <var>url</var>, with <var>base</var>. </li>
+						<li> Set <var>testURLRecord</var> to be the result of applying the <a>URL parser</a> to
+								<var>url</var>, with <var>base</var>. </li>
 
-						<li> Let <var>testURLStringB</var> be the result of applying the <a>URL Serializer</a> to <var>testURLRecord</var>. </li>
+						<li> Let <var>testURLStringB</var> be the result of applying the <a>URL Serializer</a> to
+								<var>testURLRecord</var>. </li>
 
 						<li> If <var>testURLStringA</var> does not start with <code>https://a.example.org/</code> or
 								<var>testURLStringB</var> does not start with <code>https://b.example.org/</code>,
@@ -1952,8 +1947,7 @@
 
 						<li> If <var>testURLStringA</var> starts with <code>https://a.example.org/A/</code> and
 								<var>testURLStringB</var> starts with <code>https://b.example.org/B/</code>, return
-								<var>true</var>. 
-							<details class="explanation">
+								<var>true</var>. <details class="explanation">
 								<summary>Explanation</summary>
 								<p>The presence of the first test path segments (<code>A</code>, respectively
 										<code>B</code>) indicate that the URL doesn't leak outside the container.</p>
@@ -1964,10 +1958,12 @@
 					</ol>
 
 					<p id="urls-in-ocf-constraints"> In the <a>OCF Abstract Container</a>, any URL string MUST be an
-						<a>absolute-url-with-fragment string</a> or a <a>valid-relative-ocf-URL-with-fragment string</a>.</p>
+							<a>absolute-url-with-fragment string</a> or a <a>valid-relative-ocf-URL-with-fragment
+							string</a>.</p>
 
-					<p>In addition, all <a>relative-URL-with-fragment strings</a> [[URL]] MUST, after <a data-lt="url parser">parsing</a>, be equal
-						to the <a>Content URL</a> of an existing file in the OCF Abstract Container.</p>
+					<p>In addition, all <a>relative-URL-with-fragment strings</a> [[URL]] MUST, after <a
+							data-lt="url parser">parsing</a>, be equal to the <a>Content URL</a> of an existing file in
+						the OCF Abstract Container.</p>
 
 					<div class="note">
 						<p>These constraints on URL strings mean that:</p>
@@ -1975,15 +1971,15 @@
 						<ul>
 							<li>relative URL strings starting with a <code>/</code> (<code>U+002F</code>) (for example,
 									<code>/EPUB/content.xhtml</code>) are disallowed; </li>
-							<li>relative URL strings containing more <a>double-dot path segments</a> than 
-								needed to reach the target file (for example,
-									<code>EPUB/../../../../config.xml</code>) are disallowed; </li>
+							<li>relative URL strings containing more <a>double-dot path segments</a> than needed to
+								reach the target file (for example, <code>EPUB/../../../../config.xml</code>) are
+								disallowed; </li>
 							<li>any other absolute or relative URL string is allowed.</li>
 						</ul>
 
 						<p> Note that in any case, even the disallowed URL strings described above will not "leak"
-							outside the container after parsing (as explained in the 
-							<a href="#note-cru-explanation">first note</a> of this section). They are nevertheless disallowed for better
+							outside the container after parsing (as explained in the <a href="#note-cru-explanation"
+								>first note</a> of this section). They are nevertheless disallowed for better
 							interoperability with non-conforming or legacy Reading Systems and toolchains. </p>
 					</div>
 
@@ -2039,10 +2035,10 @@
 						<h5>Parsing URLs in the <code>META-INF</code> Directory</h5>
 
 						<p id="sec-container-metainf-url-parsing" data-tests="#ocf-url_relative">To parse a URL string
-								<var>url</var> used in files located in the <code>META-INF</code> directory 
-								the <a data-lt="url parser">URL Parser</a> MUST be applied to <var>url</var>,
-							with the <a>container root URL</a> as <a data-cite="url#concept-base-url"
-								><var>base</var></a>.</p>
+								<var>url</var> used in files located in the <code>META-INF</code> directory the <a
+								data-lt="url parser">URL Parser</a> MUST be applied to <var>url</var>, with the
+								<a>container root URL</a> as <a data-cite="url#concept-base-url"
+							><var>base</var></a>.</p>
 
 						<aside class="example" title="Resolving paths in the container file">
 							<p>If container file (<code>META-INF/container.xml</code>) has the following content:</p>
@@ -2189,9 +2185,9 @@
 											</dt>
 											<dd>
 												<p>Identifies the location of a <a>Package Document</a>.</p>
-												<p>The value of the attribute MUST be a <a>path-relative-scheme-less-URL string</a> [[URL]]. 
-													The path is
-													relative to the <a>Root Directory</a>.</p>
+												<p>The value of the attribute MUST be a <a>path-relative-scheme-less-URL
+														string</a> [[URL]]. The path is relative to the <a>Root
+														Directory</a>.</p>
 											</dd>
 
 											<dt>
@@ -2290,8 +2286,8 @@
 											<dd>
 												<p>Identifies the location of a resource.</p>
 												<p>The value of the <code>link</code> element <code>href</code>
-													attribute MUST be a <a>path-relative-scheme-less-URL string</a> [[URL]]. The path is
-													relative to the <a>Root Directory</a>.</p>
+													attribute MUST be a <a>path-relative-scheme-less-URL string</a>
+													[[URL]]. The path is relative to the <a>Root Directory</a>.</p>
 											</dd>
 
 											<dt>
@@ -3168,7 +3164,7 @@
 
 				<p id="pkg-parse-package-url" data-tests="#ocf-url_link-relative,#ocf-url_relative"> To parse a URL
 					string <var>url</var> used in the Package Document, the <a data-lt="url parser">URL
-						Parser</a> [[URL]] MUST be applied to <var>url</var>, with the <a>content URL</a> of the Package
+					Parser</a> [[URL]] MUST be applied to <var>url</var>, with the <a>content URL</a> of the Package
 					Document as <var>base</var>.</p>
 			</section>
 
@@ -3226,9 +3222,8 @@
 				<section id="attrdef-href">
 					<h4>The <code>href</code> Attribute</h4>
 
-					<p>A <a>valid URL string</a> [[URL]] that references a resource. If
-						the value is an <a>absolute-URL string</a>, it SHOULD NOT use the
-						"file" URI scheme [[rfc8089]].</p>
+					<p>A <a>valid URL string</a> [[URL]] that references a resource. If the value is an <a>absolute-URL
+							string</a>, it SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
 
 					<aside class="example" title="Linking a metadata record">
 						<pre>&lt;package …>
@@ -3334,9 +3329,9 @@
 					<h4>The <code>refines</code> Attribute</h4>
 
 					<p>Establishes an association between the current expression and the element or resource identified
-						by its value. EPUB Creators MUST use as the value a <a>path-relative-scheme-less-URL
-							string</a>, optionally followed by <code>U+0023 (#)</code> and a <a>URL-fragment string</a> that references the resource or
-						element they are describing.</p>
+						by its value. EPUB Creators MUST use as the value a <a>path-relative-scheme-less-URL string</a>,
+						optionally followed by <code>U+0023 (#)</code> and a <a>URL-fragment string</a> that references
+						the resource or element they are describing.</p>
 
 					<aside class="example" title="Specifying that a creator is the illustrator">
 						<pre>&lt;package …>
@@ -3727,9 +3722,8 @@
 					<h4>Metadata Values</h4>
 
 					<p>The Dublin Core elements [[DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code> element</a>
-						have mandatory <a>child text content</a> [[DOM]].
-						This specification refers to this content as the <dfn>value</dfn> of the element in their
-						descriptions.</p>
+						have mandatory <a>child text content</a> [[DOM]]. This specification refers to this content as
+						the <dfn>value</dfn> of the element in their descriptions.</p>
 
 					<p>These elements MUST have non-empty values after <a
 							data-lt="strip leading and trailing ascii whitespace">leading and trailing ASCII
@@ -3738,7 +3732,7 @@
 
 					<p>Whitespace within these element values is not significant. Sequences of one or more whitespace
 						characters are <a data-lt="strip and collapse ascii whitespace">collapsed to a single
-							space</a> [[Infra]] during processing .</p>
+						space</a> [[Infra]] during processing .</p>
 				</section>
 
 				<section id="sec-opf-dcmes-required">
@@ -4618,8 +4612,8 @@
 						</li>
 						<li>
 							<p>included or embedded in an EPUB Content Document (e.g., a metadata record serialized as
-								RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]] embedded in an 
-								[[HTML]] [^script^] element).</p>
+								RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]] embedded in an [[HTML]] [^script^]
+								element).</p>
 						</li>
 					</ul>
 
@@ -5392,12 +5386,11 @@ No Entry</pre>
 					<p id="spine-inclusion-req">EPUB Creators MUST list in the <code>spine</code> all EPUB and Foreign
 						Content Documents that are hyperlinked to from Publication Resources in the <code>spine</code>,
 						where hyperlinking encompasses any linking mechanism that requires the user to navigate away
-						from the current resource. Common hyperlinking mechanisms include the [^a/href^]
-						attribute of the [[HTML]] <a data-lt="a"><code>a</code></a> and <a
-							data-lt="area"><code>area</code></a> elements and scripted links (e.g.,
-						using DOM Events and/or form elements). The requirement to list hyperlinked resources applies
-						recursively (i.e., EPUB Creators must list all EPUB and Foreign Content Documents hyperlinked to
-						from hyperlinked documents, and so on.).</p>
+						from the current resource. Common hyperlinking mechanisms include the [^a/href^] attribute of
+						the [[HTML]] <a data-lt="a"><code>a</code></a> and <a data-lt="area"><code>area</code></a>
+						elements and scripted links (e.g., using DOM Events and/or form elements). The requirement to
+						list hyperlinked resources applies recursively (i.e., EPUB Creators must list all EPUB and
+						Foreign Content Documents hyperlinked to from hyperlinked documents, and so on.).</p>
 
 					<p>EPUB Creators also MUST list in the <code>spine</code> all EPUB and Foreign Content Documents
 						hyperlinked to from the <a>EPUB Navigation Document</a>, regardless of whether EPUB Creators
@@ -5408,9 +5401,8 @@ No Entry</pre>
 							not subject to the requirement to include in the spine (e.g., web pages and web-hosted
 							resources).</p>
 
-						<p>Publication Resources used in the rendering of spine items (e.g., referenced from [[HTML]] 
-							<a>embedded content</a>) similarly do not have to be
-							included in the spine.</p>
+						<p>Publication Resources used in the rendering of spine items (e.g., referenced from [[HTML]]
+								<a>embedded content</a>) similarly do not have to be included in the spine.</p>
 					</div>
 
 					<p id="attrdef-spine-page-progression-direction">The <code>page-progression-direction</code>
@@ -5802,9 +5794,9 @@ No Entry</pre>
 								attribute</a> in <a>XHTML Content Documents</a> to express <a
 								href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
-						<p>As the [[HTML]] <a data-lt="head"><code>head</code> element</a> contains
-							metadata for the document, structural semantics expressed on this element or any descendant
-							of it have no meaning.</p>
+						<p>As the [[HTML]] <a data-lt="head"><code>head</code> element</a> contains metadata for the
+							document, structural semantics expressed on this element or any descendant of it have no
+							meaning.</p>
 					</section>
 
 					<section id="sec-xhtml-rdfa">
@@ -5950,10 +5942,9 @@ No Entry</pre>
 						<section id="sec-xhtml-deviations-base">
 							<h6>The <code>base</code> Element</h6>
 
-							<p id="confreq-html-vocab-base"> The [[HTML]] <a data-lt="base"
-										><code>base</code> element</a> can be used to specify the 
-										<a>document base URL</a> for the purposes of parsing
-								URLs. When using it in an <a>EPUB Publication</a>, the interpretation of the
+							<p id="confreq-html-vocab-base"> The [[HTML]] <a data-lt="base"><code>base</code>
+									element</a> can be used to specify the <a>document base URL</a> for the purposes of
+								parsing URLs. When using it in an <a>EPUB Publication</a>, the interpretation of the
 									<code>base</code> element may inadvertently result in references to <a>Remote
 									Resources</a>. It may also cause Reading Systems to misinterpret the location of
 								hyperlinks (e.g., relative links to other documents in the publication might appear as
@@ -5965,22 +5956,22 @@ No Entry</pre>
 						<section id="sec-xhtml-deviations-rp">
 							<h6>The <code>rp</code> Element</h6>
 
-							<p id="confreq-html-vocab-rp">The [[HTML]] <a data-lt="rp"
-										><code>rp</code> element</a> is intended to provide a fallback for older
-									<a>Reading Systems</a> that do not recognize ruby markup (i.e., a parenthesis
-								display around <code>ruby</code> markup). As EPUB 3 Reading Systems are ruby-aware, and
-								can provide fallbacks, EPUB Creators should not use <code>rp</code> elements.</p>
+							<p id="confreq-html-vocab-rp">The [[HTML]] <a data-lt="rp"><code>rp</code> element</a> is
+								intended to provide a fallback for older <a>Reading Systems</a> that do not recognize
+								ruby markup (i.e., a parenthesis display around <code>ruby</code> markup). As EPUB 3
+								Reading Systems are ruby-aware, and can provide fallbacks, EPUB Creators should not use
+									<code>rp</code> elements.</p>
 						</section>
 
 						<section id="sec-xhtml-deviations-embed">
 							<h6>The <code>embed</code> Element</h6>
 
-							<p id="confreq-html-vocab-embed">Since the [[HTML]] <a data-lt="embed"
-										><code>embed</code> element</a> element does not include intrinsic facilities to provide
-								fallback content for Reading Systems that do not support scripting, <a>EPUB Creators</a>
-								are discouraged from using the element when the referenced resource includes scripting.
-								The [[HTML]] <a data-lt="object"><code>object</code> element</a> is a
-								better alternative, as it includes intrinsic fallback capabilities.</p>
+							<p id="confreq-html-vocab-embed">Since the [[HTML]] <a data-lt="embed"><code>embed</code>
+									element</a> element does not include intrinsic facilities to provide fallback
+								content for Reading Systems that do not support scripting, <a>EPUB Creators</a> are
+								discouraged from using the element when the referenced resource includes scripting. The
+								[[HTML]] <a data-lt="object"><code>object</code> element</a> is a better alternative, as
+								it includes intrinsic fallback capabilities.</p>
 						</section>
 					</section>
 				</section>
@@ -6057,8 +6048,8 @@ No Entry</pre>
 										><code>foreignObject</code></a> element:</p>
 							<ul class="conformance-list">
 								<li>
-									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[HTML]] 
-										<a>flow content</a> or exactly one [[HTML]] [^body^] element.</p>
+									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[HTML]] <a>flow
+											content</a> or exactly one [[HTML]] [^body^] element.</p>
 									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
 											<code>body</code> element is not permitted per the <a data-cite="html#svg-0"
 											>restrictions on SVG</a> defined in [[HTML]].</p>
@@ -6131,8 +6122,7 @@ No Entry</pre>
 									exceptions:</p>
 								<ul class="conformance-list">
 									<li>
-										<p id="confreq-css-props-exc-direction">It MUST NOT include the 											
-											<a
+										<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
 												data-cite="css-writing-modes-3#direction"><code>direction</code>
 												property</a> [[CSS-Writing-Modes-3]].</p>
 									</li>
@@ -6160,15 +6150,15 @@ No Entry</pre>
 
 							<ul>
 								<li>
-									<p>the [^html-global/dir^] attribute [[HTML]]
-										and <a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
+									<p>the [^html-global/dir^] attribute [[HTML]] and <a
+											href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
 												><code>direction</code></a> attribute [[SVG]] for inline base
 										directionality.</p>
 								</li>
 								<li>
-									<p>the <a><code>bdo</code></a> element with the 
-										[^html-global/dir^] attribute [[HTML]]
-										and the <a href="https://www.w3.org/TR/SVG/styling.html#PresentationAttributes"
+									<p>the <a><code>bdo</code></a> element with the [^html-global/dir^]
+										attribute [[HTML]] and the <a
+											href="https://www.w3.org/TR/SVG/styling.html#PresentationAttributes"
 											>presentation attribute alternative</a> for <code>unicode-bidi</code>
 										[[SVG]] for bidirectionality.</p>
 								</li>
@@ -6224,10 +6214,9 @@ No Entry</pre>
 								if a future update adds the concept.</p>
 						</div>
 
-						<p>EPUB Creators should note that Reading Systems are required to behave as though a unique 
-							<a>origin</a> [[URL]] has been assigned to each EPUB Publication. In
-							practice, this means that it is not possible for scripts to share data between EPUB
-							Publications.</p>
+						<p>EPUB Creators should note that Reading Systems are required to behave as though a unique
+								<a>origin</a> [[URL]] has been assigned to each EPUB Publication. In practice, this
+							means that it is not possible for scripts to share data between EPUB Publications.</p>
 
 						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
 							rights and restrictions that a Reading System places on it (refer to <a
@@ -6281,15 +6270,14 @@ No Entry</pre>
 								<li>
 									<p>An instance of the [[HTML]] [^script^] element contained in an <a>XHTML Content
 											Document</a> that is embedded in an XHTML Content Document using the
-										[[HTML]] <a data-lt="iframe"><code>iframe</code></a>
-										element.</p>
+										[[HTML]] <a data-lt="iframe"><code>iframe</code></a> element.</p>
 								</li>
 								<li>
 									<p>An instance of the [[SVG]] <a
 											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
 												><code>script</code></a> element contained in an <a>SVG Content
 											Document</a> that is embedded in a XHTML Content Document using the [[HTML]]
-											<a><code>iframe</code></a> element.</p>
+												<a><code>iframe</code></a> element.</p>
 								</li>
 							</ul>
 
@@ -6359,10 +6347,9 @@ No Entry</pre>
 
 						<p id="confreq-cd-scripted-fallback">EPUB Content Documents that contain scripting MAY provide
 							fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
-							available for the [[HTML]] <a><code>object</code></a>
-							and <a><code>canvas</code></a> elements) or, when an
-							intrinsic fallback is not applicable, by using a <a href="#sec-manifest-fallbacks"
-								>manifest-level fallback</a>.</p>
+							available for the [[HTML]] <a><code>object</code></a> and <a><code>canvas</code></a>
+							elements) or, when an intrinsic fallback is not applicable, by using a <a
+								href="#sec-manifest-fallbacks">manifest-level fallback</a>.</p>
 
 						<p id="confreq-cd-scripted-foreign-resources">EPUB Creators MUST ensure that scripts only
 							generate <a href="#sec-core-media-types">Core Media Type Resources</a> or fragments
@@ -6471,8 +6458,7 @@ No Entry</pre>
 								</ul>
 							</dd>
 
-							<dt><a><code>span</code></a> and 
-								<a><code>a</code></a></dt>
+							<dt><a><code>span</code></a> and <a><code>a</code></a></dt>
 							<dd>
 								<p>In any order:</p>
 								<ul class="nomark">
@@ -6514,9 +6500,9 @@ No Entry</pre>
 					</li>
 					<li>
 						<p id="confreq-nav-a-title">If an <code>a</code> or <code>span</code> element contains instances
-							of <a data-lt="embedded content">HTML embedded content</a> that do not provide
-							intrinsic text alternatives, the element MUST also contain a <code>title</code> attribute
-							with an alternate text rendering of the link label.</p>
+							of <a data-lt="embedded content">HTML embedded content</a> that do not provide intrinsic
+							text alternatives, the element MUST also contain a <code>title</code> attribute with an
+							alternate text rendering of the link label.</p>
 					</li>
 					<li>
 						<p id="confreq-nav-a-href">The URL [[URL]] reference provided in the <code>href</code> attribute
@@ -6823,8 +6809,8 @@ No Entry</pre>
 						property</a> [[CSSSnapshot]] controls the visual rendering of EPUB Navigation Documents in
 					Reading Systems with <a>Viewports</a>, Reading Systems without Viewports may not support CSS. To
 					better ensure the proper rendering in these Reading Systems, EPUB Creators should use the [[HTML]]
-						[^html-global/hidden^] attribute to indicate which (if
-					any) portions of the navigation data are excluded from rendering in the content flow.</p>
+					[^html-global/hidden^] attribute to indicate which (if any) portions of the navigation data are
+					excluded from rendering in the content flow.</p>
 
 				<p>The <code>hidden</code> attribute has no effect on how Reading Systems render the navigation data
 					outside of the content flow (such as in dedicated navigation user interfaces provided by Reading
@@ -8142,8 +8128,8 @@ No Entry</pre>
 									<dd>
 										<p>Refers to the associated EPUB Content Document and, optionally, identifies a
 											specific part of it.</p>
-										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally followed by
-												<code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
+										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally
+											followed by <code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
 									</dd>
 								</dl>
 							</dd>
@@ -8226,8 +8212,8 @@ No Entry</pre>
 									<dd>
 										<p>Refers to the associated EPUB Content Document and, optionally, identifies a
 											specific part of it.</p>
-										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally followed by
-												<code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
+										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally
+											followed by <code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
 										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
 											information.</p>
 									</dd>
@@ -8363,8 +8349,8 @@ No Entry</pre>
 									<dd>
 										<p>Refers to the associated EPUB Content Document and, optionally, identifies a
 											specific part of it.</p>
-										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally followed by
-												<code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
+										<p>The value MUST be a <a>path-relative-scheme-less-URL string</a>, optionally
+											followed by <code>U+0023 (#)</code> and a <a>URL-fragment string</a>.</p>
 									</dd>
 
 									<dt>
@@ -8387,8 +8373,8 @@ No Entry</pre>
 						<p class="note"> This specification places no restriction on the <code>src</code> attribute of a
 								<code>text</code> element. Authors should, however, refer to a content that can be
 							styled with CSS to make the <a href="#sec-docs-assoc-style">association with style
-								information</a> effective, i.e., <a>palpable
-								content</a> for XHTML or <a href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a
+								information</a> effective, i.e., <a>palpable content</a> for XHTML or <a
+								href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a
 								href="https://www.w3.org/TR/SVG11/shapes.html">basic shapes</a>, or <a
 								href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG. </p>
 					</section>
@@ -8430,10 +8416,9 @@ No Entry</pre>
 									</dt>
 									<dd>
 										<p>The <a data-lt="relative-url string">relative-</a> or <a
-												data-lt="absolute-url string">absolute-URL string</a> [[URL]]
-											reference to an audio file. The audio file MUST be one of the audio formats
-											listed in the <a href="#sec-core-media-types">Core Media Type Resources</a>
-											table.</p>
+												data-lt="absolute-url string">absolute-URL string</a> [[URL]] reference
+											to an audio file. The audio file MUST be one of the audio formats listed in
+											the <a href="#sec-core-media-types">Core Media Type Resources</a> table.</p>
 									</dd>
 
 									<dt id="attrdef-smil-clipBegin">
@@ -8758,8 +8743,9 @@ No Entry</pre>
 
 						<p>Both the <code>epub:textref</code> attribute and the <a href="#elemdef-smil-text"
 									><code>text</code> element's</a>
-							<code>src</code> attribute may contain a <a>URL-fragment string</a> that references a specific part (e.g., an element via its ID) of the
-							associated <a>EPUB Content Document</a>.</p>
+							<code>src</code> attribute may contain a <a>URL-fragment string</a> that references a
+							specific part (e.g., an element via its ID) of the associated <a>EPUB Content
+							Document</a>.</p>
 
 						<p>For XHTML and SVG Content Documents, the URL-fragment string SHOULD be a reference to a
 							specific element via its ID, or an <a
@@ -8780,12 +8766,12 @@ No Entry</pre>
 							elements' <code>epub:textref</code> attrbutes. For example, when referencing [[HTML]]
 							elements, if the finest level of markup is at the paragraph level, then that is the finest
 							possible level for Media Overlay synchronization. Likewise, if sub-paragraph markup is
-							available, such as [[HTML]] <a data-lt="span"><code>span</code> element</a>
-							representing phrases or sentences, then finer granularity is possible in the Media
-							Overlay. Finer granularity gives users more precise results for synchronized playback when
-							navigating by word or phrase and when searching the text but increases the file size of the
-							Media Overlay Documents. Fragment identifier schemes that do not rely on the presence of
-							elements could provide even finer granularity, where supported.</p>
+							available, such as [[HTML]] <a data-lt="span"><code>span</code> element</a> representing
+							phrases or sentences, then finer granularity is possible in the Media Overlay. Finer
+							granularity gives users more precise results for synchronized playback when navigating by
+							word or phrase and when searching the text but increases the file size of the Media Overlay
+							Documents. Fragment identifier schemes that do not rely on the presence of elements could
+							provide even finer granularity, where supported.</p>
 					</section>
 
 					<section id="sec-embedded-media">
@@ -9825,7 +9811,9 @@ html.my-document-playing * {
 					the structural information it carries complementing the underlying vocabulary.</p>
 
 				<p>The applied semantics refine the meaning of their containing elements without changing their nature
-					for assistive technologies, as happens when using the similar [^/role^] attribute [[HTML]]. The attribute does not enhance the accessibility of the content, in other words, only provides hints about the purpose.</p>
+					for assistive technologies, as happens when using the similar [^/role^] attribute [[HTML]]. The
+					attribute does not enhance the accessibility of the content, in other words, only provides hints
+					about the purpose.</p>
 
 				<p>Semantic metadata enriches content for use in publishing workflows and for author-defined purposes.
 					It also allows Reading Systems to learn more about the structure and content of a document (e.g., to
@@ -9870,13 +9858,13 @@ html.my-document-playing * {
 				</dl>
 
 				<div class="caution">
-					<p>Although the <code>epub:type</code> attribute is similar in nature to the 
-						[^/role^] attribute [[HTML]], the attributes
-						serve different purposes. The values of the <code>epub:type</code> attribute do not enhance
-						access through assistive technologies like screen readers as they do not map to the
-						accessibility <abbr title="Application Programming Interfaces">APIs</abbr> used by these
-						technologies. This means that adding <code>epub:type</code> values to semantically neutral
-						elements like [[HTML]] <a><code>div</code></a> and <a><code>span</code></a> does not make them any more
+					<p>Although the <code>epub:type</code> attribute is similar in nature to the [^/role^]
+						attribute [[HTML]], the attributes serve different purposes. The values of the
+							<code>epub:type</code> attribute do not enhance access through assistive technologies like
+						screen readers as they do not map to the accessibility <abbr
+							title="Application Programming Interfaces">APIs</abbr> used by these technologies. This
+						means that adding <code>epub:type</code> values to semantically neutral elements like [[HTML]]
+								<a><code>div</code></a> and <a><code>span</code></a> does not make them any more
 						accessible to assistive technologies. Only ARIA roles influence how assistive technologies
 						understand such elements.</p>
 
@@ -10955,10 +10943,10 @@ html.my-document-playing * {
 					<dt><code>style.css</code></dt>
 					<dd>
 						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[HTML]]
-								<a data-lt="link"><code>link</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the
-								<a>content plane</a>. No fallback is necessary.</p>
+								<a data-lt="link"><code>link</code> element</a>. It is a <a>Publication Resource</a> on
+							the <a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine
+								plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.otf</code></dt>
@@ -10990,27 +10978,27 @@ html.my-document-playing * {
 					<dt><code>speech/cmn.pls</code></dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
-							from an [[HTML]] <a data-lt="link"><code>link</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							not present on the <a>spine plane</a>, and is an <a>Exempt Resource</a> on the <a>content
-								plane</a>. No fallback is necessary.</p>
+							from an [[HTML]] <a data-lt="link"><code>link</code> element</a>. It is a <a>Publication
+								Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, not present on
+							the <a>spine plane</a>, and is an <a>Exempt Resource</a> on the <a>content plane</a>. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_1.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-lt="img"><code>img</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the
-								<a>content plane</a>. No fallback is necessary.</p>
+							[[HTML]] <a data-lt="img"><code>img</code> element</a>. It is a <a>Publication Resource</a>
+							on the <a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine
+								plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_2.png</code></dt>
 					<dd>
-						<p>The resource is a PNG image file. It is referenced via an [[HTML]] <a
-								data-lt="a"><code>a</code> element</a>. Because it is referenced from
-							a hyperlink, it <em>must</em> be listed in the spine. It is a <a>Publication Resource</a> on
-							the <a>manifest plane</a>, a <a>Container Resource</a>, a <a>Foreign Content Document</a> on
+						<p>The resource is a PNG image file. It is referenced via an [[HTML]] <a data-lt="a"
+									><code>a</code> element</a>. Because it is referenced from a hyperlink, it
+								<em>must</em> be listed in the spine. It is a <a>Publication Resource</a> on the
+								<a>manifest plane</a>, a <a>Container Resource</a>, a <a>Foreign Content Document</a> on
 							the <a>spine plane</a>, and a <a>Core Media Type Resource</a> on the <a>content plane</a>.
 							As a <a>Foreign Content Document</a> a fallback is required, which is provided via a <a
 								href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
@@ -11029,43 +11017,40 @@ html.my-document-playing * {
 					<dt><code>image/image_3.heic</code></dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
-							referenced from an [[HTML]] <a data-lt="source"><code>source</code>
-								element</a>. Its media type is not listed as a <a href="#sec-core-media-types">core
-								media type</a>. It is a <a>Publication Resource</a> on the <a>manifest plane</a>, a
-								<a>Container Resource</a>, is not present on the <a>spine plane</a>, and is a <a>Foreign
-								Resource</a> on the <a>content plane</a>. As a <a>Foreign Resource</a>, a fallback is
-							required, which is provided via the sibling [[HTML]] <a data-lt="img"
-									><code>img</code> element</a> in an [[HTML]] <a data-lt="picture"
-									><code>picture</code> element</a>.</p>
+							referenced from an [[HTML]] <a data-lt="source"><code>source</code> element</a>. Its media
+							type is not listed as a <a href="#sec-core-media-types">core media type</a>. It is a
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Foreign Resource</a> on the <a>content
+								plane</a>. As a <a>Foreign Resource</a>, a fallback is required, which is provided via
+							the sibling [[HTML]] <a data-lt="img"><code>img</code> element</a> in an [[HTML]] <a
+								data-lt="picture"><code>picture</code> element</a>.</p>
 					</dd>
 
 					<dt><code>image/image_3.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-lt="img"><code>img</code> element</a> that is used as an
-							intrinsic fallback of the [[HTML]] <a data-lt="picture"
-									><code>picture</code> element</a>. It is a <a>Publication Resource</a> on the
-								<a>manifest plane</a>, a <a>Container Resource</a>, is not present on the <a>spine
-								plane</a>, and is a <a>Core Media Type Resource</a> on the <a>content plane</a>. No
-							fallback is necessary.</p>
+							[[HTML]] <a data-lt="img"><code>img</code> element</a> that is used as an intrinsic fallback
+							of the [[HTML]] <a data-lt="picture"><code>picture</code> element</a>. It is a
+								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
+							is not present on the <a>spine plane</a>, and is a <a>Core Media Type Resource</a> on the
+								<a>content plane</a>. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>widget.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-lt="iframe"><code>iframe</code> element</a>. It is a
-								<a>Publication Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>,
-							is not present on <a>spine plane</a>, and, because it is "used" when rendering another
-							Content Document, a <a>Core Media Type Resource</a> on the <a>content plane</a>. No fallback
-							is necessary.</p>
+							[[HTML]] <a data-lt="iframe"><code>iframe</code> element</a>. It is a <a>Publication
+								Resource</a> on the <a>manifest plane</a>, a <a>Container Resource</a>, is not present
+							on <a>spine plane</a>, and, because it is "used" when rendering another Content Document, a
+								<a>Core Media Type Resource</a> on the <a>content plane</a>. No fallback is
+							necessary.</p>
 					</dd>
 
 					<dt><code>https://www.example.org/some_content</code></dt>
 					<dd>
-						<p>The resource is referenced via an [[HTML]] <a data-lt="a"><code>a</code>
-								element</a> and is not stored in the <a>EPUB Container</a>. Reading Systems will
-							normally open this link via a separate browser instance. It is not on any planes defined by
-							this specification.</p>
+						<p>The resource is referenced via an [[HTML]] <a data-lt="a"><code>a</code> element</a> and is
+							not stored in the <a>EPUB Container</a>. Reading Systems will normally open this link via a
+							separate browser instance. It is not on any planes defined by this specification.</p>
 					</dd>
 				</dl>
 
@@ -11720,6 +11705,9 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and updated
+					the list of semantics to use for escaping to match the guidance. See <a
+						href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>
 				<li>6-Apr-2022: Removed the restrictions on the value of the <code>authority</code> property and added a
 					note referencing the old IDPF registry. See <a href="https://github.com/w3c/epub-specs/issues/2118"
 						>issue 2200</a>.</li>


### PR DESCRIPTION
I noticed I only put a change log entry into the accessibility spec for the changes to escapability, but we should mention the note and the changed semantics list in the core spec, too.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2249.html" title="Last updated on Apr 14, 2022, 2:46 PM UTC (5b31861)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2249/5389a55...5b31861.html" title="Last updated on Apr 14, 2022, 2:46 PM UTC (5b31861)">Diff</a>