### PR TITLE
Add better anchors for many normative MUSTs, and a few data-tests

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -303,13 +303,13 @@
 					language for the documents' contents, when applicable. This includes:</p>
 
 				<ul>
-					<li>the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a> [[xml]] for all XML
-						documents (e.g., the [=package document=], [=XHTML content documents=], <a>SVG content
-							documents</a>, and [=media overlay documents=]).</li>
+					<li id="confreq-rs-xml-lang">the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a>
+							[[xml]] for all XML documents (e.g., the [=package document=], [=XHTML content documents=],
+							<a>SVG content documents</a>, and [=media overlay documents=]).</li>
 
-					<li>the <code>lang</code> attribute for XHTML content documents and SVG content documents. (Refer to
-						respective "The 'lang' and 'xml:lang' attributes" sections in [[html]] and [[svg]] for more
-						information.)</li>
+					<li id="confreq-rs-lang-attr">the <code>lang</code> attribute for XHTML content documents and
+						SVG content documents. (Refer to respective "The 'lang' and 'xml:lang' attributes" sections in
+						[[html]] and [[svg]] for more information.)</li>
 				</ul>
 
 				<p>Similarly, a reading system MUST process, for all [=publication resources=], the attributes that set
@@ -320,9 +320,11 @@
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
 						>the <a data-cite="epub-33#attrdef-dir"><code>dir</code></a> attribute [[epub-33]] for the
 						[=package document=]. (See also <a href="#sec-pkg-doc-base-dir"></a> for further details.)</li>
-					<li>the [[html]] [^html-global/dir^] attribute for XHTML content documents.</li>
-					<li>the [[svg]] <a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
-								><code>direction</code></a> attribute for SVG content documents.</li>
+					<li id="confreq-rs-html-dir">the [[html]] [^html-global/dir^] attribute for XHTML content
+						documents.</li>
+					<li id="confreq-rs-svg-direction">the [[svg]]
+						<a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"><code>direction</code></a>
+						attribute for SVG content documents.</li>
 				</ul>
 
 				<p id="confreq-rs-pkg-lang-no-content"
@@ -784,10 +786,10 @@
 							[[epub-33]] define expressions they do not recognize. <span id="confreq-rs-pkg-meta-unknown"
 								data-tests="#pkg-meta-unknown">A reading system MUST NOT fail when encountering unknown
 								expressions.</span></p>
-						<p>If the <code>property</code> attribute's value does not include a <a
-								data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST
-							use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to <a
-								href="#sec-property-datatype">expand the value</a>.</p>
+						<p id="confreq-rs-pkg-meta-prefix">If the <code>property</code> attribute's value does not
+							include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading
+							systems MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to
+							<a href="#sec-property-datatype">expand the value</a>.</p>
 						<p>If a reading system does not recognize the <a data-cite="epub-33#attrdef-scheme"
 									><code>scheme</code> attribute</a> [[epub-33]] value, it SHOULD treat the value of
 							the element as a string.</p>
@@ -796,25 +798,28 @@
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
 					<dd>
 						<p>Retrieval and support of [=linked resources=] is OPTIONAL.</p>
-						<p>The language identified in an <a data-cite="epub-33#attrdef-hreflang"><code>hreflang</code>
-								attribute</a> is purely advisory. Upon fetching the resource, a reading system MUST use
-							the language information associated with the resource to determine its language, not the
-							metadata included in the link to the resource.</p>
+						<p id="confreq-rs-pkg-hreflang">The language identified in an
+							<a data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attribute</a> is purely
+							advisory. Upon fetching the resource, a reading system MUST use the language information
+							associated with the resource to determine its language, not the metadata included in the
+							link to the resource.</p>
 						<p id="sec-linked-records" data-tests="#pkg-linked-records">In the case of a <a
 								data-cite="epub-33#record">linked metadata record</a> [[epub-33]], reading systems MUST
 							NOT skip processing the metadata expressed in the package document (i.e., use only the
 							information expressed in the record). Reading systems MAY compile metadata from multiple
 							linked records.</p>
-						<p>When resolving discrepancies and conflicts between metadata expressed in the package document
-							and in linked metadata records, reading systems MUST use the document order of <span
-								data-cite="epub-33">[^link^]</span> elements [[epub-33]] in the package document to
-							establish precedence (i.e., metadata in the first linked record has the highest precedence
-							and metadata in the package document the lowest, regardless of whether the <code>link</code>
-							elements occur before, within, or after the package metadata elements).</p>
-						<p>Reading systems MUST ignore any instructions contained in linked resources related to the
-							layout and rendering of the EPUB publication.</p>
-						<p>If any of the <a data-cite="epub-33#attrdef-link-rel"><code>rel</code></a> or <a
-								data-cite="epub-33#attrdef-properties"><code>properties</code></a> [[epub-33]]
+						<p id="confreq-rs-pkg-link-order">When resolving discrepancies and conflicts between metadata
+							expressed in the package document and in linked metadata records, reading systems MUST use
+							the document order of <span data-cite="epub-33">[^link^]</span> elements [[epub-33]] in the
+							package document to establish precedence (i.e., metadata in the first linked record has the
+							highest precedence and metadata in the package document the lowest, regardless of whether
+							the <code>link</code> elements occur before, within, or after the package metadata
+							elements).</p>
+						<p id="confreq-rs-pkg-link-rendering">Reading systems MUST ignore any instructions contained in
+							linked resources related to the layout and rendering of the EPUB publication.</p>
+						<p id="confreq-rs-pkg-link-prefix">If any of the
+							<a data-cite="epub-33#attrdef-link-rel"><code>rel</code></a> or
+							<a data-cite="epub-33#attrdef-properties"><code>properties</code></a> [[epub-33]]
 							attributes' values do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a>,
 							reading systems MUST use the prefix URL
 								"<code>http://idpf.org/epub/vocab/package/link/#</code>" to <a
@@ -835,27 +840,33 @@
 					limitations and risks involved (e.g., lack of information about the resource and how to process it,
 					security risks from remotely-hosted sources, lack of fallbacks, etc.).</p>
 
-				<p>A reading system that does not support the MIME media type [[rfc2046]] of a given publication
-					resource MUST traverse the <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a>
-					[[epub-33]] until it identifies a supported publication resource to use in place of the unsupported
-					resource. If the reading system supports multiple publication resources in the fallback chain, it
-					MAY select the resource to use based on the resource's <a
-						data-cite="epub-33#attrdef-item-properties"><code>properties</code> attribute</a> [[epub-33]]
-					values, otherwise it SHOULD honor the EPUB creator's preferred fallback order. If a reading system
-					does not support any resource in the fallback chain, it MUST alert the reader that it could not
-					display the content.</p>
+				<p>
+					<span id="confreq-rs-pkg-manifest-fallback">A reading system that does not support the MIME media
+						type [[rfc2046]] of a given publication resource MUST traverse the
+						<a data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a> [[epub-33]] until it
+						identifies a supported publication resource to use in place of the unsupported resource.
+					</span>
+					<span id="confreq-rs-pkg-manifest-fallback-order">If the reading system supports multiple
+						publication resources in the fallback chain, it MAY select the resource to use based on the
+						resource's <a data-cite="epub-33#attrdef-item-properties"><code>properties</code> attribute</a>
+						[[epub-33]] values, otherwise it SHOULD honor the EPUB creator's preferred fallback order.
+					</span>
+					<span id="confreq-rs-pkg-manifest-fallback-fail">If a reading system does not support any resource
+						in the fallback chain, it MUST alert the reader that it could not display the content.
+					</span>
+				</p>
 
 				<p>When <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-33]] are provided
 					for [=top-level content documents=], reading systems MAY choose from the available options to find
 					the optimal version to render in a given context (e.g., by inspecting the properties attribute for
 					each).</p>
 
-				<p>A reading system MUST terminate the fallback chain at the first reference to a manifest item it has
-					already encountered.</p>
+				<p id="confreq-rs-pkg-manifest-fallback-cycle">A reading system MUST terminate the fallback chain at
+					the first reference to a manifest item it has already encountered.</p>
 
-				<p>If any of the <code>properties</code> attribute's values do not include a <a
-						data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST use the
-					prefix URL "<code>http://idpf.org/epub/vocab/package/item/#</code>" to <a
+				<p id="confreq-rs-pkg-manifest-prefix">If any of the <code>properties</code> attribute's values do not
+					include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST
+					use the prefix URL "<code>http://idpf.org/epub/vocab/package/item/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 			</section>
 
@@ -892,9 +903,10 @@
 					the reading system MUST ignore any directionality computed from <a href="#layout"
 							><code>pre-paginated</code></a> [=XHTML content documents=].</p>
 
-				<p>If any values of the <a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a>
-					do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems
-					MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
+				<p id="confreq-rs-spine-prefix">If any values of the
+					<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> do not include a
+					<a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST use the
+					prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 
 				<p id="confreq-rs-pkg-spine-unknown" data-tests="#pkg-spine-unknown">Reading systems MUST ignore all
@@ -917,9 +929,9 @@
 				<section id="spine-overrides">
 					<h4>Spine overrides</h4>
 
-					<p>When a spine [^itemref^] element's <a data-cite="epub-33#attrdef-properties"
-								><code>properties</code> attribute</a> overrides a <a
-							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
+					<p id="confreq-rs-pkg-spine-override">When a spine [^itemref^] element's
+						<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a
+						<a data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
 						systems MUST follow the requirements for the override's global value to display that spine
 						item.</p>
 
@@ -928,8 +940,9 @@
 						requirements of the global <a href="#def-layout-pre-paginated"><code>pre-paginated</code>
 							value</a>.</p>
 
-					<p>If more than one override for the same property is specified in a <code>properties</code>
-						attribute, reading systems MUST use only the first value.</p>
+					<p id="confreq-rs-pkg-spine-override-first">If more than one override for the same property is
+						specified in a <code>properties</code> attribute, reading systems MUST use only the first
+					value.</p>
 				</section>
 			</section>
 
@@ -1104,16 +1117,23 @@
 							expressed therein, unless explicitly defined by this specification as overridden.</p>
 					</li>
 					<li>
-						<p id="confreq-svg-rs-scrpt">MUST meet the conformance criteria defined in <a
+						<p id="confreq-svg-rs-script">MUST meet the conformance criteria defined in <a
 								href="#sec-scripted-content"></a>.</p>
 					</li>
 					<li>
-						<p id="confreq-svg-rs-css">MUST, if it has a [=viewport=], support the visual rendering of SVG
-							using CSS as defined in <a href="https://www.w3.org/TR/SVG/styling.html#">Styling</a>
-							[[svg]] and it SHOULD support all properties defined in the <a
-								href="https://www.w3.org/TR/SVG/propidx.html#">Property Index</a> [[svg]]. In the case
-							of embedded SVG, a reading system MUST also conform to the constraints defined in <a
-								href="#sec-xhtml-svg-css"></a>.</p>
+						<p>
+							<span id="confreq-svg-rs-css">MUST, if it has a [=viewport=], support the visual rendering
+								of SVG using CSS as defined in
+								<a href="https://www.w3.org/TR/SVG/styling.html#">Styling</a> [[svg]]
+							</span>
+							<span id="confreq-svg-rs-css-properties">and it SHOULD support all properties defined in
+								the <a href="https://www.w3.org/TR/SVG/propidx.html#">Property Index</a> [[svg]].
+							</span>
+							<span id="confreq-svg-rs-css-embedded"
+								data-tests="#cnt-svg-css-inclusion,#cnt-svg-css-reference">
+								In the case of embedded SVG, a reading system MUST also conform to the constraints
+								defined in <a href="#sec-xhtml-svg-css"></a>.</span>
+							</p>
 					</li>
 				</ul>
 			</section>
@@ -1121,9 +1141,9 @@
 			<section id="sec-css">
 				<h3>Cascading Style Sheets (CSS)</h3>
 
-				<p id="confreq-rs-epub3-css" class="support">If a reading system has a [=viewport=], it MUST support the
-						<a data-cite="epub-33#sec-css">visual rendering of XHTML content documents via CSS</a>
-					[[epub-33]].</p>
+				<p id="confreq-rs-epub3-css" data-tests="#cnt-css-support" class="support">If a reading system has a
+					[=viewport=], it MUST support the <a data-cite="epub-33#sec-css">visual rendering of XHTML content
+					documents via CSS</a> [[epub-33]].</p>
 
 				<p>To support CSS, a reading system:</p>
 
@@ -1402,8 +1422,8 @@
 			<section id="sec-fixed-layouts">
 				<h3>Fixed-layout documents</h3>
 
-				<p id="confreq-rs-epub3-fxl" class="support">Reading systems MUST support the rendering of <a
-						data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a> [[epub-33]].</p>
+				<p id="confreq-rs-epub3-fxl" data-tests="#fxl-spread-none" class="support">Reading systems MUST support
+					the rendering of <a data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a> [[epub-33]].</p>
 
 				<section id="sec-fxl-props">
 					<h4>Fixed-layout properties</h4>


### PR DESCRIPTION
I identified the need for these anchors in https://tinyurl.com/epub-tests (but the notes saying "needs more specific anchor" are now removed, because that's done here, which should be committed before we get people to sign up in that spreadsheet).

No textual changes, just anchors and a few data-tests for things that were already tested.