### PR TITLE
Added the defintion for fxl viewports in xhtml

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7505,7 +7505,7 @@ No Entry</pre>
 									<dt>name</dt>
 									<dd>The attribute value MUST be <code>viewport</code>.</dd>
 									<dt>content</dt>
-									<dd> <p>The attribute value MUST be of the following form:</p>
+									<dd> <p>The <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#AVNormalize">normalized</a> [[XML]] attribute value MUST be of the following form:</p>
 										<table class="productionset">
 											<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
 												14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
@@ -7553,18 +7553,15 @@ No Entry</pre>
 												</td>
 												<td>=</td>
 												<td>
-													{ <a href="#viewport.ebnf.whitespace">whitespace</a> }, 
-													(";" | "," | #x20), 
-													{ <a href="#viewport.ebnf.whitespace">whitespace</a> } ;</td>
+													[space], (";" | "," | space), [space]
+												</td>
 											</tr>
 											<tr>
 												<td id="viewport.ebnf.assign">
 													<a href="#viewport.ebnf.assign">assign</a>
 												</td>
 												<td>=</td>
-												<td>{ <a href="#viewport.ebnf.whitespace">whitespace</a> }, 
-													"=", 
-													{ <a href="#viewport.ebnf.whitespace">whitespace</a> } ;</td>
+												<td>[space], "=", [space] ;</td>
 											</tr>
 											<tr>
 												<td id="viewport.ebnf.dimension">
@@ -7574,11 +7571,11 @@ No Entry</pre>
 												<td>? positive number ? ;</td>
 											</tr>
 											<tr>
-												<td id="viewport.ebnf.whitespace">
-													<a href="#viewport.ebnf.whitespace">whitespace</a>
+												<td id="viewport.ebnf.space">
+													<a href="#viewport.ebnf.space">space</a>
 												</td>
 												<td>=</td>
-												<td>(#x20 | #x9 | #xD | #xA) ;</td>
+												<td>#x20 ;</td>
 											</tr>
 										</table>
 									</dd>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7492,7 +7492,7 @@ No Entry</pre>
 								containing block</a> [[css2]] in the manner applicable to their format:</p>
 
 						<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
-							<dt id="sec-fxl-icb-html" data-tests="#fxl-xhtml-icb">Expressing in XHTML</dt>
+							<dt id="sec-fxl-icb-html" data-tests="#fxl-xhtml-icb,#fxl-xhtml-icb_multi">Expressing in XHTML</dt>
 							<dd>
 								<p>
 									For XHTML [=fixed-layout documents=] the <a
@@ -7608,7 +7608,7 @@ No Entry</pre>
 								</aside>
 							</dd>
 
-							<dt id="sec-fxl-icb-svg">Expressing in SVG</dt>
+							<dt id="sec-fxl-icb-svg" data-tests="#fxl-svg-icb_multi">Expressing in SVG</dt>
 							<dd>
 								<p>For SVG [=fixed-layout documents=], the initial containing block [[css2]] dimensions
 									MUST be expressed using the <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11574,6 +11574,10 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>24-June-2022: The <code>meta</code> element in XHTML to specify the initial containing boundary in FXL
+						documents is now formally defined. See <a
+						href="https://github.com/w3c/epub-specs/issues/2292">issue 2292</a>.
+					</li>
 					<li>10-June-2022: Clarified that data blocks are exempt from fallback requirements. See <a
 							href="https://github.com/w3c/epub-specs/issues/2331">issue 2331</a>.</li>
 					<li>07-June-2022: The usage of File URLs has been disallowed. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7505,13 +7505,93 @@ No Entry</pre>
 									<dt>name</dt>
 									<dd>The attribute value MUST be <code>viewport</code>.</dd>
 									<dt>content</dt>
-									<dd>
-										The attribute value MUST be either <code>width=XX,height=YY</code> or 
-										<code>height=YY,width=XX</code>, where <code>XX</code> and <code>YY</code> are 
-										positive numbers, and express the horizontal, respectively vertical, dimensions 
-										of the initial containing block in pixels.
+									<dd> <p>The attribute value MUST be of the following form:</p>
+										<table class="productionset">
+											<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
+												14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
+												U+007F).</caption>
+
+											<tr>
+												<td id="viewport.ebnf.def">
+													<a href="viewport.ebnf.def">viewport</a>
+												</td>
+												<td>=</td>
+												<td>
+													( <a href="#viewport.ebnf.width">width</a>, 
+													  <a href="#viewport.ebnf.sep">sep</a>,
+													  <a href="#viewport.ebnf.height">height</a>
+													)
+													|
+													( <a href="#viewport.ebnf.height">height</a>, 
+													  <a href="#viewport.ebnf.sep">sep</a>,
+													  <a href="#viewport.ebnf.width">width</a>
+													)
+													;
+												</td>
+											</tr>
+											<tr>
+												<td id="viewport.ebnf.width">
+													<a href="#viewport.ebnf.width">width</a>
+												</td>
+												<td>=</td>
+												<td>"width", 
+													<a href="#viewport.ebnf.assign">assign</a>, 
+													( <a href="#viewport.ebnf.dimension">dimension</a> | "device-width" ) ;</td>
+											</tr>
+											<tr>
+												<td id="viewport.ebnf.height">
+													<a href="#viewport.ebnf.height">height</a href="#viewport.ebnf.height">
+												</td>
+												<td>=</td>
+												<td>"height" , 
+													<a href="#viewport.ebnf.assign">assign</a>, 
+													( <a href="#viewport.ebnf.dimension">dimension</a> | "device-height" ) ;</td>
+											</tr>
+											<tr>
+												<td id="viewport.ebnf.sep">
+													<a href="#viewport.ebnf.sep">sep</a>
+												</td>
+												<td>=</td>
+												<td>
+													{ <a href="#viewport.ebnf.whitespace">whitespace</a> }, 
+													(";" | "," | #x20), 
+													{ <a href="#viewport.ebnf.whitespace">whitespace</a> } ;</td>
+											</tr>
+											<tr>
+												<td id="viewport.ebnf.assign">
+													<a href="#viewport.ebnf.assign">assign</a>
+												</td>
+												<td>=</td>
+												<td>{ <a href="#viewport.ebnf.whitespace">whitespace</a> }, 
+													"=", 
+													{ <a href="#viewport.ebnf.whitespace">whitespace</a> } ;</td>
+											</tr>
+											<tr>
+												<td id="viewport.ebnf.dimension">
+													<a href="#viewport.ebnf.dimension">dimension</a>
+												</td>
+												<td>=</td>
+												<td>? positive number ? ;</td>
+											</tr>
+											<tr>
+												<td id="viewport.ebnf.whitespace">
+													<a href="#viewport.ebnf.whitespace">whitespace</a>
+												</td>
+												<td>=</td>
+												<td>(#x20 | #x9 | #xD | #xA) ;</td>
+											</tr>
+										</table>
 									</dd>
 								</dl>
+
+								<p>The <code>device-width</code> and <code>device-height</code> values refer to the 100% of the width, respectively height, of the reading system's [=viewport=].</p>
+
+								<p class="note">
+									Earlier iterations of EPUB referred to the 
+									<a href="https://www.w3.org/TR/css-device-adapt-1/#viewport-meta"><code>meta</code> element syntax</a> [[css-device-adapt-1]] for the
+									the definition of the attribute value, which includes features that are not relevant for EPUB use. All aspects of that syntax that
+									is not defined by this section are <a href="#deprecated">deprecated</a>.
+								</p>
 
 								<aside class="example"
 									title="Specifying the initial containing block in a viewport meta tag">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5846,7 +5846,7 @@ No Entry</pre>
 							<h6>The <code>base</code> element</h6>
 
 							<p id="confreq-html-vocab-base"> The [[html]] <a data-lt="base"><code>base</code>
-									element</a> can be used to specify the [=document base URL=] for the purposes of
+									</a> element can be used to specify the [=document base URL=] for the purposes of
 								parsing URLs. When using it in an [=EPUB publication=], the interpretation of the
 									<code>base</code> element may inadvertently result in references to <a>remote
 									resources</a>. It may also cause reading systems to misinterpret the location of
@@ -7494,11 +7494,25 @@ No Entry</pre>
 						<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
 							<dt id="sec-fxl-icb-html" data-tests="#fxl-xhtml-icb">Expressing in XHTML</dt>
 							<dd>
-								<p>For XHTML [=fixed-layout documents=], the <a
-										href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-										containing block</a> [[css2]] dimensions MUST be expressed in a
-										<code>viewport</code>
-									<code>meta</code> tag using the syntax defined in [[css-device-adapt-1]].</p>
+								<p>
+									For XHTML [=fixed-layout documents=] the <a
+									href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
+									containing block</a> [[css2]] MUST be expressed using the [[html]] 
+									<a data-cite="html#meta"><code>meta</code></a> element with the following attributes:
+								</p>
+
+								<dl>
+									<dt>name</dt>
+									<dd>the attribute value MUST be <code>viewport</code>.</dd>
+									<dt>content</dt>
+									<dd>the attribute value MUST be either <code>width=XX,height=YY</code> or <code>height=YY,width=XX</code>,
+									where <code>XX</code> and <code>YY</code> express the horizontal, 
+									respectively vertical, dimensions of the initial containing block as
+									<a href="https://www.w3.org/TR/css-values/#absolute-lengths">absolute &lt;length&gt;</a> data type values [[css-values]]. If the <a href="https://www.w3.org/TR/css-values/#absolute-length">absolute length unit</a>
+									is missing from a dimension value, it defaults to pixels (i.e., <code>px</code>).
+								</dd>
+								</dl>
+
 								<aside class="example"
 									title="Specifying the initial containing block in a viewport meta tag">
 									<pre>&lt;html …>
@@ -7534,6 +7548,12 @@ No Entry</pre>
 								</aside>
 							</dd>
 						</dl>
+
+						<p class="note">
+							The initial containing block definition affects only the document where it is defined.
+							The dimensions of the containing blocks in the other content documents within the same 
+							publication may be different.
+						</p>
 					</section>
 				</section>
 			</section>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7503,14 +7503,14 @@ No Entry</pre>
 
 								<dl>
 									<dt>name</dt>
-									<dd>the attribute value MUST be <code>viewport</code>.</dd>
+									<dd>The attribute value MUST be <code>viewport</code>.</dd>
 									<dt>content</dt>
-									<dd>the attribute value MUST be either <code>width=XX,height=YY</code> or <code>height=YY,width=XX</code>,
-									where <code>XX</code> and <code>YY</code> express the horizontal, 
-									respectively vertical, dimensions of the initial containing block as
-									<a href="https://www.w3.org/TR/css-values/#absolute-lengths">absolute &lt;length&gt;</a> data type values [[css-values]]. If the <a href="https://www.w3.org/TR/css-values/#absolute-length">absolute length unit</a>
-									is missing from a dimension value, it defaults to pixels (i.e., <code>px</code>).
-								</dd>
+									<dd>
+										The attribute value MUST be either <code>width=XX,height=YY</code> or 
+										<code>height=YY,width=XX</code>, where <code>XX</code> and <code>YY</code> are 
+										positive numbers, and express the horizontal, respectively vertical, dimensions 
+										of the initial containing block in pixels.
+									</dd>
 								</dl>
 
 								<aside class="example"

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1598,8 +1598,12 @@
 									positioned outside of the ICB.</span>
 							</p>
 							<p>
-								If the <code>viewport</code> <code>meta</code> does not contain a width or a height value, 
-								the reading system SHOULD use the width, respectively the height, of the device.
+								If the <code>viewport</code> <code>meta</code> does not contain a width or a height value,
+								or if these values are invalid, reading systems SHOULD consider these as having the value of 
+								<code>device-width</code>, respectively <code>device-height</code>. 
+								Reading systems MAY also use best effort in interpreting values that 
+								follow a deprecated syntax defined in the 
+								<a href="https://www.w3.org/TR/css-device-adapt-1/#viewport-meta"><code>meta</code> element syntax</a> [[css-device-adapt-1]]. 
 							</p>
 							<p id="confreq-fxl-rs-xhtml-icb-ratio"> When the ICB aspect ratio does not match the aspect
 								ratio of the reading system [=content display area=], reading systems MAY position the
@@ -1611,7 +1615,15 @@
 						<dd>
 							<p id="confreq-fxl-rs-svg">Reading systems MUST create the initial containing block (ICB)
 								using the dimensions as defined in <a data-cite="epub-33#sec-fxl-icb-svg">Expressing the
-									ICB in SVG</a> [[epub-33]] to render [=SVG content documents=].</p>
+									ICB in SVG</a> [[epub-33]] to render [=SVG content documents=].
+							</p>
+
+							<p id="confreq-fxl-rs-svg-icb-ratio" class="note"> When the ICB aspect ratio does not match the aspect
+								ratio of the reading system [=content display area=], reading systems should follow the rules for the 
+								<a href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code></a>
+								and the <a href="https://www.w3.org/TR/SVG/coords.html#PreserveAspectRatioAttribute"><code>preserveAspectRatio</code></a>
+								attributes, as defined in [[SVG]]. 
+							</p>
 						</dd>
 					</dl>
 				</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1594,7 +1594,7 @@
 										<code>viewport</code>
 									<code>meta</code> tag for [=XHTML content documents=], as defined in <a
 										data-cite="epub-33#sec-fxl-icb-html">Expressing in HTML</a> [[epub-33]].</span>
-								<span id="confreq-fxl-rs-xhtml-icb" data-tests="#fxl-xhtml-icb">They MUST clip content
+								<span id="confreq-fxl-rs-xhtml-icb" data-tests="#fxl-xhtml-icb,fxl-xhtml-icb_multi">They MUST clip content
 									positioned outside of the ICB.</span>
 							</p>
 							<p>
@@ -1613,7 +1613,7 @@
 
 						<dt>SVG</dt>
 						<dd>
-							<p id="confreq-fxl-rs-svg">Reading systems MUST create the initial containing block (ICB)
+							<p id="confreq-fxl-rs-svg" data-tests="#fxl-svg-icb_multi">Reading systems MUST create the initial containing block (ICB)
 								using the dimensions as defined in <a data-cite="epub-33#sec-fxl-icb-svg">Expressing the
 									ICB in SVG</a> [[epub-33]] to render [=SVG content documents=].
 							</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1598,8 +1598,8 @@
 									positioned outside of the ICB.</span>
 							</p>
 							<p>
-								If the <code>viewport</code> <code>meta</code> does not contain a height or a width value, 
-								the reading system SHOULD use the height, respectively the width, of the device.
+								If the <code>viewport</code> <code>meta</code> does not contain a width or a height value, 
+								the reading system SHOULD use the width, respectively the height, of the device.
 							</p>
 							<p id="confreq-fxl-rs-xhtml-icb-ratio"> When the ICB aspect ratio does not match the aspect
 								ratio of the reading system [=content display area=], reading systems MAY position the

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1597,6 +1597,10 @@
 								<span id="confreq-fxl-rs-xhtml-icb" data-tests="#fxl-xhtml-icb">They MUST clip content
 									positioned outside of the ICB.</span>
 							</p>
+							<p>
+								If the <code>viewport</code> <code>meta</code> does not contain a height or a width value, 
+								the reading system SHOULD use the height, respectively the width, of the device.
+							</p>
 							<p id="confreq-fxl-rs-xhtml-icb-ratio"> When the ICB aspect ratio does not match the aspect
 								ratio of the reading system [=content display area=], reading systems MAY position the
 								ICB inside the area to accommodate the user interface; in other words, added


### PR DESCRIPTION
Following the [WG resolution](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-06-23-epub#resolution2) of June 23.

Notes/questions

- I have restricted the dimension value to be absolute &lt;length&gt; of CSS; I do not think we want relative values (at least in my reading of the minutes)
- I have not found any explicit statement in the CSS specs whereby the value of "500" defaults to "500px". All definitions I have seen seem to indicate that a unit string is needed. I would be happy if someone proved me wrong and we could remove the last sentence on this.
- It is not clear to me whether a value of `content="width=123"` is valid or not. AFAIK, it is valid in CSS, in which case the missing dimension is set to the device's (or browser window's) own size. I do not know whether we do allow this in EPUB FXL. For the time being I did not include that possibility (and the definition will become a bit convoluted if we do...)

    Note, b.t.w., that if we allow some default value for width or height, this should be normatively added to the RS. Actually, we may want to define what happens in such a case in any case; input would be welcome...

Fix #2292


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2341.html" title="Last updated on Jun 30, 2022, 9:45 AM UTC (f008cee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2341/4fadce3...f008cee.html" title="Last updated on Jun 30, 2022, 9:45 AM UTC (f008cee)">Diff</a>