### PR TITLE
Remove redundant paragraph about spine overrides from layout property definition

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1453,14 +1453,6 @@
 									rendering.</p>
 							</dd>
 						</dl>
-
-						<p id="layout-spine-override">When a spine <code>itemref</code> element's <a
-								data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> contains an
-								<a data-cite="epub-33#layout-overrides">override of the global rendition:layout
-								property</a> [[epub-33]], reading systems MUST follow the requirements for the
-							override's global value when displaying that spine item (e.g., a spine item that specifies
-								<code>layout-prepaginated</code> is rendered following the requirements of the global
-								<code>pre-paginated</code> value).</p>
 					</section>
 
 					<section id="orientation">


### PR DESCRIPTION
Fixes #2279 