### PR TITLE
changed contact mail to the WG's public list.

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11396,7 +11396,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
 					<dd>
-						<p>public-epub-wg@w3.org</p>
+						<p>EPUB 3 Working Group (public-epub-wg@w3.org)</p>
 					</dd>
 
 					<dt>Intended usage:</dt>
@@ -11521,7 +11521,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
 					<dd>
-						<p>public-epub-wg@w3.org</p>
+						<p>EPUB 3 Working Group (public-epub-wg@w3.org)</p>
 					</dd>
 
 					<dt>Intended usage:</dt>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11396,7 +11396,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
 					<dd>
-						<p>public-epub3@w3.org</p>
+						<p>public-epub-wg@w3.org</p>
 					</dd>
 
 					<dt>Intended usage:</dt>
@@ -11521,7 +11521,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
 					<dd>
-						<p>public-epub3@w3.org</p>
+						<p>public-epub-wg@w3.org</p>
 					</dd>
 
 					<dt>Intended usage:</dt>


### PR DESCRIPTION
The contact email for the IETF registration is now set to public-epub-wg@w3.org

Fix #2346


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2347.html" title="Last updated on Jul 2, 2022, 1:55 PM UTC (c3052ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2347/551db57...c3052ac.html" title="Last updated on Jul 2, 2022, 1:55 PM UTC (c3052ac)">Diff</a>