### PR TITLE
Add recommendations to use https for remote resources

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1270,7 +1270,6 @@
 					automatically becomes exempt from fallbacks.</p>
 			</section>
 
-
 			<section id="sec-resource-fallbacks">
 				<h4>Resource fallbacks</h4>
 
@@ -1385,6 +1384,7 @@
 					</section>
 				</section>
 			</section>
+
 			<section id="sec-resource-locations">
 				<h4>Resource locations</h4>
 
@@ -1410,6 +1410,11 @@
 
 				<p>Storing all resources inside the EPUB container is strongly encouraged whenever possible as it allows
 					users access to the entire presentation regardless of connectivity status.</p>
+
+				<p>When resources have to be located outside the EPUB container, EPUB creators are strongly RECOMMENDED
+					to securely reference them via the <code>https</code> URI scheme [rfc7230] to limit the threat of
+					exposing their publications, and users, to network attacks. Reading systems may not load remote
+					resources referenced using insecure schemes such as <code>http</code>.</p>
 
 				<p>These rules for locating publication resource apply regardless of whether the given resource is a
 					[=core media type resource=] or a [=foreign resource=].</p>
@@ -11503,6 +11508,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>19-May-2022: Added recommendation to only reference remote resources via https. See <a
+						href="https://github.com/w3c/epub-specs/issues/2263">issue 2263</a>.</li>
 				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>
 				<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and updated

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1411,8 +1411,8 @@
 				<p>Storing all resources inside the EPUB container is strongly encouraged whenever possible as it allows
 					users access to the entire presentation regardless of connectivity status.</p>
 
-				<p>When resources have to be located outside the EPUB container, EPUB creators are strongly RECOMMENDED
-					to reference them via the secure <code>https</code> URI scheme [rfc7230] to limit the threat of
+				<p>When resources have to be located outside the EPUB container, EPUB creators are RECOMMENDED to
+					reference them via the secure <code>https</code> URI scheme [rfc7230] to limit the threat of
 					exposing their publications, and users, to network attacks. Reading systems might not load remote
 					resources referenced using insecure schemes such as <code>http</code>.</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1412,7 +1412,7 @@
 					users access to the entire presentation regardless of connectivity status.</p>
 
 				<p>When resources have to be located outside the EPUB container, EPUB creators are strongly RECOMMENDED
-					to securely reference them via the <code>https</code> URI scheme [rfc7230] to limit the threat of
+					to reference them via the secure <code>https</code> URI scheme [rfc7230] to limit the threat of
 					exposing their publications, and users, to network attacks. Reading systems might not load remote
 					resources referenced using insecure schemes such as <code>http</code>.</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1413,7 +1413,7 @@
 
 				<p>When resources have to be located outside the EPUB container, EPUB creators are strongly RECOMMENDED
 					to securely reference them via the <code>https</code> URI scheme [rfc7230] to limit the threat of
-					exposing their publications, and users, to network attacks. Reading systems may not load remote
+					exposing their publications, and users, to network attacks. Reading systems might not load remote
 					resources referenced using insecure schemes such as <code>http</code>.</p>
 
 				<p>These rules for locating publication resource apply regardless of whether the given resource is a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -259,6 +259,9 @@
 
 				<p id="confreq-rs-remote">Reading systems SHOULD support [=remote resources=], as defined in <a
 						data-cite="epub-33#sec-resource-locations">Resource locations</a> [[epub-33]].</p>
+
+				<p>To limit the risk of network attacks, reading systems SHOULD only load remote resources referenced
+					via the <code>https</code> URI scheme [[rfc7230]].</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-data-urls">
@@ -2544,6 +2547,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>19-May-2022: Added recommendation to only load remote resources referenced via https. See <a
+						href="https://github.com/w3c/epub-specs/issues/2263">issue 2263</a>.</li>
 				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>
 				<li>31-Mar-2022: Moved custom attribute authoring requirements to the authoring specification. Added

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -357,7 +357,7 @@
 					are not vulnerable to attacks. More information about these risks is provided in <a
 						href="#sec-security-privacy"></a>.</p>
 
-				<p>If reading system developers allow network access, it is strongly RECOMMENDED both that they:</p>
+				<p>If reading system developers allow network access, it is RECOMMENDED both that they:</p>
 
 				<ul>
 					<li>notify users when network activity occurs; and</li>
@@ -1155,8 +1155,8 @@
 					</li>
 					<li>
 						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts">MUST support [[truetype]],
-							[[opentype]], [[woff]], and [[woff2]] font resources referenced from
-							<a data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
+							[[opentype]], [[woff]], and [[woff2]] font resources referenced from <a
+								data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
 							[[css-fonts-4]].</p>
 					</li>
 					<li>


### PR DESCRIPTION
Adds authoring recommendation to reference resources via https to limit possibility of network attacks and adds reading system recommendation to only load remote resources referenced via https.
		
This could lead to warnings in existing content, but in this case I think there's a strong security basis for making the change. I don't get the impression that publishers actually use a lot of remote resources, either, but we should discuss this in a WG meeting before merging.

Fixes #2263


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 27, 2022, 1:45 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2Ff74eb6516d2662915e58a809eee6591eb2725261%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/iYt5U4?isPreview=true&publishDate=2022-05-27
ReSpec version: 32.1.7
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 27830ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:244:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232299.)._
</details>
