### PR TITLE
Add reading system conformance section

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -225,12 +225,16 @@
 			<p>Whether a reading system has to support a feature is mentioned at the beginning of its section. To be
 				conformant with this specification, reading systems MUST support all required features as well as all
 				applicable conditionally-required features (e.g., to support image rendering if the reading system has a
-				[=viewport=]).</p>
+				[=viewport=]) as defined in their respective sections.</p>
 
-			<p>When support for a feature is only recommended, reading system developers can typically ignore all the
-				normative statements in its section. In some cases, however, there may be alternative requirements when
-				not implementing a feature (e.g., to <a href="#confreq-rs-scripted-flbk">process fallbacks</a> when
-				scripting is not supported).</p>
+			<p>When supporting recommended and optional features, reading systems MUST meet all normative requirements
+				as defined in their respective sections.</p>
+
+			<p>When reading system developers opt not to support a recommended or optional feature, it does not always
+				mean none of the normative requirements of the section apply. In some cases, there may be alternative
+				requirements when not implementing a feature (e.g., to <a href="#confreq-rs-scripted-flbk">process
+					fallbacks</a> when scripting is not supported). Reading systems MUST meet these alternative
+				requirements when not supporting a feature.</p>
 
 			<div class="note">
 				<p>EPUB publications typically contain more information than there are support requirements for in this

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -224,7 +224,7 @@
 
 			<p>Whether a reading system has to support a feature is mentioned at the beginning of its section. To be
 				conformant with this specification, reading systems MUST support all required features as well as all
-				applicable conditionally-required features (e.g., to support image rendering if the reading system has a
+				applicable conditionally required features (e.g., to support image rendering if the reading system has a
 				[=viewport=]).</p>
 
 			<p>When support for a feature is only recommended, reading system developers can typically ignore all the

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -219,6 +219,25 @@
 				</section>
 			</section>
 		</section>
+		<section id="sec-rs-conformance">
+			<h3>Reading system conformance</h3>
+
+			<p>Whether a reading system has to support a feature is mentioned at the beginning of its section. To be
+				conformant with this specification, reading systems MUST support all required features as well as all
+				applicable conditionally-required features (e.g., to support image rendering if the reading system has a
+				[=viewport=]).</p>
+
+			<p>When support for a feature is only recommended, reading system developers can typically ignore all the
+				normative statements in its section. In some cases, however, there may be alternative requirements when
+				not implementing a feature (e.g., to <a href="#confreq-rs-scripted-flbk">process fallbacks</a> when
+				scripting is not supported).</p>
+
+			<div class="note">
+				<p>EPUB publications typically contain more information than there are support requirements for in this
+					specification (e.g., [=package document=] metadata). Reading systems may use this additional
+					information for any purposes (e.g., to improve the user interface).</p>
+			</div>
+		</section>
 		<section id="sec-pub-resources">
 			<h3>Publication resource processing</h3>
 
@@ -1152,8 +1171,8 @@
 					</li>
 					<li>
 						<p id="confreq-css-rs-fonts" data-tests="#cnt-css-fonts">MUST support [[truetype]],
-							[[opentype]], [[woff]], and [[woff2]] font resources referenced from
-							<a data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
+							[[opentype]], [[woff]], and [[woff2]] font resources referenced from <a
+								data-cite="css-fonts-4#font-face-rule"><code>@font-face</code> rules</a>
 							[[css-fonts-4]].</p>
 					</li>
 					<li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -233,7 +233,7 @@
 				scripting is not supported).</p>
 
 			<div class="note">
-				<p>EPUB publications typically contain more information than there are support requirements for in this
+				<p>EPUB publications frequently contain information not required by this
 					specification (e.g., [=package document=] metadata). Reading systems may use this additional
 					information for any purposes (e.g., to improve the user interface).</p>
 			</div>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2563,6 +2563,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>20-May-2022: Added reading system conformance section. See <a
+						href="https://github.com/w3c/epub-specs/issues/2271">issue 2271</a>.</li>
 				<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260"
 						>issue 2260</a>.</li>
 				<li>31-Mar-2022: Moved custom attribute authoring requirements to the authoring specification. Added


### PR DESCRIPTION
May be stating the obvious by adding this, but probably better to err on the side of clarity:

- states that all required and conditionally required features must be met to be conformant
- for recommended feature, processing can typically be ignored, but not always (e.g., scripting has fallback requirements when not supporting)

Addresses part of #2271 but not going to close that issue automatically.

EPUB Reading Systems 3.3:
- [Preview](https://raw.githack.com/w3c/epub-specs/feature/rs-conformance/epub33/rs/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/feature/rs-conformance/epub33/rs/index.html)
