### PR TITLE
Clarify that data blocks are exempt from fallbacks

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1268,6 +1268,10 @@
 					resources (i.e., the requirement for a fallback for the foreign content document covers any
 					rendering issues within it). As the resource is not referenced from an EPUB content document, it
 					automatically becomes exempt from fallbacks.</p>
+
+				<p>Although technically not separate resources from the XHTML and SVG content documents that embed them,
+						<a data-cite="html#data-block">data blocks</a> [[HTML]] expressed in [=script=] elements are
+					also considered exempt resources.</p>
 			</section>
 
 			<section id="sec-resource-fallbacks">
@@ -1504,15 +1508,12 @@
 
 			<section id="sec-file-urls">
 				<h3>File URLs</h3>
-				<p>
-					The <a data-cite="rfc8089#"><code>file:</code> URL scheme</a> is defined in [[rfc8089]] as "identifying an 
-					object (a 'file') stored in a structured object naming and accessing environment on a host (a 'file system')."
-					It is typically used to retrieve files from within one's own computer.
-				</p>
-				<p>
-					Using a file URL in an [=EPUB publication=], which can be transferred among different hosts, represents a security risk and is also non-interoperable.
-					As a consequence,  [=EPUB creators=] MUST NOT use file URLs in EPUB publications.
-				</p>
+				<p> The <a data-cite="rfc8089#"><code>file:</code> URL scheme</a> is defined in [[rfc8089]] as
+					"identifying an object (a 'file') stored in a structured object naming and accessing environment on
+					a host (a 'file system')." It is typically used to retrieve files from within one's own computer. </p>
+				<p> Using a file URL in an [=EPUB publication=], which can be transferred among different hosts,
+					represents a security risk and is also non-interoperable. As a consequence, [=EPUB creators=] MUST
+					NOT use file URLs in EPUB publications. </p>
 			</section>
 
 			<section id="sec-xml-constraints">
@@ -11535,14 +11536,13 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>10-June-2022: Clarified that data blocks are exempt from fallback requirements. See <a
+							href="https://github.com/w3c/epub-specs/issues/2331">issue 2331</a>.</li>
 					<li>07-June-2022: The usage of File URLs has been disallowed. See <a
-						href="https://github.com/w3c/epub-specs/issues/2263">issue 2324</a>.</li>
-
-  				<li>07-June-2022: Media type registration sections should be normative. See <a
-	  				href="https://github.com/w3c/epub-specs/issues/2313">issue 2313</a>.</li>
-
-  				<li>07-June-2022: Updated privacy and security recommendations to use normative language.</li>
-
+							href="https://github.com/w3c/epub-specs/issues/2324">issue 2324</a>.</li>
+					<li>07-June-2022: Media type registration sections should be normative. See <a
+							href="https://github.com/w3c/epub-specs/issues/2313">issue 2313</a>.</li>
+					<li>07-June-2022: Updated privacy and security recommendations to use normative language.</li>
 					<li>27-May-2022: Added recommendation to only reference remote resources via https. See <a
 							href="https://github.com/w3c/epub-specs/issues/2263">issue 2263</a>.</li>
 					<li>20-May-2022: Add recommendation not to store sensitive user data in persistent storage, and to

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1393,8 +1393,12 @@
 						<div class="note">
 							<p>The exemption from fallbacks aligns data blocks with the exemption made to <a
 									href="confreq-foreign-no-fallback">allow data files</a> to travel in the [=EPUB
-								container=]. As data blocks are not separate resources from their host EPUB content
-								document, they do not fall under the same exemption.</p>
+								container=]. As data blocks are not separate resources from their host [=EPUB content
+								document=], they do not fall under the same exemption.</p>
+						</div>
+						<div class="note">
+							<p>Since the [[SVG]] <span data-cite="svg">[^script^] element</span> is an implementation of
+								the HTML element, the same exemption applies to both formats.</p>
 						</div>
 					</section>
 				</section>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1268,10 +1268,6 @@
 					resources (i.e., the requirement for a fallback for the foreign content document covers any
 					rendering issues within it). As the resource is not referenced from an EPUB content document, it
 					automatically becomes exempt from fallbacks.</p>
-
-				<p>Although technically not separate resources from the XHTML and SVG content documents that embed them,
-						<a data-cite="html#data-block">data blocks</a> [[HTML]] expressed in [=script=] elements are
-					also considered exempt resources.</p>
 			</section>
 
 			<section id="sec-resource-fallbacks">
@@ -1385,6 +1381,21 @@
 									<code>[^img/srcset^]</code> attributes provided EPUB creators define a <a
 									href="#sec-manifest-fallbacks">manifest fallback</a>.</li>
 						</ul>
+					</section>
+					<section>
+						<h5>HTML <code>script</code> element</h5>
+
+						<p>Although the [[HTML]] [^script^] element lacks intrinsic fallback capabilities, it is not
+							required that EPUB creators provide fallbacks for <a data-cite="html#data-block">data
+								blocks</a> [[HTML]]. As the <code>script</code> element does not represent user content,
+							data blocks are not rendered unless manipulated by script.</p>
+
+						<div class="note">
+							<p>The exemption from fallbacks aligns data blocks with the exemption made to <a
+									href="confreq-foreign-no-fallback">allow data files</a> to travel in the [=EPUB
+								container=]. As data blocks are not separate resources from their host EPUB content
+								document, they do not fall under the same exemption.</p>
+						</div>
 					</section>
 				</section>
 			</section>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1385,9 +1385,9 @@
 					<section>
 						<h5>HTML <code>script</code> element</h5>
 
-						<p>Although the [[HTML]] [^script^] element lacks intrinsic fallback capabilities, it is not
+						<p>Although the [[html]] [^script^] element lacks intrinsic fallback capabilities, it is not
 							required that EPUB creators provide fallbacks for <a data-cite="html#data-block">data
-								blocks</a> [[HTML]]. As the <code>script</code> element does not represent user content,
+								blocks</a> [[html]]. As the <code>script</code> element does not represent user content,
 							data blocks are not rendered unless manipulated by script.</p>
 
 						<div class="note">
@@ -1397,8 +1397,8 @@
 								document=], they do not fall under the same exemption.</p>
 						</div>
 						<div class="note">
-							<p>Since the [[SVG]] <span data-cite="svg">[^script^] element</span> is an implementation of
-								the HTML element, the same exemption applies to both formats.</p>
+							<p>[[svg]] does not define data blocks as of publication, but the same exclusion would apply
+								if a future update adds the concept.</p>
 						</div>
 					</section>
 				</section>


### PR DESCRIPTION
I've added a new section to the intrinsic fallbacks section to clarify that they're not needed for data blocks.

There are about three places this exemption could go, but this seemed the most logical. It could also go in a couple of places in  the exempt resources section, but even if we consider them resources they aren't for use by reading systems which breaks the definition.

Fixes #2331


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 13, 2022, 12:27 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fepub-specs%2F613e6e2b905a265e805ffc64d0af31b46518cfba%2Fepub33%2Fcore%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/fOB39g?isPreview=true&publishDate=2022-06-13
ReSpec version: 32.1.8
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 27316ms.
    at ExecutionContext._evaluateInternal (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:221:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js:110:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:247:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/epub-specs%232332.)._
</details>
