### PR TITLE
Update text on self-containment and add reference to iso 22424

### DIFF
--- a/epub33/core/biblio.js
+++ b/epub33/core/biblio.js
@@ -53,6 +53,11 @@ var biblio = {
 		"href": "https://www.itu.int/ITU-T/recommendations/rec.aspx?rec=13189",
 		"date": "2017-04-13"
 	},
+	"iso22424": {
+		"title": "ISO/IEC TS 22424-1:2020 — Digital publishing — EPUB3 preservation",
+		"href": "https://www.iso.org/standard/73163.html",
+		"date": "2020-01"
+	},
 	"isoschematron": {
 		"title": "ISO/IEC 19757-3: Rule-based validation — Schematron",
 		"href": "http://standards.iso.org/ittf/PubliclyAvailableStandards/c040833_ISO_IEC_19757-3_2006(E).zip",

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9341,10 +9341,9 @@ html.my-document-playing * {
 					<dd>
 						<p>Resources embedded in the EPUB container are not immune to malicious actors, especially when
 							EPUB publications are obtained from untrusted sources. Resources may contain exploits or
-							forms that may submit sensitive information to unintended parties.
-							Such actors may also try to gain access to [=remote resources=] using file indirection techniques,
-							such as symbolic links or file aliases.
-						</p>
+							forms that may submit sensitive information to unintended parties. Such actors may also try
+							to gain access to [=remote resources=] using file indirection techniques, such as symbolic
+							links or file aliases. </p>
 						<p>The use of third-party content, such as games and quizzes, may also lead to security and
 							privacy issues if the EPUB creator is not able to fully vet the content.</p>
 					</dd>
@@ -9478,10 +9477,13 @@ html.my-document-playing * {
 					that do not utilize or transmit information about the user or their content to external parties to
 					perform encryption or decryption.</p>
 
-				<p>EPUB creators who want to maximally limit the privacy and security issues in their EPUB publications
-					SHOULD make the content as self-contained as possible. An EPUB publication that comes with all its
-					needed resources and has no dependencies on network access or links to external content not only
-					benefits users but reduces future maintenance and improves archivability.</p>
+				<p>To maximally reduce security and privacy risks, EPUB creators SHOULD produce their EPUB publications
+					with the goal of long-term preservation. EPUB publications created this way are normally
+					self-contained, not dependent on network access, and not encrypted with digital rights management,
+					removing many of the possible attack vectors. [[?iso22424]] is an example of such a preservation
+					format for EPUB publications. While it is understood that not all EPUB creators can achieve these
+					levels of self-containment, following as many of these practices as possible will still benefit
+					overall user privacy and security.</p>
 			</section>
 		</section>
 		<section id="app-overview-unsupported" class="appendix">


### PR DESCRIPTION
This PR reworks the last paragrah about self containment and adds a reference to OAIS preservation document that was produced in ISO as an example.

Fixes #1876


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2342.html" title="Last updated on Jun 24, 2022, 9:54 AM UTC (76b381f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2342/947d70f...76b381f.html" title="Last updated on Jun 24, 2022, 9:54 AM UTC (76b381f)">Diff</a>