### PR TITLE
Update external link handling recommendations

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -387,9 +387,9 @@
 				<p>When a link has an <code>http</code> or <code>https</code>
 					<a data-cite="url#concept-url-scheme">scheme</a> [[url]], reading systems:</p>
 
-				<ul>
-					<li id="sec-external-links-consent">SHOULD obtain the user's consent before opening the link.</li>
-					<li data-tests="#pub-external-links" id="sec-external-links-open">SHOULD open the link in a new browser instance to ensure that the browser's security and privacy
+				<ul data-tests="#pub-external-links" id="sec-external-links-open">
+					<li>SHOULD obtain the user's consent before opening the link.</li>
+					<li>SHOULD open the link in a new browser instance to ensure that the browser's security and privacy
 						controls are available to users.</li>
 				</ul>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -388,7 +388,7 @@
 							data-cite="url#concept-url-scheme">scheme</a> [[url]] (i.e., that resolves to web content
 						outside the [=EPUB publication=] or requires a system application to open).</span>
 					<span data-tests="#pub-external-links">If the user consents to open the link, reading systems SHOULD
-						open the link using the default application registered for the scheme (i.e., to help ensure
+						open it using the default application registered for the scheme (i.e., to help ensure
 						appropriate security and privacy controls are available).</span></p>
 
 				<div class="note">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -393,7 +393,7 @@
 						controls are available to users.</li>
 				</ul>
 
-				<p>For links that use schemes that require a helper application to load, reading systems SHOULD obtain
+				<p>For links that have schemes that require a helper application to load, reading systems SHOULD obtain
 					the user's consent and follow platform guidance for opening the helper application.</p>
 
 				<div class="note">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -384,7 +384,7 @@
 			<section id="sec-epub-rs-external-links">
 				<h3>External links</h3>
 
-				<p data-tests="#pub-external-links">When a link has an <code>http</code> or <code>https</code>
+				<p>When a link has an <code>http</code> or <code>https</code>
 					<a data-cite="url#concept-url-scheme">scheme</a> [[url]], reading systems:</p>
 
 				<ul>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -384,18 +384,18 @@
 			<section id="sec-epub-rs-external-links">
 				<h3>External links</h3>
 
-				<p>Reading systems SHOULD alert users before opening hyperlinks that declare a <a
-						data-cite="url#concept-url-scheme">scheme</a> [[url]] (i.e., that resolve outside the [=EPUB
-					publication=] or require a specialized application to open).</p>
+				<p><span>Reading systems SHOULD alert users before opening a link that declares a <a
+							data-cite="url#concept-url-scheme">scheme</a> [[url]] (i.e., that resolves to web content
+						outside the [=EPUB publication=] or requires a system application to open).</span>
+					<span data-tests="#pub-external-links">If the user consents to open the link, reading systems SHOULD
+						open the link using the default application registered for the scheme (i.e., to help ensure
+						appropriate security and privacy controls are available).</span></p>
 
-				<p data-tests="#pub-external-links">Reading systems SHOULD open links that declare a scheme in an
-					appropriate application to ensure security and privacy controls are available.</p>
-
-				<p>Although links to external web sites and resources are commonly found in <a>EPUB content
-						documents</a>, these are not the only sources of hyperlinks with schemes. For example, if a
-					reading system provides access to external <a data-cite="epub-33#sec-link-elem">linked records</a>
-					[[epub-33]] in the <a>package document</a> metadata, it should open the links in a new browser
-					instance.</p>
+				<div class="note">
+					<p>External links are not only found in [=EPUB content documents=]. A reading system might provides
+						access to external <a data-cite="epub-33#sec-link-elem">linked records</a> [[epub-33]] in the
+							<a>package document</a> metadata, for example.</p>
+				</div>
 
 				<div class="note">
 					<p>For more information about security and privacy issues with external links, see <a

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -393,7 +393,7 @@
 						controls are available to users.</li>
 				</ul>
 
-				<p>For links that have schemes that require a helper application to load, reading systems SHOULD obtain
+				<p id="sec-external-links-consent" data-tests="#pub-external-links_consent">For links that have schemes that require a helper application to load, reading systems SHOULD obtain
 					the user's consent and follow platform guidance for opening the helper application.</p>
 
 				<div class="note">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -384,15 +384,20 @@
 			<section id="sec-epub-rs-external-links">
 				<h3>External links</h3>
 
-				<p><span>Reading systems SHOULD alert users before opening a link that declares a <a
-							data-cite="url#concept-url-scheme">scheme</a> [[url]] (i.e., that resolves to web content
-						outside the [=EPUB publication=] or requires a system application to open).</span>
-					<span data-tests="#pub-external-links">If the user consents to open the link, reading systems SHOULD
-						open it using the default application registered for the scheme (i.e., to help ensure
-						appropriate security and privacy controls are available).</span></p>
+				<p data-tests="#pub-external-links">When a link has an <code>http</code> or <code>https</code>
+					<a data-cite="url#concept-url-scheme">scheme</a> [[url]], reading systems:</p>
+
+				<ul>
+					<li>SHOULD obtain the user's consent before opening the link.</li>
+					<li>SHOULD open the link in a new browser instance to ensure that the browser's security and privacy
+						controls are available to users</li>
+				</ul>
+
+				<p>For links that use schemes that require a helper application to load, reading systems SHOULD obtain
+					the user's consent and follow platform guidance for opening the helper application.</p>
 
 				<div class="note">
-					<p>External links are not only found in [=EPUB content documents=]. A reading system might provides
+					<p>External links are not only found in [=EPUB content documents=]. A reading system might provide
 						access to external <a data-cite="epub-33#sec-link-elem">linked records</a> [[epub-33]] in the
 							<a>package document</a> metadata, for example.</p>
 				</div>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -388,7 +388,7 @@
 					<a data-cite="url#concept-url-scheme">scheme</a> [[url]], reading systems:</p>
 
 				<ul>
-					<li>SHOULD obtain the user's consent before opening the link.</li>
+					<li id="sec-external-links-consent">SHOULD obtain the user's consent before opening the link.</li>
 					<li data-tests="#pub-external-links" id="sec-external-links-open">SHOULD open the link in a new browser instance to ensure that the browser's security and privacy
 						controls are available to users.</li>
 				</ul>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -389,8 +389,8 @@
 
 				<ul>
 					<li>SHOULD obtain the user's consent before opening the link.</li>
-					<li>SHOULD open the link in a new browser instance to ensure that the browser's security and privacy
-						controls are available to users</li>
+					<li data-tests="#pub-external-links" id="sec-external-links-open">SHOULD open the link in a new browser instance to ensure that the browser's security and privacy
+						controls are available to users.</li>
 				</ul>
 
 				<p>For links that use schemes that require a helper application to load, reading systems SHOULD obtain

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -384,14 +384,18 @@
 			<section id="sec-epub-rs-external-links">
 				<h3>External links</h3>
 
-				<p data-tests="#pub-external-links">Reading systems SHOULD open links that resolve outside the <a>EPUB
-						publication</a> in a new browser instance to ensure that the browser's security and privacy
-					controls are available to users.</p>
+				<p>Reading systems SHOULD alert users before opening hyperlinks that declare a <a
+						data-cite="url#concept-url-scheme">scheme</a> [[url]] (i.e., that resolve outside the [=EPUB
+					publication=] or require a specialized application to open).</p>
+
+				<p data-tests="#pub-external-links">Reading systems SHOULD open links that declare a scheme in an
+					appropriate application to ensure security and privacy controls are available.</p>
 
 				<p>Although links to external web sites and resources are commonly found in <a>EPUB content
-						documents</a>, these are not the only sources. For example, if a reading system provides access
-					to <a data-cite="epub-33#sec-link-elem">linked records</a> [[epub-33]] in the <a>package
-						document</a> metadata, it should similarly open the links in a new browser instance.</p>
+						documents</a>, these are not the only sources of hyperlinks with schemes. For example, if a
+					reading system provides access to external <a data-cite="epub-33#sec-link-elem">linked records</a>
+					[[epub-33]] in the <a>package document</a> metadata, it should open the links in a new browser
+					instance.</p>
 
 				<div class="note">
 					<p>For more information about security and privacy issues with external links, see <a
@@ -2338,6 +2342,12 @@
 				<p>Reading systems that allow users to load untrustworthy EPUB publications (e.g., unsigned EPUB
 					publications through the process of "sideloading") SHOULD treat such content as insecure (e.g.,
 					prompt users to allow scripting and network access).</p>
+
+				<div class="note">
+					<p>Additional security recommendations for external links, network access and scripting are
+						available in <a href="#sec-epub-rs-external-links"></a>, <a href="#sec-epub-rs-network-access"
+						></a>, and <a href="#sec-scripted-content-security"></a>, respectively.</p>
+				</div>
 			</section>
 		</section>
 		<section id="app-epubReadingSystem">
@@ -2572,6 +2582,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>17-June-2022: Add recommendation to alert user before opening URLs with a scheme and clarify the
+						external links section to account for more than just web schemes. See <a
+							href="https://github.com/w3c/epub-specs/issues/2320">issue 2320</a>.</li>
 					<li>07-June-2022: The usage of File URLs has been disallowed. See <a
 							href="https://github.com/w3c/epub-specs/issues/2263">issue 2324</a>.</li>
 					<li>07-June-2022: Noted that unsigned EPUB publications represent a security risk and added

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -392,7 +392,7 @@
 						appropriate security and privacy controls are available).</span></p>
 
 				<div class="note">
-					<p>External links are not only found in [=EPUB content documents=]. A reading system might provides
+					<p>External links are not only found in [=EPUB content documents=]. A reading system might provide
 						access to external <a data-cite="epub-33#sec-link-elem">linked records</a> [[epub-33]] in the
 							<a>package document</a> metadata, for example.</p>
 				</div>


### PR DESCRIPTION
When I read over the external links section again, I didn't like what was there so I've made more changes than just adding a warning about opening external links.

Specifically, the section was talking about opening all external links in a browser, but I'm not sure how much sense that makes for mailto and tel links. Our original focus was only on ensuring the browser security model was available when launching web content. I'm also not sure "links that resolve outside the epub publication" is an accurate description of mailto and tel links and the like. They require a specialized application, but what are they really resolving to?

To try and fix these ambiguities, I've reworded the recommendation to "hyperlinks that declare a scheme". That should cover everything that is not internal without having to be specific about what is being linked.

For the original recommendation about opening in a browser, I've generalized it to opening an appropriate application.

Otherwise, the only other change I made was to add a note to the end of the security recommendations to point to the security sections we have in the body. We talk about external links, network access and scripting in the threats, but then kind of fall silent in the recommendations because the specifics are already in the body.

Anyway, let me know if the new wording makes sense or if it still needs improvement.

Fixes #2320 

EPUB Reading Systems 3.3:
- [Preview](https://raw.githack.com/w3c/epub-specs/fix/issue-2320/epub33/rs/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/fix/issue-2320/epub33/rs/index.html)
