### PR TITLE
Adding i18n test references

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -303,11 +303,11 @@
 					language for the documents' contents, when applicable. This includes:</p>
 
 				<ul>
-					<li id="confreq-rs-xml-lang">the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a>
+					<li id="confreq-rs-xml-lang" data-tests="#cnt-18n_xhtml_xml_lang">the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a>
 						[[xml]] for all XML documents (e.g., the [=package document=], [=XHTML content documents=],
 							<a>SVG content documents</a>, and [=media overlay documents=]).</li>
 
-					<li id="confreq-rs-lang-attr">the <code>lang</code> attribute for XHTML content documents and SVG
+					<li id="confreq-rs-lang-attr" data-tests="#cnt-i18n_xhtml_lang">the <code>lang</code> attribute for XHTML content documents and SVG
 						content documents. (Refer to respective "The 'lang' and 'xml:lang' attributes" sections in
 						[[html]] and [[svg]] for more information.)</li>
 				</ul>
@@ -320,9 +320,9 @@
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
 						>the <a data-cite="epub-33#attrdef-dir"><code>dir</code></a> attribute [[epub-33]] for the
 						[=package document=]. (See also <a href="#sec-pkg-doc-base-dir"></a> for further details.)</li>
-					<li id="confreq-rs-html-dir">the [[html]] [^html-global/dir^] attribute for XHTML content
+					<li id="confreq-rs-html-dir" data-tests="#cnt-i18n_xhtml_dir">the [[html]] [^html-global/dir^] attribute for XHTML content
 						documents.</li>
-					<li id="confreq-rs-svg-direction">the [[svg]] <a
+					<li id="confreq-rs-svg-direction" data-tests="#cnt-i18n_svg_direction">the [[svg]] <a
 							href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"><code>direction</code></a>
 						attribute for SVG content documents.</li>
 				</ul>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -303,11 +303,11 @@
 					language for the documents' contents, when applicable. This includes:</p>
 
 				<ul>
-					<li id="confreq-rs-xml-lang" data-tests="#cnt-18n_xhtml_xml_lang">the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a>
+					<li id="confreq-rs-xml-lang" data-tests="#cnt-18n_xhtml-xml-lang">the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a>
 						[[xml]] for all XML documents (e.g., the [=package document=], [=XHTML content documents=],
 							<a>SVG content documents</a>, and [=media overlay documents=]).</li>
 
-					<li id="confreq-rs-lang-attr" data-tests="#cnt-i18n_xhtml_lang">the <code>lang</code> attribute for XHTML content documents and SVG
+					<li id="confreq-rs-lang-attr" data-tests="#cnt-i18n_xhtml-lang">the <code>lang</code> attribute for XHTML content documents and SVG
 						content documents. (Refer to respective "The 'lang' and 'xml:lang' attributes" sections in
 						[[html]] and [[svg]] for more information.)</li>
 				</ul>
@@ -320,9 +320,9 @@
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
 						>the <a data-cite="epub-33#attrdef-dir"><code>dir</code></a> attribute [[epub-33]] for the
 						[=package document=]. (See also <a href="#sec-pkg-doc-base-dir"></a> for further details.)</li>
-					<li id="confreq-rs-html-dir" data-tests="#cnt-i18n_xhtml_dir">the [[html]] [^html-global/dir^] attribute for XHTML content
+					<li id="confreq-rs-html-dir" data-tests="#cnt-i18n_xhtml-dir">the [[html]] [^html-global/dir^] attribute for XHTML content
 						documents.</li>
-					<li id="confreq-rs-svg-direction" data-tests="#cnt-i18n_svg_direction">the [[svg]] <a
+					<li id="confreq-rs-svg-direction" data-tests="#cnt-i18n_svg-direction">the [[svg]] <a
 							href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"><code>direction</code></a>
 						attribute for SVG content documents.</li>
 				</ul>


### PR DESCRIPTION
This is the pair of https://github.com/w3c/epub-tests/pull/150 : references to i18n tests. To be merged only when the tests are merged.