### PR TITLE
Allow other properties in viewport meta

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7625,7 +7625,7 @@ No Entry</pre>
 								<p>The <code>device-width</code> and <code>device-height</code> values refer to the 100%
 									of the width and height, respectively, of the reading system's [=viewport=].</p>
 								<p class="note">The value of the <code>viewport</code> [^meta^] element's
-										<code>content</code> attribute allows the inclusion of the additional properties
+										<code>content</code> attribute allows the inclusion of additional properties
 									only for compatibility with the Apple definition this metadata tag was originally
 									based on. These properties are ignored when obtaining the ICB dimensions.</p>
 								<aside class="example"

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5846,7 +5846,7 @@ No Entry</pre>
 							<h6>The <code>base</code> element</h6>
 
 							<p id="confreq-html-vocab-base"> The [[html]] <a data-lt="base"><code>base</code>
-									</a> element can be used to specify the [=document base URL=] for the purposes of
+								</a> element can be used to specify the [=document base URL=] for the purposes of
 								parsing URLs. When using it in an [=EPUB publication=], the interpretation of the
 									<code>base</code> element may inadvertently result in references to <a>remote
 									resources</a>. It may also cause reading systems to misinterpret the location of
@@ -7492,60 +7492,95 @@ No Entry</pre>
 								containing block</a> [[css2]] in the manner applicable to their format:</p>
 
 						<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
-							<dt id="sec-fxl-icb-html" data-tests="#fxl-xhtml-icb,#fxl-xhtml-icb_multi">Expressing in XHTML</dt>
+							<dt id="sec-fxl-icb-html" data-tests="#fxl-xhtml-icb,#fxl-xhtml-icb_multi">Expressing in
+								XHTML</dt>
 							<dd>
-								<p>
-									For XHTML [=fixed-layout documents=] the <a
-									href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
-									containing block</a> [[css2]] MUST be expressed using the [[html]] 
-									<a data-cite="html#meta"><code>meta</code></a> element with the following attributes:
-								</p>
-
+								<p>For XHTML [=fixed-layout documents=] the <a
+										href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
+										containing block</a> [[css2]] is obtained from the <code>height</code> and
+										<code>width</code> definitions in a <code>viewport</code> [^meta^] [[html]]
+									tag.</p>
+								<p>The <code>viewport</code>
+									<code>meta</code> tag MUST have <code>name</code> and <code>content</code>
+									attributes that conform to the following definition:</p>
 								<dl>
 									<dt>name</dt>
-									<dd>The attribute value MUST be <code>viewport</code>.</dd>
+									<dd>The value of the attribute after <a
+											href="https://www.w3.org/TR/2008/REC-xml-20081126/#AVNormalize">whitespace
+											normalization</a> [[xml]] MUST be <code>viewport</code>.</dd>
 									<dt>content</dt>
-									<dd> <p>The <a href="https://www.w3.org/TR/2008/REC-xml-20081126/#AVNormalize">normalized</a> [[XML]] attribute value MUST be of the following form:</p>
+									<dd>
+										<p>The value of the attribute after <a
+												href="https://www.w3.org/TR/2008/REC-xml-20081126/#AVNormalize"
+												>whitespace normalization</a> [[xml]] MUST be of the following form:</p>
 										<table class="productionset">
-											<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-												14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
-												U+007F).</caption>
+											<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html"
+													>ISO/IEC 14977</a>)<br /> All terminal symbols are in the Unicode
+												Block 'Basic Latin' (U+0000 to U+007F).</caption>
 
 											<tr>
 												<td id="viewport.ebnf.def">
-													<a href="viewport.ebnf.def">viewport</a>
+													<a href="#viewport.ebnf.def">viewport</a>
 												</td>
 												<td>=</td>
-												<td>
-													( <a href="#viewport.ebnf.width">width</a>, 
-													  <a href="#viewport.ebnf.sep">sep</a>,
-													  <a href="#viewport.ebnf.height">height</a>
-													)
-													|
-													( <a href="#viewport.ebnf.height">height</a>, 
-													  <a href="#viewport.ebnf.sep">sep</a>,
-													  <a href="#viewport.ebnf.width">width</a>
-													)
-													;
+												<td>( <a href="#viewport.ebnf.width-and-height">width-and-height</a> |
+														<a href="#viewport.ebnf.height-and-width">height-and-width</a> )
+													;</td>
+											</tr>
+											<tr>
+												<td id="viewport.ebnf.width-and-height">
+													<a href="#viewport.ebnf.width-and-height">width-and-height</a>
 												</td>
+												<td>=</td>
+												<td>{ <a href="#viewport.ebnf.compat">compat</a>, <a
+														href="#viewport.ebnf.sep">sep</a> }, <a
+														href="#viewport.ebnf.width">width</a>, { <a
+														href="#viewport.ebnf.sep">sep</a>, <a
+														href="#viewport.ebnf.compat">compat</a> }, <a
+														href="#viewport.ebnf.sep">sep</a>, <a
+														href="#viewport.ebnf.height">height</a>, { <a
+														href="#viewport.ebnf.sep">sep</a>, <a
+														href="#viewport.ebnf.compat">compat</a> } ;</td>
+											</tr>
+											<tr>
+												<td id="viewport.ebnf.height-and-width">
+													<a href="#viewport.ebnf.height-and-width">height-and-width</a>
+												</td>
+												<td>=</td>
+												<td>{ <a href="#viewport.ebnf.compat">compat</a>, <a
+														href="#viewport.ebnf.sep">sep</a> }, <a
+														href="#viewport.ebnf.height">height</a>, { <a
+														href="#viewport.ebnf.sep">sep</a>, <a
+														href="#viewport.ebnf.compat">compat</a> }, <a
+														href="#viewport.ebnf.sep">sep</a>, <a
+														href="#viewport.ebnf.width">width</a>, { <a
+														href="#viewport.ebnf.sep">sep</a>, <a
+														href="#viewport.ebnf.compat">compat</a> } ;</td>
+											</tr>
+											<tr>
+												<td id="viewport.ebnf.compat">
+													<a href="#viewport.ebnf.compat">compat</a>
+												</td>
+												<td>=</td>
+												<td>? compatibility properties ?</td>
 											</tr>
 											<tr>
 												<td id="viewport.ebnf.width">
 													<a href="#viewport.ebnf.width">width</a>
 												</td>
 												<td>=</td>
-												<td>"width", 
-													<a href="#viewport.ebnf.assign">assign</a>, 
-													( <a href="#viewport.ebnf.dimension">dimension</a> | "device-width" ) ;</td>
+												<td>"width", <a href="#viewport.ebnf.assign">assign</a>, ( <a
+														href="#viewport.ebnf.dimension">dimension</a> | "device-width" )
+													;</td>
 											</tr>
 											<tr>
 												<td id="viewport.ebnf.height">
-													<a href="#viewport.ebnf.height">height</a href="#viewport.ebnf.height">
+													<a href="#viewport.ebnf.height">height</a>
 												</td>
 												<td>=</td>
-												<td>"height" , 
-													<a href="#viewport.ebnf.assign">assign</a>, 
-													( <a href="#viewport.ebnf.dimension">dimension</a> | "device-height" ) ;</td>
+												<td>"height" , <a href="#viewport.ebnf.assign">assign</a>, ( <a
+														href="#viewport.ebnf.dimension">dimension</a> | "device-height"
+													) ;</td>
 											</tr>
 											<tr>
 												<td id="viewport.ebnf.sep">
@@ -7553,8 +7588,15 @@ No Entry</pre>
 												</td>
 												<td>=</td>
 												<td>
-													[space], (";" | "," | space), [space]
+													<a href="#viewport.ebnf.sep_char">sep_char</a>, { <a
+														href="#viewport.ebnf.sep_char">sep_char</a> } </td>
+											</tr>
+											<tr>
+												<td id="viewport.ebnf.sep_char">
+													<a href="#viewport.ebnf.sep_char">sep_char</a>
 												</td>
+												<td>=</td>
+												<td>( ";" | "," | space )</td>
 											</tr>
 											<tr>
 												<td id="viewport.ebnf.assign">
@@ -7580,16 +7622,12 @@ No Entry</pre>
 										</table>
 									</dd>
 								</dl>
-
-								<p>The <code>device-width</code> and <code>device-height</code> values refer to the 100% of the width, respectively height, of the reading system's [=viewport=].</p>
-
-								<p class="note">
-									Earlier iterations of EPUB referred to the 
-									<a href="https://www.w3.org/TR/css-device-adapt-1/#viewport-meta"><code>meta</code> element syntax</a> [[css-device-adapt-1]] for the
-									the definition of the attribute value, which includes features that are not relevant for EPUB use. All aspects of that syntax that
-									is not defined by this section are <a href="#deprecated">deprecated</a>.
-								</p>
-
+								<p>The <code>device-width</code> and <code>device-height</code> values refer to the 100%
+									of the width and height, respectively, of the reading system's [=viewport=].</p>
+								<p class="note">The value of the <code>viewport</code> [^meta^] element's
+										<code>content</code> attribute allows the inclusion of the additional properties
+									only for compatibility with the Apple definition this metadata tag was originally
+									based on. These properties are ignored when obtaining the ICB dimensions.</p>
 								<aside class="example"
 									title="Specifying the initial containing block in a viewport meta tag">
 									<pre>&lt;html …>
@@ -7626,11 +7664,9 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p class="note">
-							The initial containing block definition affects only the document where it is defined.
-							The dimensions of the containing blocks in the other content documents within the same 
-							publication may be different.
-						</p>
+						<p class="note"> The initial containing block definition affects only the document where it is
+							defined. The dimensions of the containing blocks in the other content documents within the
+							same publication may be different. </p>
 					</section>
 				</section>
 			</section>
@@ -9438,10 +9474,9 @@ html.my-document-playing * {
 					<dd>
 						<p>Resources embedded in the EPUB container are not immune to malicious actors, especially when
 							EPUB publications are obtained from untrusted sources. Resources may contain exploits or
-							forms that may submit sensitive information to unintended parties.
-							Such actors may also try to gain access to [=remote resources=] using file indirection techniques,
-							such as symbolic links or file aliases.
-						</p>
+							forms that may submit sensitive information to unintended parties. Such actors may also try
+							to gain access to [=remote resources=] using file indirection techniques, such as symbolic
+							links or file aliases. </p>
 						<p>The use of third-party content, such as games and quizzes, may also lead to security and
 							privacy issues if the EPUB creator is not able to fully vet the content.</p>
 					</dd>
@@ -11651,10 +11686,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>24-June-2022: The <code>meta</code> element in XHTML to specify the initial containing boundary in FXL
-						documents is now formally defined. See <a
-						href="https://github.com/w3c/epub-specs/issues/2292">issue 2292</a>.
-					</li>
+					<li>24-June-2022: The <code>meta</code> element in XHTML to specify the initial containing boundary
+						in FXL documents is now formally defined. See <a
+							href="https://github.com/w3c/epub-specs/issues/2292">issue 2292</a>. </li>
 					<li>10-June-2022: Clarified that data blocks are exempt from fallback requirements. See <a
 							href="https://github.com/w3c/epub-specs/issues/2331">issue 2331</a>.</li>
 					<li>07-June-2022: The usage of File URLs has been disallowed. See <a


### PR DESCRIPTION
This PR adds a simple "compat" definition that allows other properties to optionally be used around and between the width and height definitions just to show how this might alternatively be done. 

I used a prose description for it, as I don't believe we need to expend much effort on these other properties when they're ignored. We could always list off the four properties from the apple def and use a prose descriptor to avoid time on defining their values, but I'm not sure why we even need to care if someone makes a typo or adds a completely unknown property. It's all the same to getting the ICB.

(I also allow for other syntactic weirdness that doesn't harm anything by changing the separator definition as I mentioned in the original PR.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2349.html" title="Last updated on Jul 5, 2022, 1:06 PM UTC (0594c00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2349/f008cee...0594c00.html" title="Last updated on Jul 5, 2022, 1:06 PM UTC (0594c00)">Diff</a>