### PR TITLE
Removal of the acid test reference

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1167,7 +1167,7 @@
 			<section id="sec-css">
 				<h3>Cascading Style Sheets (CSS)</h3>
 
-				<p id="confreq-rs-epub3-css" data-tests="#cnt-css-support" class="support">If a reading system has a
+				<p id="confreq-rs-epub3-css" class="support">If a reading system has a
 					[=viewport=], it MUST support the <a data-cite="epub-33#sec-css">visual rendering of XHTML content
 						documents via CSS</a> [[epub-33]].</p>
 
@@ -1175,7 +1175,7 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-css-rs-support" data-tests="#cnt-css-support">MUST support the official
+						<p id="confreq-css-rs-support">MUST support the official
 							definition of CSS as described in the [[csssnapshot]].</p>
 					</li>
 					<li>


### PR DESCRIPTION
This is the counterpart of https://github.com/w3c/epub-tests/pull/167