### PR TITLE
Media type registrations are normative

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11259,7 +11259,7 @@ EPUB/images/cover.png</pre>
 				</ul>
 			</section>
 		</section>
-		<section id="app-media-types" class="appendix informative">
+		<section id="app-media-types" class="appendix">
 			<h2>Media type registrations</h2>
 
 			<section id="app-media-type-app-oebps-package">
@@ -11381,7 +11381,7 @@ EPUB/images/cover.png</pre>
 				</dl>
 			</section>
 
-			<section class="informative" id="app-media-type">
+			<section id="app-media-type">
 				<h3>The <code>application/epub+zip</code> media type</h3>
 
 				<p>This appendix registers the media type <code>application/epub+zip</code> for the EPUB Open Container
@@ -11519,6 +11519,8 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<ul>
+				<li>06-June-2022: Media type registration sections should be normative. See <a
+					href="https://github.com/w3c/epub-specs/issues/2313">issue 2313</a>.</li>
 				<li id="crs-05-22">31-May-2022: Updated privacy and security recommendations to use normative language.</li>
 				<li>27-May-2022: Added recommendation to only reference remote resources via https. See <a
 						href="https://github.com/w3c/epub-specs/issues/2263">issue 2263</a>.</li>


### PR DESCRIPTION
This is a PR for the branch behind #2297 in view of a CRS publication.

Fix #2313


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 7, 2022, 1:35 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2F37179bf137e43ef78b88240b3f7ad85cdac5674b%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/fttDRc?isPreview=true&publishDate=2022-06-07
ReSpec version: 32.1.8
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 27664ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:247:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232325.)._
</details>
