### PR TITLE
Added the link priority test references

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4661,7 +4661,7 @@ XHTML:
 							href="#record">linked metadata records</a> to enhance the information available to reading
 						systems, but reading systems may ignore these records.</p>
 
-					<p>When a reading system <a data-cite="epub-rs-33#sec-linked-records">processes linked records</a>
+					<p id="sec-linked-records-priority" data-tests="#pkg-linked-records_link-priority,#pkg-linked-records_link-order">When a reading system <a data-cite="epub-rs-33#sec-linked-records">processes linked records</a>
 						[[epub-rs-33]], the document order of <code>link</code> elements is used to determine which has
 						the highest priority in the case of conflicts (i.e., first in document order has the highest
 						priority).</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -831,7 +831,7 @@
 							NOT skip processing the metadata expressed in the package document (i.e., use only the
 							information expressed in the record). Reading systems MAY compile metadata from multiple
 							linked records.</p>
-						<p id="confreq-rs-pkg-link-order">When resolving discrepancies and conflicts between metadata
+						<p id="confreq-rs-pkg-link-order" data-tests="#pkg-linked-records_link-priority,#pkg-linked-records_link-order">When resolving discrepancies and conflicts between metadata
 							expressed in the package document and in linked metadata records, reading systems MUST use
 							the document order of <span data-cite="epub-33">[^link^]</span> elements [[epub-33]] in the
 							package document to establish precedence (i.e., metadata in the first linked record has the


### PR DESCRIPTION
This is the counterpart of https://github.com/w3c/epub-tests/pull/172 for two missing tests. To be merged when that one is merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2338.html" title="Last updated on Jun 23, 2022, 1:37 PM UTC (f94b805)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2338/947d70f...f94b805.html" title="Last updated on Jun 23, 2022, 1:37 PM UTC (f94b805)">Diff</a>