### PR TITLE
Remove redundant processing requirement for hreflang attribute

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -393,8 +393,9 @@
 						controls are available to users.</li>
 				</ul>
 
-				<p id="sec-external-links-consent" data-tests="#pub-external-links_consent">For links that have schemes that require a helper application to load, reading systems SHOULD obtain
-					the user's consent and follow platform guidance for opening the helper application.</p>
+				<p id="sec-external-links-consent" data-tests="#pub-external-links_consent">For links that have schemes
+					that require a helper application to load, reading systems SHOULD obtain the user's consent and
+					follow platform guidance for opening the helper application.</p>
 
 				<div class="note">
 					<p>External links are not only found in [=EPUB content documents=]. A reading system might provide
@@ -822,10 +823,10 @@
 					<dd>
 						<p>Retrieval and support of [=linked resources=] is OPTIONAL.</p>
 						<p id="confreq-rs-pkg-hreflang">The language identified in an <a
-								data-cite="epub-33#attrdef-hreflang"><code>hreflang</code> attribute</a> is purely
-							advisory. Upon fetching the resource, a reading system MUST use the language information
-							associated with the resource to determine its language, not the metadata included in the
-							link to the resource.</p>
+								data-cite="epub-33#attrdef-hreflang"><code>hreflang</code></a> [[EPUB-33]] attribute is
+							purely advisory. The language information expressed in the resource determines its language
+							for processing and rendering purposes, as defined in the <a
+								href="#confreq-rs-pkg-lang-no-content">internationalization requirements</a>.</p>
 						<p id="sec-linked-records" data-tests="#pkg-linked-records">In the case of a <a
 								data-cite="epub-33#record">linked metadata record</a> [[epub-33]], reading systems MUST
 							NOT skip processing the metadata expressed in the package document (i.e., use only the
@@ -2257,12 +2258,10 @@
 
 					<dt>Malicious content</dt>
 					<dd>
-						<p>
-							EPUB publications may contain resources designed to exploit security flaws in reading systems
-							or the operating systems they run on. Attackers may also try to gain access to
-							[=remote resources=] using file indirection techniques, such as symbolic links or 
-							file aliases.
-						</p>
+						<p> EPUB publications may contain resources designed to exploit security flaws in reading
+							systems or the operating systems they run on. Attackers may also try to gain access to
+							[=remote resources=] using file indirection techniques, such as symbolic links or file
+							aliases. </p>
 						<p>The lack of a standard method of signing EPUB publications means that reading systems cannot
 							always verify whether the content has been tampered with between authoring and loading in
 							the device.</p>
@@ -2594,7 +2593,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
-
+					<li>24-June-2022: Removed duplicate requirement not to use <code>hreflang</code> value for
+						processing purposes. See <a href="https://github.com/w3c/epub-specs/pull/2343">pull request
+							2343</a>.</li>
 					<li>17-June-2022: Add recommendation to alert user before opening URLs with a scheme and clarify the
 						external links section to account for more than just web schemes. See <a
 							href="https://github.com/w3c/epub-specs/issues/2320">issue 2320</a>.</li>


### PR DESCRIPTION
As discussed in https://github.com/w3c/epub-tests/pull/173, we have a redundant requirement on language processing for the `hreflang` attribute.

The internationalization section already defines that language and direction are obtained from resources, not information in the package document, and specifically calls out `hreflang` as one case.

This pull request just removes the redundant must for now, replacing it with a pointer to the overarching requirement, but I'm easily convinced we can drop the entire paragraph. It only seems to serve the purpose of reminding a developer of an existing requirement, but we don't repeat this for every element that has a language or direction property, so why here?

EPUB Reading Systems 3.3:
- [Preview](https://raw.githack.com/w3c/epub-specs/fix/hreflang-req/epub33/rs/index.html)
- [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/fix/hreflang-req/epub33/rs/index.html)
