### PR TITLE
Fix terminology references in RS spec

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2963,7 +2963,7 @@
 					<p>This specification does not claim that obfuscation constitutes encryption, nor does it guarantee
 						that the resource will be secure from copyright infringement. The hope is only that this
 						algorithm will meet the requirements of vendors who require some assurance that their fonts
-						cannot be extracted simply by unzipping the OCF container and copying the resource.</p>
+						cannot be extracted simply by unzipping the OCF ZIP container and copying the resource.</p>
 
 					<p>Obfuscation, like any protection scheme, cannot fully protect fonts from being accessed in their
 						deobfuscated state. The mechanism only provides an obstacle for those who are unaware of the
@@ -3023,15 +3023,15 @@
 						the source. Once 1040 bytes are encoded in this way (or the end of the source is reached),
 						directly copy any remaining data in the source to the destination.</p>
 
-					<p>EPUB creators MUST obfuscate fonts before compressing and adding them to the OCF container. Note
-						that as obfuscation is not encryption, this requirement is not a violation of the one in <a
+					<p>EPUB creators MUST obfuscate fonts before compressing and adding them to the OCF ZIP container.
+						Note that as obfuscation is not encryption, this requirement is not a violation of the one in <a
 							href="#sec-container-metainf-encryption.xml"></a> to compress fonts before encrypting
 						them.</p>
 
 					<p>The following pseudo-code exemplifies the obfuscation algorithm.</p>
 
 					<ol class="algorithm">
-						<li>set <var>ocf</var> to OCF container file</li>
+						<li>set <var>ocf</var> to OCF ZIP container file</li>
 						<li>set <var>source</var> to font file</li>
 						<li>set <var>destination</var> to obfuscated font file</li>
 						<li>set <var>keyData</var> to key for file</li>
@@ -9341,10 +9341,9 @@ html.my-document-playing * {
 					<dd>
 						<p>Resources embedded in the EPUB container are not immune to malicious actors, especially when
 							EPUB publications are obtained from untrusted sources. Resources may contain exploits or
-							forms that may submit sensitive information to unintended parties.
-							Such actors may also try to gain access to [=remote resources=] using file indirection techniques,
-							such as symbolic links or file aliases.
-						</p>
+							forms that may submit sensitive information to unintended parties. Such actors may also try
+							to gain access to [=remote resources=] using file indirection techniques, such as symbolic
+							links or file aliases. </p>
 						<p>The use of third-party content, such as games and quizzes, may also lead to security and
 							privacy issues if the EPUB creator is not able to fully vet the content.</p>
 					</dd>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -133,9 +133,9 @@
 			<section id="sec-intro-overview" class="informative">
 				<h3>Overview</h3>
 
-				<p>The EPUB 3 standard is separated into two distinct concerns: the authoring of <a>EPUB
-						publications</a> is defined in the <a data-cite="epub-33#">core specification</a> [[epub-33]],
-					while this specification details the rendering requirements for them in EPUB reading systems.</p>
+				<p>The EPUB 3 standard is separated into two distinct concerns: the authoring of [=EPUB publications=]
+					is defined in the <a data-cite="epub-33#">core specification</a> [[epub-33]], while this
+					specification details the rendering requirements for them in [=EPUB reading system=].</p>
 
 				<p>An EPUB reading system can take many forms. It might have a visual display area for rendering the
 					content to users, for example, or it might only provide audio playback of the content. Therefore,
@@ -195,7 +195,7 @@
 						it. That standard, in turn, references various technologies that continue to evolve, such as
 						MathML, SVG, CSS, and JavaScript.</p>
 
-					<p>Reading system developers must keep track of the changes to HTML, and the technologies it
+					<p>[=Reading system=] developers must keep track of the changes to HTML, and the technologies it
 						references, to ensure they keep their systems up to date.</p>
 
 					<p>This specification does not require EPUB reading systems to support scripting, HTML forms or the
@@ -213,16 +213,16 @@
 						reference. Whenever there is any ambiguity in this reference, the latest recommended
 						specification is the authoritative reference.</p>
 
-					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. Reading
-						system developers must keep track of changes to the SVG standard to ensure that they keep their
-						systems up to date.</p>
+					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. [=Reading
+						system=] developers must keep track of changes to the SVG standard to ensure that they keep
+						their systems up to date.</p>
 				</section>
 			</section>
 		</section>
 		<section id="sec-rs-conformance">
 			<h3>Reading system conformance</h3>
 
-			<p>Whether a reading system has to support a feature is mentioned at the beginning of its section. To be
+			<p>Whether a [=reading system=] has to support a feature is mentioned at the beginning of its section. To be
 				conformant with this specification, reading systems MUST support all required features as well as all
 				applicable conditionally-required features (e.g., to support image rendering if the reading system has a
 				[=viewport=]) as defined in their respective sections.</p>
@@ -245,8 +245,8 @@
 		<section id="sec-pub-resources">
 			<h3>Publication resource processing</h3>
 
-			<p id="confreq-rs-epub-pub-res" class="support" data-tests="#cnt-xhtml-support">Reading systems MUST process
-					<a data-cite="epub-33#sec-publication-resources">publication resources</a> [[epub-33]].</p>
+			<p id="confreq-rs-epub-pub-res" class="support" data-tests="#cnt-xhtml-support">[=Reading systems=] MUST
+				process <a data-cite="epub-33#sec-publication-resources">publication resources</a> [[epub-33]].</p>
 
 			<section id="sec-epub-rs-conf-cmt">
 				<h4>Core Media types</h4>
@@ -301,8 +301,8 @@
 
 			<section id="sec-epub-rs-conf-file-urls">
 				<h4>File URLs</h4>
-				<p id="confreq-rs-file-urls"> Reading Systems MUST prevent access to resources referenced via file
-					URLs [[rfc8089]]. </p>
+				<p id="confreq-rs-file-urls">Reading Systems MUST prevent access to resources referenced via file
+					URLs [[rfc8089]].</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-xml">
@@ -331,15 +331,15 @@
 			<section id="sec-epub-rs-i18n">
 				<h2>Internationalization</h2>
 
-				<p> As part of processing [=publication resources=], the reading system is required to process the
-					attributes to set the language and the base directions in [=XHTML Content documents=] or [=SVG
-					Content documents=], as well as the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code>
+				<p> As part of processing [=publication resources=], a reading system is required to process the
+					attributes to set the language and the base directions in [=XHTML content documents=] or [=SVG
+					content documents=], as well as the <a data-cite="xml#sec-lang-tag"><code>xml:lang</code>
 						attribute</a> for all XML documents (e.g., the [=package document=] and [=media overlay
 					documents=]). </p>
 
 				<p id="confreq-rs-pkg-dir-intro"
 					data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset"
-					> Furthermore, the reading system MUST also process the <a data-cite="epub-33#attrdef-dir"
+					>Furthermore, a reading system MUST also process the <a data-cite="epub-33#attrdef-dir"
 							><code>dir</code></a> attribute [[epub-33]] for the [=package document=], where the base
 					direction specified by <code>dir</code> applies to the element where it is specified, and to all
 					elements in its content unless overridden with another instance of <code>dir</code>. (See also <a
@@ -412,7 +412,7 @@
 		<section id="sec-ocf">
 			<h2>Open Container Format (OCF) processing</h2>
 
-			<p id="confreq-rs-epub3-ocf" class="support" data-tests="#ocf-package_arbitrary">Reading systems MUST
+			<p id="confreq-rs-epub3-ocf" class="support" data-tests="#ocf-package_arbitrary">[=Reading systems=] MUST
 				process the <a data-cite="epub-33#sec-ocf">EPUB container</a> [[epub-33]].</p>
 
 			<div class="note">
@@ -447,8 +447,8 @@
 								root URL</a>.</li>
 
 						<li id="sec-container-iri-origin" data-tests="#ocf-url_origin">The [=origin=] of the [=container
-							root URL=] is unique for each user-specific instance of an <a>EPUB publication</a> in a
-							reading system.</li>
+							root URL=] is unique for each user-specific instance of an [=EPUB publication=] in a reading
+							system.</li>
 					</ul>
 
 					<p class="note">The unicity of the [=origin=] per each user-specific instance of an EPUB publication
@@ -586,8 +586,8 @@
 				<section id="sec-container-filenames">
 					<h4>File names</h4>
 
-					<p>Although EPUB creators are required to follow various <a
-							data-cite="epub-33#sec-container-filenames">File name and file path restrictions</a>
+					<p>Although [=EPUB creators=] are required to follow various <a
+							data-cite="epub-33#sec-container-filenames">file name and file path restrictions</a>
 						[[epub-33]] for maximum interoperability, reading systems SHOULD attempt to process file names
 						and paths that do not adhere to these requirements. Invalid file names and paths may only be
 						problematic on some operating systems.</p>
@@ -604,11 +604,10 @@
 						<dd>
 							<p id="container-default-rendition"
 								data-tests="#ocf-package_arbitrary,#ocf-package_multiple">A reading system MUST, by
-								default, use the [=package document=] referenced the from first <a
-									data-cite="epub-33#sec-container.xml-rootfile-elem"><code>rootfile</code>
-									element</a> [[epub-33]] to render the [=EPUB publication=]. If the reading system
-								recognizes a means of selecting from the other available options, it MAY choose a more
-								appropriate package document.</p>
+								default, use the [=package document=] referenced the from first [^rootfile^] element
+								[[epub-33]] to render the [=EPUB publication=]. If the reading system recognizes a means
+								of selecting from the other available options, it MAY choose a more appropriate package
+								document.</p>
 						</dd>
 
 						<dt id="sec-container-metainf-metadata.xml">Metadata file (<code>metadata.xml</code>)</dt>
@@ -623,8 +622,8 @@
 						<dd>
 							<p>Reading systems MUST NOT use ancillary manifest information contained in the ZIP archive
 								or in the <a data-cite="epub-33#sec-container-metainf-manifest.xml"
-										><code>manifest.xml</code> file</a> [[epub-33]] for processing an <a>EPUB
-									publication</a>.</p>
+										><code>manifest.xml</code> file</a> [[epub-33]] for processing an [=EPUB
+								publication=].</p>
 						</dd>
 
 						<dt id="sec-container-metainf-signatures.xml">Signature file (<code>signatures.xml</code>)</dt>
@@ -654,23 +653,23 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-zip-mult">MUST treat any OCF containers that specify the [[zip]] file is split
-							across multiple storage media as in error.</p>
+						<p id="confreq-zip-mult">MUST treat any [=OCF ZIP container=] that specifies the [[zip]] file is
+							split across multiple storage media as in error.</p>
 					</li>
 					<li>
-						<p id="confreq-zip-comp">MUST treat any OCF containers that use compression techniques other
+						<p id="confreq-zip-comp">MUST treat any OCF ZIP container that uses compression techniques other
 							than Deflate [[rfc1951]] as in error.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-64">MUST support the ZIP64 extensions defined as "Version 1" [[zip]].</p>
 					</li>
 					<li>
-						<p id="confreq-zip-enc">MUST treat OCF ZIP containers that use [[zip]] encryption features as in
-							error.</p>
+						<p id="confreq-zip-enc">MUST treat an OCF ZIP container that uses [[zip]] encryption features as
+							in error.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-rootdir">MAY generate a physical directory for the [=root directory=] of the
-							OCF abstract container if it unzips the contents.</p>
+							[=OCF abstract container=] if it unzips the contents.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-preserve">does not have to preserve information from an OCF ZIP container
@@ -724,7 +723,7 @@
 		<section id="sec-package-doc">
 			<h2>Package document processing</h2>
 
-			<p id="confreq-rs-epub-pub" class="support">Reading systems MUST process the <a
+			<p id="confreq-rs-epub-pub" class="support">[=Reading systems=] MUST process the <a
 					data-cite="epub-33#sec-package-doc">package document</a> [[epub-33]].</p>
 
 			<section id="sec-pkg-doc-base-dir">
@@ -748,8 +747,8 @@
 				<h3>Unique identifier</h3>
 
 				<p id="confreq-rs-pkg-unique-id" data-tests="#pkg-unique-id">Reading systems SHOULD NOT depend on the
-					[=unique identifier=] being unique to one and only one EPUB publication. Determining whether two
-					EPUB publications with the same Unique Identifier represent different versions of the same
+					[=unique identifier=] being unique to one and only one [=EPUB publication=]. Determining whether two
+					EPUB publications with the same unique identifier represent different versions of the same
 					publication, or different publications, may require inspecting other metadata, such as their last
 					modification dates, titles, and authors.</p>
 			</section>
@@ -777,15 +776,15 @@
 					<dt id="dc-title">The <code>dc:title</code> element</dt>
 					<dd>
 						<p id="title-order" data-tests="#pkg-title-order">Reading systems MUST recognize the first
-							[^dc:title^] element [[epub-33]] in document order as the main title of the EPUB publication
-							and present it to users before other title elements.</p>
+							[^dc:title^] element [[epub-33]] in document order as the main title of the [=EPUB
+							publication=] and present it to users before other title elements.</p>
 						<p>This specification does not define how to process additional <code>dc:title</code>
 							elements.</p>
 					</dd>
 
 					<dt id="sec-opf-dclanguage">The <code>dc:language</code> element</dt>
 					<dd>
-						<p>The language(s) of the [=EPUB publication=] specified in [^dc:language^] elements are
+						<p>The language(s) of the EPUB publication specified in [^dc:language^] elements are
 							informational. Some uses of this information include:</p>
 						<ul>
 							<li>exposing it to the user through the reading system user interface</li>
@@ -853,21 +852,22 @@
 						attribute</a> [[epub-33]] they do not recognize.</p>
 
 				<p id="confreq-rendition-rs-manifest" data-tests="#pkg-manifest-unlisted-resource">Reading systems
-					SHOULD NOT use [=linked resources=] in the rendering of an EPUB publication due to the inherent
+					SHOULD NOT use [=linked resources=] in the rendering of an [=EPUB publication=] due to the inherent
 					limitations and risks involved (e.g., lack of information about the resource and how to process it,
 					security risks from remotely-hosted sources, lack of fallbacks, etc.).</p>
 
 				<p>
 					<span id="confreq-rs-pkg-manifest-fallback">A reading system that does not support the MIME media
-						type [[rfc2046]] of a given publication resource MUST traverse the <a
+						type [[rfc2046]] of a given [=publication resource=] MUST traverse the <a
 							data-cite="epub-33#sec-manifest-fallbacks">manifest fallback chain</a> [[epub-33]] until it
 						identifies a supported publication resource to use in place of the unsupported resource. </span>
 					<span id="confreq-rs-pkg-manifest-fallback-order">If the reading system supports multiple
 						publication resources in the fallback chain, it MAY select the resource to use based on the
 						resource's <a data-cite="epub-33#attrdef-item-properties"><code>properties</code> attribute</a>
-						[[epub-33]] values, otherwise it SHOULD honor the EPUB creator's preferred fallback order. </span>
+						[[epub-33]] values, otherwise it SHOULD honor the [=EPUB creator|EPUB creator's=] preferred
+						fallback order.</span>
 					<span id="confreq-rs-pkg-manifest-fallback-fail">If a reading system does not support any resource
-						in the fallback chain, it MUST alert the reader that it could not display the content. </span>
+						in the fallback chain, it MUST alert the user that it could not display the content. </span>
 				</p>
 
 				<p>When <a data-cite="epub-33#sec-manifest-fallbacks">manifest fallbacks</a> [[epub-33]] are provided
@@ -883,7 +883,7 @@
 				<h3>Spine</h3>
 
 				<p id="confreq-rs-spine-order" data-tests="#pkg-spine-order">Reading systems MUST provide a means of
-					rendering the EPUB publication in the order defined in the [^spine^] element [[epub-33]], which
+					rendering an [=EPUB publication=] in the order defined in the [^spine^] element [[epub-33]], which
 					includes:</p>
 				<ul>
 					<li>recognizing the first <a data-cite="epub-33#attrdef-itemref-linear">primary (linear)
@@ -901,8 +901,8 @@
 						fallback.</span> Reading systems MAY also provide the option for users to skip non-linear
 					content by default or not.</p>
 
-				<p id="confreq-rs-spine-progression-default" data-tests="#pkg-spine-progression-default">If the EPUB
-					creator has not specified the <a data-cite="epub-33#attrdef-spine-page-progression-direction"
+				<p id="confreq-rs-spine-progression-default" data-tests="#pkg-spine-progression-default">If the [=EPUB
+					creator=] has not specified the <a data-cite="epub-33#attrdef-spine-page-progression-direction"
 							><code>page-progression-direction</code> attribute</a> [[epub-33]], the reading system MUST
 					assume the value of <code>default</code>. When <code>page-progression-direction</code> value is
 						<code>default</code>, the reading system can choose the rendering direction.</p>
@@ -914,12 +914,13 @@
 
 				<p id="confreq-rs-pkg-spine-unknown" data-tests="#pkg-spine-unknown">Reading systems MUST ignore all
 					values expressed in spine <code>itemref</code>
-					<code>properties</code> attributes that they do not recognize.</p>
+					<a data-cite="epub-33#attrdef-properties"><code>properties</code> attributes</a> [[EPUB-33]] that
+					they do not recognize.</p>
 
 				<p>
 					<span id="confreq-rs-pkg-duplicate-item-rendering" data-tests="#pkg-spine-duplicate-item-rendering">
-						Reading systems MUST NOT skip spine references to duplicate manifest items when rendering the
-						linear reading order.</span>
+						Reading systems MUST NOT skip spine references to duplicate <a data-cite="epub-33#sec-item-elem"
+							>manifest items</a> [[EPUB-33]] when rendering the linear reading order.</span>
 					<span id="confreq-rs-pkg-duplicate-item-ui" data-tests="#pkg-spine-duplicate-item-ui">The reading
 						system MUST treat these as distinct items for user interface (UI) purposes (for example, each
 						occurrence could be independently bookmarked or annotated).</span>
@@ -932,7 +933,7 @@
 				<section id="spine-overrides">
 					<h4>Spine overrides</h4>
 
-					<p id="confreq-rs-pkg-spine-override">When a spine [^itemref^] element's <a
+					<p id="confreq-rs-pkg-spine-override">When a [=spine=] [^itemref^] element's <a
 							data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a <a
 							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
 						systems MUST follow the requirements for the override's global value to display that spine
@@ -970,7 +971,7 @@
 			<section id="sec-xhtml">
 				<h3>XHTML content documents</h3>
 
-				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="#cnt-xhtml-support">Reading systems MUST
+				<p id="confreq-rs-epub3-xhtml" class="support" data-tests="#cnt-xhtml-support">[=Reading systems=] MUST
 					process <a data-cite="epub-33#sec-xhtml">XHTML content documents</a> [[epub-33]].</p>
 
 				<p id="confreq-html-rs-behavior">Unless explicitly defined in this section as overridden, reading
@@ -1107,8 +1108,8 @@
 			<section id="sec-svg">
 				<h3>SVG content documents</h3>
 
-				<p id="confreq-rs-epub3-svg" class="support" data-tests="#cnt-svg-support">Reading systems MUST process
-						<a data-cite="epub-33#sec-svg">SVG content documents</a> [[epub-33]].</p>
+				<p id="confreq-rs-epub3-svg" class="support" data-tests="#cnt-svg-support">[=Reading systems=] MUST
+					process <a data-cite="epub-33#sec-svg">SVG content documents</a> [[epub-33]].</p>
 
 				<p>To process SVG content documents and <a href="#sec-xhtml-svg">SVG embedded in XHTML content
 						documents</a>, a reading system:</p>
@@ -1142,7 +1143,7 @@
 			<section id="sec-css">
 				<h3>Cascading Style Sheets (CSS)</h3>
 
-				<p id="confreq-rs-epub3-css" data-tests="#cnt-css-support" class="support">If a reading system has a
+				<p id="confreq-rs-epub3-css" data-tests="#cnt-css-support" class="support">If a [=reading system=] has a
 					[=viewport=], it MUST support the <a data-cite="epub-33#sec-css">visual rendering of XHTML content
 						documents via CSS</a> [[epub-33]].</p>
 
@@ -1199,7 +1200,7 @@
 				<h3>Scripting</h3>
 
 				<p id="confreq-rs-scripted" class="support"
-					data-test="#scr-support,#scr-support_iframe,#scr-support_svg">Reading systems SHOULD support <a
+					data-test="#scr-support,#scr-support_iframe,#scr-support_svg">[=Reading systems=] SHOULD support <a
 						data-cite="epub-33#sec-scripted-content">scripting</a> [[epub-33]].</p>
 
 				<p>Reading system support for scripting depends on its usage context:</p>
@@ -1208,7 +1209,7 @@
 					<li>
 						<p id="confreq-rs-scripted-reflow-support">Reading systems SHOULD support <a
 								data-cite="epub-33#sec-scripted-container-constrained">container-constrained
-								scripting</a> [[epub-33]] in reflowable EPUB content documents.</p>
+								scripting</a> [[epub-33]] in reflowable [=EPUB content documents=].</p>
 					</li>
 					<li>
 						<p id="confreq-rs-scripted-fxl-support">Reading systems SHOULD support <a
@@ -1247,7 +1248,7 @@
 						<p id="confreq-rs-scripted-origin">
 							<span id="confreq-rs-scripted-origin-shared" data-tests="#scr-support_origin">It MUST assign
 								a unique [=origin=] [[url]], shared by all <a data-cite="epub-33#sec-scripted-spine"
-									>spine-level scripts</a> of the EPUB publication.</span>
+									>spine-level scripts</a> of the [=EPUB publication=].</span>
 							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin">That
 								[=origin=] [[url]] MUST be <em>unique</em> for each user-specific instance of an EPUB
 								publication in a reading system.</span>
@@ -1258,9 +1259,9 @@
 						<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to modify
 							the [[dom]] of the host EPUB content document or other contents in the EPUB publication and
 							MUST NOT allow it to manipulate the size of its containing rectangle. (Note: Even if a
-							script is not container-constrained, the reading system MAY impose restrictions on
-							modifications (see also the <a href="#feature-dom-manipulation">dom-manipulation
-							feature</a>).)</p>
+							script is not container-constrained, a reading system might impose restrictions on
+							modifications. See the <a href="#feature-dom-manipulation">dom-manipulation
+							feature</a>.)</p>
 					</li>
 					<li>
 						<p id="confreq-rs-scripted-limit">It MAY place additional limitations on the capabilities
@@ -1329,7 +1330,7 @@
 								causing unexpected behavior);</p>
 						</li>
 						<li>
-							<p>an attack of one EPUB content document against another (e.g., stealing data that
+							<p>an attack of one [=EPUB content document=] against another (e.g., stealing data that
 								originated in a different document);</p>
 						</li>
 						<li>
@@ -1370,7 +1371,7 @@
 		<section id="sec-nav">
 			<h3>Navigation document processing</h3>
 
-			<p id="sec-nav-rs-conf" class="support" data-tests="#nav-spine_in-spine">Reading systems MUST process <a
+			<p id="sec-nav-rs-conf" class="support" data-tests="#nav-spine_in-spine">[=Reading systems=] MUST process <a
 					data-cite="epub-33#sec-nav">EPUB navigation documents</a> [[epub-33]].</p>
 
 			<p>To process the EPUB navigation document, a reading system:</p>
@@ -1398,8 +1399,8 @@
 				</li>
 				<li>
 					<p id="confreq-nav-activation" data-tests="#nav-activation">MUST relocate the current reading
-						position to the destination identified by an activated link when the link is to a <a>publication
-							resource</a>.</p>
+						position to the destination identified by an activated link when the link is to a [=publication
+						resource=].</p>
 				</li>
 				<li>
 					<p id="confreq-nav-ol-style" data-tests="#nav-spine_in-spine-no-list-style">MUST NOT show list item
@@ -1420,8 +1421,8 @@
 			<section id="sec-fixed-layouts">
 				<h3>Fixed-layout documents</h3>
 
-				<p id="confreq-rs-epub3-fxl" data-tests="#fxl-spread-none" class="support">Reading systems MUST support
-					the rendering of <a data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a>
+				<p id="confreq-rs-epub3-fxl" data-tests="#fxl-spread-none" class="support">[=Reading systems=] MUST
+					support the rendering of <a data-cite="epub-33#sec-fixed-layouts">fixed-layout documents</a>
 					[[epub-33]].</p>
 
 				<section id="sec-fxl-props">
@@ -1471,19 +1472,20 @@
 						<dl class="variablelist">
 							<dt id="def-orientation-auto">auto</dt>
 							<dd>
-								<p>The reading system determines the orientation in which to render the content.</p>
+								<p>The reading system determines the orientation in which to render [=EPUB content
+									documents=].</p>
 							</dd>
 
 							<dt id="def-orientation-landscape" data-tests="#fxl-orientation-landscape">landscape</dt>
 							<dd>
-								<p>Reading systems that support multiple orientations SHOULD render the content in
-									landscape orientation.</p>
+								<p>Reading systems that support multiple orientations SHOULD render EPUB content
+									documents in landscape orientation.</p>
 							</dd>
 
 							<dt id="def-orientation-portrait">portrait</dt>
 							<dd>
-								<p>Reading systems that support multiple orientations SHOULD render the content in
-									portrait orientation.</p>
+								<p>Reading systems that support multiple orientations SHOULD render EPUB content
+									documents in portrait orientation.</p>
 							</dd>
 						</dl>
 
@@ -1493,11 +1495,11 @@
 					<section id="spread">
 						<h5>The <code>rendition:spread</code> property</h5>
 
-						<p id="fxl-spread-default" data-tests="#fxl-spread-default" data-cite="epub-33">The default
-							value <code>auto</code> MUST be assumed by EPUB reading systems as the global value if no
-							[^meta^] element carrying the <a data-cite="epub-33#spread"
-								><code>rendition:spread</code></a> property occurs in the <a
-								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[epub-33]].</p>
+						<p id="fxl-spread-default" data-tests="#fxl-spread-default" data-cite="epub-33">Reading Systems
+							MUSt assume the default value <code>auto</code> as the global value if no [^meta^] element
+							carrying the <a data-cite="epub-33#spread"><code>rendition:spread</code></a> property occurs
+							in the <a data-cite="epub-33#elemdef-opf-metadata">package document metadata</a>
+							[[epub-33]].</p>
 
 						<p>The <code>rendition:spread</code> property values have the following processing
 							requirements:</p>
@@ -1539,16 +1541,16 @@
 							<span id="page-spread-left" data-tests="#fxl-page-spread-left">The <a
 									data-cite="epub-33#fxl-page-spread-left"><code>rendition:page-spread-left</code>
 									property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in
-								the left-hand slot in the spread. </span>
+								the left-hand slot of a spread.</span>
 							<span id="page-spread-right" data-tests="#fxl-page-spread-right">The <a
 									data-cite="epub-33#fxl-page-spread-right"><code>rendition:page-spread-right</code>
 									property</a> [[epub-33]] indicates that the given spine item SHOULD be rendered in
-								the right-hand slot in the spread. </span>
+								the right-hand slot of a spread.</span>
 						</p>
 
 						<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
 							properties apply to both pre-paginated and reflowable content, and they only apply when the
-							reading system is creating synthetic spreads.</p>
+							reading system is creating [=synthetic spreads=].</p>
 
 						<p id="page-break-precedence">The <code>rendition:page-spread-*</code> properties MUST take
 							precedence over whatever value of the <a
@@ -1563,17 +1565,17 @@
 									><code>page-progression-direction</code> attribute</a> [[epub-33]] &#8212; when it
 							lacks a <code>rendition:page-spread-*</code> property value.</p>
 
-						<p id="page-spread-flow" data-tests="#page-layout-both-spread">If the reflowable spine item has
-							a <code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by inserting
-							a blank page).</p>
+						<p id="page-spread-flow" data-tests="#page-layout-both-spread">Reading systems MUST honor
+								<code>rendition:page-spread-*</code> properties on reflowable spine items (e.g., by
+							inserting a blank page).</p>
 
 						<p id="page-spread-both-pre-pag" data-tests="#page-layout-both-spread">Similarly, when a
 							pre-paginated spine item follows a reflowable one, the pre-paginated one SHOULD start on the
 							next page (as defined by the <code>page-progression-direction</code> attribute) when it
 							lacks a <code>rendition:page-spread-*</code> property value.</p>
 
-						<p id="page-spread-both-dir" data-tests="#page-layout-both-spread">If the pre-paginated spine
-							item has a <code>rendition:page-spread-*</code> specification, it MUST be honored (e.g., by
+						<p id="page-spread-both-dir" data-tests="#page-layout-both-spread">Reading systems MUST honor
+								<code>rendition:page-spread-*</code> properties on pre-paginated spine items (e.g., by
 							inserting a blank page).</p>
 
 						<p id="fxl-page-spread-combined" data-tests="#fxl-page-spread-combined">When a reading system
@@ -1616,10 +1618,10 @@
 				<section id="sec-fxl-viewport">
 					<h4>Viewport rendering</h4>
 
-					<p>When rendering [=fixed-layout documents=], the default intent is that the <a>content display
-							area</a> SHOULD occupy as much of the available [=viewport=] area as possible. Reading
-						systems SHOULD NOT inject additional content such as border, margins, headers, or footers into
-						the viewport.</p>
+					<p>When rendering [=fixed-layout documents=], the default intent is that the [=content display
+						area=] SHOULD occupy as much of the available [=viewport=] area as possible. Reading systems
+						SHOULD NOT inject additional content such as border, margins, headers, or footers into the
+						viewport.</p>
 
 					<div class="note">
 						<p>This specification does not define how the <a
@@ -1638,7 +1640,7 @@
 			<section id="sec-reflowable-layouts">
 				<h3>Reflowable layouts</h3>
 
-				<p id="confreq-rs-epub3-presentational-meta" class="support">Reading systems SHOULD process the <a
+				<p id="confreq-rs-epub3-presentational-meta" class="support">[=Reading systems=] SHOULD process the <a
 						data-cite="epub-33#sec-reflowable-layouts">reflowable layout properties</a> [[epub-33]].</p>
 
 				<section id="flow">
@@ -1661,10 +1663,11 @@
 
 						<dt id="scrolled-continuous">scrolled-continuous</dt>
 						<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
-							<p>The reading system SHOULD render all EPUB content documents such that overflow content is
-								scrollable, and SHOULD present the EPUB publication as one continuous scroll from spine
-								item to spine item (except where <a data-cite="epub-33#layout-property-flow-overrides"
-									>locally overridden</a> [[epub-33]]).</p>
+							<p>The reading system SHOULD render all [=EPUB content documents=] such that overflow
+								content is scrollable, and SHOULD present the [=EPUB publication=] as one continuous
+								scroll from spine item to spine item (except where <a
+									data-cite="epub-33#layout-property-flow-overrides">locally overridden</a>
+								[[epub-33]]).</p>
 						</dd>
 
 						<dt id="scrolled-doc">scrolled-doc</dt>
@@ -1682,10 +1685,11 @@
 					</dl>
 
 					<p>For the <code>rendition:flow-scrolled-continuous</code> property, the scroll direction MUST be
-						defined relative to the block flow direction of the root element of the XHTML content document
-						referenced by the [^itemref^] element [[epub-33]]. The scroll direction MUST be vertical if the
-						block flow direction is downward (top-to-bottom). It MUST be horizontal if the block flow
-						direction of the root element is rightward (left-to-right) or leftward (right-to-left).</p>
+						defined relative to the block flow direction of the root element of the [=XHTML content
+						document=] referenced by the [^itemref^] element [[epub-33]]. The scroll direction MUST be
+						vertical if the block flow direction is downward (top-to-bottom). It MUST be horizontal if the
+						block flow direction of the root element is rightward (left-to-right) or leftward
+						(right-to-left).</p>
 
 					<p>Reading systems MUST ignore the <code>rendition:flow</code> property and its overrides when
 						processing <a href="https://www.w3.org/TR/epub-33/#def-layout-pre-paginated">pre-paginated spine
@@ -1704,15 +1708,15 @@
 						page.</p>
 
 					<p>This specification does not define a default rendering behavior when reading systems do not
-						support this property or EPUB creators do not specify it. Reading systems MAY render spine items
-						by their own design.</p>
+						support this property or [=EPUB creators=] do not specify it. Reading systems MAY render spine
+						items by their own design.</p>
 				</section>
 			</section>
 
 			<section id="sec-custom-properties">
 				<h3>Custom properties</h3>
 
-				<p>Reading systems MAY support custom properties provided they do not introduce expressions that
+				<p>[=Reading systems=] MAY support custom properties provided they do not introduce expressions that
 					conflict behaviorally with the properties defined in the <a
 						href="https://www.w3.org/TR/epub-33/#app-rendering-vocab">Package rendering vocabulary</a>
 					[[epub-33]].</p>
@@ -1721,8 +1725,8 @@
 		<section id="sec-media-overlays">
 			<h2>Media overlays processing</h2>
 
-			<p id="confreq-rs-epub3-mo" class="support">Reading systems with the capability to render prerecorded audio
-				SHOULD support <a data-cite="epub-33#sec-media-overlays">media overlays</a> [[epub-33]].</p>
+			<p id="confreq-rs-epub3-mo" class="support">[=Reading systems=] with the capability to render prerecorded
+				audio SHOULD support <a data-cite="epub-33#sec-media-overlays">media overlays</a> [[epub-33]].</p>
 
 			<p>If a reading system does not support media overlays, it MUST ignore both:</p>
 
@@ -1760,34 +1764,32 @@
 				<section id="sec-rsconf-timing-synch">
 					<h3>Timing and synchronization</h3>
 
-					<p id="mol-timing-sync"
+					<p id="mol-timing-sync" data-cite="epub-33"
 						data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio"
-						>Reading systems MUST render immediate children of the <a data-cite="epub-33#elemdef-smil-body"
-								><code>body</code> element</a> [[epub-33]] in a sequence. A <a
-							data-cite="epub-33#elemdef-smil-seq"><code>seq</code> element's</a> [[epub-33]] children
-						MUST be rendered in sequence, and playback completes when the last child finishes playing.
-						Reading system MUST render a <a data-cite="epub-33#elemdef-smil-par"><code>par</code>
-							element's</a> [[epub-33]] children in parallel (with each starting at the same time), and
-						playback completes when all the children finish playing. Reading system playback of the media
-						overlay document completes when the <code>body</code> element's last child finishes playing.</p>
+						>Reading systems MUST render immediate children of the [^body^] element [[epub-33]] in a
+						sequence. A [^seq^] element's [[epub-33]] children MUST be rendered in sequence, and playback
+						completes when the last child finishes playing. Reading system MUST render a [^par^] element's
+						[[epub-33]] children in parallel (with each starting at the same time), and playback completes
+						when all the children finish playing. Reading system playback of the media overlay document
+						completes when the <code>body</code> element's last child finishes playing.</p>
 				</section>
 
 				<section id="sec-rsconf-rendering-audio">
 					<h5>Rendering audio</h5>
 
-					<p id="mol-audio" data-tests="#mol-audio">When presented with a media overlay <a
-							data-cite="epub-33#elemdef-smil-audio"><code>audio</code> element</a>, reading systems MUST
-						play the audio resource referenced by the <code>src</code> attribute, starting at the clip
-						offset time given by the <a data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code>
-							attribute</a> and ending at the clip offset time given by the <a
-							data-cite="epub-33#attrdef-smil-clipEnd"><code>clipEnd</code> attribute</a> [[epub-33]].</p>
+					<p id="mol-audio" data-cite="epub-33" data-tests="#mol-audio">When presented with a media overlay
+						[^audio^] element [[EPUB-33]], reading systems MUST play the audio resource referenced by the
+							<code>src</code> attribute, starting at the clip offset time given by the <a
+							data-cite="epub-33#attrdef-smil-clipBegin"><code>clipBegin</code></a> attribute and ending
+						at the clip offset time given by the <a data-cite="epub-33#attrdef-smil-clipEnd"
+								><code>clipEnd</code></a> attribute [[epub-33]].</p>
 
 					<p>In addition:</p>
 
 					<ul>
 						<li id="mol-audio-no-clipbegin" data-tests="#mol-audio-no-clipbegin">
-							<p>If the EPUB creator has not specified a <code>clipBegin</code> attribute, reading systems
-								MUST assume the value "<code>0</code>".</p>
+							<p>If the [=EPUB creator=] has not specified a <code>clipBegin</code> attribute, reading
+								systems MUST assume the value "<code>0</code>".</p>
 						</li>
 						<li id="mol-audio-no-clipend" data-tests="#mol-audio-no-clipend">
 							<p>If the EPUB creator has not specified a <code>clipEnd</code> attribute, reading systems
@@ -1802,27 +1804,25 @@
 					<p>User-controllable audio playback options SHOULD include timescale modification, in which the user
 						can alter the playback rate without distorting the pitch. The suggested range is half-speed to
 						double-speed.</p>
-
 				</section>
 
 				<section id="sec-rsconf-rendering-text">
 					<h5>Rendering EPUB content document elements</h5>
 
-					<p>When presented with a media overlay <a data-cite="epub-33#elemdef-smil-text"><code>text</code>
-							element</a> [[epub-33]] whose <code>src</code> attribute contains a <a>URL-fragment
-							string</a> referencing a specific part of an EPUB content document, reading systems SHOULD
-						ensure the referenced portion is visible in the [=viewport=]. In addition to [[html]] element ID
-						references and <a href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG
-							Fragment Identifiers</a> [[svg]], reading systems MAY support other fragment identifier
-						schemes.</p>
+					<p>When presented with a media overlay [^text^] element [[epub-33]] whose <code>src</code> attribute
+						contains a <a>URL-fragment string</a> referencing a specific part of an EPUB content document,
+						reading systems SHOULD ensure the referenced portion is visible in the [=viewport=]. In addition
+						to [[html]] element ID references and <a
+							href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
+							Identifiers</a> [[svg]], reading systems MAY support other fragment identifier schemes.</p>
 
 					<p id="mol-rendering-with-styling"
 						data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg">During
 						media overlays playback, reading systems with a viewport SHOULD add the class names given by the
 						metadata properties <a data-cite="epub-33#active-class"><code>active-class</code></a> and <a
 							data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a> [[epub-33]]
-						to the appropriate elements, when specified, in the EPUB content document. Conversely, the class
-						names SHOULD be removed when the playback state changes, as described in <a
+						to the appropriate elements, when specified, in the [=EPUB content document=]. Conversely, the
+						class names SHOULD be removed when the playback state changes, as described in <a
 							data-cite="epub-33#sec-docs-assoc-style">Associating style information</a> [[epub-33]].</p>
 
 					<p>The <code>active-class</code> and <code>playback-active-class</code> metadata properties are
@@ -1854,11 +1854,11 @@
 						navigation point target.</p>
 
 					<div class="note">
-						<p>EPUB creators may associate a media overlay document directly with an <a>EPUB navigation
-								document</a>t in order to provide synchronized playback of its contents, regardless of
-							whether the [=XHTML content document=] in which it resides is included in the [=EPUB spine |
-							spine=]. See <a data-cite="epub-33#sec-mo-nav-doc">EPUB navigation document</a> [[epub-33]]
-							for more information.</p>
+						<p>[=EPUB creators=] may associate a [=media overlay document=] directly with an <a>EPUB
+								navigation document</a> in order to provide synchronized playback of its contents,
+							regardless of whether the [=XHTML content document=] in which it resides is included in the
+							[=EPUB spine | spine=]. See <a data-cite="epub-33#sec-mo-nav-doc">EPUB navigation
+								document</a> [[epub-33]] for more information.</p>
 					</div>
 
 					<div class="note" id="note-table-reading-mode">
@@ -1929,14 +1929,13 @@
 								There are two possible scenarios:</p>
 							<ul>
 								<li>
-									<p>When a media overlay <code>text</code> element has no <a
-											data-cite="epub-33#elemdef-smil-audio"><code>audio</code></a> [[epub-33]]
-										sibling within its <a data-cite="epub-33#elemdef-smil-par"><code>par</code></a>
-										[[epub-33]] parent container, the referenced EPUB content document audio or
-										video media MUST play until it ends, at which point the <code>text</code>
-										element's lifespan terminates. In this case, the implicit duration of the
-											<code>text</code> element (and by inference, of the parent <code>par</code>
-										container) is that of the referenced audio or video clip.</p>
+									<p data-cite="epub-33">When a media overlay <code>text</code> element has no
+										[^audio^] [[epub-33]] sibling within its [^par^] [[epub-33]] parent container,
+										the referenced EPUB content document audio or video media MUST play until it
+										ends, at which point the <code>text</code> element's lifespan terminates. In
+										this case, the implicit duration of the <code>text</code> element (and by
+										inference, of the parent <code>par</code> container) is that of the referenced
+										audio or video clip.</p>
 								</li>
 								<li>
 									<p>When a media overlay <code>text</code> element has an <code>audio</code> sibling
@@ -1977,18 +1976,17 @@
 				<section id="sec-text-to-speech">
 					<h5>Text-to-speech</h5>
 
-					<p id="mol-tts" data-tests="#mol-tts_multi,#mol-tts_single">When a media overlay <a
-							data-cite="epub-33#elemdef-smil-text"><code>text</code> element</a> [[epub-33]] with no <a
-							data-cite="epub-33#elemdef-smil-audio"><code>audio</code></a> [[epub-33]] sibling element
-						references text within the target [=EPUB content document=], reading systems capable of
-						text-to-speech (TTS) playback SHOULD render the referenced text using TTS.</p>
+					<p id="mol-tts" data-cite="epub-33" data-tests="#mol-tts_multi,#mol-tts_single">When a media overlay
+						[^text^] element with no [^audio^] [[epub-33]] sibling element references text within the target
+						[=EPUB content document=], reading systems capable of text-to-speech (TTS) playback SHOULD
+						render the referenced text using TTS.</p>
 
 					<p>Reading systems SHOULD use the speech-related information provided in the target EPUB content
 						document to play the audio stream as part of the media overlay rendering.</p>
 
 					<div class="note">
 						<p>See <a data-cite="epub-tts-10#">EPUB 3 Text-to-Speech Support</a> [[epub-tts-10]] for more
-							information about supporting TTS technologies in EPUB publications.</p>
+							information about supporting TTS technologies in [=EPUB publications=].</p>
 					</div>
 
 					<p>The media overlay <code>text</code> element's lifespan corresponds to the rendering time of the
@@ -2033,7 +2031,7 @@
 		<section id="sec-structural-semantics">
 			<h2>Processing structural semantics</h2>
 
-			<p id="confreq-rs-epub-epub-type" class="support">Reading systems MAY support <a
+			<p id="confreq-rs-epub-epub-type" class="support">[=Reading systems=] MAY support <a
 					data-cite="epub-33#app-structural-semantics">structural semantics</a> [[epub-33]] in <a>EPUB content
 					documents</a>.</p>
 
@@ -2055,7 +2053,7 @@
 		<section id="sec-vocab-assoc">
 			<h2>Vocabulary association mechanisms</h2>
 
-			<p id="confreq-rs-vocab-assoc" class="support">Reading systems MAY support <a
+			<p id="confreq-rs-vocab-assoc" class="support">[=Reading systems=] MAY support <a
 					data-cite="epub-33#sec-vocab-assoc">vocabulary association mechanisms</a> [[epub-33]] in [=EPUB
 				content documents=].</p>
 
@@ -2065,8 +2063,8 @@
 					<p>
 						<span id="confreq-rs-vocab-reserved-prefixes">Reading systems MUST resolve all <a
 								data-cite="epub-33#sec-reserved-prefixes">reserved prefixes</a> [[epub-33]] used in
-							package documents using their predefined URLs unless the EPUB creator declares a local <a
-								href="#sec-prefix-attr">prefix</a>. </span>
+							[=package documents=] using their predefined URLs unless the [=EPUB creator=] declares a
+							local <a href="#sec-prefix-attr">prefix</a>. </span>
 						<span id="confreq-rs-vocab-local-prefixes">Reading systems MUST use the URLs defined for locally
 							overridden prefixes (using the <code>prefix</code> attribute) when encountered. </span>
 					</p>
@@ -2085,7 +2083,7 @@
 
 				<dt id="sec-default-vocab">Default vocabularies</dt>
 				<dd>
-					<p>Default vocabularies are defined for [=package document=] attributes that accept <a
+					<p>Default vocabularies are defined for package document attributes that accept <a
 							data-cite="epub-33#sec-property-datatype"><code>property</code> data types</a> [[EPUB-33]].
 						When unprefixed terms are encountered in these attributes, the URL of the applicable default
 						vocabulary URL is used to <a href="#sec-property-datatype">expand the values</a>.</p>
@@ -2142,9 +2140,10 @@
 		<section id="sec-epub-rs-conf-backward">
 			<h3>Backward compatibility</h3>
 
-			<p id="confreq-rs-backward-epub" data-tests="#pkg-version-backward">Reading systems MUST attempt to process
-				an [=EPUB publication=] whose [=package document=] <a data-cite="epub-33#attrdef-package-version"
-						><code>version</code> attribute</a> [[epub-33]] is less than "<code>3.0</code>".</p>
+			<p id="confreq-rs-backward-epub" data-tests="#pkg-version-backward">[=Reading systems=] MUST attempt to
+				process an [=EPUB publication=] whose [=package document=] <a
+					data-cite="epub-33#attrdef-package-version"><code>version</code> attribute</a> [[epub-33]] is less
+				than "<code>3.0</code>".</p>
 
 			<p id="confreq-rs-backward-conf">EPUB publications with older version numbers will not always render exactly
 				as intended unless processed according to their respective specifications. Reading systems SHOULD
@@ -2153,17 +2152,17 @@
 		<section id="sec-epub-rs-conf-forward">
 			<h3>Forward compatibility</h3>
 
-			<p id="confreq-rs-forward-epubn">Reading systems SHOULD attempt to process an [=EPUB publication=] whose
+			<p id="confreq-rs-forward-epubn">[=Reading systems=] SHOULD attempt to process an [=EPUB publication=] whose
 				[=package document=] <a data-cite="epub-33#attrdef-package-version"><code>version</code> attribute</a>
 				[[epub-33]] is greater than "<code>3.0</code>".</p>
 		</section>
 		<section id="sec-accessibility" class="informative">
 			<h2>Accessibility</h2>
 
-			<p>Although the primary focus of this specification is on how to process and render [=EPUB publications=] it
-				does not mandate specific user interfaces that all reading systems must offer. This does not mean that
-				there are not common accessibility issues that all reading systems developers should be aware of, or
-				seek to avoid in their applications.</p>
+			<p>Although the primary focus of this specification is on how to process and render [=EPUB publications=],
+				it does not mandate specific user interfaces that all [=reading systems=] must offer. This does not mean
+				that there are not common accessibility issues that all reading systems developers should be aware of,
+				or seek to avoid in their applications.</p>
 
 			<p>The W3C's User Agent Accessibility Guidelines [[uaag20]] provides many useful practices developers should
 				apply to improve their reading systems as many browser accessibility issues have parallels in
@@ -2181,8 +2180,8 @@
 					and buttons to load features such as the table of contents) are exposed to assistive technologies
 					and that their actions do not rely on specific modalities (e.g., they only operate through touch or
 					a mouse).</li>
-				<li>Search &#8212; Search access to the full text content of all EPUB content documents is necessary to
-					ensure users can locate information easily.</li>
+				<li>Search &#8212; Search access to the full text content of all [=EPUB content documents=] is necessary
+					to ensure users can locate information easily.</li>
 				<li>Display Control &#8212; Provide methods for users to tailor the styling of the content to their
 					preferences (e.g., to change and increase fonts, increase line and word spacing, and apply alternate
 					contrasts).</li>
@@ -2214,7 +2213,7 @@
 					representing, packaging, and encoding structured and semantically enhanced web content — including
 					HTML, CSS, SVG, and other resources — for distribution in a single-file container.</p>
 
-				<p>For reading systems, this means that the security and privacy issues are primarily based on the
+				<p>For [=reading systems=], this means that the security and privacy issues are primarily based on the
 					features of those formats, and closely mirror the threats presented by web content generally.</p>
 
 				<p>Reading system developers also have a dual responsibility of both ensuring the security and privacy
@@ -2258,10 +2257,9 @@
 
 					<dt>Malicious content</dt>
 					<dd>
-						<p> EPUB publications may contain resources designed to exploit security flaws in reading
-							systems or the operating systems they run on. Attackers may also try to gain access to
-							[=remote resources=] using file indirection techniques, such as symbolic links or file
-							aliases. </p>
+						<p>EPUB publications may contain resources designed to exploit security flaws in reading systems
+							or the operating systems they run on. Attackers may also try to gain access to [=remote
+							resources=] using file indirection techniques, such as symbolic links or file aliases.</p>
 						<p>The lack of a standard method of signing EPUB publications means that reading systems cannot
 							always verify whether the content has been tampered with between authoring and loading in
 							the device.</p>
@@ -2275,10 +2273,10 @@
 						<p>Calls to remote resources can also be used to track information about users (e.g., through
 							server logs). Reading systems should limit the information they expose through HTTP requests
 							to only what is essential to obtain the resource.</p>
-						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB creator
-							and specific to each reading system implementation. Consequently, if the EPUB creator hosts
-							remote resources on a web server they control, the server effectively cannot use security
-							features that require specifying allowable origins, such as headers for <a
+						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the [=EPUB
+							creator=] and specific to each reading system implementation. Consequently, if the EPUB
+							creator hosts remote resources on a web server they control, the server effectively cannot
+							use security features that require specifying allowable origins, such as headers for <a
 								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
 								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
 									><code>Content-Security-Policy</code></a>, or <a
@@ -2333,10 +2331,10 @@
 					information, it SHOULD treat that data as sensitive and not allow access to it by third parties.</p>
 
 				<p>It is understood that the collection of some user data may be required for the sale, delivery, and
-					operation of an EPUB publication, particularly on platforms where the sale of an EPUB publication
-					and the method of reading it are connected. In these cases, the reading system SHOULD identify the
-					data being collected, how it is used, and allow for user opt-outs (retailers may choose to inform
-					users by other means, however, such as when a user creates an account on their web site).
+					operation of an [=EPUB publication=], particularly on platforms where the sale of an EPUB
+					publication and the method of reading it are connected. In these cases, the reading system SHOULD
+					identify the data being collected, how it is used, and allow for user opt-outs (retailers may choose
+					to inform users by other means, however, such as when a user creates an account on their web site).
 					Anonymization of any collected data is RECOMMENDED for the privacy and the security of the user and
 					reading system.</p>
 
@@ -2364,7 +2362,7 @@
 		<section id="app-epubReadingSystem">
 			<h2><dfn class="export">epubReadingSystem</dfn> object</h2>
 
-			<p class="note">Reading systems act as the core rendering engines of EPUB publications and provide a
+			<p class="note">[=Reading systems=] act as the core rendering engines of EPUB publications and provide a
 				scripting environment based on the [[dom]] specification. So, although this interface definition uses
 				the [[webidl]] notation for implementation by reading systems, web browsers generally do not have to
 				implement these objects.</p>
@@ -2388,8 +2386,8 @@ partial interface Navigator {
 				<div class="note">
 					<p>This specification does not define an <code>epubReadingSystem</code> property extension for the
 						{{WorkerNavigator}} object [[html]]. Reading systems therefore do not have to expose the
-							<code>epubReadingSystem</code> object in the scripting context of Workers, and EPUB creators
-						cannot rely on its presence.</p>
+							<code>epubReadingSystem</code> object in the scripting context of Workers, and [=EPUB
+						creators=] cannot rely on its presence.</p>
 				</div>
 			</section>
 
@@ -2481,7 +2479,7 @@ partial interface Navigator {
 							feature, or <code>undefined</code> if the reading system does not recognize the specified
 							feature.</p>
 
-						<p>The optional <code>version</code> parameter allows EPUB creators to query custom features
+						<p>The optional <code>version</code> parameter allows [=EPUB creators=] to query custom features
 							that could change in incompatible ways over time. The return value indicates support only
 							for the specified version of the feature.</p>
 
@@ -2502,13 +2500,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 					<section id="app-ers-hasFeature-features">
 						<h5>Features</h5>
 
-
 						<p id="scripting-req-readingsystem-features" data-tests="#scr-readingsystem-features">The
 							following table lists the set of features that reading systems that support the
 								<code>epubReadingSystem</code> object MUST recognize. When the features are queried from
 							the <code>hasFeature</code> method, reading systems MUST return a boolean value indicating
 							their support.</p>
-
 
 						<table>
 							<thead>


### PR DESCRIPTION
Going through the chore of fixing #2241. Will do the core spec another day.

The only thing worth noting is whether we should link every first instance of "reading system" in every section. None of the references were linked, which sort of makes sense if you consider it's a reading system specification. To improve a bit on this, I linked only the very first reference in the major top-level sections, which usually meant linking the reference in the support box.

I'm going to merge this as-is, as I don't see the value in going overboard with linking that term.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2344.html" title="Last updated on Jun 24, 2022, 3:40 PM UTC (9940b54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2344/90d98fd...9940b54.html" title="Last updated on Jun 24, 2022, 3:40 PM UTC (9940b54)">Diff</a>