### PR TITLE
Clarify "otherwise" for spread-none, and reorganize a bit

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1541,12 +1541,17 @@
 							properties apply to both pre-paginated and reflowable content, and they only apply when the
 							reading system is creating synthetic spreads.</p>
 
-						<p id="page-spread-center">Reading systems that support the
-							<a href="#def-spread-none"><code>spread-none</code> property</a> MUST recognize the
-							<a data-cite="epub-33#page-spread-center"><code>rendition:page-spread-center</code>
-							property</a> as an alias for it. Reading systems do not that support the
-							<code>spread-none</code> property MUST ignore the <code>rendition:page-spread-center</code>
-							property.</p>
+						<p>
+							<span id="page-spread-center">Reading systems that support the
+								<a href="#def-spread-none"><code>spread-none</code> property</a> MUST recognize the
+								<a data-cite="epub-33#page-spread-center"><code>rendition:page-spread-center</code>
+								property</a> as an alias for it.
+							</span>
+							<span id="page-spread-center-ignore">Reading systems that do not that support the
+								<code>spread-none</code> property MUST ignore the
+								<code>rendition:page-spread-center</code> property.
+							</span>
+						</p>
 
 						<p>The <code id="page-break-precedence">rendition:page-spread-*</code> properties MUST take
 							precedence over whatever value of the <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1544,7 +1544,7 @@
 						<p id="page-spread-center">Reading systems that support the
 							<a href="#def-spread-none"><code>spread-none</code> property</a> MUST recognize the
 							<a data-cite="epub-33#page-spread-center"><code>rendition:page-spread-center</code>
-							property</a> as an alias for it. Reading systems do not that support the
+							property</a> as an alias for it. Reading systems that do not support the
 							<code>spread-none</code> property MUST ignore the <code>rendition:page-spread-center</code>
 							property.</p>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1524,22 +1524,29 @@
 					<section id="page-spread">
 						<h4>The <code>rendition:page-spread-*</code> properties</h4>
 
-						<p>The <a data-cite="epub-33#fxl-page-spread-left"><span id="page-spread-left"
-									data-tests="#fxl-page-spread-left"><code>rendition:page-spread-left</code></span>
+						<p>
+							<span id="page-spread-left" data-tests="#fxl-page-spread-left">The
+								<a data-cite="epub-33#fxl-page-spread-left"><code>rendition:page-spread-left</code>
 								property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in the
-							left-hand slot in the spread, and <a data-cite="epub-33#fxl-page-spread-right"><span
-									id="page-spread-right"><code>rendition:page-spread-right</code></span> property</a>
-							[[epub-33]] that it SHOULD be rendered in the right-hand slot.</p>
-
-						<p>Reading systems that support the <a href="#def-spread-none"><code>spread-none</code>
-								property</a> MUST recognize the <a data-cite="epub-33#page-spread-center"><span
-									id="page-spread-center"><code>rendition:page-spread-center</code></span>
-								property</a> as an alias for it, otherwise they MUST ignore the
-								<code>rendition:page-spread-center</code> property.</p>
+								left-hand slot in the spread.
+							</span>
+							<span id="page-spread-right" data-tests="#fxl-page-spread-right">The
+								<a data-cite="epub-33#fxl-page-spread-right"><code>rendition:page-spread-right</code>
+								property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in the
+								right-hand slot in the spread.
+							</span>
+						</p>
 
 						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 							properties apply to both pre-paginated and reflowable content, and they only apply when the
 							reading system is creating synthetic spreads.</p>
+
+						<p id="page-spread-center">Reading systems that support the
+							<a href="#def-spread-none"><code>spread-none</code> property</a> MUST recognize the
+							<a data-cite="epub-33#page-spread-center"><code>rendition:page-spread-center</code>
+							property</a> as an alias for it. Reading systems do not that support the
+							<code>spread-none</code> property MUST ignore the <code>rendition:page-spread-center</code>
+							property.</p>
 
 						<p>The <code id="page-break-precedence">rendition:page-spread-*</code> properties MUST take
 							precedence over whatever value of the <a


### PR DESCRIPTION
This breaks the first sentence into two, adds a missing data-test, moves the third paragraph ahead of the second paragraph, and rewrites the "otherwise" requirement for clarity.

Fixes #2280.