### PR TITLE
reorganized section 7.1.2 for issue 2269

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1606,17 +1606,21 @@
 					<dl>
 						<dt>XHTML</dt>
 						<dd>
-							<p>Reading systems MUST use the width and height expressions as defined in <a
-									data-cite="epub-33#sec-fxl-icb-html">Expressing in HTML</a> [[epub-33]] to render
-								[=XHTML content documents=].</p>
-							<p id="confreq-fxl-rs-xhtml-icb" data-tests="#fxl-xhtml-icb">Reading systems MUST clip XHTML
-								content to the initial containing block (ICB) dimensions declared in the
-									<code>viewport</code>
-								<code>meta</code> tag — content positioned outside of the initial containing block will
-								not be visible. When the ICB aspect ratio does not match the aspect ratio of the reading
+							<p>
+								<span id="confreq-fxl-rs-xhtml-icb-def"> Reading systems MUST create the initial containing block (ICB) using the 
+								width and height expressions declared in the <code>viewport</code> <code>meta</code>
+								tag for [=XHTML content documents=], as defined in 
+								<a data-cite="epub-33#sec-fxl-icb-html">Expressing in HTML</a> [[epub-33]].</span>
+								<span id="confreq-fxl-rs-xhtml-icb" data-tests="#fxl-xhtml-icb">They MUST clip content 
+								positioned outside of the ICB.</span>
+							</p>
+
+							<p id="confreq-fxl-rs-xhtml-icb-ratio">
+								When the ICB aspect ratio does not match the aspect ratio of the reading
 								system [=content display area=], reading systems MAY position the ICB inside the area to
 								accommodate the user interface; in other words, added letter-boxing space MAY appear on
-								either side (or both) of the content.</p>
+								either side (or both) of the content.
+							</p>
 						</dd>
 
 						<dt>SVG</dt>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -304,11 +304,11 @@
 
 				<ul>
 					<li id="confreq-rs-xml-lang">the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a>
-							[[xml]] for all XML documents (e.g., the [=package document=], [=XHTML content documents=],
+						[[xml]] for all XML documents (e.g., the [=package document=], [=XHTML content documents=],
 							<a>SVG content documents</a>, and [=media overlay documents=]).</li>
 
-					<li id="confreq-rs-lang-attr">the <code>lang</code> attribute for XHTML content documents and
-						SVG content documents. (Refer to respective "The 'lang' and 'xml:lang' attributes" sections in
+					<li id="confreq-rs-lang-attr">the <code>lang</code> attribute for XHTML content documents and SVG
+						content documents. (Refer to respective "The 'lang' and 'xml:lang' attributes" sections in
 						[[html]] and [[svg]] for more information.)</li>
 				</ul>
 
@@ -322,16 +322,15 @@
 						[=package document=]. (See also <a href="#sec-pkg-doc-base-dir"></a> for further details.)</li>
 					<li id="confreq-rs-html-dir">the [[html]] [^html-global/dir^] attribute for XHTML content
 						documents.</li>
-					<li id="confreq-rs-svg-direction">the [[svg]]
-						<a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"><code>direction</code></a>
+					<li id="confreq-rs-svg-direction">the [[svg]] <a
+							href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"><code>direction</code></a>
 						attribute for SVG content documents.</li>
 				</ul>
 
-				<p id="confreq-rs-pkg-lang-no-content"
-					data-tests="#pkg-lang_but_not_content,#pkg-dir_but_not_content">In the absence of this
-					information in a [=publication resource=], reading systems MUST NOT assume either the the language
-					or the base direction of that resource from information expressed in the package document (i.e., in
-						<a data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
+				<p id="confreq-rs-pkg-lang-no-content" data-tests="#pkg-lang_but_not_content,#pkg-dir_but_not_content"
+					>In the absence of this information in a [=publication resource=], reading systems MUST NOT assume
+					either the the language or the base direction of that resource from information expressed in the
+					package document (i.e., in <a data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
 						data-cite="epub-33#attrdef-dir"><code>dir</code></a> attributes, in <a
 						data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attributes</a> on <span
 						data-cite="epub-33">[^link^]</span> elements, or from [^dc:language^] elements [[epub-33]]).
@@ -789,7 +788,7 @@
 						<p id="confreq-rs-pkg-meta-prefix">If the <code>property</code> attribute's value does not
 							include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading
 							systems MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to
-							<a href="#sec-property-datatype">expand the value</a>.</p>
+								<a href="#sec-property-datatype">expand the value</a>.</p>
 						<p>If a reading system does not recognize the <a data-cite="epub-33#attrdef-scheme"
 									><code>scheme</code> attribute</a> [[epub-33]] value, it SHOULD treat the value of
 							the element as a string.</p>
@@ -798,8 +797,8 @@
 					<dt id="conf-metadata-link">The <code>link</code> element</dt>
 					<dd>
 						<p>Retrieval and support of [=linked resources=] is OPTIONAL.</p>
-						<p id="confreq-rs-pkg-hreflang">The language identified in an
-							<a data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attribute</a> is purely
+						<p id="confreq-rs-pkg-hreflang">The language identified in an <a
+								data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attribute</a> is purely
 							advisory. Upon fetching the resource, a reading system MUST use the language information
 							associated with the resource to determine its language, not the metadata included in the
 							link to the resource.</p>
@@ -817,12 +816,11 @@
 							elements).</p>
 						<p id="confreq-rs-pkg-link-rendering">Reading systems MUST ignore any instructions contained in
 							linked resources related to the layout and rendering of the EPUB publication.</p>
-						<p id="confreq-rs-pkg-link-prefix">If any of the
-							<a data-cite="epub-33#attrdef-link-rel"><code>rel</code></a> or
-							<a data-cite="epub-33#attrdef-properties"><code>properties</code></a> [[epub-33]]
-							attributes' values do not include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a>,
-							reading systems MUST use the prefix URL
-								"<code>http://idpf.org/epub/vocab/package/link/#</code>" to <a
+						<p id="confreq-rs-pkg-link-prefix">If any of the <a data-cite="epub-33#attrdef-link-rel"
+									><code>rel</code></a> or <a data-cite="epub-33#attrdef-properties"
+									><code>properties</code></a> [[epub-33]] attributes' values do not include a <a
+								data-cite="epub-33#property.ebnf.prefix">prefix</a>, reading systems MUST use the prefix
+							URL "<code>http://idpf.org/epub/vocab/package/link/#</code>" to <a
 								href="#sec-property-datatype">expand the values</a>.</p>
 					</dd>
 				</dl>
@@ -842,18 +840,15 @@
 
 				<p>
 					<span id="confreq-rs-pkg-manifest-fallback">A reading system that does not support the MIME media
-						type [[rfc2046]] of a given publication resource MUST traverse the
-						<a data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a> [[epub-33]] until it
-						identifies a supported publication resource to use in place of the unsupported resource.
-					</span>
+						type [[rfc2046]] of a given publication resource MUST traverse the <a
+							data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a> [[epub-33]] until it
+						identifies a supported publication resource to use in place of the unsupported resource. </span>
 					<span id="confreq-rs-pkg-manifest-fallback-order">If the reading system supports multiple
 						publication resources in the fallback chain, it MAY select the resource to use based on the
 						resource's <a data-cite="epub-33#attrdef-item-properties"><code>properties</code> attribute</a>
-						[[epub-33]] values, otherwise it SHOULD honor the EPUB creator's preferred fallback order.
-					</span>
+						[[epub-33]] values, otherwise it SHOULD honor the EPUB creator's preferred fallback order. </span>
 					<span id="confreq-rs-pkg-manifest-fallback-fail">If a reading system does not support any resource
-						in the fallback chain, it MUST alert the reader that it could not display the content.
-					</span>
+						in the fallback chain, it MUST alert the reader that it could not display the content. </span>
 				</p>
 
 				<p>When <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-33]] are provided
@@ -861,8 +856,8 @@
 					the optimal version to render in a given context (e.g., by inspecting the properties attribute for
 					each).</p>
 
-				<p id="confreq-rs-pkg-manifest-fallback-cycle">A reading system MUST terminate the fallback chain at
-					the first reference to a manifest item it has already encountered.</p>
+				<p id="confreq-rs-pkg-manifest-fallback-cycle">A reading system MUST terminate the fallback chain at the
+					first reference to a manifest item it has already encountered.</p>
 
 				<p id="confreq-rs-pkg-manifest-prefix">If any of the <code>properties</code> attribute's values do not
 					include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST
@@ -903,9 +898,9 @@
 					the reading system MUST ignore any directionality computed from <a href="#layout"
 							><code>pre-paginated</code></a> [=XHTML content documents=].</p>
 
-				<p id="confreq-rs-spine-prefix">If any values of the
-					<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> do not include a
-					<a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST use the
+				<p id="confreq-rs-spine-prefix">If any values of the <a data-cite="epub-33#attrdef-properties"
+							><code>properties</code> attribute</a> do not include a <a
+						data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST use the
 					prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
 						href="#sec-property-datatype">expand the values</a>.</p>
 
@@ -929,9 +924,9 @@
 				<section id="spine-overrides">
 					<h4>Spine overrides</h4>
 
-					<p id="confreq-rs-pkg-spine-override">When a spine [^itemref^] element's
-						<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a
-						<a data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
+					<p id="confreq-rs-pkg-spine-override">When a spine [^itemref^] element's <a
+							data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a <a
+							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
 						systems MUST follow the requirements for the override's global value to display that spine
 						item.</p>
 
@@ -942,7 +937,7 @@
 
 					<p id="confreq-rs-pkg-spine-override-first">If more than one override for the same property is
 						specified in a <code>properties</code> attribute, reading systems MUST use only the first
-					value.</p>
+						value.</p>
 				</section>
 			</section>
 
@@ -1123,17 +1118,15 @@
 					<li>
 						<p>
 							<span id="confreq-svg-rs-css" data-tests="#cnt-svg-css">MUST, if it has a [=viewport=],
-								support the visual rendering of SVG using CSS as defined in
-								<a href="https://www.w3.org/TR/SVG/styling.html#">Styling</a> [[svg]]
-							</span>
-							<span id="confreq-svg-rs-css-properties">and it SHOULD support all properties defined in
-								the <a href="https://www.w3.org/TR/SVG/propidx.html#">Property Index</a> [[svg]].
-							</span>
+								support the visual rendering of SVG using CSS as defined in <a
+									href="https://www.w3.org/TR/SVG/styling.html#">Styling</a> [[svg]] </span>
+							<span id="confreq-svg-rs-css-properties">and it SHOULD support all properties defined in the
+									<a href="https://www.w3.org/TR/SVG/propidx.html#">Property Index</a> [[svg]]. </span>
 							<span id="confreq-svg-rs-css-embedded"
-								data-tests="#cnt-svg-css-inclusion,#cnt-svg-css-reference">
-								In the case of embedded SVG, a reading system MUST also conform to the constraints
-								defined in <a href="#sec-xhtml-svg-css"></a>.</span>
-							</p>
+								data-tests="#cnt-svg-css-inclusion,#cnt-svg-css-reference"> In the case of embedded SVG,
+								a reading system MUST also conform to the constraints defined in <a
+									href="#sec-xhtml-svg-css"></a>.</span>
+						</p>
 					</li>
 				</ul>
 			</section>
@@ -1143,7 +1136,7 @@
 
 				<p id="confreq-rs-epub3-css" data-tests="#cnt-css-support" class="support">If a reading system has a
 					[=viewport=], it MUST support the <a data-cite="epub-33#sec-css">visual rendering of XHTML content
-					documents via CSS</a> [[epub-33]].</p>
+						documents via CSS</a> [[epub-33]].</p>
 
 				<p>To support CSS, a reading system:</p>
 
@@ -1159,8 +1152,8 @@
 					</li>
 					<li>
 						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts">MUST support [[truetype]],
-							[[opentype]], [[woff]] and [[woff2]] font resources referenced from
-							<a data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
+							[[opentype]], [[woff]] and [[woff2]] font resources referenced from <a
+								data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
 							[[css-fonts-4]].</p>
 					</li>
 					<li>
@@ -1286,16 +1279,13 @@
 					<h4>Local storage</h4>
 
 					<p>
-						<span id="confreq-rs-scripted-storage-block">Scripts may save persistent data through
-							<a data-cite="html#dom-document-cookie">cookies</a> and
-							<a data-cite="html#webstorage">web storage</a> [[html]], but reading systems MAY block such
-							attempts.
-						</span>
-						<span id="confreq-rs-scripted-storage-protection">Reading systems that allow users to store
-							data MUST ensure they do not make that data available to other unrelated documents (e.g.,
-							ones that could be spoofed). In particular, checking for a matching document identifier (or
-							similar metadata) is not a valid method to control access to persistent data.
-						</span>
+						<span id="confreq-rs-scripted-storage-block">Scripts may save persistent data through <a
+								data-cite="html#dom-document-cookie">cookies</a> and <a data-cite="html#webstorage">web
+								storage</a> [[html]], but reading systems MAY block such attempts. </span>
+						<span id="confreq-rs-scripted-storage-protection">Reading systems that allow users to store data
+							MUST ensure they do not make that data available to other unrelated documents (e.g., ones
+							that could be spoofed). In particular, checking for a matching document identifier (or
+							similar metadata) is not a valid method to control access to persistent data. </span>
 					</p>
 
 					<p>Reading systems that allow <a data-cite="html#dom-localstorage">local storage</a> [[html]] SHOULD
@@ -1430,7 +1420,8 @@
 				<h3>Fixed-layout documents</h3>
 
 				<p id="confreq-rs-epub3-fxl" data-tests="#fxl-spread-none" class="support">Reading systems MUST support
-					the rendering of <a data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a> [[epub-33]].</p>
+					the rendering of <a data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a>
+					[[epub-33]].</p>
 
 				<section id="sec-fxl-props">
 					<h4>Fixed-layout properties</h4>
@@ -1463,11 +1454,11 @@
 							</dd>
 						</dl>
 
-						<p id="layout-spine-override">When a spine <code>itemref</code> element's
-							<a data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> contains an
-							<a data-cite="epub-33#layout-overrides">override of the global rendition:layout property</a>
-							[[epub-33]], reading systems MUST follow the requirements for the override's global value
-							when displaying that spine item (e.g., a spine item that specifies
+						<p id="layout-spine-override">When a spine <code>itemref</code> element's <a
+								data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> contains an
+								<a data-cite="epub-33#layout-overrides">override of the global rendition:layout
+								property</a> [[epub-33]], reading systems MUST follow the requirements for the
+							override's global value when displaying that spine item (e.g., a spine item that specifies
 								<code>layout-prepaginated</code> is rendered following the requirements of the global
 								<code>pre-paginated</code> value).</p>
 					</section>
@@ -1552,16 +1543,14 @@
 						<h4>The <code>rendition:page-spread-*</code> properties</h4>
 
 						<p>
-							<span id="page-spread-left" data-tests="#fxl-page-spread-left">The
-								<a data-cite="epub-33#fxl-page-spread-left"><code>rendition:page-spread-left</code>
-								property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in the
-								left-hand slot in the spread.
-							</span>
-							<span id="page-spread-right" data-tests="#fxl-page-spread-right">The
-								<a data-cite="epub-33#fxl-page-spread-right"><code>rendition:page-spread-right</code>
-								property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in the
-								right-hand slot in the spread.
-							</span>
+							<span id="page-spread-left" data-tests="#fxl-page-spread-left">The <a
+									data-cite="epub-33#fxl-page-spread-left"><code>rendition:page-spread-left</code>
+									property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in
+								the left-hand slot in the spread. </span>
+							<span id="page-spread-right" data-tests="#fxl-page-spread-right">The <a
+									data-cite="epub-33#fxl-page-spread-right"><code>rendition:page-spread-right</code>
+									property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in
+								the right-hand slot in the spread. </span>
 						</p>
 
 						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
@@ -1581,17 +1570,18 @@
 									><code>page-progression-direction</code> attribute</a> [[epub-33]] &#8212; when it
 							lacks a <code>rendition:page-spread-*</code> property value.</p>
 
-						<p id="page-spread-flow" data-tests="#page-layout-both-spread">If the reflowable spine item has a
-								<code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by
-							inserting a blank page).</p>
+						<p id="page-spread-flow" data-tests="#page-layout-both-spread">If the reflowable spine item has
+							a <code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by inserting
+							a blank page).</p>
 
-						<p id="page-spread-both-pre-pag" data-tests="#page-layout-both-spread">Similarly, when a pre-paginated spine item follows a reflowable one, the pre-paginated one
-							SHOULD start on the next page (as defined by the <code>page-progression-direction</code>
-							attribute) when it lacks a <code>rendition:page-spread-*</code> property value.</p> 
-							
-						<p id="page-spread-both-dir" data-tests="#page-layout-both-spread">If the
-							pre-paginated spine item has a <code>rendition:page-spread-*</code> specification, it MUST
-							be honored (e.g., by inserting a blank page).</p>
+						<p id="page-spread-both-pre-pag" data-tests="#page-layout-both-spread">Similarly, when a
+							pre-paginated spine item follows a reflowable one, the pre-paginated one SHOULD start on the
+							next page (as defined by the <code>page-progression-direction</code> attribute) when it
+							lacks a <code>rendition:page-spread-*</code> property value.</p>
+
+						<p id="page-spread-both-dir" data-tests="#page-layout-both-spread">If the pre-paginated spine
+							item has a <code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by
+							inserting a blank page).</p>
 
 						<p id="fxl-page-spread-combined" data-tests="#fxl-page-spread-combined">When a reading system
 							encounters two spine items that represent a true spread (i.e., two adjacent spine items with
@@ -1607,27 +1597,25 @@
 						<dt>XHTML</dt>
 						<dd>
 							<p>
-								<span id="confreq-fxl-rs-xhtml-icb-def"> Reading systems MUST create the initial containing block (ICB) using the 
-								width and height expressions declared in the <code>viewport</code> <code>meta</code>
-								tag for [=XHTML content documents=], as defined in 
-								<a data-cite="epub-33#sec-fxl-icb-html">Expressing in HTML</a> [[epub-33]].</span>
-								<span id="confreq-fxl-rs-xhtml-icb" data-tests="#fxl-xhtml-icb">They MUST clip content 
-								positioned outside of the ICB.</span>
+								<span id="confreq-fxl-rs-xhtml-icb-def"> Reading systems MUST create the initial
+									containing block (ICB) using the width and height expressions declared in the
+										<code>viewport</code>
+									<code>meta</code> tag for [=XHTML content documents=], as defined in <a
+										data-cite="epub-33#sec-fxl-icb-html">Expressing in HTML</a> [[epub-33]].</span>
+								<span id="confreq-fxl-rs-xhtml-icb" data-tests="#fxl-xhtml-icb">They MUST clip content
+									positioned outside of the ICB.</span>
 							</p>
-
-							<p id="confreq-fxl-rs-xhtml-icb-ratio">
-								When the ICB aspect ratio does not match the aspect ratio of the reading
-								system [=content display area=], reading systems MAY position the ICB inside the area to
-								accommodate the user interface; in other words, added letter-boxing space MAY appear on
-								either side (or both) of the content.
-							</p>
+							<p id="confreq-fxl-rs-xhtml-icb-ratio"> When the ICB aspect ratio does not match the aspect
+								ratio of the reading system [=content display area=], reading systems MAY position the
+								ICB inside the area to accommodate the user interface; in other words, added
+								letter-boxing space MAY appear on either side (or both) of the content. </p>
 						</dd>
 
 						<dt>SVG</dt>
 						<dd>
-							<p id="confreq-fxl-rs-svg">Reading systems MUST use the dimensions as defined in <a
-									data-cite="epub-33#sec-fxl-icb-svg">Expressing the ICB in SVG</a> [[epub-33]] to
-								render [=SVG content documents=].</p>
+							<p id="confreq-fxl-rs-svg">Reading systems MUST create the initial containing block (ICB)
+								using the dimensions as defined in <a data-cite="epub-33#sec-fxl-icb-svg">Expressing the
+									ICB in SVG</a> [[epub-33]] to render [=SVG content documents=].</p>
 						</dd>
 					</dl>
 				</section>
@@ -1760,8 +1748,8 @@
 					media overlays for [=EPUB content documents=].</p>
 
 				<p id="confreq-rs-xhtml-svg">
-					<span id="mol-xhtml-support">Reading systems MUST support playback for
-						[=XHTML content documents=], and</span>
+					<span id="mol-xhtml-support">Reading systems MUST support playback for [=XHTML content documents=],
+						and</span>
 					<span id="mol-svg-support">MAY support [=SVG content documents=].</span>
 				</p>
 
@@ -1985,9 +1973,9 @@
 						<li>
 							<p id="mol-text-inactive">When a <code>text</code> element becomes inactive in the media
 								overlay, and when it points to embedded video or audio media, that referenced media MUST
-								be reset to its initial "stopped" state, ready to be played from the zero-position within
-								their content stream (possibly displaying the poster image specified using the [[html]]
-								markup).</p>
+								be reset to its initial "stopped" state, ready to be played from the zero-position
+								within their content stream (possibly displaying the poster image specified using the
+								[[html]] markup).</p>
 						</li>
 					</ul>
 				</section>
@@ -2037,11 +2025,10 @@
 					<h5>Escapability</h5>
 
 					<p>
-						<span id="mol-escaping-support">Reading systems SHOULD allow escaping of nested structures.
-						</span>
-						<span id="mol-escaping-structure">Reading systems MUST determine the start of nested
-							structures by the value of the [^/epub:type^] attribute and SHOULD offer users the option
-							to skip playback of that structure and resume with whatever content comes after it.</span>
+						<span id="mol-escaping-support">Reading systems SHOULD allow escaping of nested structures. </span>
+						<span id="mol-escaping-structure">Reading systems MUST determine the start of nested structures
+							by the value of the [^/epub:type^] attribute and SHOULD offer users the option to skip
+							playback of that structure and resume with whatever content comes after it.</span>
 					</p>
 				</section>
 			</section>
@@ -2086,14 +2073,12 @@
 				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
 				<dd>
 					<p>
-						<span id="confreq-rs-vocab-reserved-prefixes">Reading systems MUST resolve all
-							<a data-cite="epub-33#sec-reserved-prefixes">reserved prefixes</a> [[epub-33]] used in
-							package documents using their predefined URLs unless the EPUB creator declares a local
-							<a href="#sec-prefix-attr">prefix</a>.
-						</span>
-						<span id="confreq-rs-vocab-local-prefixes">Reading systems MUST use the URLs defined for
-							locally overridden prefixes (using the <code>prefix</code> attribute) when encountered.
-						</span>
+						<span id="confreq-rs-vocab-reserved-prefixes">Reading systems MUST resolve all <a
+								data-cite="epub-33#sec-reserved-prefixes">reserved prefixes</a> [[epub-33]] used in
+							package documents using their predefined URLs unless the EPUB creator declares a local <a
+								href="#sec-prefix-attr">prefix</a>. </span>
+						<span id="confreq-rs-vocab-local-prefixes">Reading systems MUST use the URLs defined for locally
+							overridden prefixes (using the <code>prefix</code> attribute) when encountered. </span>
 					</p>
 					<p>As changes to the reserved prefixes and updates to reading systems are not always going happen in
 						synchrony, reading systems MUST NOT fail when encountering unrecognized prefixes (i.e., not
@@ -2102,10 +2087,10 @@
 
 				<dt id="sec-prefix-attr">The <code>prefix</code> attribute</dt>
 				<dd>
-					<p id="confreq-rs-vocab-prefix-attr">If the <code>prefix</code> attribute includes a declaration
-						for a <a href="#sec-metadata-reserved-prefixes">predefined prefix</a>, reading systems MUST use
-						the URL mapping defined in the <code>prefix</code> attribute, regardless of whether of it maps
-						to the same URL as the predefined prefix.</p>
+					<p id="confreq-rs-vocab-prefix-attr">If the <code>prefix</code> attribute includes a declaration for
+						a <a href="#sec-metadata-reserved-prefixes">predefined prefix</a>, reading systems MUST use the
+						URL mapping defined in the <code>prefix</code> attribute, regardless of whether of it maps to
+						the same URL as the predefined prefix.</p>
 				</dd>
 
 				<dt id="sec-property-datatype">Expanding <code>property</code> Data Types</dt>
@@ -2115,28 +2100,27 @@
 					<ul>
 						<li>
 							<p id="confreq-rs-vocab-property-reference">If the property consists only of a reference,
-								concatenate the prefix URL associated with the
-								<a data-cite="epub-33#sec-default-vocab">default vocabulary</a> [[epub-33]] to the
-								reference.</p>
+								concatenate the prefix URL associated with the <a data-cite="epub-33#sec-default-vocab"
+									>default vocabulary</a> [[epub-33]] to the reference.</p>
 						</li>
 						<li>
 							<p>
 								<span id="confreq-rs-vocab-property-prefixed">If the property consists of a prefix and
 									reference, concatenate the URL defined for the prefix to the reference.</span>
-								<span id="confreq-rs-vocab-property-invalid-prefix">If the EPUB creator has not
-									defined a matching prefix, and it is not a
-									<a data-cite="epub-33#sec-reserved-prefixes">reserved prefix</a> [[epub-33]],
-									the property is invalid and reading systems MUST ignore it.</span>
+								<span id="confreq-rs-vocab-property-invalid-prefix">If the EPUB creator has not defined
+									a matching prefix, and it is not a <a data-cite="epub-33#sec-reserved-prefixes"
+										>reserved prefix</a> [[epub-33]], the property is invalid and reading systems
+									MUST ignore it.</span>
 							</p>
 						</li>
 						<li>
 							<p id="confreq-rs-vocab-property-only-prefix">If the property consists only of a prefix
 								(i.e., there is no reference after the colon), the property is invalid and reading
-							systems MUST ignore it.</p>
+								systems MUST ignore it.</p>
 						</li>
 					</ul>
-					<p id="confreq-rs-vocab-property-valid-url">If the process does not result in a
-						[=valid URL string=], reading systems MUST ignore the property.</p>
+					<p id="confreq-rs-vocab-property-valid-url">If the process does not result in a [=valid URL
+						string=], reading systems MUST ignore the property.</p>
 					<p>Reading systems do not have to [=url parser | parse the resulting URL=] [[url]] or attempt to
 						dereference the resource.</p>
 				</dd>


### PR DESCRIPTION
Implementing the consensus reached in #2269. In doing so, I have also added an `@id` value for the first MUST statement in view of an upcoming test, as well to the second paragraph for a possible test (it is a _MAY_, so there may not be an extra test).

Fix #2269

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/editorial/icb-normative-statements-issue2269/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/editorial/icb-normative-statements-issue2269/epub33/rs/index.html)
