### PR TITLE
Add technique for media overlays and access modes

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -357,8 +357,7 @@
 						would only declare the following sufficient access modes: "<code>textual</code>",
 							"<code>auditory</code>, and "<code>textual,visual</code>".</p>
 
-					<p>It would <strong>not</strong> declare: "<code>textual</code>", "<code>auditory</code>",
-							"<code>textual,auditory</code>", "<code>textual,visual</code>", and
+					<p>It would <strong>not</strong> declare "<code>textual,auditory</code>" or
 							"<code>textual,visual,auditory</code>".</p>
 				</div>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -317,6 +317,80 @@
 				</div>
 			</section>
 
+			<section id="meta-access-modes-sync-audio">
+				<h3>Setting access modes for synchronized text-audio</h3>
+
+				<p>Setting the correct access modes and sufficient access modes for EPUB 3 publications that contain
+					synchronized text-audio playback requires evaluating whether playback is essential to reading the
+					publication or an additional feature.</p>
+
+				<p>EPUB 3's <a href="https://www.w3.org/TR/epub/#sec-media-overlays">media overlays</a> [[EPUB-3]]
+					allows EPUB creators to synchronize the full text of a publication with full audio narration. These
+					types of publications are commonly referred to as "read aloud" books, as the user chooses whether or
+					not to turn on the narration (unlike traditional audiobooks where only the audio is available).</p>
+
+				<p>In this case, because the audio playback is an extra feature, EPUB creators would
+						<strong>not</strong> list "<code>auditory</code>" as an <a href="#meta-001">access mode</a>.
+					Rather, they would indicate the presence of text and audio synchronization as an <a href="#meta-003"
+						>accessibility feature</a>:</p>
+
+				<pre>&lt;meta
+    property="schema:accessibilityFeature">
+   synchronizedAudioText
+&lt;/meta></pre>
+
+				<p>Although the audio is not essential to reading the publication, having full audio playback capability
+					means that there is an auditory <a href="#meta-002">sufficient access mode</a> &#8212; the user can
+					listen to the complete publication. Consequently, the EPUB creator would declare a
+						<code>schema:accessModeSufficient</code> property with the value <code>auditory</code>:</p>
+
+				<pre>&lt;meta
+    property="schema:accessModeSufficient">
+   auditory
+&lt;/meta></pre>
+
+				<div class="note">
+					<p>When media overlays are present, EPUB creators should not add "<code>auditory</code>" to all the
+						possible sufficient access modes just because it is possible to turn on text-audio playback.</p>
+
+					<p>For example, a publication with media overlays that has text and images (with text alternatives)
+						would only declare the following sufficient access modes: "<code>textual</code>",
+							"<code>auditory</code>, and "<code>textual,visual</code>".</p>
+
+					<p>It would <strong>not</strong> declare: "<code>textual</code>", "<code>auditory</code>",
+							"<code>textual,auditory</code>", "<code>textual,visual</code>", and
+							"<code>textual,visual,auditory</code>".</p>
+				</div>
+
+				<p>Another use for media overlays &#8212; more typical among accessible republishers such as libraries
+					that serve blind and low vision readers &#8212; is to provide full audio synchronized to the major
+					headings of a publication. These types of publications are more like traditional audiobooks, as all
+					the information in the work is typically available in auditory form. The minimal text does not allow
+					meaningful visual reading or text-to-speech playback; it is only to provide structured navigation
+					capabilities.</p>
+
+				<p>In this case, being able to hear the audio is essential to being able to read the publication, so
+					EPUB creators will list an auditory access mode:</p>
+
+				<pre>&lt;meta
+    property="schema:accessMode">
+   auditory
+&lt;/meta></pre>
+
+				<p>In a reverse of the first case discussed, EPUB creators will <strong>not</strong> identify text-audio
+					synchronization as a feature of the publication since the amount of text provided is trivial.</p>
+
+				<p>Likewise, since the text in the publication only provides heading navigation, EPUB creators will
+						<strong>not</strong> list a textual access mode. The user does not need to, and is not expected
+					to, visually read this text.</p>
+
+				<div class="note">
+					<p>Some publications that provide the body in auditory form may include the backmatter in text form,
+						allowing users to use text-to-speech playback to render it. In this case, there would be a
+						textual component.</p>
+				</div>
+			</section>
+
 			<section id="meta-003">
 				<h3>Identify accessibility features</h3>
 
@@ -2169,6 +2243,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>24-May-2022: Added a technique explaining how to set access modes and features when media overlays
+					are present. See <a href="https://github.com/w3c/epub-specs/issues/2303">issue 2303</a>.</li>
 				<li>07-Apr-2022: Added techniques for addressing synchronized text-audio playback objectives using media
 					overlays. See <a href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>
 				<li>10-Nov-2021: Added techniques for setting language in the package document. See <a


### PR DESCRIPTION
I've added a new technique to discuss the two cases for media overlays I'm aware of -- full text with full audio and structured audio. For full text with audio, the recommendation is to not set an auditory access mode and instead indicate the synchronizedAudioText feature. For structured audio, you do the opposite and set an auditory access mode and don't set synchronizedAudioText.

Let me know what you all think of this guidance.

Fixes #2303

EPUB Accessibility Techniques 1.1:
- [Preview](https://raw.githack.com/w3c/epub-specs/a11y/issue-2303/epub33/a11y-tech/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/a11y/issue-2303/epub33/a11y-tech/index.html)
