### PR TITLE
Changed the RS section on i18n

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -334,7 +334,7 @@
 				</p>
 
 				<p id="confreq-rs-pkg-dir-intro" data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">
-					Furthermore, the readings system MUST also process the
+					Furthermore, the reading system MUST also process the
 					<a data-cite="epub-33#attrdef-dir"><code>dir</code></a> attribute [[epub-33]] for the [=package document=],
 					where the base direction specified by <code>dir</code> applies to the element where it is specified, and
 					to all elements in its content unless overridden with another instance of <code>dir</code>. (See also <a href="#sec-pkg-doc-base-dir"></a> for further details.)</span>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -325,37 +325,24 @@
 			<section id="sec-epub-rs-i18n">
 				<h2>Internationalization</h2>
 
-				<p>A reading system MUST process, for all [=publication resources=], the attributes that set the
-					language for the documents' contents, when applicable. This includes:</p>
+				<p>
+					As part of processing [=publication resources=], the reading system is required to process the 
+					attributes to set the language and the base directions in [=XHTML Content documents=] or
+					[=SVG Content documents=]. Furthermore, the readings system MUST also process:
+				</p>
 
 				<ul>
 					<li id="confreq-rs-xml-lang">the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a>
-						[[xml]] for all XML documents (e.g., the [=package document=], [=XHTML content documents=],
-							<a>SVG content documents</a>, and [=media overlay documents=]).</li>
-
-					<li id="confreq-rs-lang-attr">the <code>lang</code> attribute for XHTML content documents and SVG
-						content documents. (Refer to respective "The 'lang' and 'xml:lang' attributes" sections in
-						[[html]] and [[svg]] for more information.)</li>
-				</ul>
-
-				<p>Similarly, a reading system MUST process, for all [=publication resources=], the attributes that set
-					the base direction for the documents' contents, when applicable. This includes:</p>
-
-				<ul>
+						[[xml]] for all XML documents (e.g., the [=package document=] and [=media overlay documents=]).</li>
 					<li id="confreq-rs-pkg-dir-intro"
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
 						>the <a data-cite="epub-33#attrdef-dir"><code>dir</code></a> attribute [[epub-33]] for the
 						[=package document=]. (See also <a href="#sec-pkg-doc-base-dir"></a> for further details.)</li>
-					<li id="confreq-rs-html-dir">the [[html]] [^html-global/dir^] attribute for XHTML content
-						documents.</li>
-					<li id="confreq-rs-svg-direction">the [[svg]] <a
-							href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"><code>direction</code></a>
-						attribute for SVG content documents.</li>
 				</ul>
 
 				<p id="confreq-rs-pkg-lang-no-content" data-tests="#pkg-lang_but_not_content,#pkg-dir_but_not_content"
 					>In the absence of this information in a [=publication resource=], reading systems MUST NOT assume
-					either the the language or the base direction of that resource from information expressed in the
+					either the language or the base direction of that resource from information expressed in the
 					package document (i.e., in <a data-cite="epub-33#attrdef-xml-lang"><code>xml:lang</code></a> and <a
 						data-cite="epub-33#attrdef-dir"><code>dir</code></a> attributes, in <a
 						data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attributes</a> on <span

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -328,17 +328,17 @@
 				<p>
 					As part of processing [=publication resources=], the reading system is required to process the 
 					attributes to set the language and the base directions in [=XHTML Content documents=] or
-					[=SVG Content documents=]. Furthermore, the readings system MUST also process:
+					[=SVG Content documents=], as well as the 
+					<a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a> for all XML documents
+					(e.g., the [=package document=] and [=media overlay documents=]).
 				</p>
 
-				<ul>
-					<li id="confreq-rs-xml-lang">the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code> attribute</a>
-						[[xml]] for all XML documents (e.g., the [=package document=] and [=media overlay documents=]).</li>
-					<li id="confreq-rs-pkg-dir-intro"
-						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
-						>the <a data-cite="epub-33#attrdef-dir"><code>dir</code></a> attribute [[epub-33]] for the
-						[=package document=]. (See also <a href="#sec-pkg-doc-base-dir"></a> for further details.)</li>
-				</ul>
+				<p id="confreq-rs-pkg-dir-intro" data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">
+					Furthermore, the readings system MUST also process the
+					<a data-cite="epub-33#attrdef-dir"><code>dir</code></a> attribute [[epub-33]] for the [=package document=],
+					where the base direction specified by <code>dir</code> applies to the element where it is specified, and
+					to all elements in its content unless overridden with another instance of <code>dir</code>. (See also <a href="#sec-pkg-doc-base-dir"></a> for further details.)</span>
+				</p>
 
 				<p id="confreq-rs-pkg-lang-no-content" data-tests="#pkg-lang_but_not_content,#pkg-dir_but_not_content"
 					>In the absence of this information in a [=publication resource=], reading systems MUST NOT assume


### PR DESCRIPTION
This comes from the discussion around testing the i18n features, see https://github.com/w3c/epub-tests/pull/150. Based on that discussion thread, the PR removes the normative statements regarding the handling of the `dir` and `lang` attributes in XHTML and SVG; listing these as normative statements is superfluous and makes it unclear what and how should be formally tested. The proposed section includes normative statements on EPUB specific files and features only


See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/rs-i18n-section-update/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/rs-i18n-section-update/epub33/rs/index.html)
