### PR TITLE
Fix conflicting element citations

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -143,10 +143,9 @@
 				<p>An EPUB publication is typically represented by a single [=package document=]. This document includes
 					metadata used by [=reading systems=] to present the content to the user, such as the title and
 					author for display in a bookshelf as well as rendering metadata (e.g., whether the content is
-					reflowable or has a fixed layout). It also provides a manifest of resources and includes a <a
-						data-lt="EPUB spine">spine</a> that lists the default sequence in which to render documents as a
-					user progresses through the content. Refer to <a href="#sec-package-doc"></a> for the requirements
-					for the package document.</p>
+					reflowable or has a fixed layout). It also provides a manifest of resources and includes a [=spine=]
+					that lists the default sequence in which to render documents as a user progresses through the
+					content. Refer to <a href="#sec-package-doc"></a> for the requirements for the package document.</p>
 
 				<p>An EPUB publication also includes another key file called the [=EPUB navigation document=]. This
 					document provides critical navigation capabilities, such as the table of contents, that allow users
@@ -392,13 +391,6 @@
 					</dd>
 
 					<dt>
-						<dfn class="export">EPUB manifest</dfn> (or manifest) </dt>
-					<dd>
-						<p>The section of the [=package document=] that lists the [=publication resources=].</p>
-						<p>Refer to <a href="#sec-manifest-elem"></a> for more information.</p>
-					</dd>
-
-					<dt>
 						<dfn class="export">EPUB navigation document</dfn>
 					</dt>
 					<dd>
@@ -423,15 +415,6 @@
 					<dd>
 						<p>A system that processes [=EPUB publications=] for presentation to a user in a manner
 							conformant with this specification.</p>
-					</dd>
-
-					<dt>
-						<dfn class="export">EPUB spine</dfn> (or spine) </dt>
-					<dd>
-						<p>The section of the [=package document=] that defines an ordered list of <a>EPUB content
-								documents</a> and [=foreign content documents=]. This list represents the default
-							reading order of the [=EPUB publication=].</p>
-						<p>Refer to <a href="#sec-spine-elem"></a> for more information.</p>
 					</dd>
 
 					<dt>
@@ -466,18 +449,17 @@
 						<dfn class="export">fixed-layout document</dfn>
 					</dt>
 					<dd>
-						<p>An [=EPUB content document=] with fixed dimensions directly referenced from the <a
-								data-lt="EPUB spine">spine</a>. Fixed-layout documents are designated
-								<code>pre-paginated</code> in the [=package document=], as defined in <a
-								href="#sec-fixed-layouts"></a>.</p>
+						<p>An [=EPUB content document=] with fixed dimensions directly referenced from the [=spine=].
+							Fixed-layout documents are designated <code>pre-paginated</code> in the [=package
+							document=], as defined in <a href="#sec-fixed-layouts"></a>.</p>
 					</dd>
 
 					<dt>
 						<dfn class="export">foreign content document</dfn>
 					</dt>
 					<dd>
-						<p>Any [=publication resource=] referenced from a [=EPUB spine | spine=] [^itemref^] element, or
-							a [=manifest fallback chain=], that is not an [=EPUB content document=].</p>
+						<p>Any [=publication resource=] referenced from a [=EPUB spine | spine=] [^package/itemref^]
+							element, or a [=manifest fallback chain=], that is not an [=EPUB content document=].</p>
 						<p>When a foreign content document is referenced from a spine <code>itemref</code> element, it
 							requires a [=manifest fallback chain=] with at least one EPUB content document.</p>
 						<div class="note">
@@ -507,10 +489,17 @@
 						<dfn class="export">linked resource</dfn>
 					</dt>
 					<dd>
-						<p>A resource that is only referenced from a [=package document=] [^link^] element (i.e., not
-							also used in the rendering of an <a>EPUB publication</a>.</p>
+						<p>A resource that is only referenced from a [=package document=] [^package/link^] element
+							(i.e., not also used in the rendering of an <a>EPUB publication</a>.</p>
 						<p>Linked resources are not [=publication resources=] but may be stored in the <a>EPUB
 								container</a>. They do not require fallbacks.</p>
+					</dd>
+
+					<dt>
+						<dfn class="export">manifest</dfn></dt>
+					<dd>
+						<p>The section of the [=package document=] that lists the [=publication resources=].</p>
+						<p>Refer to <a href="#sec-manifest-elem"></a> for more information.</p>
 					</dd>
 
 					<dt>
@@ -558,9 +547,8 @@
 							render the EPUB publication as the [=EPUB creator=] intends. Examples of publication
 							resources include the [=package document=], [=EPUB content document=], CSS Style Sheets,
 							audio, video, images, embedded fonts, and scripts.</p>
-						<p>EPUB creators typically list publication resources in the package document <a
-								data-lt="EPUB manifest">manifest</a> and bundle them in the [=EPUB container=], with the
-							following exceptions:</p>
+						<p>EPUB creators typically list publication resources in the package document [=manifest=] and
+							bundle them in the [=EPUB container=], with the following exceptions:</p>
 						<ul>
 							<li>
 								<p>they do not have to list resources encoded as <a href="#sec-data-urls">data URLs</a>
@@ -608,6 +596,15 @@
 					</dd>
 
 					<dt>
+						<dfn class="export">spine</dfn></dt>
+					<dd>
+						<p>The section of the [=package document=] that defines an ordered list of <a>EPUB content
+								documents</a> and [=foreign content documents=]. This list represents the default
+							reading order of the [=EPUB publication=].</p>
+						<p>Refer to <a href="#sec-spine-elem"></a> for more information.</p>
+					</dd>
+
+					<dt>
 						<dfn class="export">SVG content document</dfn>
 					</dt>
 					<dd>
@@ -626,9 +623,8 @@
 						<dfn class="export">top-level content document</dfn>
 					</dt>
 					<dd>
-						<p>An [=EPUB content document=] or [=foreign content document=] referenced from the <a
-								data-lt="EPUB spine">spine</a>, whether directly or via a <a
-								href="#sec-manifest-fallbacks">fallback chain</a>.</p>
+						<p>An [=EPUB content document=] or [=foreign content document=] referenced from the [=spine=],
+							whether directly or via a <a href="#sec-manifest-fallbacks">fallback chain</a>.</p>
 					</dd>
 
 					<dt>
@@ -636,8 +632,9 @@
 					</dt>
 					<dd>
 						<p>The primary identifier for an [=EPUB publication=]. The unique identifier is the [=value=] of
-							the [^dc:identifier^] element specified by the <a href="#attrdef-package-unique-identifier"
-									><code>unique-identifier</code> attribute</a> in the [=package document=].</p>
+							the [^package/dc:identifier^] element specified by the <a
+								href="#attrdef-package-unique-identifier"><code>unique-identifier</code> attribute</a>
+							in the [=package document=].</p>
 						<p>Significant revision, abridgement, etc. of the content requires a new unique identifier.</p>
 					</dd>
 
@@ -768,9 +765,8 @@
 				<ul>
 					<li>The [=manifest plane=] &#8212; The manifest plane holds all the resources of the EPUB
 						publication (namely, [=publication resources=] and [=linked resources=]).</li>
-					<li>The [=spine plane=] &#8212; The spine plane holds only the resources used in rendering the <a
-							data-lt="EPUB spine">spine</a> (namely, [=EPUB content documents=] and <a>foreign content
-							documents</a>).</li>
+					<li>The [=spine plane=] &#8212; The spine plane holds only the resources used in rendering the
+						[=spine=] (namely, [=EPUB content documents=] and <a>foreign content documents</a>).</li>
 					<li>The [=content plane=] &#8212; The content plane holds only the resources used in the rendering
 						of EPUB and foreign content documents (namely, [=core media type resources=], [=foreign
 						resources=] and [=exempt resources=]).</li>
@@ -797,7 +793,7 @@
 
 					<p>The primary resources in this group are designated [=publication resources=], which are all the
 						resources used in rendering an EPUB publication to the user. [=EPUB creators=] always have to
-						list these resources in the [^manifest^] element.</p>
+						list these resources in the [^package/manifest^] element.</p>
 
 					<p>Publication resources are further classified by their use(s) in the [=spine plane=] and [=content
 						plane=].</p>
@@ -807,10 +803,10 @@
 						(e.g., where to purchase an EPUB publication).</p>
 
 					<p>Unlike publication resources, they are not listed in the package document manifest (i.e., because
-						they are not essential to rendering the EPUB publication). They are instead defined in [^link^]
-						elements in the package document metadata. These elements define their nature and purpose
-						similar to how manifest [^item^] elements define publication resource. (In this way, they are
-						like an extension of the manifest.)</p>
+						they are not essential to rendering the EPUB publication). They are instead defined in
+						[^package/link^] elements in the package document metadata. These elements define their nature
+						and purpose similar to how manifest [^package/item^] elements define publication resource. (In
+						this way, they are like an extension of the manifest.)</p>
 
 					<p>Refer to <a href="#sec-link-elem"></a> for more information about linked resources.</p>
 
@@ -854,13 +850,13 @@
 						documents.</p>
 
 					<p>A mechanism called <a href="#sec-manifest-fallbacks">manifest fallbacks</a> allows EPUB creators
-						to provide fallbacks for foreign content documents. In this model, the <a
-							data-lt="EPUB manifest">manifest</a> entry for the foreign content document must include a
-							<a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> that points to the next
-						possible resource for reading systems to try when they do not support its format. Although not
-						common, a fallback resource can specify another fallback, thereby making chains many resources
-						deep. The one requirement is that there must be at least one EPUB content document in a
-						[=manifest fallback chain=].</p>
+						to provide fallbacks for foreign content documents. In this model, the [=manifest=] entry for
+						the foreign content document must include a <a href="#attrdef-item-fallback"
+								><code>fallback</code> attribute</a> that points to the next possible resource for
+						reading systems to try when they do not support its format. Although not common, a fallback
+						resource can specify another fallback, thereby making chains many resources deep. The one
+						requirement is that there must be at least one EPUB content document in a [=manifest fallback
+						chain=].</p>
 
 					<p>Although they are not directly listed in the spine, all of the resources in the fallback chain
 						are considered part of the spine, and by extension part of the spine plane, since any may be
@@ -1173,8 +1169,8 @@
 							embedded message when a media type cannot be rendered); or</p>
 					</li>
 					<li>
-						<p><a href="#sec-manifest-fallbacks">manifest fallback</a> chains defined on [^item^] elements
-							in the [=package document=].</p>
+						<p><a href="#sec-manifest-fallbacks">manifest fallback</a> chains defined on [^package/item^]
+							elements in the [=package document=].</p>
 					</li>
 				</ul>
 
@@ -1250,8 +1246,8 @@
 
 				<ul>
 					<li>
-						<p>it is not referenced from a spine [^itemref^] element (i.e., used as a [=foreign content
-							document=]); <strong><em>and</em></strong></p>
+						<p>it is not referenced from a spine [^package/itemref^] element (i.e., used as a [=foreign
+							content document=]); <strong><em>and</em></strong></p>
 					</li>
 					<li>
 						<p>it is not embedded directly in EPUB content documents (e.g., via [[?html]] <a>embedded
@@ -1287,12 +1283,12 @@
 						select an alternative format they can render.</p>
 
 					<p>Fallback chains are created using the <a href="#attrdef-item-fallback"><code>fallback</code>
-							attribute</a> on manifest [^item^] elements. This attribute references the ID [[xml]] of
-						another manifest <code>item</code> that is a fallback for the current <code>item</code>. The
-						ordered list of all the references that a reading system can reach, starting from a given
-							<code>item</code>'s <code>fallback</code> attribute, represents the full fallback chain for
-						that <code>item</code>. This chain also represents the EPUB creator's preferred fallback
-						order.</p>
+							attribute</a> on manifest [^package/item^] elements. This attribute references the ID
+						[[xml]] of another manifest <code>item</code> that is a fallback for the current
+							<code>item</code>. The ordered list of all the references that a reading system can reach,
+						starting from a given <code>item</code>'s <code>fallback</code> attribute, represents the full
+						fallback chain for that <code>item</code>. This chain also represents the EPUB creator's
+						preferred fallback order.</p>
 
 					<p>There are two cases for manifest fallbacks:</p>
 
@@ -1422,7 +1418,7 @@
 
 				<div class="note">
 					<p>Refer to the <a href="#remote-resources"><code>remote-resources</code> property</a> for more
-						information on how to indicate that a [=EPUB manifest | manifest=] [^item^] references a
+						information on how to indicate that a [=EPUB manifest | manifest=] [^package/item^] references a
 						[=remote resource=].</p>
 				</div>
 
@@ -1470,7 +1466,7 @@
 
 				<ul>
 					<li>
-						<p>in manifest [^item^] elements referenced from the <a data-lt="EPUB spine">spine</a>;</p>
+						<p>in manifest [^package/item^] elements referenced from the [=spine=];</p>
 					</li>
 					<li>
 						<p>in the <code>href</code> attribute on [[html]] or [[svg]] <code>a</code> elements (except
@@ -2034,7 +2030,7 @@
 					<section id="sec-container-metainf-files">
 						<h5>Reserved files</h5>
 
-						<section id="sec-container-metainf-container.xml">
+						<section id="sec-container-metainf-container.xml" data-dfn-for="container">
 							<h6>Container file (<code>container.xml</code>)</h6>
 
 							<p>The REQUIRED <code>container.xml</code> file in the <code>META-INF</code> directory
@@ -2087,8 +2083,8 @@
 									<dd>
 										<p>In this order:</p>
 										<ul class="nomark">
-											<li>[^rootfiles^] [exactly one]</li>
-											<li>[^links^] [0 or 1]</li>
+											<li>[^container/rootfiles^] [exactly one]</li>
+											<li>[^container/links^] [0 or 1]</li>
 										</ul>
 									</dd>
 								</dl>
@@ -2122,7 +2118,7 @@
 									<dt>Content Model:</dt>
 									<dd>
 										<ul class="nomark">
-											<li>[^rootfile^] [1 or more]</li>
+											<li>[^container/rootfile^] [1 or more]</li>
 										</ul>
 									</dd>
 								</dl>
@@ -2145,7 +2141,7 @@
 
 									<dt>Usage:</dt>
 									<dd>
-										<p>As child of the [^rootfiles^] element. Repeatable.</p>
+										<p>As child of the [^container/rootfiles^] element. Repeatable.</p>
 									</dd>
 
 									<dt>Attributes:</dt>
@@ -2238,13 +2234,14 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<code>link</code>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
+													><code>link</code></dfn>
 										</p>
 									</dd>
 
 									<dt>Usage:</dt>
 									<dd>
-										<p>As child of the [^links^] element. Repeatable.</p>
+										<p>As child of the [^container/links^] element. Repeatable.</p>
 									</dd>
 
 									<dt>Attributes:</dt>
@@ -2305,7 +2302,7 @@
 							</section>
 						</section>
 
-						<section id="sec-container-metainf-encryption.xml">
+						<section id="sec-container-metainf-encryption.xml" data-dfn-for="encryption">
 							<h6>Encryption file (<code>encryption.xml</code>)</h6>
 
 							<p>The OPTIONAL <code>encryption.xml</code> file in the <code>META-INF</code> directory
@@ -2613,7 +2610,7 @@
 								abstract container is rights governed.</p>
 						</section>
 
-						<section id="sec-container-metainf-signatures.xml">
+						<section id="sec-container-metainf-signatures.xml" data-dfn-for="signatures">
 							<h6>Digital signatures file (<code>signatures.xml</code>)</h6>
 
 							<div class="note">
@@ -3081,7 +3078,7 @@
 				</section>
 			</section>
 		</section>
-		<section id="sec-package-doc">
+		<section id="sec-package-doc" data-dfn-for="package">
 			<h2>Package document</h2>
 
 			<p>All [[xml]] elements defined in this section are in the <code>http://www.idpf.org/2007/opf</code>
@@ -3181,12 +3178,13 @@
 &lt;/package></pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:coverage</code></a>, [^dc:creator^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:rights</code></a>, [^dc:subject^], [^dc:title^], [^meta^] and [^package^].</p>
+					<p>Allowed on: [^package/collection^], [^package/dc:contributor^], <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, [^package/dc:creator^], <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, [^package/dc:subject^],
+						[^package/dc:title^], [^package/meta^] and [^package^].</p>
 				</section>
 
 
@@ -3210,7 +3208,7 @@
 &lt;/package></pre>
 					</aside>
 
-					<p>Allowed on: [^item^] and [^link^].</p>
+					<p>Allowed on: [^package/item^] and [^package/link^].</p>
 				</section>
 
 				<section id="attrdef-id">
@@ -3222,16 +3220,16 @@
 						<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:coverage</code></a>, [^dc:creator^], [^dc:date^], <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, [^dc:identifier^],
-						[^dc:language^], <a href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+					<p>Allowed on: [^package/collection^], [^package/dc:contributor^], <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, [^package/dc:creator^],
+						[^package/dc:date^], <a href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, [^package/dc:identifier^],
+						[^package/dc:language^], <a href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
 							href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
 							href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, [^dc:subject^], [^dc:title^],
-						[^dc:type^], [^item^], [^itemref^], [^link^], [^manifest^], [^meta^], [^package^] and
-						[^spine^].</p>
+							href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, [^package/dc:subject^],
+						[^package/dc:title^], [^package/dc:type^], [^package/item^], [^package/itemref^],
+						[^package/link^], [^package/manifest^], [^package/meta^], [^package^] and [^package/spine^].</p>
 				</section>
 
 				<section id="attrdef-media-type">
@@ -3254,7 +3252,7 @@
 &lt;/package></pre>
 					</aside>
 
-					<p>Allowed on: [^item^] and [^link^].</p>
+					<p>Allowed on: [^package/item^] and [^package/link^].</p>
 				</section>
 
 				<section id="attrdef-properties">
@@ -3281,7 +3279,7 @@
 &lt;/package></pre>
 					</aside>
 
-					<p>Allowed on: [^item^], [^itemref^] and [^link^].</p>
+					<p>Allowed on: [^package/item^], [^package/itemref^] and [^package/link^].</p>
 				</section>
 
 				<section id="attrdef-refines">
@@ -3343,7 +3341,7 @@
 &lt;/package></pre>
 					</aside>
 
-					<p>Allowed on: [^link^] and [^meta^].</p>
+					<p>Allowed on: [^package/link^] and [^package/meta^].</p>
 				</section>
 
 				<section id="attrdef-xml-lang">
@@ -3360,12 +3358,13 @@
 &lt;/package></pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:coverage</code></a>, [^dc:creator^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:rights</code></a>, [^dc:subject^], [^dc:title^], [^meta^] and [^package^].</p>
+					<p>Allowed on: [^package/collection^], [^package/dc:contributor^], <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, [^package/dc:creator^], <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
+							href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, [^package/dc:subject^],
+						[^package/dc:title^], [^package/meta^] and [^package^].</p>
 				</section>
 			</section>
 
@@ -3446,15 +3445,15 @@
 						<p>In this order:</p>
 						<ul class="nomark">
 							<li>
-								<p> [^metadata^] <code>[exactly 1]</code>
+								<p> [^package/metadata^] <code>[exactly 1]</code>
 								</p>
 							</li>
 							<li>
-								<p> [^manifest^] <code>[exactly 1]</code>
+								<p> [^package/manifest^] <code>[exactly 1]</code>
 								</p>
 							</li>
 							<li>
-								<p> [^spine^] <code>[exactly 1]</code>
+								<p> [^package/spine^] <code>[exactly 1]</code>
 								</p>
 							</li>
 							<li>
@@ -3476,7 +3475,7 @@
 								</p>
 							</li>
 							<li>
-								<p> [^collection^] <code>[0 or more]</code>
+								<p> [^package/collection^] <code>[0 or more]</code>
 								</p>
 							</li>
 						</ul>
@@ -3495,8 +3494,8 @@
 				</div>
 
 				<p id="attrdef-package-unique-identifier">The <code>unique-identifier</code> attribute takes an IDREF
-					[[xml]] that identifies the [^dc:identifier^] element that provides the preferred, or primary,
-					identifier.</p>
+					[[xml]] that identifies the [^package/dc:identifier^] element that provides the preferred, or
+					primary, identifier.</p>
 
 				<p id="attrdef-package-prefix">The <code>prefix</code> attribute provides a declaration mechanism for
 					prefixes not <a href="#sec-metadata-reserved-prefixes">reserved by this specification</a>. Refer to
@@ -3535,15 +3534,15 @@
 							<p>In any order:</p>
 							<ul class="nomark">
 								<li>
-									<p> [^dc:identifier^] <code>[1 or more]</code>
+									<p> [^package/dc:identifier^] <code>[1 or more]</code>
 									</p>
 								</li>
 								<li>
-									<p> [^dc:title^] <code>[1 or more]</code>
+									<p> [^package/dc:title^] <code>[1 or more]</code>
 									</p>
 								</li>
 								<li>
-									<p> [^dc:language^] <code>[1 or more]</code>
+									<p> [^package/dc:language^] <code>[1 or more]</code>
 									</p>
 								</li>
 								<li>
@@ -3555,7 +3554,7 @@
 									</p>
 								</li>
 								<li>
-									<p> [^meta^] <code>[1 or more]</code>
+									<p> [^package/meta^] <code>[1 or more]</code>
 									</p>
 								</li>
 								<li>
@@ -3566,7 +3565,7 @@
 									</p>
 								</li>
 								<li>
-									<p> [^link^] <code>[0 or more]</code>
+									<p> [^package/link^] <code>[0 or more]</code>
 									</p>
 								</li>
 							</ul>
@@ -3590,14 +3589,14 @@
 					<p>The package document does not provide complex metadata encoding capabilities. If EPUB creators
 						need to provide more detailed information, they can associate metadata records (e.g., that
 						conform to an international standard such as [[onix]] or are created for custom purposes) using
-						the [^link^] element. This approach allows reading systems to process the metadata in its native
-						form, avoiding the potential problems and information loss caused by translating to use the
-						minimal package document structure.</p>
+						the [^package/link^] element. This approach allows reading systems to process the metadata in
+						its native form, avoiding the potential problems and information loss caused by translating to
+						use the minimal package document structure.</p>
 
 					<p id="core-metadata-reqs">In keeping with this philosophy, the package document only has the
-						following minimal metadata requirements: it MUST contain the [[dcterms]] [^dc:title^],
-						[^dc:identifier^], and [^dc:language^] elements together with the [[dcterms]]
-						[^dcterms:modified^] property. All other metadata is OPTIONAL.</p>
+						following minimal metadata requirements: it MUST contain the [[dcterms]] [^package/dc:title^],
+						[^package/dc:identifier^], and [^package/dc:language^] elements together with the [[dcterms]]
+						[^package/dcterms:modified^] property. All other metadata is OPTIONAL.</p>
 
 					<aside class="example" title="The minimal set of metadata required in the package document">
 						<pre>&lt;package … unique-identifier="pub-id">
@@ -3623,10 +3622,10 @@
 </pre>
 					</aside>
 
-					<p>The [^meta^] element provides a generic mechanism for including <a href="#sec-vocab-assoc"
-							>metadata properties from any vocabulary</a>. Although EPUB creators MAY use this mechanism
-						for any metadata purposes, they will typically use it to include rendering metadata defined in
-						EPUB specifications.</p>
+					<p>The [^package/meta^] element provides a generic mechanism for including <a
+							href="#sec-vocab-assoc">metadata properties from any vocabulary</a>. Although EPUB creators
+						MAY use this mechanism for any metadata purposes, they will typically use it to include
+						rendering metadata defined in EPUB specifications.</p>
 
 					<div class="note">
 						<p>See [[epub-a11y-11]] for accessibility metadata recommendations.</p>
@@ -3636,7 +3635,7 @@
 				<section id="sec-metadata-values">
 					<h4>Metadata values</h4>
 
-					<p>The Dublin Core elements [[dcterms]] and [^meta^] element have mandatory <a>child text
+					<p>The Dublin Core elements [[dcterms]] and [^package/meta^] element have mandatory <a>child text
 							content</a> [[dom]]. This specification refers to this content as the <dfn>value</dfn> of
 						the element in their descriptions.</p>
 
@@ -3679,7 +3678,7 @@
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>REQUIRED child of [^metadata^]. Repeatable.</p>
+								<p>REQUIRED child of [^package/metadata^]. Repeatable.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -3779,7 +3778,7 @@
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>REQUIRED child of [^metadata^]. Repeatable.</p>
+								<p>REQUIRED child of [^package/metadata^]. Repeatable.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -3897,7 +3896,7 @@
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>REQUIRED child of [^metadata^]. Repeatable.</p>
+								<p>REQUIRED child of [^package/metadata^]. Repeatable.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -3947,8 +3946,9 @@
 					<section id="sec-opf-dcmes-optional-def">
 						<h5>General definition</h5>
 
-						<p>All [[dcterms]] elements except for [^dc:identifier^], [^dc:language^], and [^dc:title^] are
-							designated as OPTIONAL. These elements conform to the following generalized definition:</p>
+						<p>All [[dcterms]] elements except for [^package/dc:identifier^], [^package/dc:language^], and
+							[^package/dc:title^] are designated as OPTIONAL. These elements conform to the following
+							generalized definition:</p>
 
 						<dl class="elemdef">
 							<dt>Element Name:</dt>
@@ -3969,7 +3969,7 @@
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>OPTIONAL child of [^metadata^]. Repeatable.</p>
+								<p>OPTIONAL child of [^package/metadata^]. Repeatable.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -4017,7 +4017,7 @@
 							content.</p>
 
 						<p>The requirements for the <code>dc:contributor</code> element are identical to those for the
-							[^dc:creator^] element in all other respects.</p>
+							[^package/dc:creator^] element in all other respects.</p>
 					</section>
 
 					<section id="sec-opf-dccreator">
@@ -4105,7 +4105,7 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<p>EPUB creators should represent secondary contributors using the [^dc:contributor^]
+						<p>EPUB creators should represent secondary contributors using the [^package/dc:contributor^]
 							element.</p>
 					</section>
 
@@ -4231,7 +4231,7 @@
 
 						<dt>Usage:</dt>
 						<dd>
-							<p>As child of the [^metadata^] element. Repeatable.</p>
+							<p>As child of the [^package/metadata^] element. Repeatable.</p>
 						</dd>
 
 						<dt>Attributes:</dt>
@@ -4423,7 +4423,7 @@
 
 						<dt>Usage:</dt>
 						<dd>
-							<p>As a child of [^metadata^]. Repeatable.</p>
+							<p>As a child of [^package/metadata^]. Repeatable.</p>
 						</dd>
 
 						<dt>Attributes:</dt>
@@ -4494,8 +4494,9 @@
 						</dd>
 					</dl>
 
-					<p>The [^metadata^] element MAY contain zero or more <code>link</code> elements, each of which
-						identifies the location of a [=linked resource=] in its REQUIRED <code>href</code> attribute</p>
+					<p>The [^package/metadata^] element MAY contain zero or more <code>link</code> elements, each of
+						which identifies the location of a [=linked resource=] in its REQUIRED <code>href</code>
+						attribute</p>
 
 					<p id="linked-res-manifest">linked resources are [=publication resources=] only when they are:</p>
 
@@ -4704,7 +4705,7 @@ XHTML:
 
 						<dt>Usage:</dt>
 						<dd>
-							<p>REQUIRED second child of [^package^], following [^metadata^].</p>
+							<p>REQUIRED second child of [^package^], following [^package/metadata^].</p>
 						</dd>
 
 						<dt>Attributes:</dt>
@@ -4719,14 +4720,14 @@ XHTML:
 
 						<dt>Content Model:</dt>
 						<dd>
-							<p> [^item^] <code>[1 or more]</code>
+							<p> [^package/item^] <code>[1 or more]</code>
 							</p>
 						</dd>
 					</dl>
 
 					<p id="confreq-rendition-manifest">EPUB creators MUST list all [=publication resources=] in the
 							<code>manifest</code>, regardless of whether they are [=container resources=] or [=remote
-						resources=], using [^item^] elements.</p>
+						resources=], using [^package/item^] elements.</p>
 
 					<p>Note that the <code>manifest</code> is not self-referencing: EPUB creators MUST NOT specify an
 							<code>item</code> element that refers to the package document itself.</p>
@@ -4753,7 +4754,7 @@ XHTML:
 
 						<dt>Usage:</dt>
 						<dd>
-							<p>As a child of [^manifest^]. Repeatable.</p>
+							<p>As a child of [^package/manifest^]. Repeatable.</p>
 						</dd>
 
 						<dt>Attributes:</dt>
@@ -4842,7 +4843,7 @@ XHTML:
 
 					<div class="note">
 						<p>The order of <code>item</code> elements in the <code>manifest</code> is not significant. The
-							[^spine^] element provides the presentation sequence of content documents.</p>
+							[^package/spine^] element provides the presentation sequence of content documents.</p>
 					</div>
 
 					<section id="sec-item-resource-properties">
@@ -5219,7 +5220,7 @@ No Entry</pre>
 
 						<dt>Usage:</dt>
 						<dd>
-							<p>REQUIRED third child of [^package^], following [^manifest^].</p>
+							<p>REQUIRED third child of [^package^], following [^package/manifest^].</p>
 						</dd>
 
 						<dt>Attributes:</dt>
@@ -5255,7 +5256,7 @@ No Entry</pre>
 
 						<dt>Content Model:</dt>
 						<dd>
-							<p> [^itemref^] <code>[1 or more]</code>
+							<p> [^package/itemref^] <code>[1 or more]</code>
 							</p>
 						</dd>
 					</dl>
@@ -5319,7 +5320,7 @@ No Entry</pre>
 
 						<dt>Usage:</dt>
 						<dd>
-							<p>As a child of [^spine^]. Repeatable.</p>
+							<p>As a child of [^package/spine^]. Repeatable.</p>
 						</dd>
 
 						<dt>Attributes:</dt>
@@ -5366,9 +5367,9 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an [^item^] in the
-						[=EPUB manifest | manifest=] via the IDREF [[xml]] in its <code>idref</code> attribute, and item
-						IDs MUST NOT be referenced more than once. </p>
+					<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an [^package/item^] in
+						the [=EPUB manifest | manifest=] via the IDREF [[xml]] in its <code>idref</code> attribute, and
+						item IDs MUST NOT be referenced more than once. </p>
 
 					<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a) an
 						[=EPUB content document=] or b) a [=foreign content document=] that includes an EPUB content
@@ -5511,8 +5512,8 @@ No Entry</pre>
 						<dt>Content Model:</dt>
 						<dd>
 							<p>In this order: <code>metadata</code>
-								<code>[0 or 1]</code>, ( [^collection^] <code>[1 or more]</code> or ( [^collection^]
-									<code>[0 or more]</code>, <code>link</code>
+								<code>[0 or 1]</code>, ( [^package/collection^] <code>[1 or more]</code> or (
+								[^package/collection^] <code>[0 or more]</code>, <code>link</code>
 								<code>[1 or more]</code> ))</p>
 						</dd>
 					</dl>
@@ -5569,7 +5570,7 @@ No Entry</pre>
 
 					<p>The <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"><code>meta</code>
 							element</a> [[opf-201]] is a <a href="#legacy">legacy</a> feature that previously provided a
-						means of including generic metadata. The EPUB 3 [^meta^] element, which uses different
+						means of including generic metadata. The EPUB 3 [^package/meta^] element, which uses different
 						attributes and requires text content, replaces this element.</p>
 
 					<p>Refer to the <a href="http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
@@ -5579,7 +5580,8 @@ No Entry</pre>
 						<p>The [[opf-201]] <code>meta</code> element is retained in EPUB 3 primarily so that EPUB
 							creators can identify the cover image for compatibility with EPUB 2 reading systems. In EPUB
 							3, the cover image must be identified using the <a href="#sec-cover-image"
-									><code>cover-image</code> property</a> on the manifest [^item^] for the image.</p>
+									><code>cover-image</code> property</a> on the manifest [^package/item^] for the
+							image.</p>
 					</div>
 				</section>
 
@@ -5667,7 +5669,7 @@ No Entry</pre>
 					<section id="sec-xhtml-structural-semantics">
 						<h5>Structural semantics</h5>
 
-						<p>EPUB creators MAY use the [^epub:type^] attribute in <a>XHTML content documents</a> to
+						<p>EPUB creators MAY use the [^/epub:type^] attribute in <a>XHTML content documents</a> to
 							express <a href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
 						<p>As the [[html]] <a data-lt="head"><code>head</code> element</a> contains metadata for the
@@ -5787,9 +5789,8 @@ No Entry</pre>
 							while retaining compatibility with [[html]] user agents.</p>
 
 						<div class="note">
-							<p>The <a href="#mathml"><code>mathml</code> property</a> of the <a data-lt="EPUB manifest"
-									>manifest</a>
-								<code>item</code> element indicates that an XHTML content document contains embedded
+							<p>The <a href="#mathml"><code>mathml</code> property</a> of the [=manifest=]
+									<code>item</code> element indicates that an XHTML content document contains embedded
 								MathML.</p>
 						</div>
 					</section>
@@ -5807,9 +5808,8 @@ No Entry</pre>
 							as defined for [=SVG content documents=] in <a href="#sec-svg-restrictions"></a>.</p>
 
 						<div class="note">
-							<p>The <a href="#svg"><code>svg</code> property</a> of the <a data-lt="EPUB manifest"
-									>manifest</a> [^item^] element indicates that an XHTML content document contains
-								embedded SVG.</p>
+							<p>The <a href="#svg"><code>svg</code> property</a> of the [=manifest=] [^package/item^]
+								element indicates that an XHTML content document contains embedded SVG.</p>
 						</div>
 					</section>
 
@@ -5899,7 +5899,7 @@ No Entry</pre>
 								constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-svg-structural-semantics">MAY specify the [^epub:type^] attribute for
+							<p id="confreq-svg-structural-semantics">MAY specify the [^/epub:type^] attribute for
 								expressing <a href="#app-structural-semantics">structural semantics</a> and use all
 								applicable <a href="#sec-vocab-assoc">vocabulary association mechanisms</a>.</p>
 						</li>
@@ -6077,10 +6077,9 @@ No Entry</pre>
 							This label also applies to [=XHTML content documents=] when they contain instances of
 							[[html]] [=forms=].</p>
 
-						<p>The <a href="#scripted"><code>scripted</code> property</a> of the <a data-lt="EPUB manifest"
-								>manifest</a>
-							<code>item</code> element is used to indicate that an EPUB content document is a <a>scripted
-								content document</a>.</p>
+						<p>The <a href="#scripted"><code>scripted</code> property</a> of the [=manifest=]
+								<code>item</code> element is used to indicate that an EPUB content document is a
+								<a>scripted content document</a>.</p>
 
 						<p>When an [[html]] <code>script</code> element contains a <a data-cite="html#data-block">data
 								block</a> [[html]], it does not represent scripted content.</p>
@@ -6270,7 +6269,7 @@ No Entry</pre>
 			<section id="sec-nav-def-model">
 				<h3>The <code>nav</code> element: restrictions</h3>
 
-				<p>When a <code>nav</code> element carries the [^epub:type^] attribute in an <a>EPUB navigation
+				<p>When a <code>nav</code> element carries the [^/epub:type^] attribute in an <a>EPUB navigation
 						document</a>, this specification restricts the content model of the element and its descendants
 					as follows:</p>
 
@@ -6451,7 +6450,7 @@ No Entry</pre>
 					<h4>Introduction</h4>
 
 					<p>The <code>nav</code> elements defined in an EPUB navigation document are distinguished
-						semantically by the value of their [^epub:type^] attribute.</p>
+						semantically by the value of their [^/epub:type^] attribute.</p>
 
 					<p>This specification defines three types of navigation aid:</p>
 
@@ -6555,7 +6554,7 @@ No Entry</pre>
 						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
 						nested sublists).</p>
 
-					<p>The [^epub:type^] attribute is REQUIRED on <code>a</code> element descendants of the
+					<p>The [^/epub:type^] attribute is REQUIRED on <code>a</code> element descendants of the
 							<code>landmarks</code>
 						<code>nav</code> element. The structural semantics of each link target within the
 							<code>landmarks</code>
@@ -6624,7 +6623,7 @@ No Entry</pre>
 					<p>EPUB navigation documents MAY contain one or more <code>nav</code> elements in addition to the
 							<code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
 						<code>nav</code> elements defined in the preceding sections. If these <code>nav</code> elements
-						are intended for reading system processing, they MUST have an [^epub:type^] attribute and are
+						are intended for reading system processing, they MUST have an [^/epub:type^] attribute and are
 						subject to the content model restrictions defined in <a href="#sec-nav-def-model"></a>.</p>
 
 					<p>This specification imposes no restrictions on the semantics of any additional <code>nav</code>
@@ -6665,11 +6664,11 @@ No Entry</pre>
 			<section id="sec-nav-doc-use-spine" class="informative">
 				<h3>Using in the spine</h3>
 
-				<p>Although it is possible to reuse the EPUB navigation document in the <a data-lt="EPUB spine"
-						>spine</a>, it is often the case that not all of the navigation structures, or branches within
-					them, are needed. [=EPUB creators=] will often want to hide the <a href="#sec-nav-pagelist">page
-						list</a> and <a href="#sec-nav-landmarks">landmarks</a> navigation elements or trim the branches
-					of the table of contents for books that have many levels of subsections.</p>
+				<p>Although it is possible to reuse the EPUB navigation document in the [=spine=], it is often the case
+					that not all of the navigation structures, or branches within them, are needed. [=EPUB creators=]
+					will often want to hide the <a href="#sec-nav-pagelist">page list</a> and <a
+						href="#sec-nav-landmarks">landmarks</a> navigation elements or trim the branches of the table of
+					contents for books that have many levels of subsections.</p>
 
 				<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
 						property</a> [[csssnapshot]] controls the visual rendering of EPUB navigation documents in
@@ -6817,7 +6816,7 @@ No Entry</pre>
 							<dt id="def-layout-pre-paginated">pre-paginated</dt>
 							<dd>
 								<p>The content is pre-paginated (i.e., reading systems produce exactly one page per
-									spine [^itemref^] when rendering).</p>
+									spine [^package/itemref^] when rendering).</p>
 							</dd>
 						</dl>
 
@@ -6897,8 +6896,8 @@ No Entry</pre>
 							<h6>Layout overrides</h6>
 
 							<p id="property-layout-local">EPUB creators MAY specify the following properties locally on
-								spine [^itemref^] elements to override the <a href="#property-layout-global">global
-									value</a> for the given spine item:</p>
+								spine [^package/itemref^] elements to override the <a href="#property-layout-global"
+									>global value</a> for the given spine item:</p>
 
 							<dl>
 								<dt id="layout-pre-paginated">rendition:layout-pre-paginated</dt>
@@ -6974,7 +6973,7 @@ No Entry</pre>
 							<h6>Orientation overrides</h6>
 
 							<p id="property-orientation-local">EPUB creators MAY specify the following properties
-								locally on spine [^itemref^] elements to override the <a
+								locally on spine [^package/itemref^] elements to override the <a
 									href="#property-orientation-global">global value</a> for the given spine item:</p>
 
 							<dl>
@@ -7055,7 +7054,7 @@ No Entry</pre>
 						</div>
 
 						<div class="note">
-							<p>Refer to the [^spine^] element for information about declaration of global flow
+							<p>Refer to the [^package/spine^] element for information about declaration of global flow
 								directionality using the <code>page-progression-direction</code> attribute and that of
 								local page-progression-direction within content documents.</p>
 						</div>
@@ -7249,8 +7248,8 @@ No Entry</pre>
 							<h6>Synthetic spread overrides</h6>
 
 							<p id="property-spread-local">EPUB creators MAY specify the following properties locally on
-								spine [^itemref^] elements to override the <a href="#property-spread-global">global
-									value</a> for the given spine item:</p>
+								spine [^package/itemref^] elements to override the <a href="#property-spread-global"
+									>global value</a> for the given spine item:</p>
 
 							<dl>
 								<dt id="spread-auto">rendition:spread-auto</dt>
@@ -7654,8 +7653,8 @@ No Entry</pre>
 						<h5>Spine overrides</h5>
 
 						<p id="layout-property-flow-local">EPUB creators MAY specify the following properties locally on
-							spine [^itemref^] elements to override the <a href="#property-flow-global">global value</a>
-							for the given spine item:</p>
+							spine [^package/itemref^] elements to override the <a href="#property-flow-global">global
+								value</a> for the given spine item:</p>
 
 						<dl>
 							<dt id="flow-auto">rendition:flow-auto</dt>
@@ -7711,10 +7710,10 @@ No Entry</pre>
 					<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should be
 						centered horizontally in the viewport or spread.</p>
 
-					<p>The property MUST NOT be set globally for all EPUB content documents (i.e., in a [^meta^] element
-						without a <a href="#attrdef-refines"><code>refines</code> attribute</a>). It is only available
-						as a spine override for individual EPUB content documents via the [^itemref^] element's
-							<code>properties</code> attribute.</p>
+					<p>The property MUST NOT be set globally for all EPUB content documents (i.e., in a [^package/meta^]
+						element without a <a href="#attrdef-refines"><code>refines</code> attribute</a>). It is only
+						available as a spine override for individual EPUB content documents via the [^package/itemref^]
+						element's <code>properties</code> attribute.</p>
 
 					<div class="note">
 						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title pages),
@@ -7780,7 +7779,7 @@ No Entry</pre>
 					</ul>
 				</section>
 
-				<section id="sec-overlays-def">
+				<section id="sec-overlays-def" data-dfn-for="smil">
 					<h3>Media overlay document definition</h3>
 
 					<p>All elements [[xml]] defined in this section are in the <code>https://www.w3.org/ns/SMIL</code>
@@ -7844,11 +7843,11 @@ No Entry</pre>
 								<p>In this order:</p>
 								<ul class="nomark">
 									<li>
-										<p> [^head^] <code>[0 or 1]</code>
+										<p> [^smil/head^] <code>[0 or 1]</code>
 										</p>
 									</li>
 									<li>
-										<p> [^body^] <code>[exactly 1]</code>
+										<p> [^smil/body^] <code>[exactly 1]</code>
 										</p>
 									</li>
 								</ul>
@@ -7884,7 +7883,7 @@ No Entry</pre>
 
 							<dt>Content Model:</dt>
 							<dd>
-								<p> [^metadata^] <code>[0 or 1]</code>
+								<p> [^package/metadata^] <code>[0 or 1]</code>
 								</p>
 							</dd>
 						</dl>
@@ -7904,13 +7903,14 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<code>metadata</code>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
+											><code>metadata</code></dfn>
 								</p>
 							</dd>
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>As a child of the [^head^] element.</p>
+								<p>As a child of the [^smil/head^] element.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -7947,7 +7947,7 @@ No Entry</pre>
 							<dt>Usage:</dt>
 							<dd>
 								<p>The <code>body</code> element is a REQUIRED child of the [^smil^] element. It follows
-									the [^head^] element, when that element is present.</p>
+									the [^smil/head^] element, when that element is present.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -7992,11 +7992,11 @@ No Entry</pre>
 								<p>In any order:</p>
 								<ul class="nomark">
 									<li>
-										<p> [^seq^] <code>[0 or more]</code>
+										<p> [^smil/seq^] <code>[0 or more]</code>
 										</p>
 									</li>
 									<li>
-										<p> [^par^] <code>[0 or more]</code>
+										<p> [^smil/par^] <code>[0 or more]</code>
 										</p>
 									</li>
 								</ul>
@@ -8022,8 +8022,8 @@ No Entry</pre>
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>One or more <code>seq</code> elements MAY occur as children of the [^body^] element
-									and of the [^seq^] element.</p>
+								<p>One or more <code>seq</code> elements MAY occur as children of the [^smil/body^]
+									element and of the [^smil/seq^] element.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -8070,11 +8070,11 @@ No Entry</pre>
 								<p>In any order:</p>
 								<ul class="nomark">
 									<li>
-										<p> [^seq^] <code>[0 or more]</code>
+										<p> [^smil/seq^] <code>[0 or more]</code>
 										</p>
 									</li>
 									<li>
-										<p> [^par^] <code>[0 or more]</code>
+										<p> [^smil/par^] <code>[0 or more]</code>
 										</p>
 									</li>
 								</ul>
@@ -8085,6 +8085,7 @@ No Entry</pre>
 
 					<section id="sec-smil-par-elem">
 						<h5>The <code>par</code> element</h5>
+
 						<p>The <code>par</code> element is a parallel time container for media objects.</p>
 
 						<dl class="elemdef" id="elemdef-smil-par">
@@ -8098,8 +8099,8 @@ No Entry</pre>
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>One or more <code>par</code> elements MAY occur as children of the [^body^] and
-									[^seq^] elements.</p>
+								<p>One or more <code>par</code> elements MAY occur as children of the [^smil/body^] and
+									[^smil/seq^] elements.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -8133,11 +8134,11 @@ No Entry</pre>
 								<p>In any order:</p>
 								<ul class="nomark">
 									<li>
-										<p> [^text^] <code>[exactly 1]</code>
+										<p> [^smil/text^] <code>[exactly 1]</code>
 										</p>
 									</li>
 									<li>
-										<p> [^audio^] <code>[0 or 1]</code>
+										<p> [^smil/audio^] <code>[0 or 1]</code>
 										</p>
 									</li>
 								</ul>
@@ -8148,11 +8149,11 @@ No Entry</pre>
 					<section id="sec-smil-text-elem">
 						<h5>The <code>text</code> element</h5>
 
-						<p> The <code>text</code> element references an element in an [=EPUB content document=]. A
+						<p>The <code>text</code> element references an element in an [=EPUB content document=]. A
 								<code>text</code> element typically refers to a textual element but can also refer to
 							other EPUB content document media elements (see <a href="#sec-embedded-media"></a>). In the
 							absence of a sibling <code>audio</code> element textual content referred to by this element
-							may be rendered via <a href="#sec-tts">text-to-speech</a>. </p>
+							may be rendered via <a href="#sec-tts">text-to-speech</a>.</p>
 
 						<dl class="elemdef" id="elemdef-smil-text">
 							<dt>Element Name:</dt>
@@ -8165,7 +8166,7 @@ No Entry</pre>
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>As a REQUIRED child of the [^par^] element.</p>
+								<p>As a REQUIRED child of the [^smil/par^] element.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -8224,7 +8225,7 @@ No Entry</pre>
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>An OPTIONAL child of the [^par^] element.</p>
+								<p>An OPTIONAL child of the [^smil/par^] element.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -8301,18 +8302,18 @@ No Entry</pre>
 						content document using [[smil3]] markup. Media overlays are, in fact, a simplified subset of
 						SMIL 3.0 that define the playback sequence of these clips.</p>
 
-					<p>The SMIL elements primarily used for structuring media overlays are [^body^] (used for the main
-						sequence), [^seq^] (sequence) and [^par^] (parallel). (Refer to <a href="#sec-overlays-def"></a>
-						for more information on these and other SMIL elements.)</p>
+					<p>The SMIL elements primarily used for structuring media overlays are [^smil/body^] (used for the
+						main sequence), [^smil/seq^] (sequence) and [^smil/par^] (parallel). (Refer to <a
+							href="#sec-overlays-def"></a> for more information on these and other SMIL elements.)</p>
 
 					<p>The <code>par</code> element is the basic building block of an Overlay and corresponds to a
 						phrase in the EPUB content document. The element provides two key pieces of information for
 						synchronizing content: 1) the audio clip containing the narration for the phrase; and 2) a
 						pointer to the associated EPUB content document fragment. The <code>par</code> element uses two
-						media element children to represent this information: an [^audio^] element and a [^text^]
-						element. Because <code>par</code> elements' media object children are timed in parallel, reading
-						systems render the audio clip and EPUB content document fragment at the same time, resulting in
-						a synchronized presentation.</p>
+						media element children to represent this information: an [^smil/audio^] element and a
+						[^smil/text^] element. Because <code>par</code> elements' media object children are timed in
+						parallel, reading systems render the audio clip and EPUB content document fragment at the same
+						time, resulting in a synchronized presentation.</p>
 
 					<p>The <code>text</code> element <code>src</code> attribute references the associated phrase,
 						sentence, or other segment of the EPUB content document by its URL [[url]] reference. The
@@ -8390,14 +8391,14 @@ No Entry</pre>
 					<section id="sec-media-overlays-structure">
 						<h5>Overlay structure</h5>
 
-						<p>The [^body^] of a media overlay document consists of two elements: the [^par^] element and
-							the [^seq^] element. The ordering of these elements represents how reading systems render
-							the content in the corresponding EPUB content documents during playback.</p>
+						<p>The [^smil/body^] of a media overlay document consists of two elements: the [^smil/par^]
+							element and the [^smil/seq^] element. The ordering of these elements represents how reading
+							systems render the content in the corresponding EPUB content documents during playback.</p>
 
 						<p>The <code>par</code> element represents a segment of content, such as a word, phrase,
 							sentence, table cell, list item, image, or other identifiable piece of content in the
-							markup. Each element identifies both the content to display (in the [^text^] element) and
-							audio to synchronize (in the [^audio^] element) during playback.</p>
+							markup. Each element identifies both the content to display (in the [^smil/text^] element)
+							and audio to synchronize (in the [^smil/audio^] element) during playback.</p>
 
 						<p>The <code>seq</code> element represents sequences &#8212; sets of <code>seq</code> and/or
 								<code>par</code> elements that together represent a logical component of the content.
@@ -8565,7 +8566,7 @@ No Entry</pre>
 					<section id="sec-media-overlays-fragids">
 						<h5>Referencing document fragments</h5>
 
-						<p>Both the <code>epub:textref</code> attribute and the [^text^] element's <code>src</code>
+						<p>Both the <code>epub:textref</code> attribute and the [^smil/text^] element's <code>src</code>
 							attribute may contain a [=URL-fragment string=] that references a specific part (e.g., an
 							element via its ID) of the associated <a>EPUB content document</a>.</p>
 
@@ -8582,8 +8583,8 @@ No Entry</pre>
 						<h5>Overlay granularity</h5>
 
 						<p>The granularity level of the media overlay depends on how EPUB creators mark up the EPUB
-							content document and the type of fragment identifier they use in the [^text^] elements'
-								<code>src</code> attributes and the [^seq^] elements' <code>epub:textref</code>
+							content document and the type of fragment identifier they use in the [^smil/text^] elements'
+								<code>src</code> attributes and the [^smil/seq^] elements' <code>epub:textref</code>
 							attrbutes. For example, when referencing [[html]] elements, if the finest level of markup is
 							at the paragraph level, then that is the finest possible level for media overlay
 							synchronization. Likewise, if sub-paragraph markup is available, such as [[html]] <a
@@ -8600,14 +8601,14 @@ No Entry</pre>
 
 						<p>Any [=EPUB content document=] associated with a [=media overlay document=] MAY contain
 							embedded media such as video, audio, and images. EPUB creators MAY use the media overlay
-							[^text^] element in such instances to reference the embedded media by its element's
+							[^smil/text^] element in such instances to reference the embedded media by its element's
 								<code>id</code> attribute value.</p>
 
 						<section id="sec-emb-audio-video">
 							<h6>Embedded audio and video</h6>
 
-							<p> When a [^text^] element references embedded audio or video, reading systems will
-								initiate playback of the media in the absence of an [^audio^] element sibling. </p>
+							<p> When a [^smil/text^] element references embedded audio or video, reading systems will
+								initiate playback of the media in the absence of an [^smil/audio^] element sibling. </p>
 
 							<p>[=EPUB creators=] SHOULD avoid using scripts to control playback of referenced embedded
 								EPUB content document media, as this might conflict with media overlays playback
@@ -8621,7 +8622,7 @@ No Entry</pre>
 						<section id="sec-emb-img">
 							<h6>Embedded images</h6>
 
-							<p>When a <code>text</code> element references an embedded image, the [^audio^] sibling
+							<p>When a <code>text</code> element references an embedded image, the [^smil/audio^] sibling
 								element is OPTIONAL. In the absence of an <code>audio</code> element, reading systems
 								will voice the image using <a href="#sec-tts">Text-to-Speech rendering</a>.</p>
 
@@ -8638,10 +8639,10 @@ No Entry</pre>
 							textual content of an [=EPUB publication=] as artificial human speech using a synthesized
 							voice &#8212; in addition to pre-recorded audio clips.</p>
 
-						<p>When a media overlay [^par^] element omits its [^audio^] element, its [^text^] element may be
-							rendered in reading systems via TTS. If the text fragment is not appropriate for TTS
-							rendering (e.g., is not a text element and/or has no text fallback), this may produce
-							unexpected results.</p>
+						<p>When a media overlay [^smil/par^] element omits its [^smil/audio^] element, its [^smil/text^]
+							element may be rendered in reading systems via TTS. If the text fragment is not appropriate
+							for TTS rendering (e.g., is not a text element and/or has no text fallback), this may
+							produce unexpected results.</p>
 
 						<div class="note">
 							<p>See <a data-cite="epub-tts-10#">EPUB 3 Text-to-Speech Support</a> [[epub-tts-10]] for
@@ -8654,8 +8655,8 @@ No Entry</pre>
 					<h4>Structural semantics in overlays</h4>
 
 					<p>To express <a href="#app-structural-semantics">structural semantics</a> in <a>media overlay
-							documents</a>, EPUB creators MAY specify the [^epub:type^] attribute on [^par^], [^seq^],
-						and [^body^] elements.</p>
+							documents</a>, EPUB creators MAY specify the [^/epub:type^] attribute on [^smil/par^],
+						[^smil/seq^], and [^smil/body^] elements.</p>
 
 					<p>The <code>epub:type</code> attribute facilitates reading system behavior appropriate for the
 						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
@@ -8811,9 +8812,9 @@ html.my-document-playing * {
 						<h5>Including media overlays</h5>
 
 						<p>If an [=EPUB content document=] is wholly or partially referenced by a <a>media overlay
-								document</a>, then its [=EPUB manifest | manifest=] [^item^] element MUST specify a
-								<code>media-overlay</code> attribute. The attribute MUST reference the ID [[xml]] of the
-							manifest <code>item</code> for the corresponding media overlay document.</p>
+								document</a>, then its [=EPUB manifest | manifest=] [^package/item^] element MUST
+							specify a <code>media-overlay</code> attribute. The attribute MUST reference the ID [[xml]]
+							of the manifest <code>item</code> for the corresponding media overlay document.</p>
 
 						<p>EPUB creators MUST only specify the <code>media-overlay</code> attribute on manifest
 								<code>item</code> elements that reference [=EPUB content documents=].</p>
@@ -8846,13 +8847,12 @@ html.my-document-playing * {
 						<h5>Overlays package metadata</h5>
 
 						<p id="total-duration">EPUB creators MUST specify the duration of the entire <a>EPUB
-								publication</a> in the [=package document=] using a [^meta^] element with the <a
+								publication</a> in the [=package document=] using a [^package/meta^] element with the <a
 								href="#duration"><code>duration</code> property</a>.</p>
 
 						<p>In addition, EPUB creators MUST provide the duration of each media overlay document. EPUB
 							creators MUST use the <a href="#attrdef-refines"><code>refines</code> attribute</a> to
-							associate each duration declaration to the corresponding <a data-lt="EPUB manifest"
-								>manifest</a> [^item^].</p>
+							associate each duration declaration to the corresponding [=manifest=] [^package/item^].</p>
 
 						<p>The sum of the durations for each media overlay document SHOULD equal the <a
 								href="#total-duration">total duration</a> plus or minus one second.</p>
@@ -9619,7 +9619,7 @@ html.my-document-playing * {
 				<h3>Introduction</h3>
 
 				<p>Structural semantics add additional meaning about the specific structural purpose an element plays.
-					The [^epub:type^] attribute is used to express domain-specific semantics in <a>EPUB content
+					The [^/epub:type^] attribute is used to express domain-specific semantics in <a>EPUB content
 						documents</a> and [=media overlay documents=], with the structural information it carries
 					complementing the underlying vocabulary.</p>
 
@@ -9860,7 +9860,7 @@ html.my-document-playing * {
 
 					<aside class="example" title="Expanding a manifest property value">
 						<p>In this example, the <a href="#mathml"><code>mathml</code> property</a> is specified on a
-							manifest [^item^] element:</p>
+							manifest [^package/item^] element:</p>
 
 						<pre>&lt;item … properties="mathml"/></pre>
 
@@ -10722,18 +10722,18 @@ html.my-document-playing * {
 				<dl>
 					<dt><code>meta/data.xml</code></dt>
 					<dd>
-						<p>The resource is a metadata record, stored in the container. It is linked via a [^link^]
-							element in the package document metadata. It is therefore a [=linked resource=] on the
-							[=manifest plane=], i.e., is not listed in the <a data-lt="EPUB manifest">manifest</a>. It
-							is not part on any other planes. </p>
+						<p>The resource is a metadata record, stored in the container. It is linked via a
+							[^package/link^] element in the package document metadata. It is therefore a [=linked
+							resource=] on the [=manifest plane=], i.e., is not listed in the [=manifest=]. It is not
+							part on any other planes. </p>
 					</dd>
 
 					<dt><code>https://www.example.org/meta/data2.xml</code></dt>
 					<dd>
-						<p>The resource is a metadata record, stored remotely. It is linked via a [^link^] element in
-							the package document metadata. It is therefore a [=linked resource=] on the [=manifest
-							plane=], i.e., is not listed in the <a data-lt="EPUB manifest">manifest</a>. It is not part
-							on any other planes.</p>
+						<p>The resource is a metadata record, stored remotely. It is linked via a [^package/link^]
+							element in the package document metadata. It is therefore a [=linked resource=] on the
+							[=manifest plane=], i.e., is not listed in the [=manifest=]. It is not part on any other
+							planes.</p>
 					</dd>
 
 					<dt><code>page.xhtml</code></dt>
@@ -11557,7 +11557,7 @@ EPUB/images/cover.png</pre>
 					Properties section. See <a href="https://github.com/w3c/epub-specs/issues/2030">issue 2030</a>.</li>
 				<li>05-Mar-2022: Forbid circular references and self-references in refinement chains. See <a
 						href="https://github.com/w3c/epub-specs/issues/2031">issue 2031</a>.</li>
-				<li>19-Feb-2022: Clarified the [^audio^] element's definition by making it optional and adapted the
+				<li>19-Feb-2022: Clarified the [^smil/audio^] element's definition by making it optional and adapted the
 					specification's text elsewhere to address the situation when the element is indeed not present. See
 						<a href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>.</li>
 				<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -1,7 +1,7 @@
 <section id="app-item-properties-vocab" class="vocab">
 	<h3>Manifest properties vocabulary</h3>
 	
-	<p>The properties in this vocabulary are usable in the manifest [^item^]
+	<p>The properties in this vocabulary are usable in the manifest [^package/item^]
 		element's <a href="#attrdef-item-properties"><code>properties</code> attribute</a>.</p>
 	
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -2,7 +2,7 @@
 <section id="app-itemref-properties-vocab" class="vocab">
 	<h3>Spine properties vocabulary</h3>
 	
-	<p>The properties in this vocabulary are usable in the spine [^itemref^] element's
+	<p>The properties in this vocabulary are usable in the spine [^package/itemref^] element's
 		<a href="#attrdef-itemref-properties"><code>properties</code> attribute</a>.</p>
 
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -2,7 +2,7 @@
 <section id="app-link-vocab" class="vocab">
 	<h3>Metadata link vocabulary</h3>
 	
-	<p>The properties in this vocabulary are usable in the metadata [^link^]
+	<p>The properties in this vocabulary are usable in the metadata [^package/link^]
 		element's <code>rel</code> and <code>properties</code> attributes.</p>
 	
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
@@ -73,7 +73,7 @@
 								<li>If an alternate link is included in the package document metadata, it
 									identifies an alternate representation of the package document in the format
 									specified in the <code>media-type</code> attribute.</li>
-								<li>If an alternate link is included in a [^collection^] element's
+								<li>If an alternate link is included in a [^package/collection^] element's
 									metadata, it identifies an alternate representation of the <code>collection</code>
 									in the format specified in the <code>media-type</code> attribute.</li>
 								<li>Reading systems do not have to generate hyperlinks for alternate links.</li>
@@ -250,7 +250,7 @@
 	</section>
 	<section id="sec-link-properties">
 		<h4>Link properties</h4>
-		<p>The following values can be used in the [^link^] element's
+		<p>The following values can be used in the [^package/link^] element's
 			<code>properties</code> attribute to establish the type of record a referenced resource represents.
 			These values are provided for record formats that cannot be uniquely identified by their media
 			type.</p>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -1,11 +1,11 @@
 <section id="app-meta-property-vocab" class="vocab">
 	<h3>Meta properties vocabulary</h3>
 	
-	<p>The properties in this vocabulary are usable in the [^meta^]
+	<p>The properties in this vocabulary are usable in the [^package/meta^]
 		element's <code>property</code> attribute.</p>
 	
 	<p>Unless indicated otherwise in its "Extends" field, the properties defined in this section are used to
-		define <a href="#subexpression">subexpressions</a>: in other words, a [^meta^] element
+		define <a href="#subexpression">subexpressions</a>: in other words, a [^package/meta^] element
 		carrying a property defined in this section MUST have a <code><a
 				href="#attrdef-refines">refines</a></code> attribute referencing a resource or expression being
 		augmented.</p>
@@ -107,7 +107,7 @@
 				<tr>
 					<th>Extends:</th>
 					<td>
-						[^dc:subject^]
+						[^package/dc:subject^]
 					</td>
 				</tr>
 			</tbody>
@@ -485,7 +485,7 @@
 				<tr>
 					<th>Extends:</th>
 					<td>
-						[^dc:identifier^], <a href="#sec-opf-dcmes-optional-def"
+						[^package/dc:identifier^], <a href="#sec-opf-dcmes-optional-def"
 								><code>dc:source</code></a>
 					</td>
 				</tr>
@@ -559,7 +559,7 @@
 				<tr>
 					<th>Extends:</th>
 					<td>
-						[^dc:contributor^], [^dc:creator^], <a
+						[^package/dc:contributor^], [^package/dc:creator^], <a
 							href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>
 					</td>
 				</tr>
@@ -729,7 +729,7 @@
 				<tr>
 					<th>Extends:</th>
 					<td>
-						[^dc:subject^]
+						[^package/dc:subject^]
 					</td>
 				</tr>
 			</tbody>
@@ -795,7 +795,7 @@
 				<tr>
 					<th>Extends:</th>
 					<td>
-						[^dc:title^]
+						[^package/dc:title^]
 					</td>
 				</tr>
 			</tbody>

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -1,6 +1,6 @@
 <section id="app-overlays-vocab" class="vocab">
 	<h3>Media overlays vocabulary</h3>
-	<p>The properties in this vocabulary are usable in the [^meta^] element's
+	<p>The properties in this vocabulary are usable in the [^package/meta^] element's
 			<code>property</code> attribute.</p>
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 			<code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -10,8 +10,8 @@
 	
 	<div class="note">
 		<p>Unlike the other vocabularies in this appendix, the properties in the Package Rendering Vocabulary
-			consist of a mix of properties (expressed in [^meta^] elements)
-			and spine overrides (expressed on [^itemref^] elements).</p>
+			consist of a mix of properties (expressed in [^package/meta^] elements)
+			and spine overrides (expressed on [^package/itemref^] elements).</p>
 		
 		<p>The usage requirements are also defined in <a href="#sec-rendering-control"></a> not in this appendix.
 			The following table provides a map to the properties, overrides, and where they are defined.</p>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -901,11 +901,11 @@
 					a [=multiple-rendition publication=], allowing reading systems to switch between renditions while
 					keeping the user's place.</p>
 
-				<p>The rendition mapping document is represented as XHTML, and uses [^nav^] elements with unordered
-					lists to group the mappings. There is no display component to the rendition mapping document; it is
-					designed to enable automated switching. The lack of a rendering context means that the XHTML content
-					model for this document is very restrictive, allowing only a single [^nav^] element in the [^body^],
-					to ease both authoring and processing.</p>
+				<p data-cite="html">The rendition mapping document is represented as XHTML, and uses [^nav^] elements
+					with unordered lists to group the mappings. There is no display component to the rendition mapping
+					document; it is designed to enable automated switching. The lack of a rendering context means that
+					the XHTML content model for this document is very restrictive, allowing only a single [^nav^]
+					element in the [^body^], to ease both authoring and processing.</p>
 
 				<p>To enable the mapping of content locations between renditions, the rendition mapping document's
 						<code>nav</code> element consists of a series of one or more unordered lists, each of which

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -172,10 +172,11 @@
 					selection properties expressed on a <code>rootfile</code> element [[epub-33]] and the metadata
 					expressed in the corresponding package document, as direct equivalence is not always possible.</p>
 
-				<p>For example, a multilingual EPUB publication will define more than one [^dc:language^] element
-					[[epub-33]] &#8212; one for each language &#8212; but for rendition selection only the primary
-					language is defined. Likewise, the language defined in the package document could include a specific
-					region code, but for selection purposes the EPUB creator might identify only the language code.</p>
+				<p>For example, a multilingual EPUB publication will define more than one [^package/dc:language^]
+					element [[epub-33]] &#8212; one for each language &#8212; but for rendition selection only the
+					primary language is defined. Likewise, the language defined in the package document could include a
+					specific region code, but for selection purposes the EPUB creator might identify only the language
+					code.</p>
 
 				<p>The reason for common metadata in both locations is to simplify the selection process: including
 					attributes avoids the requirement to parse each referenced package document and allows for
@@ -901,11 +902,11 @@
 					a [=multiple-rendition publication=], allowing reading systems to switch between renditions while
 					keeping the user's place.</p>
 
-				<p data-cite="html">The rendition mapping document is represented as XHTML, and uses [^nav^] elements
-					with unordered lists to group the mappings. There is no display component to the rendition mapping
-					document; it is designed to enable automated switching. The lack of a rendering context means that
-					the XHTML content model for this document is very restrictive, allowing only a single [^nav^]
-					element in the [^body^], to ease both authoring and processing.</p>
+				<p>The rendition mapping document is represented as XHTML, and uses [^nav^] elements with unordered
+					lists to group the mappings. There is no display component to the rendition mapping document; it is
+					designed to enable automated switching. The lack of a rendering context means that the XHTML content
+					model for this document is very restrictive, allowing only a single [^nav^] element in the [^body^],
+					to ease both authoring and processing.</p>
 
 				<p>To enable the mapping of content locations between renditions, the rendition mapping document's
 						<code>nav</code> element consists of a series of one or more unordered lists, each of which

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -169,16 +169,16 @@
 					resources within its content, which, while a simple and flexible means of identifying resources,
 					makes it difficult to enumerate all the resources required to render it. In addition, there is no
 					standard way for a web site to define that a sequence of pages make up a larger publication, which
-					is precisely what EPUB's [^spine^] element [[epub-33]] does (i.e., it provides an external
+					is precisely what EPUB's [^package/spine^] element [[epub-33]] does (i.e., it provides an external
 					declarative means to explicitly specify navigation through a collection of documents). Finally, the
 					package document defines a standard way to represent metadata globally applicable to a collection of
 					pages.</p>
 
-				<p>The package document also includes a [^collection^] element [[epub-33]], which allows grouping of
-					logically related [=publication resources=]. This element exists to enable the development of
-					specialized content identification, processing, and rendering features such as the ability to define
-					embedded preview content or assemble an index or dictionary from its constituent XHTML content
-					documents.</p>
+				<p>The package document also includes a [^package/collection^] element [[epub-33]], which allows
+					grouping of logically related [=publication resources=]. This element exists to enable the
+					development of specialized content identification, processing, and rendering features such as the
+					ability to define embedded preview content or assemble an index or dictionary from its constituent
+					XHTML content documents.</p>
 
 				<p class="note"> The <code>collection</code> element is not currently used in any specifications that
 					are actively maintained by the EPUB 3 Working Group. </p>
@@ -231,8 +231,8 @@
 
 					<p>Note that EPUB reading systems are not <em>required</em> to use these advanced XHTML features,
 						such as ruby annotations, when generating a reading system specific table of contents. However,
-						EPUB creators may also include the EPUB navigation document in the <a data-lt="EPUB spine"
-							>spine</a> [[epub-33]] to make use of the richer markup.</p>
+						EPUB creators may also include the EPUB navigation document in the [=spine=] [[epub-33]] to make
+						use of the richer markup.</p>
 
 					<p>EPUB navigation documents also provide a flexible means of tailoring the navigation display using
 						CSS and the <a data-cite="epub-33#sec-nav-doc-use-spine"><code>hidden</code> attribute</a>
@@ -246,12 +246,11 @@
 			<section id="sec-metadata">
 				<h2>Metadata</h2>
 
-				<p data-cite="epub-33">EPUB publications provide a rich array of options for adding metadata. Each
-					package document includes a dedicated <a data-cite="epub-33#sec-pkg-metadata"><code>metadata</code>
-						section</a> [[epub-33]] for general information about the EPUB publication, allowing titles,
-					authors, identifiers, and other information about the EPUB publication to be easily accessed. It
-					also provides the means to attach complete bibliographic records using the [^link^] element
-					[[epub-33]].</p>
+				<p>EPUB publications provide a rich array of options for adding metadata. Each package document includes
+					a dedicated <a data-cite="epub-33#sec-pkg-metadata"><code>metadata</code> section</a> [[epub-33]]
+					for general information about the EPUB publication, allowing titles, authors, identifiers, and other
+					information about the EPUB publication to be easily accessed. It also provides the means to attach
+					complete bibliographic records using the [^package/link^] element [[epub-33]].</p>
 
 				<p>The package document also allows a [=Unique Identifier=] to be established for the EPUB publication
 					using the <a data-cite="epub-33#attrdef-package-unique-identifier"><code>unique-identifier</code>
@@ -327,10 +326,10 @@
 			<section id="sec-multimedia">
 				<h2>Multimedia</h2>
 
-				<p>EPUB 3 supports audio and video embedded in [=XHTML content documents=] via the [[html]] <span
-						data-cite="html">[^audio^] and [^video^]</span> elements, inheriting all the functionality and
-					features these elements provide. For more information on audio and video formats, refer to the
-					section on <a data-cite="epub-33#sec-core-media-types">core media types</a> [[epub-33]].</p>
+				<p>EPUB 3 supports audio and video embedded in [=XHTML content documents=] via the [[html]] [^audio^]
+					and [^video^] elements, inheriting all the functionality and features these elements provide. For
+					more information on audio and video formats, refer to the section on <a
+						data-cite="epub-33#sec-core-media-types">core media types</a> [[epub-33]].</p>
 
 				<p id="para-media-overlay">Another key multimedia feature in EPUB 3 is the inclusion of <a>media overlay
 						documents</a> [[epub-33]]. When pre-recorded narration is available for an EPUB publication,
@@ -534,8 +533,8 @@
 					be desirable to display the complete table of contents to users in the body of the publication, the
 					display level can be modified using the <a data-cite="epub-33#sec-nav-doc-use-spine"
 							><code>hidden</code> attribute</a> [[epub-33]]. This attribute is ignored by reading systems
-					when they render the table of contents outside the <a data-lt="EPUB spine">spine</a> (e.g., in their
-					own specialized views), which avoids minimizing the information that is available.</p>
+					when they render the table of contents outside the [=spine=] (e.g., in their own specialized views),
+					which avoids minimizing the information that is available.</p>
 
 				<p>EPUB creators are also encouraged to supply additional [^nav^] elements if their EPUB publications
 					contain non-structural points of interest, such as figures, tables, etc., to further enhance access
@@ -555,10 +554,10 @@
 					[[dpub-aria-1.0]] roles, enhancing the ability of Assistive Technologies to interact with the
 					content.</p>
 
-				<p>EPUB 3 also includes the <code>epub:type</code> attribute, which allows the inclusion of additional
-					information to any element in an EPUB content document to express its purpose and meaning within the
-					work. Refer to the section on <a data-cite="epub-33#app-structural-semantics">Expressing Structural
-						Semantics</a> [EPUB-33] for more information.</p>
+				<p>EPUB 3 also includes the [^/epub:type^] attribute [[epub-33]], which allows the inclusion of
+					additional information to any element in an EPUB content document to express its purpose and meaning
+					within the work. Refer to the section on <a data-cite="epub-33#app-structural-semantics">Expressing
+						Structural Semantics</a> [[epub-33]] for more information.</p>
 			</section>
 
 			<section id="sec-access-layout">

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -246,11 +246,12 @@
 			<section id="sec-metadata">
 				<h2>Metadata</h2>
 
-				<p>EPUB publications provide a rich array of options for adding metadata. Each package document includes
-					a dedicated <a data-cite="epub-33#sec-pkg-metadata"><code>metadata</code> section</a> [[epub-33]]
-					for general information about the EPUB publication, allowing titles, authors, identifiers, and other
-					information about the EPUB publication to be easily accessed. It also provides the means to attach
-					complete bibliographic records using the [^link^] element [[epub-33]].</p>
+				<p data-cite="epub-33">EPUB publications provide a rich array of options for adding metadata. Each
+					package document includes a dedicated <a data-cite="epub-33#sec-pkg-metadata"><code>metadata</code>
+						section</a> [[epub-33]] for general information about the EPUB publication, allowing titles,
+					authors, identifiers, and other information about the EPUB publication to be easily accessed. It
+					also provides the means to attach complete bibliographic records using the [^link^] element
+					[[epub-33]].</p>
 
 				<p>The package document also allows a [=Unique Identifier=] to be established for the EPUB publication
 					using the <a data-cite="epub-33#attrdef-package-unique-identifier"><code>unique-identifier</code>
@@ -326,10 +327,10 @@
 			<section id="sec-multimedia">
 				<h2>Multimedia</h2>
 
-				<p>EPUB 3 supports audio and video embedded in [=XHTML content documents=] via the [[html]] [^audio^]
-					and [^video^] elements, inheriting all the functionality and features these elements provide. For
-					more information on audio and video formats, refer to the section on <a
-						data-cite="epub-33#sec-core-media-types">core media types</a> [[epub-33]].</p>
+				<p>EPUB 3 supports audio and video embedded in [=XHTML content documents=] via the [[html]] <span
+						data-cite="html">[^audio^] and [^video^]</span> elements, inheriting all the functionality and
+					features these elements provide. For more information on audio and video formats, refer to the
+					section on <a data-cite="epub-33#sec-core-media-types">core media types</a> [[epub-33]].</p>
 
 				<p id="para-media-overlay">Another key multimedia feature in EPUB 3 is the inclusion of <a>media overlay
 						documents</a> [[epub-33]]. When pre-recorded narration is available for an EPUB publication,

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -326,10 +326,9 @@
 				</ul>
 
 				<p id="confreq-rs-pkg-lang-no-content"
-					data-tests="#pgk-lang_pkg_non_content_dir,#pgk-lang_pkg_non_content">In the absence of this
-					information in a [=publication resource=], reading systems MUST NOT assume either the language or
-					the base direction of that resource from information expressed in the package document (i.e., in <a
-						data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
+					absence of this information in a [=publication resource=], reading systems MUST NOT assume either
+					the language or the base direction of that resource from information expressed in the package
+					document (i.e., in <a data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
 						data-cite="epub-33#attrdef-dir"><code>dir</code></a> attributes, in <a
 						data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attributes</a> on [^link^] elements,
 					or from [^dc:language^] elements [[epub-33]]). Refer to a resource's formal specification for more
@@ -730,8 +729,9 @@
 					<dt id="conf-meta-ws">White Space</dt>
 					<dd>
 						<p id="confreq-rs-pkg-whitespace" data-tests="#pkg-meta-whitespace">Reading systems MUST [=strip
-							and collapse ASCII whitespace=] [[infra]] from Dublin Core [[dcterms]] and [^meta^] element
-								<a data-cite="epub-33#dfn-value">values</a> [[epub-33]] before processing.</p>
+							and collapse ASCII whitespace=] [[infra]] from Dublin Core [[dcterms]] and <span
+								data-cite="epub-33">[^meta^]</span> element <a data-cite="epub-33#dfn-value">values</a>
+							[[epub-33]] before processing.</p>
 					</dd>
 
 					<dt id="dc-identifier">The <code>dc:identifier</code> element</dt>
@@ -777,7 +777,7 @@
 
 					<dt id="meta">The <code>meta</code> element</dt>
 					<dd>
-						<p>Reading systems SHOULD ignore all [^meta^] elements whose <a
+						<p data-cite="epub-33">Reading systems SHOULD ignore all [^meta^] elements whose <a
 								data-cite="epub-33#attrdef-meta-property"><code>property</code> attributes</a>
 							[[epub-33]] define expressions they do not recognize. <span id="confreq-rs-pkg-meta-unknown"
 								data-tests="#pkg-meta-unknown">A reading system MUST NOT fail when encountering unknown
@@ -803,12 +803,12 @@
 							NOT skip processing the metadata expressed in the package document (i.e., use only the
 							information expressed in the record). Reading systems MAY compile metadata from multiple
 							linked records.</p>
-						<p>When resolving discrepancies and conflicts between metadata expressed in the package document
-							and in linked metadata records, reading systems MUST use the document order of [^link^]
-							elements [[epub-33]] in the package document to establish precedence (i.e., metadata in the
-							first linked record has the highest precedence and metadata in the package document the
-							lowest, regardless of whether the <code>link</code> elements occur before, within, or after
-							the package metadata elements).</p>
+						<p data-cite="epub-33">When resolving discrepancies and conflicts between metadata expressed in
+							the package document and in linked metadata records, reading systems MUST use the document
+							order of [^link^] elements [[epub-33]] in the package document to establish precedence
+							(i.e., metadata in the first linked record has the highest precedence and metadata in the
+							package document the lowest, regardless of whether the <code>link</code> elements occur
+							before, within, or after the package metadata elements).</p>
 						<p>Reading systems MUST ignore any instructions contained in linked resources related to the
 							layout and rendering of the EPUB publication.</p>
 						<p>If any of the <a data-cite="epub-33#attrdef-link-rel"><code>rel</code></a> or <a
@@ -973,7 +973,7 @@
 					<section id="sec-xhtml-structural-semantics">
 						<h5>Structural semantics</h5>
 
-						<p id="confreq-rs-epubtype-head">In addition to the requirements in <a
+						<p id="confreq-rs-epubtype-head" data-cite="html">In addition to the requirements in <a
 								href="#sec-structural-semantics"></a>, a reading system MUST ignore semantics expressed
 							on the [[html]] [^head^] element or its descendants.</p>
 					</section>
@@ -1409,9 +1409,9 @@
 					<section id="layout">
 						<h5>The <code>rendition:layout</code> property</h5>
 
-						<p>The default value <code>reflowable</code> MUST be assumed by EPUB reading systems as the
-							global value if no [^meta^] element carrying the <a data-cite="epub-33#layout"
-									><code>rendition:layout</code> property</a> occurs in the <a
+						<p data-cite="epub-33">The default value <code>reflowable</code> MUST be assumed by EPUB reading
+							systems as the global value if no [^meta^] element carrying the <a
+								data-cite="epub-33#layout"><code>rendition:layout</code> property</a> occurs in the <a
 								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[epub-33]].</p>
 
 						<p id="layout-pre-paginated" data-tests="#fxl-layout-pre-paginated-spreads">When the
@@ -1446,9 +1446,9 @@
 					<section id="orientation">
 						<h5>The <code>rendition:orientation</code> property</h5>
 
-						<p id="fxl-orientation-default" data-tests="#fxl-orientation-default">The default value
-								<code>auto</code> MUST be assumed by EPUB reading systems as the global value if no
-							[^meta^] element carrying the <a data-cite="epub-33#orientation"
+						<p id="fxl-orientation-default" data-tests="#fxl-orientation-default" data-cite="epub-33">The
+							default value <code>auto</code> MUST be assumed by EPUB reading systems as the global value
+							if no [^meta^] element carrying the <a data-cite="epub-33#orientation"
 									><code>rendition:orientation</code> property</a> occurs in the <a
 								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[epub-33]].</p>
 
@@ -1480,11 +1480,11 @@
 					<section id="spread">
 						<h5>The <code>rendition:spread</code> property</h5>
 
-						<p id="fxl-spread-default" data-tests="#fxl-spread-default">The default value <code>auto</code>
-							MUST be assumed by EPUB reading systems as the global value if no [^meta^] element carrying
-							the <a data-cite="epub-33#spread"><code>rendition:spread</code></a> property occurs in the
-								<a data-cite="epub-33#elemdef-opf-metadata">package document metadata</a>
-							[[epub-33]].</p>
+						<p id="fxl-spread-default" data-tests="#fxl-spread-default" data-cite="epub-33">The default
+							value <code>auto</code> MUST be assumed by EPUB reading systems as the global value if no
+							[^meta^] element carrying the <a data-cite="epub-33#spread"
+								><code>rendition:spread</code></a> property occurs in the <a
+								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[epub-33]].</p>
 
 						<p>The <code>rendition:spread</code> property values have the following processing
 							requirements:</p>
@@ -1860,12 +1860,11 @@
 							synchronization described by a media overlay, it MUST override the default playback behavior
 							of audio and video media embedded within the associated EPUB content document.</span></p>
 
-					<p>Note that the rules below apply only to <em>referenced</em> [[html]] [^video^] or [^audio^]
-						elements within the associated EPUB content document. That is to say, the rules apply to only
-						those elements pointed to by <a data-cite="epub-33#elemdef-smil-text"><code>text</code>
-							elements</a> [[epub-33]] within the media overlay (i.e., via the <code>src</code>
-						attribute). These rules do not apply to embedded media not referenced by media overlay
-						elements.</p>
+					<p>Note that the rules below apply only to <em>referenced</em> [[html]] <span data-cite="epub-33"
+							>[^video^] or [^audio^]</span> elements within the associated EPUB content document. That is
+						to say, the rules apply to only those elements pointed to by [^text^] elements [[epub-33]]
+						within the media overlay (i.e., via the <code>src</code> attribute). These rules do not apply to
+						embedded media not referenced by media overlay elements.</p>
 
 					<ul>
 						<li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -326,14 +326,15 @@
 				</ul>
 
 				<p id="confreq-rs-pkg-lang-no-content"
-					data-tests="#pgk-lang_pkg_non_content_dir,#pgk-lang_pkg_non_content" data-cite="epub-33">In the
-					absence of this information in a [=publication resource=], reading systems MUST NOT assume either
-					the the language or the base direction of that resource from information expressed in the package
-					document (i.e., in <a data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
+					data-tests="#pgk-lang_pkg_non_content_dir,#pgk-lang_pkg_non_content">In the absence of this
+					information in a [=publication resource=], reading systems MUST NOT assume either the the language
+					or the base direction of that resource from information expressed in the package document (i.e., in
+						<a data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
 						data-cite="epub-33#attrdef-dir"><code>dir</code></a> attributes, in <a
-						data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attributes</a> on [^link^] elements,
-					or from [^dc:language^] elements [[epub-33]]). Refer to a resource's formal specification for more
-					information about to handle the absence of explicit language or direction information.</p>
+						data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attributes</a> on [^package/link^]
+					elements, or from [^package/dc:language^] elements [[epub-33]]). Refer to a resource's formal
+					specification for more information about to handle the absence of explicit language or direction
+					information.</p>
 			</section>
 
 			<section id="sec-epub-rs-network-access">
@@ -730,31 +731,30 @@
 					<dt id="conf-meta-ws">White Space</dt>
 					<dd>
 						<p id="confreq-rs-pkg-whitespace" data-tests="#pkg-meta-whitespace">Reading systems MUST [=strip
-							and collapse ASCII whitespace=] [[infra]] from Dublin Core [[dcterms]] and <span
-								data-cite="epub-33">[^meta^]</span> element <a data-cite="epub-33#dfn-value">values</a>
-							[[epub-33]] before processing.</p>
+							and collapse ASCII whitespace=] [[infra]] from Dublin Core [[dcterms]] and [^package/meta^]
+							element <a data-cite="epub-33#dfn-value">values</a> [[epub-33]] before processing.</p>
 					</dd>
 
 					<dt id="dc-identifier">The <code>dc:identifier</code> element</dt>
 					<dd>
-						<p>To determine whether the value of a [^dc:identifier^] element [[epub-33]] conforms to an
-							established system or has been granted by an issuing authority, reading systems SHOULD check
-							for an <a data-cite="epub-33#identifier-type"><code>identifier-type</code> property</a>
-							[[epub-33]].</p>
+						<p>To determine whether the value of a [^package/dc:identifier^] element [[epub-33]] conforms to
+							an established system or has been granted by an issuing authority, reading systems SHOULD
+							check for an <a data-cite="epub-33#identifier-type"><code>identifier-type</code>
+								property</a> [[epub-33]].</p>
 					</dd>
 
 					<dt id="dc-title">The <code>dc:title</code> element</dt>
 					<dd>
 						<p id="title-order" data-tests="#pkg-title-order">Reading systems MUST recognize the first
-							[^dc:title^] element [[epub-33]] in document order as the main title of the EPUB publication
-							and present it to users before other title elements.</p>
+							[^package/dc:title^] element [[epub-33]] in document order as the main title of the EPUB
+							publication and present it to users before other title elements.</p>
 						<p>This specification does not define how to process additional <code>dc:title</code>
 							elements.</p>
 					</dd>
 
 					<dt id="sec-opf-dclanguage">The <code>dc:language</code> element</dt>
 					<dd>
-						<p>The language(s) of the [=EPUB publication=] specified in [^dc:language^] elements are
+						<p>The language(s) of the [=EPUB publication=] specified in [^package/dc:language^] elements are
 							informational. Some uses of this information include:</p>
 						<ul>
 							<li>exposing it to the user through the reading system user interface</li>
@@ -769,16 +769,16 @@
 					<dt id="dc-creator">The <code>dc:creator</code> element</dt>
 					<dd>
 						<p id="confreq-rs-pkg-creator-order" data-tests="#pkg-creator-order">When determining display
-							priority, reading systems MUST use the document order of [^dc:creator^] elements [[epub-33]]
-							in the <code>metadata</code> section, where the first <code>creator</code> element
-							encountered is the primary creator. If a reading system exposes creator metadata to the
-							user, it SHOULD include all the creators listed in the <code>metadata</code> section
+							priority, reading systems MUST use the document order of [^package/dc:creator^] elements
+							[[epub-33]] in the <code>metadata</code> section, where the first <code>creator</code>
+							element encountered is the primary creator. If a reading system exposes creator metadata to
+							the user, it SHOULD include all the creators listed in the <code>metadata</code> section
 							whenever possible (e.g., when not constrained by display considerations).</p>
 					</dd>
 
 					<dt id="meta">The <code>meta</code> element</dt>
 					<dd>
-						<p data-cite="epub-33">Reading systems SHOULD ignore all [^meta^] elements whose <a
+						<p>Reading systems SHOULD ignore all [^package/meta^] elements whose <a
 								data-cite="epub-33#attrdef-meta-property"><code>property</code> attributes</a>
 							[[epub-33]] define expressions they do not recognize. <span id="confreq-rs-pkg-meta-unknown"
 								data-tests="#pkg-meta-unknown">A reading system MUST NOT fail when encountering unknown
@@ -804,12 +804,12 @@
 							NOT skip processing the metadata expressed in the package document (i.e., use only the
 							information expressed in the record). Reading systems MAY compile metadata from multiple
 							linked records.</p>
-						<p data-cite="epub-33">When resolving discrepancies and conflicts between metadata expressed in
-							the package document and in linked metadata records, reading systems MUST use the document
-							order of [^link^] elements [[epub-33]] in the package document to establish precedence
-							(i.e., metadata in the first linked record has the highest precedence and metadata in the
-							package document the lowest, regardless of whether the <code>link</code> elements occur
-							before, within, or after the package metadata elements).</p>
+						<p>When resolving discrepancies and conflicts between metadata expressed in the package document
+							and in linked metadata records, reading systems MUST use the document order of
+							[^package/link^] elements [[epub-33]] in the package document to establish precedence (i.e.,
+							metadata in the first linked record has the highest precedence and metadata in the package
+							document the lowest, regardless of whether the <code>link</code> elements occur before,
+							within, or after the package metadata elements).</p>
 						<p>Reading systems MUST ignore any instructions contained in linked resources related to the
 							layout and rendering of the EPUB publication.</p>
 						<p>If any of the <a data-cite="epub-33#attrdef-link-rel"><code>rel</code></a> or <a
@@ -862,8 +862,8 @@
 				<h3>Spine</h3>
 
 				<p id="confreq-rs-spine-order" data-tests="#pkg-spine-order">Reading systems MUST provide a means of
-					rendering the EPUB publication in the order defined in the [^spine^] element [[epub-33]], which
-					includes:</p>
+					rendering the EPUB publication in the order defined in the [^package/spine^] element [[epub-33]],
+					which includes:</p>
 				<ul>
 					<li>recognizing the first <a data-cite="epub-33#attrdef-itemref-linear">primary (linear)
 								<code>itemref</code></a> [[epub-33]] as the beginning of the default reading order;
@@ -916,7 +916,7 @@
 				<section id="spine-overrides">
 					<h4>Spine overrides</h4>
 
-					<p>When a spine [^itemref^] element's <a data-cite="epub-33#attrdef-properties"
+					<p>When a spine [^package/itemref^] element's <a data-cite="epub-33#attrdef-properties"
 								><code>properties</code> attribute</a> overrides a <a
 							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
 						systems MUST follow the requirements for the override's global value to display that spine
@@ -974,7 +974,7 @@
 					<section id="sec-xhtml-structural-semantics">
 						<h5>Structural semantics</h5>
 
-						<p id="confreq-rs-epubtype-head" data-cite="html">In addition to the requirements in <a
+						<p id="confreq-rs-epubtype-head">In addition to the requirements in <a
 								href="#sec-structural-semantics"></a>, a reading system MUST ignore semantics expressed
 							on the [[html]] [^head^] element or its descendants.</p>
 					</section>
@@ -1374,8 +1374,8 @@
 				</li>
 				<li>
 					<p id="confreq-nav-other-access">MAY provide access to <code>nav</code> elements that do not specify
-						an <code>epub:type</code> attribute or that <a data-cite="epub-33#sec-nav-def-types-other"
-							>declare an unknown value</a> [[epub-33]].</p>
+						an [^/epub:type^] attribute or that <a data-cite="epub-33#sec-nav-def-types-other">declare an
+							unknown value</a> [[epub-33]].</p>
 				</li>
 				<li>
 					<p id="confreq-nav-activation" data-tests="#nav-activation">MUST relocate the current reading
@@ -1392,8 +1392,8 @@
 			</ul>
 
 			<p id="confreq-nav-spine" data-tests="#nav-spine_in-spine,#nav-spine_not-in-spine">Reading systems MUST
-				honor the above requirements irrespective of whether the EPUB navigation document is part of the <a
-					data-lt="EPUB spine">spine</a>.</p>
+				honor the above requirements irrespective of whether the EPUB navigation document is part of the
+				[=spine=].</p>
 		</section>
 		<section id="sec-rendering-control">
 			<h2>Layout rendering control processing</h2>
@@ -1410,9 +1410,9 @@
 					<section id="layout">
 						<h5>The <code>rendition:layout</code> property</h5>
 
-						<p data-cite="epub-33">The default value <code>reflowable</code> MUST be assumed by EPUB reading
-							systems as the global value if no [^meta^] element carrying the <a
-								data-cite="epub-33#layout"><code>rendition:layout</code> property</a> occurs in the <a
+						<p>The default value <code>reflowable</code> MUST be assumed by EPUB reading systems as the
+							global value if no [^package/meta^] element carrying the <a data-cite="epub-33#layout"
+									><code>rendition:layout</code> property</a> occurs in the <a
 								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[epub-33]].</p>
 
 						<p id="layout-pre-paginated" data-tests="#fxl-layout-pre-paginated-spreads">When the
@@ -1430,8 +1430,8 @@
 							</dd>
 							<dt id="def-layout-pre-paginated" data-tests="#fxl-layout-pre-paginated">pre-paginated</dt>
 							<dd>
-								<p>Reading systems MUST produce exactly one page per spine [^itemref^] [[epub-33]] when
-									rendering.</p>
+								<p>Reading systems MUST produce exactly one page per spine [^package/itemref^]
+									[[epub-33]] when rendering.</p>
 							</dd>
 						</dl>
 
@@ -1447,9 +1447,9 @@
 					<section id="orientation">
 						<h5>The <code>rendition:orientation</code> property</h5>
 
-						<p id="fxl-orientation-default" data-tests="#fxl-orientation-default" data-cite="epub-33">The
-							default value <code>auto</code> MUST be assumed by EPUB reading systems as the global value
-							if no [^meta^] element carrying the <a data-cite="epub-33#orientation"
+						<p id="fxl-orientation-default" data-tests="#fxl-orientation-default">The default value
+								<code>auto</code> MUST be assumed by EPUB reading systems as the global value if no
+							[^package/meta^] element carrying the <a data-cite="epub-33#orientation"
 									><code>rendition:orientation</code> property</a> occurs in the <a
 								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[epub-33]].</p>
 
@@ -1481,11 +1481,11 @@
 					<section id="spread">
 						<h5>The <code>rendition:spread</code> property</h5>
 
-						<p id="fxl-spread-default" data-tests="#fxl-spread-default" data-cite="epub-33">The default
-							value <code>auto</code> MUST be assumed by EPUB reading systems as the global value if no
-							[^meta^] element carrying the <a data-cite="epub-33#spread"
-								><code>rendition:spread</code></a> property occurs in the <a
-								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[epub-33]].</p>
+						<p id="fxl-spread-default" data-tests="#fxl-spread-default">The default value <code>auto</code>
+							MUST be assumed by EPUB reading systems as the global value if no [^package/meta^] element
+							carrying the <a data-cite="epub-33#spread"><code>rendition:spread</code></a> property occurs
+							in the <a data-cite="epub-33#elemdef-opf-metadata">package document metadata</a>
+							[[epub-33]].</p>
 
 						<p>The <code>rendition:spread</code> property values have the following processing
 							requirements:</p>
@@ -1669,8 +1669,8 @@
 
 					<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction MUST be
 						defined relative to the block flow direction of the root element of the XHTML content document
-						referenced by the [^itemref^] element [[epub-33]]. The scroll direction MUST be vertical if the
-						block flow direction is downward (top-to-bottom). It MUST be horizontal if the block flow
+						referenced by the [^package/itemref^] element [[epub-33]]. The scroll direction MUST be vertical
+						if the block flow direction is downward (top-to-bottom). It MUST be horizontal if the block flow
 						direction of the root element is rightward (left-to-right) or leftward (right-to-left).</p>
 
 					<p>Reading systems MUST ignore the <code>rendition:flow</code> property and its overrides when
@@ -1713,8 +1713,8 @@
 			<p>If a reading system does not support media overlays, it MUST ignore both:</p>
 
 			<ul>
-				<li>the <a data-cite="epub-33#attrdef-item-media-overlay"><code>media-overlay</code> attribute</a> on <a
-						data-lt="EPUB manifest">manifest</a> [^item^] elements [[epub-33]]; and</li>
+				<li>the <a data-cite="epub-33#attrdef-item-media-overlay"><code>media-overlay</code> attribute</a> on
+					[=manifest=] [^package/item^] elements [[epub-33]]; and</li>
 				<li><code>item</code> elements where the <code>media-type</code> attribute value equals
 						<code>application/smil+xml</code>.</li>
 			</ul>
@@ -1722,9 +1722,9 @@
 			<section id="sec-behaviors-loading">
 				<h4>Loading the media overlay</h4>
 
-				<p>When a reading system loads a [=package document=], it MUST refer to the <a data-lt="EPUB manifest"
-						>manifest</a> [^item^] elements' [[epub-33]] <code>media-overlay</code> attributes to discover
-					the corresponding media overlays for [=EPUB content documents=].</p>
+				<p>When a reading system loads a [=package document=], it MUST refer to the [=manifest=]
+					[^package/item^] elements' [[epub-33]] <code>media-overlay</code> attributes to discover the
+					corresponding media overlays for [=EPUB content documents=].</p>
 
 				<p id="confreq-rs-xhtml-svg">Reading systems MUST support playback for [=XHTML content documents=], and
 					MAY support [=SVG content documents=].</p>
@@ -1838,9 +1838,9 @@
 					<div class="note">
 						<p>EPUB creators may associate a media overlay document directly with an <a>EPUB navigation
 								document</a>t in order to provide synchronized playback of its contents, regardless of
-							whether the [=XHTML content document=] in which it resides is included in the <a
-								data-lt="EPUB spine">spine</a>. See <a data-cite="epub-33#sec-mo-nav-doc">EPUB
-								navigation document</a> [[epub-33]] for more information.</p>
+							whether the [=XHTML content document=] in which it resides is included in the [=spine=]. See
+								<a data-cite="epub-33#sec-mo-nav-doc">EPUB navigation document</a> [[epub-33]] for more
+							information.</p>
 					</div>
 
 					<div class="note" id="note-table-reading-mode">
@@ -1861,11 +1861,11 @@
 							synchronization described by a media overlay, it MUST override the default playback behavior
 							of audio and video media embedded within the associated EPUB content document.</span></p>
 
-					<p>Note that the rules below apply only to <em>referenced</em> [[html]] <span data-cite="epub-33"
-							>[^video^] or [^audio^]</span> elements within the associated EPUB content document. That is
-						to say, the rules apply to only those elements pointed to by [^text^] elements [[epub-33]]
-						within the media overlay (i.e., via the <code>src</code> attribute). These rules do not apply to
-						embedded media not referenced by media overlay elements.</p>
+					<p>Note that the rules below apply only to <em>referenced</em> [[html]] [^video^] or [^audio^]
+						elements within the associated EPUB content document. That is to say, the rules apply to only
+						those elements pointed to by [^text^] elements [[epub-33]] within the media overlay (i.e., via
+						the <code>src</code> attribute). These rules do not apply to embedded media not referenced by
+						media overlay elements.</p>
 
 					<ul>
 						<li>
@@ -1988,9 +1988,8 @@
 				<section id="sec-skippability">
 					<h5>Skippability</h5>
 
-					<p>Reading systems SHOULD use the semantic information provided by media overlay elements' <a
-							href="#sec-structural-semantics"><code>epub:type</code> attribute</a> to offer users the
-						option of skipping content.</p>
+					<p>Reading systems SHOULD use the semantic information provided by media overlay elements'
+						[^/epub:type^] attribute to offer users the option of skipping content.</p>
 
 					<p>When skipping of content is enabled, reading systems MUST suppress playback of any
 							<code>par</code> and <code>seq</code> elements whose <code>epub:type</code> attribute
@@ -2001,9 +2000,9 @@
 					<h5>Escapability</h5>
 
 					<p>Reading systems SHOULD allow escaping of nested structures. Reading systems MUST determine the
-						start of nested structures by the value of the <a href="#sec-structural-semantics"
-								><code>epub:type</code> attribute</a> and SHOULD offer users the option to skip playback
-						of that structure and resume with whatever content comes after it.</p>
+						start of nested structures by the value of the [^/epub:type^] attribute and SHOULD offer users
+						the option to skip playback of that structure and resume with whatever content comes after
+						it.</p>
 				</section>
 			</section>
 		</section>
@@ -2014,7 +2013,7 @@
 					data-cite="epub-33#app-structural-semantics">structural semantics</a> [[epub-33]] in <a>EPUB content
 					documents</a>.</p>
 
-			<p>When processing the <code>epub:type</code> attribute, a reading system:</p>
+			<p>When processing the [^/epub:type^] attribute, a reading system:</p>
 
 			<ul class="conformance-list">
 				<li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -326,8 +326,9 @@
 				</ul>
 
 				<p id="confreq-rs-pkg-lang-no-content"
+					data-tests="#pgk-lang_pkg_non_content_dir,#pgk-lang_pkg_non_content" data-cite="epub-33">In the
 					absence of this information in a [=publication resource=], reading systems MUST NOT assume either
-					the language or the base direction of that resource from information expressed in the package
+					the the language or the base direction of that resource from information expressed in the package
 					document (i.e., in <a data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
 						data-cite="epub-33#attrdef-dir"><code>dir</code></a> attributes, in <a
 						data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attributes</a> on [^link^] elements,

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -104,7 +104,7 @@
 			<h2>Introduction</h2>
 
 			<p>Structural semantics add additional meaning about the specific structural purpose an HTML (or SVG)
-				element plays. The [^epub:type^] attribute [[epub-33]] is used to express domain-specific semantics in
+				element plays. The [^/epub:type^] attribute [[epub-33]] is used to express domain-specific semantics in
 				[=EPUB content documents=] and <a>media overlay documents</a> [[epub-33]], with the structural
 				information it carries complementing the underlying vocabulary.</p>
 
@@ -136,8 +136,8 @@
 
 				<p>The <i>DPUB-ARIA role</i> fields indicate the [[dpub-aria-1.0]] roles that can alternatively be used
 					with the [[html]] <code>role</code> attribute to improve accessibility. These roles may have more
-					restrictive usage contexts, however, so may not be valid wherever the <code>epub:type</code>
-					attribute is used. Refer to [[html-aria]] for more information about where the roles are
+					restrictive usage contexts, however, so may not be valid wherever the [^/epub:type^] attribute
+					[[epub-33]] is used. Refer to [[html-aria]] for more information about where the roles are
 					allowed.</p>
 
 				<p>When processing HTML documents, reading systems may ignore such non-compliant properties, unless


### PR DESCRIPTION
Have to watch out when our element names match those in html. Need to put a data-cite attribute on a nearby element to indicate which spec has precedence as these errors only popped up once our newly exported elements went live.

It appears to happen most often with the package link and meta elements and MO audio element.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2254.html" title="Last updated on Apr 19, 2022, 8:30 PM UTC (978e1ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2254/c70d251...978e1ed.html" title="Last updated on Apr 19, 2022, 8:30 PM UTC (978e1ed)">Diff</a>