### PR TITLE
Add test reference for font resources

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1158,9 +1158,10 @@
 								Recommendation</a> status [[w3cprocess]] (and are widely implemented).</p>
 					</li>
 					<li>
-						<p id="confreq-css-rs-fonts">MUST support [[truetype]], [[opentype]], [[woff]] and [[woff2]]
-							font resources referenced from <a data-cite="css-fonts-4#font-face-rule"
-									><code>@font-face</code> rules</a> [[css-fonts-4]].</p>
+						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts">MUST support [[truetype]],
+							[[opentype]], [[woff]] and [[woff2]] font resources referenced from
+							<a data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
+							[[css-fonts-4]].</p>
 					</li>
 					<li>
 						<p id="confreq-css-rs-prefixed"


### PR DESCRIPTION
This corresponds to https://github.com/w3c/epub-tests/pull/144.