### PR TITLE
Adding reference to symbolic links to the threat models (issue 2322)

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9341,7 +9341,10 @@ html.my-document-playing * {
 					<dd>
 						<p>Resources embedded in the EPUB container are not immune to malicious actors, especially when
 							EPUB publications are obtained from untrusted sources. Resources may contain exploits or
-							forms may submit sensitive information to unintended parties.</p>
+							forms that may submit sensitive information to unintended parties.
+							Such actors may also try to gain access to [=remote resources=] using file indirection techniques,
+							such as symbolic links or file aliases.
+						</p>
 						<p>The use of third-party content, such as games and quizzes, may also lead to security and
 							privacy issues if the EPUB creator is not able to fully vet the content.</p>
 					</dd>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2245,8 +2245,12 @@
 
 					<dt>Malicious content</dt>
 					<dd>
-						<p>EPUB publications may contain resources designed to exploit security flaws in reading systems
-							or the operating systems they run on.</p>
+						<p>
+							EPUB publications may contain resources designed to exploit security flaws in reading systems
+							or the operating systems they run on. Attackers may also try to gain access to
+							[=remote resources=] using file indirection techniques, such as symbolic links or 
+							file aliases.
+						</p>
 						<p>The lack of a standard method of signing EPUB publications means that reading systems cannot
 							always verify whether the content has been tampered with between authoring and loading in
 							the device.</p>


### PR DESCRIPTION
The PR adds a reference to symbolic links to the threat models of both the core and the RS specs, essentially along the lines of what had been proposed in https://github.com/w3c/epub-specs/issues/2322#issuecomment-1156635255. Both threat models already had an item on "malicious content", and that seemed like the good place to add this.

Because the threat models' section implicitly says to RS systems that "you ought to deal with these", adding a separate warning along these lines on symbolic links (and friends), as also mentioned in https://github.com/w3c/epub-specs/issues/2322#issuecomment-1156635255, seemed superfluous.

I did not find a proper place to add a note on _not_ using the `-y` option in the `zip` command; we do not refer to that command in the spec in the first place. So I dropped this, too.

Fix #2322

See:

* For EPUB 3.3:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/symb-link-warning-issue-2322/epub33/core/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/core/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/symb-link-warning-issue-2322/epub33/core/index.html)
* For EPUB 3.3 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/symb-link-warning-issue-2322/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/symb-link-warning-issue-2322/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2337.html" title="Last updated on Jun 21, 2022, 1:22 PM UTC (2544a68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2337/c4ced5a...2544a68.html" title="Last updated on Jun 21, 2022, 1:22 PM UTC (2544a68)">Diff</a>