### PR TITLE
changed media queries reference

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6838,7 +6838,7 @@ No Entry</pre>
 
 						<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
 							<p>In this example, the document's layout is set to <code>pre-paginated</code>, i.e., it is
-								defined to be a fixed layout document. Furthermore, media queries [[mediaqueries-3]] are
+								defined to be a fixed layout document. Furthermore, media queries [[css3-mediaqueries]] are
 								used to apply different style sheets for three different device categories. Note that
 								the media queries only affect the style sheet applied to the document; the size of the
 								content area set in the <code>viewport</code>


### PR DESCRIPTION
In specref the (old) reference to media queries level 3 is marked as 'aliased' to css3-mediaqueries. But the generated code by respec does not seem to understand this 'alias', and this leads to a wrong fragment reference (and link checker complain).

I exchanged the reference to the 'official' one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 6, 2022, 1:13 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Fb16ea9a1573c0e9879156723ba520198ee3a0088%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/o7ZETJ?isPreview=true&publishDate=2022-05-06
ReSpec version: 32.1.6
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 27514ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:244:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232262.)._
</details>
