### PR TITLE
Clarify that vocabulary association mechanisms support is optional

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2046,7 +2046,8 @@
 			<h2>Vocabulary association mechanisms</h2>
 
 			<p id="confreq-rs-vocab-assoc" class="support">Reading systems MAY support <a
-					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[epub-33]] in [=EPUB content documents=].</p>
+					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[epub-33]] in [=EPUB
+				content documents=].</p>
 
 			<dl class="conformance-list">
 				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
@@ -2068,8 +2069,8 @@
 				<dd>
 					<p id="confreq-rs-vocab-prefix-attr">If the <code>prefix</code> attribute includes a declaration for
 						a <a href="#sec-metadata-reserved-prefixes">predefined prefix</a>, reading systems MUST use the
-						URL mapping defined in the <code>prefix</code> attribute, regardless of whether of it maps to
-						the same URL as the predefined prefix.</p>
+						URL mapping defined in the <code>prefix</code> attribute, regardless of whether it maps to the
+						same URL as the predefined prefix.</p>
 				</dd>
 
 				<dt id="sec-default-vocab">Default vocabularies</dt>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2045,9 +2045,8 @@
 		<section id="sec-vocab-assoc">
 			<h2>Vocabulary association mechanisms</h2>
 
-			<p id="confreq-rs-vocab-assoc" class="support">Reading systems support for <a
-					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[epub-33]] is
-				OPTIONAL.</p>
+			<p id="confreq-rs-vocab-assoc" class="support">Reading systems MAY support <a
+					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[epub-33]] in [=EPUB content documents=].</p>
 
 			<dl class="conformance-list">
 				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -804,10 +804,6 @@
 							[[epub-33]] define expressions they do not recognize. <span id="confreq-rs-pkg-meta-unknown"
 								data-tests="#pkg-meta-unknown">A reading system MUST NOT fail when encountering unknown
 								expressions.</span></p>
-						<p id="confreq-rs-pkg-meta-prefix">If the <code>property</code> attribute's value does not
-							include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading
-							systems MUST use the prefix URL "<code>http://idpf.org/epub/vocab/package/meta/#</code>" to
-								<a href="#sec-property-datatype">expand the value</a>.</p>
 						<p>If a reading system does not recognize the <a data-cite="epub-33#attrdef-scheme"
 									><code>scheme</code> attribute</a> [[epub-33]] value, it SHOULD treat the value of
 							the element as a string.</p>
@@ -835,12 +831,6 @@
 							elements).</p>
 						<p id="confreq-rs-pkg-link-rendering">Reading systems MUST ignore any instructions contained in
 							linked resources related to the layout and rendering of the EPUB publication.</p>
-						<p id="confreq-rs-pkg-link-prefix">If any of the <a data-cite="epub-33#attrdef-link-rel"
-									><code>rel</code></a> or <a data-cite="epub-33#attrdef-properties"
-									><code>properties</code></a> [[epub-33]] attributes' values do not include a <a
-								data-cite="epub-33#property.ebnf.prefix">prefix</a>, reading systems MUST use the prefix
-							URL "<code>http://idpf.org/epub/vocab/package/link/#</code>" to <a
-								href="#sec-property-datatype">expand the values</a>.</p>
 					</dd>
 				</dl>
 			</section>
@@ -877,11 +867,6 @@
 
 				<p id="confreq-rs-pkg-manifest-fallback-cycle">A reading system MUST terminate the fallback chain at the
 					first reference to a manifest item it has already encountered.</p>
-
-				<p id="confreq-rs-pkg-manifest-prefix">If any of the <code>properties</code> attribute's values do not
-					include a <a data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST
-					use the prefix URL "<code>http://idpf.org/epub/vocab/package/item/#</code>" to <a
-						href="#sec-property-datatype">expand the values</a>.</p>
 			</section>
 
 			<section id="sec-pkg-doc-spine">
@@ -916,12 +901,6 @@
 					the <code>page-progression-direction</code> attribute has a value other than <code>default</code>,
 					the reading system MUST ignore any directionality computed from <a href="#layout"
 							><code>pre-paginated</code></a> [=XHTML content documents=].</p>
-
-				<p id="confreq-rs-spine-prefix">If any values of the <a data-cite="epub-33#attrdef-properties"
-							><code>properties</code> attribute</a> do not include a <a
-						data-cite="epub-33#property.ebnf.prefix">prefix</a> [[epub-33]], reading systems MUST use the
-					prefix URL "<code>http://idpf.org/epub/vocab/package/itemref/#</code>" to <a
-						href="#sec-property-datatype">expand the values</a>.</p>
 
 				<p id="confreq-rs-pkg-spine-unknown" data-tests="#pkg-spine-unknown">Reading systems MUST ignore all
 					values expressed in spine <code>itemref</code>
@@ -2066,8 +2045,9 @@
 		<section id="sec-vocab-assoc">
 			<h2>Vocabulary association mechanisms</h2>
 
-			<p id="confreq-rs-vocab-assoc" class="support">Reading systems MUST support <a
-					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[epub-33]].</p>
+			<p id="confreq-rs-vocab-assoc" class="support">Reading systems support for <a
+					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[epub-33]] is
+				OPTIONAL.</p>
 
 			<dl class="conformance-list">
 				<dt id="sec-metadata-reserved-prefixes">Reserved Prefixes</dt>
@@ -2093,15 +2073,38 @@
 						the same URL as the predefined prefix.</p>
 				</dd>
 
-				<dt id="sec-property-datatype">Expanding <code>property</code> Data Types</dt>
+				<dt id="sec-default-vocab">Default vocabularies</dt>
+				<dd>
+					<p>Default vocabularies are defined for [=package document=] attributes that accept <a
+							data-cite="epub-33#sec-property-datatype"><code>property</code> data types</a> [[EPUB-33]].
+						When unprefixed terms are encountered in these attributes, the URL of the applicable default
+						vocabulary URL is used to <a href="#sec-property-datatype">expand the values</a>.</p>
+					<p>The default vocabulary URLs for these attributes are as follows:</p>
+					<ul data-cite="epub-33">
+						<li id="confreq-rs-pkg-meta-prefix">For the [^meta^] element's <a
+								data-cite="epub-33#attrdef-meta-property"><code>property</code> attribute</a>
+							[[epub-33]]: <br /><code>http://idpf.org/epub/vocab/package/meta/#</code></li>
+						<li id="confreq-rs-pkg-link-prefix">For the [^link^] element's <a
+								data-cite="epub-33#attrdef-link-rel"><code>rel</code></a> and <a
+								data-cite="epub-33#attrdef-properties"><code>properties</code></a> [[epub-33]]
+							attributes: <br /><code>http://idpf.org/epub/vocab/package/link/#</code></li>
+						<li id="confreq-rs-pkg-manifest-prefix">For the [^item^] element's <code>properties</code>
+							attribute: <br /><code>http://idpf.org/epub/vocab/package/item/#</code></li>
+						<li id="confreq-rs-spine-prefix">For the [^itemref^] element's <a
+								data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a>
+							[[epub-33]]: <br /><code>http://idpf.org/epub/vocab/package/itemref/#</code></li>
+					</ul>
+				</dd>
+
+				<dt id="sec-property-datatype">Expanding <code>property</code> data types</dt>
 				<dd>
 					<p>Reading systems MUST expand <a data-cite="epub-33#sec-property-datatype"><code>property</code>
 							values</a> [[epub-33]] as follows:</p>
 					<ul>
 						<li>
 							<p id="confreq-rs-vocab-property-reference">If the property consists only of a reference,
-								concatenate the prefix URL associated with the <a data-cite="epub-33#sec-default-vocab"
-									>default vocabulary</a> [[epub-33]] to the reference.</p>
+								concatenate the prefix URL associated with the <a href="#sec-default-vocab">default
+									vocabulary</a> to the reference.</p>
 						</li>
 						<li>
 							<p>
@@ -2572,8 +2575,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>17-June-2022: Clarify support for the vocabulary association mechanisms is optional. See <a
+							href="https://github.com/w3c/epub-specs/issues/2317">issue 2317</a>.</li>
 					<li>07-June-2022: The usage of File URLs has been disallowed. See <a
-							href="https://github.com/w3c/epub-specs/issues/2263">issue 2324</a>.</li>
+							href="https://github.com/w3c/epub-specs/issues/2324">issue 2324</a>.</li>
 					<li>07-June-2022: Noted that unsigned EPUB publications represent a security risk and added
 						recommendation to treat sideloaded unsigned publications as untrusted. See <a
 							href="https://github.com/w3c/epub-specs/issues/2265">issue 2265</a>.</li>


### PR DESCRIPTION
The primary change is to make section 11 optional.

There were a number of statements about the URLs to use to expand default vocab values sprinkled around the package document section, but this was a recent change as part of splitting out the reading system requirements. In the past, we had all this info in a default vocabularies section. See https://www.w3.org/publishing/epub3/epub-packages.html#sec-metadata-default-vocab

To fix these, I've taken all the statements and recombined them under section 11. There's no need for them to be with their attribute definitions when all of this processing is optional. Better to have all the information in one place for anyone who wants to implement the processing.

Fixes #2317 

EPUB Reading Systems 3.3:
- [Preview](https://raw.githack.com/w3c/epub-specs/fix/issue-2317/epub33/rs/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/fix/issue-2317/epub33/rs/index.html)
