### PR TITLE
Privacy and security changes

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1854,7 +1854,7 @@
 
 			<ul>
 				<li>18-May-2022: Updated privacy and security recommendations to use normative language.</li>
-				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
+				<li id="crs-05-22">17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>
 				<li>12-Apr-2022: Restored recommendation to include links to all reproduced pages in the page list and
 					added a requirement to link to all page break markers to address concerns with the previous change.

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1640,7 +1640,7 @@
 					accessibility by activating a feature that would normally not be active.</p>
 			</div>
 		</section>
-		<section id="privacy" class="informative">
+		<section id="privacy">
 			<h2>Privacy and security</h2>
 
 			<p>The authoring of accessible content does not introduce any new privacy or security considerations for
@@ -1656,16 +1656,16 @@
 					>reading systems</a>, bookstores and any other interface that can build a profile of the user, on
 				the other hand, has the potential to violate individual privacy laws. While it might seem helpful to
 				store and anticipate the type of content a user is most likely to consume, for example, or how best to
-				initiate its playback, developers should not engage in such profiling unless explicit permission is
+				initiate its playback, developers SHOULD NOT engage in such profiling unless explicit permission is
 				obtained from the user and a means of easily removing the profile is available.</p>
 
 			<p>Even in the case where a user assents to the application maintaining information about their
-				accessibility needs, developers must ensure that this information is kept private (e.g., it must not be
-				shared with third party advertisers or even with the original publisher).</p>
+				accessibility needs, developers SHOULD ensure that this information is kept private (e.g., not share the
+				information with third party advertisers or even with the original publisher).</p>
 
-			<p>Developers should also be mindful about storing or mining information about the types of searches a user
-				performs when searching for content based on its accessibility characteristics. This information can be
-				used to indirectly profile the abilities of users.</p>
+			<p>Developers SHOULD NOT store or mine information about the types of searches a user performs when
+				searching for content based on its accessibility characteristics. This information can be used to
+				indirectly profile the abilities of users.</p>
 		</section>
 		<section id="app-a11y-vocab" class="appendix vocab">
 			<h2>EPUB accessibility vocabulary</h2>
@@ -1853,6 +1853,7 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>18-May-2022: Updated privacy and security recommendations to use normative language.</li>
 				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>
 				<li>12-Apr-2022: Restored recommendation to include links to all reproduced pages in the page list and

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9232,10 +9232,10 @@ html.my-document-playing * {
 					reference the latest accessibility requirements).</p>
 			</div>
 		</section>
-		<section id="sec-security-privacy" class="informative">
+		<section id="sec-security-privacy">
 			<h2>Security and privacy</h2>
 
-			<section id="security-privacy-overview">
+			<section id="security-privacy-overview" class="informative">
 				<h3>Overview</h3>
 
 				<p>The particularity of an [=EPUB publication=] is its structure. The EPUB format provides a means of
@@ -9257,7 +9257,7 @@ html.my-document-playing * {
 				</div>
 			</section>
 
-			<section id="epub-threat-model">
+			<section id="epub-threat-model" class="informative">
 				<h3>Threat model</h3>
 
 				<p>EPUB publications pose a variety of privacy and security threats to unsuspecting users. Many of these
@@ -9392,7 +9392,7 @@ html.my-document-playing * {
 				<h3>Recommendations</h3>
 
 				<p>Although EPUB creators cannot prevent every method of exploiting users, they are ultimately
-					responsible for the secure construction of their content. That means that they should take
+					responsible for the secure construction of their content. That means that they need to take
 					precautions to limit the exposure of their EPUB publications to the types of <a
 						href="#epub-threat-model">malicious exploits</a> described in the previous section.</p>
 
@@ -9414,27 +9414,27 @@ html.my-document-playing * {
 				</ul>
 
 				<p>EPUB creators also need to consider the privacy rights of users and avoid situations where they are
-					intentionally collecting data. Ideally, EPUB creators should not track their users, but this is not
+					intentionally collecting data. Ideally, EPUB creators SHOULD NOT track their users, but this is not
 					realistic for all types of publishing.</p>
 
-				<p>When tracking must occur, EPUB creators should obtain the approval of the user to collect information
-					prior to opening the EPUB publication (e.g., in educational course work). If this is not possible,
-					they should obtain permission when users access the EPUB publication for the first time. EPUB
-					creators should also allow users to opt out of tracking, when feasible, and provide users the
-					ability to manage and delete any data that is collected about them.</p>
+				<p>When EPUB creators have to track users, they SHOULD obtain the approval of the user to collect
+					information prior to opening the EPUB publication (e.g., in educational course work). If this is not
+					possible, they SHOULD obtain permission when users access the EPUB publication for the first time.
+					EPUB creators SHOULD also allow users to opt out of tracking, and provide users the ability to
+					manage and delete any data that is collected about them.</p>
 
-				<p>Content authors also need to consider the inadvertent collection of information about users. Linking
-					to content on a publisher's web site, or remotely hosting resources on their servers, can lead to
+				<p>Content authors also SHOULD avoid inadvertent collection of information about users. Linking to
+					content on a publisher's web site, or remotely hosting resources on their servers, can lead to
 					profiling users, especially if unique tracking identifiers are added to the URLs.</p>
 
-				<p>When publishers and vendors must use digital rights management schemes, they should prefer schemes
+				<p>When publishers and vendors have to use digital rights management schemes, they SHOULD prefer schemes
 					that do not utilize or transmit information about the user or their content to external parties to
 					perform encryption or decryption.</p>
 
 				<p>EPUB creators who want to maximally limit the privacy and security issues in their EPUB publications
-					should work to make the content as self-contained as possible. An EPUB publication that comes with
-					all its needed resources and has no dependencies on network access or links to external content not
-					only benefits users but reduces future maintenance and improves archivability.</p>
+					SHOULD make the content as self-contained as possible. An EPUB publication that comes with all its
+					needed resources and has no dependencies on network access or links to external content not only
+					benefits users but reduces future maintenance and improves archivability.</p>
 			</section>
 		</section>
 		<section id="app-overview-unsupported" class="appendix">
@@ -11503,6 +11503,7 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>18-May-2022: Updated privacy and security recommendations to use normative language.</li>
 				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>
 				<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and updated

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11519,7 +11519,7 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
-				<li>31-May-2022: Updated privacy and security recommendations to use normative language.</li>
+				<li id="crs-05-22">31-May-2022: Updated privacy and security recommendations to use normative language.</li>
 				<li>27-May-2022: Added recommendation to only reference remote resources via https. See <a
 						href="https://github.com/w3c/epub-specs/issues/2263">issue 2263</a>.</li>
 				<li>20-May-2022: Add recommendation not to store sensitive user data in persistent storage, and to

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2575,7 +2575,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<li>31-May-2022: Noted that unsigned EPUB publications represent a security risk and added
 					recommendation to treat sideloaded unsigned publications as untrusted. See <a
 						href="https://github.com/w3c/epub-specs/issues/2265">issue 2265</a>.</li>
-				<li>31-May-2022: Updated privacy and security recommendations to use normative language.</li>
+				<li id="crs-05-22">31-May-2022: Updated privacy and security recommendations to use normative language.</li>
 				<li>27-May-2022: Added reading system conformance section. See <a
 						href="https://github.com/w3c/epub-specs/issues/2271">issue 2271</a>.</li>
 				<li>27-May-2022: Added recommendation to only load remote resources referenced via https. See <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -354,7 +354,7 @@
 					are not vulnerable to attacks. More information about these risks is provided in <a
 						href="#sec-security-privacy"></a>.</p>
 
-				<p>If reading system developers allow network access, it is strongly RECOMMENDED both that they:</p>
+				<p>If reading system developers allow network access, it is RECOMMENDED both that they:</p>
 
 				<ul>
 					<li>notify users when network activity occurs; and</li>
@@ -1730,8 +1730,8 @@
 					media overlays for [=EPUB content documents=].</p>
 
 				<p id="confreq-rs-xhtml-svg">
-					<span id="mol-xhtml-support" data-tests="#mol-css">Reading systems MUST support playback for
-						[=XHTML content documents=], and</span>
+					<span id="mol-xhtml-support" data-tests="#mol-css">Reading systems MUST support playback for [=XHTML
+						content documents=], and</span>
 					<span id="mol-svg-support">MAY support [=SVG content documents=].</span>
 				</p>
 
@@ -1764,12 +1764,12 @@
 				<section id="sec-rsconf-rendering-audio">
 					<h5>Rendering audio</h5>
 
-					<p id="mol-audio" data-tests="#mol-audio">When presented with a media overlay
-						<a data-cite="epub-33#elemdef-smil-audio"><code>audio</code> element</a>, reading systems MUST play
-						the audio resource referenced by the <code>src</code> attribute, starting at the clip offset time
-						given by the <a data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code> attribute</a> and
-						ending at the clip offset time given by the
-						<a data-cite="epub-33#attrdef-smil-clipEnd"><code>clipEnd</code> attribute</a> [[epub-33]].</p>
+					<p id="mol-audio" data-tests="#mol-audio">When presented with a media overlay <a
+							data-cite="epub-33#elemdef-smil-audio"><code>audio</code> element</a>, reading systems MUST
+						play the audio resource referenced by the <code>src</code> attribute, starting at the clip
+						offset time given by the <a data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code>
+							attribute</a> and ending at the clip offset time given by the <a
+							data-cite="epub-33#attrdef-smil-clipEnd"><code>clipEnd</code> attribute</a> [[epub-33]].</p>
 
 					<p>In addition:</p>
 
@@ -1829,13 +1829,13 @@
 				<section id="sec-rsconf-navigation">
 					<h5>Navigation</h5>
 
-					<p id="mol-navigation" data-tests="#mol-navigation">Because the media overlay is closely linked to the
-						[=EPUB content document=], it is very easy for reading systems to locate a position in the EPUB
-						content document based on the current position in the media overlay playback. If the user pauses
-						synchronized playback and navigates to a different part of the [=EPUB publication=], synchronized
-						playback MUST resume at that point. For example, if a specific page number in the EPUB content
-						document is the desired location, then this same point is located in the media overlay and playback
-						started there.</p>
+					<p id="mol-navigation" data-tests="#mol-navigation">Because the media overlay is closely linked to
+						the [=EPUB content document=], it is very easy for reading systems to locate a position in the
+						EPUB content document based on the current position in the media overlay playback. If the user
+						pauses synchronized playback and navigates to a different part of the [=EPUB publication=],
+						synchronized playback MUST resume at that point. For example, if a specific page number in the
+						EPUB content document is the desired location, then this same point is located in the media
+						overlay and playback started there.</p>
 
 					<p>This same approach allows for synchronizing the media overlay playback with user selection of a
 						navigation point in the [=EPUB navigation document=]. The reading system loads the media overlay
@@ -2300,12 +2300,12 @@
 					and the method of reading it are connected. In these cases, the reading system SHOULD identify the
 					data being collected, how it is used, and allow for user opt-outs (retailers may choose to inform
 					users by other means, however, such as when a user creates an account on their web site).
-					Anonymization of any collected data is strongly RECOMMENDED for the privacy and the security of the
-					user and reading system.</p>
+					Anonymization of any collected data is RECOMMENDED for the privacy and the security of the user and
+					reading system.</p>
 
 				<p>It is also understood that user data may be required or helpful for some reading system affordances.
-					In these cases, anonymization is also strongly RECOMMENDED. Reading systems also SHOULD inform users
-					of what data is needed, what it is to be used for, and to provide methods to opt-out.</p>
+					In these cases, anonymization is also RECOMMENDED. Reading systems also SHOULD inform users of what
+					data is needed, what it is to be used for, and to provide methods to opt-out.</p>
 
 				<p>Content processors &#8212; defined as entities that handle the ingestion of EPUB content for
 					distribution, display, or sale &#8212; also need to be aware of the potential risks in ingestion. It

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1152,8 +1152,8 @@
 					</li>
 					<li>
 						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts">MUST support [[truetype]],
-							[[opentype]], [[woff]], and [[woff2]] font resources referenced from
-							<a data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
+							[[opentype]], [[woff]], and [[woff2]] font resources referenced from <a
+								data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
 							[[css-fonts-4]].</p>
 					</li>
 					<li>
@@ -2183,10 +2183,10 @@
 			<p>The DAISY Consortium maintains an <a href="https://epubtest.org/test-books">accessibility test suite</a>
 				to aid in evaluating these issues and more.</p>
 		</section>
-		<section id="sec-security-privacy" class="informative">
+		<section id="sec-security-privacy">
 			<h2>Security and privacy</h2>
 
-			<section id="security-privacy-overview">
+			<section id="security-privacy-overview" class="informative">
 				<h3>Overview</h3>
 
 				<p>The particularity of an [=EPUB publication=] is its structure. The EPUB format provides a means of
@@ -2208,13 +2208,14 @@
 				</div>
 			</section>
 
-			<section id="epub-threat-model">
+			<section id="epub-threat-model" class="informative">
 				<h3>Threat model</h3>
 
 				<p>The greatest threats to users come from the <a data-cite="epub-33#epub-threat-model">content they
 						read</a> [[epub-33]], and the first line of defense against these attacks is the reading systems
 					they use. Users expect that reading systems act as safeguards against malicious content and are
-					often unaware that EPUB publications are susceptible to the same security risks as web sites.</p>
+					often unaware that [=EPUB publications=] are susceptible to the same security risks as web
+					sites.</p>
 
 				<p>But although reading systems are relied on to provide security and privacy, they can also pose
 					unintended threats to users depending on how information is handled. Tracking user information to
@@ -2238,6 +2239,9 @@
 					<dd>
 						<p>EPUB publications may contain resources designed to exploit security flaws in reading systems
 							or the operating systems they run on.</p>
+						<p>The lack of a standard method of signing EPUB publications means that reading systems cannot
+							always verify whether the content has been tampered with between authoring and loading in
+							the device.</p>
 					</dd>
 
 					<dt>Remote resources</dt>
@@ -2300,28 +2304,32 @@
 
 				<p>The strongest measure that reading system developers can take for privacy is to specify the data they
 					intend to collect and use about the user and/or their reading behavior and seek the consent of users
-					to obtain it. They should also allow personalization and control over this information.</p>
+					to obtain it. They SHOULD also allow personalization and control over this information.</p>
 
 				<p>If a reading system allows users to store persistent data, especially personally identifiable
-					information, it must treat that data as sensitive.</p>
+					information, it SHOULD treat that data as sensitive and not allow access to it by third parties.</p>
 
 				<p>It is understood that the collection of some user data may be required for the sale, delivery, and
 					operation of an EPUB publication, particularly on platforms where the sale of an EPUB publication
-					and the method of reading it are connected. In these cases, it is recommended that the reading
-					system or retailer be clear about the data being collected, how it is used, and allow for user
-					opt-outs where possible. Anonymization of data is strongly recommended for the privacy and the
-					security of the user and reading system.</p>
+					and the method of reading it are connected. In these cases, the reading system SHOULD identify the
+					data being collected, how it is used, and allow for user opt-outs (retailers may choose to inform
+					users by other means, however, such as when a user creates an account on their web site).
+					Anonymization of any collected data is strongly RECOMMENDED for the privacy and the security of the
+					user and reading system.</p>
 
 				<p>It is also understood that user data may be required or helpful for some reading system affordances.
-					In these cases, anonymization is strongly recommended. It is also recommended that reading systems
-					inform users of what data is needed, what it is to be used for, and to provide methods to
-					opt-out.</p>
+					In these cases, anonymization is also strongly RECOMMENDED. Reading systems also SHOULD inform users
+					of what data is needed, what it is to be used for, and to provide methods to opt-out.</p>
 
 				<p>Content processors &#8212; defined as entities that handle the ingestion of EPUB content for
-					distribution, display, or sale &#8212; should also be aware of the potential risks in ingestion. It
+					distribution, display, or sale &#8212; also need to be aware of the potential risks in ingestion. It
 					is advised that content processors check content for malicious content on ingestion, in addition to
 					the validation steps that usually occur. This could include running virus scans, validating external
 					links and remote resources, and other precautions.</p>
+
+				<p>Reading systems that allow users to load untrustworthy EPUB publications (e.g., unsigned EPUB
+					publications through the process of "sideloading") SHOULD treat such content as insecure (e.g.,
+					prompt users to allow scripting and network access).</p>
 			</section>
 		</section>
 		<section id="app-epubReadingSystem">
@@ -2552,6 +2560,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>18-May-2022: Updated privacy and security recommendations to use normative language.</li>
 				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>
 				<li>31-Mar-2022: Moved custom attribute authoring requirements to the authoring specification. Added

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2560,6 +2560,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>18-May-2022: Noted that unsigned EPUB publications represent a security risk and added
+					recommendation to treat sideloaded unsigned publications as untrusted. See <a
+						href="https://github.com/w3c/epub-specs/issues/2265">issue 2265</a>.</li>
 				<li>18-May-2022: Updated privacy and security recommendations to use normative language.</li>
 				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>


### PR DESCRIPTION
This pull request comes from a response from @iherman to the email from @npdoty recorded in the chairs mailing list. His suggestion was to potentially make the privacy and security sections normative but ensure that they are only recommendations (almost all were).

I've gone through the three REC track documents and fixed them so that all applicable recommendations are now normative.

We will probably want to discuss this with the WG on a call before making this change, though.

The PR also fixes #2265 by noting under the malicious content heading that because we don't have a standard means of signing publications there isn't always a way to verify the integrity. I've also added a pargraph to the end of the recommendations to say that reading systems should treat unsigned content loaded by the user as untrustworthy. Improvements to the text welcome.

(If we decide not to incorporate the first part, I'll split the second out, but they're tightly bound to each other until we know which direction we're taking.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 7, 2022, 12:46 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2F31b6584ae7edce3d941a9d88e019bcf757ea9db5%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/a51ive?isPreview=true&publishDate=2022-06-07
ReSpec version: 32.1.8
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 27539ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:247:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232297.)._
</details>
