### PR TITLE
Fix references to html spec that collide with local element names

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -905,10 +905,8 @@
 						one of two ways: using the capabilities of the host format or via manifest fallbacks.</p>
 
 					<p>The preferred method is to use the fallback capabilities of the host format. Many HTML elements,
-						for example, have intrinsic fallback capabilities. One example is the <a data-lt="picture"
-								><code>picture</code> element</a> [[html]], which allows EPUB creators to specify
-						multiple alternative image formats.</p>
-
+						for example, have intrinsic fallback capabilities. One example is the [^picture^]
+						element [[html]], which allows EPUB creators to specify multiple alternative image formats.</p>
 					<p>If an intrinsic fallback method is not available, it is also possible to use manifest fallbacks,
 						but this method, as <a href="#caution-fallbacks">cautioned against</a> in the previous section,
 						is discouraged. For more information about foreign resources, refer to <a
@@ -921,7 +919,7 @@
 					<p>Exempt resources tend to address specific cases for which there are no core media types defined,
 						but for which providing a fallback would prove cumbersome or unnecessary. These include
 						embedding video, adding accessibility tracks, and linking to resources from the [[html]] <a
-							data-lt="link"><code>link</code> element</a>.</p>
+							data-cite="html#the-link-element"><code>link</code></a> element.</p>
 
 					<p>Refer to <a href="#sec-exempt-resources"></a> for more information about these exceptions.</p>
 
@@ -1213,16 +1211,15 @@
 
 					<dt id="exempt-links">Linked resources</dt>
 					<dd id="confreq-resources-cd-fallback-link">
-						<p>Any resource referenced from the [[html]] <a data-lt="link"><code>link</code> element</a>
-							that is not already a core media type resource (e.g., CSS style sheets) is an exempt
-							resource.</p>
+						<p>Any resource referenced from the [[html]] <a data-cite="html#the-link-element"
+									><code>link</code></a> element that is not already a core media type resource (e.g.,
+							CSS style sheets) is an exempt resource.</p>
 					</dd>
 
 					<dt id="exempt-track">Tracks</dt>
 					<dd id="confreq-resources-cd-fallback-track">
 						<p>All audio and video tracks (e.g., [[?webvtt]] captions, subtitles and descriptions)
-							referenced from the [[html]] <a data-lt="track"><code>track</code> element</a> are exempt
-							resources.</p>
+							referenced from the [[html]] [^track^] element are exempt resources.</p>
 					</dd>
 
 					<dt id="exempt-video">Video</dt>
@@ -1311,10 +1308,10 @@
 						<dd>
 							<div class="note">
 								<p>The original purpose for content fallbacks was to specify fallback images for the
-									[[html]] <a data-lt="img"><code>img</code> element</a>. As HTML now has intrinsic
-									fallback mechanism for images, the use of content fallbacks is strongly discouraged.
-									EPUB creators should always use the intrinsic fallback capabilities of [[html]] and
-									[[svg]] to provide fallback content.</p>
+									[[html]] [^img^] element. As HTML now has intrinsic fallback mechanism for images,
+									the use of content fallbacks is strongly discouraged. EPUB creators should always
+									use the intrinsic fallback capabilities of [[html]] and [[svg]] to provide fallback
+									content.</p>
 							</div>
 							<p>EPUB creators MUST provide a content fallback for [=foreign resources=] when the elements
 								that reference them do not have intrinsic fallback capabilities. In this case, the
@@ -1344,8 +1341,9 @@
 						<h5>HTML <code>audio</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-media">EPUB creators MUST NOT use embedded [[html]] <a>flow
-								content</a> within the [^audio^] element as an intrinsic fallback for foreign resources.
-							Only child [^source^] elements [[html]] provide intrinsic fallback capabilities.</p>
+								content</a> within the <a data-cite="html#the-audio-element"><code>audio</code></a>
+							element as an intrinsic fallback for foreign resources. Only child [^source^]
+							elements [[html]] provide intrinsic fallback capabilities.</p>
 
 						<p>Only older reading systems that do not recognize the <code>audio</code> element (e.g., EPUB 2
 							reading systems) will render the embedded content. When reading systems support the
@@ -1364,21 +1362,19 @@
 						<h5>HTML <code>img</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that EPUB creators can
-							specify in the [[html]] <a data-lt="img"><code>img</code> element</a>, the following
-							fallback conditions apply to its use:</p>
-
+							specify in the [[html]] [^img^] element, the following fallback conditions apply to its
+							use:</p>
 						<ul>
 							<li>
-								<p>If it is the child of a <a data-lt="picture"><code>picture</code> element</a>:</p>
+								<p>If it is the child of a [^picture^] element:</p>
 								<ul>
 									<li>it MUST reference core media type resources from its <code>src</code> and
 											<code>srcset</code> attributes, when EPUB creators specify those attributes;
 										and</li>
-									<li>each sibling <a data-lt="source"><code>source</code> element</a> MUST reference
-										a core media type resource from its <code>[^source/src^]</code> and
-											<code>[^source/srcset^]</code> attributes unless it specifies the MIME media
-										type [[rfc2046]] of a foreign resource in its <code>[^source/type^]</code>
-										attribute.</li>
+									<li>each sibling [^source^] element MUST reference a core media type resource from
+										its <code>[^source/src^]</code> and <code>[^source/srcset^]</code> attributes
+										unless it specifies the MIME media type [[rfc2046]] of a foreign resource in its
+											<code>[^source/type^]</code> attribute.</li>
 								</ul>
 							</li>
 
@@ -1425,8 +1421,9 @@
 				</div>
 
 				<aside class="example" title="Referencing a container resource">
-					<p>In this example, the audio file referenced from the [[html]] <a data-lt="audio"
-								><code>audio</code> element</a> is located inside the [=EPUB container=].</p>
+					<p>In this example, the audio file referenced from the [[html]] <a
+							data-cite="html#the-audio-element"><code>audio</code></a> element is located inside the
+						[=EPUB container=].</p>
 					<pre>&lt;html …>
    …
    &lt;body>
@@ -1440,8 +1437,8 @@
 				</aside>
 
 				<aside class="example" title="Referencing a remote resource">
-					<p>In this example, the audio file referenced from the [[html]] <a data-lt="audio"
-								><code>audio</code> element</a> is hosted on the web.</p>
+					<p>In this example, the audio file referenced from the [[html]] <a
+							data-cite="html#the-audio-element"><code>audio</code></a> element is hosted on the web.</p>
 					<pre>&lt;html …>
    …
    &lt;body>
@@ -1472,7 +1469,7 @@
 					</li>
 					<li>
 						<p>in the <code>href</code> attribute on [[html]] or [[svg]] <code>a</code> elements (except
-							when inside an <a data-lt="iframe"><code>iframe</code> element</a> [[html]]);</p>
+							when inside an [^iframe^] element [[html]]);</p>
 					</li>
 					<li>
 						<p>in the <code>href</code> attribute on [[html]] <code>area</code> elements (except when inside
@@ -5668,9 +5665,9 @@ No Entry</pre>
 						<p>EPUB creators MAY use the [^/epub:type^] attribute in <a>XHTML content documents</a> to
 							express <a href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
-						<p>As the [[html]] <a data-lt="head"><code>head</code> element</a> contains metadata for the
-							document, structural semantics expressed on this element or any descendant of it have no
-							meaning.</p>
+						<p>As the [[html]] <a data-cite="html#the-head-element"><code>head</code></a> element contains
+							metadata for the document, structural semantics expressed on this element or any descendant
+							of it have no meaning.</p>
 					</section>
 
 					<section id="sec-xhtml-rdfa">
@@ -5829,11 +5826,10 @@ No Entry</pre>
 						<section id="sec-xhtml-deviations-rp">
 							<h6>The <code>rp</code> element</h6>
 
-							<p id="confreq-html-vocab-rp">The [[html]] <a data-lt="rp"><code>rp</code> element</a> is
-								intended to provide a fallback for older [=reading systems=] that do not recognize ruby
-								markup (i.e., a parenthesis display around <code>ruby</code> markup). As EPUB 3 reading
-								systems are ruby-aware, and can provide fallbacks, EPUB creators should not use
-									<code>rp</code> elements.</p>
+							<p id="confreq-html-vocab-rp">The [[html]] [^rp^] element is intended to provide a fallback
+								for older [=reading systems=] that do not recognize ruby markup (i.e., a parenthesis
+								display around <code>ruby</code> markup). As EPUB 3 reading systems are ruby-aware, and
+								can provide fallbacks, EPUB creators should not use <code>rp</code> elements.</p>
 						</section>
 
 						<section id="sec-xhtml-deviations-embed">
@@ -5843,8 +5839,8 @@ No Entry</pre>
 									element</a> element does not include intrinsic facilities to provide fallback
 								content for reading systems that do not support scripting, [=EPUB creators=] are
 								discouraged from using the element when the referenced resource includes scripting. The
-								[[html]] <a data-lt="object"><code>object</code> element</a> is a better alternative, as
-								it includes intrinsic fallback capabilities.</p>
+								[[html]] [^object^] element is a better alternative, as it includes intrinsic fallback
+								capabilities.</p>
 						</section>
 					</section>
 				</section>
@@ -5921,7 +5917,8 @@ No Entry</pre>
 							<ul class="conformance-list">
 								<li>
 									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[html]] <a>flow
-											content</a> or exactly one [[html]] [^body^] element.</p>
+											content</a> or exactly one [[html]] <a data-cite="html#the-body-element"
+												><code>body</code></a> element.</p>
 									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
 											<code>body</code> element is not permitted per the <a data-cite="html#svg-0"
 											>restrictions on SVG</a> defined in [[html]].</p>
@@ -6115,8 +6112,8 @@ No Entry</pre>
 
 						<div class="note">
 							<p>Scripts may execute in other contexts, but reading system support for these contexts is
-								optional. For example, a scripted SVG document may be referenced from an [[html]] <a
-									data-lt="object"><code>object</code> element</a>.</p>
+								optional. For example, a scripted SVG document may be referenced from an [[html]]
+								[^object^] element.</p>
 							<p>Refer to the <a data-cite="epub-rs-33#sec-scripted-content">processing of scripts</a>
 								[[epub-rs-33]] for more information.</p>
 						</div>
@@ -8582,13 +8579,12 @@ No Entry</pre>
 								<code>src</code> attributes and the [^seq^] elements' <code>epub:textref</code>
 							attrbutes. For example, when referencing [[html]] elements, if the finest level of markup is
 							at the paragraph level, then that is the finest possible level for media overlay
-							synchronization. Likewise, if sub-paragraph markup is available, such as [[html]] <a
-								data-lt="span"><code>span</code> element</a> representing phrases or sentences, then
-							finer granularity is possible in the media overlay. Finer granularity gives users more
-							precise results for synchronized playback when navigating by word or phrase and when
-							searching the text but increases the file size of the media overlay documents. Fragment
-							identifier schemes that do not rely on the presence of elements could provide even finer
-							granularity, where supported.</p>
+							synchronization. Likewise, if sub-paragraph markup is available, such as [[html]] [^span^]
+							element representing phrases or sentences, then finer granularity is possible in the media
+							overlay. Finer granularity gives users more precise results for synchronized playback when
+							navigating by word or phrase and when searching the text but increases the file size of the
+							media overlay documents. Fragment identifier schemes that do not rely on the presence of
+							elements could provide even finer granularity, where supported.</p>
 					</section>
 
 					<section id="sec-embedded-media">
@@ -10751,9 +10747,10 @@ html.my-document-playing * {
 					<dt><code>style.css</code></dt>
 					<dd>
 						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[html]]
-								<a data-lt="link"><code>link</code> element</a>. It is a [=publication resource=] on the
-							[=manifest plane=], a [=container resource=], is not present on the <a>spine plane</a>, and
-							is a [=core media type resource=] on the [=content plane=]. No fallback is necessary.</p>
+								<a data-cite="html#the-link-element"><code>link</code></a> element. It is a
+							[=publication resource=] on the [=manifest plane=], a [=container resource=], is not present
+							on the <a>spine plane</a>, and is a [=core media type resource=] on the [=content plane=].
+							No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.otf</code></dt>
@@ -10784,30 +10781,28 @@ html.my-document-playing * {
 					<dt><code>speech/cmn.pls</code></dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
-							from an [[html]] <a data-lt="link"><code>link</code> element</a>. It is a <a>publication
-								resource</a> on the [=manifest plane=], a [=container resource=], not present on the
-							[=spine plane=], and is an [=exempt resource=] on the [=content plane=]. No fallback is
-							necessary.</p>
+							from an [[html]] <a data-cite="html#the-link-element"><code>link</code></a> element. It is a
+								<a>publication resource</a> on the [=manifest plane=], a [=container resource=], not
+							present on the [=spine plane=], and is an [=exempt resource=] on the [=content plane=]. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_1.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[html]] <a data-lt="img"><code>img</code> element</a>. It is a [=publication resource=] on
-							the [=manifest plane=], a [=container resource=], is not present on the <a>spine plane</a>,
-							and is a [=core media type resource=] on the [=content plane=]. No fallback is
-							necessary.</p>
+							[[html]] [^img^] element. It is a [=publication resource=] on the [=manifest plane=], a
+							[=container resource=], is not present on the <a>spine plane</a>, and is a [=core media type
+							resource=] on the [=content plane=]. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_2.png</code></dt>
 					<dd>
-						<p>The resource is a PNG image file. It is referenced via an [[html]] <a data-lt="a"
-									><code>a</code> element</a>. Because it is referenced from a hyperlink, it
-								<em>must</em> be listed in the spine. It is a [=publication resource=] on the [=manifest
-							plane=], a [=container resource=], a [=foreign content document=] on the [=spine plane=],
-							and a [=core media type resource=] on the [=content plane=]. As a [=foreign content
-							document=] a fallback is required, which is provided via a <a href="#sec-manifest-fallbacks"
-								>manifest fallback</a>.</p>
+						<p>The resource is a PNG image file. It is referenced via an [[html]] [^a^] element. Because it
+							is referenced from a hyperlink, it <em>must</em> be listed in the spine. It is a
+							[=publication resource=] on the [=manifest plane=], a [=container resource=], a [=foreign
+							content document=] on the [=spine plane=], and a [=core media type resource=] on the
+							[=content plane=]. As a [=foreign content document=] a fallback is required, which is
+							provided via a <a href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
 					<dt><code>image_desc.xhtml</code></dt>
@@ -10823,39 +10818,37 @@ html.my-document-playing * {
 					<dt><code>image/image_3.heic</code></dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
-							referenced from an [[html]] <a data-lt="source"><code>source</code> element</a>. Its media
-							type is not listed as a <a href="#sec-core-media-types">core media type</a>. It is a
-							[=publication resource=] on the [=manifest plane=], a [=container resource=], is not present
-							on the [=spine plane=], and is a [=foreign resource=] on the <a>content plane</a>. As a
-							[=foreign resource=], a fallback is required, which is provided via the sibling [[html]] <a
-								data-lt="img"><code>img</code> element</a> in an [[html]] <a data-lt="picture"
-									><code>picture</code> element</a>.</p>
+							referenced from an [[html]] [^source^] element. Its media type is not listed as a <a
+								href="#sec-core-media-types">core media type</a>. It is a [=publication resource=] on
+							the [=manifest plane=], a [=container resource=], is not present on the [=spine plane=], and
+							is a [=foreign resource=] on the <a>content plane</a>. As a [=foreign resource=], a fallback
+							is required, which is provided via the sibling [[html]] [^img^] element in an [[html]]
+							[^picture^] element.</p>
 					</dd>
 
 					<dt><code>image/image_3.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[html]] <a data-lt="img"><code>img</code> element</a> that is used as an intrinsic fallback
-							of the [[html]] <a data-lt="picture"><code>picture</code> element</a>. It is a [=publication
-							resource=] on the [=manifest plane=], a [=container resource=], is not present on the
-							[=spine plane=], and is a [=core media type resource=] on the [=content plane=]. No fallback
-							is necessary.</p>
+							[[html]] [^img^] element that is used as an intrinsic fallback of the [[html]] [^picture^]
+							element. It is a [=publication resource=] on the [=manifest plane=], a [=container
+							resource=], is not present on the [=spine plane=], and is a [=core media type resource=] on
+							the [=content plane=]. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>widget.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
-							[[html]] <a data-lt="iframe"><code>iframe</code> element</a>. It is a <a>publication
-								resource</a> on the [=manifest plane=], a [=container resource=], is not present on
-							[=spine plane=], and, because it is "used" when rendering another EPUB content document, a
-							[=core media type resource=] on the [=content plane=]. No fallback is necessary.</p>
+							[[html]] [^iframe^] element. It is a <a>publication resource</a> on the [=manifest plane=],
+							a [=container resource=], is not present on [=spine plane=], and, because it is "used" when
+							rendering another EPUB content document, a [=core media type resource=] on the [=content
+							plane=]. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>https://www.example.org/some_content</code></dt>
 					<dd>
-						<p>The resource is referenced via an [[html]] <a data-lt="a"><code>a</code> element</a> and is
-							not stored in the [=EPUB container=]. Reading systems will normally open this link via a
-							separate browser instance. It is not on any planes defined by this specification.</p>
+						<p>The resource is referenced via an [[html]] [^a^] element and is not stored in the [=EPUB
+							container=]. Reading systems will normally open this link via a separate browser instance.
+							It is not on any planes defined by this specification.</p>
 					</dd>
 				</dl>
 


### PR DESCRIPTION
This reverts to using the `<a data-cite="...">` syntax for HTML elements with the same names as ones in our spec (`head`, `body`, `link`, and `audio` - we don't reference `meta`).

I also found a few instances of `data-cite` still being used for elements, so I've switched those to the `[^...^]` syntax.

This is a workaround for #2293, so leaving that issue open.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 17, 2022, 11:33 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2F452a1385184e18cc485e6f48ae30addb72d41c0a%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/wVoKWL?isPreview=true&publishDate=2022-05-17
ReSpec version: 32.1.6
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 27495ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:244:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232294.)._
</details>
