### PR TITLE
Lowercase all normative/informative reference identifiers

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -51,7 +51,7 @@
 				xref: ["epub-33"],
 				profile: "web-platform",
 				localBiblio: {
-					"A11Y-DISCOV-VOCAB": {
+					"a11y-discov-vocab": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
 						"href": "https://www.w3.org/2021/a11y-discov-vocab/latest/",
 						"editors": [
@@ -60,38 +60,38 @@
 							"Matt Garrish"
 						]
 					},
-					"EPUB-3": {
+					"epub-3": {
 						"title": "EPUB 3",
 						"href": "https://www.w3.org/TR/epub/",
 						"publisher": "W3C"
 					},
-					"ISO24751-3": {
+					"iso24751-3": {
 						"title": " ISO/IEC 24751-3:2008 Information technology -- Individualized adaptability and accessibility in e-learning, education and training -- Part 3: &quot;Access for all&quot; digital resource description",
 						"href": "http://www.iso.org/iso/catalogue_detail?csnumber=43604",
 						"date": "2008-10-01"
 					},
-					"OPF-201": {
+					"opf-201": {
 						"title": "Open Packaging Format 2.0.1",
 						"href": "http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
 						"date": "04 September 2010",
 						"publisher": "IDPF"
 					},
-					"SVG": {
+					"svg": {
 						"title": "SVG",
 						"href": "https://www.w3.org/TR/SVG/",
 						"publisher": "W3C"
 					},
-					"SWF": {
+					"swf": {
 						"title": "SWF File Format Specification Version 19",
 						"href": "https://www.adobe.com/content/dam/acom/en/devnet/pdf/swf-file-format-spec.pdf",
 						"date": "2012"
 					},
-					"WAI-ARIA": {
+					"wai-aria": {
 						"title": "Accessible Rich Internet Applications (WAI-ARIA)",
 						"href": "https://www.w3.org/TR/wai-aria/",
 						"publisher": "W3C"
 					},
-					"WCAG2": {
+					"wcag2": {
 						"title": "Web Content Accessibility Guidelines (WCAG) 2",
 						"href": "https://www.w3.org/TR/WCAG2/",
 						"publisher": "W3C"
@@ -116,18 +116,18 @@
 				<h3>Purpose and scope</h3>
 
 				<p>This document, EPUB Accessibility Techniques, provides guidance on how to meet the
-					[[EPUB-A11Y-11]] discovery and accessibility requirements for <a>EPUB publications</a>.</p>
+					[[epub-a11y-11]] discovery and accessibility requirements for <a>EPUB publications</a>.</p>
 
-				<p>This document does not cover techniques and best practices already addressed in [[WCAG2]] and
-					[[WAI-ARIA]] for which no substantive differences in application exist.</p>
+				<p>This document does not cover techniques and best practices already addressed in [[wcag2]] and
+					[[wai-aria]] for which no substantive differences in application exist.</p>
 			</section>
 
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
 				<p>This document uses terminology defined in <a data-cite="epub-a11y-11#sec-terminology">EPUB 3.3</a>
-					[[EPUB-33]] and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.1</a>
-					[[EPUB-A11Y-11]]:</p>
+					[[epub-33]] and <a data-cite="epub-a11y-11#sec-terminology">EPUB Accessibility 1.1</a>
+					[[epub-a11y-11]]:</p>
 
 				<p>Only the first instance of a term in a section links to its definition.</p>
 			</section>
@@ -137,19 +137,19 @@
 
 			<p>The accessibility techniques described in this document are advisory in nature. They are intended to help
 					<a>EPUB creators</a> create <a>EPUB publications</a> that conform to the requirements in
-				[[EPUB-A11Y-11]], but they are not all applicable in all situations and there may be other ways to meet
+				[[epub-a11y-11]], but they are not all applicable in all situations and there may be other ways to meet
 				the requirements of that specification. As a result, this document should not be read as providing
 				prescriptive requirements.</p>
 
 			<p>These techniques also do not address issues in digital publishing for which no universally accessible
 				solutions exist. The W3C's Digital Publishing Interest Group has published a note that outlines many of
-				these issues [[DPUB-Accessibility]]. As solutions become available, they will be incorporated into the
+				these issues [[dpub-accessibility]]. As solutions become available, they will be incorporated into the
 				appropriate document, whether this one or one it refers to.</p>
 
 			<p>If EPUB creators encounter issues that are not covered in these or related techniques, they are
 				encouraged to report the issue to the appropriate community for guidance on how to meet accessibility
 				standards. The <a href="https://www.w3.org/WAI/IG/">W3C Web Accessibility Interest Group</a> has a
-				public mailing list where issues meeting [[WCAG2]] and [[WAI-ARIA]] requirements can be raised. The <a
+				public mailing list where issues meeting [[wcag2]] and [[wai-aria]] requirements can be raised. The <a
 					href="https://github.com/w3c/publ-a11y/issues">W3C Publishing Community Group issue tracker</a> can
 				be used to ask for support implementing EPUB-specific requirements and the <a
 					href="https://github.com/w3c/epub-specs/issues">EPUB 3 Working Group's issue tracker</a> to report
@@ -162,7 +162,7 @@
 				<h3>Identify primary access modes</h3>
 
 				<p>An access mode is defined as a "human sense perceptual system or cognitive faculty through which a
-					user may process or perceive the content of a digital resource." [[ISO24751-3]] For example, if an
+					user may process or perceive the content of a digital resource." [[iso24751-3]] For example, if an
 						<a>EPUB publication</a> contains images and video, visual perception is required to consume the
 					content exactly as it was created.</p>
 
@@ -209,7 +209,7 @@
 					indicate that the available adaptations allow the content to be consumed in another mode.</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessMode">The
-							<code>accessMode</code> Property</a> [[A11Y-DISCOV-VOCAB]] for more information about this
+							<code>accessMode</code> Property</a> [[a11y-discov-vocab]] for more information about this
 					property and its values.</p>
 			</section>
 
@@ -299,7 +299,7 @@
 					to understand the concepts being conveyed.</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessModeSufficient">The
-							<code>accessModeSufficient</code> Property</a> [[A11Y-DISCOV-VOCAB]] for more information
+							<code>accessModeSufficient</code> Property</a> [[a11y-discov-vocab]] for more information
 					about this property and its values.</p>
 
 				<div class="note">
@@ -343,7 +343,7 @@
 					discoverability of the publication when users search for specific features.</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature">The
-							<code>accessibilityFeature</code> Property</a> [[A11Y-DISCOV-VOCAB]] for more information
+							<code>accessibilityFeature</code> Property</a> [[a11y-discov-vocab]] for more information
 					about this property and its values.</p>
 			</section>
 
@@ -355,12 +355,12 @@
 				<ul>
 					<li>
 						<p>flashing — if a resource flashes more than three times a second, it can cause seizures (e.g.,
-							videos and animations). See also [[WCAG2]] <a
-								data-cite="WCAG2#seizures-and-physical-reactions">Guideline 2.3</a>.</p>
+							videos and animations). See also [[wcag2]] <a
+								data-cite="wcag2#seizures-and-physical-reactions">Guideline 2.3</a>.</p>
 					</li>
 					<li>
 						<p>motion simulation — if a resource simulates motion, it can cause a user to become nauseated
-							(e.g., a video game drawn on the [[HTML]] <a data-lt="canvas"
+							(e.g., a video game drawn on the [[html]] <a data-lt="canvas"
 								><code>canvas</code> element</a> or parallax scrolling with CSS).</p>
 					</li>
 					<li>
@@ -413,7 +413,7 @@
 				<p>If hazards cannot be definitively determined, report the value "<code>unknown</code>".</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityHazard">The
-							<code>accessibilityHazard</code> Property</a> [[A11Y-DISCOV-VOCAB]] for more information
+							<code>accessibilityHazard</code> Property</a> [[a11y-discov-vocab]] for more information
 					about this property and its values.</p>
 			</section>
 
@@ -423,7 +423,7 @@
 				<p>An accessibility summary provides a brief, human-readable description of the accessibility
 					characteristics of an <a>EPUB publication</a>, or lack thereof.</p>
 
-				<p>If an EPUB publication does not meet the requirements for content accessibility in [[EPUB-A11Y-11]],
+				<p>If an EPUB publication does not meet the requirements for content accessibility in [[epub-a11y-11]],
 					the reason(s) it fails should be noted in the summary.</p>
 
 				<p>An accessibility summary is provided using the [[schema-org]] <a
@@ -453,7 +453,7 @@
 					multiple summaries, use the <code>xml:lang</code> attribute to differentiate the language.</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilitySummary">The
-							<code>accessibilitySummary</code> Property</a> [[A11Y-DISCOV-VOCAB]] for more information
+							<code>accessibilitySummary</code> Property</a> [[a11y-discov-vocab]] for more information
 					about this property.</p>
 			</section>
 
@@ -464,7 +464,7 @@
 						publications</a>. <a>EPUB creators</a> are not responsible for the interaction between
 						<a>reading systems</a> and the underlying platform APIs.</p>
 
-				<p>Meeting the requirements of [[WCAG2]] is a better measure of the accessibility of scripting, as this
+				<p>Meeting the requirements of [[wcag2]] is a better measure of the accessibility of scripting, as this
 					property does not differentiate between ARIA markup used for document structure or for identifying
 					controls.</p>
 			</section>
@@ -477,7 +477,7 @@
 						system</a> interface from those in the underlying content, which has led to confusion about its
 					use.</p>
 
-				<p>Meeting the requirements of [[WCAG2]] will mitigate most known issues with the content and is
+				<p>Meeting the requirements of [[wcag2]] will mitigate most known issues with the content and is
 					sufficient for authoring purposes.</p>
 			</section>
 
@@ -605,7 +605,7 @@
 			<section id="sec-wcag-general">
 				<h3>General guidance</h3>
 
-				<p>Techniques for meeting the requirements of the [[WCAG2]] are defined in <a
+				<p>Techniques for meeting the requirements of the [[wcag2]] are defined in <a
 						href="https://www.w3.org/WAI/WCAG21/Techniques/">Techniques for WCAG</a>. This document does not
 					repeat those techniques.</p>
 
@@ -647,13 +647,13 @@
 					</li>
 				</ul>
 
-				<p>Other techniques will apply depending on the technologies used (e.g., a [[SWF]] video in EPUB 2) or
+				<p>Other techniques will apply depending on the technologies used (e.g., a [[swf]] video in EPUB 2) or
 					any alternative formats embedded in the EPUB publication (e.g., a PDF form).</p>
 
 				<section id="sec-wcag-general-res">
 					<h4>Helpful resources</h4>
 
-					<p>EPUB creators not familiar with the [[WCAG2]] may find the number of techniques daunting, as they
+					<p>EPUB creators not familiar with the [[wcag2]] may find the number of techniques daunting, as they
 						are intended to provide broad coverage of possible solutions.</p>
 
 					<p>Assistance applying these techniques to EPUB content documents is available from the following
@@ -680,12 +680,12 @@
 				<section id="access-001">
 					<h4>Ensure meaningful order of content across spreads</h4>
 
-					<p>[[WCAG2]] <a data-cite="WCAG2#meaningful-sequence">Success Criterion 1.3.2</a> specifies that
+					<p>[[wcag2]] <a data-cite="wcag2#meaningful-sequence">Success Criterion 1.3.2</a> specifies that
 						each web page have a meaningful order (i.e., that the visual presentation of the content match
 						the underlying markup).</p>
 
 					<p>As EPUB allows two <a>EPUB content documents</a> to be rendered together in a <a
-							href="https://www.w3.org/TR/epub/#spread">synthetic spread</a> [[EPUB-3]], the order of
+							href="https://www.w3.org/TR/epub/#spread">synthetic spread</a> [[epub-3]], the order of
 						content within a single document cannot always be evaluated in isolation. Content may span
 						visually from one document to the next. For example, a sidebar might span the bottom of two
 						pages.</p>
@@ -702,19 +702,19 @@
 				<section id="access-002">
 					<h4>Provide multiple ways to access the content</h4>
 
-					<p>[[WCAG2]] <a data-cite="WCAG2#multiple-ways">Success Criterion 2.4.5</a> requires there be more
+					<p>[[wcag2]] <a data-cite="wcag2#multiple-ways">Success Criterion 2.4.5</a> requires there be more
 						than one way to locate a web page within a set of web pages. By default, <a>EPUB
 							publications</a> meet this WCAG requirement so long as <a>EPUB creators</a> follow the EPUB
 						requirements to <a href="https://www.w3.org/TR/epub/#sec-spine-elem">include all EPUB content
 							documents in the spine</a> and <a href="https://www.w3.org/TR/epub/#sec-itemref-elem">ensure
-							access to all non-linear documents</a> [[EPUB-3]].</p>
+							access to all non-linear documents</a> [[epub-3]].</p>
 
 					<p>The reason an EPUB publication passes by meeting these requirements has to do with differences in
 						how a user interacts with the set of documents in an EPUB publication. In particular, although
 						an EPUB publication typically consists of many <a>EPUB content documents</a>, <a>reading
 							systems</a> automatically provide the ability for the user to move seamlessly from one
 						document to the next, so long as they are listed in the <a
-							href="https://www.w3.org/TR/epub/#sec-spine-elem">spine</a> [[EPUB-3]]. To the user, an EPUB
+							href="https://www.w3.org/TR/epub/#sec-spine-elem">spine</a> [[epub-3]]. To the user, an EPUB
 						publication is a single document they have complete access to, not a set of disconnected pages
 						that they need links to move through.</p>
 
@@ -832,7 +832,7 @@
 
 					<p>Although the <code>role</code> attribute may seem similar in nature to the <a
 							href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
-						><code>type</code> attribute</a> [[EPUB-3]], their target uses in EPUB content documents do not
+						><code>type</code> attribute</a> [[epub-3]], their target uses in EPUB content documents do not
 						overlap.</p>
 
 					<p>The key difference between these attributes is that the <code>role</code> attribute bridges
@@ -845,7 +845,7 @@
 					<p>Since each attribute offers different advantages, it is not necessary that they be used together.
 						Due to the lack of restrictions on where <a>EPUB creators</a> can use the <code>type</code>
 						attribute, pairing the attributes may cause accessibility issues (e.g., putting roles on the
-						[[HTML]] <a data-lt="body"><code>body</code> element</a>).</p>
+						[[html]] <a data-lt="body"><code>body</code> element</a>).</p>
 
 					<p>In particular, the use of the <code>type</code> attribute is not a means of satisfying
 						requirements for ARIA roles in WCAG.</p>
@@ -854,7 +854,7 @@
 							<a href="https://idpf.github.io/epub-guides/epub-aria-authoring/">EPUB Type to ARIA Role
 							Authoring Guide</a> guide details notable authoring differences between the two attributes.
 						It also includes a mapping table of semantics in the EPUB Structural Semantics Vocabulary to
-						equivalent ARIA roles in [[DPUB-ARIA-1.0]] and [[WAI-ARIA]].</p>
+						equivalent ARIA roles in [[dpub-aria-1.0]] and [[wai-aria]].</p>
 				</section>
 
 				<section id="sem-002">
@@ -874,14 +874,14 @@
 
 					<p>Although visually these restructuring decisions can be hidden from readers, they impact the
 						functionality of <a data-cite="epub-a11y-11#dfn-assistive-technology">assistive
-						technologies</a>. In the case of [[WAI-ARIA]] roles, the result is that only the subset present
+						technologies</a>. In the case of [[wai-aria]] roles, the result is that only the subset present
 						in the currently-loaded EPUB content document are exposed to users. An assistive technology
 						cannot provide a list of landmarks for the whole publication, as it cannot see outside the
 						current document.</p>
 
 					<p>To counteract this destructuring effect, EPUB creators sometimes think to re-add or re-identify
 						structures in the belief that having this information in every document will be helpful to users
-						(e.g., adding an extra [[HTML]] <a data-lt="section"><code>section</code> element</a> around a
+						(e.g., adding an extra [[html]] <a data-lt="section"><code>section</code> element</a> around a
 						chapter to indicate it belongs to a part, or putting the part semantic on the
 						<code>body</code> tag). All this practice does, however, is add repetition that is not only
 						disruptive when reading but can make the structure of the publication harder to follow. EPUB
@@ -946,8 +946,8 @@
 				<section id="sem-003">
 					<h4>Include EPUB landmarks</h4>
 
-					<p>[[WAI-ARIA]] <a data-cite="wai-aria#dfn-landmark">landmarks</a> are similar in nature to <a
-							href="https://www.w3.org/TR/epub/#sec-nav-landmarks">EPUB landmarks</a> [[EPUB-3]]: both are
+					<p>[[wai-aria]] <a data-cite="wai-aria#dfn-landmark">landmarks</a> are similar in nature to <a
+							href="https://www.w3.org/TR/epub/#sec-nav-landmarks">EPUB landmarks</a> [[epub-3]]: both are
 						designed to provide users with quick access to the major structures of a document, such as
 						chapters, glossaries and indexes. ARIA landmarks are compiled automatically by <a
 							data-cite="epub-a11y-11#dfn-assistive-technology">assistive technologies</a> from the <a
@@ -965,7 +965,7 @@
 					<p>EPUB landmarks, on the other hand, are compiled by the EPUB creator prior to distribution, and
 						are not directly linked to the use of the <a
 							href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
-						><code>type</code> attribute</a> [[EPUB-3]] in the content. They are designed to simplify
+						><code>type</code> attribute</a> [[epub-3]] in the content. They are designed to simplify
 						linking to major sections of the publication in a machine-readable way, as <a>reading
 							systems</a> do not scan the entire publication for landmarks, either. EPUB landmarks are
 						typically not as numerous as ARIA landmarks, as reading systems only expose so many of these
@@ -1078,10 +1078,10 @@
 				<section id="titles-001">
 					<h4>Include publication and document titles</h4>
 
-					<p>[[WCAG2]] <a data-cite="WCAG2#page-titled">Success Criterion 2.4.2</a> requires that each web
+					<p>[[wcag2]] <a data-cite="wcag2#page-titled">Success Criterion 2.4.2</a> requires that each web
 						page include a title. EPUB has a similar requirement for <a>EPUB publications</a>: publications
-						require a [[DCTERMS]] <code>title</code> element in the <a>package document</a> metadata. The
-						[[WCAG2]] requirement is not satisfied by the EPUB requirement, however.</p>
+						require a [[dcterms]] <code>title</code> element in the <a>package document</a> metadata. The
+						[[wcag2]] requirement is not satisfied by the EPUB requirement, however.</p>
 
 					<p>When authoring an EPUB publication each <a>EPUB content document</a> also requires a descriptive
 						title that describes its content. If not provided, <a
@@ -1133,7 +1133,7 @@
 						to end, even though the content is often split across numerous <a>EPUB content documents</a>. As
 						a result, their natural expectation is that the headings reflect their position in the overall
 						hierarchy of the publication, despite the publication not actually being a single document
-						(e.g., if a part heading is expressed in an [[HTML]] <a data-lt="h1"
+						(e.g., if a part heading is expressed in an [[html]] <a data-lt="h1"
 						><code>h1</code> element</a>, each chapter that belongs to the part will have an <a data-lt="h2"
 								><code>h2</code></a> heading).</p>
 
@@ -1204,7 +1204,7 @@
 				<section id="titles-003">
 					<h4>Heading topic or purpose</h4>
 
-					<p>[[WCAG2]] <a data-cite="WCAG2#non-text-content">Success Criterion 2.4.6</a> currently states that
+					<p>[[wcag2]] <a data-cite="wcag2#non-text-content">Success Criterion 2.4.6</a> currently states that
 						all headings must describe their topic or purpose. The implication of this wording is that all
 						chapters in a novel, for example, have a topic or purpose and that the topic or purpose is
 						always clearly reflected by the title of the chapter. Not only is this not always the case, but
@@ -1236,8 +1236,8 @@
 					<p>The first version of these techniques only required alternative text for images regardless of
 						their complexity. This exception is no longer valid.</p>
 
-					<p><a>EPUB creators</a> must now ensure that their image-based content meets [[WCAG2]] requirements
-						for alternative text and extended descriptions to conform with [[EPUB-A11Y-11]].</p>
+					<p><a>EPUB creators</a> must now ensure that their image-based content meets [[wcag2]] requirements
+						for alternative text and extended descriptions to conform with [[epub-a11y-11]].</p>
 
 					<section id="sec-desc-001-res">
 						<h5>Helpful resources</h5>
@@ -1261,8 +1261,8 @@
 				<section id="lang-001">
 					<h4>Language of package document</h4>
 
-					<p>[[WCAG2]] Success Criterions <a data-cite="WCAG2#language-of-page">3.1.1</a> and <a
-							data-cite="WCAG2#language-of-parts">3.1.2</a> deal with the language of a page and changes
+					<p>[[wcag2]] Success Criterions <a data-cite="wcag2#language-of-page">3.1.1</a> and <a
+							data-cite="wcag2#language-of-parts">3.1.2</a> deal with the language of a page and changes
 						of language with in, respectively.</p>
 
 					<p>For <a>EPUB publications</a>, the <a>package document</a> is also an important source of metadata
@@ -1273,7 +1273,7 @@
 						to conform with these WCAG success criteria. The easiest way to meet this requirement is to add
 						an <code>xml:lang</code> attribute on the root <a
 							href="https://www.w3.org/TR/epub/#sec-package-elem"><code>package</code> element</a>
-						[[EPUB-3]].</p>
+						[[epub-3]].</p>
 
 					<aside class="example" title="All text declared to be in Japanese by default">
 						<pre><code>&lt;package … xml:lang="jp">
@@ -1309,7 +1309,7 @@
 					<p>In addition to being able to express the language of text content, the <a>package document</a>
 						also allows <a>EPUB creators</a> to identify the languages of the <a>EPUB publication</a> in <a
 							href="https://www.w3.org/TR/epub/#sec-opf-dclanguage"><code>dc:language</code> elements</a>
-						[[EPUB-3]].</p>
+						[[epub-3]].</p>
 
 					<aside class="example" title="Setting the language of an EPUB publication to Italian">
 						<pre><code>&lt;package …>
@@ -1322,8 +1322,8 @@
 &lt;/package></code></pre>
 					</aside>
 
-					<p>Although it is not strictly required to set this information to meet [[WCAG2]] <a
-							data-cite="WCAG2#language-of-page">Success Criterion 3.1.1</a>, as it is non-normative, it
+					<p>Although it is not strictly required to set this information to meet [[wcag2]] <a
+							data-cite="wcag2#language-of-page">Success Criterion 3.1.1</a>, as it is non-normative, it
 						should be considered a best practice to always set this field with the proper language
 						information. (Note that EPUB3 requires the language always be specified, so omitting will fail
 						validation requirements.)</p>
@@ -1344,7 +1344,7 @@
 				<section id="text-001">
 					<h4>Use Unicode for text content</h4>
 
-					<p>[[WCAG2]] <a data-cite="WCAG2#non-text-content">Success Criterion 1.1.1</a> requires that text
+					<p>[[wcag2]] <a data-cite="wcag2#non-text-content">Success Criterion 1.1.1</a> requires that text
 						equivalents be provided for all non-text content to meet Level A. In some regions (e.g., Asia),
 						it is not uncommon to find images of individual text characters, despite the availability of
 						Unicode character equivalents. This practice occurs for various reasons, such as ease of
@@ -1361,7 +1361,7 @@
 					<p>The use of Unicode characters for all text content avoids this problem, allowing content to
 						successfully meet the minimum requirement for Level A.</p>
 
-					<p>For compliance with Level AA, EPUB creators are directed to <a data-cite="WCAG2#images-of-text"
+					<p>For compliance with Level AA, EPUB creators are directed to <a data-cite="wcag2#images-of-text"
 							>Success Criterion 1.4.5</a> which further restricts the use of images of text to only a set
 						of essential cases.</p>
 				</section>
@@ -1374,24 +1374,24 @@
 					versions of the content will have different levels of accessibility. For example, an image-based
 					version of the content that lacks alternative text or descriptions could be bundled with a
 					WCAG-compliant text-based serialization. This type of accessible bundling is acceptable, as
-					[[WCAG2]] allows non-conforming content provided a <a
-						data-cite="WCAG2#dfn-conforming-alternate-version">conforming alternate version</a> is
+					[[wcag2]] allows non-conforming content provided a <a
+						data-cite="wcag2#dfn-conforming-alternate-version">conforming alternate version</a> is
 					available.</p>
 
-				<p>The [[EPUB-MULTI-REND-11]] specification defines a set of features for creating these types of EPUB
+				<p>The [[epub-multi-rend-11]] specification defines a set of features for creating these types of EPUB
 					publications. It specifies a set of attributes that allow a <a>reading system</a> to automatically
 					select a preferred rendition for the user or to provide the user the option to manually select
-					between the available options. This functionality technically meets the requirements of [[WCAG2]] in
+					between the available options. This functionality technically meets the requirements of [[wcag2]] in
 					terms of ensuring the user can access the accessible version.</p>
 
-				<p>In practice, however, the [[EPUB-MULTI-REND-11]] specification is not broadly supported in reading
+				<p>In practice, however, the [[epub-multi-rend-11]] specification is not broadly supported in reading
 					systems at the time of publication. As a result, a user who obtains an EPUB publication that
 					contains more than one rendition will only have access to the default. Unless this rendition is the
 					accessible one, the EPUB publication might not be readable by them.</p>
 
 				<p><a>EPUB creators</a> therefore need to use their best discretion when implementing this functionality
 					to meet accessibility requirements. EPUB publications that contain multiple renditions are
-					conformant to the [[EPUB-A11Y-11]] specification if at least one rendition meets all the content
+					conformant to the [[epub-a11y-11]] specification if at least one rendition meets all the content
 					requirements, but EPUB creators at a minimum need to note that a reading system that supports
 					multiple renditions is required in their <a href="#meta-005">accessibility summary</a>. Any other
 					methods the EPUB creator can use to make this dependence known is advisable (e.g., in the <a
@@ -1410,8 +1410,8 @@
 				<section id="page-001">
 					<h4>Provide page break markers</h4>
 
-					<p>Both the EPUB Structural Semantics Vocabulary [[EPUB-SSV]] and Digital Publishing WAI-ARIA 1.0
-						Module [[DPUB-ARIA-1.0]] include a semantic for static page breaks: <a
+					<p>Both the EPUB Structural Semantics Vocabulary [[epub-ssv]] and Digital Publishing WAI-ARIA 1.0
+						Module [[dpub-aria-1.0]] include a semantic for static page breaks: <a
 							href="https://www.w3.org/TR/epub/#pagebreak">pagebreak</a> and <a
 							data-cite="dpub-aria-1.0#doc-pagebreak">doc-pagebreak</a>, respectively.</p>
 
@@ -1451,9 +1451,9 @@
 &lt;/html></pre>
 					</aside>
 
-					<p>Do not use the [[HTML]] <a data-lt="a"><code>a</code> element</a> to identify page break
+					<p>Do not use the [[html]] <a data-lt="a"><code>a</code> element</a> to identify page break
 						locations in EPUB 3 publications. Although this element was previously defined as the anchor for
-						a hyperlink destination, its purpose has been changed in [[HTML]] for use solely as a link.</p>
+						a hyperlink destination, its purpose has been changed in [[html]] for use solely as a link.</p>
 				</section>
 
 				<section id="page-002">
@@ -1470,8 +1470,8 @@
 
 					<p>To identify page numbers in media overlay documents, attach an <code>epub:type</code> attribute
 						with the value "<a href="https://www.w3.org/TR/epub/#pagebreak"><code>pagebreak</code></a>"
-						[[EPUB-SSV]] to each <a href="https://www.w3.org/TR/epub/#sec-smil-par-elem"><code>par</code>
-							element</a> [[EPUB-3]] that identifies a page number.</p>
+						[[epub-ssv]] to each <a href="https://www.w3.org/TR/epub/#sec-smil-par-elem"><code>par</code>
+							element</a> [[epub-3]] that identifies a page number.</p>
 
 					<aside class="example" title="A page number identified in a Media Overlays Document">
 						<pre>&lt;smil
@@ -1532,9 +1532,9 @@
 
 					<p>The <a>EPUB navigation document</a> allows the inclusion of a <a
 							href="https://www.w3.org/TR/epub/#sec-nav-pagelist"><code>page-list</code>
-							<code>nav</code></a> [[EPUB-3]], while the EPUB 2 NCX file provides the same functionality
+							<code>nav</code></a> [[epub-3]], while the EPUB 2 NCX file provides the same functionality
 						through the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1.2"
-								><code>pageList</code> element</a> [[OPF-201]].</p>
+								><code>pageList</code> element</a> [[opf-201]].</p>
 
 					<aside class="example" title="A page-list nav element">
 						<pre>&lt;nav
@@ -1623,7 +1623,7 @@
 
 					<p>EPUB 3 allows the source of pagination to be explicitly identified using the <a
 							href="https://www.w3.org/TR/epub/#source-of"><code>source-of</code> property</a> with the
-						value "<code>pagination</code>" [[EPUB-3]].</p>
+						value "<code>pagination</code>" [[epub-3]].</p>
 
 					<aside class="example" title="Adding a source-of declaration">
 						<p>In this example, a <code>dc:source</code> element is explicitly identified as the source of
@@ -1674,7 +1674,7 @@
 						allowing users who require full synchronized playback, or even audio-only playback, have access
 						to the same information as users who do not require synchronized playback.</p>
 
-					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] allows
+					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[epub-33]] allows
 						audio to be synchronized with any element in an <a>EPUB content document</a>, so there is no
 						technical barrier to providing synchronized playback.</p>
 
@@ -1682,14 +1682,14 @@
 						publication. The minimal candidates for synchronization with audio are all the elements with
 						visible text content.</p>
 
-					<p>In HTML, the class of elements called <a>palpable content</a> [[HTML]] can typically be
+					<p>In HTML, the class of elements called <a>palpable content</a> [[html]] can typically be
 						synchronized with audio or have their own built-in audio. Embedded text in SVG documents, on the
 						other hand, is found in the <a href="https://www.w3.org/TR/SVG/text.html#TextElement"
-								><code>text</code> element</a> [[SVG]] and its descendants.</p>
+								><code>text</code> element</a> [[svg]] and its descendants.</p>
 
 					<p>The Media Overlays <a data-cite="epub-33#sec-smil-text-elem"><code>text</code> element</a> is
 						used to reference these elements, either to play back the pre-recorded audio in a sibling <a
-							data-cite="epub-33#sec-smil-audio-elem"><code>audio</code> element</a> [[EPUB-33]] or to
+							data-cite="epub-33#sec-smil-audio-elem"><code>audio</code> element</a> [[epub-33]] or to
 						initiate playback of an audio or video element if the <code>audio</code> element is missing
 						(e.g., for embedded audio and video in the document).</p>
 
@@ -1699,7 +1699,7 @@
 							for sighted readers following the playback.</p>
 
 						<p>Text content in a collapsed element, like the <a data-lt="details"><code>details</code>
-								element</a> [[HTML]], is not considered hidden content.</p>
+								element</a> [[html]], is not considered hidden content.</p>
 					</div>
 
 					<p>In addition to synchronizing the visible text, synchronized text-audio playback must also address
@@ -1709,9 +1709,9 @@
 						providing the user all the information in the EPUB publication.</p>
 
 					<p>Text alternatives and descriptions in HTML may be represented in the <a
-							data-cite="html#attr-img-alt"><code>alt</code> attribute</a> [[HTML]] and linked by ARIA
+							data-cite="html#attr-img-alt"><code>alt</code> attribute</a> [[html]] and linked by ARIA
 						attributes (e.g., <a data-cite="wai-aria#aria-describedby"><code>aria-describedby</code></a> and
-							<a data-cite="wai-aria#aria-details"><code>aria-details</code></a> [[WAI-ARIA]]).
+							<a data-cite="wai-aria#aria-details"><code>aria-details</code></a> [[wai-aria]]).
 						Descriptions for image elements in SVG are typically represented in a <a
 							href="https://www.w3.org/TR/SVG/struct.html#DescElement"><code>desc</code> element</a> but
 						ARIA attributes may also be used.</p>
@@ -1729,7 +1729,7 @@
 						content) diverges from the default reading order, <a>EPUB creators</a> can order the playback
 						sequence of <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
 							data-cite="epub-33#sec-smil-par-elem"><code>par</code></a> elements in a <a
-							data-cite="epub-33#sec-overlay-docs">Media Overlays Document</a> [[EPUB-33]] to match the
+							data-cite="epub-33#sec-overlay-docs">Media Overlays Document</a> [[epub-33]] to match the
 						logical order.</p>
 
 					<p>EPUB creators need to use caution when making alterations, however, as other accessibility issues
@@ -1753,25 +1753,25 @@
 						after finishing the <a>EPUB publication</a>. The announcement of page break numbers can be
 						similarly annoying to readers.</p>
 
-					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] does
+					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[epub-33]] does
 						not allow <a>reading systems</a> to determine if playback sequences are skippable unless <a>EPUB
 							creators</a> add additional semantics to the markup, however. EPUB creators must use the <a
-							data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[EPUB-33]]
+							data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code> attribute</a> [[epub-33]]
 						to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"><code>seq</code></a> and <a
-							data-cite="epub-33#sec-smil-par-elem"><code>par</code></a> elements [[EPUB-33]], thereby
+							data-cite="epub-33#sec-smil-par-elem"><code>par</code></a> elements [[epub-33]], thereby
 						allowing reading systems to provide users the option to skip their playback sequences.</p>
 
 					<p>The recommended structures to identify for skippability are:</p>
 
 					<ul>
 						<li>Endnotes &#8212; use the <a data-cite="epub-ssv-11#endnotes"><code>endnotes</code></a> and
-								<a data-cite="epub-ssv-11#endnote"><code>endnote</code></a> semantics [[EPUB-SSV-11]]
+								<a data-cite="epub-ssv-11#endnote"><code>endnote</code></a> semantics [[epub-ssv-11]]
 							for groups of notes and individual endnotes, respectively.</li>
 						<li>Footnotes &#8212; use the <a data-cite="epub-ssv-11#footnotes"><code>footnotes</code></a>
-							and <a data-cite="epub-ssv-11#footnote"><code>footnote</code></a> semantics [[EPUB-SSV-11]]
+							and <a data-cite="epub-ssv-11#footnote"><code>footnote</code></a> semantics [[epub-ssv-11]]
 							for groups of footnotes and individual footnotes, respectively.</li>
 						<li>Page breaks &#8212; use the <a data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code>
-								semantic</a> [[EPUB-SSV-11]] to identify each.</li>
+								semantic</a> [[epub-ssv-11]] to identify each.</li>
 					</ul>
 
 					<p>EPUB creators may identify other structures but it is not necessary to meet this requirement.</p>
@@ -1853,32 +1853,32 @@
 						These are called escapable elements, because the user needs to be able to escape from them
 						whenever they choose to simplify the reading experience.</p>
 
-					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[EPUB-33]] only
+					<p>EPUB 3's <a data-cite="epub-33#sec-media-overlays">Media Overlays feature</a> [[epub-33]] only
 						supports escapability if <a>EPUB creators</a> add structural semantics to the markup. EPUB
 						creators must use the <a data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code>
-							attribute</a> [[EPUB-33]] to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"
+							attribute</a> [[epub-33]] to add semantics to <a data-cite="epub-33#sec-smil-seq-elem"
 								><code>seq</code></a> and <a data-cite="epub-33#sec-smil-seq-elem"><code>par</code></a>
-						elements [[EPUB-33]] to allow <a>reading systems</a> to provide users the option to escape their
+						elements [[epub-33]] to allow <a>reading systems</a> to provide users the option to escape their
 						playback sequences.</p>
 
 					<p>The recommended structures to identify for escapability are:</p>
 
 					<ul>
 						<li>Figures &#8212; use the <a data-cite="epub-ssv-11#figure"><code>figure</code> semantic</a>
-							[[EPUB-SSV-11]] to identify each.</li>
+							[[epub-ssv-11]] to identify each.</li>
 						<li>Lists &#8212; using the <a data-cite="epub-ssv-11#list"><code>list</code> semantic</a>
-							[[EPUB-SSV-11]] to identify each.</li>
+							[[epub-ssv-11]] to identify each.</li>
 						<li>Sidebars &#8212; use the <a data-cite="epub-ssv-11#aside"><code>aside</code> semantic</a>
-							[[EPUB-SSV-11]] to identify each.</li>
+							[[epub-ssv-11]] to identify each.</li>
 						<li>Tables &#8212; use the <a data-cite="epub-ssv-11#table"><code>table</code> semantic</a>
-							[[EPUB-SSV-11]] to identify each.</li>
+							[[epub-ssv-11]] to identify each.</li>
 					</ul>
 
 					<p>EPUB creators may identify other structures but it is not necessary to meet this requirement.</p>
 
 					<div class="note">
 						<p>Identifying nested escapable structures is not recommended at this time. Refer to <a
-								href="https://www.w3.org/TR/epub/#sec-escapability">Escapability</a> [[EPUB-3]] for more
+								href="https://www.w3.org/TR/epub/#sec-escapability">Escapability</a> [[epub-3]] for more
 							information.</p>
 					</div>
 

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -52,7 +52,7 @@
 				},
 				xref: ["epub-33"],
 				localBiblio: {
-					"A11Y-DISCOV-VOCAB": {
+					"a11y-discov-vocab": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
 						"href": "https://www.w3.org/2021/a11y-discov-vocab/latest/",
 						"editors": [
@@ -61,16 +61,16 @@
 							"Matt Garrish"
 						]
 					},
-					"DAISYAudio": {
+					"daisyaudio": {
 						"title": "Navigable audio-only EPUB 3 Guidelines",
 						"href": "http://www.daisy.org/guidelines/epub/navigable-audio-only-epub3-guidelines"
 					},
-					"EPUB-3": {
+					"epub-3": {
 						"title": "EPUB 3",
 						"href": "https://www.w3.org/TR/epub/",
 						"publisher": "W3C"
 					},
-					"EPUB-A11Y-10": {
+					"epub-a11y-10": {
 						"authors":[
 						"Matt Garrish",
 						"George Kerscher",
@@ -81,21 +81,21 @@
 						"date": "05 January 2017",
 						"publisher": "IDPF"
 					},
-					"MARC21": {
+					"marc21": {
 						"title": "MARC 21 XML",
 						"href": "https://www.loc.gov/standards/marcxml/"		
 					},
-					"ONIX": {
+					"onix": {
 						"title": "ONIX for Books 3.0",
 						"href": "https://www.editeur.org/8/ONIX/"
 					},
-					"OPF-201": {
+					"opf-201": {
 						"title": "Open Packaging Format 2.0.1",
 						"href": "http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
 						"date": "04 September 2010",
 						"publisher": "IDPF"
 					},
-					"WCAG2": {
+					"wcag2": {
 						"title": "Web Content Accessibility Guidelines (WCAG) 2",
 						"href": "https://www.w3.org/TR/WCAG2/",
 						"publisher": "W3C"
@@ -125,7 +125,7 @@
 		<section id="sotd">
 			<div class="ednote">
 				<p>Publishers not currently producing accessible content are encouraged to begin updating their
-					production processes to meet the requirements of [[EPUB-A11Y-10]] while this specification is being
+					production processes to meet the requirements of [[epub-a11y-10]] while this specification is being
 					developed. Content that meets the requirements of that version will typically also meet the
 					requirements of this specification with few changes necessary.</p>
 			</div>
@@ -181,12 +181,12 @@
 				<h3>Success techniques</h3>
 
 				<p>This specification takes an abstract approach to the accessibility requirements for <a>EPUB
-						publications</a>, similar to how WCAG [[WCAG2]] separates its accessibility guidelines from the
+						publications</a>, similar to how WCAG [[wcag2]] separates its accessibility guidelines from the
 					techniques to achieve them. This approach allows the guidelines to remain stable even as the format
 					evolves.</p>
 
 				<p>To facilitate this approach, the companion <a data-cite="epub-a11y-tech-11#">EPUB Accessibility
-						Techniques</a> [[EPUB-A11Y-TECH-11]] document outlines conformance techniques. These techniques
+						Techniques</a> [[epub-a11y-tech-11]] document outlines conformance techniques. These techniques
 					explain how to meet the requirements of this specification for different versions of EPUB.</p>
 
 				<section id="sec-sc-i18n">
@@ -194,12 +194,12 @@
 
 					<p>This specification is also designed to address the accessibility needs of users independent of
 						what languages they read. The same is true for the principles and success criteria defined in
-						[[WCAG2]]. The goal is to ensure that users can fully consume the information of a publication
+						[[wcag2]]. The goal is to ensure that users can fully consume the information of a publication
 						regardless of their preferred reading modality.</p>
 
 					<p>At the same time, the language and writing conventions of the authored text will influence the
 						techniques necessary to meet the accessibility requirements. EPUB <a
-							data-cite="epub-33#confreq-xml-enc">requires support for Unicode text</a> [[EPUB-3]], for
+							data-cite="epub-33#confreq-xml-enc">requires support for Unicode text</a> [[epub-3]], for
 						example, which ensures the correct character data can be used (i.e., <a>EPUB creators</a> do not
 						have to use images of text). Although this is an important feature, it is often not enough on
 						its own to ensure that the text is fully accessible in any given language (e.g., additional
@@ -216,7 +216,7 @@
 				<h3>Application to older versions</h3>
 
 				<p>This specification is applicable to any <a>EPUB publication</a>, even if the content conforms to an
-					older version of EPUB that does not refer to this specification (e.g., EPUB 2 [[OPF-201]]).</p>
+					older version of EPUB that does not refer to this specification (e.g., EPUB 2 [[opf-201]]).</p>
 
 				<p>Creators of such EPUB publications should create content in conformance with the accessibility and
 					discoverability requirements of this specification. <a>EPUB creators</a> should also upgrade to the
@@ -225,7 +225,7 @@
 				<p>Note that not all metadata expressions defined in this specification are supported in older version
 					of EPUB. EPUB 2, in particular, does not support the <a
 						href="https://www.w3.org/TR/epub-33/#attrdef-refines"><code>refines</code> attribute</a>
-					[[EPUB-33]]. If EPUB creators cannot avoid expressions that require this attribute, they will have
+					[[epub-33]]. If EPUB creators cannot avoid expressions that require this attribute, they will have
 					to accept a certain amount of ambiguity in their statements (i.e., relationships between expression
 					may only be apparent by their placement in the package document metadata).</p>
 			</section>
@@ -234,7 +234,7 @@
 				<h3>Terminology</h3>
 
 				<p>This document uses <a data-cite="epub-33#sec-terminology">terminology defined in EPUB 3</a>
-					[[EPUB-3]]:</p>
+					[[epub-3]]:</p>
 
 				<p>In addition, it defines the following term:</p>
 
@@ -242,8 +242,8 @@
 					<dt><dfn id="dfn-assistive-technology" data-lt="assistive techonolgies">assistive
 						technology</dfn></dt>
 					<dd>
-						<p>This specification uses the <a data-cite="WCAG2#dfn-assistive-technologies">definition of
-								assistive technology</a> from [[WCAG2]].</p>
+						<p>This specification uses the <a data-cite="wcag2#dfn-assistive-technologies">definition of
+								assistive technology</a> from [[wcag2]].</p>
 						<p>In the case of EPUB, an assistive technology is not always a separate application from a
 								<a>reading system</a>. Reading systems often integrate features of standalone assistive
 							technologies, such as text-to-speech playback.</p>
@@ -341,14 +341,14 @@
 				<div class="note">
 					<p>For the complete list of approved terms to use with these properties, refer to the <a
 							href="https://www.w3.org/2021/a11y-discov-vocab/latest/">Schema.org Accessibility Properties
-							for Discoverability Vocabulary</a> [[A11Y-DISCOV-VOCAB]].</p>
+							for Discoverability Vocabulary</a> [[a11y-discov-vocab]].</p>
 				</div>
 
 				<div class="note">
 					<p>See <a data-cite="epub-a11y-tech-11#sec-discovery">Discovery Metadata Techniques</a>
-						[[EPUB-A11Y-TECH-11]] for more information on these properties and how to include them in
+						[[epub-a11y-tech-11]] for more information on these properties and how to include them in
 						different versions of EPUB. See also <a data-cite="epub-a11y-tech-11#dist-002">Include
-							accessibility metadata in distribution records</a> [[EPUB-A11Y-TECH-11]] for more
+							accessibility metadata in distribution records</a> [[epub-a11y-tech-11]] for more
 						information on including accessibility metadata in other formats.</p>
 				</div>
 			</section>
@@ -357,7 +357,7 @@
 				<h3>Linked metadata records</h3>
 
 				<p>Accessibility metadata can also be included in <a href="https://www.w3.org/TR/epub/#sec-link-elem"
-						>linked records</a> [[EPUB-3]] (i.e., metadata records referenced from <code>link</code>
+						>linked records</a> [[epub-3]] (i.e., metadata records referenced from <code>link</code>
 					elements), but the inclusion of such metadata solely in a linked record does not satisfy the
 					discoverability requirements of this specification.</p>
 			</section>
@@ -374,7 +374,7 @@
 					application of established web accessibility techniques.</p>
 
 				<p>The primary source producing accessible web content is the W3C Web Content Accessibility Guidelines
-					(WCAG) [[WCAG2]]. This specification leverages the extensive work done in WCAG to establish
+					(WCAG) [[wcag2]]. This specification leverages the extensive work done in WCAG to establish
 					benchmarks for accessible content, and the same four high-level content principles — perceivable,
 					operable, understandable, and robust — are central to creating EPUB publications that are
 					accessible.</p>
@@ -389,7 +389,7 @@
 			<section id="sec-rel-wcag" class="informative">
 				<h3>Relationship to WCAG</h3>
 
-				<p>WCAG [[WCAG2]] and its <a href="https://www.w3.org/WAI/WCAG21/Techniques/">associated techniques</a>
+				<p>WCAG [[wcag2]] and its <a href="https://www.w3.org/WAI/WCAG21/Techniques/">associated techniques</a>
 					provide extensive coverage of issues and solutions for web content accessibility — from tables to
 					embedded multimedia to rich semantics. They represent the foundation that this specification builds
 					upon.</p>
@@ -406,7 +406,7 @@
 					publications. (Each requirement explains its relationship to WCAG in its respective section.)</p>
 
 				<p>The same is true of the techniques in the EPUB Accessibility Techniques document
-					[[EPUB-A11Y-TECH-11]]. It provides coverage of techniques that are unique to EPUB publications, or
+					[[epub-a11y-tech-11]]. It provides coverage of techniques that are unique to EPUB publications, or
 					that need clarification in the context of an EPUB publication. It does not mean that the rest of the
 					WCAG techniques are not applicable.</p>
 
@@ -428,9 +428,9 @@
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-wcag-20">MUST, at the minimum, meet the requirements of WCAG 2.0 [[WCAG20]],
+							<p id="confreq-wcag-20">MUST, at the minimum, meet the requirements of WCAG 2.0 [[wcag20]],
 								but it is strongly recommended that it meet the requirements of the <a
-									data-cite="WCAG2#">latest recommended version of WCAG 2</a>.</p>
+									data-cite="wcag2#">latest recommended version of WCAG 2</a>.</p>
 						</li>
 
 						<li>
@@ -438,7 +438,7 @@
 								of Level A, but it is strongly recommended that it meet the requirements of Level
 								AA.</p>
 							<div class="note">
-								<p>Although, as <a data-cite="WCAG21#h-note-29">noted in WCAG</a>, conforming at level
+								<p>Although, as <a data-cite="wcag21#h-note-29">noted in WCAG</a>, conforming at level
 									AAA is typically not possible, and not required by this specification, <a>EPUB
 										creators</a> are encouraged to follow the practices detailed in AAA success
 									criteria when producing accessible EPUB publications.</p>
@@ -496,10 +496,10 @@
 					<section id="sec-wcag-eval-page-pub">
 						<h5>Page and publication</h5>
 
-						<p>The WCAG <a data-cite="WCAG2#wcag-2-layers-of-guidance">principles</a> [[WCAG2]] focus on the
+						<p>The WCAG <a data-cite="wcag2#wcag-2-layers-of-guidance">principles</a> [[wcag2]] focus on the
 							evaluation of individual web pages, but an <a>EPUB publication</a> more closely resembles
-							what WCAG refers to as a <a data-cite="WCAG2#dfn-set-of-web-pages">set of web pages</a>:
-							"[a] collection of web pages that share a common purpose" [[WCAG2]].</p>
+							what WCAG refers to as a <a data-cite="wcag2#dfn-set-of-web-pages">set of web pages</a>:
+							"[a] collection of web pages that share a common purpose" [[wcag2]].</p>
 
 						<p>Consequently, when evaluating the accessibility of an EPUB publication, <a>EPUB creators</a>
 							cannot review individual pages — or EPUB content documents, as they are known in EPUB 3 — in
@@ -516,32 +516,32 @@
 							understandable, and robust against the full EPUB publication, not only against each EPUB
 							content document within it.</p>
 
-						<p>The EPUB Accessibility Techniques [[?EPUB-A11Y-TECH-11]] provide more information about
+						<p>The EPUB Accessibility Techniques [[?epub-a11y-tech-11]] provide more information about
 							applying these guidelines to EPUB publications.</p>
 					</section>
 
 					<section id="sec-wcag-application">
 						<h5>Applying the conformance criteria</h5>
 
-						<p>When evaluating an <a>EPUB publication</a>, the WCAG <a data-cite="WCAG2#conformance-reqs"
-								>conformance criteria</a> [[WCAG2]] are applied as follows:</p>
+						<p>When evaluating an <a>EPUB publication</a>, the WCAG <a data-cite="wcag2#conformance-reqs"
+								>conformance criteria</a> [[wcag2]] are applied as follows:</p>
 
 						<ul>
 							<li>When determining compliance with a conformance level, the whole EPUB publication MUST
 								meet the conformance requirements of the level claimed.</li>
 
 							<li><a>EPUB creators</a> MUST NOT use EPUB's fallback mechanisms to provide a <a
-									data-cite="WCAG2#dfn-conforming-alternate-version">conforming alternate version</a>
-								[[WCAG2]], as there is no reliable way for users to access such fallbacks. If an EPUB
+									data-cite="wcag2#dfn-conforming-alternate-version">conforming alternate version</a>
+								[[wcag2]], as there is no reliable way for users to access such fallbacks. If an EPUB
 								creator uses fallbacks, both the primary content and its fallback(s) MUST meet the
 								requirements for the conformance level claimed. EPUB-specific fallback mechanisms
 								include <a href="https://www.w3.org/TR/epub/#sec-manifest-fallbacks">manifest
-									fallbacks</a> [[EPUB-3]], <a href="https://www.w3.org/TR/epub/#sec-opf-bindings"
-									>bindings</a> [[EPUB-3]] and content switching via the <a
+									fallbacks</a> [[epub-3]], <a href="https://www.w3.org/TR/epub/#sec-opf-bindings"
+									>bindings</a> [[epub-3]] and content switching via the <a
 									href="https://www.w3.org/TR/epub/#sec-xhtml-content-switch"><code>epub:switch</code>
-									element</a> [[EPUB-3]].</li>
+									element</a> [[epub-3]].</li>
 
-							<li>The "<a data-cite="WCAG2#cc2">Full Pages</a>" requirement [WCAG2] -- that parts of a
+							<li>The "<a data-cite="wcag2#cc2">Full Pages</a>" requirement [WCAG2] -- that parts of a
 								page cannot be excluded when making a conformance claim -- applies to every <a>EPUB
 									content document</a> in the EPUB publication (i.e., they must all conform in full to
 								the conformance level claimed).</li>
@@ -578,7 +578,7 @@
 								publication</a> can be complicated without static references.</p>
 
 						<p>The inclusion of page navigation represents one method of achieving the <a
-								data-cite="WCAG2#multiple-ways">Multiple Ways success criterion</a> [[WCAG2]], as it
+								data-cite="wcag2#multiple-ways">Multiple Ways success criterion</a> [[wcag2]], as it
 							provides another meaningful way for users to access the content (e.g., in addition to the
 							table of contents, linear reading order and any other navigation aids).</p>
 
@@ -588,7 +588,7 @@
 
 						<div class="note">
 							<p>Refer to <a href="https://www.w3.org/TR/epub-a11y-tech-11/#sec-epub-page-markers">Page
-									Markers</a> [[EPUB-A11Y-TECH-11]] for more information on the inclusion of page
+									Markers</a> [[epub-a11y-tech-11]] for more information on the inclusion of page
 								navigation in EPUB publications.</p>
 						</div>
 					</section>
@@ -655,7 +655,7 @@
 										identify that source in the <a>package document</a> metadata.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-004">Identifying the pagination
-												source</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
+												source</a> [[epub-a11y-tech-11]] for more information on meeting this
 											objective.</p>
 									</div>
 								</dd>
@@ -697,7 +697,7 @@
 										reproduced or not, but this is not a requirement.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-003">Provide a page list</a>
-											[[EPUB-A11Y-TECH-11]] for more information on meeting this objective.</p>
+											[[epub-a11y-tech-11]] for more information on meeting this objective.</p>
 									</div>
 								</dd>
 							</dl>
@@ -737,11 +737,11 @@
 											reproduced or not), but this is not a requirement.</li>
 									</ul>
 									<p>In addition, if page numbers are read aloud in a synchronized text-audio playback
-										of the content (e.g., EPUB 3 media overlays [[?EPUB-3]]), EPUB creators MUST
+										of the content (e.g., EPUB 3 media overlays [[?epub-3]]), EPUB creators MUST
 										identify the page numbers in the markup that controls the playback.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#page-001">Provide page break
-												markers</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
+												markers</a> [[epub-a11y-tech-11]] for more information on meeting this
 											objective.</p>
 									</div>
 								</dd>
@@ -774,8 +774,8 @@
 							escape users from deeply nested structures like tables.</p>
 
 						<p>Adding structure and semantics to synchronized text-audio playback broadly falls under the
-							objective of the <a data-cite="WCAG2#info-and-relationships">Info and Relationships success
-								criterion</a> [[WCAG2]]. Without structured and semantically meaningful playback
+							objective of the <a data-cite="wcag2#info-and-relationships">Info and Relationships success
+								criterion</a> [[wcag2]]. Without structured and semantically meaningful playback
 							sequences, the effect is to deprive users of rich navigation of the content.</p>
 					</section>
 
@@ -783,8 +783,8 @@
 						<h5>Applicability</h5>
 
 						<p><a>EPUB publications</a> with synchronized text-audio playback MUST conform to all
-							requirements in [[EPUB-3]]. It is not necessary to meet any additional requirements beyond
-							those defined in [[EPUB-3]] to be conformant with this specification.</p>
+							requirements in [[epub-3]]. It is not necessary to meet any additional requirements beyond
+							those defined in [[epub-3]] to be conformant with this specification.</p>
 
 						<p>To maximize the effectiveness of synchronized text-audio playback for people with different
 							reading needs, however, <a>EPUB creators</a> are strongly encouraged to meet the <a
@@ -827,7 +827,7 @@
 										textual content as well as all textual alternatives for visual media.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-004">Ensuring complete text
-												coverage</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
+												coverage</a> [[epub-a11y-tech-11]] for more information on meeting this
 											objective.</p>
 									</div>
 								</dd>
@@ -851,7 +851,7 @@
 										the <a>EPUB content documents</a> that make up the publication, while the markup
 										within each EPUB content document provides the default progression through the
 										content elements (i.e., as represented in the document object model
-										[[DOM]]).</p>
+										[[dom]]).</p>
 									<p>For many languages, the default reading order also matches the logical reading
 										order &#8212; the way that users will naturally follow the narrative. It ensures
 										that readers can follow the primary narrative and that they encounter secondary
@@ -878,7 +878,7 @@
 										instructions such that they reflect both:</p>
 									<ul>
 										<li>the order of the referenced EPUB content documents in the <a
-												href="https://www.w3.org/TR/epub/#dfn-spine">spine</a> [[EPUB-3]];
+												href="https://www.w3.org/TR/epub/#dfn-spine">spine</a> [[epub-3]];
 											and</li>
 										<li>the order of each element within its respective EPUB content document.</li>
 									</ul>
@@ -886,7 +886,7 @@
 										logical playback of the content.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-002">Specifying the reading
-												order</a> [[EPUB-A11Y-TECH-11]] for more information on meeting this
+												order</a> [[epub-a11y-tech-11]] for more information on meeting this
 											objective.</p>
 									</div>
 								</dd>
@@ -924,7 +924,7 @@
 									<p>EPUB creators SHOULD identify all skippable structures.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-003">Identifying skippable
-												structures</a> [[EPUB-A11Y-TECH-11]] for more information on meeting
+												structures</a> [[epub-a11y-tech-11]] for more information on meeting
 											this objective.</p>
 									</div>
 								</dd>
@@ -962,7 +962,7 @@
 									<p>EPUB creators SHOULD identify all escapable structures.</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-004">Identifying escapable
-												structures</a> [[EPUB-A11Y-TECH-11]] for more information on meeting
+												structures</a> [[epub-a11y-tech-11]] for more information on meeting
 											this objective.</p>
 									</div>
 								</dd>
@@ -995,10 +995,10 @@
 								<dd>
 									<p><a>EPUB creators</a> SHOULD provide synchronized text-audio playback for the <a
 											href="https://www.w3.org/TR/epub/#sec-mo-nav-doc">EPUB navigation
-											document</a> [[EPUB-3]].</p>
+											document</a> [[epub-3]].</p>
 									<div class="note">
 										<p>Refer to <a data-cite="epub-a11y-tech-11#sync-005">Synchronizing the
-												navigation document</a> [[EPUB-A11Y-TECH-11]] for more information on
+												navigation document</a> [[epub-a11y-tech-11]] for more information on
 											meeting this objective.</p>
 									</div>
 								</dd>
@@ -1024,7 +1024,7 @@
 						<li>information about <a href="#sec-conf-reporting-eval">who performed the evaluation</a>.</li>
 					</ul>
 
-					<p>The metadata uses a combination of properties from DCMI Metadata Terms [[DCTERMS]] and the <a
+					<p>The metadata uses a combination of properties from DCMI Metadata Terms [[dcterms]] and the <a
 							href="#app-a11y-vocab">EPUB Accessibility Vocabulary</a>, as explained in more detail in the
 						following sections.</p>
 
@@ -1055,10 +1055,10 @@
 					<h4>Publication conformance</h4>
 
 					<p>To indicate conformance to the accessibility requirements of this specification, an <a>EPUB
-							publication</a> [[EPUB-33]] MUST specify in its <a data-cite="epub-33#sec-pkg-metadata"
+							publication</a> [[epub-33]] MUST specify in its <a data-cite="epub-33#sec-pkg-metadata"
 							>metadata section</a> a <a
 							href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/conformsTo"
-								><code id="dcterms-conformsTo">conformsTo</code> property</a> [[DCTERMS]] exactly
+								><code id="dcterms-conformsTo">conformsTo</code> property</a> [[dcterms]] exactly
 						matching (i.e., both in case and spacing) the following pattern:</p>
 
 					<p class="conf-pattern">EPUB-A11Y-<a href="#acc-ver"><var>A11Y-VER</var></a>_WCAG-<a
@@ -1133,11 +1133,11 @@
 
 						<p>EPUB creators may also use a conformance URL, as defined in the <a
 								href="https://www.w3.org/TR/WCAG/#conformance-required">Required Components of a
-								Conformance Claim</a> [[WCAG2]], with the <code>conformsTo</code> property for EPUB
+								Conformance Claim</a> [[wcag2]], with the <code>conformsTo</code> property for EPUB
 							publications that only meet WCAG conformance requirements (i.e., that do not fully conform
 							to this specification).</p>
 
-						<p>As [[WCAG2]] does not define how to specify the conformance level in the URL, however, EPUB
+						<p>As [[wcag2]] does not define how to specify the conformance level in the URL, however, EPUB
 							creators will have to find an alternative means of relating this information when necessary
 							(e.g., through the accessibility summary).</p>
 					</div>
@@ -1263,7 +1263,7 @@
 
 						<p>If the date the evaluation was performed on is known, include that information in a <a
 								data-cite="dcterms#http://purl.org/dc/terms/date"><code>dcterms:date</code> property</a>
-							[[DCTERMS]] <a data-cite="epub-33#subexpression">associated with</a> [[EPUB-33]] the <a
+							[[dcterms]] <a data-cite="epub-33#subexpression">associated with</a> [[epub-33]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
 						<aside class="example" title="Expressing the evaluation date">
@@ -1291,7 +1291,7 @@
 						<p>If the evaluator has credentials or badges that establish their authority to evaluate
 							content, include that information in an <a href="#certifierCredential"><code
 									id="a11y-certifierCredential">a11y:certifierCredential</code> properties</a>
-							<a data-cite="epub-33#subexpression">associated with</a> [[EPUB-33]] the <a
+							<a data-cite="epub-33#subexpression">associated with</a> [[epub-33]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
 						<aside class="example" title="Expressing a basic credential">
@@ -1327,7 +1327,7 @@
 						<p>If the evaluator provides a publicly-readable report of its assessment, provide a link to the
 							assessment in an <a href="#certifierReport"><code id="a11y-certifierReport"
 									>a11y:certifierReport</code> property</a>
-							<a data-cite="epub-33#subexpression">associated with</a> [[EPUB-33]] the <a
+							<a data-cite="epub-33#subexpression">associated with</a> [[epub-33]] the <a
 								href="#sec-evaluator-name">evaluator's name</a>.</p>
 
 						<aside class="example" title="An external accessibility report">
@@ -1412,7 +1412,7 @@
 						release, the EPUB creator may only need to evaluate the new modifications to re-confirm
 						conformance.</p>
 
-					<p>If an updated version of this specification or [[WCAG2]] has been published since the last
+					<p>If an updated version of this specification or [[wcag2]] has been published since the last
 						release of the EPUB publication, however, this specification also recommends performing a new
 						evaluation to ensure conformance to the latest standards. EPUB creators may not have to perform
 						a full re-evaluation even in this case (i.e., they may only need to check new or modified
@@ -1447,7 +1447,7 @@
 		<section id="sec-optimized-pubs" class="informative">
 			<h2>Optimized publications</h2>
 
-			<p>Although WCAG [[WCAG2]] provides a general set of guidelines for making content broadly accessible,
+			<p>Although WCAG [[wcag2]] provides a general set of guidelines for making content broadly accessible,
 				conformant content is not always optimal for specific user groups. Conversely, content optimized for a
 				specific need or reading modality is often not conformant to WCAG exactly because it targets a specific
 				audience.</p>
@@ -1474,10 +1474,10 @@
 				<li>The EPUB publication should meet the <a href="#sec-discovery">discovery metadata requirements</a> of
 					this specification so its accessible properties are machine-readable.</li>
 				<li>The EPUB publication should identify the standard or guidelines it follows in a
-						<code>conformsTo</code> property in accordance with [[DCTERMS]] so this information can be made
+						<code>conformsTo</code> property in accordance with [[dcterms]] so this information can be made
 					available to users.</li>
 				<li>If the standard does not define conformance values for the <code>conformsTo</code> property, EPUB
-					creators should use a URL [[URL]] to where the standard is publicly available so users can look up
+					creators should use a URL [[url]] to where the standard is publicly available so users can look up
 					the specific details of the standard.</li>
 				<li>If the identifier is not sufficient for a user to understand conformance (e.g., the guidelines are
 					not publicly available), EPUB creators should provide additional information about they have
@@ -1495,7 +1495,7 @@
 
 			<aside class="example" title="Expressing conformance to an optimization standard">
 				<p>In this example, the conformance statement indicates the EPUB 3 publication conforms to the DAISY
-					Navigable Audio-only EPUB 3 Guidelines [[DAISYAudio]].</p>
+					Navigable Audio-only EPUB 3 Guidelines [[daisyaudio]].</p>
 				<pre>&lt;metadata …>
    …
    &lt;link
@@ -1567,7 +1567,7 @@
 			<ul>
 				<li>they must not impose restrictions that impair access by assistive technologies; and</li>
 				<li>they must include accessibility metadata in the record format required for distribution of an EPUB
-					publication (e.g., [[ONIX]] or [[MARC21]]) when the format supports such metadata.</li>
+					publication (e.g., [[onix]] or [[marc21]]) when the format supports such metadata.</li>
 			</ul>
 
 			<div class="note">

--- a/epub33/core/biblio.js
+++ b/epub33/core/biblio.js
@@ -1,14 +1,14 @@
 var biblio = {
-	"CSSSnapshot": {
+	"csssnapshot": {
 		"title": "CSS Snapshot",
 		"href": "https://www.w3.org/TR/CSS/"
 	},
-	"DPUB-ARIA" : {
+	"dpub-aria" : {
 		"title": "Digital Publishing WAI-ARIA Module",
 		"href": "https://www.w3.org/TR/dpub-aria/",
 		"publisher": "W3C"
 	},
-	"EPUBContentDocs-301": {
+	"epubcontentdocs-301": {
 		"authors":[
 		"Markus Gylling",
 		"William McCoy",
@@ -19,7 +19,7 @@ var biblio = {
 		"date": "26 June 2014",
 		"publisher": "IDPF"
 	},
-	"EPUBPackages-32": {
+	"epubpackages-32": {
 		"authors":[
 		"Matt Garrish",
 		"Dave Cramer"],
@@ -28,7 +28,7 @@ var biblio = {
 		"date": "08 May 2019",
 		"publisher": "EPUB 3 Community Group"
 	},
-	"EPUBPublications-30": {
+	"epubpublications-30": {
 		"authors":[
 		"Markus Gylling",
 		"William McCoy",
@@ -38,7 +38,7 @@ var biblio = {
 		"date": "11 October 2011",
 		"publisher": "IDPF"
 	},
-	"EPUBPublications-301": {
+	"epubpublications-301": {
 		"authors":[
 		"Markus Gylling",
 		"William McCoy",
@@ -48,59 +48,59 @@ var biblio = {
 		"date": "26 June 2014",
 		"publisher": "IDPF"
 	},
-	"H264": {
+	"h264": {
 		"title": "H.264 : Advanced video coding for generic audiovisual services",
 		"href": "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=13189",
 		"date": "2017-04-13"
 	},
-	"ISOSchematron": {
+	"isoschematron": {
 		"title": "ISO/IEC 19757-3: Rule-based validation — Schematron",
 		"href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c040833_ISO_IEC_19757-3_2006(E).zip",
 		"date": "2006-06-01"
 	},
-	"NVDL": {
+	"nvdl": {
 		"title": "ISO/IEC 19757-4: NVDL (Namespace-based Validation Dispatching Language)",
 		"href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c038615_ISO_IEC_19757-4_2006(E).zip",
 		"date": "2006-06-01"
 	},
-	"ODF": {
+	"odf": {
 		"title": "Open Document Format for Office Applications (OpenDocument) v1.0",
 		"href": "https://www.oasis-open.org/committees/download.php/12572/OpenDocument-v1.0-os.pdf",
 		"date": "1 May 2005"
 	},
-	"ONIX": {
+	"onix": {
 		"title": "ONIX for Books 3.0",
 		"href": "https://www.editeur.org/8/ONIX/"
 	},
-	"OPF-201": {
+	"opf-201": {
 		"title": "Open Packaging Format 2.0.1",
 		"href": "http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
 		"date": "04 September 2010",
 		"publisher": "IDPF"
 	},
-	"SVG": {
+	"svg": {
 		"title": "SVG",
 		"href": "https://www.w3.org/TR/SVG/",
 		"publisher": "W3C"
 	},
-	"US-ASCII": {
+	"us-ascii": {
 		"title": "&quot;Coded Character Set - 7-bit American Standard Code for Information Interchange&quot;, ANSI X3.4, 1986."
 	},
-	"WAI-ARIA": {
+	"wai-aria": {
 		"title": "Accessible Rich Internet Applications (WAI-ARIA)",
 		"href": "https://www.w3.org/TR/wai-aria/",
 		"publisher": "W3C"
 	},
-	"WCAG2": {
+	"wcag2": {
 		"title": "Web Content Accessibility Guidelines (WCAG) 2",
 		"href": "https://www.w3.org/TR/WCAG2/",
 		"publisher": "W3C"
 	},
-	"WebP-Container": {
+	"webp-container": {
 		"title": "WebP Container Specification",
 		"href": "https://developers.google.com/speed/webp/docs/riff_container"
 	},
-	"WebP-LB": {
+	"webp-lb": {
 		"title": "WebP Lossless Bitstream Specification",
 		"href": "https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification"
 	},

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -110,12 +110,12 @@
 
 				<ul>
 					<li>
-						<p><a data-cite="epub-rs-33#">EPUB 3 Reading Systems</a> [[EPUB-RS-33]] — defines the processing
+						<p><a data-cite="epub-rs-33#">EPUB 3 Reading Systems</a> [[epub-rs-33]] — defines the processing
 							requirements for <a>EPUB reading systems</a> — the applications that consume EPUB
 							publications and present their content to users.</p>
 					</li>
 					<li>
-						<p><a data-cite="epub-a11y-11#">EPUB Accessibility</a> [[EPUB-A11Y-11]] — defines accessibility
+						<p><a data-cite="epub-a11y-11#">EPUB Accessibility</a> [[epub-a11y-11]] — defines accessibility
 							conformance and discovery requirements for EPUB publications.</p>
 					</li>
 				</ul>
@@ -127,7 +127,7 @@
 					specification, are nonetheless available for <a>EPUB creators</a> and reading system developers to
 					use.</p>
 
-				<p>The non-normative <a data-cite="epub-overview-33#">EPUB 3 Overview</a> [[EPUB-OVERVIEW-33]] provides
+				<p>The non-normative <a data-cite="epub-overview-33#">EPUB 3 Overview</a> [[epub-overview-33]] provides
 					a general introduction to EPUB 3. A list of technical changes from the previous version is also
 					available in the <a href="#change-log">change log</a>.</p>
 			</section>
@@ -167,7 +167,7 @@
 					sheets.</p>
 
 				<p>Refer to <a href="#sec-contentdocs"></a> for detailed information about the rules and requirements to
-					produce EPUB content documents, and [[EPUB-A11Y-11]] for accessibility requirements.</p>
+					produce EPUB content documents, and [[epub-a11y-11]] for accessibility requirements.</p>
 
 				<p><a>Media overlay documents</a> complement EPUB content documents. They provide declarative markup for
 					synchronizing the text in EPUB content documents with prerecorded audio. The result is the ability
@@ -188,9 +188,9 @@
 					dependent assets in a ZIP package as presented here. Additional information about the primary
 					features and functionality that EPUB publications provide to enhance the reading experience is
 					available from the referenced specifications, and a more general introduction to the features of
-					EPUB 3 is provided in the non-normative [[EPUB-OVERVIEW-33]].</p>
+					EPUB 3 is provided in the non-normative [[epub-overview-33]].</p>
 
-				<p>Refer to [[EPUB-RS-33]] for the processing requirements for reading systems. Although it is not
+				<p>Refer to [[epub-rs-33]] for the processing requirements for reading systems. Although it is not
 					necessary that <a>EPUB creators</a> read that document to create EPUB publications, an understanding
 					of how reading systems present the content can help craft publications for optimal presentation to
 					users.</p>
@@ -213,7 +213,7 @@
 				<section id="sec-overview-relations-html">
 					<h4>Relationship to HTML</h4>
 
-					<p>The [[HTML]] standard is continuously evolving &#8212; there are no longer versioned releases of
+					<p>The [[html]] standard is continuously evolving &#8212; there are no longer versioned releases of
 						it. That standard, in turn, references various technologies that continue to evolve, such as
 						MathML, SVG, CSS, and JavaScript.</p>
 
@@ -226,14 +226,14 @@
 						of semantics, structure and processing behaviors from HTML unless otherwise specified.</p>
 
 					<p>In addition, this specification <a href="#sec-xhtml-extensions">defines a set of extensions</a>
-						to the [[HTML]] document model that EPUB creators may include in <a>XHTML content
+						to the [[html]] document model that EPUB creators may include in <a>XHTML content
 						documents</a>.</p>
 				</section>
 
 				<section id="sec-overview-relations-svg">
 					<h4>Relationship to SVG</h4>
 
-					<p>This specification does not reference a specific version of [[SVG]], but instead uses an undated
+					<p>This specification does not reference a specific version of [[svg]], but instead uses an undated
 						reference. Whenever there is any ambiguity in this reference, the latest recommended
 						specification is the authoritative reference.</p>
 
@@ -245,7 +245,7 @@
 				<section id="sec-overview-relations-css">
 					<h4>Relationship to CSS</h4>
 
-					<p>EPUB 3 supports CSS as defined by the CSS Working Group Snapshot [[CSSSnapshot]]. EPUB 3 also
+					<p>EPUB 3 supports CSS as defined by the CSS Working Group Snapshot [[csssnapshot]]. EPUB 3 also
 						maintains some prefixed CSS properties, to ensure consistent support for global languages.</p>
 				</section>
 
@@ -253,7 +253,7 @@
 					<h4>Relationship to MathML</h4>
 
 					<p>EPUB 3 only supports <a href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation
-							Markup</a> [[MathML3]]. <a href="https://www.w3.org/TR/MathML3/chapter4.html">Content
+							Markup</a> [[mathml3]]. <a href="https://www.w3.org/TR/MathML3/chapter4.html">Content
 							Markup</a> is only allowed in <a
 							href="https://www.w3.org/TR/MathML3/chapter5.html#mixing.elements.annotation.xml">structured
 							markup annotations</a>.</p>
@@ -262,19 +262,19 @@
 				<section id="sec-overview-relations-smil">
 					<h4>Relationship to SMIL</h4>
 
-					<p>This specification relies on a subset of [[SMIL3]], from which the Media Overlays elements and
+					<p>This specification relies on a subset of [[smil3]], from which the Media Overlays elements and
 						attributes defined in <a href="#sec-overlays-def"></a> are derived.</p>
 				</section>
 
 				<section id="sec-overview-relations-url">
 					<h4>Relationship to URL</h4>
 
-					<p>This specification refers to the [[URL]] standard for terminology and processing related to URLs
+					<p>This specification refers to the [[url]] standard for terminology and processing related to URLs
 						expressed in EPUB publications. It is anticipated that new and revised web formats will adopt
 						this standard, but until then this may put this specification in conflict with the internal
 						requirements for some formats (e.g., valid relative paths), specifically with respect to the use
 						of internationalized URLs. If a format does not allow internationalized URLs (i.e., URLs must
-						conform to [[RFC3986]] or earlier), that requirement takes precedence within those
+						conform to [[rfc3986]] or earlier), that requirement takes precedence within those
 						resources.</p>
 				</section>
 			</section>
@@ -312,7 +312,7 @@
 						<dfn class="export" id="dfn-container-root-url">container root URL</dfn>
 					</dt>
 					<dd>
-						<p>The <a>URL</a> [[URL]] of the <a>root directory</a> representing the <a>OCF abstract
+						<p>The <a>URL</a> [[url]] of the <a>root directory</a> representing the <a>OCF abstract
 								container</a>. It is implementation specific, but EPUB creators must assume it has
 							properties defined in <a href="#sec-container-iri"></a>.</p>
 					</dd>
@@ -330,7 +330,7 @@
 							media type resource</dfn>
 					</dt>
 					<dd>
-						<p>A <a>publication resource</a> that conforms to one of the MIME media types [[RFC2046]] listed
+						<p>A <a>publication resource</a> that conforms to one of the MIME media types [[rfc2046]] listed
 							in <a href="#sec-core-media-types"></a> and, therefore, does not require the provision of a
 								<a href="#sec-foreign-resources">fallback</a> (cf. <a>foreign resource</a>).</p>
 						<p>The designation "core media type resource" only applies when a resource is used in the
@@ -478,7 +478,7 @@
 						<dfn class="export" id="dfn-foreign-resource" data-lt="foreign resources">foreign resource</dfn>
 					</dt>
 					<dd>
-						<p>A <a>publication resource</a> with a MIME media type [[RFC2046]] that does not match any of
+						<p>A <a>publication resource</a> with a MIME media type [[rfc2046]] that does not match any of
 							those listed in <a href="#sec-core-media-types"></a>. Foreign resources are subject to the
 							fallback requirements defined in <a href="#sec-foreign-resources"></a>.</p>
 						<p>The designation "foreign resource" only applies to resources used in the rendering of <a>EPUB
@@ -574,7 +574,7 @@
 						</ul>
 						<div class="note">
 							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
-									<code>href</code> attribute of an [[HTML]] <a data-lt="a"><code>a</code>
+									<code>href</code> attribute of an [[html]] <a data-lt="a"><code>a</code>
 								element</a>) are not publication resources.</p>
 						</div>
 					</dd>
@@ -605,7 +605,7 @@
 					</dt>
 					<dd>
 						<p>An <a>EPUB content document</a> that includes scripting or an <a>XHTML content document</a>
-							that contains [[HTML]] <a>forms</a>.</p>
+							that contains [[html]] <a>forms</a>.</p>
 						<p>Refer to <a href="#sec-scripted-content"></a> for more information.</p>
 					</dd>
 
@@ -669,10 +669,10 @@
 							content document</dfn>
 					</dt>
 					<dd>
-						<p>An <a>EPUB content document</a> that conforms to the profile of [[HTML]] defined in <a
+						<p>An <a>EPUB content document</a> that conforms to the profile of [[html]] defined in <a
 								href="#sec-xhtml"></a>.</p>
 						<p>XHTML content documents use the <a data-cite="html#the-xhtml-syntax">XML syntax</a> defined
-							in [[HTML]].</p>
+							in [[html]].</p>
 					</dd>
 				</dl>
 			</section>
@@ -687,11 +687,11 @@
 				<p>In <a>package document</a> metadata examples, <a href="#sec-metadata-reserved-prefixes">reserved
 						prefixes</a> are used without declaration.</p>
 
-				<p>References to Dublin Core elements [[DCTERMS]] use the <code>dc:</code> prefix. This prefix must be
+				<p>References to Dublin Core elements [[dcterms]] use the <code>dc:</code> prefix. This prefix must be
 					declared in the <a>package document</a> for their use to be valid
 						(<code>xmlns:dc="http://purl.org/dc/elements/1.1/"</code>)</p>
 
-				<p>The <code>epub</code> namespace prefix [[XML-NAMES]] is also used on elements and attributes without
+				<p>The <code>epub</code> namespace prefix [[xml-names]] is also used on elements and attributes without
 					always having an explicit declaration (<code>xmlns:epub="http://www.idpf.org/2007/ops"</code>).</p>
 			</section>
 		</section>
@@ -717,7 +717,7 @@
 				</li>
 				<li>
 					<p id="confreq-a11y">SHOULD conform to the accessibility requirements defined in
-						[[EPUB-A11Y-11]].</p>
+						[[epub-a11y-11]].</p>
 				</li>
 				<li>
 					<p id="confreq-ocf">MUST be packaged in an <a>EPUB container</a> as defined in <a href="#sec-ocf"
@@ -926,7 +926,7 @@
 
 					<p>The preferred method is to use the fallback capabilities of the host format. Many HTML elements,
 						for example, have intrinsic fallback capabilities. One example is the <a data-lt="picture"
-								><code>picture</code> element</a> [[HTML]], which allows EPUB creators to specify
+								><code>picture</code> element</a> [[html]], which allows EPUB creators to specify
 						multiple alternative image formats.</p>
 
 					<p>If an intrinsic fallback method is not available, it is also possible to use manifest fallbacks,
@@ -940,7 +940,7 @@
 
 					<p>Exempt resources tend to address specific cases for which there are no core media types defined,
 						but for which providing a fallback would prove cumbersome or unnecessary. These include
-						embedding video, adding accessibility tracks, and linking to resources from the [[HTML]] <a
+						embedding video, adding accessibility tracks, and linking to resources from the [[html]] <a
 							data-lt="link"><code>link</code> element</a>.</p>
 
 					<p>Refer to <a href="#sec-exempt-resources"></a> for more information about these exceptions.</p>
@@ -965,7 +965,7 @@
 				<h3>Core media types</h3>
 
 				<p><a>EPUB creators</a> MAY include <a>publication resources</a> that conform to the MIME media type
-					[[RFC2046]] specifications defined in the following table without fallbacks when they are used in
+					[[rfc2046]] specifications defined in the following table without fallbacks when they are used in
 						<a>EPUB content documents</a> and <a>foreign content documents</a>. These resources are
 					classified as <a>core media type resources</a>.</p>
 
@@ -978,7 +978,7 @@
 
 				<ul>
 					<li>
-						<p><strong>Media Type</strong>—The MIME media type [[RFC2046]] used to represent the given
+						<p><strong>Media Type</strong>—The MIME media type [[rfc2046]] used to represent the given
 							publication resource in the <a href="#sec-manifest-elem">manifest</a>.</p>
 						<p>If the table lists more than one media type, the first one is the preferred media type. EPUB
 							creators should use the preferred media type for all new EPUB publications.</p>
@@ -1005,21 +1005,21 @@
 							<td id="cmt-gif" data-tests="#pub-cmt-gif">
 								<code>image/gif</code>
 							</td>
-							<td> [[GIF]] </td>
+							<td> [[gif]] </td>
 							<td>GIF Images</td>
 						</tr>
 						<tr>
 							<td id="cmt-jpeg" data-tests="#pub-cmt-jpeg">
 								<code>image/jpeg</code>
 							</td>
-							<td> [[JPEG]] </td>
+							<td> [[jpeg]] </td>
 							<td>JPEG Images</td>
 						</tr>
 						<tr>
 							<td id="cmt-png" data-tests="#pub-cmt-png">
 								<code>image/png</code>
 							</td>
-							<td> [[PNG]] </td>
+							<td> [[png]] </td>
 							<td>PNG Images</td>
 						</tr>
 						<tr>
@@ -1035,7 +1035,7 @@
 							<td id="cmt-webp" data-tests="#pub-cmt-webp">
 								<code>image/webp</code>
 							</td>
-							<td> [[WebP-Container]], [[WebP-LB]] </td>
+							<td> [[webp-container]], [[webp-lb]] </td>
 							<td>WebP Images</td>
 						</tr>
 						<tr>
@@ -1045,21 +1045,21 @@
 							<td id="cmt-mp3" data-tests="#pub-cmt-mp3">
 								<code>audio/mpeg</code>
 							</td>
-							<td> [[MP3]] </td>
+							<td> [[mp3]] </td>
 							<td>MP3 audio</td>
 						</tr>
 						<tr>
 							<td id="cmt-mp4-aac" data-tests="#pub-cmt-mp4">
 								<code>audio/mp4</code>
 							</td>
-							<td> [[MPEG4-Audio]], [[MP4]] </td>
+							<td> [[mpeg4-audio]], [[mp4]] </td>
 							<td>AAC LC audio using MP4 container</td>
 						</tr>
 						<tr>
 							<td id="cmt-ogg-opus" data-tests="#pub-cmt-opus">
 								<code>audio/opus</code>
 							</td>
-							<td> [[RFC7845]] </td>
+							<td> [[rfc7845]] </td>
 							<td>OPUS audio using OGG container</td>
 						</tr>
 						<tr>
@@ -1084,7 +1084,7 @@
 									<li><code>application/font-sfnt</code></li>
 								</ol>
 							</td>
-							<td>[[TrueType]] </td>
+							<td>[[truetype]] </td>
 							<td>TrueType fonts</td>
 						</tr>
 						<tr>
@@ -1095,7 +1095,7 @@
 									<li><code>application/vnd.ms-opentype</code></li>
 								</ol>
 							</td>
-							<td>[[OpenType]]</td>
+							<td>[[opentype]]</td>
 							<td>OpenType fonts</td>
 						</tr>
 						<tr>
@@ -1105,14 +1105,14 @@
 									<li><code>application/font-woff</code></li>
 								</ol>
 							</td>
-							<td> [[WOFF]] </td>
+							<td> [[woff]] </td>
 							<td>WOFF fonts</td>
 						</tr>
 						<tr>
 							<td id="cmt-woff2">
 								<code>font/woff2</code>
 							</td>
-							<td> [[WOFF2]] </td>
+							<td> [[woff2]] </td>
 							<td>WOFF2 fonts</td>
 						</tr>
 						<tr>
@@ -1126,7 +1126,7 @@
 								<a href="#sec-xhtml">XHTML content documents</a>
 							</td>
 							<td>HTML documents that use the <a data-cite="html#the-xhtml-syntax">XML syntax</a>
-								[[HTML]].</td>
+								[[html]].</td>
 						</tr>
 						<tr>
 							<td id="cmt-js">
@@ -1136,14 +1136,14 @@
 									<li><code>text/javascript</code></li>
 								</ol>
 							</td>
-							<td> [[RFC4329]] </td>
+							<td> [[rfc4329]] </td>
 							<td>Scripts.</td>
 						</tr>
 						<tr>
 							<td id="cmt-ncx">
 								<code>application/x-dtbncx+xml</code>
 							</td>
-							<td> [[OPF-201]] </td>
+							<td> [[opf-201]] </td>
 							<td>The <a href="#legacy">legacy</a> NCX.</td>
 						</tr>
 						<tr>
@@ -1163,7 +1163,7 @@
 						rendering of a resource. Reading system support also depends on the capabilities of the
 						application (e.g., a reading system with a <a>viewport</a> must support image core media type
 						resources, but a reading system without a viewport does not). Refer to <a
-							data-cite="epub-rs-33#sec-epub-rs-conf-cmt">Core media types</a> [[EPUB-RS-33]] for more
+							data-cite="epub-rs-33#sec-epub-rs-conf-cmt">Core media types</a> [[epub-rs-33]] for more
 						information about which reading systems rendering capabilities require support for which core
 						media type resources.</p>
 
@@ -1186,7 +1186,7 @@
 
 				<ul>
 					<li>
-						<p>intrinsic fallback mechanisms provided by the host format (e.g., [[?HTML]] elements often
+						<p>intrinsic fallback mechanisms provided by the host format (e.g., [[?html]] elements often
 							provide the ability to reference more than one media type or to display an alternate
 							embedded message when a media type cannot be rendered); or</p>
 					</li>
@@ -1197,7 +1197,7 @@
 				</ul>
 
 				<div class="note">
-					<p>Refer to the [[HTML]] and [[SVG]] specifications for the intrinsic fallback capabilities their
+					<p>Refer to the [[html]] and [[svg]] specifications for the intrinsic fallback capabilities their
 						elements provide.</p>
 					<p><a href="#sec-intrinsic-fallbacks"></a> also provides additional information about how fallbacks
 						are interpreted for specific elements.</p>
@@ -1229,31 +1229,31 @@
 							reading system support expectations, as CSS rules will ensure a fallback font in case of no
 							support.</p>
 						<p>Refer to the <a data-cite="epub-rs-33#confreq-css-rs-fonts">reading system support
-								requirements for fonts</a> [[EPUB-RS-33]] for more information.</p>
+								requirements for fonts</a> [[epub-rs-33]] for more information.</p>
 					</dd>
 
 					<dt id="exempt-links">Linked resources</dt>
 					<dd id="confreq-resources-cd-fallback-link">
-						<p>Any resource referenced from the [[HTML]] <a data-lt="link"><code>link</code> element</a>
+						<p>Any resource referenced from the [[html]] <a data-lt="link"><code>link</code> element</a>
 							that is not already a core media type resource (e.g., CSS style sheets) is an exempt
 							resource.</p>
 					</dd>
 
 					<dt id="exempt-track" class="tbl-group">Tracks</dt>
 					<dd id="confreq-resources-cd-fallback-track">
-						<p>All audio and video tracks (e.g., [[?WebVTT]] captions, subtitles and descriptions)
-							referenced from the [[HTML]] <a data-lt="track"><code>track</code> element</a> are exempt
+						<p>All audio and video tracks (e.g., [[?webvtt]] captions, subtitles and descriptions)
+							referenced from the [[html]] <a data-lt="track"><code>track</code> element</a> are exempt
 							resources.</p>
 					</dd>
 
 					<dt id="exempt-video" class="tbl-group">Video</dt>
 					<dd id="confreq-resources-cd-fallback-video">
-						<p>All video codecs referenced from the [[HTML]] <a data-lt="video"><code>video</code></a>
+						<p>All video codecs referenced from the [[html]] <a data-lt="video"><code>video</code></a>
 							— including any child <a data-lt="source"><code>source</code></a> elements — are exempt
 							resources.</p>
 						<div class="note">
-							<p>Although reading systems are encouraged to support at least one of the H.264 [[?H264]]
-								and VP8 [[?RFC6386]] video codecs, support for video codecs is not a conformance
+							<p>Although reading systems are encouraged to support at least one of the H.264 [[?h264]]
+								and VP8 [[?rfc6386]] video codecs, support for video codecs is not a conformance
 								requirement. EPUB creators must consider factors such as breadth of adoption, playback
 								quality, and technology royalties when deciding which video formats to include.</p>
 						</div>
@@ -1275,8 +1275,8 @@
 								<strong><em>and</em></strong></p>
 					</li>
 					<li>
-						<p>it is not embedded directly in EPUB content documents (e.g., via [[?HTML]] <a>embedded
-								content</a> and [[?SVG]] <a href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"
+						<p>it is not embedded directly in EPUB content documents (e.g., via [[?html]] <a>embedded
+								content</a> and [[?svg]] <a href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"
 									><code>image</code></a> and <a
 								href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
 									><code>foreignObject</code></a> elements).</p>
@@ -1309,7 +1309,7 @@
 
 					<p>Fallback chains are created using the <a href="#attrdef-item-fallback"><code>fallback</code>
 							attribute</a> on manifest <a href="#sec-item-elem"><code>item</code> elements</a>. This
-						attribute references the ID [[XML]] of another manifest <code>item</code> that is a fallback for
+						attribute references the ID [[xml]] of another manifest <code>item</code> that is a fallback for
 						the current <code>item</code>. The ordered list of all the references that a reading system can
 						reach, starting from a given <code>item</code>'s <code>fallback</code> attribute, represents the
 						full fallback chain for that <code>item</code>. This chain also represents the EPUB creator's
@@ -1334,10 +1334,10 @@
 						<dd>
 							<div class="note">
 								<p>The original purpose for content fallbacks was to specify fallback images for the
-									[[HTML]] <a data-lt="img"><code>img</code> element</a>. As HTML now has intrinsic
+									[[html]] <a data-lt="img"><code>img</code> element</a>. As HTML now has intrinsic
 									fallback mechanism for images, the use of content fallbacks is strongly discouraged.
-									EPUB creators should always use the intrinsic fallback capabilities of [[HTML]] and
-									[[SVG]] to provide fallback content.</p>
+									EPUB creators should always use the intrinsic fallback capabilities of [[html]] and
+									[[svg]] to provide fallback content.</p>
 							</div>
 							<p>EPUB creators MUST provide a content fallback for <a>foreign resources</a> when the
 								elements that reference them do not have intrinsic fallback capabilities. In this case,
@@ -1366,9 +1366,9 @@
 					<section id="sec-fallbacks-audio">
 						<h5>HTML <code>audio</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-media">EPUB creators MUST NOT use embedded [[HTML]] <a>flow
+						<p id="confreq-resources-cd-fallback-media">EPUB creators MUST NOT use embedded [[html]] <a>flow
 								content</a> within the <a><code>audio</code></a> element as an intrinsic fallback for
-							foreign resources. Only child <a><code>source</code></a> elements [[HTML]] provide intrinsic
+							foreign resources. Only child <a><code>source</code></a> elements [[html]] provide intrinsic
 							fallback capabilities.</p>
 
 						<p>Only older reading systems that do not recognize the <code>audio</code> element (e.g., EPUB 2
@@ -1388,7 +1388,7 @@
 						<h5>HTML <code>img</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that EPUB creators can
-							specify in the [[HTML]] <a data-lt="img"><code>img</code> element</a>, the following
+							specify in the [[html]] <a data-lt="img"><code>img</code> element</a>, the following
 							fallback conditions apply to its use:</p>
 
 						<ul>
@@ -1401,7 +1401,7 @@
 									<li>each sibling <a data-lt="source"><code>source</code> element</a> MUST reference
 										a core media type resource from its <code>[^source/src^]</code> and
 											<code>[^source/srcset^]</code> attributes unless it specifies the MIME media
-										type [[RFC2046]] of a foreign resource in its <code>[^source/type^]</code>
+										type [[rfc2046]] of a foreign resource in its <code>[^source/type^]</code>
 										attribute.</li>
 								</ul>
 							</li>
@@ -1427,7 +1427,7 @@
 					</li>
 					<li>
 						<p id="sec-resource-locations-script">Resources retrieved via scripting APIs (e.g.,
-							XmlHttpRequest [[?XHR]] and Fetch [[?FETCH]]).</p>
+							XmlHttpRequest [[?xhr]] and Fetch [[?fetch]]).</p>
 					</li>
 					<li>
 						<p id="sec-resource-locations-fonts"><a href="#cmt-grp-font">Font resources</a>.</p>
@@ -1449,7 +1449,7 @@
 				</div>
 
 				<aside class="example" title="Referencing a container resource">
-					<p>In this example, the audio file referenced from the [[HTML]] <a data-lt="audio"
+					<p>In this example, the audio file referenced from the [[html]] <a data-lt="audio"
 								><code>audio</code> element</a> is located inside the <a>EPUB container</a>.</p>
 					<pre>&lt;html …>
    …
@@ -1464,7 +1464,7 @@
 				</aside>
 
 				<aside class="example" title="Referencing a remote resource">
-					<p>In this example, the audio file referenced from the [[HTML]] <a data-lt="audio"
+					<p>In this example, the audio file referenced from the [[html]] <a data-lt="audio"
 								><code>audio</code> element</a> is hosted on the web.</p>
 					<pre>&lt;html …>
    …
@@ -1482,12 +1482,12 @@
 			<section id="sec-data-urls">
 				<h3>Data URLs</h3>
 
-				<p>The <a data-cite="rfc2397#"><code>data:</code> URL scheme</a> [[RFC2397]] is used to encode resources
+				<p>The <a data-cite="rfc2397#"><code>data:</code> URL scheme</a> [[rfc2397]] is used to encode resources
 					directly into a URL string. The advantage of this scheme is that it allows EPUB creators to embed a
 					resource within another, avoiding the need for an external file.</p>
 
 				<p><a>EPUB creators</a> MAY use data URLs in EPUB publications provided their use does not result in a
-						<a>top-level content document</a> or <a>top-level browsing context</a> [[HTML]]. This
+						<a>top-level content document</a> or <a>top-level browsing context</a> [[html]]. This
 					restriction applies to data URLs used in the following scenarios:</p>
 
 				<ul>
@@ -1496,15 +1496,15 @@
 								<a>spine</a>;</p>
 					</li>
 					<li>
-						<p>in the <code>href</code> attribute on [[HTML]] or [[SVG]] <code>a</code> elements (except
-							when inside an <a data-lt="iframe"><code>iframe</code> element</a> [[HTML]]);</p>
+						<p>in the <code>href</code> attribute on [[html]] or [[svg]] <code>a</code> elements (except
+							when inside an <a data-lt="iframe"><code>iframe</code> element</a> [[html]]);</p>
 					</li>
 					<li>
-						<p>in the <code>href</code> attribute on [[HTML]] <code>area</code> elements (except when inside
+						<p>in the <code>href</code> attribute on [[html]] <code>area</code> elements (except when inside
 							an <code>iframe</code> element);</p>
 					</li>
 					<li>
-						<p>in calls to [[ECMASCRIPT]] <code>window.open</code> or <code>document.open</code>.</p>
+						<p>in calls to [[ecmascript]] <code>window.open</code> or <code>document.open</code>.</p>
 					</li>
 				</ul>
 
@@ -1533,24 +1533,24 @@
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-xml-wellformed">MUST be a conformant XML 1.0 Document as defined in <a
-								data-cite="xml-names#Conformance">Conformance of Documents</a> [[XML-NAMES]].</p>
+								data-cite="xml-names#Conformance">Conformance of Documents</a> [[xml-names]].</p>
 					</li>
 					<li>
 						<p id="confreq-xml-identifiers">MAY only specify a <a data-cite="xml#dt-doctype">document type
 								declaration</a> that references an <a data-cite="xml#NT-ExternalID">external
 								identifier</a> appropriate for its media type &#8212; as defined in <a
 								href="#app-identifiers-allowed"></a> &#8212; or that omits external identifiers
-							[[XML]].</p>
+							[[xml]].</p>
 					</li>
 					<li>
 						<p id="confreq-xml-entities">MUST NOT contain <a data-cite="xml#dt-extent">external entity</a>
-							declarations in the internal DTD subset [[XML]].</p>
+							declarations in the internal DTD subset [[xml]].</p>
 					</li>
 					<li>
-						<p id="confreq-xml-xinc">MUST NOT make use of XInclude [[XInclude]].</p>
+						<p id="confreq-xml-xinc">MUST NOT make use of XInclude [[xinclude]].</p>
 					</li>
 					<li>
-						<p id="confreq-xml-enc">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8 as the
+						<p id="confreq-xml-enc">MUST be encoded in UTF-8 or UTF-16 [[unicode]], with UTF-8 as the
 							RECOMMENDED encoding.</p>
 					</li>
 				</ul>
@@ -1559,7 +1559,7 @@
 						type resource</a> or a <a>foreign resource</a>.</p>
 
 				<div class="note">
-					<p>[[HTML]] and [[SVG]] are removing support for the XML <code>base</code> attribute [[XMLBase]].
+					<p>[[html]] and [[svg]] are removing support for the XML <code>base</code> attribute [[xmlbase]].
 						EPUB creators should avoid using this feature.</p>
 				</div>
 			</section>
@@ -1628,7 +1628,7 @@
 							<code>[optional]</code>
 						</dt>
 						<dd>
-							<p>A manifest of container contents as allowed by Open Document Format [[ODF]].</p>
+							<p>A manifest of container contents as allowed by Open Document Format [[odf]].</p>
 						</dd>
 					</dl>
 
@@ -1661,7 +1661,7 @@
 							the directory containing the package document to avoid interoperability issues.</p>
 
 						<p>This problem is more commonly encountered when <a data-cite="epub-multi-rend-11#container"
-								>creating multiple renditions</a> [[EPUB-MULTI-REND-11]] of the publication.</p>
+								>creating multiple renditions</a> [[epub-multi-rend-11]] of the publication.</p>
 					</div>
 				</section>
 
@@ -1676,7 +1676,7 @@
 
 					<ul class="conformance-list">
 						<li>
-							<p id="ocf-fn-encoding">file names and paths MUST be UTF-8 [[Unicode]] encoded.</p>
+							<p id="ocf-fn-encoding">file names and paths MUST be UTF-8 [[unicode]] encoded.</p>
 						</li>
 						<li>
 							<p id="ocf-fn-length">file names MUST NOT exceed 255 bytes.</p>
@@ -1686,7 +1686,7 @@
 								container MUST NOT exceed 65535 bytes.</p>
 						</li>
 						<li>
-							<p id="ocf-fn-chars">file names MUST NOT use the following [[Unicode]] characters, as
+							<p id="ocf-fn-chars">file names MUST NOT use the following [[unicode]] characters, as
 								commonly used operating systems may not support these characters consistently:</p>
 							<ul>
 								<li>
@@ -1765,9 +1765,9 @@
 						</li>
 						<li>
 							<p id="ocf-fn-cn">All file names within the same directory MUST be unique following Unicode
-								canonical normalization [[UAX15]] and then full case folding [[Unicode]]. (Refer to <a
+								canonical normalization [[uax15]] and then full case folding [[unicode]]. (Refer to <a
 									data-cite="charmod-norm#CanonicalFoldNormalizationStep">Unicode Canonical Case Fold
-									Normalization Step</a> [[?CHARMOD-NORM]] for more information.)</p>
+									Normalization Step</a> [[?charmod-norm]] for more information.)</p>
 						</li>
 					</ul>
 					<div class="note">
@@ -1786,12 +1786,12 @@
 							to help avoid some known problem areas, but it does not ensure that all other Unicode
 							characters are supported. Although Unicode support is much better now than in earlier
 							iterations of EPUB, older tools and toolchains may still be encountered (e.g., ZIP tools
-							that only support [[US-ASCII]]).</p>
+							that only support [[us-ascii]]).</p>
 
 
 						<p>If EPUB creators need to ensure compatibility with EPUB 2 reading systems that only accept
-							URIs [[RFC3986]], they should further consider restricting resource names to the ASCII
-							character set [[US-ASCII]].</p>
+							URIs [[rfc3986]], they should further consider restricting resource names to the ASCII
+							character set [[us-ascii]].</p>
 					</div>
 				</section>
 
@@ -1800,7 +1800,7 @@
 
 					<p>To <strong>derive the file path</strong>, given a file or directory <var>file</var> in the <a
 							href="#sec-container-abstract">OCF abstract container</a>, apply the following steps
-						(expressed using the terminology of [[INFRA]]):</p>
+						(expressed using the terminology of [[infra]]):</p>
 
 					<ol class="algorithm">
 						<!-- <li>Let <var>file</var> be the directory or file to parse</li> -->
@@ -1822,7 +1822,7 @@
 
 					<p id="sec-container-iri-root"
 						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">The <a>container root
-							URL</a> is the <a>URL</a> [[URL]] of the <a>root directory</a>. It is
+							URL</a> is the <a>URL</a> [[url]] of the <a>root directory</a>. It is
 						implementation-specific, but EPUB creators MUST assume it has the following properties:</p>
 
 					<ul id="sec-root-url-properties">
@@ -1961,7 +1961,7 @@
 							<a>absolute-url-with-fragment string</a> or a <a>valid-relative-ocf-URL-with-fragment
 							string</a>.</p>
 
-					<p>In addition, all <a>relative-URL-with-fragment strings</a> [[URL]] MUST, after <a
+					<p>In addition, all <a>relative-URL-with-fragment strings</a> [[url]] MUST, after <a
 							data-lt="url parser">parsing</a>, be equal to the <a>content URL</a> of an existing file in
 						the OCF abstract container.</p>
 
@@ -2068,8 +2068,8 @@
 								identifies the <a>package documents</a> available in the <a>OCF abstract
 								container</a>.</p>
 
-							<p>All [[XML]] elements defined in this section are in the
-									<code>urn:oasis:names:tc:opendocument:xmlns:container</code> namespace [[XML-NAMES]]
+							<p>All [[xml]] elements defined in this section are in the
+									<code>urn:oasis:names:tc:opendocument:xmlns:container</code> namespace [[xml-names]]
 								unless specified otherwise.</p>
 
 							<p>The contents of this file MUST be valid to the definition in this section after removing
@@ -2186,7 +2186,7 @@
 											<dd>
 												<p>Identifies the location of a <a>package document</a>.</p>
 												<p>The value of the attribute MUST be a <a>path-relative-scheme-less-URL
-														string</a> [[URL]]. The path is relative to the <a>root
+														string</a> [[url]]. The path is relative to the <a>root
 														directory</a>.</p>
 											</dd>
 
@@ -2215,7 +2215,7 @@
 								<div class="note">
 									<p>Although the EPUB container provides the ability to reference more than one
 										package document, this specification does not define how to interpret, or select
-										from, the available options. Refer to [[EPUB-MULTI-REND-11]] for more
+										from, the available options. Refer to [[epub-multi-rend-11]] for more
 										information on how to bundle more than one rendering of the content.</p>
 								</div>
 							</section>
@@ -2255,7 +2255,7 @@
 
 								<div class="note">
 									<p>This specification currently does not define uses for the <code>links</code>
-										element. Refer to [[EPUB-Multi-Rend-11]] for an example of its use.</p>
+										element. Refer to [[epub-multi-rend-11]] for an example of its use.</p>
 								</div>
 							</section>
 
@@ -2287,7 +2287,7 @@
 												<p>Identifies the location of a resource.</p>
 												<p>The value of the <code>link</code> element <code>href</code>
 													attribute MUST be a <a>path-relative-scheme-less-URL string</a>
-													[[URL]]. The path is relative to the <a>root directory</a>.</p>
+													[[url]]. The path is relative to the <a>root directory</a>.</p>
 											</dd>
 
 											<dt>
@@ -2296,7 +2296,7 @@
 											</dt>
 											<dd>
 												<p>Identifies the type and format of the referenced resource.</p>
-												<p>The value of the attribute MUST be a media type [[RFC2046]].</p>
+												<p>The value of the attribute MUST be a media type [[rfc2046]].</p>
 											</dd>
 
 											<dt>
@@ -2381,7 +2381,7 @@
 
 								<p>The <code>encryption</code> element contains child elements of type
 										<code>EncryptedKey</code> and <code>EncryptedData</code> as defined by
-									[[XMLENC-CORE1]].</p>
+									[[xmlenc-core1]].</p>
 
 								<p>An <code id="elemdef-encryption-EncryptedKey">EncryptedKey</code> element describes
 									each encryption key used in the container, while an <code
@@ -2397,7 +2397,7 @@
 									Encryption in this way exposes the directory structure and file naming of the whole
 									package.</p>
 
-								<p>OCF uses XML Encryption [[XMLENC-CORE1]] to provide a framework for encryption,
+								<p>OCF uses XML Encryption [[xmlenc-core1]] to provide a framework for encryption,
 									allowing a variety of algorithms to be used. XML Encryption specifies a process for
 									encrypting arbitrary data and representing the result in XML. Even though an <a>OCF
 										abstract container</a> may contain non-XML data, EPUB creators can use XML
@@ -2449,13 +2449,13 @@
 									</li>
 								</ul>
 								<p>EPUB creators MAY subsequently encrypt signed resources using the Decryption
-									Transform for XML Signature [[XMLENC-DECRYPT]]. This feature enables a reading
+									Transform for XML Signature [[xmlenc-decrypt]]. This feature enables a reading
 									system to distinguish data encrypted before signing from data encrypted after
 									signing.</p>
 
 								<aside class="example" title="An encrypted image">
 									<p>In this example, adapted from <a data-cite="xmlenc-core1#sec-eg-Symmetric-Key"
-											>Section 2.2.1 </a> of [[XMLENC-CORE1]], the resource
+											>Section 2.2.1 </a> of [[xmlenc-core1]], the resource
 											<code>image.jpeg</code> is encrypted using a symmetric key algorithm (AES)
 										and the symmetric key is further encrypted using an asymmetric key algorithm
 										(RSA) with a key of "John Smith".</p>
@@ -2603,7 +2603,7 @@
 							<p>Note that <a>package documents</a> specify the only manifests used for processing <a>EPUB
 									publications</a>. Reading systems do not use this file.</p>
 
-							<div class="note">This feature exists only for compatibility with [[ODF]].</div>
+							<div class="note">This feature exists only for compatibility with [[odf]].</div>
 						</section>
 
 						<section id="sec-container-metainf-metadata.xml">
@@ -2613,7 +2613,7 @@
 								only for container-level metadata.</p>
 
 							<p>If EPUB creators include a <code>metadata.xml</code> file, they SHOULD use only
-								namespace-qualified elements [[XML-NAMES]] in it. The file SHOULD contain the root
+								namespace-qualified elements [[xml-names]] in it. The file SHOULD contain the root
 								element <code>metadata</code> in the namespace
 									<code>http://www.idpf.org/2013/metadata</code>, but this specification allows other
 								root elements for backwards compatibility.</p>
@@ -2685,7 +2685,7 @@
 								</dl>
 
 								<p>The <code>signature</code> element contains child elements of type
-										<code>Signature</code>, as defined by [[XMLDSIG-CORE1]]. EPUB creators can apply
+										<code>Signature</code>, as defined by [[xmldsig-core1]]. EPUB creators can apply
 									signatures to an EPUB publication as a whole or to its parts, and can specify the
 									signing of any kind of data (i.e., not just XML).</p>
 
@@ -2702,7 +2702,7 @@
 
 								<div class="note">
 									<p>Each <code>Signature</code> in the <code>signatures.xml</code> file identifies by
-										URL [[URL]] the data to which the signature applies, using the [[XMLDSIG-CORE1]]
+										URL [[url]] the data to which the signature applies, using the [[xmldsig-core1]]
 											<code>Manifest</code> element and its <code>Reference</code> sub-elements.
 										EPUB creator may sign individual container files separately or together.
 										Separately signing each file creates a digest value for the resource that
@@ -2724,7 +2724,7 @@
 								<p>If the EPUB creator wants any addition or removal of a signature to invalidate their
 									signature, they can use the Enveloped Signature transform defined in <a
 										data-cite="xmldsig-core#sec-EnvelopedSignature">Section 6.6.4</a> of
-									[[XMLDSIG-CORE1]] to sign the entire pre-existing signature file excluding the
+									[[xmldsig-core1]] to sign the entire pre-existing signature file excluding the
 										<code>Signature</code> being created. This transform would sign all previous
 									signatures, and it would become invalid if a subsequent signature were added to the
 									package.</p>
@@ -2736,15 +2736,15 @@
 										a transform are outside the scope of this specification, however.</p>
 								</div>
 
-								<p>The [[XMLDSIG-CORE1]] specification does not associate any semantics with a
+								<p>The [[xmldsig-core1]] specification does not associate any semantics with a
 									signature; an agent might include semantic information, for example, by adding
 									information to the Signature element that describes the signature. The
-									[[XMLDSIG-CORE1]] specification describes how additional information can be added to
+									[[xmldsig-core1]] specification describes how additional information can be added to
 									a signature, such as by use the <code>SignatureProperties</code> element.</p>
 
 								<aside class="example" title="Signing resources">
 									<p>In this example, based on the examples found in <a
-											data-cite="xmldsig-core1#sec-Overview">Section 2</a> of [[XMLDSIG-CORE1]],
+											data-cite="xmldsig-core1#sec-Overview">Section 2</a> of [[xmldsig-core1]],
 										one signature applies to two resources (<code>EPUB/book.xhtml</code> and
 											<code>EPUB/images/cover.jpeg</code>).</p>
 
@@ -2838,7 +2838,7 @@
 				<section id="sec-zip-container-zipreqs">
 					<h4>ZIP file requirements</h4>
 
-					<p>An <a>OCF ZIP container</a> uses the ZIP format as specified by [[ZIP]], but with the following
+					<p>An <a>OCF ZIP container</a> uses the ZIP format as specified by [[zip]], but with the following
 						constraints and clarifications:</p>
 
 					<ul class="conformance-list">
@@ -2848,7 +2848,7 @@
 						</li>
 						<li>
 							<p id="confreq-zip-mult">OCF ZIP containers MUST NOT use the features in the ZIP application
-								note [[ZIP]] that allow ZIP files to be spanned across multiple storage media or be
+								note [[zip]] that allow ZIP files to be spanned across multiple storage media or be
 								split into multiple files.</p>
 						</li>
 						<li>
@@ -2857,7 +2857,7 @@
 						</li>
 						<li>
 							<p id="confreq-zip-64">OCF ZIP containers MAY use the ZIP64 extensions defined as "Version
-								1" in section V, subsection G of the application note [[ZIP]] and SHOULD use only those
+								1" in section V, subsection G of the application note [[zip]] and SHOULD use only those
 								extensions when the content requires them.</p>
 						</li>
 						<li>
@@ -2867,7 +2867,7 @@
 						</li>
 						<li>
 							<p id="confreq-zip-utf8">OCF ZIP containers MUST encode File System Names using UTF-8
-								[[Unicode]].</p>
+								[[unicode]].</p>
 						</li>
 					</ul>
 					<p>The following constraints apply to specific fields in the OCF ZIP container archive:</p>
@@ -2894,8 +2894,8 @@
 							container</a>. In addition:</p>
 
 					<ul>
-						<li>The contents of the <code>mimetype</code> file MUST be the MIME media type [[RFC2046]]
-							string <code>application/epub+zip</code> encoded in US-ASCII [[US-ASCII]].</li>
+						<li>The contents of the <code>mimetype</code> file MUST be the MIME media type [[rfc2046]]
+							string <code>application/epub+zip</code> encoded in US-ASCII [[us-ascii]].</li>
 						<li>The <code>mimetype</code> file MUST NOT contain any leading or trailing padding or white
 							space.</li>
 						<li>The <code>mimetype</code> file MUST NOT begin with the Unicode byte order mark U+FEFF.</li>
@@ -2914,7 +2914,7 @@
 				<h3>Font obfuscation</h3>
 
 				<div class="caution">
-					<p>Better methods of protecting fonts exist. Both [[WOFF]] and [[WOFF2]] fonts, for example, allow
+					<p>Better methods of protecting fonts exist. Both [[woff]] and [[woff2]] fonts, for example, allow
 						the embedding of licensing information and provide some protection through font table
 						compression. The use of remotely hosted fonts also allows for font subsetting. EPUB creators are
 						advised to use font obfuscation as defined in this section only when no other options are
@@ -2994,12 +2994,12 @@
 							identifier</a>.</p>
 
 					<p>All white space characters, as defined in <a data-cite="xml#sec-common-syn">section 2.3 of the
-							XML 1.0 specification</a> [[XML]], MUST be removed from this identifier — specifically, the
+							XML 1.0 specification</a> [[xml]], MUST be removed from this identifier — specifically, the
 						Unicode code points <code>U+0020</code>, <code>U+0009</code>, <code>U+000D</code> and
 							<code>U+000A</code>.</p>
 
 					<p>EPUB creators MUST generate a SHA-1 digest of the UTF-8 representation of the resulting string as
-						specified by the Secure Hash Standard [[FIPS-180-4]]. They can then use this digest as the key
+						specified by the Secure Hash Standard [[fips-180-4]]. They can then use this digest as the key
 						for the algorithm.</p>
 				</section>
 
@@ -3109,8 +3109,8 @@
 		<section id="sec-package-doc">
 			<h2>Package document</h2>
 
-			<p>All [[XML]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
-				namespace [[XML-NAMES]] unless otherwise specified.</p>
+			<p>All [[xml]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
+				namespace [[xml-names]] unless otherwise specified.</p>
 
 			<section id="sec-package-intro" class="informative">
 				<h3>Introduction</h3>
@@ -3128,8 +3128,8 @@
 							about the EPUB publication.</p>
 					</li>
 					<li>
-						<p>A <a href="#sec-manifest-elem">manifest</a> — identifies via URL [[URL]], and describes via
-							MIME media type [[RFC4839]], the set of <a>publication resources</a>.</p>
+						<p>A <a href="#sec-manifest-elem">manifest</a> — identifies via URL [[url]], and describes via
+							MIME media type [[rfc4839]], the set of <a>publication resources</a>.</p>
 					</li>
 					<li>
 						<p>A <a href="#sec-spine-elem">spine</a> — an ordered sequence of ID references to top-level
@@ -3164,7 +3164,7 @@
 
 				<p id="pkg-parse-package-url" data-tests="#ocf-url_link-relative,#ocf-url_relative"> To parse a URL
 					string <var>url</var> used in the package document, the <a data-lt="url parser">URL
-					Parser</a> [[URL]] MUST be applied to <var>url</var>, with the <a>content URL</a> of the package
+					Parser</a> [[url]] MUST be applied to <var>url</var>, with the <a>content URL</a> of the package
 					document as <var>base</var>.</p>
 			</section>
 
@@ -3179,7 +3179,7 @@
 
 					<p
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
-						>Specifies the <a data-cite="bidi#BD5">base direction</a> [[BIDI]] of the textual content and
+						>Specifies the <a data-cite="bidi#BD5">base direction</a> [[bidi]] of the textual content and
 						attribute values of the carrying element and its descendants</p>
 
 					<p>Allowed values are:</p>
@@ -3188,7 +3188,7 @@
 						<li><code>ltr</code> &#8212; left-to-right base direction;</li>
 						<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
 						<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi Algorithm
-							[[BIDI]].</li>
+							[[bidi]].</li>
 					</ul>
 
 					<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading systems will assume the
@@ -3222,7 +3222,7 @@
 				<section id="attrdef-href">
 					<h4>The <code>href</code> attribute</h4>
 
-					<p>A <a>valid URL string</a> [[URL]] that references a resource. If the value is an <a>absolute-URL
+					<p>A <a>valid URL string</a> [[url]] that references a resource. If the value is an <a>absolute-URL
 							string</a>, it SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
 
 					<aside class="example" title="Linking a metadata record">
@@ -3246,7 +3246,7 @@
 				<section id="attrdef-id">
 					<h4>The <code>id</code> attribute</h4>
 
-					<p>The ID [[XML]] of the element, which MUST be unique within the document scope.</p>
+					<p>The ID [[xml]] of the element, which MUST be unique within the document scope.</p>
 
 					<aside class="example" title="Adding an identifier attribute">
 						<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
@@ -3276,7 +3276,7 @@
 				<section id="attrdef-media-type">
 					<h4>The <code>media-type</code> attribute</h4>
 
-					<p>A media type [[RFC2046]] that specifies the type and format of the referenced resource.</p>
+					<p>A media type [[rfc2046]] that specifies the type and format of the referenced resource.</p>
 
 					<aside class="example" title="Adding the media type for a linked record">
 						<pre>&lt;package …>
@@ -3393,8 +3393,8 @@
 
 					<p>Specifies the language of the textual content and attribute values of the carrying element and
 						its descendants, as defined in section <a data-cite="xml#sec-lang-tag">2.12 Language
-							Identification</a> of [[XML]]. The value of each <code>xml:lang</code> attribute MUST be a
-							<a data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
+							Identification</a> of [[xml]]. The value of each <code>xml:lang</code> attribute MUST be a
+							<a data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[bcp47]].</p>
 
 					<aside class="example" title="Setting the global language for package document text">
 						<pre>&lt;package … xml:lang="ja">
@@ -3557,7 +3557,7 @@
 				</div>
 
 				<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an IDREF
-					[[XML]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"
+					[[xml]] that identifies the <a class="codelink" href="#sec-opf-dcidentifier"
 							><code>dc:identifier</code></a> element that provides the preferred, or primary,
 					identifier.</p>
 
@@ -3671,16 +3671,16 @@
 
 					<p>The package document does not provide complex metadata encoding capabilities. If EPUB creators
 						need to provide more detailed information, they can associate metadata records (e.g., that
-						conform to an international standard such as [[ONIX]] or are created for custom purposes) using
+						conform to an international standard such as [[onix]] or are created for custom purposes) using
 						the <a href="#sec-link-elem"><code>link</code></a> element. This approach allows reading systems
 						to process the metadata in its native form, avoiding the potential problems and information loss
 						caused by translating to use the minimal package document structure.</p>
 
 					<p id="core-metadata-reqs">In keeping with this philosophy, the package document only has the
-						following minimal metadata requirements: it MUST contain the [[DCTERMS]] <a
+						following minimal metadata requirements: it MUST contain the [[dcterms]] <a
 							href="#sec-opf-dcidentifier"><code>dc:title</code></a>, <a href="#elemdef-opf-dcidentifier"
 								><code>dc:identifier</code></a>, and <a href="#elemdef-opf-dclanguage"
-								><code>dc:language</code></a> elements together with the [[DCTERMS]] <a
+								><code>dc:language</code></a> elements together with the [[dcterms]] <a
 							href="#last-modified-date"><code>dcterms:modified</code> property</a>. All other metadata is
 						OPTIONAL.</p>
 
@@ -3714,25 +3714,25 @@
 						rendering metadata defined in EPUB specifications.</p>
 
 					<div class="note">
-						<p>See [[EPUB-A11Y-11]] for accessibility metadata recommendations.</p>
+						<p>See [[epub-a11y-11]] for accessibility metadata recommendations.</p>
 					</div>
 				</section>
 
 				<section id="sec-metadata-values">
 					<h4>Metadata values</h4>
 
-					<p>The Dublin Core elements [[DCTERMS]] and <a href="#sec-meta-elem"><code>meta</code> element</a>
-						have mandatory <a>child text content</a> [[DOM]]. This specification refers to this content as
+					<p>The Dublin Core elements [[dcterms]] and <a href="#sec-meta-elem"><code>meta</code> element</a>
+						have mandatory <a>child text content</a> [[dom]]. This specification refers to this content as
 						the <dfn>value</dfn> of the element in their descriptions.</p>
 
 					<p>These elements MUST have non-empty values after <a
 							data-lt="strip leading and trailing ascii whitespace">leading and trailing ASCII
-							whitespace</a> [[Infra]] is stripped (i.e., they must consist of at least one non-whitespace
+							whitespace</a> [[infra]] is stripped (i.e., they must consist of at least one non-whitespace
 						character).</p>
 
 					<p>Whitespace within these element values is not significant. Sequences of one or more whitespace
 						characters are <a data-lt="strip and collapse ascii whitespace">collapsed to a single
-						space</a> [[Infra]] during processing .</p>
+						space</a> [[infra]] during processing .</p>
 				</section>
 
 				<section id="sec-opf-dcmes-required">
@@ -3743,7 +3743,7 @@
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
-									><code>dc:identifier</code> element</a> [[DCTERMS]] contains an identifier such as a
+									><code>dc:identifier</code> element</a> [[dcterms]] contains an identifier such as a
 								<abbr title="Universally Unique Identifier">UUID</abbr>, <abbr
 								title="Digital Object Identfier">DOI</abbr> or <abbr
 								title="International Standard Book Number">ISBN</abbr>.</p>
@@ -3848,7 +3848,7 @@
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/title"
-									><code>dc:title</code> element</a> [[DCTERMS]] represents an instance of a name for
+									><code>dc:title</code> element</a> [[dcterms]] represents an instance of a name for
 							the <a>EPUB publication</a>.</p>
 
 						<dl id="elemdef-opf-dctitle" class="elemdef">
@@ -3968,7 +3968,7 @@
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/language"
-									><code>dc:language</code> element</a> [[DCTERMS]] specifies the language of the
+									><code>dc:language</code> element</a> [[dcterms]] specifies the language of the
 							content of the <a>EPUB publication</a>.</p>
 
 						<dl id="elemdef-opf-dclanguage" class="elemdef">
@@ -4009,7 +4009,7 @@
 						</dl>
 
 						<p>The <a>value</a> of each <code>dc:language</code> element MUST be a <a
-								data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[BCP47]].</p>
+								data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[bcp47]].</p>
 
 						<aside class="example" title="Specifying U.S. English as the language of the EPUB publication">
 							<pre>&lt;metadata …>
@@ -4039,7 +4039,7 @@
 					<section id="sec-opf-dcmes-optional-def">
 						<h5>General definition</h5>
 
-						<p>All [[DCTERMS]] elements except for <a href="#sec-opf-dcidentifier"
+						<p>All [[dcterms]] elements except for <a href="#sec-opf-dcidentifier"
 									><code>dc:identifier</code></a>, <a href="#sec-opf-dclanguage"
 									><code>dc:language</code></a>, and <a href="#sec-opf-dctitle"
 								><code>dc:title</code></a> are designated as OPTIONAL. These elements conform to the
@@ -4100,7 +4100,7 @@
 							</dd>
 						</dl>
 
-						<p>This specification does not modify the [[DCTERMS]] element definitions except as noted in the
+						<p>This specification does not modify the [[dcterms]] element definitions except as noted in the
 							following sections.</p>
 					</section>
 
@@ -4109,7 +4109,7 @@
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/contributor"
-									><code>dc:contributor</code> element</a> [[DCTERMS]] is used to represent the name
+									><code>dc:contributor</code> element</a> [[dcterms]] is used to represent the name
 							of a person, organization, etc. that played a secondary role in the creation of the
 							content.</p>
 
@@ -4123,7 +4123,7 @@
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/creator"
-									><code>dc:creator</code> element</a> [[DCTERMS]] represents the name of a person,
+									><code>dc:creator</code> element</a> [[dcterms]] represents the name of a person,
 							organization, etc. responsible for the creation of the content. EPUB creators MAY <a
 								href="#subexpression">associate</a> a <a href="#role"><code>role</code> property</a>
 							with the element to indicate the function the creator played.</p>
@@ -4213,13 +4213,13 @@
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/date"
-									><code>dc:date</code> element</a> [[DCTERMS]] defines the publication date of the
+									><code>dc:date</code> element</a> [[dcterms]] defines the publication date of the
 								<a>EPUB publication</a>. The publication date is not the same as the <a
 								href="#last-modified-date">last modified date</a> (the last time the EPUB creator
 							changed the EPUB publication).</p>
 
-						<p>It is RECOMMENDED that the date string conform to [[ISO8601]], particularly the subset
-							expressed in W3C Date and Time Formats [[DateTime]], as such strings are both human and
+						<p>It is RECOMMENDED that the date string conform to [[iso8601]], particularly the subset
+							expressed in W3C Date and Time Formats [[datetime]], as such strings are both human and
 							machine readable.</p>
 
 						<aside class="example" title="Expressing the publication date">
@@ -4233,7 +4233,7 @@
 						</aside>
 
 						<p>EPUB creators should express additional dates using the specialized date properties available
-							in the [[DCTERMS]] vocabulary, or similar.</p>
+							in the [[dcterms]] vocabulary, or similar.</p>
 
 						<p>EPUB publications MUST NOT contain more than one <code>dc:date</code> element.</p>
 					</section>
@@ -4243,7 +4243,7 @@
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/subject"
-									><code>dc:subject</code> element</a> [[DCTERMS]] identifies the subject of the EPUB
+									><code>dc:subject</code> element</a> [[dcterms]] identifies the subject of the EPUB
 							publication. EPUB creators should set the <a>value</a> of the element to the human-readable
 							heading or label, but may use a code value if the subject taxonomy does not provide a
 							separate descriptive label.</p>
@@ -4302,7 +4302,7 @@
 
 						<p>The <a
 								href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/elements/1.1/type"
-									><code>dc:type</code> element</a> [[DCTERMS]] is used to indicate that the EPUB
+									><code>dc:type</code> element</a> [[dcterms]] is used to indicate that the EPUB
 							publication is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
 							format).</p>
 
@@ -4421,7 +4421,7 @@
 					<p>EPUB creators MAY use subexpressions to refine the meaning of other subexpressions, thereby
 						creating chains of information.</p>
 
-					<p class="note">All the [[DCTERMS]] elements represent primary expressions, and permit refinement by
+					<p class="note">All the [[dcterms]] elements represent primary expressions, and permit refinement by
 						meta element subexpressions.</p>
 
 					<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a
@@ -4459,7 +4459,7 @@
 
 					<aside class="example" title="Using values from a scheme">
 						<p>In this example, the <code>scheme</code> attribute indicates that the <a>value</a> of the tag
-							is from [[ONIX]] code list 5 (i.e., the value <code>15</code> indicates a 13 digit
+							is from [[onix]] code list 5 (i.e., the value <code>15</code> indicates a 13 digit
 							ISBN).</p>
 						<pre>&lt;metadata &#8230;>
    &#8230;
@@ -4477,9 +4477,9 @@
 				<section id="sec-metadata-last-modified">
 					<h4>Last modified date</h4>
 
-					<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one [[DCTERMS]]
+					<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one [[dcterms]]
 							<code>modified</code> property containing the last modification date. The <a>value</a> of
-						this property MUST be an [[XMLSCHEMA-2]] dateTime conformant date of the form:
+						this property MUST be an [[xmlschema-2]] dateTime conformant date of the form:
 							<code>CCYY-MM-DDThh:mm:ssZ</code></p>
 
 					<p>EPUB creators MUST express the last modification date in Coordinated Universal Time (UTC) and
@@ -4507,7 +4507,7 @@
 						<p>The requirements for the last modification date are to ensure compatibility with earlier
 							versions of EPUB 3 that defined a <a
 								href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
-								>release identifier</a> [[EPUBPackages-32]] for EPUB publications.</p>
+								>release identifier</a> [[epubpackages-32]] for EPUB publications.</p>
 					</div>
 				</section>
 
@@ -4612,12 +4612,12 @@
 						</li>
 						<li>
 							<p>included or embedded in an EPUB content document (e.g., a metadata record serialized as
-								RDFa [[?RDFA-CORE]] or JSON-LD [[?JSON-LD11]] embedded in an [[HTML]] [^script^]
+								RDFa [[?rdfa-core]] or JSON-LD [[?json-ld11]] embedded in an [[html]] [^script^]
 								element).</p>
 						</li>
 					</ul>
 
-					<p>In all other cases (e.g., when linking to standalone [[?ONIX]] or [[?XMP]] records), the linked
+					<p>In all other cases (e.g., when linking to standalone [[?onix]] or [[?xmp]] records), the linked
 						resources are not publication resources (i.e., are not subject to <a
 							href="#sec-core-media-types">core media type requirements</a>) and EPUB creators MUST NOT
 						list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
@@ -4666,12 +4666,12 @@ XHTML:
 
 					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
 							attribute</a> is OPTIONAL when a linked resource is located outside the EPUB container, as
-						more than one media type could be served from the same URL [[URL]]. EPUB creators MUST specify
+						more than one media type could be served from the same URL [[url]]. EPUB creators MUST specify
 						the attribute for all linked resources within the EPUB container.</p>
 
 					<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of the
 						linked resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language
-							tag</a> [[BCP47]].</p>
+							tag</a> [[bcp47]].</p>
 
 					<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated list of <a
 							href="#sec-property-datatype">property</a> values that establish the relationship the linked
@@ -4741,7 +4741,7 @@ XHTML:
 						systems, but reading systems may ignore these records.</p>
 
 					<p>When a reading system <a data-cite="epub-rs-33#sec-linked-records">processes linked records</a>
-						[[EPUB-RS-33]], the document order of <code>link</code> elements is used to determine which has
+						[[epub-rs-33]], the document order of <code>link</code> elements is used to determine which has
 						the highest priority in the case of conflicts (i.e., first in document order has the highest
 						priority).</p>
 
@@ -4929,10 +4929,10 @@ XHTML:
 						</dd>
 					</dl>
 
-					<p>Each <code>item</code> element identifies a <a>publication resource</a> by the URL [[URL]] in its
+					<p>Each <code>item</code> element identifies a <a>publication resource</a> by the URL [[url]] in its
 							<code>href</code> attribute. The value MUST be an <a data-lt="absolute-url string"
 							>absolute-</a> or <a data-lt="path-relative-scheme-less-url string"
-							>path-relative-scheme-less-URL</a> string [[URL]]. EPUB creators MUST ensure each URL is
+							>path-relative-scheme-less-URL</a> string [[url]]. EPUB creators MUST ensure each URL is
 						unique within the <code>manifest</code> scope after <a href="#sec-parse-package-urls"
 							>parsing</a>.</p>
 
@@ -4943,14 +4943,14 @@ XHTML:
 							href="#sec-core-media-types"></a>.</p>
 
 					<p id="attrdef-item-fallback">The <code>fallback</code> attribute specifies the fallback for the
-						referenced publication resource. The <code>fallback</code> attribute's IDREF [[XML]] value MUST
+						referenced publication resource. The <code>fallback</code> attribute's IDREF [[xml]] value MUST
 						resolve to another <code>item</code> in the <code>manifest</code>.</p>
 
 					<p>The fallback for one <code>item</code> MAY specify a fallback to another <code>item</code>, and
 						so on, creating a chain of fallback options. Refer to <a href="#sec-manifest-fallbacks"></a> for
 						additional requirements related to the use of fallback chains.</p>
 
-					<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF [[XML]]
+					<p id="attrdef-item-media-overlay">The <code>media-overlay</code> attribute takes an IDREF [[xml]]
 						that identifies the <a>media overlay document</a> for the resource described by this
 							<code>item</code>. Refer to <a href="#sec-docs-package"></a> for more information.</p>
 
@@ -5309,7 +5309,7 @@ No Entry</pre>
 
 					<p>Refer to the <a
 							href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
-								><code>bindings</code> element definition</a> in [[EPUBPublications-301]] for more
+								><code>bindings</code> element definition</a> in [[epubpublications-301]] for more
 						information.</p>
 				</section>
 			</section>
@@ -5387,7 +5387,7 @@ No Entry</pre>
 						content documents that are hyperlinked to from publication resources in the <code>spine</code>,
 						where hyperlinking encompasses any linking mechanism that requires the user to navigate away
 						from the current resource. Common hyperlinking mechanisms include the [^a/href^] attribute of
-						the [[HTML]] <a data-lt="a"><code>a</code></a> and <a data-lt="area"><code>area</code></a>
+						the [[html]] <a data-lt="a"><code>a</code></a> and <a data-lt="area"><code>area</code></a>
 						elements and scripted links (e.g., using DOM Events and/or form elements). The requirement to
 						list hyperlinked resources applies recursively (i.e., EPUB creators must list all EPUB and
 						foreign content documents hyperlinked to from hyperlinked documents, and so on.).</p>
@@ -5401,7 +5401,7 @@ No Entry</pre>
 							not subject to the requirement to include in the spine (e.g., web pages and web-hosted
 							resources).</p>
 
-						<p>Publication resources used in the rendering of spine items (e.g., referenced from [[HTML]]
+						<p>Publication resources used in the rendering of spine items (e.g., referenced from [[html]]
 								<a>embedded content</a>) similarly do not have to be included in the spine.</p>
 					</div>
 
@@ -5418,7 +5418,7 @@ No Entry</pre>
 						application of alternate style sheets).</p>
 
 					<p>The <a href="#legacy">legacy</a>
-						<code>toc</code> attribute takes an IDREF [[XML]] that identifies the manifest item that
+						<code>toc</code> attribute takes an IDREF [[xml]] that identifies the manifest item that
 						represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
 				</section>
 
@@ -5488,7 +5488,7 @@ No Entry</pre>
 
 					<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an <a
 							href="#elemdef-package-item"><code>item</code></a> in the <a>manifest</a> via the
-						IDREF [[XML]] in its <code>idref</code> attribute, and item IDs MUST NOT be referenced more than
+						IDREF [[xml]] in its <code>idref</code> attribute, and item IDs MUST NOT be referenced more than
 						once. </p>
 
 					<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a) an
@@ -5647,7 +5647,7 @@ No Entry</pre>
 
 					<p id="attrdef-collection-role">EPUB creators MUST identify the role of each <code>collection</code>
 						element in its <code>role</code> attribute, whose value MUST be one or more NMTOKENs
-						[[XMLSCHEMA-2]] and/or <a>absolute-URL-with-fragment strings</a> [[URL]].</p>
+						[[xmlschema-2]] and/or <a>absolute-URL-with-fragment strings</a> [[url]].</p>
 
 					<p>The requirements for authoring specialized collections are defined by their respective
 						specifications.</p>
@@ -5676,7 +5676,7 @@ No Entry</pre>
 
 					<p>Refer to the <a
 							href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
-								><code>collection</code> element definition</a> in [[EPUBPackages-32]] for more
+								><code>collection</code> element definition</a> in [[epubpackages-32]] for more
 						information about the creation of specialized collections, including the requirements and
 						restrictions on their use.</p>
 				</section>
@@ -5689,16 +5689,16 @@ No Entry</pre>
 					<h4>The <code>meta</code> element</h4>
 
 					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"><code>meta</code>
-							element</a> [[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided a
+							element</a> [[opf-201]] is a <a href="#legacy">legacy</a> feature that previously provided a
 						means of including generic metadata. The EPUB 3 <a href="#sec-meta-elem"><code>meta</code>
 							element</a>, which uses different attributes and requires text content, replaces this
 						element.</p>
 
 					<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
-								><code>meta</code> element definition</a> in [[OPF-201]] for more information.</p>
+								><code>meta</code> element definition</a> in [[opf-201]] for more information.</p>
 
 					<div class="note">
-						<p>The [[OPF-201]] <code>meta</code> element is retained in EPUB 3 primarily so that EPUB
+						<p>The [[opf-201]] <code>meta</code> element is retained in EPUB 3 primarily so that EPUB
 							creators can identify the cover image for compatibility with EPUB 2 reading systems. In EPUB
 							3, the cover image must be identified using the <a href="#sec-cover-image"
 									><code>cover-image</code> property</a> on the <a href="#sec-item-elem">manifest
@@ -5710,23 +5710,23 @@ No Entry</pre>
 					<h4>The <code>guide</code> element</h4>
 
 					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code>
-							element</a> [[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided
+							element</a> [[opf-201]] is a <a href="#legacy">legacy</a> feature that previously provided
 						machine-processable navigation to key structures. The <a href="#sec-nav-landmarks">landmarks
 							nav</a> in the <a>EPUB navigation document</a> replaces this element.</p>
 
 					<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
-								><code>guide</code> element definition</a> in [[OPF-201]] for more information.</p>
+								><code>guide</code> element definition</a> in [[opf-201]] for more information.</p>
 				</section>
 
 				<section id="sec-opf2-ncx">
 					<h4>NCX</h4>
 
 					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a>
-						[[OPF-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table of
+						[[opf-201]] is a <a href="#legacy">legacy</a> feature that previously provided the table of
 						contents. The <a href="#sec-nav">EPUB navigation document</a> replaces this document.</p>
 
 					<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
-							definition</a> in [[OPF-201]] for more information.</p>
+							definition</a> in [[opf-201]] for more information.</p>
 				</section>
 			</section>
 		</section>
@@ -5739,7 +5739,7 @@ No Entry</pre>
 				<section id="sec-xhtml-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>This section defines a profile of [[HTML]] for creating XHTML content documents. An instance of
+					<p>This section defines a profile of [[html]] for creating XHTML content documents. An instance of
 						an XML document that conforms to this profile is a <a>core media type resource</a> and is
 						referred to in this specification as an <a>XHTML content document</a>.</p>
 				</section>
@@ -5751,26 +5751,26 @@ No Entry</pre>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-cd-html-docprops-syntax">MUST be an [[HTML]] document that conforms to the <a
+							<p id="confreq-cd-html-docprops-syntax">MUST be an [[html]] document that conforms to the <a
 									data-cite="html#the-xhtml-syntax">XML</a> syntax.</p>
 						</li>
 						<li>
 							<p id="confreq-cd-html-docprops-html">MUST conform to the conformance criteria for all
-								document constructs defined by [[HTML]] unless explicitly overridden in <a
+								document constructs defined by [[html]] unless explicitly overridden in <a
 									href="#sec-xhtml-deviations"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-cd-html-docprops-schema">MAY include extensions to the [[HTML]] grammar as
+							<p id="confreq-cd-html-docprops-schema">MAY include extensions to the [[html]] grammar as
 								defined in <a href="#sec-xhtml-extensions"></a>, and MUST conform to all content
 								conformance constraints defined therein.</p>
 						</li>
 					</ul>
 					<p>Unless specified otherwise, XHTML content documents inherit all definitions of semantics,
-						structure, and processing behaviors from the [[HTML]] specification.</p>
+						structure, and processing behaviors from the [[html]] specification.</p>
 
 					<div class="note">
 						<p>The recommendation that EPUB publications follow the accessibility requirements in
-							[[EPUB-A11Y-11]] applies to XHTML content documents. See <a href="#confreq-a11y"
+							[[epub-a11y-11]] applies to XHTML content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -5778,11 +5778,11 @@ No Entry</pre>
 				<section id="sec-xhtml-extensions">
 					<h4>HTML extensions</h4>
 
-					<p>This section defines EPUB 3 <a>XHTML content document</a> extensions to the underlying [[HTML]]
+					<p>This section defines EPUB 3 <a>XHTML content document</a> extensions to the underlying [[html]]
 						document model.</p>
 
 					<div class="note">
-						<p>Although [[HTML]] allows user agents to support <a data-cite="html#extensibility-2"
+						<p>Although [[html]] allows user agents to support <a data-cite="html#extensibility-2"
 								>vendor-neutral extensions</a>, unless such extensions are listed in this section, they
 							are not supported features of EPUB 3.</p>
 					</div>
@@ -5794,7 +5794,7 @@ No Entry</pre>
 								attribute</a> in <a>XHTML content documents</a> to express <a
 								href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
-						<p>As the [[HTML]] <a data-lt="head"><code>head</code> element</a> contains metadata for the
+						<p>As the [[html]] <a data-lt="head"><code>head</code> element</a> contains metadata for the
 							document, structural semantics expressed on this element or any descendant of it have no
 							meaning.</p>
 					</section>
@@ -5802,18 +5802,18 @@ No Entry</pre>
 					<section id="sec-xhtml-rdfa">
 						<h5>RDFa</h5>
 
-						<p>The [[HTML-RDFA]] specification defines a set of attributes that EPUB creators MAY use in
+						<p>The [[html-rdfa]] specification defines a set of attributes that EPUB creators MAY use in
 								<a>XHTML content documents</a> to semantically enrich the content. The use of these
-							attributes MUST conform to the requirements defined in [[HTML-RDFA]].</p>
+							attributes MUST conform to the requirements defined in [[html-rdfa]].</p>
 
-						<p>The [[HTML-RDFA]] specification defines changes to the [[HTML]] content model when authors
+						<p>The [[html-rdfa]] specification defines changes to the [[html]] content model when authors
 							use RDFa attributes. This modified content model is valid in XHTML content documents.</p>
 
 						<div class="note">
 							<p>The listing of RDFa does not express a preference on the part of the Working Group, only
 								that these attributes represent an extension of the HTML grammar. EPUB creators can also
-								specify <a data-cite="html#microdata">microdata attributes</a> [[HTML]] and <a
-									data-cite="json-ld11#">linked data</a> [[JSON-LD11]] in XHTML content documents as
+								specify <a data-cite="html#microdata">microdata attributes</a> [[html]] and <a
+									data-cite="json-ld11#">linked data</a> [[json-ld11]] in XHTML content documents as
 								both are natively supported.</p>
 						</div>
 					</section>
@@ -5829,7 +5829,7 @@ No Entry</pre>
 
 						<p>Refer to the <a
 								href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
-									><code>switch</code> element definition</a> in [[EPUBContentDocs-301]] for more
+									><code>switch</code> element definition</a> in [[epubcontentdocs-301]] for more
 							information.</p>
 					</section>
 
@@ -5844,7 +5844,7 @@ No Entry</pre>
 
 						<p>Refer to the <a
 								href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
-									><code>epub:trigger</code> element definition</a> in [[EPUBContentDocs-301]] for
+									><code>epub:trigger</code> element definition</a> in [[epubcontentdocs-301]] for
 							more information.</p>
 					</section>
 
@@ -5852,8 +5852,8 @@ No Entry</pre>
 						<h5>Custom attributes</h5>
 
 						<p><a>XHTML content documents</a> MAY contain custom attributes, which are <a
-								data-cite="xml-names#NT-Prefix">prefixed</a> [[XML-NAMES]] attributes whose namespace
-							URL does not include either of the following strings in its <a>domain</a> [[URL]]:</p>
+								data-cite="xml-names#NT-Prefix">prefixed</a> [[xml-names]] attributes whose namespace
+							URL does not include either of the following strings in its <a>domain</a> [[url]]:</p>
 
 						<ul>
 							<li><code>w3.org</code></li>
@@ -5874,14 +5874,14 @@ No Entry</pre>
 				<section id="sec-xhtml-deviations">
 					<h4>HTML deviations and constraints</h4>
 
-					<p>This section defines deviations from, and constraints on, the underlying [[HTML]] document model
+					<p>This section defines deviations from, and constraints on, the underlying [[html]] document model
 						applicable to EPUB 3 <a>XHTML content documents</a>.</p>
 
 					<section id="sec-xhtml-mathml">
 						<h5>Embedded MathML</h5>
 
-						<p>XHTML content documents support embedded [[MATHML3]]. Occurrences of MathML markup MUST
-							conform to the constraints expressed in the MathML specification [[MATHML3]], with the
+						<p>XHTML content documents support embedded [[mathml3]]. Occurrences of MathML markup MUST
+							conform to the constraints expressed in the MathML specification [[mathml3]], with the
 							following additional restrictions:</p>
 
 						<dl class="conformance-list">
@@ -5908,7 +5908,7 @@ No Entry</pre>
 						</dl>
 
 						<p>This subset eases the implementation burden on reading systems and promotes accessibility,
-							while retaining compatibility with [[HTML]] user agents.</p>
+							while retaining compatibility with [[html]] user agents.</p>
 
 						<div class="note">
 							<p>The <a href="#mathml"><code>mathml</code> property</a> of the <a>manifest</a>
@@ -5922,7 +5922,7 @@ No Entry</pre>
 
 						<p><a>XHTML content documents</a> support the embedding of <a
 								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
-								fragments</a> [[SVG]] <em>by reference</em> (embedding via reference, for example, from
+								fragments</a> [[svg]] <em>by reference</em> (embedding via reference, for example, from
 							an <code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
 							direct inclusion of the <code>svg</code> element in the XHTML content document).</p>
 
@@ -5942,7 +5942,7 @@ No Entry</pre>
 						<section id="sec-xhtml-deviations-base">
 							<h6>The <code>base</code> element</h6>
 
-							<p id="confreq-html-vocab-base"> The [[HTML]] <a data-lt="base"><code>base</code>
+							<p id="confreq-html-vocab-base"> The [[html]] <a data-lt="base"><code>base</code>
 									element</a> can be used to specify the <a>document base URL</a> for the purposes of
 								parsing URLs. When using it in an <a>EPUB publication</a>, the interpretation of the
 									<code>base</code> element may inadvertently result in references to <a>remote
@@ -5956,7 +5956,7 @@ No Entry</pre>
 						<section id="sec-xhtml-deviations-rp">
 							<h6>The <code>rp</code> element</h6>
 
-							<p id="confreq-html-vocab-rp">The [[HTML]] <a data-lt="rp"><code>rp</code> element</a> is
+							<p id="confreq-html-vocab-rp">The [[html]] <a data-lt="rp"><code>rp</code> element</a> is
 								intended to provide a fallback for older <a>reading systems</a> that do not recognize
 								ruby markup (i.e., a parenthesis display around <code>ruby</code> markup). As EPUB 3
 								reading systems are ruby-aware, and can provide fallbacks, EPUB creators should not use
@@ -5966,11 +5966,11 @@ No Entry</pre>
 						<section id="sec-xhtml-deviations-embed">
 							<h6>The <code>embed</code> element</h6>
 
-							<p id="confreq-html-vocab-embed">Since the [[HTML]] <a data-lt="embed"><code>embed</code>
+							<p id="confreq-html-vocab-embed">Since the [[html]] <a data-lt="embed"><code>embed</code>
 									element</a> element does not include intrinsic facilities to provide fallback
 								content for reading systems that do not support scripting, <a>EPUB creators</a> are
 								discouraged from using the element when the referenced resource includes scripting. The
-								[[HTML]] <a data-lt="object"><code>object</code> element</a> is a better alternative, as
+								[[html]] <a data-lt="object"><code>object</code> element</a> is a better alternative, as
 								it includes intrinsic fallback capabilities.</p>
 						</section>
 					</section>
@@ -5981,7 +5981,7 @@ No Entry</pre>
 				<h3>SVG content documents</h3>
 
 				<div class="caution">
-					<p><a>Reading systems</a> may not support all the features of [[SVG]] or supported them across all
+					<p><a>Reading systems</a> may not support all the features of [[svg]] or supported them across all
 						platforms that reading systems run on. When utilizing such features, <a>EPUB creators</a> should
 						consider the inherent risks on interoperability and document longevity.</p>
 				</div>
@@ -5989,7 +5989,7 @@ No Entry</pre>
 				<section id="sec-svg-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>The Scalable Vector Graphics (SVG) specification [[SVG]] defines a format for representing
+					<p>The Scalable Vector Graphics (SVG) specification [[svg]] defines a format for representing
 						final-form vector graphics and text.</p>
 
 					<p>Although <a>EPUB creators</a> typically use <a href="#sec-xhtml">XHTML content documents</a> as
@@ -5998,7 +5998,7 @@ No Entry</pre>
 						certain special cases, such as when final-form page images are the only suitable representation
 						of the content (e.g., for cover art or in the context of manga or comic books).</p>
 
-					<p>This section defines a profile for [[SVG]] documents. An instance of an XML document that
+					<p>This section defines a profile for [[svg]] documents. An instance of an XML document that
 						conforms to this profile is a <a>core media type resource</a> and is referred to in this
 						specification as an <a>SVG content document</a>.</p>
 
@@ -6018,7 +6018,7 @@ No Entry</pre>
 						<li>
 							<p id="confreq-cd-svg-docprops-schema">MUST be a <a
 									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles"
-									>conforming SVG stand-alone file</a> [[SVG]] and conform to all content conformance
+									>conforming SVG stand-alone file</a> [[svg]] and conform to all content conformance
 								constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
 						</li>
 						<li>
@@ -6030,7 +6030,7 @@ No Entry</pre>
 					</ul>
 					<div class="note">
 						<p>The recommendation that EPUB publications follow the accessibility requirements in
-							[[EPUB-A11Y-11]] applies to SVG content documents. See <a href="#confreq-a11y"
+							[[epub-a11y-11]] applies to SVG content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
 				</section>
@@ -6043,16 +6043,16 @@ No Entry</pre>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-svg-foreignObject">The [[SVG]] <a
+							<p id="confreq-svg-foreignObject">The [[svg]] <a
 									href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
 										><code>foreignObject</code></a> element:</p>
 							<ul class="conformance-list">
 								<li>
-									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[HTML]] <a>flow
-											content</a> or exactly one [[HTML]] [^body^] element.</p>
+									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[html]] <a>flow
+											content</a> or exactly one [[html]] [^body^] element.</p>
 									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
 											<code>body</code> element is not permitted per the <a data-cite="html#svg-0"
-											>restrictions on SVG</a> defined in [[HTML]].</p>
+											>restrictions on SVG</a> defined in [[html]].</p>
 								</li>
 								<li>
 									<p id="confreq-svg-foreignObject-xhtml-frag">MUST contain a valid document fragment
@@ -6062,7 +6062,7 @@ No Entry</pre>
 							</ul>
 						</li>
 						<li>
-							<p id="confreq-svg-title">The [[SVG]] <a
+							<p id="confreq-svg-title">The [[svg]] <a
 									href="https://www.w3.org/TR/SVG/struct.html#TitleElement"><code>title</code></a>
 								element MUST contain only valid <a href="#sec-xhtml-req">XHTML content document Phrasing
 									content</a>.</p>
@@ -6124,12 +6124,12 @@ No Entry</pre>
 									<li>
 										<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
 												data-cite="css-writing-modes-3#direction"><code>direction</code>
-												property</a> [[CSS-Writing-Modes-3]].</p>
+												property</a> [[css-writing-modes-3]].</p>
 									</li>
 									<li>
 										<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT include the <a
 												data-cite="css-writing-modes-3#unicode-bidi"><code>unicode-bidi</code>
-												property</a> [[CSS-Writing-Modes-3]].</p>
+												property</a> [[css-writing-modes-3]].</p>
 									</li>
 								</ul>
 							</li>
@@ -6138,7 +6138,7 @@ No Entry</pre>
 										href="#sec-css-prefixed"></a>.</p>
 							</li>
 							<li>
-								<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16 [[Unicode]], with UTF-8
+								<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16 [[unicode]], with UTF-8
 									as the RECOMMENDED encoding.</p>
 							</li>
 						</ul>
@@ -6150,17 +6150,17 @@ No Entry</pre>
 
 							<ul>
 								<li>
-									<p>the [^html-global/dir^] attribute [[HTML]] and <a
+									<p>the [^html-global/dir^] attribute [[html]] and <a
 											href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
-												><code>direction</code></a> attribute [[SVG]] for inline base
+												><code>direction</code></a> attribute [[svg]] for inline base
 										directionality.</p>
 								</li>
 								<li>
 									<p>the <a><code>bdo</code></a> element with the [^html-global/dir^]
-										attribute [[HTML]] and the <a
+										attribute [[html]] and the <a
 											href="https://www.w3.org/TR/SVG/styling.html#PresentationAttributes"
 											>presentation attribute alternative</a> for <code>unicode-bidi</code>
-										[[SVG]] for bidirectionality.</p>
+										[[svg]] for bidirectionality.</p>
 								</li>
 							</ul>
 						</div>
@@ -6179,7 +6179,7 @@ No Entry</pre>
 						<div class="caution">
 							<p><a>EPUB creators</a> should use unprefixed properties and <a>reading systems</a> should
 								support current CSS specifications. This specification retains the widely used prefixed
-								properties from [[EPUBContentDocs-301]] but removes support for the less-used ones. EPUB
+								properties from [[epubcontentdocs-301]] but removes support for the less-used ones. EPUB
 								creators should use CSS-native solutions for the removed properties whenever
 								available.</p>
 
@@ -6197,30 +6197,30 @@ No Entry</pre>
 						<h4>Script inclusion</h4>
 
 						<p><a>EPUB content documents</a> MAY contain scripting using the facilities defined for this in
-							the respective underlying specifications ([[HTML]] and [[SVG]]). When an EPUB content
+							the respective underlying specifications ([[html]] and [[svg]]). When an EPUB content
 							document contains scripting, this specification refers to it as a <a>scripted content
 								document</a>. This label also applies to <a>XHTML content documents</a> when they
-							contain instances of [[HTML]] <a>forms</a>.</p>
+							contain instances of [[html]] <a>forms</a>.</p>
 
 						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a>manifest</a>
 							<code>item</code> element is used to indicate that an EPUB content document is a <a>scripted
 								content document</a>.</p>
 
-						<p>When an [[HTML]] <code>script</code> element contains a <a data-cite="html#data-block">data
-								block</a> [[HTML]], it does not represent scripted content.</p>
+						<p>When an [[html]] <code>script</code> element contains a <a data-cite="html#data-block">data
+								block</a> [[html]], it does not represent scripted content.</p>
 
 						<div class="note">
-							<p>[[SVG]] does not define data blocks as of publication, but the same exclusion would apply
+							<p>[[svg]] does not define data blocks as of publication, but the same exclusion would apply
 								if a future update adds the concept.</p>
 						</div>
 
 						<p>EPUB creators should note that reading systems are required to behave as though a unique
-								<a>origin</a> [[URL]] has been assigned to each EPUB publication. In practice, this
+								<a>origin</a> [[url]] has been assigned to each EPUB publication. In practice, this
 							means that it is not possible for scripts to share data between EPUB publications.</p>
 
 						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
 							rights and restrictions that a reading system places on it (refer to <a
-								data-cite="epub-rs-33#sec-scripted-content">Scripting conformance</a> [[?EPUB-RS-33]]
+								data-cite="epub-rs-33#sec-scripted-content">Scripting conformance</a> [[?epub-rs-33]]
 							for more information).</p>
 
 						<div class="note">
@@ -6244,10 +6244,10 @@ No Entry</pre>
 
 						<div class="note">
 							<p>Scripts may execute in other contexts, but reading system support for these contexts is
-								optional. For example, a scripted SVG document may be referenced from an [[HTML]] <a
+								optional. For example, a scripted SVG document may be referenced from an [[html]] <a
 									data-lt="object"><code>object</code> element</a>.</p>
 							<p>Refer to the <a href="https://www.w3.org/TR/epub-rs-33#sec-scripted-content">processing
-									of scripts</a> [[EPUB-RS-33]] for more information.</p>
+									of scripts</a> [[epub-rs-33]] for more information.</p>
 						</div>
 
 						<p>Whether EPUB creators embed the code directly in the <code>script</code> element or reference
@@ -6268,15 +6268,15 @@ No Entry</pre>
 							<p>A <em>container-constrained script</em> is either of the following:</p>
 							<ul>
 								<li>
-									<p>An instance of the [[HTML]] [^script^] element contained in an <a>XHTML content
+									<p>An instance of the [[html]] [^script^] element contained in an <a>XHTML content
 											document</a> that is embedded in an XHTML content document using the
-										[[HTML]] <a data-lt="iframe"><code>iframe</code></a> element.</p>
+										[[html]] <a data-lt="iframe"><code>iframe</code></a> element.</p>
 								</li>
 								<li>
-									<p>An instance of the [[SVG]] <a
+									<p>An instance of the [[svg]] <a
 											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
 												><code>script</code></a> element contained in an <a>SVG content
-											document</a> that is embedded in a XHTML content document using the [[HTML]]
+											document</a> that is embedded in a XHTML content document using the [[html]]
 												<a><code>iframe</code></a> element.</p>
 								</li>
 							</ul>
@@ -6288,7 +6288,7 @@ No Entry</pre>
 
 							<p>EPUB creators should note that <a data-cite="epub-rs-33#sec-scripted-content">support for
 									container-constrained scripting in reading systems</a> is only recommended in
-								reflowable documents [[EPUB-RS-33]]. Furthermore, reading system support in
+								reflowable documents [[epub-rs-33]]. Furthermore, reading system support in
 								fixed-layouts EPUBs is optional.</p>
 
 							<p>EPUB creators should ensure container-constrained scripts degrade gracefully in reading
@@ -6304,7 +6304,7 @@ No Entry</pre>
 						<section id="sec-scripted-spine">
 							<h5>Spine-level scripts</h5>
 
-							<p>A <em>spine-level script</em> is an instance of the [[HTML]] [^script^] or [[SVG]] <a
+							<p>A <em>spine-level script</em> is an instance of the [[html]] [^script^] or [[svg]] <a
 									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 								element contained in a <a>top-level content document</a>.</p>
 
@@ -6312,7 +6312,7 @@ No Entry</pre>
 								only recommended in <a data-cite="epub-rs-33#confreq-rs-scripted-fxl-support"
 									>fixed-layout documents</a> and <a
 									data-cite="epub-rs-33#confreq-rs-scripted-scrolled">reflowable documents set to
-									scroll</a> [[EPUB-RS-33]]. Furthermore, reading system support in all other contexts
+									scroll</a> [[epub-rs-33]]. Furthermore, reading system support in all other contexts
 								is optional.</p>
 
 							<p id="confreq-cd-scripted-spine"><a>Top-level content documents</a> that include
@@ -6338,7 +6338,7 @@ No Entry</pre>
 						<h4>Scripting accessibility</h4>
 
 						<p id="confreq-cd-scripted-a11y">EPUB content documents that contain scripting SHOULD employ
-							relevant [[WAI-ARIA]] accessibility techniques to ensure that the content remains consumable
+							relevant [[wai-aria]] accessibility techniques to ensure that the content remains consumable
 							by all users.</p>
 					</section>
 
@@ -6347,7 +6347,7 @@ No Entry</pre>
 
 						<p id="confreq-cd-scripted-fallback">EPUB content documents that contain scripting MAY provide
 							fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
-							available for the [[HTML]] <a><code>object</code></a> and <a><code>canvas</code></a>
+							available for the [[html]] <a><code>object</code></a> and <a><code>canvas</code></a>
 							elements) or, when an intrinsic fallback is not applicable, by using a <a
 								href="#sec-manifest-fallbacks">manifest-level fallback</a>.</p>
 
@@ -6505,7 +6505,7 @@ No Entry</pre>
 							alternate text rendering of the link label.</p>
 					</li>
 					<li>
-						<p id="confreq-nav-a-href">The URL [[URL]] reference provided in the <code>href</code> attribute
+						<p id="confreq-nav-a-href">The URL [[url]] reference provided in the <code>href</code> attribute
 							of the <code>a</code> element:</p>
 						<ul class="conformance-list">
 							<li>
@@ -6571,7 +6571,7 @@ No Entry</pre>
 				<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
 					items within <code>nav</code> elements is equivalent to the <a
 						href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:</code>
-						<code>none</code> property</a> [[CSSSnapshot]]. <a>EPUB creators</a> MAY specify alternative
+						<code>none</code> property</a> [[csssnapshot]]. <a>EPUB creators</a> MAY specify alternative
 					list styling using CSS for rendering of the document in the <a href="#sec-spine-elem"
 							><code>spine</code></a>.</p>
 			</section>
@@ -6669,7 +6669,7 @@ No Entry</pre>
 
 					<p>EPUB creators MAY identify the destinations of the <code>page-list</code> references in their
 						respective EPUB content documents using the <a data-cite="epub-ssv-11/#pagebreak"
-								><code>pagebreak</code> term</a> [[EPUB-SSV-11]].</p>
+								><code>pagebreak</code> term</a> [[epub-ssv-11]].</p>
 				</section>
 
 				<section id="sec-nav-landmarks">
@@ -6696,7 +6696,7 @@ No Entry</pre>
 
 					<aside class="example" title="A basic landmarks nav">
 						<p>In this example, the <code>epub:type</code> attribute value are drawn from structural
-							semantics drawn from [[EPUB-SSV-11]].</p>
+							semantics drawn from [[epub-ssv-11]].</p>
 
 						<pre>&lt;nav epub:type="landmarks">
    &lt;h2>Guide&lt;/h2>
@@ -6734,10 +6734,10 @@ No Entry</pre>
 					<p>The following landmarks are recommended to include when available:</p>
 
 					<ul>
-						<li><a data-cite="epub-ssv-11#bodymatter"><code>bodymatter</code></a> [[?EPUB-SSV-11]] &#8212;
+						<li><a data-cite="epub-ssv-11#bodymatter"><code>bodymatter</code></a> [[?epub-ssv-11]] &#8212;
 							Reading systems often use this landmark to automatically jump users past the front matter
 							when they begin reading.</li>
-						<li><a data-cite="epub-ssv-11#toc-1"><code>toc</code></a> [[?EPUB-SSV-11]] &#8212; If the table
+						<li><a data-cite="epub-ssv-11#toc-1"><code>toc</code></a> [[?epub-ssv-11]] &#8212; If the table
 							of contents is available in the spine, reading systems may use this landmark to take users
 							to the document containing it.</li>
 					</ul>
@@ -6806,9 +6806,9 @@ No Entry</pre>
 					contents for books that have many levels of subsections.</p>
 
 				<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
-						property</a> [[CSSSnapshot]] controls the visual rendering of EPUB navigation documents in
+						property</a> [[csssnapshot]] controls the visual rendering of EPUB navigation documents in
 					reading systems with <a>viewports</a>, reading systems without viewports may not support CSS. To
-					better ensure the proper rendering in these reading systems, EPUB creators should use the [[HTML]]
+					better ensure the proper rendering in these reading systems, EPUB creators should use the [[html]]
 					[^html-global/hidden^] attribute to indicate which (if any) portions of the navigation data are
 					excluded from rendering in the content flow.</p>
 
@@ -6905,7 +6905,7 @@ No Entry</pre>
 						reflows, to fit the screen and to fit the needs of the user. As noted in <a
 							data-cite="epub-overview-33#sec-rendering">Rendering and CSS</a> "content presentation
 						adapts to the user, rather than the user having to adapt to a particular presentation of
-						content." [[EPUB-OVERVIEW-33]]</p>
+						content." [[epub-overview-33]]</p>
 
 					<p>But this principle does not work for all types of documents. Sometimes content and design are so
 						intertwined it is not possible to separate them. Any change in appearance risks changing the
@@ -6962,7 +6962,7 @@ No Entry</pre>
 								should consider the negative impact on usability and accessibility that these
 								restrictions have when choosing to use pre-paginated instead of reflowable content.
 								Refer to <a data-cite="UAAG20#gl-text-config">Guideline 1.4 - Provide text
-									configuration</a> [[UAAG20]] for related information.</p>
+									configuration</a> [[uaag20]] for related information.</p>
 						</div>
 
 						<p id="fxl-layout-duplication" data-tests="#fxl-layout-duplication">When the property is set to
@@ -6977,7 +6977,7 @@ No Entry</pre>
 
 						<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
 							<p>In this example, the document's layout is set to <code>pre-paginated</code>, i.e., it is
-								defined to be a fixed layout document. Furthermore, media queries [[CSS3-MediaQueries]]
+								defined to be a fixed layout document. Furthermore, media queries [[css3-mediaqueries]]
 								are used to apply different style sheets for three different device categories. Note
 								that the media queries only affect the style sheet applied to the document; the size of
 								the content area set in the <code>viewport</code>
@@ -7411,7 +7411,7 @@ No Entry</pre>
 									<p></p>Refer to the <a
 										href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
 											><code>spread-portrait</code> property definition</a>
-									in [[EPUBPublications-301]] for more information.</dd>
+									in [[epubpublications-301]] for more information.</dd>
 							</dl>
 
 							<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
@@ -7579,14 +7579,14 @@ No Entry</pre>
 						<h5>Viewport dimensions (deprecated)</h5>
 
 						<p>The <code>rendition:viewport</code> property allows <a>EPUB creators</a> to express the CSS
-							initial containing block (ICB) [[CSS2]] for XHTML and SVG content documents whose
+							initial containing block (ICB) [[css2]] for XHTML and SVG content documents whose
 								<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
 
 						<p>Use of the property is <a href="#deprecated">deprecated</a>.</p>
 
 						<p>Refer to the <a
 								href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
-									><code>rendition:viewport</code> property definition</a> in [[EPUBPublications-301]]
+									><code>rendition:viewport</code> property definition</a> in [[epubpublications-301]]
 							for more information.</p>
 					</section>
 
@@ -7598,16 +7598,16 @@ No Entry</pre>
 
 						<p id="confreg-fxl-icb">Fixed-layout documents specify their <a
 								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-								containing block</a> [[CSS2]] in the manner applicable to their format:</p>
+								containing block</a> [[css2]] in the manner applicable to their format:</p>
 
 						<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
 							<dt id="sec-fxl-icb-html" data-tests="#fxl-xhtml-icb">Expressing in XHTML</dt>
 							<dd>
 								<p>For XHTML <a>fixed-layout documents</a>, the <a
 										href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-										containing block</a> [[CSS2]] dimensions MUST be expressed in a
+										containing block</a> [[css2]] dimensions MUST be expressed in a
 										<code>viewport</code>
-									<code>meta</code> tag using the syntax defined in [[CSS-Device-Adapt-1]].</p>
+									<code>meta</code> tag using the syntax defined in [[css-device-adapt-1]].</p>
 								<aside class="example"
 									title="Specifying the initial containing block in a viewport meta tag">
 									<pre>&lt;html …>
@@ -7625,10 +7625,10 @@ No Entry</pre>
 
 							<dt id="sec-fxl-icb-svg">Expressing in SVG</dt>
 							<dd>
-								<p>For SVG <a>fixed-layout documents</a>, the initial containing block [[CSS2]]
+								<p>For SVG <a>fixed-layout documents</a>, the initial containing block [[css2]]
 									dimensions MUST be expressed using the <a
 										href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
-											><code>viewBox</code> attribute</a> [[SVG]].</p>
+											><code>viewBox</code> attribute</a> [[svg]].</p>
 								<aside class="example"
 									title="Specifying the initial containing block in the viewBox attribute">
 									<p>In this example, the <code>viewBox</code> attribute sets the ICB to an aspect
@@ -7704,10 +7704,10 @@ No Entry</pre>
 					</dl>
 
 					<p id="html-body-page-break-before">Note that when two reflowable EPUB content documents occur
-						sequentially in the spine, the default rendering for their [[!HTML]] <a
+						sequentially in the spine, the default rendering for their [[!html]] <a
 							data-cite="html#the-body-element"><code>body</code></a> elements is consistent with the <a
 							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-								><code>page-break-before</code> property</a> [[!CSSSnapshot]] having been set to
+								><code>page-break-before</code> property</a> [[!csssnapshot]] having been set to
 							<code>always</code>. In addition to using the <code>rendition:flow</code> property, EPUB
 						creators MAY override this behavior through an appropriate style sheet declaration, if the
 						reading system supports such overrides.</p>
@@ -7872,7 +7872,7 @@ No Entry</pre>
 					some examples of works that contain synchronized audio narration. In EPUB 3, EPUB creators can
 					create these types of books using media overlay documents to describe the timing for the
 					pre-recorded audio narration and how it relates to the EPUB content document markup. The
-					specification defines the file format for Media Overlays as a subset of [[SMIL3]], a W3C
+					specification defines the file format for Media Overlays as a subset of [[smil3]], a W3C
 					recommendation for representing synchronized multimedia information in XML.</p>
 
 				<p>The text and audio synchronization enabled by Media Overlays provides enhanced accessibility for any
@@ -7887,7 +7887,7 @@ No Entry</pre>
 					are not present.</p>
 
 				<p>Media Overlays in EPUB are not an equivalent to audiobooks, as audiobooks are primarily audio-based
-					with text occasionally provided as an alternate format. The W3C [[Audiobooks]] recommendation is for
+					with text occasionally provided as an alternate format. The W3C [[audiobooks]] recommendation is for
 					building audio publications.</p>
 
 				<p>Although future versions of this specification might incorporate support for video media (e.g.,
@@ -7920,8 +7920,8 @@ No Entry</pre>
 				<section id="sec-overlays-def">
 					<h3>Media overlay document definition</h3>
 
-					<p>All elements [[XML]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
-						namespace [[XML-NAMES]] unless otherwise specified.</p>
+					<p>All elements [[xml]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
+						namespace [[xml-names]] unless otherwise specified.</p>
 
 					<section id="sec-smil-smil-elem">
 						<h5>The <code>smil</code> element</h5>
@@ -7949,7 +7949,7 @@ No Entry</pre>
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>Specifies the version number of the [[SMIL3]] specification to which the
+										<p>Specifies the version number of the [[smil3]] specification to which the
 											Media Overlay adheres.</p>
 										<p>This attribute MUST have the value "<code>3.0</code>".</p>
 									</dd>
@@ -7959,7 +7959,7 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[XML]] of the element, which MUST be unique within the document
+										<p>The ID [[xml]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 
@@ -8117,7 +8117,7 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[XML]] of the element, which MUST be unique within the document
+										<p>The ID [[xml]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 
@@ -8201,7 +8201,7 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[XML]] of the element, which MUST be unique within the document
+										<p>The ID [[xml]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 
@@ -8285,7 +8285,7 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[XML]] of the element, which MUST be unique within the document
+										<p>The ID [[xml]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 								</dl>
@@ -8358,7 +8358,7 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[XML]] of the element, which MUST be unique within the document
+										<p>The ID [[xml]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 								</dl>
@@ -8406,7 +8406,7 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[XML]] of the element, which MUST be unique within the document
+										<p>The ID [[xml]] of the element, which MUST be unique within the document
 											scope.</p>
 									</dd>
 
@@ -8416,7 +8416,7 @@ No Entry</pre>
 									</dt>
 									<dd>
 										<p>The <a data-lt="relative-url string">relative-</a> or <a
-												data-lt="absolute-url string">absolute-URL string</a> [[URL]] reference
+												data-lt="absolute-url string">absolute-URL string</a> [[url]] reference
 											to an audio file. The audio file MUST be one of the audio formats listed in
 											the <a href="#sec-core-media-types">core media type resources</a> table.</p>
 									</dd>
@@ -8428,7 +8428,7 @@ No Entry</pre>
 									<dd>
 										<p>A clock value that specifies the offset into the physical media corresponding
 											to the start point of an audio clip.</p>
-										<p>MUST be a [[SMIL3]] <a data-cite="smil3/smil-timing.html#q22">clock
+										<p>MUST be a [[smil3]] <a data-cite="smil3/smil-timing.html#q22">clock
 											value</a>.</p>
 										<p>See <a href="#clock-examples"></a>.</p>
 									</dd>
@@ -8440,7 +8440,7 @@ No Entry</pre>
 									<dd>
 										<p>A clock value that specifies the offset into the physical media corresponding
 											to the end point of an audio clip.</p>
-										<p>MUST be a [[SMIL3]] <a data-cite="smil3/smil-timing.html#q22">clock
+										<p>MUST be a [[smil3]] <a data-cite="smil3/smil-timing.html#q22">clock
 											value</a>.</p>
 										<p>See <a href="#clock-examples"></a>.</p>
 										<p>The chronological offset of the terminating position MUST be after the
@@ -8469,7 +8469,7 @@ No Entry</pre>
 						typically represents a single phrase or paragraph, but infers no order relative to the other
 						clips or to the text of a document. Media Overlays solve this problem of synchronization by
 						tying the structured audio narration to its corresponding text (or other media) in the EPUB
-						content document using [[SMIL3]] markup. Media Overlays are, in fact, a simplified subset of
+						content document using [[smil3]] markup. Media Overlays are, in fact, a simplified subset of
 						SMIL 3.0 that define the playback sequence of these clips.</p>
 
 					<p>The SMIL elements primarily used for structuring Media Overlays are <a href="#elemdef-smil-body"
@@ -8489,7 +8489,7 @@ No Entry</pre>
 						a synchronized presentation.</p>
 
 					<p>The <code>text</code> element <code>src</code> attribute references the associated phrase,
-						sentence, or other segment of the EPUB content document by its URL [[URL]] reference. The
+						sentence, or other segment of the EPUB content document by its URL [[url]] reference. The
 							<code>audio</code> element <code>src</code> attribute similarly references the location of
 						the corresponding audio clip and adds the OPTIONAL <a href="#attrdef-smil-clipBegin"
 								><code>clipBegin</code></a> and <a href="#attrdef-smil-clipEnd"><code>clipEnd</code></a>
@@ -8750,7 +8750,7 @@ No Entry</pre>
 						<p>For XHTML and SVG content documents, the URL-fragment string SHOULD be a reference to a
 							specific element via its ID, or an <a
 								href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
-								Identifier</a> [[SVG]], respectively.</p>
+								Identifier</a> [[svg]], respectively.</p>
 
 						<p>EPUB creators MAY use other fragment identifier schemes, but reading systems may not support
 							such identifiers.</p>
@@ -8763,10 +8763,10 @@ No Entry</pre>
 							content document and the type of fragment identifier they use in the <a
 								href="#elemdef-smil-text"><code>text</code> elements'</a>
 							<code>src</code> attributes and the <a href="#elemdef-smil-seq"><code>seq</code></a>
-							elements' <code>epub:textref</code> attrbutes. For example, when referencing [[HTML]]
+							elements' <code>epub:textref</code> attrbutes. For example, when referencing [[html]]
 							elements, if the finest level of markup is at the paragraph level, then that is the finest
 							possible level for Media Overlay synchronization. Likewise, if sub-paragraph markup is
-							available, such as [[HTML]] <a data-lt="span"><code>span</code> element</a> representing
+							available, such as [[html]] <a data-lt="span"><code>span</code> element</a> representing
 							phrases or sentences, then finer granularity is possible in the Media Overlay. Finer
 							granularity gives users more precise results for synchronized playback when navigating by
 							word or phrase and when searching the text but increases the file size of the media overlay
@@ -8807,7 +8807,7 @@ No Entry</pre>
 									<a href="#sec-tts">Text-to-Speech rendering</a>.</p>
 
 							<p>EPUB creators MUST ensure they provide fallback text for an image when an omitting an
-									<code>audio</code> element (e.g., using the [[HTML]] <code>alt</code>
+									<code>audio</code> element (e.g., using the [[html]] <code>alt</code>
 								attribute).</p>
 						</section>
 					</section>
@@ -8826,7 +8826,7 @@ No Entry</pre>
 							text element and/or has no text fallback), this may produce unexpected results.</p>
 
 						<div class="note">
-							<p>See <a data-cite="epub-tts-10#">EPUB 3 Text-to-Speech Support</a> [[EPUB-TTS-10]] for
+							<p>See <a data-cite="epub-tts-10#">EPUB 3 Text-to-Speech Support</a> [[epub-tts-10]] for
 								more information about using TTS technologies in EPUB publications.</p>
 						</div>
 					</section>
@@ -8844,7 +8844,7 @@ No Entry</pre>
 					<p>The <code>epub:type</code> attribute facilitates reading system behavior appropriate for the
 						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
 							>skippability and escapability</a> and <a data-cite="epub-rs-33#note-table-reading-mode"
-							>table reading mode</a> [[?EPUB-RS-33]].</p>
+							>table reading mode</a> [[?epub-rs-33]].</p>
 
 					<p>Media Overlays MAY use the applicable <a href="#sec-vocab-assoc">vocabulary association
 							mechanisms</a> for the <code>epub:type</code> attribute to define additional semantics.</p>
@@ -8902,7 +8902,7 @@ No Entry</pre>
 					<p>EPUB creators MUST define exactly one CSS class name in each property they define. Each property
 						MUST define a <a href="https://www.w3.org/TR/CSS2/syndata.html#characters">valid CSS class
 							name</a> not including any <a href="https://www.w3.org/TR/CSS2/selector.html">selectors</a>
-						[[CSS2]]. This specification <strong>does not</strong> reserve names for use with these
+						[[css2]]. This specification <strong>does not</strong> reserve names for use with these
 						properties.</p>
 
 					<p>EPUB creators MAY define any CSS properties for the specified CSS classes but must ensure that
@@ -8997,7 +8997,7 @@ html.my-document-playing * {
 						<p>If an <a>EPUB content document</a> is wholly or partially referenced by a Media Overlay, then
 							its <a>manifest</a>
 							<a href="#elemdef-package-item"><code>item</code> element</a> MUST specify a
-								<code>media-overlay</code> attribute. The attribute MUST reference the ID [[XML]] of the
+								<code>media-overlay</code> attribute. The attribute MUST reference the ID [[xml]] of the
 							manifest <code>item</code> for the corresponding media overlay document.</p>
 
 						<p>EPUB creators MUST only specify the <code>media-overlay</code> attribute on manifest
@@ -9124,18 +9124,18 @@ html.my-document-playing * {
 
 					<ul>
 						<li>
-							<p><a data-cite="epub-ssv-11#footnote"><code>footnote</code></a> [[EPUB-SSV-11]]</p>
+							<p><a data-cite="epub-ssv-11#footnote"><code>footnote</code></a> [[epub-ssv-11]]</p>
 						</li>
 						<li>
-							<p><a data-cite="epub-ssv-11#endnote"><code>endnote</code></a> [[EPUB-SSV-11]]</p>
+							<p><a data-cite="epub-ssv-11#endnote"><code>endnote</code></a> [[epub-ssv-11]]</p>
 						</li>
 						<li>
-							<p><a data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code></a> [[EPUB-SSV-11]]</p>
+							<p><a data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code></a> [[epub-ssv-11]]</p>
 						</li>
 					</ul>
 
 					<p>This list is non-exhaustive, however. It represents terms from the Structural Semantics
-						Vocabulary [[?EPUB-SSV-11]] for which reading systems are most likely to offer the option of
+						Vocabulary [[?epub-ssv-11]] for which reading systems are most likely to offer the option of
 						skippability.</p>
 
 					<aside class="example" title="Media Overlay with a page break">
@@ -9219,21 +9219,21 @@ html.my-document-playing * {
 
 					<ul>
 						<li>
-							<p><a data-cite="epub-ssv-11#table"><code>table</code></a> [[EPUB-SSV-11]]</p>
+							<p><a data-cite="epub-ssv-11#table"><code>table</code></a> [[epub-ssv-11]]</p>
 						</li>
 						<li>
-							<p><a data-cite="epub-ssv-11#list"><code>list</code></a> [[EPUB-SSV-11]]</p>
+							<p><a data-cite="epub-ssv-11#list"><code>list</code></a> [[epub-ssv-11]]</p>
 						</li>
 						<li>
-							<p><a data-cite="epub-ssv-11#figure"><code>figure</code></a> [[EPUB-SSV-11]]</p>
+							<p><a data-cite="epub-ssv-11#figure"><code>figure</code></a> [[epub-ssv-11]]</p>
 						</li>
 						<li>
-							<p><a data-cite="epub-ssv-11#aside"><code>aside</code></a> [[EPUB-SSV-11]]</p>
+							<p><a data-cite="epub-ssv-11#aside"><code>aside</code></a> [[epub-ssv-11]]</p>
 						</li>
 					</ul>
 
 					<p>This list is non-exhaustive list, however. It represents terms from the Structural Semantics
-						Vocabulary [[?EPUB-SSV-11]] for which reading systems are most likely to offer the option of
+						Vocabulary [[?epub-ssv-11]] for which reading systems are most likely to offer the option of
 						escapability.</p>
 
 					<div class="note">
@@ -9372,7 +9372,7 @@ html.my-document-playing * {
 					associate an audio Media Overlay with it. Unlike traditional XHTML content documents, however,
 						<a>reading systems</a> must present the EPUB navigation document to users even when it is not
 					included in the <a>spine</a> (see <a data-cite="epub-rs-33#sec-nav">Navigation document
-						processing</a> [[EPUB-RS-33]]). As a result, the method in which an associated Media Overlay
+						processing</a> [[epub-rs-33]]). As a result, the method in which an associated Media Overlay
 					behaves can change depending on the context:</p>
 
 				<ul>
@@ -9401,16 +9401,16 @@ html.my-document-playing * {
 				by extension, accessibility built into its underlying technologies.</p>
 
 			<p>The requirements and practices for creating accessible web content have already been documented in the
-				W3C's <a href="https://www.w3.org/TR/wcag2/">Web Content Accessibility Guidelines (WCAG)</a> [[WCAG2]].
+				W3C's <a href="https://www.w3.org/TR/wcag2/">Web Content Accessibility Guidelines (WCAG)</a> [[wcag2]].
 				These guidelines also form the basis for defining accessibility in EPUB publications.</p>
 
 			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, <a
-					data-cite="epub-a11y-11#">EPUB Accessibility</a> [[EPUB-A11Y-11]], defines how to apply the standard
+					data-cite="epub-a11y-11#">EPUB Accessibility</a> [[epub-a11y-11]], defines how to apply the standard
 				to <a>EPUB publications</a>. It also adds EPUB-specific requirements and recommendations for metadata,
 				pagination, and media overlays.</p>
 
 			<p>This specification recommends that EPUB publications <a href="#confreq-a11y">conform to the accessibility
-					requirements</a> defined in [[EPUB-A11Y-11]]. A benefit of following this recommendation is that it
+					requirements</a> defined in [[epub-a11y-11]]. A benefit of following this recommendation is that it
 				helps to ensure that EPUB publications meet the accessibility requirements legislated in jurisdictions
 				around the world.</p>
 
@@ -9448,7 +9448,7 @@ html.my-document-playing * {
 				<div class="note">
 					<p>For the risks associated with reading systems, refer to the <a
 							data-cite="epub-rs-33#sec-security-privacy">security and privacy section</a> of
-						[[EPUB-RS-33]].</p>
+						[[epub-rs-33]].</p>
 				</div>
 			</section>
 
@@ -9576,7 +9576,7 @@ html.my-document-playing * {
 					</ul>
 
 					<p>The one potential exception is the <a data-cite="epub-rs-33#app-epubReadingSystem"
-								><code>epubReadingSystem</code> object</a> [[EPUB-RS-33]] that allows EPUB creators to
+								><code>epubReadingSystem</code> object</a> [[epub-rs-33]] that allows EPUB creators to
 						query information about the current reading system. EPUB creators need to be mindful that they
 						only use the information exposed by this object to improve the rendering of their content (i.e.,
 						avoid using the information to profile the user and their environment).</p>
@@ -9601,8 +9601,8 @@ html.my-document-playing * {
 					<li>Using secure connections to external sites and resources (i.e., using the HTTPS protocol).</li>
 					<li>Not using scripts to send or receive data over the network without the consent of the user.</li>
 					<li>Obtaining user consent for the use of Web APIs with privacy implications, such as <a
-							href="https://www.w3.org/TR/geolocation/">Geolocation</a> [[GEOLOCATION]] and <a
-							href="https://www.w3.org/TR/push-api">Push Notifications</a> [[PUSH-API]].</li>
+							href="https://www.w3.org/TR/geolocation/">Geolocation</a> [[geolocation]] and <a
+							href="https://www.w3.org/TR/push-api">Push Notifications</a> [[push-api]].</li>
 					<li>Avoiding embedding content not provided by reputable organizations or individuals.</li>
 					<li>Avoiding deprecated features of EPUB due to the potential for undiscovered bugs in
 						implementations.</li>
@@ -9737,8 +9737,8 @@ html.my-document-playing * {
 			<h2>Allowed external identifiers</h2>
 
 			<p>The following table lists the <a aria-label="public identifiers" data-cite="xml#dt-pubid">public </a> and
-					<a data-cite="xml#dt-sysid">system identifiers</a> [[XML]] allowed in <a data-cite="xml#dt-doctype"
-					>document type declarations</a>. [[XML]]</p>
+					<a data-cite="xml#dt-sysid">system identifiers</a> [[xml]] allowed in <a data-cite="xml#dt-doctype"
+					>document type declarations</a>. [[xml]]</p>
 
 			<p>EPUB creators MAY use these external identifiers only in <a>publication resources</a> with the listed
 				media types specified in their <a href="#sec-manifest-elem">manifest</a> declarations. (Refer to <a
@@ -9811,7 +9811,7 @@ html.my-document-playing * {
 					the structural information it carries complementing the underlying vocabulary.</p>
 
 				<p>The applied semantics refine the meaning of their containing elements without changing their nature
-					for assistive technologies, as happens when using the similar [^/role^] attribute [[HTML]]. The
+					for assistive technologies, as happens when using the similar [^/role^] attribute [[html]]. The
 					attribute does not enhance the accessibility of the content, in other words, only provides hints
 					about the purpose.</p>
 
@@ -9853,17 +9853,17 @@ html.my-document-playing * {
 					<dd>
 						<p>A white space-separated list of <a href="#sec-property-datatype">property</a> values, with
 							restrictions as defined in <a href="#sec-vocab-assoc"></a>.</p>
-						<p>White space is the set of characters as defined in [[XML]].</p>
+						<p>White space is the set of characters as defined in [[xml]].</p>
 					</dd>
 				</dl>
 
 				<div class="caution">
 					<p>Although the <code>epub:type</code> attribute is similar in nature to the [^/role^]
-						attribute [[HTML]], the attributes serve different purposes. The values of the
+						attribute [[html]], the attributes serve different purposes. The values of the
 							<code>epub:type</code> attribute do not enhance access through assistive technologies like
 						screen readers as they do not map to the accessibility <abbr
 							title="Application Programming Interfaces">APIs</abbr> used by these technologies. This
-						means that adding <code>epub:type</code> values to semantically neutral elements like [[HTML]]
+						means that adding <code>epub:type</code> values to semantically neutral elements like [[html]]
 								<a><code>div</code></a> and <a><code>span</code></a> does not make them any more
 						accessible to assistive technologies. Only ARIA roles influence how assistive technologies
 						understand such elements.</p>
@@ -9874,7 +9874,7 @@ html.my-document-playing * {
 						interaction with assistive technologies is not essential.</p>
 
 					<p>Refer to <a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA
-						Module</a> [[?DPUB-ARIA]] for more information about accessible publishing roles.</p>
+						Module</a> [[?dpub-aria]] for more information about accessible publishing roles.</p>
 				</div>
 
 				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
@@ -9882,7 +9882,7 @@ html.my-document-playing * {
 					document instance.</p>
 
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
-					the EPUB 3 Structural Semantics Vocabulary [[?EPUB-SSV-11]]. EPUB creators MAY include unprefixed
+					the EPUB 3 Structural Semantics Vocabulary [[?epub-ssv-11]]. EPUB creators MAY include unprefixed
 					terms that are not part of this vocabulary, but the preferred method for adding custom semantics is
 					to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a href="#sec-vocab-assoc"></a>
 					for more information.</p>
@@ -9958,7 +9958,7 @@ html.my-document-playing * {
 							semantics</a>, for example, while the <code>property</code> and <code>rel</code> attributes
 						use the data type to define properties and relationships in the <a>package document</a>.</p>
 
-					<p>A <var>property</var> value is like a CURIE [[RDFA-CORE]] &#8212; it represents a URL [[URL]] in
+					<p>A <var>property</var> value is like a CURIE [[rdfa-core]] &#8212; it represents a URL [[url]] in
 						compact form. The expression consists of a prefix and a reference, where the prefix — whether
 						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
 						vocabulary. When a reading system converts the prefix to its URL representation and combines
@@ -9983,7 +9983,7 @@ html.my-document-playing * {
 				<section id="sec-property-datatype">
 					<h4>The <var>property</var> data type</h4>
 
-					<p>The <var>property</var> data type is a compact means of expressing a URL [[URL]] and consists of
+					<p>The <var>property</var> data type is a compact means of expressing a URL [[url]] and consists of
 						an OPTIONAL prefix separated from a reference by a colon.</p>
 
 					<table class="productionset">
@@ -10018,13 +10018,13 @@ html.my-document-playing * {
 							<td>
 								<code>=</code>
 							</td>
-							<td>? <a>path-relative-scheme-less-URL string</a> [[URL]] ? ;</td>
-							<td>/* as defined in [[URL]] */<br /></td>
+							<td>? <a>path-relative-scheme-less-URL string</a> [[url]] ? ;</td>
+							<td>/* as defined in [[url]] */<br /></td>
 						</tr>
 					</table>
 
 					<p>This specification derives the <var>property</var> data type from the CURIE data type defined in
-						[[RDFA-CORE]]. A <var>property</var> represents a subset of CURIEs.</p>
+						[[rdfa-core]]. A <var>property</var> represents a subset of CURIEs.</p>
 
 					<aside class="example" title="Expanding a metadata property value">
 						<p>In this example, the <var>property</var> value is composed of the prefix <code>dcterms</code>
@@ -10032,7 +10032,7 @@ html.my-document-playing * {
 
 						<pre>&lt;meta property="dcterms:modified">2011-01-01T12:00:00Z&lt;/meta></pre>
 
-						<p>After <a data-cite="epub-rs-33#sec-property-datatype">processing</a> [[EPUB-RS-33]], this
+						<p>After <a data-cite="epub-rs-33#sec-property-datatype">processing</a> [[epub-rs-33]], this
 							property would expand to the following URL:</p>
 
 						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>
@@ -10182,7 +10182,7 @@ html.my-document-playing * {
 
 					<div class="note">
 						<p>Although the <code>prefix</code> attribute is modeled on the identically named
-								<code>prefix</code> attribute in [[RDFA-CORE]], EPUB creators cannot use the attributes
+								<code>prefix</code> attribute in [[rdfa-core]], EPUB creators cannot use the attributes
 							interchangeably. The <code>prefix</code> attribute without a namespace in EPUB content
 							documents is the RDFa attribute.</p>
 
@@ -10196,17 +10196,17 @@ html.my-document-playing * {
 					</div>
 
 					<p>Note that for <a href="#sec-xhtml-svg">embedded SVG</a>, prefixes MUST be declared on the
-						[[HTML]] root <a><code>html</code></a> element.</p>
+						[[html]] root <a><code>html</code></a> element.</p>
 
 					<p>To avoid conflicts, EPUB creators MUST NOT use the <code>prefix</code> attribute to declare a
 						prefix that maps to the <a href="#sec-default-vocab">default vocabulary</a>.</p>
 
 					<p>EPUB creators MUST NOT declare the prefix '_' as this specification reserves this prefix for
-						future compatibility with RDFa [[RDFA-CORE]] processing.</p>
+						future compatibility with RDFa [[rdfa-core]] processing.</p>
 
 					<p>For future compatibility with alternative serializations of the package document, EPUB creators
-						MUST NOT declare a prefix for the Dublin Core <em>/elements/1.1/</em> namespace [[DCTERMS]].
-							<a>EPUB creators</a> MUST use only the [[DCTERMS]] elements <a href="#sec-pkg-metadata"
+						MUST NOT declare a prefix for the Dublin Core <em>/elements/1.1/</em> namespace [[dcterms]].
+							<a>EPUB creators</a> MUST use only the [[dcterms]] elements <a href="#sec-pkg-metadata"
 							>allowed in the package document metadata</a>.</p>
 				</section>
 
@@ -10316,7 +10316,7 @@ html.my-document-playing * {
 				<dl>
 					<dt>Allowed Values</dt>
 					<dd>
-						<p>Specifies the REQUIRED type of value using [[!XMLSCHEMA-2]] datatypes.</p>
+						<p>Specifies the REQUIRED type of value using [[!xmlschema-2]] datatypes.</p>
 					</dd>
 
 					<dt>Applies To</dt>
@@ -10383,14 +10383,14 @@ html.my-document-playing * {
 			<section id="sec-css-prefixed-writing-modes">
 				<h5>CSS writing modes</h5>
 
-				<p>This section describes the <code>-epub-</code> prefixed properties for [[CSS-Writing-Modes-3]].</p>
+				<p>This section describes the <code>-epub-</code> prefixed properties for [[css-writing-modes-3]].</p>
 
 				<section id="sec-css-prefixed-writing-modes-text-orientation" data-tests="#css-epub-text-orientation">
 					<h6>The <code>-epub-text-orientation</code> property</h6>
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-writing-modes-3#propdef-text-orientation"><code>text-orientation</code>
-							property</a> [[CSS-Writing-Modes-3]].</p>
+							property</a> [[css-writing-modes-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10439,7 +10439,7 @@ html.my-document-playing * {
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-writing-modes-3#propdef-writing-mode"><code>writing-mode</code> property</a>
-						[[CSS-Writing-Modes-3]], with the same syntax and behavior.</p>
+						[[css-writing-modes-3]], with the same syntax and behavior.</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10461,7 +10461,7 @@ html.my-document-playing * {
 
 					<p>These properties are prefixed versions of the <a
 							data-cite="css-writing-modes-3#text-combine-upright"><code>text-combine-upright</code>
-							property</a> [[CSS-Writing-Modes-3]], although <code>-epub-text-combine</code> is
+							property</a> [[css-writing-modes-3]], although <code>-epub-text-combine</code> is
 						deprecated.</p>
 
 					<table class="tabledef">
@@ -10531,13 +10531,13 @@ html.my-document-playing * {
 				<h5>CSS text level 3</h5>
 
 				<p>This section describes the <code>-epub-</code> prefixed properties (and one prefixed value) for
-					[[CSS-Text-3]].</p>
+					[[css-text-3]].</p>
 
 				<section id="sec-css-prefixed-text-epub-hyphens" data-tests="#css-epub-hyphens">
 					<h6>The <code>-epub-hyphens</code> property</h6>
 
 					<p>This property is a prefixed version of the <a data-cite="css-text-3#hyphens-property"
-								><code>hyphens</code> property</a> [[CSS-Text-3]].</p>
+								><code>hyphens</code> property</a> [[css-text-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10561,7 +10561,7 @@ html.my-document-playing * {
 					<h6>The <code>-epub-line-break</code> property</h6>
 
 					<p>This property is a prefixed version of the <a data-cite="css-text-3#line-break-property"
-								><code>line-break</code> property</a> [[CSS-Text-3]].</p>
+								><code>line-break</code> property</a> [[css-text-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10581,7 +10581,7 @@ html.my-document-playing * {
 					<h6>The <code>-epub-text-align-last</code> property</h6>
 
 					<p>This property is a prefixed version of the <a data-cite="css-text-3#text-align-last-property"
-								><code>text-align-last</code> property</a> [[CSS-Text-3]].</p>
+								><code>text-align-last</code> property</a> [[css-text-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10601,7 +10601,7 @@ html.my-document-playing * {
 					<h6>The <code>-epub-word-break</code> property</h6>
 
 					<p>This property is a prefixed version of the <a data-cite="css-text-3#word-break-property"
-								><code>word-break</code> property</a> [[CSS-Text-3]].</p>
+								><code>word-break</code> property</a> [[css-text-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10621,7 +10621,7 @@ html.my-document-playing * {
 					<h6>The <code>text-transform</code> property</h6>
 
 					<p>This property is a prefixed value for the <a data-cite="css-text-3#text-transform-property"
-								><code>text-transform</code> property</a> [[CSS-Text-3]].</p>
+								><code>text-transform</code> property</a> [[css-text-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10645,14 +10645,14 @@ html.my-document-playing * {
 			<section id="sec-css-prefixed-text-decoration">
 				<h5>CSS text decoration level 3</h5>
 
-				<p>This section describes the <code>-epub-</code> prefixed properties for [[CSS-Text-Decor-3]].</p>
+				<p>This section describes the <code>-epub-</code> prefixed properties for [[css-text-decor-3]].</p>
 
 				<section id="sec-css-prefixed-text-epub-text-emphasis-color" data-tests="#css-epub-text-emphasis">
 					<h6>The <code>-epub-text-emphasis-color</code> Property</h6>
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-text-decor-3#text-emphasis-color-property"><code>text-emphasis-color</code>
-							property</a> [[CSS-Text-Decor-3]].</p>
+							property</a> [[css-text-decor-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10673,7 +10673,7 @@ html.my-document-playing * {
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-text-decor-3#text-emphasis-position-property"
-								><code>text-emphasis-position</code> property</a> [[CSS-Text-Decor-3]].</p>
+								><code>text-emphasis-position</code> property</a> [[css-text-decor-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10694,7 +10694,7 @@ html.my-document-playing * {
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-text-decor-3#text-emphasis-style-property"><code>text-emphasis-style</code>
-							property</a> [[CSS-Text-Decor-3]].</p>
+							property</a> [[css-text-decor-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10717,7 +10717,7 @@ html.my-document-playing * {
 
 					<p>This property is a prefixed version of the <a
 							data-cite="css-text-decor-3#text-underline-position-property"
-								><code>text-underline-position</code> property</a> [[CSS-Text-Decor-3]].</p>
+								><code>text-underline-position</code> property</a> [[css-text-decor-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10748,8 +10748,8 @@ html.my-document-playing * {
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
 						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.</p>
 
-				<p>Validation using this schema requires a processor that supports [[NVDL]], [[RelaxNG-Schema]],
-					[[ISOSchematron]] and [[XMLSCHEMA-2]].</p>
+				<p>Validation using this schema requires a processor that supports [[nvdl]], [[relaxng-schema]],
+					[[isoschematron]] and [[xmlschema-2]].</p>
 
 				<div class="note">
 					<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG
@@ -10772,22 +10772,22 @@ html.my-document-playing * {
 							href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl">
 							<code>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl</code></a>.</p>
 
-					<p>Validation using this schema requires a processor that supports [[RelaxNG-Schema]] and
-						[[XMLSCHEMA-2]].</p>
+					<p>Validation using this schema requires a processor that supports [[relaxng-schema]] and
+						[[xmlschema-2]].</p>
 				</section>
 
 				<section id="app-schema-encryption">
 					<h4>Schema for <code>encryption.xml</code></h4>
 
 					<p>The schema for <code>encryption.xml</code> files is included in
-						[[XMLSEC-RNGSCHEMA-20130411]].</p>
+						[[xmlsec-rngschema-20130411]].</p>
 				</section>
 
 				<section id="app-schema-signatures">
 					<h4>Schema for <code>signatures.xml</code></h4>
 
 					<p>The schema for <code>signatures.xml</code> files is included in
-						[[XMLSEC-RNGSCHEMA-20130411]].</p>
+						[[xmlsec-rngschema-20130411]].</p>
 				</section>
 			</section>
 
@@ -10798,8 +10798,8 @@ html.my-document-playing * {
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl"
 						>https://github.com/w3c/epubcheck/tree/main/src/master/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl</a>.</p>
 
-				<p>Validation using this schema requires a processor that supports [[NVDL]], [[RelaxNG-Schema]],
-					[[ISOSchematron]] and [[XMLSCHEMA-2]].</p>
+				<p>Validation using this schema requires a processor that supports [[nvdl]], [[relaxng-schema]],
+					[[isoschematron]] and [[xmlschema-2]].</p>
 
 				<div class="note">
 					<p>The NVDL schema layer can be substituted by a multi-pass validation using the embedded RELAX NG
@@ -10942,7 +10942,7 @@ html.my-document-playing * {
 
 					<dt><code>style.css</code></dt>
 					<dd>
-						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[HTML]]
+						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[html]]
 								<a data-lt="link"><code>link</code> element</a>. It is a <a>publication resource</a> on
 							the <a>manifest plane</a>, a <a>container resource</a>, is not present on the <a>spine
 								plane</a>, and is a <a>core media type resource</a> on the <a>content plane</a>. No
@@ -10978,7 +10978,7 @@ html.my-document-playing * {
 					<dt><code>speech/cmn.pls</code></dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
-							from an [[HTML]] <a data-lt="link"><code>link</code> element</a>. It is a <a>publication
+							from an [[html]] <a data-lt="link"><code>link</code> element</a>. It is a <a>publication
 								resource</a> on the <a>manifest plane</a>, a <a>container resource</a>, not present on
 							the <a>spine plane</a>, and is an <a>exempt resource</a> on the <a>content plane</a>. No
 							fallback is necessary.</p>
@@ -10987,7 +10987,7 @@ html.my-document-playing * {
 					<dt><code>image/image_1.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-lt="img"><code>img</code> element</a>. It is a <a>publication resource</a>
+							[[html]] <a data-lt="img"><code>img</code> element</a>. It is a <a>publication resource</a>
 							on the <a>manifest plane</a>, a <a>container resource</a>, is not present on the <a>spine
 								plane</a>, and is a <a>core media type resource</a> on the <a>content plane</a>. No
 							fallback is necessary.</p>
@@ -10995,7 +10995,7 @@ html.my-document-playing * {
 
 					<dt><code>image/image_2.png</code></dt>
 					<dd>
-						<p>The resource is a PNG image file. It is referenced via an [[HTML]] <a data-lt="a"
+						<p>The resource is a PNG image file. It is referenced via an [[html]] <a data-lt="a"
 									><code>a</code> element</a>. Because it is referenced from a hyperlink, it
 								<em>must</em> be listed in the spine. It is a <a>publication resource</a> on the
 								<a>manifest plane</a>, a <a>container resource</a>, a <a>foreign content document</a> on
@@ -11017,20 +11017,20 @@ html.my-document-playing * {
 					<dt><code>image/image_3.heic</code></dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
-							referenced from an [[HTML]] <a data-lt="source"><code>source</code> element</a>. Its media
+							referenced from an [[html]] <a data-lt="source"><code>source</code> element</a>. Its media
 							type is not listed as a <a href="#sec-core-media-types">core media type</a>. It is a
 								<a>publication resource</a> on the <a>manifest plane</a>, a <a>container resource</a>,
 							is not present on the <a>spine plane</a>, and is a <a>foreign resource</a> on the <a>content
 								plane</a>. As a <a>foreign resource</a>, a fallback is required, which is provided via
-							the sibling [[HTML]] <a data-lt="img"><code>img</code> element</a> in an [[HTML]] <a
+							the sibling [[html]] <a data-lt="img"><code>img</code> element</a> in an [[html]] <a
 								data-lt="picture"><code>picture</code> element</a>.</p>
 					</dd>
 
 					<dt><code>image/image_3.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-lt="img"><code>img</code> element</a> that is used as an intrinsic fallback
-							of the [[HTML]] <a data-lt="picture"><code>picture</code> element</a>. It is a
+							[[html]] <a data-lt="img"><code>img</code> element</a> that is used as an intrinsic fallback
+							of the [[html]] <a data-lt="picture"><code>picture</code> element</a>. It is a
 								<a>publication resource</a> on the <a>manifest plane</a>, a <a>container resource</a>,
 							is not present on the <a>spine plane</a>, and is a <a>core media type resource</a> on the
 								<a>content plane</a>. No fallback is necessary.</p>
@@ -11039,7 +11039,7 @@ html.my-document-playing * {
 					<dt><code>widget.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
-							[[HTML]] <a data-lt="iframe"><code>iframe</code> element</a>. It is a <a>publication
+							[[html]] <a data-lt="iframe"><code>iframe</code> element</a>. It is a <a>publication
 								resource</a> on the <a>manifest plane</a>, a <a>container resource</a>, is not present
 							on <a>spine plane</a>, and, because it is "used" when rendering another EPUB content
 							document, a <a>core media type resource</a> on the <a>content plane</a>. No fallback is
@@ -11048,7 +11048,7 @@ html.my-document-playing * {
 
 					<dt><code>https://www.example.org/some_content</code></dt>
 					<dd>
-						<p>The resource is referenced via an [[HTML]] <a data-lt="a"><code>a</code> element</a> and is
+						<p>The resource is referenced via an [[html]] <a data-lt="a"><code>a</code> element</a> and is
 							not stored in the <a>EPUB container</a>. Reading systems will normally open this link via a
 							separate browser instance. It is not on any planes defined by this specification.</p>
 					</dd>
@@ -11452,7 +11452,7 @@ EPUB/images/cover.png</pre>
 				<h3>The <code>application/oebps-package+xml</code> media type</h3>
 
 				<p>This appendix registers the media type <code>application/oebps-package+xml</code> for the EPUB
-					package document. This registration supersedes [[RFC4839]].</p>
+					package document. This registration supersedes [[rfc4839]].</p>
 
 				<p>The package document is an XML file that describes an EPUB publication. It identifies the resources
 					in the EPUB publication and provides metadata information. The package document and its related
@@ -11574,7 +11574,7 @@ EPUB/images/cover.png</pre>
 					Format (OCF).</p>
 
 				<p>An <a>OCF ZIP container</a>, or <a>EPUB container</a>, file is a container technology based on the
-					[[ZIP]] archive format. It is used to encapsulate the EPUB publication. OCF and its related
+					[[zip]] archive format. It is used to encapsulate the EPUB publication. OCF and its related
 					standards are maintained and defined by the <a href="https://www.w3.org">World Wide Web
 						Consortium</a> (W3C).</p>
 
@@ -11885,7 +11885,7 @@ EPUB/images/cover.png</pre>
 				<li>08-Mar-2021: Change requirement that Media Overlay <code>par</code> and <code>seq</code> ordering
 					match the default reading order to guidance. See <a
 						href="https://github.com/w3c/epub-specs/issues/1458">issue 1458</a></li>
-				<li>05-Mar-2021: Clarified that whitespace within metadata element values is collapsed per the [[Infra]]
+				<li>05-Mar-2021: Clarified that whitespace within metadata element values is collapsed per the [[infra]]
 					specification definition. See <a href="https://github.com/w3c/epub-specs/issues/1528">issue
 					1528</a>.</li>
 				<li>26-Feb-2021: Created a new section for describing general metadata value requirements, specifically
@@ -11925,7 +11925,7 @@ EPUB/images/cover.png</pre>
 					simplified to improve the readability of the specifications (i.e., to align with the generally
 					understood concept that an EPUB publication has only a single rendering described by a single
 					package document). These changes do not affect the ability to include multiple renditions, which are
-					now more fully covered in [[EPUB-MULTI-REND-11]]. See <a
+					now more fully covered in [[epub-multi-rend-11]]. See <a
 						href="https://github.com/w3c/epub-specs/issues/1436">issue 1436</a>.</li>
 				<li>14-Nov-2020: The term "semantic inflection" is no longer used to describe the process of adding
 					structural semantics to elements. The term is not widely understood outside of EPUB and is

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -175,7 +175,7 @@
 						<p>The <code>svg</code> property indicates that the described publication resource
 							embeds one or more instances of SVG markup.</p>
 						<p>This property MUST be set when SVG markup is included directly in the resource and
-							MAY be set when the SVG is referenced from the resource (e.g., from an [[HTML]]
+							MAY be set when the SVG is referenced from the resource (e.g., from an [[html]]
 								<code>img</code>, <code>object</code> or <code>iframe</code> element).</p>
 					</td>
 				</tr>

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -113,7 +113,7 @@
 			
 			<p>Refer to the <a 
 				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"><code>marc21xml-record</code>
-				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
+				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 		<section id="sec-mods-record">
 			<h5>mods-record (deprecated)</h5>
@@ -125,7 +125,7 @@
 			
 			<p>Refer to the <a 
 				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"><code>mods-record</code>
-				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
+				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 		<section id="sec-onix-record">
 			<h5>onix-record (deprecated)</h5>
@@ -137,7 +137,7 @@
 			
 			<p>Refer to the <a 
 				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"><code>onix-record</code>
-				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
+				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 		<section id="sec-record">
 			<h5>record</h5>
@@ -235,7 +235,7 @@
 			
 			<p>Refer to the <a 
 				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"><code>xml-signature</code>
-				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
+				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 		<section id="sec-xmp-record">
 			<h5>xmp-record (deprecated)</h5>
@@ -247,7 +247,7 @@
 			
 			<p>Refer to the <a 
 				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"><code>xmp-record</code>
-				property definition</a> in [[!EPUBPublications-30]] for more information.</p>
+				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 	</section>
 	<section id="sec-link-properties">
@@ -269,7 +269,7 @@
 					<tr>
 						<th>Description:</th>
 						<td>The <code>onix</code> property indicates the referenced resource is an ONIX record
-							[[!ONIX]].</td>
+							[[!onix]].</td>
 					</tr>
 					<tr>
 						<th>Example:</th>
@@ -294,7 +294,7 @@
 					<tr>
 						<th>Description:</th>
 						<td>The <code>xmp</code> property indicates the referenced resource is an XMP record
-							[[!XMP]].</td>
+							[[!xmp]].</td>
 					</tr>
 					<tr>
 						<th>Example:</th>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -518,7 +518,7 @@
 		
 		<p>Refer to the <a 
 			href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"><code>meta-auth</code>
-			property definition</a> in [[!EPUBPublications-30]] for more information.</p>
+			property definition</a> in [[!epubpublications-30]] for more information.</p>
 	</section>
 	<section id="sec-role">
 		<h5>role</h5>
@@ -662,7 +662,7 @@
 				</tr>
 			</tbody>
 		</table>
-		<p class="note">See [[EPUB-A11Y-TECH-11]] for information on how to provide accessible page navigation.</p>
+		<p class="note">See [[epub-a11y-tech-11]] for information on how to provide accessible page navigation.</p>
 		<aside class="example" title="Identifying the print pagination source of a publication">
 			<pre>&lt;metadata …>
    …

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -68,7 +68,7 @@
 				<tr>
 					<th>Allowed value(s):</th>
 					<td>
-						<p>MUST be a [[!SMIL3]] <a data-cite="smil3/smil-timing.html#q22">clock
+						<p>MUST be a [[!smil3]] <a data-cite="smil3/smil-timing.html#q22">clock
 								value</a>.</p>
 					</td>
 				</tr>

--- a/epub33/epub-aria-authoring/index.html
+++ b/epub33/epub-aria-authoring/index.html
@@ -28,17 +28,17 @@
 					branch: "main"
 				},
 				localBiblio: {
-					"DPUB-ARIA": {
+					"dpub-aria": {
 						"title": "Digital Publishing WAI-ARIA Module",
 						"url": "https://www.w3.org/TR/dpub-aria/",
 						"publisher": "W3C"
 					},
-					"EPUB-3": {
+					"epub-3": {
 						"title": "EPUB 3",
 						"url": "https://www.w3.org/TR/epub/",
 						"publisher": "W3C"
 					},
-					"WAI-ARIA": {
+					"wai-aria": {
 						"title": "Accessible Rich Internet Applications (WAI-ARIA)",
 						"url": "https://www.w3.org/TR/wai-aria/",
 						"publisher": "W3C"
@@ -75,8 +75,8 @@
 
 			<p>It is important to understand the differences between the <a
 					href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code> attribute</a>
-				[[EPUB-3]] and the <a href="https://www.w3.org/TR/wai-aria/#host_general_role"><code>role</code>
-					attribute</a> [[WAI-ARIA]] to ensure that they are properly applied for their intended purposes and
+				[[epub-3]] and the <a href="https://www.w3.org/TR/wai-aria/#host_general_role"><code>role</code>
+					attribute</a> [[wai-aria]] to ensure that they are properly applied for their intended purposes and
 				audiences.</p>
 
 			<p>Arguably the biggest difference is in their primary applications. The <code>epub:type</code> attribute
@@ -97,7 +97,7 @@
 				and breaking the reading experience for users of assistive technologies.</p>
 
 			<p class="note">This guide is not intended as a comprehensive overview of ARIA roles. For more information
-				about ARIA and how to apply it to HTML document, refer to [[WAI-ARIA]] and [[HTML-ARIA]],
+				about ARIA and how to apply it to HTML document, refer to [[wai-aria]] and [[html-aria]],
 				respectively.</p>
 		</section>
 		<section id="sec-guidelines">
@@ -111,13 +111,13 @@
 					where they will make sense to users of assistive technologies.</p>
 
 				<p>The following table maps the semantics from the <a href="https://www.w3.org/TR/epub-ssv-11/">EPUB
-						Structural Semantics Vocabulary</a> [[EPUB-SSV-11]] to the corresponding roles in [[WAI-ARIA]]
-					and the [[DPUB-ARIA]] module.</p>
+						Structural Semantics Vocabulary</a> [[epub-ssv-11]] to the corresponding roles in [[wai-aria]]
+					and the [[dpub-aria]] module.</p>
 
 				<p>As the use of the <a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"
-							><code>epub:type</code> attribute</a> [[EPUB-3]] is much more liberal than the <a
+							><code>epub:type</code> attribute</a> [[epub-3]] is much more liberal than the <a
 						href="https://www.w3.org/TR/wai-aria/#host_general_role"><code>role</code> attribute</a>
-					[[WAI-ARIA]], you cannot interchange types and roles on every HTML element, even when a role mapping
+					[[wai-aria]], you cannot interchange types and roles on every HTML element, even when a role mapping
 					exists. The elements you are allowed to use roles on are identified in the last column of the table.
 					In addition, refer to the note at the end of the table for the <a href="#role-general">list of
 						elements that accept any role value</a>.</p>
@@ -125,10 +125,10 @@
 				<table id="mappings">
 					<thead>
 						<tr>
-							<th>[[EPUB-SSV-11]]</th>
-							<th>[[EPUB-3]] manifest</th>
-							<th>[[DPUB-ARIA]]</th>
-							<th>[[WAI-ARIA]]</th>
+							<th>[[epub-ssv-11]]</th>
+							<th>[[epub-3]] manifest</th>
+							<th>[[dpub-aria]]</th>
+							<th>[[wai-aria]]</th>
 							<th>Elements Allowed On<a href="#role-general" role="doc-noteref" aria-label="note"
 								>*</a></th>
 						</tr>
@@ -1099,7 +1099,7 @@
 					</ul>
 				</aside>
 
-				<p class="note">See also the <a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a> [[HTML-ARIA]]
+				<p class="note">See also the <a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a> [[html-aria]]
 					document for more information about the correct use of ARIA roles, states and properties.</p>
 			</section>
 
@@ -1108,24 +1108,24 @@
 
 				<p>Only use <strong>one digital publishing role</strong> per <a
 						href="https://www.w3.org/TR/wai-aria/#host_general_role"><code>role</code> attribute</a>
-					[[WAI-ARIA]].</p>
+					[[wai-aria]].</p>
 
 				<aside class="example">
 					<pre>&lt;section role="doc-chapter"></pre>
 				</aside>
 
-				<p>If you include a second role, it must be a fallback from [[WAI-ARIA]].</p>
+				<p>If you include a second role, it must be a fallback from [[wai-aria]].</p>
 
 				<aside class="example">
 					<pre>&lt;section role="doc-chapter region"></pre>
 				</aside>
 
 				<p class="note">The fallback must not be an <a href="https://www.w3.org/TR/wai-aria/#abstract_roles"
-						>Abstract roles</a> [[WAI-ARIA]]. These roles are never allowed in the <code>role</code>
+						>Abstract roles</a> [[wai-aria]]. These roles are never allowed in the <code>role</code>
 					attribute.</p>
 
 				<p>Unlike the <a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code>
-						attribute</a> [[EPUB-3]], the order of roles is important, and only the first recognized role is
+						attribute</a> [[epub-3]], the order of roles is important, and only the first recognized role is
 					applied to an element.</p>
 			</section>
 
@@ -1135,7 +1135,7 @@
 				<p>Do not reapply a semantic just because your content has been chunked into separate files.</p>
 
 				<p>For example, ensure that the <a href="https://www.w3.org/TR/dpub-aria/#doc-part"
-							><code>doc-part</code> role</a> [[DPUB-ARIA]] is only applied to the section that contains
+							><code>doc-part</code> role</a> [[dpub-aria]] is only applied to the section that contains
 					the heading for the part. Do not reapply the part role for each chapter that belongs to the part, as
 					it will be announced to users of assistive technologies each time it occurs, causing confusion.</p>
 			</section>
@@ -1146,12 +1146,12 @@
 				<p>If a landmark role (e.g., <a href="https://www.w3.org/TR/dpub-aria/#doc-chapter"
 							><code>doc-chapter</code></a>, <a href="https://www.w3.org/TR/dpub-aria/#doc-part"
 							><code>doc-part</code></a>, <a href="https://www.w3.org/TR/dpub-aria/#doc-index"
-							><code>doc-index</code></a> [[DPUB-ARIA]]) does not include a label, assistive technologies
+							><code>doc-index</code></a> [[dpub-aria]]) does not include a label, assistive technologies
 					will only announce the generic name of the role in the landmarks.</p>
 
 				<p>To include a more descriptive label, use the <a
 						href="https://www.w3.org/TR/wai-aria/#aria-labelledby"><code>aria-labelledby</code>
-						attribute</a> [[WAI-ARIA]] to associate the label with the role.</p>
+						attribute</a> [[wai-aria]] to associate the label with the role.</p>
 
 				<aside class="example">
 					<pre>&lt;section role="doc-index" aria-labelledby="idx01">
@@ -1167,7 +1167,7 @@
 
 				<p>If a label is not available in the text, you can supply one in an <a
 						href="https://www.w3.org/TR/wai-aria/#aria-label"><code>aria-label</code> attribute</a>
-					[[WAI-ARIA]].</p>
+					[[wai-aria]].</p>
 
 				<aside class="example">
 					<pre>&lt;aside role="doc-tip" aria-label="Helpful Hint">
@@ -1180,14 +1180,14 @@
 				<h3>Do not override the <code>body</code> element</h3>
 
 				<p>The <a href="https://www.w3.org/TR/epub/#sec-epub-type-attribute"><code>epub:type</code>
-						attribute</a> [[EPUB-3]] may be used to inflect sectioning semantics on the [[HTML]] <a
+						attribute</a> [[epub-3]] may be used to inflect sectioning semantics on the [[html]] <a
 						href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element"><code>body</code>
 						element</a> (e.g., to indicate front matter, or to avoid using sectioning elements), but this
 					practice is both invalid and harmful with ARIA roles.</p>
 
 				<p>The <code>body</code> element has the implied role <a href="https://www.w3.org/TR/wai-aria/#document"
-							><code>document</code></a> [[WAI-ARIA]], and <a href="https://www.w3.org/TR/html-aria/#body"
-						>you cannot define any other role on it</a> [[HTML-ARIA]]. Changing the role of the
+							><code>document</code></a> [[wai-aria]], and <a href="https://www.w3.org/TR/html-aria/#body"
+						>you cannot define any other role on it</a> [[html-aria]]. Changing the role of the
 						<code>body</code> element can affect the ability to read the content for users of assistive
 					technologies.</p>
 			</section>
@@ -1198,7 +1198,7 @@
 				<p>Assigning a role to an element overrides its default nature, so use care when applying roles to lists
 					and list items.</p>
 
-				<p>Just as [[HTML]] <a
+				<p>Just as [[html]] <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element"
 							><code>ol</code></a> and <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element"
@@ -1215,17 +1215,17 @@
 				<p>Similarly, a list item must always be enclosed inside of a list.</p>
 
 				<div class="note">
-					<p>Due to a change in the [[WAI-ARIA]] roles model, list item roles defined in modules no longer
+					<p>Due to a change in the [[wai-aria]] roles model, list item roles defined in modules no longer
 						satisfy the requirement that the <a href="https://www.w3.org/TR/wai-aria/#list"
 								><code>list</code> role</a> have list item children. As a result, use of the <a
 							href="https://www.w3.org/TR/dpub-aria/#doc-bilioentry"><code>doc-biblioentry</code></a> and
 							<a href="https://www.w3.org/TR/dpub-aria/#doc-endnote"><code>doc-endnote</code></a> roles
-						[[DPUB-ARIA]] is now deprecated.</p>
+						[[dpub-aria]] is now deprecated.</p>
 
 					<p>These roles are now implied on list items within sections that have a <a
 							href="https://www.w3.org/TR/dpub-aria/#doc-bibliography"><code>doc-bibliography</code></a>
 						or <a href="https://www.w3.org/TR/dpub-aria/#doc-endnotes"><code>doc-endnotes</code></a> role
-						[[DPUB-ARIA]], respectively.</p>
+						[[dpub-aria]], respectively.</p>
 
 					<pre>&lt;section role="doc-bibliography">
    &lt;h2>Select Bibliography&lt;/h2>
@@ -1242,10 +1242,10 @@
 				<h3>Cover role is for images</h3>
 
 				<p>Although the <a href="https://www.w3.org/TR/DPUB-ARIA/#doc-cover"><code>doc-cover</code> role</a>
-					[[DPUB-ARIA]] seems like it should be the same as the <a
-						href="https://www.w3.org/TR/epub-ssv/#cover"><code>cover</code> semantic</a> [[EPUB-SSV-11]], it
+					[[dpub-aria]] seems like it should be the same as the <a
+						href="https://www.w3.org/TR/epub-ssv/#cover"><code>cover</code> semantic</a> [[epub-ssv-11]], it
 					is actually related to the <a href="https://www.w3.org/TR/epub/#cover-image"
-							><code>cover-image</code> semantic</a> [[EPUB-3]] used to identify cover images in the EPUB
+							><code>cover-image</code> semantic</a> [[epub-3]] used to identify cover images in the EPUB
 					package document. The role is used to identify an image that represents the cover.</p>
 
 				<aside class="example">
@@ -1256,7 +1256,7 @@
 				</aside>
 
 				<p><strong>Do not</strong> use this role to identify a section of content containing the cover. Placing
-					the role on an [[HTML]] <a
+					the role on an [[html]] <a
 						href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element"
 							><code>section</code> element</a>, for example, informs assistive technologies to treat the
 					element like they would an image. In practical terms, this means that none of its content will be
@@ -1265,7 +1265,7 @@
 				<p>If a section of cover content needs to be identified as a landmark, you can use the <a
 						href="https://www.w3.org/TR/wai-aria/#aria-label"><code>aria-label</code></a> or <a
 						href="https://www.w3.org/TR/wai-aria/#aria-labelledby"><code>aria-labelledby</code></a>
-					attributes [[WAI-ARIA]] with a <code>section</code> element.</p>
+					attributes [[wai-aria]] with a <code>section</code> element.</p>
 
 				<aside class="example">
 					<pre>&lt;section aria-label="Cover: As I Lay Dying. William Faulkner">
@@ -1273,12 +1273,12 @@
 &lt;/section></pre>
 				</aside>
 
-				<p class="note">For [[HTML]] <a
+				<p class="note">For [[html]] <a
 						href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element"
 							><code>div</code> elements</a>, the general <a href="https://www.w3.org/TR/wai-aria/#region"
-							><code>region</code> role</a> [[WAI-ARIA]] is also needed. For more information about how to
+							><code>region</code> role</a> [[wai-aria]] is also needed. For more information about how to
 					use roles in content, refer to <a href="https://www.w3.org/TR/html-aria/">ARIA in HTML</a>
-					[[HTML-ARIA]].</p>
+					[[html-aria]].</p>
 			</section>
 		</section>
 	</body>

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -64,7 +64,7 @@
                   }
               ],
 				localBiblio: {
-					"SVG": {
+					"svg": {
 						"title": "SVG",
 						"href": "https://www.w3.org/TR/SVG/",
 						"publisher": "W3C"
@@ -148,7 +148,7 @@
 			<p>In the case of both <a>standard EPUB CFIs</a> and <a>intra-publication EPUB CFI</a>, this specification
 				conforms with the guidelines expressed by W3C in <a
 					href="https://www.w3.org/TR/fragid-best-practices/#structures">Section 6. Best Practices for Fragid
-					Structures</a> [[FRAGID-BEST-PRACTICES]].</p>
+					Structures</a> [[fragid-best-practices]].</p>
 
 			<p>In other words, both standard CFI URIs (e.g., "<code>book.epub#epubcfi(…)</code>", referred media type
 					"<code>application/epub+zip</code>") and intra-publication CFI URIs (e.g.,
@@ -165,7 +165,7 @@
 			<section id="sec-terminology">
 				<h2>Terminology</h2>
 
-				<p>Please refer to [[EPUB-33]] for definitions of EPUB-specific terminology used in this document. </p>
+				<p>Please refer to [[epub-33]] for definitions of EPUB-specific terminology used in this document. </p>
 
 				<dl class="termlist">
 					<dt>
@@ -195,10 +195,10 @@
 			<section id="sec-epubcfi-intro" class="informative">
 				<h2>Introduction</h2>
 
-				<p>A fragment identifier is the part of an IRI [[RFC3987]] that defines a location within a resource.
+				<p>A fragment identifier is the part of an IRI [[rfc3987]] that defines a location within a resource.
 					Syntactically, it is the segment attached to the end of the resource IRI starting with a hash
 						(<code>#</code>). For HTML documents, IDs and named anchors are used as fragment identifiers,
-					while for XML documents the Shorthand XPointer [[XPTR-FRAMEWORK]] notation is used to refer to a
+					while for XML documents the Shorthand XPointer [[xptr-framework]] notation is used to refer to a
 					given ID.</p>
 
 				<p>A Canonical Fragment Identifier (CFI) is a similar construct to these, but expresses a location
@@ -576,14 +576,14 @@
 				<aside id="unicode-chars">
 					<h3>Unicode characters</h3>
 
-					<p>The definition of allowed Unicode characters is the same as [[XML]]. This excludes the surrogate
+					<p>The definition of allowed Unicode characters is the same as [[xml]]. This excludes the surrogate
 						blocks, FFFE, and FFFF:</p>
 
 					<pre>
 #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
 </pre>
 					<p>Document authors are encouraged to avoid "compatibility characters", as defined in section 2.3 of
-						[[Unicode]]. The characters defined in the following ranges are also discouraged. They are
+						[[unicode]]. The characters defined in the following ranges are also discouraged. They are
 						either control characters or permanently undefined Unicode characters:</p>
 
 					<pre>
@@ -676,7 +676,7 @@
 						<ul>
 							<li>
 								<p> The EPUB CFI (fragment identifier) scheme is designed to be used within URI and IRI
-									references. The [[RFC3986]] specification defines a number of "reserved" characters
+									references. The [[rfc3986]] specification defines a number of "reserved" characters
 									that have a specific purpose as delimiters, and which MAY need to be escaped in
 									cases when they would otherwise conflict with the syntactical structure of the
 									URI/IRI reference. The character used for escaping is the percent sign
@@ -690,16 +690,16 @@
 									ASCII-encoded. Although the EPUB specification itself is based on IRIs (i.e. authors
 									and production tools are expected to use IRIs), some systems or APIs might only
 									support URIs. As a result, implementors MAY still need too handle the conversion of
-									IRI to URI references, as defined in [[RFC3987]]. Disallowed characters are escaped
+									IRI to URI references, as defined in [[rfc3987]]. Disallowed characters are escaped
 									as follows: </p>
 								<ul>
 									<li>
-										<p> Each disallowed character is converted to UTF-8 [[RFC2279]] as one or more
+										<p> Each disallowed character is converted to UTF-8 [[rfc2279]] as one or more
 											bytes. The disallowed characters in URI references include all non-ASCII
 											characters, plus the excluded characters listed in Section 2.4 of
-											[[RFC2396]], except for the number sign '<code>#</code>' and percent sign
+											[[rfc2396]], except for the number sign '<code>#</code>' and percent sign
 												'<code>%</code>' and the square bracket characters re-allowed in
-											[[RFC2732]].</p>
+											[[rfc2732]].</p>
 										<p> The resulting bytes are escaped with the URI escaping mechanism (that is,
 											converted to '<code>%HH</code>', where HH is the hexadecimal notation of the
 											byte value). </p>
@@ -794,18 +794,18 @@
 
 					<ul>
 						<li>
-							<p>[[XML]] content other than element and character data is ignored. Note that as per the
-								[[XML]] specification, character data inside CDATA sections is included, and conversely,
+							<p>[[xml]] content other than element and character data is ignored. Note that as per the
+								[[xml]] specification, character data inside CDATA sections is included, and conversely,
 								XML comments are ignored.</p>
 						</li>
 						<li>
-							<p>[[XML]] character data that corresponds to insignificant white space (typically used for
+							<p>[[xml]] character data that corresponds to insignificant white space (typically used for
 								markup formatting/indenting) is preserved. Character and entity references are
 								considered expanded, and character data is obtained from the "included replacement text"
-								(as per the terminology defined in the [[XML]] specification).</p>
+								(as per the terminology defined in the [[xml]] specification).</p>
 						</li>
 						<li>
-							<p>[[XML]] character data that is interspersed amongst sibling child elements (i.e., "mixed
+							<p>[[xml]] character data that is interspersed amongst sibling child elements (i.e., "mixed
 								content" context) is logically organised into (potentially-empty) chunks of contiguous
 								character data: the first chunk is located before the first child element (left
 								sibling), the last chunk is located after the last child element (right sibling), and
@@ -815,7 +815,7 @@
 								starting at 1, followed by 3, etc.).</p>
 						</li>
 						<li>
-							<p>Child [[XML]] elements are assigned even indices (i.e., starting at 2, followed by 4,
+							<p>Child [[xml]] elements are assigned even indices (i.e., starting at 2, followed by 4,
 								etc.). Additionally, 0 is a valid index that refers to a non-existing element which
 								virtually precedes the first potentially-empty chunk of character data within the parent
 								element's content. Similarly, <code>n+2</code> is a valid index that refers to a
@@ -855,7 +855,7 @@
 				<section id="sec-path-xmlid">
 					<h3>XML ID assertion (<code>[</code>)</h3>
 
-					<p>When an EPUB CFI references an element that contains an ID [[XML]], the corresponding path step
+					<p>When an EPUB CFI references an element that contains an ID [[xml]], the corresponding path step
 						MUST include that ID in square brackets (i.e., after the slash (<code>/</code>) and even number
 						that identifies the element).</p>
 
@@ -885,7 +885,7 @@
 									<code>idref</code> attribute references).</p>
 						</li>
 						<li>
-							<p>For [[HTML]] <code><a
+							<p>For [[html]] <code><a
 										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-iframe-element"
 										>iframes</a></code> and <code><a
 										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-embed-element"
@@ -893,13 +893,13 @@
 								attribute</p>
 						</li>
 						<li>
-							<p>For the [[HTML]] <code><a
+							<p>For the [[html]] <code><a
 										href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-object-element"
 										>object</a></code> element, the reference is defined by the <code>data</code>
 								attribute</p>
 						</li>
 						<li>
-							<p>For [[SVG]] <code><a href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"
+							<p>For [[svg]] <code><a href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"
 										>image</a></code> and <code><a
 										href="https://www.w3.org/TR/SVG/struct.html#UseElement">use</a></code> elements,
 								references are defined by the <code>xlink:href</code> attribute</p>
@@ -908,7 +908,7 @@
 
 					<div class="note">
 						<p>This scheme does not take into account hyperlinks, only embedding references. Consequently,
-							it is illegal to follow links from the [[HTML]] (or [[SVG]]) <code>a</code> element.</p>
+							it is illegal to follow links from the [[html]] (or [[svg]]) <code>a</code> element.</p>
 					</div>
 				</section>
 				<section id="sec-path-terminating-char">
@@ -916,7 +916,7 @@
 
 					<p>A path terminating with a leading colon (<code>:</code>) followed by an integer refers to a
 						character offset. The given character offset MAY apply to an element only if this element is the
-						[[HTML]] <code><a
+						[[html]] <code><a
 								href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-img-element"
 								>img</a></code> element with an <code>alt</code> attribute containing the text to which
 						the character offset applies.</p>
@@ -929,7 +929,7 @@
 					<p>In this specification, the definition of an "offset" within XML character data is based on the
 						UTF-16 text encoding, whereby each "character" (Unicode code point) MAY be represented using a
 						single 16-bit code unit, or two units (surrogate pairs, for Unicode characters outside of BMP /
-						Basic Multilingual Plane) [[Unicode]]. A CFI "character offset" is a zero-based number that
+						Basic Multilingual Plane) [[unicode]]. A CFI "character offset" is a zero-based number that
 						refers to a position between UTF-16 code units. Here, the "length" of the text is the total
 						count of 16-bit units. Offset zero therefore means before the first 16-bit unit, and a number
 						equal to the "length" of the text means after the last 16-bit unit. An offset value greater than
@@ -937,10 +937,10 @@
 
 					<div class="note">
 						<p>Counting the number of text "characters" based on UTF-16 code units (instead of Unicode code
-							points) is compatible with the <a data-cite="dom#ranges">DOM Range model</a> [[DOM]], and
+							points) is compatible with the <a data-cite="dom#ranges">DOM Range model</a> [[dom]], and
 							with the <a
 								href="http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-language-types-string-type"
-								>String API</a> [[ECMA-262]]</p>
+								>String API</a> [[ecma-262]]</p>
 					</div>
 
 					<p>A character offset MAY follow a <code>/N</code> step. For XHTML content documents, <code>N</code>
@@ -1035,7 +1035,7 @@
 						take two values: '<code>b</code>' ("before") means that the location is attached to the content
 						that precedes (according to the XML serialization document order), '<code>a</code>' ("after")
 						refers to the content that follows. This parameter MUST always be used inside square brackets at
-						the end of the CFI, even if the ID [[XML]] or text location assertion is empty.</p>
+						the end of the CFI, even if the ID [[xml]] or text location assertion is empty.</p>
 
 					<p>The location just after <code>yyy</code> in the <a href="#sec-path-examples">sample content
 							below</a> can be expressed as belonging with the content before it as follows:</p>
@@ -1298,7 +1298,7 @@
 				<p>As an EPUB publication can be updated, corrected or otherwise altered over time, it is useful to be
 					able to derive an EPUB CFI for the modified document from one that targeted a previous version. This
 					specification provides two mechanisms to detect and adapt to content changes that impact CFIs: IDs
-					[[XML]] and <a href="#sec-path-text-location">text location assertions</a>.</p>
+					[[xml]] and <a href="#sec-path-text-location">text location assertions</a>.</p>
 
 				<p>When a reading system is processing a CFI, it SHOULD check the correctness of any encountered
 					assertions. For example, given the path <code>/6/4[chap01ref]!…</code>, the reading system SHOULD

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -34,7 +34,7 @@
                 },
                 pluralize: true,
                 localBiblio: {
-					"WCAG2": {
+					"wcag2": {
 						"title": "Web Content Accessibility Guidelines (WCAG) 2",
 						"href": "https://www.w3.org/TR/WCAG2/",
 						"publisher": "W3C"
@@ -66,11 +66,11 @@ Fixed Layout publications, or publications where the print layout is preserved i
 
 The main motivation behind creating fixed layout publications is the need to preserve the print layout of the book, either because of it's importance to the text (i.e. complex diagrams) or it's artistic purpose (i.e. illustrated text). However, these publications are often partially or completely inaccessible to people with print disabilities.
 
-This note serves to help content authors and publishers try to address some of the common accessibility issues found in fixed layout content, including navigation, reading order, and text alternatives. This document is a companion to [[EPUB-A11Y-11]], specifically for fixed layout publications. All recommendations made in [[EPUB-A11Y-11]], [[EPUB-33]], and [[EPUB-RS-33]] are applied and extended here.
+This note serves to help content authors and publishers try to address some of the common accessibility issues found in fixed layout content, including navigation, reading order, and text alternatives. This document is a companion to [[epub-a11y-11]], specifically for fixed layout publications. All recommendations made in [[epub-a11y-11]], [[epub-33]], and [[epub-rs-33]] are applied and extended here.
 
 ### The Limits of fixed layout accessibility {#limits}
 
-Fixed Layout publications present some unique challenges for accessibility. The requirements laid out in [[EPUB-A11Y-11]] recommend [[WCAG2]] AA, but for many use cases in fixed layout, that might not be possible without fundamental changes to the content.
+Fixed Layout publications present some unique challenges for accessibility. The requirements laid out in [[epub-a11y-11]] recommend [[wcag2]] AA, but for many use cases in fixed layout, that might not be possible without fundamental changes to the content.
 
 In particular, the needs of people with low vision or learning disabilities that rely on the transformation of text are still almost impossible to accommodate in fixed layout content. Content creators concerned about this may choose not to use fixed layout. 
 
@@ -78,7 +78,7 @@ We want to recognize these challenges for content creators, and in this document
 
 ## Reading Order {#reading-order}
 
-> A key concept of EPUB is that an EPUB publication consists of multiple resources that can be completely navigated and consumed by a person or program in some specific order. - 1.2.1 Reading Order [[EPUB-OVERVIEW-33]]
+> A key concept of EPUB is that an EPUB publication consists of multiple resources that can be completely navigated and consumed by a person or program in some specific order. - 1.2.1 Reading Order [[epub-overview-33]]
 
 Whereas many reflowable publications have an obvious reading order, or logical progression through their content, fixed-layout publications are often more complex in their design and layout and may consist of multiple readable objects on the same page.
 
@@ -376,7 +376,7 @@ There is no single font that meets the legibility needs of all users, but consid
 
 #### Font sizing 
 
-There is no font size guideline in [[WCAG2]], however the standard default font size in most desktop and mobile browsers is 16pt for body text (I.e. in a `<p>` element). This size is sufficient for most content, and headings should be based off of it by using `em` or `rem` sizing in [[CSS]]. If content contains a great deal of text, it is also recommended to consider a larger body font size like 18pt to ensure readability. 
+There is no font size guideline in [[wcag2]], however the standard default font size in most desktop and mobile browsers is 16pt for body text (I.e. in a `<p>` element). This size is sufficient for most content, and headings should be based off of it by using `em` or `rem` sizing in [[css]]. If content contains a great deal of text, it is also recommended to consider a larger body font size like 18pt to ensure readability. 
 
 Content creators should also ensure font size patterns are consistent throughout the content, to assist users in differentiating and contextualizing the content. 
 
@@ -392,7 +392,7 @@ One of the most important factors for the readability of fonts relates to charac
 
 ### Color contrast 
 
-[[WCAG2]] specifies that the color contrast should meet certain ratios depending on its size and weight. 
+[[wcag2]] specifies that the color contrast should meet certain ratios depending on its size and weight. 
 
 Body text, or text that is less than 18pt (or 14pt bold) in size must have a contrast of at least 4.5:1 to the background. 
 

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -42,12 +42,12 @@
                 },
                 pluralize: true,
 				localBiblio: {
-					"ISO24751-3": {
+					"iso24751-3": {
 						"title": " ISO/IEC 24751-3:2008 Information technology -- Individualized adaptability and accessibility in e-learning, education and training -- Part 3: &quot;Access for all&quot; digital resource description",
 						"href": "http://www.iso.org/iso/catalogue_detail?csnumber=43604",
 						"date": "2008-10-01"
 					},
-					"EPUBCFI-11": {
+					"epubcfi-11": {
 						"authors":[
 							"Peter Sorotokin",
 							"Garth Conboy",
@@ -132,7 +132,7 @@
 					how to access them. As a result, the EPUB 3 specification generally equates an EPUB publication with
 					a single rendering of the content. Moreover, most <a>EPUB creators</a> and <a>reading system</a>
 					developers equate an EPUB publication with a single <a>package document</a> referenced from the
-					first <code>rootfile</code> element in the <code>container.xml</code> file [[EPUB-33]].</p>
+					first <code>rootfile</code> element in the <code>container.xml</code> file [[epub-33]].</p>
 
 				<p>In practice, however, the <code>container.xml</code> file does not restrict EPUB creators to listing
 					only a single package document. In EPUB 2, for example, <a>EPUB creators</a> could add additional
@@ -163,18 +163,18 @@
 				<p>It is strongly RECOMMENDED, however, that all future needs for multiple renditions in a container
 					follow this specification. Existing implementations that utilize other methods for selecting from
 					multiple renditions are also encouraged to consider migrating to use this specification to improve
-					the overall interoperability of multiple-rendition publications.</p>
+					the overall interoperability of <a>multiple-rendition publications</a>.</p>
 
 				<p>Some of the <a href="#rendition-selection-attr">rendition selection attributes</a> defined in this
-					specification share common names with package document elements and properties [[EPUB-33]] as they
+					specification share common names with package document elements and properties [[epub-33]] as they
 					are designed to reflect that information for selection purposes.</p>
 
 				<p>Despite this commonality, this specification does not enforce equivalence between the rendition
-					selection properties expressed on a <code>rootfile</code> element [[EPUB-33]] and the metadata
+					selection properties expressed on a <code>rootfile</code> element [[epub-33]] and the metadata
 					expressed in the corresponding package document, as direct equivalence is not always possible.</p>
 
 				<p>For example, a multilingual EPUB publication will define more than one <a
-						data-cite="epub-33#sec-opf-dclanguage">DCMES <code>language</code> element</a> [[EPUB-33]]
+						data-cite="epub-33#sec-opf-dclanguage">DCMES <code>language</code> element</a> [[epub-33]]
 					&#8212; one for each language &#8212; but for rendition selection only the primary language is
 					defined. Likewise, the language defined in the package document could include a specific region
 					code, but for selection purposes the EPUB creator might identify only the language code.</p>
@@ -185,7 +185,7 @@
 					ambiguities between metadata being used for different purposes (selection versus rendering).</p>
 
 				<p>The selection properties defined in the <a data-cite="epub-33#sec-container-metainf-container.xml"
-							><code>container.xml</code> file</a> [[EPUB-33]] have no rendering behaviors attached to
+							><code>container.xml</code> file</a> [[epub-33]] have no rendering behaviors attached to
 					them, either. For example, indicating that a rendition is fixed layout in the <a href="#layout-attr"
 							><code>rendition:layout</code> attribute</a> does not trigger fixed layout rendering
 					behaviors within the specified rendition.</p>
@@ -197,7 +197,7 @@
 			<section id="terminology">
 				<h3>Terminology</h3>
 
-				<p>The following terms used in this document are defined in [[EPUB-33]]:</p>
+				<p>The following terms used in this document are defined in [[epub-33]]:</p>
 
 				<ul>
 					<li><a>EPUB container</a></li>
@@ -220,18 +220,18 @@
 						<p>The <a data-cite="epub-33#sec-container-metainf-container.xml"><code>container.xml</code>
 								file</a> located in the child <a data-cite="epub-33#sec-container-metainf"
 									><code>META-INF</code> directory</a> of the EPUB container root directory
-							[[EPUB-33]]. Each <a>rendition</a> in the container is identified by a <code>rootfile</code>
-							element [[EPUB-33]].</p>
+							[[epub-33]]. Each <a>rendition</a> in the container is identified by a <code>rootfile</code>
+							element [[epub-33]].</p>
 					</dd>
 
 					<dt><dfn>default rendition</dfn></dt>
 					<dd>
 						<p>The <a>rendition</a> listed in the first <code>rootfile</code> element in the <a
 								data-cite="epub-33#sec-container-metainf-container.xml"><code>container.xml</code>
-								file</a> [[EPUB-33]].</p>
+								file</a> [[epub-33]].</p>
 					</dd>
 
-					<dt><dfn>multiple-rendition publication</dfn></dt>
+					<dt><dfn data-lt="multiple-rendition publications">multiple-rendition publication</dfn></dt>
 					<dd>
 						<p>An EPUB publication that consists of two or more <a>renditions</a> of the content.</p>
 					</dd>
@@ -241,7 +241,7 @@
 						<p>One rendering of the content of an EPUB publication, as expressed by a package document.</p>
 					</dd>
 
-					<dt><dfn>rendition mapping document</dfn></dt>
+					<dt><dfn data-lt="rendition mapping documents">rendition mapping document</dfn></dt>
 					<dd>
 						<p>A specialization of the XHTML content document, containing machine-readable mappings between
 							equivalent content in different <a>renditions</a>, conforming to the constraints expressed
@@ -256,10 +256,10 @@
 			<h2>Specifying multiple renditions</h2>
 
 			<p>Each rendition of an <a>EPUB publication</a> MUST meet the <a data-cite="epub-33#sec-epub-conf"
-					>requirements for EPUB publications</a> [[EPUB-33]].</p>
+					>requirements for EPUB publications</a> [[epub-33]].</p>
 
 			<p>The package document for each rendition MUST be listed in the <code>container.xml</code> file
-				[[EPUB-33]], where the first package document listed represents the <a>default rendition</a>.</p>
+				[[epub-33]], where the first package document listed represents the <a>default rendition</a>.</p>
 
 			<aside class="example">
 				<p>The following example shows SVG and XHTML renditions bundled in the same container:</p>
@@ -276,7 +276,7 @@
 			</aside>
 
 			<p>Each rendition of the EPUB publication SHOULD only list the <a>publication resources</a> necessary for
-				its rendering in its package document <a>manifest</a> [[EPUB-33]]. renditions MAY reference the same
+				its rendering in its package document <a>manifest</a> [[epub-33]]. renditions MAY reference the same
 				publication resources.</p>
 
 			<div class="note">
@@ -332,30 +332,30 @@
 					<p>To ensure consistency of metadata at the Publication and <a>rendition</a> levels, this
 						specification defines the content model of the root <code>metadata</code> element in the <a
 							data-cite="epub-33#sec-container-metainf-metadata.xml"><code>metadata.xml</code> file</a>
-						[[EPUB-33]] to be the same as the package document <a data-cite="epub-33#elemdef-opf-metadata"
-								><code>metadata</code> element</a> [[EPUB-33]], with the following differences in syntax
+						[[epub-33]] to be the same as the package document <a data-cite="epub-33#elemdef-opf-metadata"
+								><code>metadata</code> element</a> [[epub-33]], with the following differences in syntax
 						and semantics:</p>
 
 					<ul>
-						<li>A <code>dc:identifier</code> element [[DCTERMS]] MUST contain the <a
-								data-cite="epub-33#sec-opf-dcidentifier">unique identifier</a> [[EPUB-33]] for the EPUB
+						<li>A <code>dc:identifier</code> element [[dcterms]] MUST contain the <a
+								data-cite="epub-33#sec-opf-dcidentifier">unique identifier</a> [[epub-33]] for the EPUB
 							publication.</li>
-						<li>A <code>meta</code> element [[EPUB-33]] MUST contain the last modified date, expressed using
-							the <code>dcterms:modified</code> property [[DCTERMS]]. The value of the property MUST
+						<li>A <code>meta</code> element [[epub-33]] MUST contain the last modified date, expressed using
+							the <code>dcterms:modified</code> property [[dcterms]]. The value of the property MUST
 							conform to the pattern and rules defined in <a
-								data-cite="epub-33#sec-metadata-last-modified">Last Modified Date</a> [[EPUB-33]]. Only
+								data-cite="epub-33#sec-metadata-last-modified">Last Modified Date</a> [[epub-33]]. Only
 							one <code>dcterms:modified</code> property without a <a data-cite="epub-33#attrdef-refines"
-									><code>refines</code> attribute</a> [[EPUB-33]] is allowed.</li>
+									><code>refines</code> attribute</a> [[epub-33]] is allowed.</li>
 						<li>All other metadata is OPTIONAL.</li>
 						<li>The obsolete <a data-cite="epub-33#sec-opf2-meta">OPF2 <code>meta</code> element</a>
-							[[EPUB-33]] is not allowed.</li>
+							[[epub-33]] is not allowed.</li>
 						<li>The <code>meta</code> and <code>link</code> elements are defined in the same namespace as
 							the <code>metadata</code> root element: <code class="uri"><a
 									href="http://www.idpf.org/2013/metadata"
 								>http://www.idpf.org/2013/metadata</a></code></li>
 						<li>In order to enable the full expression of metadata in the <code>metadata.xml</code> file,
 							all attributes allowed on the <a data-cite="epub-33#sec-package-elem"><code>package</code>
-								element</a> [[EPUB-33]] are allowed on the root <code class="markup">metadata</code>
+								element</a> [[epub-33]] are allowed on the root <code class="markup">metadata</code>
 							element.</li>
 					</ul>
 
@@ -379,11 +379,11 @@
 					</div>
 
 					<div class="note">
-						<p>As [[EPUB-33]] does not define a content model for the <code>metadata.xml</code> file, EPUB
+						<p>As [[epub-33]] does not define a content model for the <code>metadata.xml</code> file, EPUB
 							publications that do not conform to this specification can include different metadata. EPUB
 							publications that are not valid to the content model restrictions in this section are not
-							valid multiple-rendition publications as defined by this specification, but might still be
-							valid EPUB 3 publications.</p>
+							valid <a>multiple-rendition publications</a> as defined by this specification, but might
+							still be valid EPUB 3 publications.</p>
 						<p>EPUB creators are strongly encouraged to migrate to the content model defined in this
 							specification, even if not producing multiple-rendition publications, to ensure consistent
 							processing.</p>
@@ -392,8 +392,8 @@
 					<section id="pub-metadata-obfuscation">
 						<h4>Resource obfuscation</h4>
 
-						<p>The <a data-cite="epub-33#obfus-algorithm">resource obfuscation algorithm</a> [[EPUB-33]]
-							depends on creating an <a data-cite="epub-33#obfus-keygen">obfuscation key</a> [[EPUB-33]]
+						<p>The <a data-cite="epub-33#obfus-algorithm">resource obfuscation algorithm</a> [[epub-33]]
+							depends on creating an <a data-cite="epub-33#obfus-keygen">obfuscation key</a> [[epub-33]]
 							from the <a>unique identifier</a> for the EPUB publication.</p>
 
 						<p>For compatibility reasons, and due to the complexities of being able to share resources
@@ -412,12 +412,12 @@
 					<h3>Vocabulary association mechanisms</h3>
 
 					<p>This specification inherits the mechanisms for associating vocabularies defined in <a
-							data-cite="epub-33#sec-vocab-assoc">Vocabulary Association Mechanisms</a> [[EPUB-33]] as
+							data-cite="epub-33#sec-vocab-assoc">Vocabulary Association Mechanisms</a> [[epub-33]] as
 						they relate to the package document metadata, with only the following modification: the
 							<code>prefix</code> attribute MAY be attached only to the root <code>metadata</code>
 						element.</p>
 
-					<p><a data-cite="epub-33#sec-reserved-prefixes">Reserved prefixes</a> [[EPUB-33]] for metadata
+					<p><a data-cite="epub-33#sec-reserved-prefixes">Reserved prefixes</a> [[epub-33]] for metadata
 						attribute expressions are adopted without change.</p>
 				</section>
 			</section>
@@ -440,7 +440,7 @@
 
 				<p>This section redresses this problem by defining both a set of rendition selection attributes that can
 					be attached to <a data-cite="epub-33#sec-container-metainf-container.xml"><code>rootfile</code>
-						elements</a> [[EPUB-33]] in the container document and a processing model that allows EPUB
+						elements</a> [[epub-33]] in the container document and a processing model that allows EPUB
 					creators to specify which rendition is the best representation depending on various conditions.
 					Reading systems can then select the appropriate representation from the list of renditions to match
 					the current configuration and user preferences.</p>
@@ -455,12 +455,12 @@
 					<li id="confreq-container">MUST be valid to the definition and requirements for the
 							<code>container.xml</code> file specified in <a
 							data-cite="epub-33#sec-container-metainf-container.xml">container –
-							META-INF/container.xml</a> [[EPUB-33]].</li>
+							META-INF/container.xml</a> [[epub-33]].</li>
 					<li id="confreq-selection-attr">MAY include any of the selection attributes defined in <a
 							href="#rendition-selection-attr">Rendition selection attributes</a>.</li>
 					<li id="confreq-selection-default">MAY Include selection attributes on the <a
 							data-cite="epub-33#sec-container.xml-rootfiles-elem"><code>rootfile</code> element</a>
-						[[EPUB-33]] for the <a>default rendition</a></li>
+						[[epub-33]] for the <a>default rendition</a></li>
 					<li id="confreq-selection-min">SHOULD include at least one selection attribute ‒ in addition to the
 						OPTIONAL label ‒ on each subsequent <code>rootfile</code> element.</li>
 				</ul>
@@ -479,7 +479,7 @@
 				<div class="note">
 					<p>The use of the rendition selection attributes in the <a
 							data-cite="epub-33#sec-container-metainf-container.xml"><code>container.xml</code> file</a>
-						[[EPUB-33]] is also defined informally through an XML schema. See <a href="#schema-container"
+						[[epub-33]] is also defined informally through an XML schema. See <a href="#schema-container"
 						></a> for further details.</p>
 				</div>
 
@@ -512,21 +512,21 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on container document <code>rootfile</code> elements
-									[[EPUB-33]].</p>
+									[[epub-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
 							</dt>
 							<dd>
-								<p>A CSS 3 media query [[MediaQueries]], where the media type, if specified, MUST only
+								<p>A CSS 3 media query [[mediaqueries]], where the media type, if specified, MUST only
 									be the value "<code>all</code>".</p>
 							</dd>
 						</dl>
 					</div>
 
-					<p>As per [[MediaQueries]], the media query in this attribute MUST evaluate to true in order for the
+					<p>As per [[mediaqueries]], the media query in this attribute MUST evaluate to true in order for the
 						given rendition to be selected for rendering. Media queries that evaluate to "not all” per <a
-							data-cite="mediaqueries#error-handling">3.1 Error Handling</a> [[MediaQueries]] SHOULD be
+							data-cite="mediaqueries#error-handling">3.1 Error Handling</a> [[mediaqueries]] SHOULD be
 						treated as false for the purposes of rendition selection (i.e., the given rendition is not a
 						valid match).</p>
 
@@ -578,7 +578,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on container document <code>rootfile</code> elements
-									[[EPUB-33]].</p>
+									[[epub-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -591,7 +591,7 @@
 					</div>
 
 					<p>When specified, the value of this attribute MUST match the <a
-							data-cite="epub-33#property-layout-global">global rendition:layout setting</a> [[EPUB-33]]
+							data-cite="epub-33#property-layout-global">global rendition:layout setting</a> [[epub-33]]
 						for the referenced rendition.</p>
 
 					<p>If a user layout preference is defined in the reading system, the attribute evaluates to true if
@@ -646,13 +646,13 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on container document <code>rootfile</code> elements
-									[[EPUB-33]].</p>
+									[[epub-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
 							</dt>
 							<dd>
-								<p>MUST contain a valid language code conforming to [[RFC5646]].</p>
+								<p>MUST contain a valid language code conforming to [[rfc5646]].</p>
 							</dd>
 						</dl>
 					</div>
@@ -664,7 +664,7 @@
 
 					<p>If a user language preference is defined in the reading system, the attribute evaluates to true
 						if the preference matches the specified value, otherwise it evaluates to false. Several matching
-						schemes are defined in Section 3 of [[RFC4647]]. Reading systems can use the most appropriate
+						schemes are defined in Section 3 of [[rfc4647]]. Reading systems can use the most appropriate
 						matching scheme. If no user preference is defined, the reading system SHOULD ignore the
 						attribute when selecting from the available renditions.</p>
 
@@ -694,7 +694,7 @@
 					<h4>The <code>rendition:accessMode</code> attribute</h4>
 
 					<p>The <code>rendition:accessMode</code> attribute identifies the way in which intellectual content
-						is communicated in a <a>rendition</a>, and is based on the [[ISO24751-3]] "Access Mode"
+						is communicated in a <a>rendition</a>, and is based on the [[iso24751-3]] "Access Mode"
 						property.</p>
 
 					<div class="elem-synopsis" id="attrdef-accessMode">
@@ -720,7 +720,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on container document <code>rootfile</code> elements
-									[[EPUB-33]].</p>
+									[[epub-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -780,7 +780,7 @@
 				<section id="label-attr">
 					<h4>The <code>rendition:label</code> attribute</h4>
 
-					<p>The <code>rendition:label</code> attribute allows each <code>rootfile</code> element [[EPUB-33]]
+					<p>The <code>rendition:label</code> attribute allows each <code>rootfile</code> element [[epub-33]]
 						to be annotated with a human-readable name.</p>
 
 					<div class="elem-synopsis" id="attrdef-label">
@@ -806,7 +806,7 @@
 							</dt>
 							<dd>
 								<p>MAY be specified on container document <code>rootfile</code> elements
-									[[EPUB-33]].</p>
+									[[epub-33]].</p>
 							</dd>
 							<dt class="varlistentry">
 								<span class="term">Value</span>
@@ -858,7 +858,7 @@
 					viewport size).</p>
 
 				<p>When a change condition is triggered, the reading system SHOULD evaluate the <code>rootfile</code>
-					elements [[EPUB-33]] in the container document as follows, starting with the last
+					elements [[epub-33]] in the container document as follows, starting with the last
 						<code>rootfile</code> entry:</p>
 
 				<ul>
@@ -908,9 +908,9 @@
 			<section id="rendition-mapping-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>The rendition mapping document identifies related content locations across the <a>renditions</a> in a
-					multiple-rendition publication, allowing reading systems to switch between renditions while keeping
-					the user's place.</p>
+				<p>The <a>rendition mapping document</a> identifies related content locations across the
+						<a>renditions</a> in a <a>multiple-rendition publication</a>, allowing reading systems to switch
+					between renditions while keeping the user's place.</p>
 
 				<p>The rendition mapping document is represented as XHTML, and uses <a><code>nav</code></a> elements
 					with unordered lists to group the mappings. There is no display component to the rendition mapping
@@ -935,17 +935,17 @@
 			<section id="rendition-mapping-pub-conformance">
 				<h3>Content conformance</h3>
 
-				<p>An EPUB publication MAY include an EPUB rendition mapping document.</p>
+				<p>An EPUB publication MAY include a <a>rendition mapping document</a>.</p>
 
-				<p>A conformant EPUB rendition mapping document:</p>
+				<p>A conformant rendition mapping document:</p>
 
 				<ul class="conformancelist">
 					<li id="confreq-map-xhtml">MUST conform to all content conformance constraints for XHTML content
 						documents as defined in <a data-cite="epub-33#sec-xhtml-req">XHTML Requirements</a>
-						[[EPUB-33]].</li>
+						[[epub-33]].</li>
 					<li id="confreq-map-content-model">MUST conform to all content conformance constraints specific for
-						EPUB rendition mapping documents expressed in <a href="#rendition-mapping-doc-def">EPUB
-							rendition mapping document definition</a>.</li>
+						rendition mapping documents expressed in <a href="#rendition-mapping-doc-def">EPUB rendition
+							mapping document definition</a>.</li>
 					<li id="confreq-map-unlisted">MUST NOT be listed in the package document manifest of any of the EPUB
 						publication's renditions.</li>
 				</ul>
@@ -954,7 +954,8 @@
 			<section id="rendition-mapping-rs-conformance">
 				<h3>reading system conformance</h3>
 
-				<p>Reading systems SHOULD support the use of rendition mapping documents to switch between content. </p>
+				<p>Reading systems SHOULD support the use of <a>rendition mapping documents</a> to switch between
+					content. </p>
 
 				<p>A reading system that supports mapping:</p>
 
@@ -975,8 +976,8 @@
 				<section id="rendition-mapping-doc-xhtml">
 					<h4>XHTML content document: restrictions</h4>
 
-					<p>The rendition mapping document is a compliant XHTML content document, but with the following
-						restrictions on the [[HTML]] content model:</p>
+					<p>The <a>rendition mapping document</a> is a compliant XHTML content document, but with the
+						following restrictions on the [[html]] content model:</p>
 
 					<ul>
 						<li>No attributes are allowed on the <code>html</code>, <code>head</code>, <code>body</code>,
@@ -992,7 +993,7 @@
 							ignore all other <code>meta</code> elements.</li>
 						<li>The <code>body</code> element MUST include exactly one <code>nav</code> element child whose
 								<code>epub:type</code> attribute specifies the value "<code>resource-map</code>", and
-							MAY include one or more optional <code>nav</code> elements. No other [[HTML]] content is
+							MAY include one or more optional <code>nav</code> elements. No other [[html]] content is
 							allowed as a child of the <code>body</code>.</li>
 					</ul>
 				</section>
@@ -1001,7 +1002,7 @@
 					<h4>The nav element: modifications and restrictions</h4>
 
 					<p>This specification restricts the content model of <code>nav</code> elements and their descendants
-						in the rendition mapping document as follows:</p>
+						in the <a>rendition mapping document</a> as follows:</p>
 
 					<ul>
 						<li>Each <code>nav</code> element MUST identify its nature in an <code>epub:type</code>
@@ -1016,7 +1017,7 @@
 							<p>The <code>a</code> element MUST specify the rendition it is referring to either:</p>
 							<ul>
 								<li>by using an <a href="http://www.idpf.org/epub/linking/cfi/#sec-intra-cfis"
-										>Intra-Publication CFI</a> [[EPUBCFI-11]] as the value of the <code>href</code>
+										>Intra-Publication CFI</a> [[epubcfi-11]] as the value of the <code>href</code>
 									attribute or,</li>
 								<li>by having an <code>epub:rendition</code> attribute whose value is the relative path
 									to the Publication Document for the rendition.</li>
@@ -1028,8 +1029,8 @@
 				<section id="rendition-mappings">
 					<h4>Rendition mappings</h4>
 
-					<p>Each <code>ul</code> element in the rendition mapping document <code class="markup"
-							>resource-map</code>
+					<p>Each <code>ul</code> element in the <a>rendition mapping document</a>
+						<code class="markup">resource-map</code>
 						<code>nav</code> element identifies a content location, listing in its child <code>li</code>
 						elements where that location is found in each of the available renditions. Consequently, each
 							<code>ul</code> element MUST contain an <code>li</code> for each rendition.</p>
@@ -1044,11 +1045,11 @@
 					<p>Each list item in the unordered list MUST identify an EPUB content document, or a fragment
 						therein, for one of the renditions ‒ defined in a child <code>a</code> element. Each of these
 						links MUST reference a <a data-cite="epub-33#sec-itemref-elem">linear Top-level content
-							document</a> [[EPUB-33]].</p>
+							document</a> [[epub-33]].</p>
 
 					<p>Each <code>a</code> element MUST specify which rendition it refers to either 1) by including an
 							<a href="http://www.idpf.org/epub/linking/cfi/#sec-intra-cfis">Intra-Publication CFI</a>
-						[[EPUBCFI-11]] in its <code>href</code> attribute, or 2) by providing the relative path to the
+						[[epubcfi-11]] in its <code>href</code> attribute, or 2) by providing the relative path to the
 						package document for the rendition as the value of an <code>epub:rendition</code> attribute.</p>
 
 					<p>If the <code>epub:rendition</code> attribute is used to specify the target rendition, any
@@ -1056,7 +1057,7 @@
 						of <code>a</code> elements (e.g., unique identifier, or W3C Media Fragment).</p>
 
 					<div class="note">
-						<p>The use of [[EPUBCFI-11]] expressions is strongly encouraged over other fragment identifier
+						<p>The use of [[epubcfi-11]] expressions is strongly encouraged over other fragment identifier
 							schemes (particularly in the context of reflowable XHTML content documents), as they allow
 							reading systems to ingest rendition mappings without any prior pre-processing. Conversely,
 							the use of unique identifiers forces reading systems to load the targeted EPUB content
@@ -1155,9 +1156,9 @@
 				<section id="rendition-mapping-container-id">
 					<h4>Container identification</h4>
 
-					<p>The location of the rendition mapping document is identified in the container document using a <a
-							data-cite="epub-33#sec-container.xml-link-elem"><code>link</code> element</a> [[EPUB-33]],
-						where:</p>
+					<p>The location of the <a>rendition mapping document</a> is identified in the container document
+						using a <a data-cite="epub-33#sec-container.xml-link-elem"><code>link</code> element</a>
+						[[epub-33]], where:</p>
 
 					<ul>
 						<li>the <code>href</code> attribute MUST reference the location of the rendition mapping
@@ -1198,7 +1199,7 @@
 			<section id="rendition-mapping-proc-model" class="informative">
 				<h3>Processing model</h3>
 
-				<p>This section provides a non-normative model by which the rendition mapping document could be
+				<p>This section provides a non-normative model by which the <a>rendition mapping document</a> could be
 					processed by a reading system. It does not address how or when a reading system should switch
 					renditions. </p>
 
@@ -1245,8 +1246,8 @@
 		<section id="app-schemas" class="appendix informative">
 			<h2>Schemas</h2>
 
-			<p>Validation using the schemas in this appendix requires a processor that supports [[RELAXNG-SCHEMA]] and
-				[[XMLSCHEMA11-2]].</p>
+			<p>Validation using the schemas in this appendix requires a processor that supports [[relaxng-schema]] and
+				[[xmlschema11-2]].</p>
 
 			<section id="schema-metadata">
 				<h3>Metadata.xml Schema</h3>
@@ -1298,7 +1299,7 @@
 						<code>metadata.xml</code> file remain for backwards compatibility. See <a
 						href="https://github.com/w3c/publ-epub-revision/issues/1440">issue 1440</a>.</li>
 				<li>16-Dec-2020: Terminology and requirements related to renditions of an EPUB publication have been
-					moved to this specification to simplify readability of both this and the [[EPUB-33]] specification.
+					moved to this specification to simplify readability of both this and the [[epub-33]] specification.
 					These changes do not affect the ability to include multiple renditions in an EPUB publication. See
 						<a href="https://github.com/w3c/publ-epub-revision/issues/1436">issue 1436</a>.</li>
 			</ul>

--- a/epub33/overview/biblio.js
+++ b/epub33/overview/biblio.js
@@ -1,9 +1,9 @@
 var biblio = {
-	"CSSSnapshot": {
+	"csssnapshot": {
 		"title": "CSS Snapshot",
 		"href": "https://www.w3.org/TR/CSS/"
 	},
-	"EPUB-31": {
+	"epub-31": {
 		"authors":[
 		"Markus Gylling",
 		"Tzviya Siegman",
@@ -13,7 +13,7 @@ var biblio = {
 		"date": "05 January 2017",
 		"publisher": "IDPF"
 	},
-	"EPUB-32": {
+	"epub-32": {
 		"authors":[
 		"Matt Garrish",
 		"Dave Cramer"],
@@ -22,7 +22,7 @@ var biblio = {
 		"date": "08 May 2019",
 		"publisher": "EPUB 3 Community Group"
 	},
-	"EPUBChanges-30": {
+	"epubchanges-30": {
 		"authors":[
 		"William McCoy",
 		"Markus Gylling"],
@@ -31,7 +31,7 @@ var biblio = {
 		"date": "11 October 2011",
 		"publisher": "IDPF"
 	},
-	"EPUBChanges-301": {
+	"epubchanges-301": {
 		"authors":[
 		"Markus Gylling",
 		"Matt Garrish"],
@@ -40,7 +40,7 @@ var biblio = {
 		"date": "26 June 2014",
 		"publisher": "IDPF"
 	},
-	"EPUBChanges-31": {
+	"epubchanges-31": {
 		"authors":[
 		"Markus Gylling",
 		"Matt Garrish"],
@@ -49,7 +49,7 @@ var biblio = {
 		"date": "05 January 2017",
 		"publisher": "IDPF"
 	},
-	"EPUBChanges-32": {
+	"epubchanges-32": {
 		"authors":[
 		"Matt Garrish",
 		"Dave Cramer"],
@@ -58,50 +58,50 @@ var biblio = {
 		"date": "08 May 2019",
 		"publisher": "EPUB 3 Community Group"
 	},
-	"EPUBContentDocs-30": {
+	"epubcontentdocs-30": {
 		"authors":[
 		"Markus Gylling",
 		"William McCoy",
 		"Elika J. Etimad",
 		"Matt Garrish"],
-		"title": "EPUB content documents 3.0",
+		"title": "EPUB Content Documents 3.0",
 		"href": "http://idpf.org/epub/30/spec/epub30-contentdocs-20111011.html",
 		"date": "11 October 2011",
 		"publisher": "IDPF"
 	},
-	"EPUBContentDocs-301": {
+	"epubcontentdocs-301": {
 		"authors":[
 		"Markus Gylling",
 		"William McCoy",
 		"Elika J. Etimad",
 		"Matt Garrish"],
-		"title": "EPUB content documents 3.0.1",
+		"title": "EPUB Content Documents 3.0.1",
 		"href": "http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
 		"date": "26 June 2014",
 		"publisher": "IDPF"
 	},
-	"EPUBContentDocs-31": {
+	"epubcontentdocs-31": {
 		"authors":[
 		"Markus Gylling",
 		"William McCoy",
 		"Dave Cramer",
 		"Elika J. Etimad",
 		"Matt Garrish"],
-		"title": "EPUB content documents 3.1",
+		"title": "EPUB Content Documents 3.1",
 		"href": "http://idpf.org/epub/31/spec/epub-contentdocs-20170105.html",
 		"date": "05 January 2017",
 		"publisher": "IDPF"
 	},
-	"EPUBContentDocs-32": {
+	"epubcontentdocs-32": {
 		"authors":[
 		"Dave Cramer",
 		"Matt Garrish"],
-		"title": "EPUB content documents 3.2",
+		"title": "EPUB Content Documents 3.2",
 		"href": "https://www.w3.org/publishing/epub32/epub-contentdocs.html",
 		"date": "08 May 2019",
 		"publisher": "EPUB 3 Community Group"
 	},
-	"EPUBMediaOverlays-30": {
+	"epubmediaoverlays-30": {
 		"authors":[
 		"Marisa DeMeglio",
 		"Daniel Weck"],
@@ -110,7 +110,7 @@ var biblio = {
 		"date": "11 October 2011",
 		"publisher": "IDPF"
 	},
-	"EPUBMediaOverlays-301": {
+	"epubmediaoverlays-301": {
 		"authors":[
 		"Marisa DeMeglio",
 		"Daniel Weck"],
@@ -119,7 +119,7 @@ var biblio = {
 		"date": "26 June 2014",
 		"publisher": "IDPF"
 	},
-	"EPUBMediaOverlays-31": {
+	"epubmediaoverlays-31": {
 		"authors":[
 		"Marisa DeMeglio",
 		"Daniel Weck"],
@@ -128,7 +128,7 @@ var biblio = {
 		"date": "05 January 2017",
 		"publisher": "IDPF"
 	},
-	"EPUBMediaOverlays-32": {
+	"epubmediaoverlays-32": {
 		"authors":[
 		"Marisa DeMeglio",
 		"Daniel Weck"],
@@ -137,7 +137,7 @@ var biblio = {
 		"date": "08 May 2019",
 		"publisher": "EPUB 3 Community Group"
 	},
-	"EPUBPackages-31": {
+	"epubpackages-31": {
 		"authors":[
 		"Markus Gylling",
 		"William McCoy",
@@ -147,7 +147,7 @@ var biblio = {
 		"date": "05 January 2017",
 		"publisher": "IDPF"
 	},
-	"EPUBPackages-32": {
+	"epubpackages-32": {
 		"authors":[
 		"Matt Garrish",
 		"Dave Cramer"],
@@ -156,33 +156,33 @@ var biblio = {
 		"date": "08 May 2019",
 		"publisher": "EPUB 3 Community Group"
 	},
-	"EPUBPublications-30": {
+	"epubpublications-30": {
 		"authors":[
 		"Markus Gylling",
 		"William McCoy",
 		"Matt Garrish"],
-		"title": "EPUB publications 3.0",
+		"title": "EPUB Publications 3.0",
 		"href": "http://idpf.org/epub/30/spec/epub30-publications-20111011.html",
 		"date": "11 October 2011",
 		"publisher": "IDPF"
 	},
-	"EPUBPublications-301": {
+	"epubpublications-301": {
 		"authors":[
 		"Markus Gylling",
 		"William McCoy",
 		"Matt Garrish"],
-		"title": "EPUB publications 3.0.1",
+		"title": "EPUB Publications 3.0.1",
 		"href": "http://idpf.org/epub/301/spec/epub-publications-20140626.html",
 		"date": "26 June 2014",
 		"publisher": "IDPF"
 	},
-	"OCF-201": {
+	"ocf-201": {
 		"title": "EPUB Open Container Format (OCF) 2.0.1",
 		"href": "http://www.idpf.org/epub/20/spec/OCF_2.0.1_draft.doc",
 		"date": "04 September 2010",
 		"publisher": "IDPF"
 	},
-	"OCF-30": {
+	"ocf-30": {
 		"authors":[
 		"James Pritchett",
 		"Markus Gylling"],
@@ -191,7 +191,7 @@ var biblio = {
 		"date": "11 October 2011",
 		"publisher": "IDPF"
 	},
-	"OCF-301": {
+	"ocf-301": {
 		"authors":[
 		"James Pritchett",
 		"Markus Gylling"],
@@ -200,7 +200,7 @@ var biblio = {
 		"date": "26 June 2014",
 		"publisher": "IDPF"
 	},
-	"OCF-31": {
+	"ocf-31": {
 		"authors":[
 		"James Pritchett",
 		"Markus Gylling"],
@@ -209,7 +209,7 @@ var biblio = {
 		"date": "05 January 2017",
 		"publisher": "IDPF"
 	},
-	"OCF-32": {
+	"ocf-32": {
 		"authors":[
 		"Garth Conboy"],
 		"title": "Open Container Format (OCF) 3.2",
@@ -217,19 +217,19 @@ var biblio = {
 		"date": "08 May 2019",
 		"publisher": "EPUB 3 Community Group"
 	},
-	"OPF-201": {
+	"opf-201": {
 		"title": "Open Packaging Format 2.0.1",
 		"href": "http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
 		"date": "04 September 2010",
 		"publisher": "IDPF"
 	},
-	"OPS-201": {
+	"ops-201": {
 		"title": "Open Publication Structure 2.0.1",
 		"href": "http://www.idpf.org/epub/20/spec/OPS_2.0.1_draft.htm",
 		"date": "04 September 2010",
 		"publisher": "IDPF"
 	},
-	"SVG": {
+	"svg": {
 		"title": "SVG",
 		"href": "https://www.w3.org/TR/SVG/",
 		"publisher": "W3C"

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -92,39 +92,39 @@
 		<section id="sec-documents">
 			<h2>Documents</h2>
 
-			<p>EPUB 3.3 [[EPUB-33]] is the current version of EPUB 3. It is defined by the following specifications:</p>
+			<p>EPUB 3.3 [[epub-33]] is the current version of EPUB 3. It is defined by the following specifications:</p>
 
 			<dl>
 				<dt>Recommendation-track Documents:</dt>
 				<dd>
 					<ul>
-						<li>EPUB 3.3 [[EPUB-33]]: defines the authoring format and requirements for EPUB publications,
+						<li>EPUB 3.3 [[epub-33]]: defines the authoring format and requirements for EPUB publications,
 							comprising features such as the <a href="#sec-package-file">package</a> and <a
 								href="#sec-nav-nav-doc">navigation</a> Documents, <a href="#sec-content-docs">EPUB
 								content documents</a>, <a href="#sec-fxl">fixed layouts</a>, <a
 								href="#para-media-overlay">media overlays</a>, and the <a href="#sec-container"
 								>container format</a>. </li>
-						<li>EPUB Reading Systems 3.3 [[EPUB-RS-33]]: defines the conformance requirements for EPUB 3
+						<li>EPUB Reading Systems 3.3 [[epub-rs-33]]: defines the conformance requirements for EPUB 3
 							reading systems — the user agents that render EPUB 3 Publications. </li>
-						<li>EPUB Accessibility 1.1 [[EPUB-A11Y-11]]: specifies content conformance requirements for
+						<li>EPUB Accessibility 1.1 [[epub-a11y-11]]: specifies content conformance requirements for
 							verifying the accessibility of EPUB 3 Publications. </li>
 					</ul>
 				</dd>
 				<dt> Working Group Notes: </dt>
 				<dd>
 					<ul>
-						<li>EPUB Accessibility - EU Accessibility Act Mapping [[EPUB-A11Y-EAA-MAPPING]]: aims to
+						<li>EPUB Accessibility - EU Accessibility Act Mapping [[epub-a11y-eaa-mapping]]: aims to
 							demonstrate that the technical requirements of the <a
 								href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">European
 								Accessibility Act</a> related to ebooks are met by the EPUB standard.</li>
-						<li>EPUB Accessibility Techniques 1.1 [[EPUB-A11Y-TECH-11]]: provides guidance on how to meet
-							the EPUB Accessibility 1.1 [[EPUB-A11Y-11]] discovery and accessibility requirements for
+						<li>EPUB Accessibility Techniques 1.1 [[epub-a11y-tech-11]]: provides guidance on how to meet
+							the EPUB Accessibility 1.1 [[epub-a11y-11]] discovery and accessibility requirements for
 							EPUB publications. </li>
-						<li>EPUB Multiple-Rendition Publications 1.1 [[EPUB-MULTI-REND-11]]: defines the creation and
+						<li>EPUB Multiple-Rendition Publications 1.1 [[epub-multi-rend-11]]: defines the creation and
 							rendering of EPUB publications consisting of more than one Rendition. </li>
-						<li>EPUB 3 Structural Semantics Vocabulary 1.1 [[EPUB-SSV-11]]: defines a set of properties
+						<li>EPUB 3 Structural Semantics Vocabulary 1.1 [[epub-ssv-11]]: defines a set of properties
 							relating to the description of structural semantics of written works.</li>
-						<li>EPUB 3 Text-to-Speech Enhancements 1.0 [[EPUB-TTS-10]]: describes authoring features and
+						<li>EPUB 3 Text-to-Speech Enhancements 1.0 [[epub-tts-10]]: describes authoring features and
 							reading system support for improving the voicing of EPUB 3 publications. </li>
 					</ul>
 				</dd>
@@ -171,12 +171,12 @@
 					makes it difficult to enumerate all the resources required to render it. In addition, there is no
 					standard way for a web site to define that a sequence of pages make up a larger publication, which
 					is precisely what EPUB's <a data-cite="epub-33#sec-spine-elem"><code>spine</code> element</a>
-					[[EPUB-33]] does (i.e., it provides an external declarative means to explicitly specify navigation
+					[[epub-33]] does (i.e., it provides an external declarative means to explicitly specify navigation
 					through a collection of documents). Finally, the package document defines a standard way to
 					represent metadata globally applicable to a collection of pages.</p>
 
 				<p>The package document also includes a <a data-cite="epub-33#sec-collection-elem"
-							><code>collection</code> element</a> [[EPUB-33]], which allows grouping of logically related
+							><code>collection</code> element</a> [[epub-33]], which allows grouping of logically related
 						<a>publication resources</a>. This element exists to enable the development of specialized
 					content identification, processing, and rendering features such as the ability to define embedded
 					preview content or assemble an index or dictionary from its constituent XHTML content documents.</p>
@@ -185,7 +185,7 @@
 					are actively maintained by the EPUB 3 Working Group. </p>
 
 				<p>The package document is specified in the dedicated <a data-cite="epub-33#sec-package-doc">section</a>
-					of [[EPUB-33]].</p>
+					of [[epub-33]].</p>
 			</section>
 
 			<section id="sec-nav">
@@ -206,8 +206,8 @@
 
 					<p>Each EPUB publication defines at least one such logical ordering of all its top-level content in
 						the <a data-cite="epub-33#sec-spine-elem">spine</a> of the <a href="#sec-package-file">package
-							document</a> [[EPUB-33]]. Each one also defines a declarative table of contents in the <a
-							href="#sec-nav-nav-doc">EPUB navigation document</a> [[EPUB-33]]. EPUB publications make
+							document</a> [[epub-33]]. Each one also defines a declarative table of contents in the <a
+							href="#sec-nav-nav-doc">EPUB navigation document</a> [[epub-33]]. EPUB publications make
 						these data structures available in a machine-readable way <em>external</em> to the content,
 						simplifying their discovery and use.</p>
 
@@ -221,7 +221,7 @@
 					<h3>Navigation document</h3>
 
 					<p>Each EPUB publication contains a special XHTML content document called the <a>EPUB navigation
-							document</a>, which uses the [[HTML]] <a><code>nav</code></a> element to define human- and
+							document</a>, which uses the [[html]] <a><code>nav</code></a> element to define human- and
 						machine-readable navigation information. All reading systems make use of the EPUB navigation
 						document to present a table of contents to their users.</p>
 
@@ -234,15 +234,15 @@
 					<p>Note that EPUB reading systems are not <em>required</em> to use these advanced XHTML features,
 						such as ruby annotations, when generating a reading system specific table of contents. However,
 						EPUB creators may also include the EPUB navigation document in the <a
-							data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]] to make use of the richer
+							data-cite="epub-33#sec-spine-elem">spine</a> [[epub-33]] to make use of the richer
 						markup.</p>
 
 					<p>EPUB navigation documents also provide a flexible means of tailoring the navigation display using
 						CSS and the <a data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a>
-						[[EPUB-33]] while not impacting access to information for accessible reading systems.</p>
+						[[epub-33]] while not impacting access to information for accessible reading systems.</p>
 
 					<p>The structure and semantics of EPUB navigation documents are defined in the dedicated <a
-							data-cite="epub-33#sec-nav">section</a> of [[EPUB-33]].</p>
+							data-cite="epub-33#sec-nav">section</a> of [[epub-33]].</p>
 				</section>
 			</section>
 
@@ -250,19 +250,19 @@
 				<h2>Metadata</h2>
 
 				<p>EPUB publications provide a rich array of options for adding metadata. Each package document includes
-					a dedicated <a data-cite="epub-33#sec-pkg-metadata"><code>metadata</code> section</a> [[EPUB-33]]
+					a dedicated <a data-cite="epub-33#sec-pkg-metadata"><code>metadata</code> section</a> [[epub-33]]
 					for general information about the EPUB publication, allowing titles, authors, identifiers, and other
 					information about the EPUB publication to be easily accessed. It also provides the means to attach
 					complete bibliographic records using the <a data-cite="epub-33#sec-link-elem"><code>link</code>
-						element</a> [[EPUB-33]].</p>
+						element</a> [[epub-33]].</p>
 
 				<p>The package document also allows a <a>Unique Identifier</a> to be established for the EPUB
 					publication using the <a data-cite="epub-33#attrdef-package-unique-identifier"
-							><code>unique-identifier</code> attribute</a> [[EPUB-33]].</p>
+							><code>unique-identifier</code> attribute</a> [[epub-33]].</p>
 
 				<p>XHTML content documents also include the means of annotating document markup with rich metadata,
 					making them more semantically meaningful and useful both for processing and accessibility purposes.
-					Both RDFa [[RDFA-IN-HTML]] and Microdata [[Microdata]] attributes can be used in XHTML content
+					Both RDFa [[rdfa-in-html]] and Microdata [[microdata]] attributes can be used in XHTML content
 					documents for that purpose. </p>
 
 			</section>
@@ -271,11 +271,11 @@
 				<h2>Content documents</h2>
 
 				<p>Each EPUB publication contains one or more <a>EPUB content documents</a>, as defined in the dedicated
-						<a data-cite="epub-33#sec-contentdocs">section</a> of [[EPUB-33]]. These are XHTML or SVG
+						<a data-cite="epub-33#sec-contentdocs">section</a> of [[epub-33]]. These are XHTML or SVG
 					documents that describe the readable content and reference associated media resources (e.g., images,
 					audio, and video clips).</p>
 
-				<p><a>XHTML content documents</a> are defined by a profile of [[HTML]].</p>
+				<p><a>XHTML content documents</a> are defined by a profile of [[html]].</p>
 			</section>
 
 			<section id="sec-fxl">
@@ -286,20 +286,20 @@
 					children's books, comics and manga, magazines, and many other content forms.</p>
 
 				<p>EPUB 3 includes metadata that allows the creation of <a data-cite="epub-33#sec-fixed-layouts"
-						>fixed-layout XHTML content documents</a> [[EPUB-33]], in addition to existing capabilities for
+						>fixed-layout XHTML content documents</a> [[epub-33]], in addition to existing capabilities for
 					fixed layouts in SVG. This metadata enables the control of the <a
-						data-cite="epub-33#sec-fxl-content-dimensions">page dimensions</a> [[EPUB-33]], creating a
+						data-cite="epub-33#sec-fxl-content-dimensions">page dimensions</a> [[epub-33]], creating a
 					canvas on which elements can be absolutely positioned.</p>
 
 				<p>The metadata does not just flag whether content is to be fixed or reflowed, but also allows EPUB
 					creators to specify the desired <a data-cite="epub-33#orientation">orientation of
-					pages</a> [[EPUB-33]], when to <a data-cite="epub-33#spread">create synthetic
-					spreads</a> [[EPUB-33]], and <a data-cite="epub-33#page-spread">how to position
-					pages</a> [[EPUB-33]] within those spreads, providing a broad range of control over the presentation
+					pages</a> [[epub-33]], when to <a data-cite="epub-33#spread">create synthetic
+					spreads</a> [[epub-33]], and <a data-cite="epub-33#page-spread">how to position
+					pages</a> [[epub-33]] within those spreads, providing a broad range of control over the presentation
 					of EPUB publications.</p>
 
 				<p>The <a data-cite="epub-33#sec-fixed-layouts">structure and semantics of EPUB Documents with Fixed
-						Layouts</a> are defined in [[EPUB-33]].</p>
+						Layouts</a> are defined in [[epub-33]].</p>
 
 			</section>
 
@@ -321,7 +321,7 @@
 					throughout the evolution of the EPUB standard.</p>
 
 				<p>EPUB content documents can reference CSS Style Sheets, allowing EPUB creators to define the desired
-					rendering properties. EPUB 3 follows support for CSS as defined in the [[CSSSnapshot]].</p>
+					rendering properties. EPUB 3 follows support for CSS as defined in the [[csssnapshot]].</p>
 
 				<p>EPUB 3 also supports CSS styles that enable both horizontal and vertical layout and both
 					left-to-right and right-to-left writing.</p>
@@ -330,19 +330,19 @@
 			<section id="sec-multimedia">
 				<h2>Multimedia</h2>
 
-				<p>EPUB 3 supports audio and video embedded in <a>XHTML content documents</a> via the [[HTML]]
+				<p>EPUB 3 supports audio and video embedded in <a>XHTML content documents</a> via the [[html]]
 							<a><code>audio</code></a> and <a><code>video</code></a> elements, inheriting all the
 					functionality and features these elements provide. For more information on audio and video formats,
 					refer to the section on <a data-cite="epub-33#sec-core-media-types">core media
-					types</a> [[EPUB-33]].</p>
+					types</a> [[epub-33]].</p>
 
 				<p id="para-media-overlay">Another key multimedia feature in EPUB 3 is the inclusion of <a>media overlay
-						documents</a> [[EPUB-33]]. When pre-recorded narration is available for an EPUB publication,
+						documents</a> [[epub-33]]. When pre-recorded narration is available for an EPUB publication,
 					Media Overlays provide the ability to synchronize that audio with the text of a Content Document
 					(see also <a href="#sec-access-overlays"></a>).</p>
 
 				<p>The <a data-cite="epub-33#sec-media-overlays">structure and semantics of EPUB Documents with Media
-						Overlays</a> are defined in [[EPUB-33]].</p>
+						Overlays</a> are defined in [[epub-33]].</p>
 
 
 			</section>
@@ -350,8 +350,8 @@
 			<section id="sec-fonts">
 				<h2>Fonts</h2>
 
-				<p>EPUB 3 supports two closely related font formats — OpenType [[OpenType]] and WOFF [[WOFF]]
-					[[WOFF2]] — to accommodate both traditional publishing workflows and emerging web-based workflows.
+				<p>EPUB 3 supports two closely related font formats — OpenType [[opentype]] and WOFF [[woff]]
+					[[woff2]] — to accommodate both traditional publishing workflows and emerging web-based workflows.
 					Word processing programs used to create EPUB publications are likely to have access only to a
 					collection of installed OpenType fonts, for example, whereas web-archival EPUB generators will
 					likely only have access to WOFF resources (which cannot be converted to OpenType without
@@ -360,7 +360,7 @@
 				<p>EPUB 3 also supports both obfuscated and regular font resources for both OpenType and WOFF font
 					formats. Support for obfuscated font resources is required to accommodate font licensing
 					restrictions for many commercially available fonts. See the dedicated <a
-						data-cite="epub-33#sec-font-obfuscation">section on Font Obfuscation</a> in [[EPUB-33]] for more
+						data-cite="epub-33#sec-font-obfuscation">section on Font Obfuscation</a> in [[epub-33]] for more
 					details.</p>
 
 			</section>
@@ -369,8 +369,8 @@
 				<h2>Scripting</h2>
 
 				<p>EPUB strives to treat content <em>declaratively</em> — as data that can be manipulated, not as
-					programs to be executed — but does support scripting as defined in [[HTML]] and [[SVG]] (refer to
-					the section on <a data-cite="epub-33#sec-scripted-content">Scripting</a> [[EPUB-33]] for more
+					programs to be executed — but does support scripting as defined in [[html]] and [[svg]] (refer to
+					the section on <a data-cite="epub-33#sec-scripted-content">Scripting</a> [[epub-33]] for more
 					information).</p>
 
 				<p>It is important to note, however, that EPUB 3 does not require scripting support in reading systems,
@@ -382,7 +382,7 @@
 					system. Therefore, it is strongly encouraged that scripting be limited to container constrained
 					contexts, as further described in the section on <a
 						data-cite="epub-33#sec-scripted-container-constrained">container-constrained
-					scripts</a> [[EPUB-33]].</p>
+					scripts</a> [[epub-33]].</p>
 
 				<p>In other words, consider limiting scripting to cases where it is essential to the user experience,
 					since it greatly increases the likelihood that content will not be portable across all reading
@@ -400,25 +400,25 @@
 					<dt>Pronunciation Lexicons</dt>
 					<dd>
 						<p>The inclusion of generic pronunciation lexicons using the W3C PLS format
-							[[PRONUNCIATION-LEXICON]] enables EPUB creators to provide pronunciation rules that apply to
+							[[pronunciation-lexicon]] enables EPUB creators to provide pronunciation rules that apply to
 							the entire EPUB publication. Refer to <a data-cite="epub-tts-10#pls">Pronunciation
-								Lexicons</a> [[EPUB-TTS-10]] for more information.</p>
+								Lexicons</a> [[epub-tts-10]] for more information.</p>
 					</dd>
 					<dt>Inline SSML Phonemes</dt>
 					<dd>
-						<p> The incorporation of SSML phonemes functionality [[SSML]] directly into a <a>EPUB content
+						<p> The incorporation of SSML phonemes functionality [[ssml]] directly into a <a>EPUB content
 								document</a> enables fine-grained pronunciation control, taking precedence over default
 							pronunciation rules and/or referenced pronunciation lexicons (as provided by the PLS format
 							mentioned above). Refer to <a data-cite="epub-tts-10#ssml">SSML Attributes</a>
-							[[EPUB-TTS-10]] for more information.</p>
+							[[epub-tts-10]] for more information.</p>
 					</dd>
 				</dl>
 
-				<p>Note that EPUB creators may also rely on CSS Speech [[CSS-SPEECH-1]] properties in their style sheet
+				<p>Note that EPUB creators may also rely on CSS Speech [[css-speech-1]] properties in their style sheet
 					definitions.</p>
 
 				<p>The authoring features for improving the voicing of EPUB 3 publication are described in the separate
-					Working Group Note on Text-to-Speech Enhancements [[EPUB-TTS-10]].</p>
+					Working Group Note on Text-to-Speech Enhancements [[epub-tts-10]].</p>
 
 			</section>
 
@@ -436,7 +436,7 @@
 					network transport or file system specifics.</p>
 
 				<p>An EPUB publication's representation as a container file is specified in the dedicated <a
-						data-cite="epub-33#sec-ocf">section</a> of [[EPUB-33]].</p>
+						data-cite="epub-33#sec-ocf">section</a> of [[epub-33]].</p>
 
 			</section>
 		</section>
@@ -445,7 +445,7 @@
 
 
 			<p> EPUB 3 leverages the features in XHTML, SVG, CSS, or MathML for global language support, and it also
-				relies on [[Unicode]] for encoding the content. This means that content documents in EPUB 3 have the
+				relies on [[unicode]] for encoding the content. This means that content documents in EPUB 3 have the
 				possibility to use different character sets and express bidirectional text, ruby annotations, or
 				typography for many different languages and cultures. Features have also been added to the various
 				components defined by EPUB 3 to ensure language support. </p>
@@ -455,7 +455,7 @@
 
 				<p>EPUB 3 supports alternate representations of all text metadata items in the package metadata section
 					to improve global distribution of EPUB publications. The <a data-cite="epub-33#alternate-script"
-							><code>alternate-script</code> property</a> [[EPUB-33]] can be combined with the
+							><code>alternate-script</code> property</a> [[epub-33]] can be combined with the
 						<code>xml:lang</code> attribute to include and identify alternate script renderings of
 					language-specific metadata.</p>
 
@@ -464,13 +464,13 @@
 					a Romance language.</p>
 
 				<p>Text metadata items may also rely on <a data-cite="epub-33#attrdef-dir">attributes specifying base
-						direction</a> [[EPUB-33]] that allow for a finer control of bidirectional texts (e.g., titles
+						direction</a> [[epub-33]] that allow for a finer control of bidirectional texts (e.g., titles
 					that combine Latin and Arabic or Hebrew characters). </p>
 
 				<p>Finally, the <code>page-progression-direction</code> attribute allows the content flow direction to
 					be globally specified for all EPUB content documents to facilitate rendering (see the <a
 						data-cite="epub-33#attrdef-spine-page-progression-direction">page-progression-direction</a>
-					[[EPUB-33]]).</p>
+					[[epub-33]]).</p>
 			</section>
 
 			<!-- <section id="sec-gls-fonts">
@@ -517,10 +517,10 @@
 				this requirement. This section reviews these features, detailing some established best practices for
 				ensuring that EPUB publications are accessible where applicable.</p>
 
-			<p>EPUB 3 also includes an Accessibility specification [[EPUB-A11Y-11]] that leverages the extensive work
-				done to make web content accessible in [[WCAG21]]. The specification defines requirements to produce
+			<p>EPUB 3 also includes an Accessibility specification [[epub-a11y-11]] that leverages the extensive work
+				done to make web content accessible in [[wcag21]]. The specification defines requirements to produce
 				EPUB publications that can be accessed by a wide range of users. It is accompanied by a techniques
-				document [[EPUB-A11Y-TECH-11]] that outlines best practices for meeting these requirements.</p>
+				document [[epub-a11y-tech-11]] that outlines best practices for meeting these requirements.</p>
 
 			<p>It is important to note that while accessibility is important in its own right, accessible content is
 				also more valuable content: an accessible EPUB publication will be adaptable to more devices and be
@@ -537,7 +537,7 @@
 					the <a data-cite="epub-33#sec-spine-elem"><code>spine</code></a>. To avoid the situation in highly
 					structured documents where it might not be desirable to display the complete table of contents to
 					users in the body of the publication, the display level can be modified using the <a
-						data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a> [[EPUB-33]]. This
+						data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a> [[epub-33]]. This
 					attribute is ignored by reading systems when they render the table of contents outside the <a
 						data-cite="epub-33#sec-spine-elem"><code>spine</code></a> (e.g., in their own specialized
 					views), which avoids minimizing the information that is available.</p>
@@ -551,13 +551,13 @@
 			<section id="sec-access-semantic-markup">
 				<h2>Semantic markup</h2>
 
-				<p>[[HTML]] supports a number of elements that make markup more semantically meaningful (e.g.,
+				<p>[[html]] supports a number of elements that make markup more semantically meaningful (e.g.,
 							<a><code>section</code></a>, <a><code>nav</code></a>, and <a><code>aside</code></a>). EPUB
 					creators are encouraged to use these elements, in conjunction with best practices for authoring
 					well-structured web content, when creating EPUB XHTML content documents. These additions allow
 					content to be better grouped and defined, both to represent the structure of documents and to
 					facilitate their logical navigation. XHTML content documents also natively support the inclusion of
-					ARIA role and state attributes and events, including the dedicated [[DPUB-ARIA-1.0]] roles,
+					ARIA role and state attributes and events, including the dedicated [[dpub-aria-1.0]] roles,
 					enhancing the ability of Assistive Technologies to interact with the content.</p>
 
 				<p>EPUB 3 also includes the <code>epub:type</code> attribute, which allows the inclusion of additional
@@ -594,7 +594,7 @@
 					layout. Refer to <a href="#sec-tts"></a> for more information on how to use the native facilities
 					that XHTML content documents include.</p>
 
-				<p><a data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[EPUB-33]] provide the ability to
+				<p><a data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[epub-33]] provide the ability to
 					synchronize the text and audio content of an EPUB publication. Beyond benefiting accessibility,
 					overlays have other applications, e.g., synchronizing text and audio as a tool for learning to
 					read.</p>
@@ -608,7 +608,7 @@
 					renderings can be made available in these cases.</p>
 
 				<p>Publication- and content-level fallbacks are defined in the section on <a
-						data-cite="epub-33#sec-foreign-resources">foreign resources</a> [[EPUB-33]]. These fallback
+						data-cite="epub-33#sec-foreign-resources">foreign resources</a> [[epub-33]]. These fallback
 					mechanisms enable the inclusion of foreign resources in an EPUB publication and ensure compatibility
 					of EPUB 3 content across reading systems with varying capabilities (e.g., they allow the inclusion
 					of multiple video formats, and the inclusion of XHTML fallbacks to SVG content documents for EPUB 2
@@ -621,11 +621,11 @@
 				<p>EPUB 3 adopts a progressive enhancement approach for scripted content, whereby scripting is not
 					allowed to interfere with the integrity of the document (i.e., not result in information loss when
 					scripting is not available). Consequently, although documents that do employ scripting <a
-						data-cite="epub-33#sec-scripted-content">can provide fallbacks</a> [[EPUB-33]] to further
+						data-cite="epub-33#sec-scripted-content">can provide fallbacks</a> [[epub-33]] to further
 					facilitate access to their contents, the documents have to be accessible without them.</p>
 
 				<p>EPUB creators should always implement best practices for accessible scripting in web documents, such
-					as provided in [[WAI-ARIA]], and reserve the use of scripting for situations in which interactivity
+					as provided in [[wai-aria]], and reserve the use of scripting for situations in which interactivity
 					is critical to the user experience.</p>
 			</section>
 		</section>
@@ -646,8 +646,8 @@
 					began in parallel which was renamed EPUB 2.0 in October 2007 and approved in September 2010. This
 					revision consisted of a triumvirate of specifications: Open Package Format (OPF), Open Publication
 					Format (OPF), and OCF. EPUB 2.0.1, which was a maintenance update to the 2.0 specification set,
-					primarily intended to clarify and correct errata in the specifications. See [[OPF-201]] [[OPS-201]]
-					[[OCF-201]]. </p>
+					primarily intended to clarify and correct errata in the specifications. See [[opf-201]] [[ops-201]]
+					[[ocf-201]]. </p>
 
 			</section>
 			<section id="epub30">
@@ -660,8 +660,8 @@
 					allowing for text and audio synchronization in EPUB publications. To better align the specification
 					names with the standard, the Open Package Format specification was renamed EPUB publications and the
 					Open Publication Format specification was renamed EPUB content documents. The EPUB 3.0
-					specifications were approved in October 2011. See [[EPUBPublications-30]] [[EPUBContentDocs-30]]
-					[[OCF-30]] [[EPUBMediaOverlays-30]] [[EPUBChanges-30]].</p>
+					specifications were approved in October 2011. See [[epubpublications-30]] [[epubcontentdocs-30]]
+					[[ocf-30]] [[epubmediaoverlays-30]] [[epubchanges-30]].</p>
 			</section>
 
 			<section id="epub301">
@@ -669,8 +669,8 @@
 				<p>The EPUB 3.0.1 revision was undertaken in 2013-14. Although introducing mostly minor fixes and
 					updates, it did see the integration of Fixed Layout Documents, which give EPUB creators greater
 					control over presentation when a reflowable EPUB is not suitable for the content.
-					See [[EPUBPublications-301]] [[EPUBContentDocs-301]] [[OCF-301]] [[EPUBMediaOverlays-301]]
-					[[EPUBChanges-301]].</p>
+					See [[epubpublications-301]] [[epubcontentdocs-301]] [[ocf-301]] [[epubmediaoverlays-301]]
+					[[epubchanges-301]].</p>
 			</section>
 
 			<section id="epub31">
@@ -682,8 +682,8 @@
 					the use of EPUB-specific properties reduced.</p>
 				<p>Many EPUB-specific features were also removed from the standard, in particular content switching,
 					triggers, and bindings. This change necessitated a new package document version number.
-					See [[EPUB-31]] [[EPUBPackages-31]] [[EPUBContentDocs-31]] [[OCF-31]] [[EPUBMediaOverlays-31]]
-					[[EPUBChanges-31]]</p>
+					See [[epub-31]] [[epubpackages-31]] [[epubcontentdocs-31]] [[ocf-31]] [[epubmediaoverlays-31]]
+					[[epubchanges-31]]</p>
 			</section>
 
 			<section id="epub32">
@@ -693,13 +693,13 @@
 					reading system developers would have to produce, distribute and consume two versions of EPUB
 					content, but the costs of this change outweighed the benefits of the new version. EPUB 3.2 instead
 					keeps all the best parts of EPUB 3.1 but deprecates elements instead of removing them so that a new
-					version number is not necessary in the package document. See [[EPUB-32]] [[EPUBPackages-32]]
-					[[EPUBContentDocs-32]] [[OCF-32]] [[EPUBMediaOverlays-32]] [[EPUBChanges-32]]</p>
+					version number is not necessary in the package document. See [[epub-32]] [[epubpackages-32]]
+					[[epubcontentdocs-32]] [[ocf-32]] [[epubmediaoverlays-32]] [[epubchanges-32]]</p>
 			</section>
 
 			<section id="epub33">
 				<h3>EPUB 3.3: 2022</h3>
-				<p>The work on EPUB 3.3 [[EPUB-33]] was undertaken in 2020-21, and is the first version of the EPUB 3
+				<p>The work on EPUB 3.3 [[epub-33]] was undertaken in 2020-21, and is the first version of the EPUB 3
 					series published as a W3C Recommendation. EPUB 3.3 does not include any significant technical change
 					to, and is strongly backward compatible with, EPUB 3.2. This means that any valid EPUB 3.2
 					Publication is also a valid EPUB 3.3 Publication. </p>
@@ -715,7 +715,7 @@
 					they may have some authoring uptakes, still lack support in reading systems; as a result, these
 					technologies should not yet be considered stable and interoperable.</p>
 
-				<p>The separate <a data-cite="epub-33#change-log">section</a> in [[EPUB-33]] provides a more detailed
+				<p>The separate <a data-cite="epub-33#change-log">section</a> in [[epub-33]] provides a more detailed
 					overview of the changes.</p>
 			</section>
 		</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -65,22 +65,22 @@
 					branch: "main"
 				},
 				localBiblio: {
-					"CSSSnapshot": {
+					"csssnapshot": {
 						"title": "CSS Snapshot",
 						"href": "https://www.w3.org/TR/CSS/"
 					},
-					"EPUBContentDocs-301": {
+					"epubcontentdocs-301": {
 						"authors":[
 						"Markus Gylling",
 						"William McCoy",
 						"Elika J. Etimad",
 						"Matt Garrish"],
-						"title": "EPUB content documents 3.0.1",
+						"title": "EPUB Content Documents 3.0.1",
 						"href": "http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
 						"date": "26 June 2014",
 						"publisher": "IDPF"
 					},
-					"EPUBPackages-32": {
+					"epubpackages-32": {
 						"authors":[
 						"Matt Garrish",
 						"Dave Cramer"],
@@ -89,17 +89,17 @@
 						"date": "08 May 2019",
 						"publisher": "EPUB 3 Community Group"
 					},
-					"H264": {
+					"h264": {
 						"title": "H.264 : Advanced video coding for generic audiovisual services",
 						"href": "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=13189",
 						"date": "2017-04-13"
 					},
-					"SVG": {
+					"svg": {
 						"title": "SVG",
 						"href": "https://www.w3.org/TR/SVG/",
 						"publisher": "W3C"
 					},
-					"W3CProcess": {
+					"w3cprocess": {
 						"title": "W3C Process Document",
 						"href": "https://www.w3.org/Consortium/Process/"
 					},
@@ -133,7 +133,7 @@
 				<h3>Overview</h3>
 
 				<p>The EPUB 3 standard is separated into two distinct concerns: the authoring of <a>EPUB
-						publications</a> is defined in the <a data-cite="epub-33#">core specification</a> [[EPUB-33]],
+						publications</a> is defined in the <a data-cite="epub-33#">core specification</a> [[epub-33]],
 					while this specification details the rendering requirements for them in EPUB reading systems.</p>
 
 				<p>An EPUB reading system can take many forms. It might have a visual display area for rendering the
@@ -161,7 +161,7 @@
 				<h3>Terminology</h3>
 
 				<p>This specification uses <a data-cite="epub-33#sec-terminology">terminology defined in EPUB 3.3</a>
-					[[EPUB-33]] as well as the term defined in this section. Terms appear capitalized wherever used.</p>
+					[[epub-33]] as well as the term defined in this section. Terms appear capitalized wherever used.</p>
 
 				<p>Only the first instance of a term in a section links to its definition.</p>
 
@@ -186,7 +186,7 @@
 				<section id="rel">
 					<h4>Relationship to HTML</h4>
 
-					<p>The [[HTML]] standard is continuously evolving &#8212; there are no longer versioned releases of
+					<p>The [[html]] standard is continuously evolving &#8212; there are no longer versioned releases of
 						it. That standard, in turn, references various technologies that continue to evolve, such as
 						MathML, SVG, CSS, and JavaScript.</p>
 
@@ -204,7 +204,7 @@
 				<section id="sec-overview-relations-svg">
 					<h4>Relationship to SVG</h4>
 
-					<p>This specification does not reference a specific version of [[SVG]], but instead uses an undated
+					<p>This specification does not reference a specific version of [[svg]], but instead uses an undated
 						reference. Whenever there is any ambiguity in this reference, the latest recommended
 						specification is the authoritative reference.</p>
 
@@ -218,7 +218,7 @@
 			<h3>Publication resource processing</h3>
 
 			<p id="confreq-rs-epub-pub-res" class="support" data-tests="#cnt-xhtml-support">Reading systems MUST process
-					<a data-cite="epub-33#sec-publication-resources">publication resources</a> [[EPUB-33]].</p>
+					<a data-cite="epub-33#sec-publication-resources">publication resources</a> [[epub-33]].</p>
 
 			<section id="sec-epub-rs-conf-cmt">
 				<h4>Core Media types</h4>
@@ -226,14 +226,14 @@
 				<p id="confreq-rs-epub3-images"
 					data-tests="#pub-cmt-gif,#pub-cmt-jpg,#pub-cmt-png,#pub-cmt-svg,#pub-cmt-webp">If a reading system
 					has a <a>viewport</a>, it MUST support the <a data-cite="epub-33#cmt-grp-image">image core media
-						type resources</a> [[EPUB-33]].</p>
+						type resources</a> [[epub-33]].</p>
 
 				<p id="confreq-rs-epub3-mp3-aac" data-tests="#pub-cmt-mp3,#pub-cmt-mp4,#pub-cmt-opus">If it has the
 					capability to render prerecorded audio, it MUST support the <a data-cite="epub-33#cmt-grp-audio"
-						>audio core media type resources</a> [[EPUB-33]].</p>
+						>audio core media type resources</a> [[epub-33]].</p>
 
 				<p class="note" id="note-video-codecs">It is recommended that reading systems support at least one of
-					the H.264 [[H264]] and VP8 [[RFC6386]] video codecs, but this is not a conformance requirement
+					the H.264 [[h264]] and VP8 [[rfc6386]] video codecs, but this is not a conformance requirement
 					&#8212; a reading system may support any video codec, or none at all. Reading system developers
 					should take into consideration factors such as breadth of adoption, playback quality, and technology
 					royalties when deciding which video formats to support.</p>
@@ -246,14 +246,14 @@
 					data-tests="#pub-foreign_image,#pub-foreign_xml-spine,#pub-foreign_xml-suffix-spine,#pub-foreign_bad-fallback,#pub-foreign_json-spine"
 					>Reading systems MAY support an arbitrary set of <a>foreign resource</a> types, and if a foreign
 					resource is not supported, MUST process fallbacks as defined in <a
-						data-cite="epub-33#sec-foreign-restrictions">foreign resources</a> [[EPUB-33]].</p>
+						data-cite="epub-33#sec-foreign-restrictions">foreign resources</a> [[epub-33]].</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-remote-res">
 				<h4>Resource locations</h4>
 
 				<p id="confreq-rs-remote">Reading systems SHOULD support <a>remote resources</a>, as defined in <a
-						data-cite="epub-33#sec-resource-locations">Resource locations</a> [[EPUB-33]].</p>
+						data-cite="epub-33#sec-resource-locations">Resource locations</a> [[epub-33]].</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-data-urls">
@@ -261,7 +261,7 @@
 
 				<p id="confreq-rs-data-urls"
 					data-tests="#pub-data-urls_browsing-context,#pub-data-urls_top-level-content">Reading systems MUST
-					prevent data URLs [[RFC2397]] from opening in <a>top-level browsing contexts</a> [[HTML]], except
+					prevent data URLs [[rfc2397]] from opening in <a>top-level browsing contexts</a> [[html]], except
 					when initiated through a reading system affordance such as a context menu. If a reading system does
 					not use a top-level browsing context for <a>top-level content documents</a>, for example if the
 					top-level content document is an SVG, it MUST also prevent data URLs from opening as though they are
@@ -277,18 +277,18 @@
 					<li>
 						<p id="confreq-rs-xml-nval"
 							data-tests="#pub-xml-non-validating_invalid,#pub-xml-non-validating_unclosed">a <a
-								data-cite="xml#proc-types">conformant non-validating XML processor</a> [[XML]].</p>
+								data-cite="xml#proc-types">conformant non-validating XML processor</a> [[xml]].</p>
 					</li>
 					<li>
 						<p id="confreq-rs-xml-ns" data-tests="#pub-xml-names">a <a
 								data-cite="xml-names#ProcessorConformance">conformant processor</a> as defined in
-							[[XML-NAMES]].</p>
+							[[xml-names]].</p>
 					</li>
 				</ul>
 
 				<p id="confreq-rs-xml-extid" data-tests="#pub-xml-external-id">In addition, when processing XML
 					documents, a reading system MUST NOT resolve <a data-cite="xml#NT-ExternalID">external
-						identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[XML]].</p>
+						identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[xml]].</p>
 			</section>
 
 			<section id="sec-epub-rs-i18n">
@@ -299,27 +299,27 @@
 					applicable. This includes:</p>
 
 				<ul>
-					<li>the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a> [[XML]] for all XML
+					<li>the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a> [[xml]] for all XML
 						documents (e.g., the <a>package document</a>, <a>XHTML content documents</a>, <a>SVG content
 							documents</a>, and <a>media overlay documents</a>).</li>
 
 					<li>the <code>lang</code> attribute for XHTML content documents and SVG content documents. (Refer to
-						respective "The 'lang' and 'xml:lang' attributes" sections in [[HTML]] and [[SVG]] for more
+						respective "The 'lang' and 'xml:lang' attributes" sections in [[html]] and [[svg]] for more
 						information.)</li>
 				</ul>
 
 				<p>Similarly, a reading system MUST process, for all <a data-cite="epub-33#dfn-publication-resource"
-						>publication resources</a> [[EPUB-33]], the attributes that set the base direction for the
+						>publication resources</a> [[epub-33]], the attributes that set the base direction for the
 					documents' contents, when applicable. This includes:</p>
 
 				<ul>
 					<li id="confreq-rs-pkg-dir-intro"
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
-						>the <a data-cite="epub-33#attrdef-dir"><code>dir</code></a> attribute [[EPUB-33]] for the
+						>the <a data-cite="epub-33#attrdef-dir"><code>dir</code></a> attribute [[epub-33]] for the
 							<a>package document</a>. (See also <a href="#sec-pkg-doc-base-dir"></a> for further
 						details.)</li>
-					<li>the [[HTML]] [^html-global/dir^] attribute for XHTML content documents.</li>
-					<li>the [[SVG]] <a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
+					<li>the [[html]] [^html-global/dir^] attribute for XHTML content documents.</li>
+					<li>the [[svg]] <a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
 								><code>direction</code></a> attribute for SVG content documents.</li>
 				</ul>
 
@@ -331,7 +331,7 @@
 						data-cite="epub-33#attrdef-dir"><code>dir</code></a> attributes, in <a
 						data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attributes</a> on <a
 						data-cite="epub-33#sec-link-elem"><code>link</code> elements</a>, or from <a
-						data-cite="epub-33#sec-opf-dclanguage"><code>dc:language</code> elements</a> [[EPUB-33]]). Refer
+						data-cite="epub-33#sec-opf-dclanguage"><code>dc:language</code> elements</a> [[epub-33]]). Refer
 					to a resource's formal specification for more information about to handle the absence of explicit
 					language or direction information.</p>
 			</section>
@@ -370,7 +370,7 @@
 
 				<p>Although links to external web sites and resources are commonly found in <a>EPUB content
 						documents</a>, these are not the only sources. For example, if a reading system provides access
-					to <a data-cite="epub-33#sec-link-elem">linked records</a> [[EPUB-33]] in the <a>package
+					to <a data-cite="epub-33#sec-link-elem">linked records</a> [[epub-33]] in the <a>package
 						document</a> metadata, it should similarly open the links in a new browser instance.</p>
 
 				<div class="note">
@@ -383,7 +383,7 @@
 			<h2>Open Container Format (OCF) processing</h2>
 
 			<p id="confreq-rs-epub3-ocf" class="support" data-tests="#ocf-package_arbitrary">Reading systems MUST
-				process the <a data-cite="epub-33#sec-ocf">EPUB container</a> [[EPUB-33]].</p>
+				process the <a data-cite="epub-33#sec-ocf">EPUB container</a> [[epub-33]].</p>
 
 			<div class="note">
 				<p>An application that processes EPUB containers does not have to be a full-fledged reading system
@@ -400,19 +400,19 @@
 
 					<p id="sec-container-iri-root"
 						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">Reading systems MUST
-						assign a URL [[URL]] to the <a>root directory</a> of the <a>OCF abstract container</a>. This URL
-						is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a> [[EPUB-33]].
+						assign a URL [[url]] to the <a>root directory</a> of the <a>OCF abstract container</a>. This URL
+						is called the <a data-cite="epub-33#dfn-container-root-url">container root URL</a> [[epub-33]].
 						It is implementation specific, but the implementation MUST have the following properties:</p>
 
 					<ul>
 						<li id="sec-container-iri-root-parse"
 							data-tests="#ocf-url_link-path-absolute,#ocf-url_parse-path-absolute">The result of <a
-								data-lt="url parser">parsing</a> [[URL]] "<code>/</code>" with the <a>container root
+								data-lt="url parser">parsing</a> [[url]] "<code>/</code>" with the <a>container root
 								URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container
 								root URL</a>.</li>
 						<li id="sec-container-iri-step-parse"
 							data-tests="#ocf-url_link-leaking-relative,#ocf-url_parse-leaking-relative">The result of <a
-								data-lt="url parser">parsing</a> [[URL]] "<code>..</code>" with the <a>container root
+								data-lt="url parser">parsing</a> [[url]] "<code>..</code>" with the <a>container root
 								URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container
 								root URL</a>.</li>
 
@@ -540,16 +540,16 @@
 
 					<div class="note">
 						<p>Some language specifications reference <a href="https://www.ietf.org/standards/rfcs/"
-								>Requests For Comments</a> that preceded [[URL]], in which case the earlier RFC applies
+								>Requests For Comments</a> that preceded [[url]], in which case the earlier RFC applies
 							for content in that particular language.</p>
 					</div>
 
 					<div class="note">
 						<p>Unlike most language specifications, reading systems must use the <a>container root URL</a>
-							as the <a data-cite="url#concept-base-url">base URL</a> [[URL]] for all files within the
+							as the <a data-cite="url#concept-base-url">base URL</a> [[url]] for all files within the
 								<code>META-INF</code> directory. See also the section on <a
 								data-cite="epub-33#sec-parsing-urls-metainf">Parsing URLs in the <code>META-INF</code>
-								directory</a> in [[!EPUB-33]].</p>
+								directory</a> in [[!epub-33]].</p>
 					</div>
 				</section>
 
@@ -558,7 +558,7 @@
 
 					<p>Although EPUB creators are required to follow various <a
 							data-cite="epub-33#sec-container-filenames">File name and file path restrictions</a>
-						[[EPUB-33]] for maximum interoperability, reading systems SHOULD attempt to process file names
+						[[epub-33]] for maximum interoperability, reading systems SHOULD attempt to process file names
 						and paths that do not adhere to these requirements. Invalid file names and paths may only be
 						problematic on some operating systems.</p>
 
@@ -576,7 +576,7 @@
 								data-tests="#ocf-package_arbitrary,#ocf-package_multiple">A reading system MUST, by
 								default, use the <a>package document</a> referenced the from first <a
 									data-cite="epub-33#sec-container.xml-rootfile-elem"><code>rootfile</code>
-									element</a> [[EPUB-33]] to render the <a>EPUB publication</a>. If the reading system
+									element</a> [[epub-33]] to render the <a>EPUB publication</a>. If the reading system
 								recognizes a means of selecting from the other available options, it MAY choose a more
 								appropriate package document.</p>
 						</dd>
@@ -584,7 +584,7 @@
 						<dt id="sec-container-metainf-metadata.xml">Metadata File (<code>metadata.xml</code>)</dt>
 						<dd>
 							<p>Reading systems SHOULD ignore <a data-cite="epub-33#sec-container-metainf-metadata.xml"
-										><code>metadata.xml</code> files</a> [[EPUB-33]] with unrecognized root
+										><code>metadata.xml</code> files</a> [[epub-33]] with unrecognized root
 								elements.</p>
 						</dd>
 
@@ -592,7 +592,7 @@
 						<dd>
 							<p>Reading systems MUST NOT use ancillary manifest information contained in the ZIP archive
 								or in the <a data-cite="epub-33#sec-container-metainf-manifest.xml"
-										><code>manifest.xml</code> file</a> [[EPUB-33]] for processing an <a>EPUB
+										><code>manifest.xml</code> file</a> [[epub-33]] for processing an <a>EPUB
 									publication</a>.</p>
 						</dd>
 
@@ -600,9 +600,9 @@
 						<dd>
 							<p>Before computing the digest used to validate the signature in the <a
 									data-cite="epub-33#sec-container-metainf-signature.xml"><code>signature.xml</code>
-									file</a> [[EPUB-33]], reading systems MUST decrypt any data encrypted after signing
+									file</a> [[epub-33]], reading systems MUST decrypt any data encrypted after signing
 								&#8212; data encrypted before signing MUST NOT be decrypted.</p>
-							<p>Refer to Decryption Transform for XML Signature [[XMLENC-DECRYPT]] for more information
+							<p>Refer to Decryption Transform for XML Signature [[xmlenc-decrypt]] for more information
 								about identifying data encrypted after signing.</p>
 						</dd>
 
@@ -610,7 +610,7 @@
 						<dd>
 							<p>Reading systems MUST NOT fail when encountering configuration files in the <code
 									class="filename">META-INF</code> directory not listed in <a
-									data-cite="epub-33#sec-container-metainf-files">Reserved files</a> [[EPUB-33]].</p>
+									data-cite="epub-33#sec-container-metainf-files">Reserved files</a> [[epub-33]].</p>
 						</dd>
 					</dl>
 				</section>
@@ -623,18 +623,18 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-zip-mult">MUST treat any OCF containers that specify the [[ZIP]] file is split
+						<p id="confreq-zip-mult">MUST treat any OCF containers that specify the [[zip]] file is split
 							across multiple storage media as in error.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-comp">MUST treat any OCF containers that use compression techniques other
-							than Deflate [[RFC1951]] as in error.</p>
+							than Deflate [[rfc1951]] as in error.</p>
 					</li>
 					<li>
-						<p id="confreq-zip-64">MUST support the ZIP64 extensions defined as "Version 1" [[ZIP]].</p>
+						<p id="confreq-zip-64">MUST support the ZIP64 extensions defined as "Version 1" [[zip]].</p>
 					</li>
 					<li>
-						<p id="confreq-zip-enc">MUST treat OCF ZIP containers that use [[ZIP]] encryption features as in
+						<p id="confreq-zip-enc">MUST treat OCF ZIP containers that use [[zip]] encryption features as in
 							error.</p>
 					</li>
 					<li>
@@ -657,16 +657,16 @@
 					<li>
 						<p id="confreq-zip-fld-version">MUST treat <code>version needed to extract</code> field values
 							other than <code>10</code>, <code>20</code> or <code>45</code> in the local file header
-							table [[ZIP]] as being in error.</p>
+							table [[zip]] as being in error.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-fld-comp">MUST treat <code>compression</code> method field values other than
-								<code>0</code> or <code>8</code> in the local file header table [[ZIP]] as being in
+								<code>0</code> or <code>8</code> in the local file header table [[zip]] as being in
 							error.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-fld-er">MUST treat OCF ZIP containers with an <code>Archive decryption
-								header</code> or an <code>Archive extra data record</code> [[ZIP]] as being in
+								header</code> or an <code>Archive extra data record</code> [[zip]] as being in
 							error.</p>
 					</li>
 				</ul>
@@ -676,7 +676,7 @@
 				<h3>Font obfuscation</h3>
 
 				<p id="confreq-ocf-fobfus">Reading systems SHOULD support deobfuscation of fonts as defined in <a
-						data-cite="epub-33#sec-font-obfuscation">Font obfuscation</a> [[EPUB-33]].</p>
+						data-cite="epub-33#sec-font-obfuscation">Font obfuscation</a> [[epub-33]].</p>
 
 				<p>To restore the original data, reading systems should simply reverse the process: the source file
 					becomes the obfuscated data, and the destination file contains the raw data.</p>
@@ -694,23 +694,23 @@
 			<h2>Package document processing</h2>
 
 			<p id="confreq-rs-epub-pub" class="support">Reading systems MUST process the <a
-					data-cite="epub-33#sec-package-doc">package document</a> [[EPUB-33]].</p>
+					data-cite="epub-33#sec-package-doc">package document</a> [[epub-33]].</p>
 
 			<section id="sec-pkg-doc-base-dir">
 				<h4>Base direction</h4>
 
 				<p id="confreq-rs-pkg-dir"
 					data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
-					>If the <a data-cite="epub-33#attrdef-dir"><code>dir</code> attribute</a> [[EPUB-33]] is set and
+					>If the <a data-cite="epub-33#attrdef-dir"><code>dir</code> attribute</a> [[epub-33]] is set and
 					indicates a base direction of <code>ltr</code> or <code>rtl</code>, reading systems MUST override
 					the bidi algorithm per <a data-cite="bidi#Higher-Level_Protocols">the higher-level protocols</a>
-					defined in [[BIDI]], setting the paragraph embedding level to 0 if the base direction is
+					defined in [[bidi]], setting the paragraph embedding level to 0 if the base direction is
 						<code>ltr</code>, or 1 if the base direction is <code>rtl</code>.</p>
 
 				<p id="confreq-rs-pkg-dir-auto" data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Otherwise
 					the base direction is <code>auto</code>, in which case reading systems MUST determine the text's
 					direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a>
-					of [[BIDI]].</p>
+					of [[bidi]].</p>
 			</section>
 
 			<section id="sec-pkg-doc-pub-identifiers">
@@ -730,24 +730,24 @@
 					<dt id="conf-meta-ws">White Space</dt>
 					<dd>
 						<p id="confreq-rs-pkg-whitespace" data-tests="#pkg-meta-whitespace">Reading systems MUST
-								<a>strip and collapse ASCII whitespace</a> [[Infra]] from Dublin Core [[DCTERMS]] and <a
+								<a>strip and collapse ASCII whitespace</a> [[infra]] from Dublin Core [[dcterms]] and <a
 								data-cite="epub-33#sec-meta-elem"><code>meta</code></a> element <a
-								data-cite="epub-33#dfn-value">values</a> [[EPUB-33]] before processing.</p>
+								data-cite="epub-33#dfn-value">values</a> [[epub-33]] before processing.</p>
 					</dd>
 
 					<dt id="dc-identifier">The <code>dc:identifier</code> element</dt>
 					<dd>
 						<p>To determine whether the value of a <a data-cite="epub-33#sec-opf-dcidentifier"
-									><code>dc:identifier</code> element</a> [[EPUB-33]] conforms to an established
+									><code>dc:identifier</code> element</a> [[epub-33]] conforms to an established
 							system or has been granted by an issuing authority, reading systems SHOULD check for an <a
 								data-cite="epub-33#identifier-type"><code>identifier-type</code> property</a>
-							[[EPUB-33]].</p>
+							[[epub-33]].</p>
 					</dd>
 
 					<dt id="dc-title">The <code>dc:title</code> element</dt>
 					<dd>
 						<p id="title-order" data-tests="#pkg-title-order">Reading systems MUST recognize the first <a
-								data-cite="epub-33#sec-opf-dctitle"><code>dc:title</code> element</a> [[EPUB-33]] in
+								data-cite="epub-33#sec-opf-dctitle"><code>dc:title</code> element</a> [[epub-33]] in
 							document order as the main title of the EPUB publication and present it to users before
 							other title elements.</p>
 						<p>This specification does not define how to process additional <code>dc:title</code>
@@ -773,7 +773,7 @@
 					<dd>
 						<p id="confreq-rs-pkg-creator-order" data-tests="#pkg-creator-order">When determining display
 							priority, reading systems MUST use the document order of <a
-								data-cite="epub-33#sec-opf-dccreator"><code>dc:creator</code> elements</a> [[EPUB-33]]
+								data-cite="epub-33#sec-opf-dccreator"><code>dc:creator</code> elements</a> [[epub-33]]
 							in the <code>metadata</code> section, where the first <code>creator</code> element
 							encountered is the primary creator. If a reading system exposes creator metadata to the
 							user, it SHOULD include all the creators listed in the <code>metadata</code> section
@@ -784,15 +784,15 @@
 					<dd>
 						<p>Reading systems SHOULD ignore all <a data-cite="epub-33#sec-meta-elem"><code>meta</code>
 								elements</a> whose <a data-cite="epub-33#attrdef-meta-property"><code>property</code>
-								attributes</a> [[EPUB-33]] define expressions they do not recognize. <span
+								attributes</a> [[epub-33]] define expressions they do not recognize. <span
 								id="confreq-rs-pkg-meta-unknown" data-tests="#pkg-meta-unknown">A reading system MUST
 								NOT fail when encountering unknown expressions.</span></p>
 						<p>If the <code>property</code> attribute's value does not include a <a
-								data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], reading systems MUST
+								data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST
 							use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to <a
 								href="#sec-property-datatype">expand the value</a>.</p>
 						<p>If a reading system does not recognize the <a data-cite="epub-33#attrdef-scheme"
-									><code>scheme</code> attribute</a> [[EPUB-33]] value, it SHOULD treat the value of
+									><code>scheme</code> attribute</a> [[epub-33]] value, it SHOULD treat the value of
 							the element as a string.</p>
 					</dd>
 
@@ -804,13 +804,13 @@
 							the language information associated with the resource to determine its language, not the
 							metadata included in the link to the resource.</p>
 						<p id="sec-linked-records" data-tests="#pkg-linked-records">In the case of a <a
-								data-cite="epub-33#record">linked metadata record</a> [[EPUB-33]], reading systems MUST
+								data-cite="epub-33#record">linked metadata record</a> [[epub-33]], reading systems MUST
 							NOT skip processing the metadata expressed in the package document (i.e., use only the
 							information expressed in the record). Reading systems MAY compile metadata from multiple
 							linked records.</p>
 						<p>When resolving discrepancies and conflicts between metadata expressed in the package document
 							and in linked metadata records, reading systems MUST use the document order of <a
-								data-cite="epub-33#sec-link-elem"><code>link</code> elements</a> [[EPUB-33]] in the
+								data-cite="epub-33#sec-link-elem"><code>link</code> elements</a> [[epub-33]] in the
 							package document to establish precedence (i.e., metadata in the first linked record has the
 							highest precedence and metadata in the package document the lowest, regardless of whether
 							the <code>link</code> elements occur before, within, or after the package metadata
@@ -818,7 +818,7 @@
 						<p>Reading systems MUST ignore any instructions contained in linked resources related to the
 							layout and rendering of the EPUB publication.</p>
 						<p>If any of the <a data-cite="epub-33#attrdef-link-rel"><code>rel</code></a> or <a
-								data-cite="epub-33#attrdef-properties"><code>properties</code></a> [[EPUB-33]]
+								data-cite="epub-33#attrdef-properties"><code>properties</code></a> [[epub-33]]
 							attributes' values do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a>,
 							reading systems MUST use the prefix URL
 								"<code>http://idpf.org/epub/vocab/package/link/#</code>" to <a
@@ -832,24 +832,24 @@
 
 				<p id="confreq-rs-pkg-manifest-unknown" data-tests="#pkg-manifest-unknown">Reading systems MUST ignore
 					values of the <a data-cite="epub-33#sec-item-resource-properties"><code>properties</code>
-						attribute</a> [[EPUB-33]] they do not recognize.</p>
+						attribute</a> [[epub-33]] they do not recognize.</p>
 
 				<p id="confreq-rendition-rs-manifest" data-tests="#pkg-manifest-unlisted-resource">Reading systems
 					SHOULD NOT use <a>linked resources</a> in the rendering of an EPUB publication due to the inherent
 					limitations and risks involved (e.g., lack of information about the resource and how to process it,
 					security risks from remotely-hosted sources, lack of fallbacks, etc.).</p>
 
-				<p>A reading system that does not support the MIME media type [[RFC2046]] of a given publication
+				<p>A reading system that does not support the MIME media type [[rfc2046]] of a given publication
 					resource MUST traverse the <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a>
-					[[EPUB-33]] until it identifies a supported publication resource to use in place of the unsupported
+					[[epub-33]] until it identifies a supported publication resource to use in place of the unsupported
 					resource. If the reading system supports multiple publication resources in the fallback chain, it
 					MAY select the resource to use based on the resource's <a
-						data-cite="epub-33#attrdef-item-properties"><code>properties</code> attribute</a> [[EPUB-33]]
+						data-cite="epub-33#attrdef-item-properties"><code>properties</code> attribute</a> [[epub-33]]
 					values, otherwise it SHOULD honor the EPUB creator's preferred fallback order. If a reading system
 					does not support any resource in the fallback chain, it MUST alert the reader that it could not
 					display the content.</p>
 
-				<p>When <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallbacks</a> [[EPUB-33]] are provided
+				<p>When <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-33]] are provided
 					for <a>top-level content documents</a>, reading systems MAY choose from the available options to
 					find the optimal version to render in a given context (e.g., by inspecting the properties attribute
 					for each).</p>
@@ -858,7 +858,7 @@
 					already encountered.</p>
 
 				<p>If any of the <code>properties</code> attribute's values do not include a <a
-						data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], reading systems MUST use the
+						data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST use the
 					prefix URL "<code>http://idpf.org/epub/vocab/package/item/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 			</section>
@@ -868,10 +868,10 @@
 
 				<p id="confreq-rs-spine-order" data-tests="#pkg-spine-order">Reading systems MUST provide a means of
 					rendering the EPUB publication in the order defined in the <a data-cite="epub-33#sec-spine-elem"
-							><code>spine</code> element</a> [[EPUB-33]], which includes:</p>
+							><code>spine</code> element</a> [[epub-33]], which includes:</p>
 				<ul>
 					<li>recognizing the first <a data-cite="epub-33#attrdef-itemref-linear">primary (linear)
-								<code>itemref</code></a> [[EPUB-33]] as the beginning of the default reading order;
+								<code>itemref</code></a> [[epub-33]] as the beginning of the default reading order;
 						and,</li>
 					<li>rendering successive primary items in the order given in the <code>spine</code>.</li>
 				</ul>
@@ -879,7 +879,7 @@
 				<p id="confreq-rendition-rs-spine-nonlinear">When a user traverses the default reading order defined in
 					the <code>spine</code> element, a reading system MAY automatically skip <a
 						data-cite="epub-33#attrdef-itemref-linear">non-linear <code>itemref</code> elements</a>
-					[[EPUB-33]]. <span id="confreq-rs-spine-nonlinear-activation"
+					[[epub-33]]. <span id="confreq-rs-spine-nonlinear-activation"
 						data-tests="#pkg-spine-nonlinear-activation">When a user activates a hyperlink to a non-linear
 						resource, however, reading systems MUST render the referenced resource or a designated
 						fallback.</span> Reading systems MAY also provide the option for users to skip non-linear
@@ -887,7 +887,7 @@
 
 				<p id="confreq-rs-spine-progression-default" data-tests="#pkg-spine-progression-default">If the EPUB
 					creator has not specified the <a data-cite="epub-33#attrdef-spine-page-progression-direction"
-							><code>page-progression-direction</code> attribute</a> [[EPUB-33]], the reading system MUST
+							><code>page-progression-direction</code> attribute</a> [[epub-33]], the reading system MUST
 					assume the value of <code>default</code>. When <code>page-progression-direction</code> value is
 						<code>default</code>, the reading system can choose the rendering direction.</p>
 
@@ -898,7 +898,7 @@
 					<a>XHTML content documents</a>.</p>
 
 				<p>If any values of the <a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a>
-					do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[EPUB-33]], reading systems
+					do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems
 					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 
@@ -924,12 +924,12 @@
 
 					<p>When a spine <a data-cite="epub-33#sec-itemref-elem"><code>itemref</code> element's</a>
 						<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a <a
-							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[EPUB-33]], reading
+							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
 						systems MUST follow the requirements for the override's global value to display that spine
 						item.</p>
 
 					<p>For example, a spine item that contains the <a data-cite="epub-33#layout-overrides"
-								><code>layout-pre-paginated</code> override</a> [[EPUB-33]] is rendered following the
+								><code>layout-pre-paginated</code> override</a> [[epub-33]] is rendered following the
 						requirements of the global <a href="#def-layout-pre-paginated"><code>pre-paginated</code>
 							value</a>.</p>
 
@@ -942,7 +942,7 @@
 				<h3>Collections</h3>
 
 				<p>In the context of this specification, support for <a data-cite="epub-33#sec-collection-elem"
-						>collections</a> [[EPUB-33]] in reading systems is OPTIONAL. <span
+						>collections</a> [[epub-33]] in reading systems is OPTIONAL. <span
 						id="confreq-rs-pkg-collections-unknown" data-tests="#pkg-collections-unknown">Reading systems
 						MUST ignore <code>collection</code> elements that define unrecognized roles.</span></p>
 			</section>
@@ -950,20 +950,20 @@
 		<section id="sec-contentdocs">
 			<h2>EPUB content document processing</h2>
 
-			<p>The definition of <a data-cite="epub-33#sec-contentdocs">EPUB content documents</a> [[EPUB-33]] includes
+			<p>The definition of <a data-cite="epub-33#sec-contentdocs">EPUB content documents</a> [[epub-33]] includes
 				various authoring restrictions to optimize the cross-compatibility of content (e.g., <a
 					data-cite="epub-33#sec-css-req">prohibiting CSS for setting language and direction</a>
-				[[?EPUB-33]]). Unless stated otherwise in this specification, reading systems MAY support these
+				[[?epub-33]]). Unless stated otherwise in this specification, reading systems MAY support these
 				restricted features.</p>
 
 			<section id="sec-xhtml">
 				<h3>XHTML content documents</h3>
 
 				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="#cnt-xhtml-support">Reading systems MUST
-					process <a data-cite="epub-33#sec-xhtml">XHTML content documents</a> [[EPUB-33]].</p>
+					process <a data-cite="epub-33#sec-xhtml">XHTML content documents</a> [[epub-33]].</p>
 
 				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, reading
-					systems MUST process XHTML content documents using semantics defined by the [[HTML]] specification
+					systems MUST process XHTML content documents using semantics defined by the [[html]] specification
 					and honor any applicable user agent conformance constraints expressed therein.</p>
 
 				<section id="sec-xhtml-extensions">
@@ -974,7 +974,7 @@
 
 						<p id="confreq-html-rs-a11y">Reading systems SHOULD recognize embedded ARIA markup and support
 							exposure of any given ARIA roles, states and properties to platform accessibility APIs
-							[[WAI-ARIA]].</p>
+							[[wai-aria]].</p>
 					</section>
 
 					<section id="sec-xhtml-structural-semantics">
@@ -982,14 +982,14 @@
 
 						<p id="confreq-rs-epubtype-head">In addition to the requirements in <a
 								href="#sec-structural-semantics"></a>, a reading system MUST ignore semantics expressed
-							on the [[HTML]] <a><code>head</code></a> element or its descendants.</p>
+							on the [[html]] <a><code>head</code></a> element or its descendants.</p>
 					</section>
 
 					<section id="sec-xhtml-rdfa">
 						<h5>RDFa</h5>
 
 						<p>Reading system support for the <a data-cite="rdfa-core#s_model">attribute processing
-								model</a> [[RDFA-CORE]] is OPTIONAL.</p>
+								model</a> [[rdfa-core]] is OPTIONAL.</p>
 					</section>
 
 					<section id="sec-xhtml-microdata">
@@ -997,14 +997,14 @@
 
 						<p>Reading system support for the <a data-cite="microdata#encoding-microdata">attribute
 								processing model</a> is OPTIONAL, as is the <a data-cite="microdata#json">conversion to
-								JSON</a> [[Microdata]].</p>
+								JSON</a> [[microdata]].</p>
 					</section>
 
 					<section id="sec-xhtml-content-switch">
 						<h5>Content switching (deprecated)</h5>
 
 						<p>Use of the <code>switch</code> element is <a data-cite="epub-33#deprecated">deprecated</a>
-							[[EPUB-33]]. Refer to its definition in [[EPUBContentDocs-301]] for implementation
+							[[epub-33]]. Refer to its definition in [[epubcontentdocs-301]] for implementation
 							information.</p>
 					</section>
 
@@ -1012,7 +1012,7 @@
 						<h5>The <code>epub:trigger</code> element (deprecated)</h5>
 
 						<p>Use of the <code>trigger</code> element is <a data-cite="epub-33#deprecated">deprecated</a>
-							[[EPUB-33]]. Refer to its definition in [[EPUBContentDocs-301]] for implementation
+							[[epub-33]]. Refer to its definition in [[epubcontentdocs-301]] for implementation
 							information.</p>
 					</section>
 
@@ -1030,7 +1030,7 @@
 					<section id="sec-xhtml-mathml">
 						<h3>MathML</h3>
 
-						<p>To support MathML [[MathML3]] embedded in <a>XHTML content documents</a>, a reading
+						<p>To support MathML [[mathml3]] embedded in <a>XHTML content documents</a>, a reading
 							system:</p>
 
 						<ul class="conformance-list">
@@ -1038,7 +1038,7 @@
 								<p id="confreq-mathml-rs-behavior" data-tests="#cnt-mathml-support">MUST be an <a
 										data-cite="mathml3/chapter2.html#fund.mathmlconf">input-compliant processor</a>
 									for <a data-cite="mathml3/chapter3.html#">Presentation MathML</a>, as defined in the
-									[[MATHML3]] specification.</p>
+									[[mathml3]] specification.</p>
 							</li>
 							<li>
 								<p id="confreq-mathml-rs-render" data-tests="#cnt-mathml-support">MUST, if it has a
@@ -1048,7 +1048,7 @@
 								<p id="confreq-mathml-rs-anno">MAY support rendering of <a
 										data-cite="mathml3/chapter4.html#">Content MathML</a> found in <a
 										data-cite="mathml3/chapter5.html#mixing.elements.annotation.xml"
-											><code>annotation-xml</code> elements</a> [[MathML3]].</p>
+											><code>annotation-xml</code> elements</a> [[mathml3]].</p>
 							</li>
 						</ul>
 
@@ -1078,8 +1078,8 @@
 							<div class="note">
 								<p>SVG included <em>by reference</em> is processed as a separate document, and can
 									include its own CSS style rules just like an <a>SVG content document</a> would. Note
-									that this is consistent with situations where an [[HTML]] <a data-lt="object"
-											><code>object</code> element</a> references an external [[HTML]]
+									that this is consistent with situations where an [[html]] <a data-lt="object"
+											><code>object</code> element</a> references an external [[html]]
 									element.</p>
 							</div>
 						</section>
@@ -1088,7 +1088,7 @@
 					<section id="sec-xhtml-forms">
 						<h5>Form submission</h5>
 
-						<p>Reading system support for the submission of [[HTML]] forms is OPTIONAL. A reading system
+						<p>Reading system support for the submission of [[html]] forms is OPTIONAL. A reading system
 							might, for example, prevent form submissions by limiting access to networking.</p>
 					</section>
 				</section>
@@ -1098,7 +1098,7 @@
 				<h3>SVG content documents</h3>
 
 				<p id="confreq-rs-epub3-svg" class="support" data-tests="#cnt-svg-support">Reading systems MUST process
-						<a data-cite="epub-33#sec-svg">SVG content documents</a> [[EPUB-33]].</p>
+						<a data-cite="epub-33#sec-svg">SVG content documents</a> [[epub-33]].</p>
 
 				<p>To process SVG content documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML content
 						documents</a>, a reading system:</p>
@@ -1106,7 +1106,7 @@
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-svg-rs-behavior">MUST process SVG content documents using semantics defined by
-							the [[SVG]] specification, and honor any applicable user agent conformance constraints
+							the [[svg]] specification, and honor any applicable user agent conformance constraints
 							expressed therein, unless explicitly defined by this specification as overridden.</p>
 					</li>
 					<li>
@@ -1116,8 +1116,8 @@
 					<li>
 						<p id="confreq-svg-rs-css">MUST, if it has a <a>viewport</a>, support the visual rendering of
 							SVG using CSS as defined in <a href="https://www.w3.org/TR/SVG/styling.html#">Styling</a>
-							[[SVG]] and it SHOULD support all properties defined in the <a
-								href="https://www.w3.org/TR/SVG/propidx.html#">Property Index</a> [[SVG]]. In the case
+							[[svg]] and it SHOULD support all properties defined in the <a
+								href="https://www.w3.org/TR/SVG/propidx.html#">Property Index</a> [[svg]]. In the case
 							of embedded SVG, a reading system MUST also conform to the constraints defined in <a
 								href="#sec-xhtml-svg-css"></a>.</p>
 					</li>
@@ -1129,30 +1129,30 @@
 
 				<p id="confreq-rs-epub3-css" class="support">If a reading system has a <a>viewport</a>, it MUST support
 					the <a data-cite="epub-33#sec-css">visual rendering of XHTML content documents via CSS</a>
-					[[EPUB-33]].</p>
+					[[epub-33]].</p>
 
 				<p>To support CSS, a reading system:</p>
 
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-css-rs-support" data-tests="#cnt-css-support">MUST support the official
-							definition of CSS as described in the [[CSSSnapshot]].</p>
+							definition of CSS as described in the [[csssnapshot]].</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-modules">SHOULD support all applicable modules in [[CSSSnapshot]] that
+						<p id="confreq-css-rs-modules">SHOULD support all applicable modules in [[csssnapshot]] that
 							have reached at least <a href="https://www.w3.org/Consortium/Process/#RecsCR">Candidate
-								Recommendation</a> status [[W3CProcess]] (and are widely implemented).</p>
+								Recommendation</a> status [[w3cprocess]] (and are widely implemented).</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-fonts">MUST support [[TrueType]], [[OpenType]], [[WOFF]] and [[WOFF2]]
+						<p id="confreq-css-rs-fonts">MUST support [[truetype]], [[opentype]], [[woff]] and [[woff2]]
 							font resources referenced from <a data-cite="css-fonts-4#font-face-rule"
-									><code>@font-face</code> rules</a> [[CSS-FONTS-4]].</p>
+									><code>@font-face</code> rules</a> [[css-fonts-4]].</p>
 					</li>
 					<li>
 						<p id="confreq-css-rs-prefixed"
 							data-tests="#css-epub-hyphens, #css-epub-line-break, #css-epub-text-align-last, #css-epub-text-combine-horizontal, #css-epub-text-emphasis, #css-epub-text-orientation, #css-epub-text-transform, #css-epub-text-underline-position, #css-epub-word-break, #css-epub-writing-mode"
 							>MUST support all prefixed properties defined in <a data-cite="epub-33#sec-css-prefixed">CSS
-								Style Sheets — Prefixed properties</a> [[EPUB-33]].</p>
+								Style Sheets — Prefixed properties</a> [[epub-33]].</p>
 					</li>
 					<li>
 						<p id="confreq-css-creator-styles">SHOULD apply <a>EPUB creator</a> style sheets as written to
@@ -1162,7 +1162,7 @@
 						<p id="confreq-css-overrides">SHOULD NOT override the EPUB creator's style sheets, but SHOULD do
 							so in a way that preserves the Cascade when necessary: through a user agent style sheet, the
 								<a data-cite="DOM-Level-2-Style/css.html#CSS-OverrideAndComputed"
-									><code>getOverrideStyle</code></a> method [[DOM-Level-2-Style]], or [[HTML]]
+									><code>getOverrideStyle</code></a> method [[dom-level-2-style]], or [[html]]
 							[^html-global/style^] attributes.</p>
 					</li>
 					<li>
@@ -1172,7 +1172,7 @@
 				</ul>
 
 				<p id="confreq-css-rs-html-default">In addition to supporting CSS properties as defined above, a reading
-					system's user agent style sheet SHOULD support the [[HTML]] <a data-cite="html#rendering">suggested
+					system's user agent style sheet SHOULD support the [[html]] <a data-cite="html#rendering">suggested
 						default rendering</a>.</p>
 
 				<p>Reading system developers should implement CSS support at the level of major browsers and publicly
@@ -1184,7 +1184,7 @@
 
 				<p id="confreq-rs-scripted" class="support"
 					data-test="#scr-support,#scr-support_iframe,#scr-support_svg">Reading systems SHOULD support <a
-						data-cite="epub-33#sec-scripted-content">scripting</a> [[EPUB-33]].</p>
+						data-cite="epub-33#sec-scripted-content">scripting</a> [[epub-33]].</p>
 
 				<p>Reading system support for scripting depends on its usage context:</p>
 
@@ -1192,18 +1192,18 @@
 					<li>
 						<p id="confreq-rs-scripted-reflow-support">Reading systems SHOULD support <a
 								data-cite="epub-33#sec-scripted-container-constrained">container-constrained
-								scripting</a> [[EPUB-33]] in reflowable EPUB content documents.</p>
+								scripting</a> [[epub-33]] in reflowable EPUB content documents.</p>
 					</li>
 					<li>
 						<p id="confreq-rs-scripted-fxl-support">Reading systems SHOULD support <a
-								data-cite="epub-33#sec-scripted-spine">spine-level scripting</a> [[EPUB-33]] in <a
-								data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a> [[EPUB-33]].</p>
+								data-cite="epub-33#sec-scripted-spine">spine-level scripting</a> [[epub-33]] in <a
+								data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a> [[epub-33]].</p>
 					</li>
 					<li>
 						<p id="confreq-rs-scripted-scrolled">Reading systems SHOULD support spine-level scripting in
 							reflowable EPUB content documents that use the <a data-cite="epub-33#flow-scrolled-doc"
 									>"<code>scrolled-doc</code>"</a> or <a data-cite="epub-33#flow-scrolled-continuous"
-									>"<code>scrolled-continuous</code>"</a> [[EPUB-33]] presentation modes defined by <a
+									>"<code>scrolled-continuous</code>"</a> [[epub-33]] presentation modes defined by <a
 								href="#flow">the <code>rendition:flow</code> property</a>. Similarly, if it supports
 							spine-level scripting in reflowable EPUB content documents, it MUST implement the
 								"<code>scrolled-doc</code>" presentation mode and SHOULD implement the
@@ -1221,23 +1221,23 @@
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-rs-scripted-ua">It MAY render <a>scripted content documents</a> as an
-							interactive, scripted user agent according to [[HTML]].</p>
+							interactive, scripted user agent according to [[html]].</p>
 					</li>
 
 					<li>
 						<p id="confreq-rs-scripted-origin">
 							<span id="confreq-rs-scripted-origin-shared" data-tests="#scr-support_origin">It MUST assign
-								a unique <a>origin</a> [[URL]], shared by all <a data-cite="epub-33#sec-scripted-spine"
+								a unique <a>origin</a> [[url]], shared by all <a data-cite="epub-33#sec-scripted-spine"
 									>spine-level scripts</a> of the EPUB publication.</span>
 							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin">That
-								<a>origin</a> [[URL]] MUST be <em>unique</em> for each user-specific instance of an EPUB
+								<a>origin</a> [[url]] MUST be <em>unique</em> for each user-specific instance of an EPUB
 								publication in a reading system.</span>
 						</p>
 					</li>
 
 					<li>
 						<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to modify
-							the [[DOM]] of the host EPUB content document or other contents in the EPUB publication and
+							the [[dom]] of the host EPUB content document or other contents in the EPUB publication and
 							MUST NOT allow it to manipulate the size of its containing rectangle. (Note: Even if a
 							script is not container-constrained, the reading system MAY impose restrictions on
 							modifications (see also the <a href="#feature-dom-manipulation">dom-manipulation
@@ -1250,7 +1250,7 @@
 					<li>
 						<p id="confreq-rs-scripted-readingsystem-object"
 							data-tests="#scr-readingsystem-features,#scr-readingsystem-support,#scr-readingsystem-support_svg"
-							>It MUST extend the <a data-cite="html#the-navigator-object">navigator object</a> [[!HTML]]
+							>It MUST extend the <a data-cite="html#the-navigator-object">navigator object</a> [[!html]]
 							with the <code>epubReadingSystem</code> interface defined in <a
 								href="#app-epubReadingSystem"></a>. It also MUST support the
 								<code>dom-manipulation</code> and <code>layout-change</code> features defined in <a
@@ -1265,26 +1265,26 @@
 
 				<p id="confreq-rs-scripted-flbk">If a reading system does not support scripting, it MUST process
 					fallbacks for scripted content as defined in <a data-cite="epub-33#confreq-cd-scripted-flbk"
-						>Fallbacks for scripted content documents</a> [[EPUB-33]].</p>
+						>Fallbacks for scripted content documents</a> [[epub-33]].</p>
 
 				<section id="sec-local-storage">
 					<h4>Local storage</h4>
 
 					<p>Scripts may save persistent data through <a data-cite="html#dom-document-cookie">cookies</a> and
-							<a data-cite="html#webstorage">web storage</a> [[HTML]], but reading systems MAY block such
+							<a data-cite="html#webstorage">web storage</a> [[html]], but reading systems MAY block such
 						attempts. Reading systems that allow users to store data MUST ensure they do not make that data
 						available to other unrelated documents (e.g., ones that could be spoofed). In particular,
 						checking for a matching document identifier (or similar metadata) is not a valid method to
 						control access to persistent data.</p>
 
-					<p>Reading systems that allow <a data-cite="html#dom-localstorage">local storage</a> [[HTML]] SHOULD
+					<p>Reading systems that allow <a data-cite="html#dom-localstorage">local storage</a> [[html]] SHOULD
 						provide methods for users to inspect or delete that data.</p>
 				</section>
 
 				<section id="sec-scripted-content-events">
 					<h4>Event model</h4>
 
-					<p>Reading systems SHOULD follow the DOM Event model as per [[HTML]] and pass UI events to the
+					<p>Reading systems SHOULD follow the DOM Event model as per [[html]] and pass UI events to the
 						scripting environment before performing any default action associated with these events.</p>
 
 					<p>Reading system developers must ensure that scripts cannot disable critical functionality (such as
@@ -1331,21 +1331,21 @@
 					</ul>
 
 					<p>To limit the possible damage of untrusted scripts, this specification recommends that reading
-						systems establish a unique <a>origin</a> [[URL]] allocated to each <a>EPUB publication</a> (see
+						systems establish a unique <a>origin</a> [[url]] allocated to each <a>EPUB publication</a> (see
 							<a href="#sec-container-iri"></a>). Assigning a unique origin ensures that <a
-							data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> [[EPUB-33]] are isolated from
+							data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> [[epub-33]] are isolated from
 						other EPUB publications, and limits access to <a data-cite="html#dom-document-cookie"
-							>cookies</a> [[HTML]], <a data-cite="html#webstorage">web storage</a> [[HTML]], etc.</p>
+							>cookies</a> [[html]], <a data-cite="html#webstorage">web storage</a> [[html]], etc.</p>
 
-					<p>Examples of web APIs that are tied to the concept of "origin" include web storage [[HTML]] and
-						IndexedDB [[INDEXEDDB]], which EPUB content documents can interact with via scripting. Reading
+					<p>Examples of web APIs that are tied to the concept of "origin" include web storage [[html]] and
+						IndexedDB [[indexeddb]], which EPUB content documents can interact with via scripting. Reading
 						systems that allow users to add/remove publications from a managed library (their "bookshelf")
 						may maintain the publication's unique origin when the publication is removed and subsequently
 						re-imported into the content library. Conversely, reading systems may create a new unique origin
 						for every newly added publication.</p>
 
 					<p>This specification also recommends that <a data-cite="epub-33#sec-scripted-container-constrained"
-							>container-constrained scripts</a> [[EPUB-33]] not be allowed to modify the DOM of the host
+							>container-constrained scripts</a> [[epub-33]] not be allowed to modify the DOM of the host
 						EPUB content document and/or manipulate the containing rectangle (see <a
 							href="#sec-scripted-content"></a>).</p>
 
@@ -1359,7 +1359,7 @@
 			<h3>Navigation document processing</h3>
 
 			<p id="sec-nav-rs-conf" class="support" data-tests="#nav-spine_in-spine">Reading systems MUST process <a
-					data-cite="epub-33#sec-nav">EPUB navigation documents</a> [[EPUB-33]].</p>
+					data-cite="epub-33#sec-nav">EPUB navigation documents</a> [[epub-33]].</p>
 
 			<p>To process the EPUB navigation document, a reading system:</p>
 
@@ -1367,22 +1367,22 @@
 				<li>
 					<p id="confreq-nav-toc-access" data-tests="#nav-access">MUST provide users access to the <a
 							data-cite="epub-33#confreq-nav-a">links and headings</a> in the <a
-							data-cite="epub-33#sec-nav-toc"><code>toc nav</code> element</a> [[EPUB-33]].</p>
+							data-cite="epub-33#sec-nav-toc"><code>toc nav</code> element</a> [[epub-33]].</p>
 				</li>
 				<li>
 					<p id="confreq-nav-pagelist-access">SHOULD provide a method to navigate to the listed page breaks
 						when a <a data-cite="epub-33#sec-nav-pagelist"><code>page-list nav</code> element</a>
-						[[EPUB-33]] is present.</p>
+						[[epub-33]] is present.</p>
 				</li>
 				<li>
 					<p id="confreq-nav-landmarks-access">MAY provide users access to the links in the <a
-							data-cite="epub-33#sec-nav-landmarks"><code>landmarks nav</code> element</a> [[EPUB-33]] and
+							data-cite="epub-33#sec-nav-landmarks"><code>landmarks nav</code> element</a> [[epub-33]] and
 						MAY use the links to enable functionality in the application.</p>
 				</li>
 				<li>
 					<p id="confreq-nav-other-access">MAY provide access to <code>nav</code> elements that do not specify
 						an <code>epub:type</code> attribute or that <a data-cite="epub-33#sec-nav-def-types-other"
-							>declare an unknown value</a> [[EPUB-33]].</p>
+							>declare an unknown value</a> [[epub-33]].</p>
 				</li>
 				<li>
 					<p id="confreq-nav-activation" data-tests="#nav-activation">MUST relocate the current reading
@@ -1394,13 +1394,13 @@
 						numbering on <code>nav</code> elements when presenting them outside of the spine, regardless of
 						support for CSS, as the default display style of list items is equivalent to the <a
 							href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:
-								none</code> property</a> [[CSSSnapshot]].).</p>
+								none</code> property</a> [[csssnapshot]].).</p>
 				</li>
 			</ul>
 
 			<p id="confreq-nav-spine" data-tests="#nav-spine_in-spine,#nav-spine_not-in-spine">Reading systems MUST
 				honor the above requirements irrespective of whether the EPUB navigation document is part of the <a
-					data-cite="epub-33#sec-spine-elem">spine</a> [[EPUB-33]].</p>
+					data-cite="epub-33#sec-spine-elem">spine</a> [[epub-33]].</p>
 		</section>
 		<section id="sec-rendering-control">
 			<h2>Layout rendering control processing</h2>
@@ -1409,7 +1409,7 @@
 				<h3>Fixed-layout documents</h3>
 
 				<p id="confreq-rs-epub3-fxl" class="support">Reading systems MUST support the rendering of <a
-						data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a> [[EPUB-33]].</p>
+						data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a> [[epub-33]].</p>
 
 				<section id="sec-fxl-props">
 					<h4>Fixed-layout properties</h4>
@@ -1421,7 +1421,7 @@
 							global value if no <a data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a>
 							carrying the <a data-cite="epub-33#layout"><code>rendition:layout</code> property</a> occurs
 							in the <a data-cite="epub-33#elemdef-opf-metadata">package document metadata</a>
-							[[EPUB-33]].</p>
+							[[epub-33]].</p>
 
 						<p id="layout-pre-paginated" data-tests="#fxl-layout-pre-paginated-spreads">When the
 								<code>rendition:layout</code> property is set to <code>pre-paginated</code>, reading
@@ -1439,7 +1439,7 @@
 							<dt id="def-layout-pre-paginated" data-tests="#fxl-layout-pre-paginated">pre-paginated</dt>
 							<dd>
 								<p>Reading systems MUST produce exactly one page per spine <a
-										data-cite="epub-33#elemdef-spine-itemref"><code>itemref</code></a> [[EPUB-33]]
+										data-cite="epub-33#elemdef-spine-itemref"><code>itemref</code></a> [[epub-33]]
 									when rendering.</p>
 							</dd>
 						</dl>
@@ -1447,7 +1447,7 @@
 						<p>When a spine <code>itemref</code> element's <a data-cite="epub-33#attrdef-properties"
 									><code>properties</code> attribute</a> contains an <a
 								data-cite="epub-33#layout-overrides">override of the global rendition:layout
-								property</a> [[EPUB-33]], reading systems MUST follow the requirements for the
+								property</a> [[epub-33]], reading systems MUST follow the requirements for the
 							override's global value when displaying that spine item (e.g., a spine item that specifies
 								<code>layout-prepaginated</code> is rendered following the requirements of the global
 								<code>pre-paginated</code> value).</p>
@@ -1461,7 +1461,7 @@
 								data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
 								data-cite="epub-33#orientation"><code>rendition:orientation</code> property</a> occurs
 							in the <a data-cite="epub-33#elemdef-opf-metadata">package document metadata</a>
-							[[EPUB-33]].</p>
+							[[epub-33]].</p>
 
 						<p>The <code>rendition:orientation</code> property values have the following processing
 							requirements:</p>
@@ -1495,7 +1495,7 @@
 							MUST be assumed by EPUB reading systems as the global value if no <a
 								data-cite="epub-33#sec-meta-elem"><code>meta</code> element</a> carrying the <a
 								data-cite="epub-33#spread"><code>rendition:spread</code> property</a> occurs in the <a
-								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[EPUB-33]].</p>
+								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[epub-33]].</p>
 
 						<p>The <code>rendition:spread</code> property values have the following processing
 							requirements:</p>
@@ -1535,10 +1535,10 @@
 
 						<p>The <a data-cite="epub-33#fxl-page-spread-left"><span id="page-spread-left"
 									data-tests="#fxl-page-spread-left"><code>rendition:page-spread-left</code></span>
-								property</a> [[EPUB-33]] indicates that the given spine item SHOULD be rendered in the
+								property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in the
 							left-hand slot in the spread, and <a data-cite="epub-33#fxl-page-spread-right"><span
 									id="page-spread-right"><code>rendition:page-spread-right</code></span> property</a>
-							[[EPUB-33]] that it SHOULD be rendered in the right-hand slot.</p>
+							[[epub-33]] that it SHOULD be rendered in the right-hand slot.</p>
 
 						<p>Reading systems that support the <a href="#def-spread-none"><code>spread-none</code>
 								property</a> MUST recognize the <a data-cite="epub-33#fxl-page-spread-center"><span
@@ -1553,14 +1553,14 @@
 						<p>The <code id="page-break-precedence">rendition:page-spread-*</code> properties MUST take
 							precedence over whatever value of the <a
 								href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-									><code>page-break-before</code> property</a> [[CSSSnapshot]] has been set for an
+									><code>page-break-before</code> property</a> [[csssnapshot]] has been set for an
 								<a>XHTML content document</a>.</p>
 
 						<p id="page-layout-both" data-tests="#page-layout-both">When a <a href="#def-layout-reflowable"
 								>reflowable</a> spine item follows a <a href="#def-layout-pre-paginated"
 								>pre-paginated</a> one, the reflowable one SHOULD start on the next page &#8212; as
 							defined by the <a data-cite="epub-33#attrdef-spine-page-progression-direction"
-									><code>page-progression-direction</code> attribute</a> [[EPUB-33]] &#8212; when it
+									><code>page-progression-direction</code> attribute</a> [[epub-33]] &#8212; when it
 							lacks a <code>rendition:page-spread-*</code> property value.</p>
 
 						<p id="page-spread-flow" data-tests="#page-layout-both-flow">If the reflowable spine item has a
@@ -1587,7 +1587,7 @@
 						<dt>XHTML</dt>
 						<dd>
 							<p>Reading systems MUST use the width and height expressions as defined in <a
-									data-cite="epub-33#sec-fxl-icb-html">Expressing in HTML</a> [[EPUB-33]] to render
+									data-cite="epub-33#sec-fxl-icb-html">Expressing in HTML</a> [[epub-33]] to render
 									<a>XHTML content documents</a>.</p>
 							<p id="confreq-fxl-rs-xhtml-icb" data-tests="#fxl-xhtml-icb">Reading systems MUST clip XHTML
 								content to the initial containing block (ICB) dimensions declared in the
@@ -1602,7 +1602,7 @@
 						<dt>SVG</dt>
 						<dd>
 							<p id="confreq-fxl-rs-svg">Reading systems MUST use the dimensions as defined in <a
-									data-cite="epub-33#sec-fxl-icb-svg">Expressing the ICB in SVG</a> [[EPUB-33]] to
+									data-cite="epub-33#sec-fxl-icb-svg">Expressing the ICB in SVG</a> [[epub-33]] to
 								render <a>SVG content documents</a>.</p>
 						</dd>
 					</dl>
@@ -1619,7 +1619,7 @@
 					<div class="note">
 						<p>This specification does not define how the <a
 								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-								containing block</a> [[CSS2]] is placed within the reading system <a>content display
+								containing block</a> [[css2]] is placed within the reading system <a>content display
 								area</a>.</p>
 					</div>
 
@@ -1635,7 +1635,7 @@
 
 				<p id="confreq-rs-epub3-presentational-meta" class="support">Reading systems SHOULD process the <a
 						data-cite="epub-33#sec-rendering-general">general package rendering properties</a>
-					[[EPUB-33]].</p>
+					[[epub-33]].</p>
 
 				<section id="flow">
 					<h4>The <code>rendition:flow</code> property</h4>
@@ -1645,7 +1645,7 @@
 
 					<p>The default global value is <code>auto</code> if no <code>meta</code> element carrying this
 						property occurs in the <a data-cite="epub-33#elemdef-opf-metadata"><code>metadata</code>
-							section</a> [[EPUB-33]]. Reading systems MAY support only this default value.</p>
+							section</a> [[epub-33]]. Reading systems MAY support only this default value.</p>
 
 					<p>The <code>rendition:flow</code> property values have the following processing requirements:</p>
 
@@ -1660,7 +1660,7 @@
 							<p>The reading system SHOULD render all EPUB content documents such that overflow content is
 								scrollable, and SHOULD present the EPUB publication as one continuous scroll from spine
 								item to spine item (except where <a data-cite="epub-33#layout-property-flow-overrides"
-									>locally overridden</a> [[EPUB-33]]).</p>
+									>locally overridden</a> [[epub-33]]).</p>
 						</dd>
 
 						<dt id="scrolled-doc">scrolled-doc</dt>
@@ -1680,13 +1680,13 @@
 					<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction MUST be
 						defined relative to the block flow direction of the root element of the XHTML content document
 						referenced by the <a data-cite="epub-33#elemdef-spine-itemref"><code>itemref</code> element</a>
-						[[EPUB-33]]. The scroll direction MUST be vertical if the block flow direction is downward
+						[[epub-33]]. The scroll direction MUST be vertical if the block flow direction is downward
 						(top-to-bottom). It MUST be horizontal if the block flow direction of the root element is
 						rightward (left-to-right) or leftward (right-to-left).</p>
 
 					<p>Reading systems MUST ignore the <code>rendition:flow</code> property and its overrides when
 						processing <a href="https://www.w3.org/TR/epub-33/#def-layout-pre-paginated">pre-paginated spine
-							items</a> [[EPUB-33]].</p>
+							items</a> [[epub-33]].</p>
 				</section>
 
 				<section id="align-x-center">
@@ -1712,21 +1712,21 @@
 				<p>Reading systems MAY support custom properties provided they do not introduce expressions that
 					conflict behaviorally with the properties defined in the <a
 						href="https://www.w3.org/TR/epub-33/#app-rendering-vocab">Package rendering vocabulary</a>
-					[[EPUB-33]].</p>
+					[[epub-33]].</p>
 			</section>
 		</section>
 		<section id="sec-media-overlays">
 			<h2>Media overlays processing</h2>
 
 			<p id="confreq-rs-epub3-mo" class="support">Reading systems with the capability to render prerecorded audio
-				SHOULD support <a data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[EPUB-33]].</p>
+				SHOULD support <a data-cite="epub-33#sec-media-overlays">Media Overlays</a> [[epub-33]].</p>
 
 			<p>If a reading system does not support Media Overlays, it MUST ignore both:</p>
 
 			<ul>
 				<li>the <a data-cite="epub-33#attrdef-item-media-overlay"><code>media-overlay</code> attribute</a> on
 						<a>manifest</a>
-					<a data-cite="epub-33#elemdef-package-item"><code>item</code> elements</a> [[EPUB-33]]; and</li>
+					<a data-cite="epub-33#elemdef-package-item"><code>item</code> elements</a> [[epub-33]]; and</li>
 				<li><code>item</code> elements where the <code>media-type</code> attribute value equals
 						<code>application/smil+xml</code>.</li>
 			</ul>
@@ -1735,7 +1735,7 @@
 				<h4>Loading the media overlay</h4>
 
 				<p>When a reading system loads a <a>package document</a>, it MUST refer to the <a>manifest</a>
-					<a data-cite="epub-33#elemdef-package-item"><code>item</code> elements'</a> [[EPUB-33]]
+					<a data-cite="epub-33#elemdef-package-item"><code>item</code> elements'</a> [[epub-33]]
 						<code>media-overlay</code> attributes to discover the corresponding Media Overlays for <a>EPUB
 						content documents</a>.</p>
 
@@ -1759,11 +1759,11 @@
 					<p id="mol-timing-sync"
 						data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio"
 						>Reading systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
-								><code>body</code> element</a> [[EPUB-33]] in a sequence. A <a
-							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[EPUB-33]] children
+								><code>body</code> element</a> [[epub-33]] in a sequence. A <a
+							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[epub-33]] children
 						MUST be rendered in sequence, and playback completes when the last child finishes playing.
 						Reading system MUST render a <a data-cite="epub-33#elemdef-smil-par"><code>par</code>
-							element's</a> [[EPUB-33]] children in parallel (with each starting at the same time), and
+							element's</a> [[epub-33]] children in parallel (with each starting at the same time), and
 						playback completes when all the children finish playing. Reading system playback of the media
 						overlay document completes when the <code>body</code> element's last child finishes playing.</p>
 				</section>
@@ -1776,7 +1776,7 @@
 						attribute, starting at the clip offset time given by the <a
 							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> and ending
 						at the clip offset time given by the <a data-cite="epub-33#attrdef-smil-clipEnd"
-								><code>clipEnd</code> attribute</a> [[EPUB-33]].</p>
+								><code>clipEnd</code> attribute</a> [[epub-33]].</p>
 
 					<p>In addition:</p>
 
@@ -1805,27 +1805,27 @@
 					<h5>Rendering EPUB content document elements</h5>
 
 					<p>When presented with a Media Overlay <a data-cite="epub-33#elemdef-smil-text"><code>text</code>
-							element</a> [[EPUB-33]] whose <code>src</code> attribute contains a <a>URL-fragment
+							element</a> [[epub-33]] whose <code>src</code> attribute contains a <a>URL-fragment
 							string</a> referencing a specific part of an EPUB content document, reading systems SHOULD
-						ensure the referenced portion is visible in the <a>viewport</a>. In addition to [[HTML]] element
+						ensure the referenced portion is visible in the <a>viewport</a>. In addition to [[html]] element
 						ID references and <a href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG
-							Fragment Identifiers</a> [[SVG]], reading systems MAY support other fragment identifier
+							Fragment Identifiers</a> [[svg]], reading systems MAY support other fragment identifier
 						schemes.</p>
 
 					<p id="mol-rendering-with-styling"
 						data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">During
 						Media Overlays playback, reading systems with a viewport SHOULD add the class names given by the
 						metadata properties <a data-cite="epub-33#active-class"><code>active-class</code></a> and <a
-							data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a> [[EPUB-33]]
+							data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a> [[epub-33]]
 						to the appropriate elements, when specified, in the EPUB content document. Conversely, the class
 						names SHOULD be removed when the playback state changes, as described in <a
-							data-cite="epub-33#sec-docs-assoc-style">Associating style information</a> [[EPUB-33]].</p>
+							data-cite="epub-33#sec-docs-assoc-style">Associating style information</a> [[epub-33]].</p>
 
 					<p>The <code>active-class</code> and <code>playback-active-class</code> metadata properties are
 						OPTIONAL, and if omitted, reading system behavior is implementation-specific.</p>
 
 					<p>Reading system behavior when a <a data-cite="epub-33#sec-media-overlays-fragids">fragment
-							identifier</a> [[EPUB-33]] does not reference an element is also
+							identifier</a> [[epub-33]] does not reference an element is also
 						implementation-specific.</p>
 				</section>
 			</section>
@@ -1853,7 +1853,7 @@
 								document</a>t in order to provide synchronized playback of its contents, regardless of
 							whether the <a>XHTML content document</a> in which it resides is included in the
 								<a>spine</a>. See <a data-cite="epub-33#sec-mo-nav-doc">EPUB navigation document</a>
-							[[EPUB-33]] for more information.</p>
+							[[epub-33]] for more information.</p>
 					</div>
 
 					<div class="note" id="note-table-reading-mode">
@@ -1874,10 +1874,10 @@
 							synchronization described by a Media Overlay, it MUST override the default playback behavior
 							of audio and video media embedded within the associated EPUB content document.</span></p>
 
-					<p>Note that the rules below apply only to <em>referenced</em> [[HTML]] <a><code>video</code></a> or
+					<p>Note that the rules below apply only to <em>referenced</em> [[html]] <a><code>video</code></a> or
 								<a><code>audio</code></a> elements within the associated EPUB content document. That is
 						to say, the rules apply to only those elements pointed to by <a
-							data-cite="epub-33#elemdef-smil-text"><code>text</code> elements</a> [[EPUB-33]] within the
+							data-cite="epub-33#elemdef-smil-text"><code>text</code> elements</a> [[epub-33]] within the
 						Media Overlay (i.e., via the <code>src</code> attribute). These rules do not apply to embedded
 						media not referenced by Media Overlay elements.</p>
 
@@ -1893,7 +1893,7 @@
 							<ul>
 								<li>
 									<p>Hide the individual video/audio UI controls from the page, which overrides the
-										default behavior defined by the [[HTML]] [^audio/controls^] attribute.</p>
+										default behavior defined by the [[html]] [^audio/controls^] attribute.</p>
 								</li>
 								<li>
 									<p>Prevent scripts embedded within the EPUB content document from invoking the
@@ -1906,29 +1906,29 @@
 							<p>Reading systems MUST initialize all referenced audio and video media embedded within an
 								EPUB content document to their "stopped" state, and ready them to play from the
 								zero-position within their content stream (possibly displaying the image specified using
-								the [[HTML]] [^video/poster^] attribute. This requirement overrides the default behavior
-								defined by the [[HTML]] [^video/autoplay^] attribute.</p>
+								the [[html]] [^video/poster^] attribute. This requirement overrides the default behavior
+								defined by the [[html]] [^video/autoplay^] attribute.</p>
 						</li>
 						<li>
 							<p>When an EPUB content document element becomes active, the CSS Style Sheet visual
 								highlighting rules apply regardless of the content type referred to by that element's
 									<code>src</code> attribute (e.g., the CSS class name defined by the <a
 									data-cite="epub-33#active-class"><code>active-class</code> metadata property</a>
-								[[EPUB-33]] SHOULD be applied to visible video and audio player controls within the host
+								[[epub-33]] SHOULD be applied to visible video and audio player controls within the host
 								EPUB content document).</p>
 						</li>
 						<li>
 							<p id="mol-embed-start-and-stop" data-tests="#mol-embed,#mol-embed_fxl">In addition to the
 								default behavior of Media Overlay activation for textual fragments and images, audio and
 								video playback MUST be started and stopped according to the duration implied by the
-								authored Media Overlay synchronization (as per the standard [[SMIL3]] timing model).
+								authored Media Overlay synchronization (as per the standard [[smil3]] timing model).
 								There are two possible scenarios:</p>
 							<ul>
 								<li>
 									<p>When a Media Overlay <code>text</code> element has no <a
-											data-cite="epub-33#elemdef-smil-audio"><code>audio</code></a> [[EPUB-33]]
+											data-cite="epub-33#elemdef-smil-audio"><code>audio</code></a> [[epub-33]]
 										sibling within its <a data-cite="epub-33#elemdef-smil-par"><code>par</code></a>
-										[[EPUB-33]] parent container, the referenced EPUB content document audio or
+										[[epub-33]] parent container, the referenced EPUB content document audio or
 										video media MUST play until it ends, at which point the <code>text</code>
 										element's lifespan terminates. In this case, the implicit duration of the
 											<code>text</code> element (and by inference, of the parent <code>par</code>
@@ -1947,7 +1947,7 @@
 										finished (in which case the last-played video frame SHOULD remain visible until
 										the parent <code>par</code> container finally ends). This behavior is equivalent
 										of the Media Overlay <code>audio</code> element implicitly carrying the behavior
-										of the [[SMIL3]] <a data-cite="smil3/smil-timing.html#adef-endsync"
+										of the [[smil3]] <a data-cite="smil3/smil-timing.html#adef-endsync"
 												><code>endsync</code></a> attribute.</p>
 									<p>Furthermore, reading systems SHOULD expose user controls for the volume levels of
 										each independent audio track (i.e., from the <code>audio</code> element of the
@@ -1964,7 +1964,7 @@
 							<p>When a <code>text</code> element becomes inactive in the Media Overlay, and when it
 								points to embedded video or audio media, that referenced media MUST be reset to its
 								initial "stopped" state, ready to be played from the zero-position within their content
-								stream (possibly displaying the poster image specified using the [[HTML]] markup).</p>
+								stream (possibly displaying the poster image specified using the [[html]] markup).</p>
 						</li>
 					</ul>
 				</section>
@@ -1973,8 +1973,8 @@
 					<h5>Text-to-speech</h5>
 
 					<p id="mol-tts" data-tests="#mol-tts_multi,#mol-tts_single">When a Media Overlay <a
-							data-cite="epub-33#elemdef-smil-text"><code>text</code> element</a> [[EPUB-33]] with no <a
-							data-cite="epub-33#elemdef-smil-audio"><code>audio</code></a> [[EPUB-33]] sibling element
+							data-cite="epub-33#elemdef-smil-text"><code>text</code> element</a> [[epub-33]] with no <a
+							data-cite="epub-33#elemdef-smil-audio"><code>audio</code></a> [[epub-33]] sibling element
 						references text within the target <a>EPUB content document</a>, reading systems capable of
 						text-to-speech (TTS) playback SHOULD render the referenced text using TTS.</p>
 
@@ -1982,7 +1982,7 @@
 						document to play the audio stream as part of the Media Overlay rendering.</p>
 
 					<div class="note">
-						<p>See <a data-cite="epub-tts-10#">EPUB 3 Text-to-Speech Support</a> [[EPUB-TTS-10]] for more
+						<p>See <a data-cite="epub-tts-10#">EPUB 3 Text-to-Speech Support</a> [[epub-tts-10]] for more
 							information about supporting TTS technologies in EPUB publications.</p>
 					</div>
 
@@ -2025,7 +2025,7 @@
 			<h2>Processing structural semantics</h2>
 
 			<p id="confreq-rs-epub-epub-type" class="support">Reading systems MAY support <a
-					data-cite="epub-33#app-structural-semantics">structural semantics</a> [[EPUB-33]] in <a>EPUB content
+					data-cite="epub-33#app-structural-semantics">structural semantics</a> [[epub-33]] in <a>EPUB content
 					documents</a>.</p>
 
 			<p>When processing the <code>epub:type</code> attribute, a reading system:</p>
@@ -2033,7 +2033,7 @@
 			<ul class="conformance-list">
 				<li>
 					<p id="confreq-rs-epubtype-beh">MAY associate behaviors with none, some or all of the terms defined
-						in the <a data-cite="epub-33#sec-epub-type-attribute">default vocabulary</a> [[EPUB-33]].</p>
+						in the <a data-cite="epub-33#sec-epub-type-attribute">default vocabulary</a> [[epub-33]].</p>
 				</li>
 				<li>
 					<p id="confreq-rs-epubtype-oth">MAY associate behaviors with terms from other vocabularies.</p>
@@ -2055,13 +2055,13 @@
 			<h2>Vocabulary association mechanisms</h2>
 
 			<p id="confreq-res-epub-vocab-assoc" class="support">Reading systems MUST support <a
-					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[EPUB-33]].</p>
+					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[epub-33]].</p>
 
 			<dl class="conformance-list">
 				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
 				<dd>
 					<p>Reading systems MUST resolve all <a data-cite="epub-33#sec-reserved-prefixes">reserved
-							prefixes</a> [[EPUB-33]] used in package documents using their predefined URLs unless the
+							prefixes</a> [[epub-33]] used in package documents using their predefined URLs unless the
 						EPUB creator declares a local <a href="#sec-prefix-attr">prefix</a>. Reading systems MUST use
 						the URLs defined for locally overridden prefixes (using the <code>prefix</code> attribute) when
 						encountered.</p>
@@ -2081,17 +2081,17 @@
 				<dt id="sec-property-datatype">Expanding <code>property</code> Data Types</dt>
 				<dd>
 					<p>Reading systems MUST expand <a data-cite="epub-33#sec-property-datatype"><code>property</code>
-							values</a> [[EPUB-33]] as follows:</p>
+							values</a> [[epub-33]] as follows:</p>
 					<ul>
 						<li>
 							<p>If the property consists only of a reference, concatenate the prefix URL associated with
-								the <a data-cite="epub-33#sec-default-vocab">default vocabulary</a> [[EPUB-33]] to the
+								the <a data-cite="epub-33#sec-default-vocab">default vocabulary</a> [[epub-33]] to the
 								reference.</p>
 						</li>
 						<li>
 							<p>If the property consists of a prefix and reference, concatenate the URL defined for the
 								prefix to the reference. If the EPUB creator has not defined a matching prefix, and it
-								is not a <a data-cite="epub-33#sec-reserved-prefixes">reserved prefix</a> [[EPUB-33]],
+								is not a <a data-cite="epub-33#sec-reserved-prefixes">reserved prefix</a> [[epub-33]],
 								the property is invalid and reading systems MUST ignore it.</p>
 						</li>
 						<li>
@@ -2099,9 +2099,9 @@
 								the property is invalid and reading systems MUST ignore it.</p>
 						</li>
 					</ul>
-					<p>The result MUST be a <a>valid URL string</a> [[URL]]. If the process results in an invalid URL,
+					<p>The result MUST be a <a>valid URL string</a> [[url]]. If the process results in an invalid URL,
 						reading systems MUST ignore the property.</p>
-					<p>Reading systems do not have to <a data-lt="url parser">parse the resulting URL</a> [[URL]] or
+					<p>Reading systems do not have to <a data-lt="url parser">parse the resulting URL</a> [[url]] or
 						attempt to dereference the resource.</p>
 				</dd>
 			</dl>
@@ -2111,7 +2111,7 @@
 
 			<p id="confreq-rs-backward-epub" data-tests="#pkg-version-backward">Reading systems MUST attempt to process
 				an <a>EPUB publication</a> whose <a>package document</a>
-				<a data-cite="epub-33#attrdef-package-version"><code>version</code> attribute</a> [[EPUB-33]] is less
+				<a data-cite="epub-33#attrdef-package-version"><code>version</code> attribute</a> [[epub-33]] is less
 				than "<code>3.0</code>".</p>
 
 			<p id="confreq-rs-backward-conf">EPUB publications with older version numbers will not always render exactly
@@ -2123,7 +2123,7 @@
 
 			<p id="confreq-rs-forward-epubn">Reading systems SHOULD attempt to process an <a>EPUB publication</a> whose
 					<a>package document</a>
-				<a data-cite="epub-33#attrdef-package-version"><code>version</code> attribute</a> [[EPUB-33]] is greater
+				<a data-cite="epub-33#attrdef-package-version"><code>version</code> attribute</a> [[epub-33]] is greater
 				than "<code>3.0</code>".</p>
 		</section>
 		<section id="sec-accessibility" class="informative">
@@ -2134,7 +2134,7 @@
 				that there are not common accessibility issues that all reading systems developers should be aware of,
 				or seek to avoid in their applications.</p>
 
-			<p>The W3C's User Agent Accessibility Guidelines [[UAAG20]] provides many useful practices developers should
+			<p>The W3C's User Agent Accessibility Guidelines [[uaag20]] provides many useful practices developers should
 				apply to improve their reading systems as many browser accessibility issues have parallels in
 				EPUB-specific user agents.</p>
 
@@ -2161,9 +2161,9 @@
 					does not depend on physical interaction (i.e., users of assistive technologies can read the content
 					without getting trapped at the end of pages or documents).</li>
 				<li>API Integration &#8212; Ensure that the accessibility tree, including support for roles, states and
-					properties [[WAI-ARIA-11]], is exposed to the underlying operating system's accessibility API so
+					properties [[wai-aria-11]], is exposed to the underlying operating system's accessibility API so
 					that users can fully interact with the content when using assistive technologies.</li>
-				<li>Document Object Model (DOM) &#8212; Provide access to the [[DOM]] of EPUB content documents so that
+				<li>Document Object Model (DOM) &#8212; Provide access to the [[dom]] of EPUB content documents so that
 					users can investigate the semantics and structure expressed in the source.</li>
 				<li>Table of Contents &#8212; Ensure that users can access the link text, including <a
 						data-cite="epub-33#confreq-nav-a-title">text alternatives for visual content</a>. Activating the
@@ -2194,7 +2194,7 @@
 				<div class="note">
 					<p>For the risks associated with the authoring of EPUB publications, refer to the <a
 							data-cite="epub-33#sec-security-privacy">security and privacy section</a> of
-						[[EPUB-33]].</p>
+						[[epub-33]].</p>
 				</div>
 			</section>
 
@@ -2202,7 +2202,7 @@
 				<h3>Threat model</h3>
 
 				<p>The greatest threats to users come from the <a data-cite="epub-33#epub-threat-model">content they
-						read</a> [[EPUB-33]], and the first line of defense against these attacks is the reading systems
+						read</a> [[epub-33]], and the first line of defense against these attacks is the reading systems
 					they use. Users expect that reading systems act as safeguards against malicious content and are
 					often unaware that EPUB publications are susceptible to the same security risks as web sites.</p>
 
@@ -2276,7 +2276,7 @@
 					</dd>
 				</dl>
 
-				<p>Additionally, the security considerations that apply to [[XML]] and [[ZIP]] files also apply to the
+				<p>Additionally, the security considerations that apply to [[xml]] and [[zip]] files also apply to the
 						<a data-cite="epub-33#sec-package-doc">package document</a> and the <a
 						data-cite="epub-33#sec-ocf">Open Container Format</a>, respectively. See the "Security
 					Consideration" sections of the Media Type registrations for the <a
@@ -2318,14 +2318,14 @@
 			<h2><dfn class="export">epubReadingSystem</dfn> object</h2>
 
 			<p class="note">Reading systems act as the core rendering engines of EPUB publications and provide a
-				scripting environment based on the [[DOM]] specification. So, although this interface definition uses
-				the [[WEBIDL]] notation for implementation by reading systems, web browsers generally do not have to
+				scripting environment based on the [[dom]] specification. So, although this interface definition uses
+				the [[webidl]] notation for implementation by reading systems, web browsers generally do not have to
 				implement these objects.</p>
 
 			<section id="app-ers-idl">
 				<h3>Interface definition</h3>
 
-				<p>This specification extends the {{Navigator}} object [[HTML]] as follows.</p>
+				<p>This specification extends the {{Navigator}} object [[html]] as follows.</p>
 
 				<pre class="idl">[Exposed=(Window)]
 interface EpubReadingSystem {
@@ -2340,7 +2340,7 @@ partial interface Navigator {
 
 				<div class="note">
 					<p>This specification does not define an <code>epubReadingSystem</code> property extension for the
-						{{WorkerNavigator}} object [[HTML]]. Reading systems therefore do not have to expose the
+						{{WorkerNavigator}} object [[html]]. Reading systems therefore do not have to expose the
 							<code>epubReadingSystem</code> object in the scripting context of Workers, and EPUB creators
 						cannot rely on its presence.</p>
 				</div>
@@ -2366,9 +2366,9 @@ partial interface Navigator {
 					>Reading systems MUST expose the <code>epubReadingSystem</code> object on the <code>navigator</code>
 					object of all loaded scripted content documents, including any nested <a
 						data-cite="epub-33#sec-scripted-container-constrained">container-constrained scripting
-						contexts</a> [[EPUB-33]]. Reading systems MUST ensure that the <code>epubReadingSystem</code>
+						contexts</a> [[epub-33]]. Reading systems MUST ensure that the <code>epubReadingSystem</code>
 					object is available no later than when the <a data-cite="html#the-end"><code>DOMContentLoaded</code>
-						event is triggered</a> [[HTML]].</p>
+						event is triggered</a> [[html]].</p>
 
 				<div class="note">
 					<p>Reading systems implementations may create cloned instances of the <code>epubReadingSystem</code>
@@ -2416,8 +2416,8 @@ partial interface Navigator {
 				</table>
 
 				<p>This specification used to define a <code>layoutStyle</code> property, but it is now <a
-						data-cite="epub-33#deprecated">deprecated</a> [[EPUB-33]]. Refer to its definition in
-					[[EPUBContentDocs-301]] for more information.</p>
+						data-cite="epub-33#deprecated">deprecated</a> [[epub-33]]. Refer to its definition in
+					[[epubcontentdocs-301]] for more information.</p>
 			</section>
 
 			<section id="app-ers-methods">
@@ -2476,7 +2476,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 										<code>dom-manipulation</code>
 									</td>
 									<td>Scripts may make structural changes to the document’s DOM (applies to <a
-											data-cite="epub-33#sec-scripted-spine">spine-level scripting</a> [[EPUB-33]]
+											data-cite="epub-33#sec-scripted-spine">spine-level scripting</a> [[epub-33]]
 										only).</td>
 								</tr>
 								<tr>
@@ -2485,7 +2485,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 									</td>
 									<td>Scripts may modify attributes and CSS styles that affect content layout (applies
 										to <a data-cite="epub-33#sec-scripted-spine">spine-level scripting</a>
-										[[EPUB-33]] only).</td>
+										[[epub-33]] only).</td>
 								</tr>
 								<tr>
 									<td id="feature-touch-events">
@@ -2513,9 +2513,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 										<code>spine-scripting</code>
 									</td>
 									<td>Indicates whether the reading system supports <a
-											data-cite="epub-33#sec-scripted-spine">spine-level scripting</a> [[EPUB-33]]
+											data-cite="epub-33#sec-scripted-spine">spine-level scripting</a> [[epub-33]]
 										(e.g., so a <a data-cite="epub-33#sec-scripted-container-constrained"
-											>container-constrained script</a> [[EPUB-33]] can determine whether any
+											>container-constrained script</a> [[epub-33]] can determine whether any
 										actions that depend on scripting support in a <a>top-level content document</a>
 										have any chance of success before attempting them).</td>
 								</tr>
@@ -2641,10 +2641,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<li>08-Mar-2021: Remove unnecessary requirement to assume default value for rendering metadata. See <a
 						href="https://github.com/w3c/epub-specs/issues/1313">issue 1313</a>.</li>
 				<li>05-Mar-2021: Added requirement for reading systems to collapse whitespace in DCMES and meta elements
-					per the [[Infra]] specification definition. See <a
+					per the [[infra]] specification definition. See <a
 						href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
 				<li>26-Feb-2021: Clarified the trimming of leading and trailing whitespace is to be done in accordance
-					with the [[Infra]] specification definition, and removed the exception that <code>meta</code>
+					with the [[infra]] specification definition, and removed the exception that <code>meta</code>
 					element properties may define their own whitespace handling rules. See <a
 						href="https://github.com/w3c/epub-specs/issues/1295">issue 1295</a>.</li>
 				<li>19-Feb-2021: Updated the <a href="#sec-scripted-content-security">scripting security
@@ -2665,7 +2665,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						href="https://github.com/w3c/epub-specs/issues/1488">issue 1488</a>.</li>
 				<li>24-Dec-2020: The creation of a <a
 						href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
-						>release identifier</a> [[EPUBPackages-32]] is no longer defined. See <a
+						>release identifier</a> [[epubpackages-32]] is no longer defined. See <a
 						href="https://github.com/w3c/epub-specs/issues/1440">issue 1440</a>.</li>
 				<li>06-Nov-2020: Reading systems are now required to <a href="#confreq-rs-xml-extid">not resolve
 						external identifiers</a> in doctype declarations. See <a

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -46,7 +46,7 @@
 					}
 				],
 				localBiblio: {
-					"EPUB-DICT-10": {
+					"epub-dict-10": {
 						"title": "EPUB Dictionaries and Glossaries 1.0",
 						"href": "http://www.idpf.org/epub/dict",
 						"editors": [
@@ -56,7 +56,7 @@
 						"date": "26 August 2015",
 						"publisher": "IDPF"
 					},
-					"EPUB-INDEXES-10": {
+					"epub-indexes-10": {
 						"title": "EPUB Indexes 1.0",
 						"href": "http://www.idpf.org/epub/idx",
 						"editors": [
@@ -66,7 +66,7 @@
 						"date": "26 August 2015",
 						"publisher": "IDPF"
 					},
-					"EPUB-REGION-NAV-10": {
+					"epub-region-nav-10": {
 						"title": "EPUB Region-Based Navigation 1.0",
 						"href": "http://www.idpf.org/epub/renditions/region-nav",
 						"editors": [
@@ -106,12 +106,12 @@
 
 			<p>Structural semantics add additional meaning about the specific structural purpose an HTML (or SVG)
 				element plays. The <a data-cite="epub-33#sec-epub-type-attribute"><code>epub:type</code>
-				attribute</a> [[EPUB-33]] is used to express domain-specific semantics in <a>EPUB content documents</a>
-				and <a>media overlay documents</a> [[EPUB-33]], with the structural information it carries complementing
+				attribute</a> [[epub-33]] is used to express domain-specific semantics in <a>EPUB content documents</a>
+				and <a>media overlay documents</a> [[epub-33]], with the structural information it carries complementing
 				the underlying vocabulary.</p>
 
 			<p>The applied semantics refine the meaning of their containing elements without changing their nature for
-				assistive technologies, as happens when using the similar [^/role^] attribute [[HTML]]. The attribute
+				assistive technologies, as happens when using the similar [^/role^] attribute [[html]]. The attribute
 				does not enhance the accessibility of the content, in other words, only provides hints about the
 				purpose.</p>
 
@@ -120,7 +120,7 @@
 					<a data-cite="epub-33#sec-behaviors-skip-escape">skippability and escapability</a> in Media
 				Overlays).</p>
 
-			<p>The [[EPUB-33]] specification defines a method for adding structural semantics using <em>the attribute
+			<p>The [[epub-33]] specification defines a method for adding structural semantics using <em>the attribute
 					axis</em>: instead of adding new elements, EPUB creators can append the <code>epub:type</code>
 				attribute to existing elements to add the desired semantics. This document defines a set of property
 				values, i.e., a vocabulary, that can be used for that purpose.</p>
@@ -136,10 +136,10 @@
 					listed, but must ensure that the semantics they express represent a subset of the carrying element's
 					semantics and do not attach an existing element's meaning to a semantically neutral element.</p>
 
-				<p>The <i>DPUB-ARIA role</i> fields indicate the [[DPUB-ARIA-1.0]] roles that can alternatively be used
-					with the [[HTML]] <code>role</code> attribute to improve accessibility. These roles may have more
+				<p>The <i>DPUB-ARIA role</i> fields indicate the [[dpub-aria-1.0]] roles that can alternatively be used
+					with the [[html]] <code>role</code> attribute to improve accessibility. These roles may have more
 					restrictive usage contexts, however, so may not be valid wherever the <code>epub:type</code>
-					attribute is used. Refer to [[HTML-ARIA]] for more information about where the roles are
+					attribute is used. Refer to [[html-aria]] for more information about where the roles are
 					allowed.</p>
 
 				<p>When processing HTML documents, reading systems may ignore such non-compliant properties, unless
@@ -478,7 +478,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">Usage details: </span>
-						<a data-cite="epub-33#sec-nav-landmarks">The <code>landmarks nav</code> Element</a> [[EPUB-33]]
+						<a data-cite="epub-33#sec-nav-landmarks">The <code>landmarks nav</code> Element</a> [[epub-33]]
 					</p>
 				</dd>
 
@@ -546,7 +546,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">Usage details: </span>
-						<a data-cite="epub-33#sec-nav-toc">The <code>toc nav</code> Element</a> [[EPUB-33]] </p>
+						<a data-cite="epub-33#sec-nav-toc">The <code>toc nav</code> Element</a> [[epub-33]] </p>
 				</dd>
 
 				<dt id="toc-brief">toc-brief<span class="status draft"> [draft]</span></dt>
@@ -706,7 +706,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.9.2">Antonym Groups</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="condensed-entry">condensed-entry</dt>
@@ -731,7 +731,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.2.2.2">The Condensed Entry</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="def">def</dt>
@@ -756,7 +756,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.6">Definitions</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="dictentry">dictentry</dt>
@@ -781,7 +781,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.2.1">The Dictionary Entry</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="dictionary">dictionary</dt>
@@ -798,7 +798,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.1">The Dictionary Container</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="etymology">etymology</dt>
@@ -823,7 +823,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.6">Etymologies</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="example">example</dt>
@@ -847,7 +847,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.3">Examples</a> [[EPUB-DICT-10]]
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.3">Examples</a> [[epub-dict-10]]
 						</p>
 					</dd>
 
@@ -874,7 +874,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.5.2">Related Grammatical
-								Information</a> [[EPUB-DICT-10]] </p>
+								Information</a> [[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="idiom">idiom</dt>
@@ -898,7 +898,7 @@
 					<dd>
 						<p>
 							<span class="subproplabel">Usage details: </span>
-							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.2">Idioms</a> [[EPUB-DICT-10]]
+							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.2">Idioms</a> [[epub-dict-10]]
 						</p>
 					</dd>
 
@@ -924,7 +924,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.1">The Dictionary Container</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="part-of-speech-list">part-of-speech-list</dt>
@@ -949,7 +949,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.2">Part of Speech Lists</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="part-of-speech-group">part-of-speech-group</dt>
@@ -974,7 +974,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.3">Part of Speech Groups</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="phonetic-transcription">phonetic-transcription</dt>
@@ -1000,7 +1000,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.4">Phonetic Transcriptions</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="phrase-list">phrase-list</dt>
@@ -1025,7 +1025,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.4">Phrase Lists</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="phrase-group">phrase-group</dt>
@@ -1050,7 +1050,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.8.5">Phrase Groups</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="sense-list">sense-list</dt>
@@ -1075,7 +1075,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.4">Sense Lists</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="sense-group">sense-group</dt>
@@ -1101,7 +1101,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.5">Sense Groups</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="synonym-group">synonym-group</dt>
@@ -1126,7 +1126,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.9.1">Synonym Groups</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="tran">tran</dt>
@@ -1152,7 +1152,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.7">Translations</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="tran-info">tran-info</dt>
@@ -1177,7 +1177,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.2.7.8">Translation-Related
-								Information</a> [[EPUB-DICT-10]] </p>
+								Information</a> [[epub-dict-10]] </p>
 					</dd>
 				</dl>
 			</section>
@@ -1206,7 +1206,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.1">The Glossary Container</a>
-							[[EPUB-DICT-10]] </p>
+							[[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="glossdef">glossdef</dt>
@@ -1231,7 +1231,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.2">Glossary Terms and
-								Definitions</a> [[EPUB-DICT-10]] </p>
+								Definitions</a> [[epub-dict-10]] </p>
 					</dd>
 
 					<dt id="glossterm">glossterm</dt>
@@ -1256,7 +1256,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/dict/epub-dict.html#sec-2.3.2">Glossary Terms and
-								Definitions</a> [[EPUB-DICT-10]] </p>
+								Definitions</a> [[epub-dict-10]] </p>
 					</dd>
 				</dl>
 			</section>
@@ -1280,7 +1280,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-index">index property</a>
-							[[EPUB-INDEXES-10]] </p>
+							[[epub-indexes-10]] </p>
 					</dd>
 					<dd>
 						<p>
@@ -1311,7 +1311,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-editor-note">index-editor-note
-								property</a> [[EPUB-INDEXES-10]] </p>
+								property</a> [[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-entry">index-entry</dt>
@@ -1337,7 +1337,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-entry">index-entry property</a>
-							[[EPUB-INDEXES-10]] </p>
+							[[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-entry-list">index-entry-list</dt>
@@ -1365,7 +1365,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-entry-list">index-entry-list
-								property</a> [[EPUB-INDEXES-10]] </p>
+								property</a> [[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-group">index-group</dt>
@@ -1391,7 +1391,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-group">index-group property</a>
-							[[EPUB-INDEXES-10]] </p>
+							[[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-headnotes">index-headnotes</dt>
@@ -1416,7 +1416,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-headnotes">index-headnotes
-								property</a> [[EPUB-INDEXES-10]] </p>
+								property</a> [[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-legend">index-legend</dt>
@@ -1442,7 +1442,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-legend">index-legend property</a>
-							[[EPUB-INDEXES-10]] </p>
+							[[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-locator">index-locator</dt>
@@ -1471,7 +1471,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator">index-locator property</a>
-							[[EPUB-INDEXES-10]] </p>
+							[[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-locator-list">index-locator-list</dt>
@@ -1496,7 +1496,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator-list">index-locator-list
-								property</a> [[EPUB-INDEXES-10]] </p>
+								property</a> [[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-locator-range">index-locator-range</dt>
@@ -1523,7 +1523,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-locator-range">index-locator-range
-								property</a> [[EPUB-INDEXES-10]] </p>
+								property</a> [[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-term">index-term</dt>
@@ -1552,7 +1552,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term">index-term property</a>
-							[[EPUB-INDEXES-10]] </p>
+							[[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-term-categories">index-term-categories</dt>
@@ -1579,7 +1579,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term-categories"
-								>index-term-categories property</a> [[EPUB-INDEXES-10]] </p>
+								>index-term-categories property</a> [[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-term-category">index-term-category</dt>
@@ -1606,7 +1606,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-term-category">index-term-category
-								property</a> [[EPUB-INDEXES-10]] </p>
+								property</a> [[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-xref-preferred">index-xref-preferred</dt>
@@ -1632,7 +1632,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-xref">index-xref-preferred
-								property</a> [[EPUB-INDEXES-10]] </p>
+								property</a> [[epub-indexes-10]] </p>
 					</dd>
 
 					<dt id="index-xref-related">index-xref-related</dt>
@@ -1658,7 +1658,7 @@
 						<p>
 							<span class="subproplabel">Usage details: </span>
 							<a href="http://idpf.org/epub/idx/epub-indexes.html#bb-xref">index-xref-related property</a>
-							[[EPUB-INDEXES-10]] </p>
+							[[epub-indexes-10]] </p>
 					</dd>
 				</dl>
 			</section>
@@ -2475,7 +2475,7 @@
 					<p>
 						<span class="subproplabel">Usage details: </span>
 						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
-						[[EPUB-REGION-NAV-10]] </p>
+						[[epub-region-nav-10]] </p>
 				</dd>
 
 				<dt id="panel">panel</dt>
@@ -2492,7 +2492,7 @@
 					<p>
 						<span class="subproplabel">Usage details: </span>
 						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
-						[[EPUB-REGION-NAV-10]] </p>
+						[[epub-region-nav-10]] </p>
 				</dd>
 
 				<dt id="panel-group">panel-group</dt>
@@ -2509,7 +2509,7 @@
 					<p>
 						<span class="subproplabel">Usage details: </span>
 						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
-						[[EPUB-REGION-NAV-10]] </p>
+						[[epub-region-nav-10]] </p>
 				</dd>
 
 				<dt id="sound-area">sound-area</dt>
@@ -2526,7 +2526,7 @@
 					<p>
 						<span class="subproplabel">Usage details: </span>
 						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
-						[[EPUB-REGION-NAV-10]] </p>
+						[[epub-region-nav-10]] </p>
 				</dd>
 
 				<dt id="text-area">text-area</dt>
@@ -2544,7 +2544,7 @@
 					<p>
 						<span class="subproplabel">Usage details: </span>
 						<a href="http://www.idpf.org/epub/renditions/region-nav">EPUB Region-Based Navigation</a>
-						[[EPUB-REGION-NAV-10]] </p>
+						[[epub-region-nav-10]] </p>
 				</dd>
 			</dl>
 		</section>
@@ -2989,7 +2989,7 @@
 				<dd>
 					<p>
 						<span class="subproplabel">Usage details: </span>
-						<a data-cite="epub-33#sec-nav-pagelist">The <code>page-list nav</code> Element</a> [[EPUB-33]]
+						<a data-cite="epub-33#sec-nav-pagelist">The <code>page-list nav</code> Element</a> [[epub-33]]
 					</p>
 				</dd>
 

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -31,18 +31,18 @@
 					branch: "main"
 				},
 				localBiblio: {
-					"EPUBContentDocs-30": {
+					"epubcontentdocs-30": {
 						"authors":[
 						"Markus Gylling",
 						"William McCoy",
 						"Elika J. Etimad",
 						"Matt Garrish"],
-						"title": "EPUB content documents 3.0",
+						"title": "EPUB Content Documents 3.0",
 						"href": "http://idpf.org/epub/30/spec/epub30-contentdocs-20111011.html",
 						"date": "11 October 2011",
 						"publisher": "IDPF"
 					},
-					"SVG": {
+					"svg": {
 						"title": "SVG",
 						"href": "https://www.w3.org/TR/SVG/",
 						"publisher": "W3C"
@@ -76,7 +76,7 @@
 					material using basic TTS playback will understand the frustration of this experience.</p>
 
 				<p>W3C has defined a variety of technologies to aid in improving the voice rendering of markup content:
-					the Synthetic Speech Markup Language [[SSML]], pronunciation lexicons [[PRONUNCIATION-LEXICON]], and
+					the Synthetic Speech Markup Language [[ssml]], pronunciation lexicons [[pronunciation-lexicon]], and
 					the CSS Speech module.</p>
 
 				<p>SSML and pronunciation lexicons provide enhanced speech rendering. Lexicons are like dictionaries of
@@ -100,11 +100,11 @@
 				<h3>Background</h3>
 
 				<p>The EPUB Working Group of the International Digital Publishing Forum (IDPF) first defined a means of
-					integrating the Synthetic Speech Markup Language [[SSML]] and pronunciation lexicons
-					[[PRONUNCIATION-LEXICON]] in EPUB 3.0 [[EPUBContentDocs-30]] so that <a>EPUB creators</a> could
+					integrating the Synthetic Speech Markup Language [[ssml]] and pronunciation lexicons
+					[[pronunciation-lexicon]] in EPUB 3.0 [[epubcontentdocs-30]] so that <a>EPUB creators</a> could
 					improve the rendering quality of text-to-speech (TTS) playback in <a>reading systems</a>. The
-					ability to include cascading style sheets [[CSS2]] also allowed EPUB creators to access the
-					in-development speech properties of the CSS Speech module [[CSS-Speech-1]].</p>
+					ability to include cascading style sheets [[css2]] also allowed EPUB creators to access the
+					in-development speech properties of the CSS Speech module [[css-speech-1]].</p>
 
 				<p>Although there has been some authoring uptake of these technologies, support in reading systems has
 					yet to materialize to a level where these technologies are considered stable. Consequently, these
@@ -117,7 +117,7 @@
 					3.</p>
 
 				<div class="note">
-					<p>The <a data-cite="spoken-html#">Specification for Spoken Presentation in HTML</a> [[Spoken-HTML]]
+					<p>The <a data-cite="spoken-html#">Specification for Spoken Presentation in HTML</a> [[spoken-html]]
 						is another initiative in W3C to bring SSML to HTML. It is still too early to determine what
 						effect, if any, it will have on this document. The Working Group will monitor the work and
 						future updates to this Note will reflect any impact it has on Text-to-Speech rendering in
@@ -128,7 +128,7 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This specification uses terminology defined in EPUB 3.3 [[EPUB-33]]. These terms appear capitalized
+				<p>This specification uses terminology defined in EPUB 3.3 [[epub-33]]. These terms appear capitalized
 					wherever used.</p>
 
 				<p>Only the first instance of a term in a section links to its definition.</p>
@@ -152,12 +152,12 @@
 			<section id="ssml-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>The W3C Speech Synthesis Markup Language [[SSML]] is a language used for assisting
+				<p>The W3C Speech Synthesis Markup Language [[ssml]] is a language used for assisting
 						<a>Text-to-Speech</a> (TTS) engines in generating synthetic speech. Although SSML is designed as
 					a standalone document type, it also defines semantics suitable for use within other markup
 					languages.</p>
 
-				<p>This specification recasts the [[SSML]] <a data-cite="speech-synthesis11#S3.1.10"
+				<p>This specification recasts the [[ssml]] <a data-cite="speech-synthesis11#S3.1.10"
 							><code>phoneme</code> element</a> as two attributes — <code>ssml:ph</code> and
 						<code>ssml:alphabet</code> — and makes them available within <a>EPUB content documents</a>.</p>
 
@@ -199,7 +199,7 @@
 					</dd>
 				</dl>
 
-				<p>The <code>ssml:ph</code> attribute inherits the authoring requirements of the [[SSML]]
+				<p>The <code>ssml:ph</code> attribute inherits the authoring requirements of the [[ssml]]
 						<code>phoneme</code> element's <a data-cite="speech-synthesis11#S3.1.10"><code>ph</code></a>
 					attribute.</p>
 
@@ -217,17 +217,17 @@
 
 				<div class="note">
 					<p>The <code>ssml:ph</code> attribute does not replace attribute values that carry additional
-						textual information (e.g., [^img/alt^] [[HTML]] and <a
-							href="https://www.w3.org/TR/wai-aria/#aria-label"><code>aria-label</code></a> [[WAI-ARIA]])
+						textual information (e.g., [^img/alt^] [[html]] and <a
+							href="https://www.w3.org/TR/wai-aria/#aria-label"><code>aria-label</code></a> [[wai-aria]])
 						or link additional textual information (e.g., <a
 							href="https://www.w3.org/TR/wai-aria/#aria-describedby"><code>aria-describedby</code></a>
-						[[WAI-ARIA]]).</p>
+						[[wai-aria]]).</p>
 				</div>
 
 				<p id="ssml-ph-empty">Similarly, EPUB creators SHOULD NOT add empty <code>ssml:ph</code> attributes to
 					try and suppress the rendering of text. Reading systems are expected to ignore empty attributes.
 					(See the <a href="https://www.w3.org/TR/wai-aria/#aria-hidden"><code>aria-hidden</code>
-						attribute</a> [[?WAI-ARIA]] for specifying that content is only for visual rendering.)</p>
+						attribute</a> [[?wai-aria]] for specifying that content is only for visual rendering.)</p>
 
 				<aside class="example">
 					<p>The following example shows the pronunciation for EPUB added to HTML markup.</p>
@@ -285,7 +285,7 @@
 					</dd>
 				</dl>
 
-				<p>The <code>ssml:alphabet</code> attribute inherits the authoring requirements of the [[SSML]]
+				<p>The <code>ssml:alphabet</code> attribute inherits the authoring requirements of the [[ssml]]
 						<code>phoneme</code> element's <a data-cite="speech-synthesis11#S3.1.10"
 						><code>alphabet</code></a> attribute.</p>
 
@@ -327,7 +327,7 @@
 				</aside>
 
 				<div class="note">
-					<p>Although the [[SSML]] specification refers to a registry of alphabets, one has not been
+					<p>Although the [[ssml]] specification refers to a registry of alphabets, one has not been
 						published. As the charter of the W3C Voice Browser Working Group has expired, the Working Group
 						does not anticipate the publication of such a registry. EPUB creators therefore should reference
 						reading system support documentation to determine what alphabet values they support. Some common
@@ -341,7 +341,7 @@
 			<section id="pls-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>The W3C Pronunciation Lexicon Specification (PLS) [[PRONUNCIATION-LEXICON]] defines syntax and
+				<p>The W3C Pronunciation Lexicon Specification (PLS) [[pronunciation-lexicon]] defines syntax and
 					semantics for XML-based pronunciation lexicons to be used by Automatic Speech Recognition and
 						<a>Text-to-Speech</a> (TTS) engines.</p>
 
@@ -350,8 +350,8 @@
 					the SSML attributes. It is a much more efficient way of defining pronunciations for words with only
 					a single pronunciation, or where a particular pronunciation is predominant.</p>
 
-				<p>EPUB creators can use the [[HTML]] <a data-cite="html#the-link-element"><code>link</code> element</a>
-					and [[SVG]] <a href="https://www.w3.org/TR/SVG/struct.html#HTMLMetadataElements"><code>link</code>
+				<p>EPUB creators can use the [[html]] <a data-cite="html#the-link-element"><code>link</code> element</a>
+					and [[svg]] <a href="https://www.w3.org/TR/SVG/struct.html#HTMLMetadataElements"><code>link</code>
 						element</a> to associate one or more lexicons with their respective <a>EPUB content document</a>
 					type. When reading systems process the documents, they can identify the linked lexicons and use them
 					to initiate text-to-speech playback.</p>
@@ -365,10 +365,10 @@
 				<ul class="conformance-list">
 					<li>
 						<p id="confreq-pls-xml">MUST meet the conformance constraints for XML documents defined in XML
-							Conformance [[EPUB-33]].</p>
+							Conformance [[epub-33]].</p>
 					</li>
 					<li>
-						<p id="confreq-pls">MUST be valid to the grammar defined in [[PRONUNCIATION-LEXICON]].</p>
+						<p id="confreq-pls">MUST be valid to the grammar defined in [[pronunciation-lexicon]].</p>
 					</li>
 				</ul>
 
@@ -376,7 +376,7 @@
 					<p>A non-normative schema for validating lexicons is available at <a
 							href="https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng"
 								><code>https://www.w3.org/TR/2008/REC-pronunciation-lexicon-20081014/pls.rng</code></a>
-						[[PRONUNCIATION-LEXICON]].</p>
+						[[pronunciation-lexicon]].</p>
 				</div>
 
 				<aside class="example">
@@ -399,12 +399,12 @@
 				<h3>Associating with EPUB content documents</h3>
 
 				<p id="confreq-cd-pls-xht">EPUB creators MAY associate zero or more pronunciation lexicons
-					[[PRONUNCIATION-LEXICON]] with an <a>EPUB content document</a>.</p>
+					[[pronunciation-lexicon]] with an <a>EPUB content document</a>.</p>
 
 				<p id="confreq-cd-pls-assoc">To associate a pronunciation lexicon with an <a>XHTML content document</a>,
-					EPUB creators MUST use the [[HTML]] <a data-cite="html#the-link-element"><code>link</code></a>
+					EPUB creators MUST use the [[html]] <a data-cite="html#the-link-element"><code>link</code></a>
 					element. Similarly, to associate a pronunciation lexicon with an <a>SVG content document</a>, EPUB
-					creators MUST use the [[SVG]] <a href="https://www.w3.org/TR/SVG/struct.html#HTMLMetadataElements"
+					creators MUST use the [[svg]] <a href="https://www.w3.org/TR/SVG/struct.html#HTMLMetadataElements"
 							><code>link</code> element</a>.</p>
 
 				<p>For both types of EPUB content document, the <code>link</code> element MUST have its <code>rel</code>
@@ -414,7 +414,7 @@
 				<p id="confreq-cd-pls-assoc-lang">EPUB creators SHOULD specify the <code>link</code> element
 						<code>hreflang</code> attribute on each <code>link</code>, and its value MUST match <a
 						data-cite="pronunciation-lexicon#S4.1">the language for which the pronunciation lexicon is
-						relevant</a> [[PRONUNCIATION-LEXICON]] when specified.</p>
+						relevant</a> [[pronunciation-lexicon]] when specified.</p>
 
 				<aside class="example">
 					<p>The following example shows two pronunciation lexicons (one for Mandarin and one for Mongolian)
@@ -434,13 +434,13 @@
 		<section id="css-speech">
 			<h2>CSS speech</h2>
 
-			<p>The CSS Speech [[CSS-SPEECH-1]] module defines properties that allow EPUB creators to declaratively
+			<p>The CSS Speech [[css-speech-1]] module defines properties that allow EPUB creators to declaratively
 				control the aural rendering of <a>EPUB content documents</a>. It includes properties for specifying the
 				preferred <a>Text-to-Speech</a> voice, the volume level, and pauses and cues to perform when
 				encountering elements.</p>
 
-			<p>As EPUB content documents support the use of cascading style sheets [[CSS2]], EPUB creators MAY use CSS
-				Speech [[CSS-SPEECH-1]] properties in their style sheet definitions.</p>
+			<p>As EPUB content documents support the use of cascading style sheets [[css2]], EPUB creators MAY use CSS
+				Speech [[css-speech-1]] properties in their style sheet definitions.</p>
 
 			<aside class="example">
 				<p>The following example shows the CSS declaration for an auditory cue to play before each new chapter
@@ -484,18 +484,18 @@
 							<li>
 								<p id="confreq-ssml-ph">MUST process the <code>ssml:ph</code> attribute per the
 									requirements for the <a data-cite="speech-synthesis11#S3.1.10"><code>phoneme</code>
-										element's <code>ph</code> attribute</a> [[SSML]] with the additional
+										element's <code>ph</code> attribute</a> [[ssml]] with the additional
 									requirements that it:</p>
 								<ul>
 									<li>
 										<p id="confreq-ssml-ph-empty">MUST ignore <code>ssml:ph</code> attributes whose
 											value is an empty string or consists only of <a
-												data-cite="infra#ascii-whitespace">ASCII whitespace</a> [[INFRA]].</p>
+												data-cite="infra#ascii-whitespace">ASCII whitespace</a> [[infra]].</p>
 									</li>
 									<li>
 										<p id="confreq-ssml-ph-emptytext">MUST ignore <code>ssml:ph</code> attributes on
 											elements whose descendant text content is an empty string or consists only
-											of <a data-cite="infra#ascii-whitespace">ASCII whitespace</a> [[INFRA]].</p>
+											of <a data-cite="infra#ascii-whitespace">ASCII whitespace</a> [[infra]].</p>
 									</li>
 									<li>
 										<p id="confreq-ssml-ph-nontext">MUST ignore <code>ssml:ph</code> attributes on
@@ -507,7 +507,7 @@
 								<p id="confreq-ssml-alphabet">MUST process the <code>ssml:alphabet</code> attribute per
 									the requirements for the <a data-cite="speech-synthesis11#S3.1.10"
 											><code>phoneme</code> element's <code>alphabet</code> attribute</a>
-									[[SSML]].</p>
+									[[ssml]].</p>
 							</li>
 						</ul>
 					</dd>
@@ -518,13 +518,13 @@
 						<ul class="conformance-list">
 							<li>
 								<p id="confreq-pls-rs-proc">MUST process all linked pronunciation lexicons in an EPUB
-									content document as defined in [[PRONUNCIATION-LEXICON]].</p>
+									content document as defined in [[pronunciation-lexicon]].</p>
 							</li>
 							<li>
 								<p id="confreq-pls-rs-scope">MUST apply the supplied lexemes to all text nodes in the
 									EPUB content document whose language matches <a
 										data-cite="pronunciation-lexicon#S4.1">the language for which the pronunciation
-										lexicon is relevant</a> [[PRONUNCIATION-LEXICON]]. [[BCP47]] defines the
+										lexicon is relevant</a> [[pronunciation-lexicon]]. [[bcp47]] defines the
 									algorithm for matching language tags.</p>
 							</li>
 						</ul>
@@ -544,7 +544,7 @@
 								<p>MUST let any pronunciation instructions provided via the <a href="#ssml-ph-attribute"
 											><code>ssml:ph</code></a> attribute take precedence in cases where a <a
 										data-cite="pronunciation-lexicon#S4.5"><code>grapheme</code> element</a>
-									[[PRONUNCIATION-LEXICON]] matches a text node of an element that carries the
+									[[pronunciation-lexicon]] matches a text node of an element that carries the
 										<code>ssml:ph</code> attribute.</p>
 							</li>
 						</ul>
@@ -553,7 +553,7 @@
 					<dt>CSS Speech</dt>
 					<dd>
 						<p>This document adds no additional requirements for reading system support to those defined in
-							[[CSS-SPEECH-1]].</p>
+							[[css-speech-1]].</p>
 					</dd>
 				</dl>
 			</section>


### PR DESCRIPTION
Chaning case didn't flip any references, so all good.

Fixes #2251


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2252.html" title="Last updated on Apr 15, 2022, 12:40 PM UTC (af5431c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2252/1d6e506...af5431c.html" title="Last updated on Apr 15, 2022, 12:40 PM UTC (af5431c)">Diff</a>