### PR TITLE
Updates to persistent storage security

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9432,10 +9432,11 @@ html.my-document-playing * {
 						storage</a> [[?html]]), EPUB creators need to consider to potential for data theft by other EPUB
 					publications on a reading system. Although [[epub-rs-33]] introduces a <a
 						data-cite="epub-rs-33#sec-container-iri">unique origin requirement</a> for EPUB publications,
-					which limits the potential for attacks, older reading systems may allow all EPUB publications access
-					to the same persistent storage. Consequently, EPUB creators SHOULD NOT store sensitive user data in
-					persistent storage. If EPUB creators must store sensitive data, they SHOULD consider encrypting the
-					data to prevent trivial access to it in the case of an exploit.</p>
+					which limits the potential for attacks, there is still a risk that reading systems will allow EPUB
+					publications access to shared persistent storage (e.g., older reading systems that have not been
+					updated and non-conforming newer reading systems). Consequently, EPUB creators SHOULD NOT store
+					sensitive user data in persistent storage. If EPUB creators must store sensitive data, they SHOULD
+					encrypt the data to prevent trivial access to it in the case of an exploit.</p>
 
 				<p>When publishers and vendors must use digital rights management schemes, they should prefer schemes
 					that do not utilize or transmit information about the user or their content to external parties to

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9423,9 +9423,19 @@ html.my-document-playing * {
 					creators should also allow users to opt out of tracking, when feasible, and provide users the
 					ability to manage and delete any data that is collected about them.</p>
 
-				<p>Content authors also need to consider the inadvertent collection of information about users. Linking
-					to content on a publisher's web site, or remotely hosting resources on their servers, can lead to
+				<p>EPUB creators also need to consider the inadvertent collection of information about users. Linking to
+					content on a publisher's web site, or remotely hosting resources on their servers, can lead to
 					profiling users, especially if unique tracking identifiers are added to the URLs.</p>
+
+				<p>When collecting and storing user information within an EPUB publication (e.g., through the use of <a
+						data-cite="html#dom-document-cookie">cookies</a> and <a data-cite="html#webstorage">web
+						storage</a> [[?html]]), EPUB creators need to consider to potential for data theft by other EPUB
+					publications on a reading system. Although [[epub-rs-33]] introduces a <a
+						data-cite="epub-rs-33#sec-container-iri">unique origin requirement</a> for EPUB publications,
+					which limits the potential for attacks, older reading systems may allow all EPUB publications access
+					to the same persistent storage. Consequently, EPUB creators SHOULD NOT store sensitive user data in
+					persistent storage. If EPUB creators must store sensitive data, they SHOULD consider encrypting the
+					data to prevent trivial access to it in the case of an exploit.</p>
 
 				<p>When publishers and vendors must use digital rights management schemes, they should prefer schemes
 					that do not utilize or transmit information about the user or their content to external parties to
@@ -11503,6 +11513,9 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>20-May-2022: Add recommendation not to store sensitive user data in persistent storage, and to
+					encrypt it if there is no other choice. See <a href="https://github.com/w3c/epub-specs/issues/2264"
+						>issue 2264</a>.</li>
 				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>
 				<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and updated

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1152,8 +1152,8 @@
 					</li>
 					<li>
 						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts">MUST support [[truetype]],
-							[[opentype]], [[woff]], and [[woff2]] font resources referenced from
-							<a data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
+							[[opentype]], [[woff]], and [[woff2]] font resources referenced from <a
+								data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
 							[[css-fonts-4]].</p>
 					</li>
 					<li>
@@ -1278,15 +1278,9 @@
 				<section id="sec-local-storage">
 					<h4>Local storage</h4>
 
-					<p>
-						<span id="confreq-rs-scripted-storage-block">Scripts may save persistent data through <a
-								data-cite="html#dom-document-cookie">cookies</a> and <a data-cite="html#webstorage">web
-								storage</a> [[html]], but reading systems MAY block such attempts. </span>
-						<span id="confreq-rs-scripted-storage-protection">Reading systems that allow users to store data
-							MUST ensure they do not make that data available to other unrelated documents (e.g., ones
-							that could be spoofed). In particular, checking for a matching document identifier (or
-							similar metadata) is not a valid method to control access to persistent data. </span>
-					</p>
+					<p id="confreq-rs-scripted-storage-block">Reading systems MAY block scripts from saving persistent
+						data through <a data-cite="html#dom-document-cookie">cookies</a> and <a
+							data-cite="html#webstorage">web storage</a> [[html]].</p>
 
 					<p>Reading systems that allow <a data-cite="html#dom-localstorage">local storage</a> [[html]] SHOULD
 						provide methods for users to inspect or delete that data.</p>
@@ -2544,6 +2538,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>20-May-2022: Removed the recommendation to prevent access to persistent storage from "unrelated
+					documents". This recommendation conflicts with, and is made redundant by, the unique origin
+					requirement introduced in this revision. See <a href="https://github.com/w3c/epub-specs/issues/2264"
+						>issue 2264</a>.</li>
 				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>
 				<li>31-Mar-2022: Moved custom attribute authoring requirements to the authoring specification. Added


### PR DESCRIPTION
This pull request removes the recommendation about limiting access to persistent storage from "unrelated documents" since the unique origin requirement already prevents other epub publications from accessing this data. (Note that this deletes a test id. Not sure if the test would be useful to keep for the unique origin requirement?)

Although I think this is sufficient for reading systems, I've also added a new paragraph to the security section in the core specification to make epub creators aware that older reading systems are susceptible to exploits. It recommends not storing sensitive user data in persistent storage, but if there is no other option then the data should be encrypted to prevent trivial access to the information. Feedback welcome on whether this is sufficient, or if we should be saying something more or something else.

Fixes #2264


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 22, 2022, 10:14 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2F08e20987af5472c4adac0705e4cc866cbff52c35%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/fPU5fW?isPreview=true&publishDate=2022-05-22
ReSpec version: 32.1.6
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 27624ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:244:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232301.)._
</details>
