### PR TITLE
Disallow file URLs

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3206,8 +3206,7 @@
 				<section id="attrdef-href">
 					<h4>The <code>href</code> attribute</h4>
 
-					<p>A [=valid URL string=] [[url]] that references a resource. If the value is an <a>absolute-URL
-							string</a>, it MUST NOT use the "file" URI scheme [[rfc8089]].</p>
+					<p>A [=valid URL string=] [[url]] that references a resource.</p>
 
 					<aside class="example" title="Linking a metadata record">
 						<pre>&lt;package …>
@@ -11536,6 +11535,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>07-06-2022: The usage of File URLs has been disallowed. See <a
+						href="https://github.com/w3c/epub-specs/issues/2263">issue 2324</a>.</li>
 					<li>27-May-2022: Added recommendation to only reference remote resources via https. See <a
 							href="https://github.com/w3c/epub-specs/issues/2263">issue 2263</a>.</li>
 					<li>20-May-2022: Add recommendation not to store sensitive user data in persistent storage, and to

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1502,6 +1502,19 @@
 						restrictions</a>).</p>
 			</section>
 
+			<section id="sec-file-urls">
+				<h3>File URLs</h3>
+				<p>
+					The <a data-cite="rfc8089#"><code>file:</code> URL scheme</a> is defined in [[rfc8089]] as "identifying an 
+					object (a 'file') stored in a structured object naming and accessing environment on a host (a 'file system')."
+					It is typically used to retrieve files from within one's own computer.
+				</p>
+				<p>
+					Using a file URL in an [=EPUB publication=], which can be transferred among different hosts, represents a security risk.
+					As a consequence,  [=EPUB creators=] MUST NOT use file URLs in EPUB publications.
+				</p>
+			</section>
+
 			<section id="sec-xml-constraints">
 				<h3>XML conformance</h3>
 
@@ -3194,7 +3207,7 @@
 					<h4>The <code>href</code> attribute</h4>
 
 					<p>A [=valid URL string=] [[url]] that references a resource. If the value is an <a>absolute-URL
-							string</a>, it SHOULD NOT use the "file" URI scheme [[rfc8089]].</p>
+							string</a>, it MUST NOT use the "file" URI scheme [[rfc8089]].</p>
 
 					<aside class="example" title="Linking a metadata record">
 						<pre>&lt;package …>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1510,7 +1510,7 @@
 					It is typically used to retrieve files from within one's own computer.
 				</p>
 				<p>
-					Using a file URL in an [=EPUB publication=], which can be transferred among different hosts, represents a security risk.
+					Using a file URL in an [=EPUB publication=], which can be transferred among different hosts, represents a security risk and is also non-interoperable.
 					As a consequence,  [=EPUB creators=] MUST NOT use file URLs in EPUB publications.
 				</p>
 			</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -302,7 +302,7 @@
 			<section id="sec-epub-rs-conf-file-urls">
 				<h4>File URLs</h4>
 				<p id="confreq-rs-file-urls">
-					Reading systems MUST prevent file URLs [[rfc8089]] from opening.
+					Reading Systems MUST prevent access to resources referenced via file URLs [[rfc8089]], both from elements that refer to resources and from script API calls. 
 				</p>
 			</section>
 
@@ -2575,6 +2575,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>07-06-2022: The usage of File URLs has been disallowed. See <a
+						href="https://github.com/w3c/epub-specs/issues/2263">issue 2324</a>.</li>
 					<li>27-May-2022: Added reading system conformance section. See <a
 							href="https://github.com/w3c/epub-specs/issues/2271">issue 2271</a>.</li>
 					<li>27-May-2022: Added recommendation to only load remote resources referenced via https. See <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -302,7 +302,7 @@
 			<section id="sec-epub-rs-conf-file-urls">
 				<h4>File URLs</h4>
 				<p id="confreq-rs-file-urls">
-					Reading Systems MUST prevent access to resources referenced via file URLs [[rfc8089]], both from elements that refer to resources and from script API calls. 
+					Reading Systems MUST prevent access to resources referenced via file URLs [[rfc8089]]. 
 				</p>
 			</section>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -299,6 +299,13 @@
 					content documents.</p>
 			</section>
 
+			<section id="sec-epub-rs-conf-file-urls">
+				<h4>File URLs</h4>
+				<p id="confreq-rs-file-urls">
+					Reading systems MUST prevent file URLs [[rfc8089]] from opening.
+				</p>
+			</section>
+
 			<section id="sec-epub-rs-conf-xml">
 				<h4>XML processing</h4>
 


### PR DESCRIPTION
This is to fix #2324

I was wondering, however, whether disallowing File URLs in general is implementable by an RS; it may require the RS to patch the fetch library or something similar if a WebView is used for implementing the system. I would welcome the reaction of @bduga or @danielweck on this. (Note that a similar question may arise for Data URLs.)


See:

* For EPUB 3.3:
    * [Preview](https://raw.githack.com/w3c/epub-specs/disallow-file-scheme/epub33/core/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/core/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/disallow-file-scheme/epub33/core/index.html)
* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/disallow-file-scheme/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/disallow-file-scheme/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 8, 2022, 9:45 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2F64670ea5fbf01ce5109b7d44862e609b193c5c26%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/rIFmii?isPreview=true&publishDate=2022-06-08
ReSpec version: 32.1.8
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 27558ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:247:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232329.)._
</details>
