### PR TITLE
Add index to core spec

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1839,6 +1839,7 @@
 				</section>
 			</section>
 		</section>
+		<section id="index"></section>
 		<section id="change-log" class="appendix informative">
 			<h2>Change log</h2>
 
@@ -1852,6 +1853,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
+						>issue 2260</a>.</li>
 				<li>12-Apr-2022: Restored recommendation to include links to all reproduced pages in the page list and
 					added a requirement to link to all page break markers to address concerns with the previous change.
 					Clarified that meeting the page navigation requirements is required, but adding page navigation is

--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -376,10 +376,3 @@ details.explanation > summary, details.desc > summary {
     font-weight: normal !important;
     font-style: italic;
 }
-
-code a[data-type~="element"], 
-code a[data-type~="dfn"],
-code a[data-type~="element-attr"]
-{
-    color: #c63501 !important;
-}

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11510,7 +11510,7 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>13-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
+				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>
 				<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and updated
 					the list of semantics to use for escaping to match the guidance. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11511,7 +11511,7 @@ EPUB/images/cover.png</pre>
 
 			<ul>
 				<li>13-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
-						>issue 2260</a></li>
+						>issue 2260</a>.</li>
 				<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and updated
 					the list of semantics to use for escaping to match the guidance. See <a
 						href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11497,6 +11497,7 @@ EPUB/images/cover.png</pre>
 				</dl>
 			</section>
 		</section>
+		<section id="index"></section>
 		<section id="change-log" class="appendix informative">
 			<h2>Change log</h2>
 
@@ -11509,6 +11510,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>13-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
+						>issue 2260</a></li>
 				<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and updated
 					the list of semantics to use for escaping to match the guidance. See <a
 						href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -304,11 +304,11 @@
 
 				<ul>
 					<li id="confreq-rs-xml-lang">the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a>
-							[[xml]] for all XML documents (e.g., the [=package document=], [=XHTML content documents=],
+						[[xml]] for all XML documents (e.g., the [=package document=], [=XHTML content documents=],
 							<a>SVG content documents</a>, and [=media overlay documents=]).</li>
 
-					<li id="confreq-rs-lang-attr">the <code>lang</code> attribute for XHTML content documents and
-						SVG content documents. (Refer to respective "The 'lang' and 'xml:lang' attributes" sections in
+					<li id="confreq-rs-lang-attr">the <code>lang</code> attribute for XHTML content documents and SVG
+						content documents. (Refer to respective "The 'lang' and 'xml:lang' attributes" sections in
 						[[html]] and [[svg]] for more information.)</li>
 				</ul>
 
@@ -322,16 +322,15 @@
 						[=package document=]. (See also <a href="#sec-pkg-doc-base-dir"></a> for further details.)</li>
 					<li id="confreq-rs-html-dir">the [[html]] [^html-global/dir^] attribute for XHTML content
 						documents.</li>
-					<li id="confreq-rs-svg-direction">the [[svg]]
-						<a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"><code>direction</code></a>
+					<li id="confreq-rs-svg-direction">the [[svg]] <a
+							href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"><code>direction</code></a>
 						attribute for SVG content documents.</li>
 				</ul>
 
-				<p id="confreq-rs-pkg-lang-no-content"
-					data-tests="#pkg-lang_but_not_content,#pkg-dir_but_not_content">In the absence of this
-					information in a [=publication resource=], reading systems MUST NOT assume either the the language
-					or the base direction of that resource from information expressed in the package document (i.e., in
-						<a data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
+				<p id="confreq-rs-pkg-lang-no-content" data-tests="#pkg-lang_but_not_content,#pkg-dir_but_not_content"
+					>In the absence of this information in a [=publication resource=], reading systems MUST NOT assume
+					either the the language or the base direction of that resource from information expressed in the
+					package document (i.e., in <a data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
 						data-cite="epub-33#attrdef-dir"><code>dir</code></a> attributes, in <a
 						data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attributes</a> on <span
 						data-cite="epub-33">[^link^]</span> elements, or from [^dc:language^] elements [[epub-33]]).
@@ -789,7 +788,7 @@
 						<p id="confreq-rs-pkg-meta-prefix">If the <code>property</code> attribute's value does not
 							include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading
 							systems MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to
-							<a href="#sec-property-datatype">expand the value</a>.</p>
+								<a href="#sec-property-datatype">expand the value</a>.</p>
 						<p>If a reading system does not recognize the <a data-cite="epub-33#attrdef-scheme"
 									><code>scheme</code> attribute</a> [[epub-33]] value, it SHOULD treat the value of
 							the element as a string.</p>
@@ -798,8 +797,8 @@
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
 					<dd>
 						<p>Retrieval and support of [=linked resources=] is OPTIONAL.</p>
-						<p id="confreq-rs-pkg-hreflang">The language identified in an
-							<a data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attribute</a> is purely
+						<p id="confreq-rs-pkg-hreflang">The language identified in an <a
+								data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attribute</a> is purely
 							advisory. Upon fetching the resource, a reading system MUST use the language information
 							associated with the resource to determine its language, not the metadata included in the
 							link to the resource.</p>
@@ -817,12 +816,11 @@
 							elements).</p>
 						<p id="confreq-rs-pkg-link-rendering">Reading systems MUST ignore any instructions contained in
 							linked resources related to the layout and rendering of the EPUB publication.</p>
-						<p id="confreq-rs-pkg-link-prefix">If any of the
-							<a data-cite="epub-33#attrdef-link-rel"><code>rel</code></a> or
-							<a data-cite="epub-33#attrdef-properties"><code>properties</code></a> [[epub-33]]
-							attributes' values do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a>,
-							reading systems MUST use the prefix URL
-								"<code>http://idpf.org/epub/vocab/package/link/#</code>" to <a
+						<p id="confreq-rs-pkg-link-prefix">If any of the <a data-cite="epub-33#attrdef-link-rel"
+									><code>rel</code></a> or <a data-cite="epub-33#attrdef-properties"
+									><code>properties</code></a> [[epub-33]] attributes' values do not include a <a
+								data-cite="epub-33#property.ebnf.prefix">prefix</a>, reading systems MUST use the prefix
+							URL "<code>http://idpf.org/epub/vocab/package/link/#</code>" to <a
 								href="#sec-property-datatype">expand the values</a>.</p>
 					</dd>
 				</dl>
@@ -842,18 +840,15 @@
 
 				<p>
 					<span id="confreq-rs-pkg-manifest-fallback">A reading system that does not support the MIME media
-						type [[rfc2046]] of a given publication resource MUST traverse the
-						<a data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a> [[epub-33]] until it
-						identifies a supported publication resource to use in place of the unsupported resource.
-					</span>
+						type [[rfc2046]] of a given publication resource MUST traverse the <a
+							data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a> [[epub-33]] until it
+						identifies a supported publication resource to use in place of the unsupported resource. </span>
 					<span id="confreq-rs-pkg-manifest-fallback-order">If the reading system supports multiple
 						publication resources in the fallback chain, it MAY select the resource to use based on the
 						resource's <a data-cite="epub-33#attrdef-item-properties"><code>properties</code> attribute</a>
-						[[epub-33]] values, otherwise it SHOULD honor the EPUB creator's preferred fallback order.
-					</span>
+						[[epub-33]] values, otherwise it SHOULD honor the EPUB creator's preferred fallback order. </span>
 					<span id="confreq-rs-pkg-manifest-fallback-fail">If a reading system does not support any resource
-						in the fallback chain, it MUST alert the reader that it could not display the content.
-					</span>
+						in the fallback chain, it MUST alert the reader that it could not display the content. </span>
 				</p>
 
 				<p>When <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-33]] are provided
@@ -861,8 +856,8 @@
 					the optimal version to render in a given context (e.g., by inspecting the properties attribute for
 					each).</p>
 
-				<p id="confreq-rs-pkg-manifest-fallback-cycle">A reading system MUST terminate the fallback chain at
-					the first reference to a manifest item it has already encountered.</p>
+				<p id="confreq-rs-pkg-manifest-fallback-cycle">A reading system MUST terminate the fallback chain at the
+					first reference to a manifest item it has already encountered.</p>
 
 				<p id="confreq-rs-pkg-manifest-prefix">If any of the <code>properties</code> attribute's values do not
 					include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST
@@ -903,9 +898,9 @@
 					the reading system MUST ignore any directionality computed from <a href="#layout"
 							><code>pre-paginated</code></a> [=XHTML content documents=].</p>
 
-				<p id="confreq-rs-spine-prefix">If any values of the
-					<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> do not include a
-					<a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST use the
+				<p id="confreq-rs-spine-prefix">If any values of the <a data-cite="epub-33#attrdef-properties"
+							><code>properties</code> attribute</a> do not include a <a
+						data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST use the
 					prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 
@@ -929,9 +924,9 @@
 				<section id="spine-overrides">
 					<h4>Spine overrides</h4>
 
-					<p id="confreq-rs-pkg-spine-override">When a spine [^itemref^] element's
-						<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a
-						<a data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
+					<p id="confreq-rs-pkg-spine-override">When a spine [^itemref^] element's <a
+							data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a <a
+							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
 						systems MUST follow the requirements for the override's global value to display that spine
 						item.</p>
 
@@ -942,7 +937,7 @@
 
 					<p id="confreq-rs-pkg-spine-override-first">If more than one override for the same property is
 						specified in a <code>properties</code> attribute, reading systems MUST use only the first
-					value.</p>
+						value.</p>
 				</section>
 			</section>
 
@@ -1123,17 +1118,15 @@
 					<li>
 						<p>
 							<span id="confreq-svg-rs-css">MUST, if it has a [=viewport=], support the visual rendering
-								of SVG using CSS as defined in
-								<a href="https://www.w3.org/TR/SVG/styling.html#">Styling</a> [[svg]]
-							</span>
-							<span id="confreq-svg-rs-css-properties">and it SHOULD support all properties defined in
-								the <a href="https://www.w3.org/TR/SVG/propidx.html#">Property Index</a> [[svg]].
-							</span>
+								of SVG using CSS as defined in <a href="https://www.w3.org/TR/SVG/styling.html#"
+									>Styling</a> [[svg]] </span>
+							<span id="confreq-svg-rs-css-properties">and it SHOULD support all properties defined in the
+									<a href="https://www.w3.org/TR/SVG/propidx.html#">Property Index</a> [[svg]]. </span>
 							<span id="confreq-svg-rs-css-embedded"
-								data-tests="#cnt-svg-css-inclusion,#cnt-svg-css-reference">
-								In the case of embedded SVG, a reading system MUST also conform to the constraints
-								defined in <a href="#sec-xhtml-svg-css"></a>.</span>
-							</p>
+								data-tests="#cnt-svg-css-inclusion,#cnt-svg-css-reference"> In the case of embedded SVG,
+								a reading system MUST also conform to the constraints defined in <a
+									href="#sec-xhtml-svg-css"></a>.</span>
+						</p>
 					</li>
 				</ul>
 			</section>
@@ -1143,7 +1136,7 @@
 
 				<p id="confreq-rs-epub3-css" data-tests="#cnt-css-support" class="support">If a reading system has a
 					[=viewport=], it MUST support the <a data-cite="epub-33#sec-css">visual rendering of XHTML content
-					documents via CSS</a> [[epub-33]].</p>
+						documents via CSS</a> [[epub-33]].</p>
 
 				<p>To support CSS, a reading system:</p>
 
@@ -1285,16 +1278,13 @@
 					<h4>Local storage</h4>
 
 					<p>
-						<span id="confreq-rs-scripted-storage-block">Scripts may save persistent data through
-							<a data-cite="html#dom-document-cookie">cookies</a> and
-							<a data-cite="html#webstorage">web storage</a> [[html]], but reading systems MAY block such
-							attempts.
-						</span>
-						<span id="confreq-rs-scripted-storage-protection">Reading systems that allow users to store
-							data MUST ensure they do not make that data available to other unrelated documents (e.g.,
-							ones that could be spoofed). In particular, checking for a matching document identifier (or
-							similar metadata) is not a valid method to control access to persistent data.
-						</span>
+						<span id="confreq-rs-scripted-storage-block">Scripts may save persistent data through <a
+								data-cite="html#dom-document-cookie">cookies</a> and <a data-cite="html#webstorage">web
+								storage</a> [[html]], but reading systems MAY block such attempts. </span>
+						<span id="confreq-rs-scripted-storage-protection">Reading systems that allow users to store data
+							MUST ensure they do not make that data available to other unrelated documents (e.g., ones
+							that could be spoofed). In particular, checking for a matching document identifier (or
+							similar metadata) is not a valid method to control access to persistent data. </span>
 					</p>
 
 					<p>Reading systems that allow <a data-cite="html#dom-localstorage">local storage</a> [[html]] SHOULD
@@ -1429,7 +1419,8 @@
 				<h3>Fixed-layout documents</h3>
 
 				<p id="confreq-rs-epub3-fxl" data-tests="#fxl-spread-none" class="support">Reading systems MUST support
-					the rendering of <a data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a> [[epub-33]].</p>
+					the rendering of <a data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a>
+					[[epub-33]].</p>
 
 				<section id="sec-fxl-props">
 					<h4>Fixed-layout properties</h4>
@@ -1462,11 +1453,11 @@
 							</dd>
 						</dl>
 
-						<p id="layout-spine-override">When a spine <code>itemref</code> element's
-							<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> contains an
-							<a data-cite="epub-33#layout-overrides">override of the global rendition:layout property</a>
-							[[epub-33]], reading systems MUST follow the requirements for the override's global value
-							when displaying that spine item (e.g., a spine item that specifies
+						<p id="layout-spine-override">When a spine <code>itemref</code> element's <a
+								data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> contains an
+								<a data-cite="epub-33#layout-overrides">override of the global rendition:layout
+								property</a> [[epub-33]], reading systems MUST follow the requirements for the
+							override's global value when displaying that spine item (e.g., a spine item that specifies
 								<code>layout-prepaginated</code> is rendered following the requirements of the global
 								<code>pre-paginated</code> value).</p>
 					</section>
@@ -1551,16 +1542,14 @@
 						<h4>The <code>rendition:page-spread-*</code> properties</h4>
 
 						<p>
-							<span id="page-spread-left" data-tests="#fxl-page-spread-left">The
-								<a data-cite="epub-33#fxl-page-spread-left"><code>rendition:page-spread-left</code>
-								property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in the
-								left-hand slot in the spread.
-							</span>
-							<span id="page-spread-right" data-tests="#fxl-page-spread-right">The
-								<a data-cite="epub-33#fxl-page-spread-right"><code>rendition:page-spread-right</code>
-								property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in the
-								right-hand slot in the spread.
-							</span>
+							<span id="page-spread-left" data-tests="#fxl-page-spread-left">The <a
+									data-cite="epub-33#fxl-page-spread-left"><code>rendition:page-spread-left</code>
+									property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in
+								the left-hand slot in the spread. </span>
+							<span id="page-spread-right" data-tests="#fxl-page-spread-right">The <a
+									data-cite="epub-33#fxl-page-spread-right"><code>rendition:page-spread-right</code>
+									property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in
+								the right-hand slot in the spread. </span>
 						</p>
 
 						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
@@ -1753,8 +1742,8 @@
 					media overlays for [=EPUB content documents=].</p>
 
 				<p id="confreq-rs-xhtml-svg">
-					<span id="mol-xhtml-support">Reading systems MUST support playback for
-						[=XHTML content documents=], and</span>
+					<span id="mol-xhtml-support">Reading systems MUST support playback for [=XHTML content documents=],
+						and</span>
 					<span id="mol-svg-support">MAY support [=SVG content documents=].</span>
 				</p>
 
@@ -1978,9 +1967,9 @@
 						<li>
 							<p id="mol-text-inactive">When a <code>text</code> element becomes inactive in the media
 								overlay, and when it points to embedded video or audio media, that referenced media MUST
-								be reset to its initial "stopped" state, ready to be played from the zero-position within
-								their content stream (possibly displaying the poster image specified using the [[html]]
-								markup).</p>
+								be reset to its initial "stopped" state, ready to be played from the zero-position
+								within their content stream (possibly displaying the poster image specified using the
+								[[html]] markup).</p>
 						</li>
 					</ul>
 				</section>
@@ -2030,11 +2019,10 @@
 					<h5>Escapability</h5>
 
 					<p>
-						<span id="mol-escaping-support">Reading systems SHOULD allow escaping of nested structures.
-						</span>
-						<span id="mol-escaping-structure">Reading systems MUST determine the start of nested
-							structures by the value of the [^/epub:type^] attribute and SHOULD offer users the option
-							to skip playback of that structure and resume with whatever content comes after it.</span>
+						<span id="mol-escaping-support">Reading systems SHOULD allow escaping of nested structures. </span>
+						<span id="mol-escaping-structure">Reading systems MUST determine the start of nested structures
+							by the value of the [^/epub:type^] attribute and SHOULD offer users the option to skip
+							playback of that structure and resume with whatever content comes after it.</span>
 					</p>
 				</section>
 			</section>
@@ -2079,14 +2067,12 @@
 				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
 				<dd>
 					<p>
-						<span id="confreq-rs-vocab-reserved-prefixes">Reading systems MUST resolve all
-							<a data-cite="epub-33#sec-reserved-prefixes">reserved prefixes</a> [[epub-33]] used in
-							package documents using their predefined URLs unless the EPUB creator declares a local
-							<a href="#sec-prefix-attr">prefix</a>.
-						</span>
-						<span id="confreq-rs-vocab-local-prefixes">Reading systems MUST use the URLs defined for
-							locally overridden prefixes (using the <code>prefix</code> attribute) when encountered.
-						</span>
+						<span id="confreq-rs-vocab-reserved-prefixes">Reading systems MUST resolve all <a
+								data-cite="epub-33#sec-reserved-prefixes">reserved prefixes</a> [[epub-33]] used in
+							package documents using their predefined URLs unless the EPUB creator declares a local <a
+								href="#sec-prefix-attr">prefix</a>. </span>
+						<span id="confreq-rs-vocab-local-prefixes">Reading systems MUST use the URLs defined for locally
+							overridden prefixes (using the <code>prefix</code> attribute) when encountered. </span>
 					</p>
 					<p>As changes to the reserved prefixes and updates to reading systems are not always going happen in
 						synchrony, reading systems MUST NOT fail when encountering unrecognized prefixes (i.e., not
@@ -2095,10 +2081,10 @@
 
 				<dt id="sec-prefix-attr">The <code>prefix</code> attribute</dt>
 				<dd>
-					<p id="confreq-rs-vocab-prefix-attr">If the <code>prefix</code> attribute includes a declaration
-						for a <a href="#sec-metadata-reserved-prefixes">predefined prefix</a>, reading systems MUST use
-						the URL mapping defined in the <code>prefix</code> attribute, regardless of whether of it maps
-						to the same URL as the predefined prefix.</p>
+					<p id="confreq-rs-vocab-prefix-attr">If the <code>prefix</code> attribute includes a declaration for
+						a <a href="#sec-metadata-reserved-prefixes">predefined prefix</a>, reading systems MUST use the
+						URL mapping defined in the <code>prefix</code> attribute, regardless of whether of it maps to
+						the same URL as the predefined prefix.</p>
 				</dd>
 
 				<dt id="sec-property-datatype">Expanding <code>property</code> Data Types</dt>
@@ -2108,28 +2094,27 @@
 					<ul>
 						<li>
 							<p id="confreq-rs-vocab-property-reference">If the property consists only of a reference,
-								concatenate the prefix URL associated with the
-								<a data-cite="epub-33#sec-default-vocab">default vocabulary</a> [[epub-33]] to the
-								reference.</p>
+								concatenate the prefix URL associated with the <a data-cite="epub-33#sec-default-vocab"
+									>default vocabulary</a> [[epub-33]] to the reference.</p>
 						</li>
 						<li>
 							<p>
 								<span id="confreq-rs-vocab-property-prefixed">If the property consists of a prefix and
 									reference, concatenate the URL defined for the prefix to the reference.</span>
-								<span id="confreq-rs-vocab-property-invalid-prefix">If the EPUB creator has not
-									defined a matching prefix, and it is not a
-									<a data-cite="epub-33#sec-reserved-prefixes">reserved prefix</a> [[epub-33]],
-									the property is invalid and reading systems MUST ignore it.</span>
+								<span id="confreq-rs-vocab-property-invalid-prefix">If the EPUB creator has not defined
+									a matching prefix, and it is not a <a data-cite="epub-33#sec-reserved-prefixes"
+										>reserved prefix</a> [[epub-33]], the property is invalid and reading systems
+									MUST ignore it.</span>
 							</p>
 						</li>
 						<li>
 							<p id="confreq-rs-vocab-property-only-prefix">If the property consists only of a prefix
 								(i.e., there is no reference after the colon), the property is invalid and reading
-							systems MUST ignore it.</p>
+								systems MUST ignore it.</p>
 						</li>
 					</ul>
-					<p id="confreq-rs-vocab-property-valid-url">If the process does not result in a
-						[=valid URL string=], reading systems MUST ignore the property.</p>
+					<p id="confreq-rs-vocab-property-valid-url">If the process does not result in a [=valid URL
+						string=], reading systems MUST ignore the property.</p>
 					<p>Reading systems do not have to [=url parser | parse the resulting URL=] [[url]] or attempt to
 						dereference the resource.</p>
 				</dd>
@@ -2556,6 +2541,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				</section>
 			</section>
 		</section>
+		<section id="index"></section>
 		<section id="change-log" class="appendix informative">
 			<h2>Change log</h2>
 
@@ -2568,6 +2554,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
+						>issue 2260</a>.</li>
 				<li>31-Mar-2022: Moved custom attribute authoring requirements to the authoring specification. Added
 					reading system handling of custom properties. See <a
 						href="https://github.com/w3c/epub-specs/issues/2134">issue 2134</a>.</li>


### PR DESCRIPTION
Adds the respec-generated index of terms. I don't think this is useful for any of the other specs as they don't add similar numbers of new terms.

Fixes #2260


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 17, 2022, 11:44 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2F452a1385184e18cc485e6f48ae30addb72d41c0a%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/KfgrHj?isPreview=true&publishDate=2022-05-17
ReSpec version: 32.1.6
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 27763ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:244:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232288.)._
</details>
