### PR TITLE
Updated accessModeSufficient technique for single values

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -222,10 +222,10 @@
 				<p>The access modes sufficient to consume an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication"
 						>EPUB publication</a> express a broader picture of the potential usability than do the <a
 						href="#meta-001">basic access modes</a>. Where the basic access modes identify the default
-					nature of the media used in the publication, sufficient access modes identify which modes, or sets
-					of modes, a user requires to read the publication. Sufficient access modes account for the
-					affordances and adaptations that have been provided, allowing a user to determine whether the
-					content will be usable regardless of its default nature.</p>
+					nature of the media used in the publication, sufficient access modes identify all the individual
+					modes, and sets of modes, that allow a user to read a publication. Sufficient access modes account
+					for the affordances and adaptations that the EPUB creators has provided, allowing users to determine
+					whether they can the read content regardless of its default nature.</p>
 
 				<p>Sufficient access modes are identified in the [[schema-org]] <a
 						href="https://schema.org/accessModeSufficient"><code>accessModeSufficient</code> property</a>.
@@ -234,7 +234,7 @@
 				<p>For example, consider an EPUB publication that contains graphics and charts, as well as descriptions
 					for all these images. The publication has both textual and visual content, so the <a
 						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> will include the following
-					metadata entries to indicate this:</p>
+						<code>schema:accessMode</code> metadata entries to indicate this:</p>
 
 				<pre>&lt;meta
     property="schema:accessMode">
@@ -246,22 +246,19 @@
 &lt;/meta></pre>
 
 				<p>This metadata does not make clear whether a textual access mode is sufficient to read the entire
-					publication, or whether a visual one is, only that two modes are required by default. This
-					discrepancy is why sufficiency is also important to know.</p>
+					publication, or whether a visual one is, only that the user requires the ability to read in those
+					two modes by default. This discrepancy is why sufficiency is also important to know.</p>
 
-				<p>The first set of sufficiency metadata the EPUB creator inputs will establish the textual and visual
-					requirement:</p>
+				<p>The most strongly recommended sufficient access modes to list are the ones that consist of only a
+					single value. Users seeking alternatives to the default encoding of the information typically want
+					to read the content without switching reading modes (e.g., they want a purely textual alternative to
+					use text-to-speech playback or an auditory alternative to listen to prerecorded narration). Listing
+					the single value sets allows users to easily determine whether a publication will meet their reading
+					needs.</p>
 
-				<pre>&lt;meta
-    property="schema:accessModeSufficient">
-   textual,visual
-&lt;/meta></pre>
-
-				<p>The order in which the access modes are listed is not important. The only requirement is that they be
-					separated by commas.</p>
-
-				<p>Since the EPUB creator has also included descriptions for all the images, the EPUB creator can also
-					indicate that a purely textual access mode is sufficient to read the content:</p>
+				<p>Since the EPUB creator has also included descriptions for all the images in the example publication,
+					the metadata can also indicate that a purely textual access mode is sufficient to read the
+					content:</p>
 
 				<pre>&lt;meta
     property="schema:accessModeSufficient">
@@ -269,16 +266,38 @@
 &lt;/meta></pre>
 
 				<p>Without this metadata, users would not have known that they could read the publication only via its
-					text content.</p>
+					textual content.</p>
+
+				<p>It is important to emphasize when listing individual values in the
+						<code>schema:accessModeSufficient</code> property not to simply restate each individual access
+					mode. When adding a <code>schema:accessModeSufficient</code> property with only a single value,
+						<strong>all information</strong> in the publication must be available in that mode.</p>
+
+				<p>For example, the EPUB creator would not declare a sufficient access mode of "<code>visual</code>" for
+					the example publication as the information is not entirely available in image-based form. (Photo
+					books without text would be examples of works with a purely visual sufficient access mode.)</p>
+
+				<p>EPUB creators may also list any sets of sufficient access modes that allow full access to the
+					information. As the most typical set of values is the combination of all the access modes, however,
+					the information this provides users is less helpful in determining the usability of a
+					publication.</p>
+
+				<p>For example, the metadata the EPUB creator inputs for the example publication re-establishes that
+					there is a textual and visual requirement:</p>
+
+				<pre>&lt;meta
+    property="schema:accessModeSufficient">
+   textual,visual
+&lt;/meta></pre>
 
 				<div class="note">
-					<p>A sufficient access mode of "<code>visual</code>" is not provided as the content is not entirely
-						image-based. Textual content is considered a separate mode as it can be read both visually and
-						aurally (text-to-speech). Photo books without text would be examples of works with a purely
-						visual sufficient access mode.</p>
+					<p>The order in which EPUB creators list the access modes in a set is not important. The only
+						requirement is to separate the values by commas.</p>
 				</div>
 
-				<p>The full set of entries in this example is as follows:</p>
+
+				<p>The complete set of <code>schema:accessMode</code> and <code>schema:accessModeSufficient</code>
+					entries for the example publication is as follows:</p>
 
 				<pre>&lt;meta
     property="schema:accessMode">
@@ -2169,13 +2188,15 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>24-May-2022: Prioritized single-value <code>accessModeSufficient</code> declarations. See <a
+						href="https://github.com/w3c/epub-specs/issues/2302">issue 2302</a>.</li>
 				<li>07-Apr-2022: Added techniques for addressing synchronized text-audio playback objectives using media
 					overlays. See <a href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>
 				<li>10-Nov-2021: Added techniques for setting language in the package document. See <a
 						href="https://github.com/w3c/epub-specs/issues/1842">issue 1842</a>.</li>
 				<li>25-Oct-2021: Removed the generic technique labels for each section. See <a
 						href="https://github.com/w3c/epub-specs/issues/1866">issue 1866</a>.</li>
-				<li>29-Sep-2021: Added <a href="#titles-003">TITLES-003</a> to explain that headings only have to be
+				<li>29-Sep-2021: Added <a href="#titles-003">new technique</a> to explain that headings only have to be
 					unique, not define the topic or purpose of a section. See <a
 						href="https://github.com/w3c/epub-specs/issues/1810">issue 1810</a>.</li>
 				<li>10-June-2021: Clarified the technique on meaningful sequence that it applies to content that spans

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -224,8 +224,8 @@
 						href="#meta-001">basic access modes</a>. Where the basic access modes identify the default
 					nature of the media used in the publication, sufficient access modes identify all the individual
 					modes, and sets of modes, that allow a user to read a publication. Sufficient access modes account
-					for the affordances and adaptations that the EPUB creators has provided, allowing users to determine
-					whether they can the read content regardless of its default nature.</p>
+					for the affordances and adaptations that the EPUB creators have provided, allowing users to
+					determine whether they can the read content regardless of its default nature.</p>
 
 				<p>Sufficient access modes are identified in the [[schema-org]] <a
 						href="https://schema.org/accessModeSufficient"><code>accessModeSufficient</code> property</a>.
@@ -283,7 +283,7 @@
 					publication.</p>
 
 				<p>For example, the metadata the EPUB creator inputs for the example publication re-establishes that
-					there is a textual and visual requirement:</p>
+					there is a textual and visual reading option:</p>
 
 				<pre>&lt;meta
     property="schema:accessModeSufficient">


### PR DESCRIPTION
I've updated the accessModeSufficient technique in this pull request to emphasize that the single-value AMS sets are the most important to list. I've also noted that you don't just list all the access modes as AMS single values.

Since AMS is only a recommended property, I've strongly recommended the single values and said that you may also list any sets of multiple values (but this will typically only be a rehash of the access modes). Is this acceptable, or should we strongly recommend single values and "regularly" recommend the multi-value sets?

/cc @madeleinerothberg

Fixes #2303 

EPUB Accessibility Techniques 1.1:
- [Preview](https://raw.githack.com/w3c/epub-specs/a11y/issue-2302/epub33/a11y-tech/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/a11y/issue-2302/epub33/a11y-tech/index.html)
