### PR TITLE
Clarify escapability requirements for reading systems

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2021,7 +2021,7 @@
 							the option to leave ("escape") <a data-cite="epub-33#sec-escapability">escapable
 								structures</a> [[epub-33]], which are determined by the presence of an [^/epub:type^]
 							attribute [[epub-33]] with a value from the escapable structures list.</span>
-						<span id="mol-escaping-structure">If the currently-playing element or an ancestor is an
+						<span id="mol-escaping-structure">If the currently playing element or an ancestor is an
 							escapable structure, and the user opts to escape out of it, then the reading system MUST
 							continue playback with the next sequential element after the escapable structure.</span>
 					</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1152,8 +1152,8 @@
 					</li>
 					<li>
 						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts">MUST support [[truetype]],
-							[[opentype]], [[woff]], and [[woff2]] font resources referenced from
-							<a data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
+							[[opentype]], [[woff]], and [[woff2]] font resources referenced from <a
+								data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
 							[[css-fonts-4]].</p>
 					</li>
 					<li>
@@ -2017,10 +2017,13 @@
 					<h5>Escapability</h5>
 
 					<p>
-						<span id="mol-escaping-support">Reading systems SHOULD allow escaping of nested structures. </span>
-						<span id="mol-escaping-structure">Reading systems MUST determine the start of nested structures
-							by the value of the [^/epub:type^] attribute and SHOULD offer users the option to skip
-							playback of that structure and resume with whatever content comes after it.</span>
+						<span id="mol-escaping-support">While playing media overlays, reading systems SHOULD offer users
+							the option to leave ("escape") <a data-cite="epub-33#sec-escapability">escapable
+								structures</a> [[epub-33]], which are determined by the presence of an [^/epub:type^]
+							attribute [[epub-33]] with a value from the escapable structures list.</span>
+						<span id="mol-escaping-structure">If the currently-playing element or an ancestor is an
+							escapable structure, and the user opts to escape out of it, then the reading system MUST
+							continue playback with the next sequential element after the escapable structure.</span>
 					</p>
 				</section>
 			</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2021,9 +2021,9 @@
 							the option to leave ("escape") <a data-cite="epub-33#sec-escapability">escapable
 								structures</a> [[epub-33]], which are determined by the presence of an [^/epub:type^]
 							attribute [[epub-33]] with a value from the escapable structures list.</span>
-						<span id="mol-escaping-structure">If the currently playing element or an ancestor is an
-							escapable structure, and the user opts to escape out of it, then the reading system MUST
-							continue playback with the next sequential element after the escapable structure.</span>
+						<span id="mol-escaping-structure">If a user opts to escape from an escapable structure, then the
+							reading system MUST continue playback with the next sequential element after the
+							structure.</span>
 					</p>
 				</section>
 			</section>


### PR DESCRIPTION
This pull request adds the text in https://github.com/w3c/epub-specs/issues/2284#issuecomment-1130260537 with the tweak in https://github.com/w3c/epub-specs/issues/2284#issuecomment-1132868661

Fixes #2284 

EPUB Reading Systems 3.3:
- [Preview](https://raw.githack.com/w3c/epub-specs/fix/issue-2284/epub33/rs/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/fix/issue-2284/epub33/rs/index.html)
