### PR TITLE
Explain bypass blocks are not necessary

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -839,6 +839,33 @@
 						or in the spine). EPUB creators can include links to these additional navigation lists in the
 						table of contents.</p>
 				</section>
+
+				<section id="access-bypass-blocks">
+					<h4>Bypass blocks not necessary</h4>
+
+					<p>Web sites are constructed very differently from EPUB publications. A typical web site wraps the
+						content of each page within a repeating template, for example. This template gives each page a
+						consistent look and feel, but users are rarely interested in the wrapper content after visiting
+						the first page. Visual readers can typically skip past the site header, navigation bars, search
+						boxes, and other helpful but seldom-used features to get right to the content.</p>
+
+					<p>To provide the same ease of access to readers who would have to navigate sequentially through the
+						repetitive content, <a href="https://www.w3.org/TR/WCAG/#bypass-blocks">success criterion
+							2.4.1</a> [[wcag2]] requires a means of bypassing the repeated content in a set of pages.
+						This success criterion does not apply to typical EPUB publications, however, as EPUB content
+						documents do not repeat content in the same way that web sites do.</p>
+
+					<p>Each new content document may begin with similar content, such as learning objectives or key
+						terms, but this content is part of the body of the publication and not identical to what came
+						before. Consequently, it is not required to add a link to skip it. (Secondary content should be
+						identified in accordance with <a href="https://www.w3.org/TR/WCAG/#info-and-relationships"
+							>success criterion 1.3.1</a>, however.)</p>
+
+					<div class="note">
+						<p>If an EPUB publication were to reproduce a set of web pages with their full site trappings,
+							then success criterion 2.4.1 would apply, but this practice is not common.</p>
+					</div>
+				</section>
 			</section>
 
 			<section id="sec-wcag-semantics">


### PR DESCRIPTION
Clarify that this success criterion is for bypassing repetitive web site content. In theory if you had an epub that reproduced a set of pages from a web site, wrapper and all, then you'd need bypass blocks, but I can't say I've seen that before. Closest is when we reproduced the set of EPUB specifications as an EPUB, but even then there weren't any repetitive IDPF site blocks to bypass. At any rate, I noted it's a possibility, if a tiny one.

Fixes #2319 

EPUB Accessibility Techniques 1.1:
- [Preview](https://raw.githack.com/w3c/epub-specs/a11y/issue-2319/epub33/a11y-tech/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/a11y/issue-2319/epub33/a11y-tech/index.html)
