### PR TITLE
Adding html wrapper around md files for reports

### DIFF
--- a/epub33/reports/a11y-properties-use.html
+++ b/epub33/reports/a11y-properties-use.html
@@ -51,7 +51,7 @@
     <script class="remove">
         var respecConfig = {
             specStatus: "base",
-            "latestVersion": "https://w3c.github.io/epub-specs/epub33/reports/index.html",
+            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/index.html",
             noRecTrack: true,
             editors: [{
                 name: "Matt Garrish",

--- a/epub33/reports/a11y-properties-use.html
+++ b/epub33/reports/a11y-properties-use.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>EPUB Accessibility 1.1 Metadata Usage Report</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <style>
+      .todo {
+        background-color: yellow;
+        color: #900;
+      }
+      .todo::before {
+        content: "(still to be done)";
+      }
+        /* Table zebra style... */
+
+        table {
+            font-size:inherit;
+            font:90%;
+            margin:1em;
+        }
+
+        table td {
+            padding-left: 0.3em;
+        }
+
+        table th {
+            font-weight: bold;
+            text-align: center;
+            background-color: rgb(0,0,128) !important;
+            font-size: 110%;
+            background: hsl(180, 30%, 50%);
+            color: #fff;
+        }
+
+        table th a:link {
+          color: #fff;
+        }
+
+        table th a:visited {
+          color: #aaa;
+        }
+
+        table tr:nth-child(even) {
+            background-color: hsl(180, 30%, 93%) !important;
+        }
+
+        table th{border-bottom:1px solid #bbb;padding:.2em 1em;}
+        table td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+    </style>
+    <script class="remove">
+        var respecConfig = {
+            specStatus: "base",
+            "latestVersion": "https://w3c.github.io/epub-specs/epub33/reports/index.html",
+            noRecTrack: true,
+            editors: [{
+                name: "Matt Garrish",
+                company: "DAISY Consortium",
+                companyURL: "https://daisy.org",
+                w3cid: 51655
+            }],
+            github: {
+                repoURL: "https://github.com/w3c/epub-specs",
+                branch: "main"
+            },
+            shortName: "exit-criteria"
+        };
+    </script>
+</head>
+
+<body>
+    <section id="abstract">
+        <p>
+            This document provides information on the usage of the accessibility metadata defined by the [EPUB Accessibility 1.1](https://w3c.github.io/epub-specs/epub33/a11y/) specification.
+    </section>
+    <section id="sotd">
+    </section>
+
+    <div data-include="a11y-properties-use.md" data-include-format="markdown" data-include-replace="true"></div>
+
+</body>
+</html>

--- a/epub33/reports/a11y-properties-use.md
+++ b/epub33/reports/a11y-properties-use.md
@@ -1,5 +1,3 @@
-# EPUB Accessibility 1.1 Metadata Usage Report
-
 ## Candidate Recommendation Exit Criteria
 
 The EPUB Working Group intends to exit the Candidate Recommendation stage and submit

--- a/epub33/reports/epub-properties-use.html
+++ b/epub33/reports/epub-properties-use.html
@@ -51,7 +51,7 @@
     <script class="remove">
         var respecConfig = {
             specStatus: "base",
-            "latestVersion": "https://w3c.github.io/epub-specs/epub33/reports/index.html",
+            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/index.html",
             noRecTrack: true,
             editors: [{
                 name: "Matt Garrish",

--- a/epub33/reports/epub-properties-use.html
+++ b/epub33/reports/epub-properties-use.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>EPUB 3.3 Metadata Usage Report</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <style>
+      .todo {
+        background-color: yellow;
+        color: #900;
+      }
+      .todo::before {
+        content: "(still to be done)";
+      }
+        /* Table zebra style... */
+
+        table {
+            font-size:inherit;
+            font:90%;
+            margin:1em;
+        }
+
+        table td {
+            padding-left: 0.3em;
+        }
+
+        table th {
+            font-weight: bold;
+            text-align: center;
+            background-color: rgb(0,0,128) !important;
+            font-size: 110%;
+            background: hsl(180, 30%, 50%);
+            color: #fff;
+        }
+
+        table th a:link {
+          color: #fff;
+        }
+
+        table th a:visited {
+          color: #aaa;
+        }
+
+        table tr:nth-child(even) {
+            background-color: hsl(180, 30%, 93%) !important;
+        }
+
+        table th{border-bottom:1px solid #bbb;padding:.2em 1em;}
+        table td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+    </style>
+    <script class="remove">
+        var respecConfig = {
+            specStatus: "base",
+            "latestVersion": "https://w3c.github.io/epub-specs/epub33/reports/index.html",
+            noRecTrack: true,
+            editors: [{
+                name: "Matt Garrish",
+                company: "DAISY Consortium",
+                companyURL: "https://daisy.org",
+                w3cid: 51655
+            }],
+            github: {
+                repoURL: "https://github.com/w3c/epub-specs",
+                branch: "main"
+            },
+            shortName: "exit-criteria"
+        };
+    </script>
+</head>
+
+<body>
+    <section id="abstract">
+        <p>
+            This document provides information on the usage of the various metadata defined by the [EPUB 3.3](https://w3c.github.io/epub-specs/epub33/core/) specification.
+    </section>
+    <section id="sotd">
+    </section>
+
+    <div data-include="epub-properties-use.md" data-include-format="markdown" data-include-replace="true"></div>
+
+</body>
+</html>

--- a/epub33/reports/epub-properties-use.md
+++ b/epub33/reports/epub-properties-use.md
@@ -1,5 +1,3 @@
-# EPUB 3.3 Metadata Usage Report
-
 ## Candidate Recommendation Exit Criteria
 
 The EPUB Working Group intends to exit the Candidate Recommendation stage and submit

--- a/epub33/reports/exit_criteria.html
+++ b/epub33/reports/exit_criteria.html
@@ -14,7 +14,7 @@
     <script class="remove">
         var respecConfig = {
             specStatus: "base",
-            "latestVersion": "https://w3c.github.io/epub-specs/epub33/reports/exit_criteria.html",
+            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/exit_criteria.html",
             noRecTrack: true,
             editors: [{
                 name: "Ivan Herman",


### PR DESCRIPTION
I got a bit bothered by having a few impl. report files in markdown when most of the files are in HTML... I used a simple respec trick to provide a more uniform html view of the two markdown files (using an almost empty respec shell that imports the markdown content).

Extra bonus: the generated HTML has anchors that can be used to link to from the specs.

Previews:

- [A11y property report](https://raw.githack.com/w3c/epub-specs/admin/all-reports-html/epub33/reports/a11y-properties-use.html)
- [EPUB property report](https://raw.githack.com/w3c/epub-specs/admin/all-reports-html/epub33/reports/epub-properties-use.html)


