### PR TITLE
Add test reference for XHTML MOL support

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1740,8 +1740,8 @@
 					media overlays for [=EPUB content documents=].</p>
 
 				<p id="confreq-rs-xhtml-svg">
-					<span id="mol-xhtml-support">Reading systems MUST support playback for [=XHTML content documents=],
-						and</span>
+					<span id="mol-xhtml-support" data-tests="#mol-css">Reading systems MUST support playback for
+						[=XHTML content documents=], and</span>
 					<span id="mol-svg-support">MAY support [=SVG content documents=].</span>
 				</p>
 


### PR DESCRIPTION
This is an existing test; IMO it's good enough for this basic requirement:

https://w3c.github.io/epub-specs/epub33/rs/#mol-xhtml-support
> Reading systems MUST support playback for XHTML content documents.

Let me know if you think it needs a separate test.