### PR TITLE
Minor cleanup

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -90,7 +90,7 @@
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
 				web content — including HTML, CSS, SVG, and other resources — for distribution in a single-file
 				container.</p>
-			<p>This specification defines the authoring requirements for EPUB publications and represents the third
+			<p>This specification defines the authoring requirements for [=EPUB publications=] and represents the third
 				major revision of the standard.</p>
 		</section>
 		<section id="sotd"></section>
@@ -162,10 +162,9 @@
 				-->
 
 				<p>The actual content of an EPUB publication &#8212; what users are presented with when they begin
-					reading &#8212; is built on the Open Web Platform and comes in two flavors: <a
-						data-lt="XHTML content document">XHTML</a> and [=SVG content document | SVG=]. Called [=EPUB
-					content documents=], these documents typically reference many additional resources required for
-					their proper rendering, such as images, audio and video clips, scripts, and style sheets.</p>
+					reading &#8212; is built on the Open Web Platform and comes in two flavors: XHTML and SVG. Called
+					[=EPUB content documents=], these documents typically reference many additional resources required
+					for their proper rendering, such as images, audio and video clips, scripts, and style sheets.</p>
 
 				<p>Refer to <a href="#sec-contentdocs"></a> for detailed information about the rules and requirements to
 					produce EPUB content documents, and [[epub-a11y-11]] for accessibility requirements.</p>
@@ -207,8 +206,8 @@
 						affect [=EPUB publications=] until EPUB 3 undergoes a new revision.</p>
 					<p>In all cases, it is possible that previously valid features may become obsolete (e.g., due to a
 						lack of support or because of security issues). [=EPUB creators=] should therefore be cautious
-						about using any feature without broad support and keep their <a>EPUB conformance checkers</a> up
-						to date.</p>
+						about using any feature without broad support and keep their [=EPUB conformance checkers=] up to
+						date.</p>
 				</div>
 
 				<section id="sec-overview-relations-html">
@@ -227,8 +226,8 @@
 						of semantics, structure and processing behaviors from HTML unless otherwise specified.</p>
 
 					<p>In addition, this specification <a href="#sec-xhtml-extensions">defines a set of extensions</a>
-						to the [[html]] document model that EPUB creators may include in <a>XHTML content
-						documents</a>.</p>
+						to the [[html]] document model that EPUB creators may include in [=XHTML content
+						documents=].</p>
 				</section>
 
 				<section id="sec-overview-relations-svg">
@@ -238,9 +237,9 @@
 						reference. Whenever there is any ambiguity in this reference, the latest recommended
 						specification is the authoritative reference.</p>
 
-					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. <a>EPUB
-							creators</a>, however, must keep track of changes to the SVG standard to ensure they keep
-						their processes up to date.</p>
+					<p>This approach ensures that EPUB will always keep pace with changes to the SVG standard. [=EPUB
+						creators=], however, must keep track of changes to the SVG standard to ensure they keep their
+						processes up to date.</p>
 				</section>
 
 				<section id="sec-overview-relations-css">
@@ -271,11 +270,11 @@
 					<h4>Relationship to URL</h4>
 
 					<p>This specification refers to the [[url]] standard for terminology and processing related to URLs
-						expressed in EPUB publications. It is anticipated that new and revised web formats will adopt
-						this standard, but until then this may put this specification in conflict with the internal
-						requirements for some formats (e.g., valid relative paths), specifically with respect to the use
-						of internationalized URLs. If a format does not allow internationalized URLs (i.e., URLs must
-						conform to [[rfc3986]] or earlier), that requirement takes precedence within those
+						expressed in [=EPUB publications=]. It is anticipated that new and revised web formats will
+						adopt this standard, but until then this may put this specification in conflict with the
+						internal requirements for some formats (e.g., valid relative paths), specifically with respect
+						to the use of internationalized URLs. If a format does not allow internationalized URLs (i.e.,
+						URLs must conform to [[rfc3986]] or earlier), that requirement takes precedence within those
 						resources.</p>
 				</section>
 			</section>
@@ -314,8 +313,8 @@
 						<dfn class="export">container root URL</dfn>
 					</dt>
 					<dd>
-						<p>The [=URL=] [[url]] of the [=root directory=] representing the <a>OCF abstract container</a>.
-							It is implementation specific, but EPUB creators must assume it has properties defined in <a
+						<p>The [=URL=] [[url]] of the [=root directory=] representing the [=OCF abstract container=]. It
+							is implementation specific, but EPUB creators must assume it has properties defined in <a
 								href="#sec-container-iri"></a>.</p>
 					</dd>
 
@@ -342,8 +341,8 @@
 
 					<dt><dfn class="export">EPUB conformance checker</dfn></dt>
 					<dd>
-						<p>An application that verifies the requirements of this specification against <a>EPUB
-								publications</a> and reports on their conformance.</p>
+						<p>An application that verifies the requirements of this specification against [=EPUB
+							publications=] and reports on their conformance.</p>
 					</dd>
 
 					<dt>
@@ -363,11 +362,11 @@
 						<dfn class="export">EPUB content document</dfn>
 					</dt>
 					<dd>
-						<p>A [=publication resource=] referenced from the spine or a [=manifest fallback chain=] that
-							conforms to either the [=XHTML content document | XHTML=] or <a
-								data-lt="SVG content document">SVG content document</a> definitions.</p>
-						<p>EPUB content documents contain all or part of the content of an EPUB publication (i.e., the
-							textual, visual and/or audio content).</p>
+						<p>A [=publication resource=] referenced from the [=EPUB spine |spine=] or a [=manifest fallback
+							chain=] that conforms to either the [=XHTML content document | XHTML=] or [=SVG content
+							document=] definitions.</p>
+						<p>EPUB content documents contain all or part of the content of an [=EPUB publication=] (i.e.,
+							the textual, visual and/or audio content).</p>
 						<p>[=EPUB creators=] can include EPUB content documents in the spine without the provision of <a
 								href="#sec-foreign-resources">fallbacks</a>.</p>
 					</dd>
@@ -428,9 +427,9 @@
 					<dt>
 						<dfn class="export">EPUB spine</dfn> (or spine)</dt>
 					<dd>
-						<p>The section of the [=package document=] that defines an ordered list of <a>EPUB content
-								documents</a> and [=foreign content documents=]. This list represents the default
-							reading order of the [=EPUB publication=].</p>
+						<p>The section of the [=package document=] that defines an ordered list of [=EPUB content
+							documents=] and [=foreign content documents=]. This list represents the default reading
+							order of the [=EPUB publication=].</p>
 						<p>Refer to <a href="#sec-spine-elem"></a> for more information.</p>
 					</dd>
 
@@ -439,7 +438,7 @@
 					</dt>
 					<dd>
 						<p>Exempt resources are a special class of [=publication resources=] that reading systems are
-							not required to support the rendering of, but EPUB creators do not have to provide <a
+							not required to support the rendering of, but [=EPUB creators=] do not have to provide <a
 								href="#sec-foreign-resources">fallbacks</a> for.</p>
 						<p>Refer to <a href="#sec-exempt-resources"></a> for more information.</p>
 					</dd>
@@ -456,10 +455,8 @@
 						<dfn class="export">file path</dfn>
 					</dt>
 					<dd>
-						<p>The file path of a file or directory is its full path relative to the root directory, as
+						<p>The file path of a file or directory is its full path relative to the [=root directory=], as
 							defined by the algorithm specified in <a href="#sec-file-names-to-path-names"></a>.</p>
-						<!-- <p>The file path of a file or directory <var>file</var> is the <a data-cite="url#concept-url-path">path</a> of the [=content URL=] for <var>file</var>. 
-						It is derived from the [=file name=] of <var>file</var> following the steps specified in <a href="#sec-file-names-to-path-names"></a>.</p> -->
 					</dd>
 
 					<dt>
@@ -478,7 +475,7 @@
 						<p>Any [=publication resource=] referenced from a [=EPUB spine | spine=] [^itemref^] element, or
 							a [=manifest fallback chain=], that is not an [=EPUB content document=].</p>
 						<p>When a foreign content document is referenced from a spine <code>itemref</code> element, it
-							requires a [=manifest fallback chain=] with at least one EPUB content document.</p>
+							requires a manifest fallback chain with at least one EPUB content document.</p>
 						<div class="note">
 							<p>With the exception of XHTML and SVG, all [=core media type resources=] are foreign
 								content documents when referenced directly from the spine.</p>
@@ -492,12 +489,12 @@
 						<p>A [=publication resource=] with a MIME media type [[rfc2046]] that does not match any of
 							those listed in <a href="#sec-core-media-types"></a>. Foreign resources are subject to the
 							fallback requirements defined in <a href="#sec-foreign-resources"></a>.</p>
-						<p>The designation "foreign resource" only applies to resources used in the rendering of <a>EPUB
-								content documents</a> and [=foreign content documents=].</p>
+						<p>The designation "foreign resource" only applies to resources used in the rendering of [=EPUB
+							content documents=] and [=foreign content documents=].</p>
 						<div class="note">
-							<p>Foreign resource and [=foreign content document=] are not interchangeable terms. The
-								types of resources considered foreign when used in the spine is greater than the types
-								of resources considered foreign when used in <a href="#sec-contentdocs">EPUB content
+							<p>Foreign resource and foreign content document are not interchangeable terms. The types of
+								resources considered foreign when used in the spine is greater than the types of
+								resources considered foreign when used in <a href="#sec-contentdocs">EPUB content
 									documents</a>.</p>
 						</div>
 					</dd>
@@ -507,9 +504,9 @@
 					</dt>
 					<dd>
 						<p>A resource that is only referenced from a [=package document=] [^link^] element (i.e., not
-							also used in the rendering of an <a>EPUB publication</a>.</p>
-						<p>Linked resources are not [=publication resources=] but may be stored in the <a>EPUB
-								container</a>. They do not require fallbacks.</p>
+							also used in the rendering of an [=EPUB publication=].</p>
+						<p>Linked resources are not [=publication resources=] but may be stored in the [=EPUB
+							container=]. They do not require fallbacks.</p>
 					</dd>
 
 					<dt>
@@ -534,8 +531,8 @@
 						<dfn class="export">OCF abstract container</dfn>
 					</dt>
 					<dd>
-						<p>The OCF abstract container defines a file system model for the contents of the <a>OCF ZIP
-								container</a>, as defined in <a href="#sec-container-abstract"></a>.</p>
+						<p>The OCF abstract container defines a file system model for the contents of the [=OCF ZIP
+							container=], as defined in <a href="#sec-container-abstract"></a>.</p>
 					</dd>
 
 					<dt>
@@ -555,7 +552,7 @@
 						<p>A resource that contains content or instructions that contribute to the logic and rendering
 							of an [=EPUB publication=]. In the absence of this resource, [=reading systems=] may not
 							render the EPUB publication as the [=EPUB creator=] intends. Examples of publication
-							resources include the [=package document=], [=EPUB content document=], CSS Style Sheets,
+							resources include the [=package document=], [=EPUB content documents=], CSS Style Sheets,
 							audio, video, images, embedded fonts, and scripts.</p>
 						<p>EPUB creators typically list publication resources in the package document [=EPUB manifest |
 							manifest=] and bundle them in the [=EPUB container=], with the following exceptions:</p>
@@ -582,8 +579,8 @@
 					<dd>
 						<p>A [=publication resource=] that is located outside of the [=EPUB container=], typically, but
 							not necessarily, on the web.</p>
-						<p>Publication resources within the EPUB container are referred to as <a>container
-							resources</a>.</p>
+						<p>Publication resources within the EPUB container are referred to as [=container
+							resources=].</p>
 						<p>Refer to <a href="#sec-resource-locations"></a> for media type specific rules for resource
 							locations.</p>
 					</dd>
@@ -680,7 +677,7 @@
 		<section id="sec-epub-conf">
 			<h2>EPUB publication conformance</h2>
 
-			<p>An EPUB publication:</p>
+			<p>An [=EPUB publication=]:</p>
 
 			<ul class="conformance-list">
 				<li>
@@ -715,9 +712,9 @@
 			<section id="sec-conformance-checking" class="informative">
 				<h3>Conformance checking</h3>
 
-				<p>Due to the complexity of this specification and number of technologies used in <a>EPUB
-						publications</a>, [=EPUB creators=] are advised to use an [=EPUB conformance checker=] to verify
-					the conformance of their content.</p>
+				<p>Due to the complexity of this specification and number of technologies used in [=EPUB publications=],
+					[=EPUB creators=] are advised to use an [=EPUB conformance checker=] to verify the conformance of
+					their content.</p>
 
 				<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto EPUB conformance
 					checker used by the publishing industry and has been updated with each new version of EPUB. It is
@@ -765,10 +762,9 @@
 
 				<ul>
 					<li>The [=manifest plane=] &#8212; The manifest plane holds all the resources of the EPUB
-						publication (namely, [=publication resources=] and [=linked resources=]).</li>
-					<li>The [=spine plane=] &#8212; The spine plane holds only the resources used in rendering the
-						[=EPUB spine | spine=] (namely, [=EPUB content documents=] and <a>foreign content
-						documents</a>).</li>
+						publication (namely, publication resources and [=linked resources=]).</li>
+					<li>The [=spine plane=] &#8212; The spine plane holds only the resources used in rendering the spine
+						(namely, EPUB content documents and [=foreign content documents=]).</li>
 					<li>The [=content plane=] &#8212; The content plane holds only the resources used in the rendering
 						of EPUB and foreign content documents (namely, [=core media type resources=], [=foreign
 						resources=] and [=exempt resources=]).</li>
@@ -841,9 +837,9 @@
 						publication=]. Although many resources may be bundled in an [=EPUB container=], they are not all
 						allowed by default in the spine.</p>
 
-					<p>EPUB 3 defines a special class of resources called [=EPUB content documents=] that <a>EPUB
-							creators</a> can use in the spine without any restrictions. EPUB content documents encompass
-						both [=XHTML content documents=] and [=SVG content documents=].</p>
+					<p>EPUB 3 defines a special class of resources called [=EPUB content documents=] that [=EPUB
+						creators=] can use in the spine without any restrictions. EPUB content documents encompass both
+						[=XHTML content documents=] and [=SVG content documents=].</p>
 
 					<p>To use any other type of resource in the spine, called a [=foreign content document=], requires
 						including a fallback to an EPUB content document. This extensibility model allows EPUB creators
@@ -885,7 +881,7 @@
 					<p>The <dfn class="export" data-lt-no-plural="">content plane</dfn> classifies resources that are
 						used when rendering [=EPUB content documents=] and [=foreign content documents=]. These types of
 						resources include embedded media, CSS style sheets, scripts, and fonts. These resources fall
-						into three categories based on their reading system support: <a>core media type resources</a>,
+						into three categories based on their reading system support: [=core media type resources=],
 						[=foreign resources=], and [=exempt resources=].</p>
 
 					<p>A core media type resource is one that [=reading systems=] have to support, so it can be used
@@ -906,7 +902,9 @@
 
 					<p>The preferred method is to use the fallback capabilities of the host format. Many HTML elements,
 						for example, have intrinsic fallback capabilities. One example is the [^picture^]
-						element [[html]], which allows EPUB creators to specify multiple alternative image formats.</p>
+						element [[html]], which allows [=EPUB creators=] to specify multiple alternative image
+						formats.</p>
+
 					<p>If an intrinsic fallback method is not available, it is also possible to use manifest fallbacks,
 						but this method, as <a href="#caution-fallbacks">cautioned against</a> in the previous section,
 						is discouraged. For more information about foreign resources, refer to <a
@@ -926,8 +924,8 @@
 					<div class="note">
 						<p>A common point of confusion arising from core media type resources is the listing of XHTML
 							and SVG as core media type resources with the requirement the markup conform to their
-							respective [=EPUB content document=] definitions. This allows EPUB creators to embed both
-							XHTML and SVG documents in EPUB content documents while keeping consistent requirements for
+							respective EPUB content document definitions. This allows EPUB creators to embed both XHTML
+							and SVG documents in EPUB content documents while keeping consistent requirements for
 							authoring and reading system support.</p>
 
 						<p>In practice, it means that EPUB creators can put XHTML and SVG core media type resources in
@@ -947,10 +945,10 @@
 					[=EPUB content documents=] and [=foreign content documents=]. These resources are classified as
 					[=core media type resources=].</p>
 
-				<p>With the exception of XHTML content documents and SVG content documents, EPUB creators MUST provide
-						<a href="#sec-manifest-fallbacks">manifest fallbacks</a> for core media type resources
-					referenced directly from the [=EPUB spine | spine=]. In this case, they are <a>foreign content
-						documents</a>.</p>
+				<p>With the exception of [=XHTML content documents=] and [=SVG content documents=], EPUB creators MUST
+					provide <a href="#sec-manifest-fallbacks">manifest fallbacks</a> for core media type resources
+					referenced directly from the [=EPUB spine | spine=]. In this case, they are [=foreign content
+					documents=].</p>
 
 				<p>The columns in the table represent the following information:</p>
 
@@ -1156,11 +1154,11 @@
 				<h3>Foreign resources</h3>
 
 				<p>A [=foreign resource=], unlike a <a href="#sec-core-media-types">core media type resource</a> is one
-					which is not guaranteed [=reading system=] support when used in an <a>EPUB content document</a> or
+					which is not guaranteed [=reading system=] support when used in an [=EPUB content document=] or
 					[=foreign content document=].</p>
 
-				<p id="confreq-cmt">EPUB creators MUST provide fallbacks for foreign resources, where fallbacks take one
-					of the following forms:</p>
+				<p id="confreq-cmt">[=EPUB creators=] MUST provide fallbacks for foreign resources, where fallbacks take
+					one of the following forms:</p>
 
 				<ul>
 					<li>
@@ -1169,7 +1167,7 @@
 							embedded message when a media type cannot be rendered); or</p>
 					</li>
 					<li>
-						<p><a href="#sec-manifest-fallbacks">manifest fallback</a> chains defined on [^item^] elements
+						<p><a href="#sec-manifest-fallbacks">manifest fallback chains</a> defined on [^item^] elements
 							in the [=package document=].</p>
 					</li>
 				</ul>
@@ -1185,14 +1183,15 @@
 			<section id="sec-exempt-resources">
 				<h3>Exempt resources</h3>
 
-				<p>An [=exempt resource=] shares properties with both [=foreign resources=] and <a>core media type
-						resources</a>. It is most similar to a [=foreign resource=] in that it is not guaranteed
-					[=reading system=] support, but, like a core media type resource, does not require a fallback.</p>
+				<p>An [=exempt resource=] shares properties with both [=foreign resources=] and [=core media type
+					resources=]. It is most similar to a [=foreign resource=] in that it is not guaranteed [=reading
+					system=] support, but, like a core media type resource, does not require a fallback.</p>
 
 				<p>There are only a small set of special cases for exempt resources. Video, for example, are exempt from
 					fallbacks because there is no consensus on a core media type video format at this time (i.e., there
-					is no format to fallback to). Similarly, audio and video tracks are exempt to allow EPUB creators to
-					meet accessibility requirements using whatever format reading systems support best.</p>
+					is no format to fallback to). Similarly, audio and video tracks are exempt to allow [=EPUB
+					creators=] to meet accessibility requirements using whatever format reading systems support
+					best.</p>
 
 				<p>The following list details cases of content-specific exempt resources, including any restrictions on
 					where EPUB creators can use them.</p>
@@ -1236,8 +1235,9 @@
 				</dl>
 
 				<div class="note">
-					<p>The exemptions made above do not apply to the spine. If an exempt resource is used in the spine,
-						and it is not also an EPUB content document, it will require a fallback in that context.</p>
+					<p>The exemptions made above do not apply to the [=EPUB spine | spine=]. If an exempt resource is
+						used in the spine, and it is not also an [=EPUB content document=], it will require a fallback
+						in that context.</p>
 				</div>
 
 				<p id="confreq-foreign-no-fallback">In addition to the content-specific exemptions, a resource is
@@ -1249,8 +1249,8 @@
 							document=]); <strong><em>and</em></strong></p>
 					</li>
 					<li>
-						<p>it is not embedded directly in EPUB content documents (e.g., via [[?html]] <a>embedded
-								content</a> and [[?svg]] <a href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"
+						<p>it is not embedded directly in EPUB content documents (e.g., via [[?html]] [=embedded
+							content=] and [[?svg]] <a href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"
 									><code>image</code></a> and <a
 								href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
 									><code>foreignObject</code></a> elements).</p>
@@ -1259,8 +1259,8 @@
 
 				<p>This exemption allows EPUB creators to include resources in the [=EPUB container=] that are not for
 					use by EPUB reading systems. The primary case for this exemption is to allow data files to travel
-					with an EPUB publication, whether for scripts to use in their constituent EPUB content documents or
-					for external applications to use (e.g., a scientific journal might include a data set with
+					with an [=EPUB publication=], whether for scripts to use in their constituent EPUB content documents
+					or for external applications to use (e.g., a scientific journal might include a data set with
 					instructions on how to extract it from the EPUB container).</p>
 
 				<p>It also allows EPUB creators to use foreign resources in foreign content documents without reading
@@ -1277,16 +1277,16 @@
 					<h5>Manifest fallbacks</h5>
 
 					<p>Manifest fallbacks are a feature of the [=package document=] that create a <dfn class="export"
-							>manifest fallback chain</dfn> for a [=publication resource=], allowing reading systems to
-						select an alternative format they can render.</p>
+							>manifest fallback chain</dfn> for a [=publication resource=], allowing [=reading systems=]
+						to select an alternative format they can render.</p>
 
 					<p>Fallback chains are created using the <a href="#attrdef-item-fallback"><code>fallback</code>
-							attribute</a> on manifest [^item^] elements. This attribute references the ID [[xml]] of
-						another manifest <code>item</code> that is a fallback for the current <code>item</code>. The
-						ordered list of all the references that a reading system can reach, starting from a given
-							<code>item</code>'s <code>fallback</code> attribute, represents the full fallback chain for
-						that <code>item</code>. This chain also represents the EPUB creator's preferred fallback
-						order.</p>
+							attribute</a> on [=EPUB Manifest | manifest=] [^item^] elements. This attribute references
+						the <a data-cite="xml#id">ID</a> [[xml]] of another manifest <code>item</code> that is a
+						fallback for the current <code>item</code>. The ordered list of all the references that a
+						reading system can reach, starting from a given <code>item</code>'s <code>fallback</code>
+						attribute, represents the full fallback chain for that <code>item</code>. This chain also
+						represents the [=EPUB creator | EPUB creator's=] preferred fallback order.</p>
 
 					<p>There are two cases for manifest fallbacks:</p>
 
@@ -1295,7 +1295,7 @@
 						<dd>
 							<p>EPUB creators MUST specify a fallback chain for a [=foreign content document=] to ensure
 								that reading systems can always render the [=EPUB spine | spine=] item. In this case,
-								the chain MUST contain at least one <a>EPUB content document</a>.</p>
+								the chain MUST contain at least one [=EPUB content document=].</p>
 							<p>EPUB creators MAY provide fallbacks for EPUB content documents (e.g., to provide a <a
 									href="#confreq-cd-scripted-flbk">fallback for scripted content</a>).</p>
 							<p>When a fallback chain includes more than one EPUB content document, EPUB creators can use
@@ -1315,8 +1315,8 @@
 							<p>EPUB creators MUST provide a content fallback for [=foreign resources=] when the elements
 								that reference them do not have intrinsic fallback capabilities. In this case, the
 								fallback chain MUST contain at least one [=core media type resource=].</p>
-							<p>EPUB creators MAY also provide manifest fallbacks for [=core media type resources=]
-								(e.g., to allow reading systems to select from more than one image format).</p>
+							<p>EPUB creators MAY also provide manifest fallbacks for core media type resources (e.g., to
+								allow reading systems to select from more than one image format).</p>
 						</dd>
 					</dl>
 
@@ -1339,13 +1339,13 @@
 					<section id="sec-fallbacks-audio">
 						<h5>HTML <code>audio</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-media">EPUB creators MUST NOT use embedded [[html]] <a>flow
-								content</a> within the <a data-cite="html#the-audio-element"><code>audio</code></a>
-							element as an intrinsic fallback for foreign resources. Only child [^source^]
-							elements [[html]] provide intrinsic fallback capabilities.</p>
+						<p id="confreq-resources-cd-fallback-media">[=EPUB creators=] MUST NOT use embedded
+							[[html]] [=flow content=] within the <a data-cite="html#the-audio-element"
+									><code>audio</code></a> element as an intrinsic fallback for [=foreign resources=].
+							Only child [^source^] elements [[html]] provide intrinsic fallback capabilities.</p>
 
-						<p>Only older reading systems that do not recognize the <code>audio</code> element (e.g., EPUB 2
-							reading systems) will render the embedded content. When reading systems support the
+						<p>Only older [=reading systems=] that do not recognize the <code>audio</code> element (e.g.,
+							EPUB 2 reading systems) will render the embedded content. When reading systems support the
 								<code>audio</code> element but not the available audio formats, they do not render the
 							embedded content for the user.</p>
 
@@ -1360,8 +1360,8 @@
 					<section id="sec-fallbacks-img">
 						<h5>HTML <code>img</code> fallbacks</h5>
 
-						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that EPUB creators can
-							specify in the [[html]] [^img^] element, the following fallback conditions apply to its
+						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that [=EPUB creators=]
+							can specify in the [[html]] [^img^] element, the following fallback conditions apply to its
 							use:</p>
 						<ul>
 							<li>
@@ -1370,10 +1370,10 @@
 									<li>it MUST reference core media type resources from its <code>src</code> and
 											<code>srcset</code> attributes, when EPUB creators specify those attributes;
 										and</li>
-									<li>each sibling [^source^] element MUST reference a core media type resource from
-										its <code>[^source/src^]</code> and <code>[^source/srcset^]</code> attributes
-										unless it specifies the MIME media type [[rfc2046]] of a foreign resource in its
-											<code>[^source/type^]</code> attribute.</li>
+									<li>each sibling [^source^] element MUST reference a [=core media type resource=]
+										from its <code>[^source/src^]</code> and <code>[^source/srcset^]</code>
+										attributes unless it specifies the MIME media type [[rfc2046]] of a [=foreign
+										resource=] in its <code>[^source/type^]</code> attribute.</li>
 								</ul>
 							</li>
 
@@ -1386,7 +1386,7 @@
 						<h5>HTML <code>script</code> element</h5>
 
 						<p>Although the [[html]] [^script^] element lacks intrinsic fallback capabilities, it is not
-							required that EPUB creators provide fallbacks for <a data-cite="html#data-block">data
+							required that [=EPUB creators=] provide fallbacks for <a data-cite="html#data-block">data
 								blocks</a> [[html]]. As the <code>script</code> element does not represent user content,
 							data blocks are not rendered unless manipulated by script.</p>
 
@@ -1407,7 +1407,8 @@
 			<section id="sec-resource-locations">
 				<h4>Resource locations</h4>
 
-				<p>EPUB creators MAY host the following types of publication resources outside the EPUB container:</p>
+				<p>[=EPUB creators=] MAY host the following types of [=publication resources=] outside the [=EPUB
+					container=]:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -1432,8 +1433,8 @@
 
 				<p>When resources have to be located outside the EPUB container, EPUB creators are RECOMMENDED to
 					reference them via the secure <code>https</code> URI scheme [rfc7230] to limit the threat of
-					exposing their publications, and users, to network attacks. Reading systems might not load remote
-					resources referenced using insecure schemes such as <code>http</code>.</p>
+					exposing their publications, and users, to network attacks. [=Reading systems=] might not load
+					[=remote resources=] referenced using insecure schemes such as <code>http</code>.</p>
 
 				<p>These rules for locating publication resource apply regardless of whether the given resource is a
 					[=core media type resource=] or a [=foreign resource=].</p>
@@ -1446,8 +1447,8 @@
 
 				<aside class="example" title="Referencing a container resource">
 					<p>In this example, the audio file referenced from the [[html]] <a
-							data-cite="html#the-audio-element"><code>audio</code></a> element is located inside the
-						[=EPUB container=].</p>
+							data-cite="html#the-audio-element"><code>audio</code></a> element is located inside the EPUB
+						container.</p>
 					<pre>&lt;html …>
    …
    &lt;body>
@@ -1480,16 +1481,17 @@
 				<h3>Data URLs</h3>
 
 				<p>The <a data-cite="rfc2397#"><code>data:</code> URL scheme</a> [[rfc2397]] is used to encode resources
-					directly into a URL string. The advantage of this scheme is that it allows EPUB creators to embed a
-					resource within another, avoiding the need for an external file.</p>
+					directly into a URL string. The advantage of this scheme is that it allows [=EPUB creators=] to
+					embed a resource within another, avoiding the need for an external file.</p>
 
-				<p>[=EPUB creators=] MAY use data URLs in EPUB publications provided their use does not result in a
+				<p>EPUB creators MAY use data URLs in [=EPUB publications=] provided their use does not result in a
 					[=top-level content document=] or [=top-level browsing context=] [[html]]. This restriction applies
 					to data URLs used in the following scenarios:</p>
 
 				<ul>
 					<li>
-						<p>in manifest [^item^] elements referenced from the [=EPUB spine | spine=];</p>
+						<p>in [EPUB manifest | manifest=] [^item^] elements referenced from the [=EPUB spine |
+							spine=];</p>
 					</li>
 					<li>
 						<p>in the <code>href</code> attribute on [[html]] or [[svg]] <code>a</code> elements (except
@@ -1509,32 +1511,35 @@
 						allow their use evolve.</p>
 				</div>
 
-				<p>This restriction on their use is to prevent security issues and also to ensure that <a>reading
-						systems</a> can determine where to take a user next (i.e., because these resources are not be
-					listed in the spine).</p>
+				<p>This restriction on their use is to prevent security issues and also to ensure that [=reading
+					systems=] can determine where to take a user next (i.e., because these resources are not be listed
+					in the spine).</p>
 
 				<p>Resources represented as data URLs are not publication resources so are exempt from the requirement
-					for EPUB creators to list them in the [=EPUB manifest | manifest=].</p>
+					for EPUB creators to list them in the manifest.</p>
 
 				<p>EPUB creators MUST encode Data URLs as core media type resources or use them where they can provide a
-					fallback (i.e., Data URLs are subject to the <a href="#sec-foreign-resources">foreign resource
+					fallback (i.e., data URLs are subject to the <a href="#sec-foreign-resources">foreign resource
 						restrictions</a>).</p>
 			</section>
 
 			<section id="sec-file-urls">
 				<h3>File URLs</h3>
-				<p> The <a data-cite="rfc8089#"><code>file:</code> URL scheme</a> is defined in [[rfc8089]] as
+
+				<p>The <a data-cite="rfc8089#"><code>file:</code> URL scheme</a> is defined in [[rfc8089]] as
 					"identifying an object (a 'file') stored in a structured object naming and accessing environment on
-					a host (a 'file system')." It is typically used to retrieve files from within one's own computer. </p>
-				<p> Using a file URL in an [=EPUB publication=], which can be transferred among different hosts,
+					a host (a 'file system')." It is typically used to retrieve files from the local operating
+					system.</p>
+
+				<p>Using a file URL in an [=EPUB publication=], which can be transferred among different hosts,
 					represents a security risk and is also non-interoperable. As a consequence, [=EPUB creators=] MUST
-					NOT use file URLs in EPUB publications. </p>
+					NOT use file URLs in EPUB publications.</p>
 			</section>
 
 			<section id="sec-xml-constraints">
 				<h3>XML conformance</h3>
 
-				<p>Any [=publication resource=] that is an XML-Based Media Type:</p>
+				<p>Any [=publication resource=] that is an XML-based media type [[rfc2046]]:</p>
 
 				<ul class="conformance-list">
 					<li>
@@ -1561,8 +1566,8 @@
 					</li>
 				</ul>
 
-				<p>The above constraints apply regardless of whether the given publication resource is a <a>core media
-						type resource</a> or a [=foreign resource=].</p>
+				<p>The above constraints apply regardless of whether the given publication resource is a [=core media
+					type resource=] or a [=foreign resource=].</p>
 
 				<div class="note">
 					<p>[[html]] and [[svg]] are removing support for the XML <code>base</code> attribute [[xmlbase]].
@@ -1592,7 +1597,7 @@
 							<code>[required]</code>
 						</dt>
 						<dd>
-							<p>Identifies one or more [=package documents=] that define the EPUB publication.</p>
+							<p>Identifies one or more [=package documents=] that define the [=EPUB publication=].</p>
 						</dd>
 
 						<dt>
@@ -1609,8 +1614,8 @@
 						</dt>
 						<dd>
 							<p>Contains information about the encryption of [=publication resources=]. This file is
-								mandatory when EPUB creators use <a href="#sec-font-obfuscation">font
-								obfuscation</a>.</p>
+								mandatory when [=EPUB creators=] use <a href="#sec-font-obfuscation">font
+									obfuscation</a>.</p>
 						</dd>
 
 						<dt>
@@ -1645,26 +1650,26 @@
 				<section id="sec-container-file-and-dir-structure">
 					<h4>File and directory structure</h4>
 
-					<p>The virtual file system for the [=OCF abstract container=] MUST have a single common <a>root
-							directory</a> for all the contents of the container.</p>
+					<p>The virtual file system for the [=OCF abstract container=] MUST have a single common [=root
+						directory=] for all the contents of the container.</p>
 
 					<p>The OCF abstract container MUST include a directory for configuration files named
 							<code>META-INF</code> that is a direct child of the container's root directory. Refer to <a
 							href="#sec-container-metainf"></a> for the requirements for the contents of this
 						directory.</p>
 
-					<p>The file name <code>mimetype</code> in the root directory is reserved for use by <a>OCF ZIP
-							containers</a>, as explained in <a href="#sec-container-zip"></a>.</p>
+					<p>The file name <code>mimetype</code> in the root directory is reserved for use by [=OCF ZIP
+						containers=], as explained in <a href="#sec-container-zip"></a>.</p>
 
-					<p>EPUB creators MAY locate all other files within the OCF abstract container in any location
+					<p>[=EPUB creators=] MAY locate all other files within the OCF abstract container in any location
 						descendant from the root directory, provided they are not within the <code>META-INF</code>
 						directory. EPUB creators MUST NOT reference files in the <code>META-INF</code> directory from an
-						EPUB publication.</p>
+						[=EPUB publication=].</p>
 
 					<div class="note">
-						<p>Some reading systems do not provide access to resources outside the directory where the
-							package document is stored. EPUB creators should therefore place all resources at or below
-							the directory containing the package document to avoid interoperability issues.</p>
+						<p>Some [=reading systems=] do not provide access to resources outside the directory where the
+							[=package document=] is stored. EPUB creators should therefore place all resources at or
+							below the directory containing the package document to avoid interoperability issues.</p>
 
 						<p>This problem is more commonly encountered when <a data-cite="epub-multi-rend-11#container"
 								>creating multiple renditions</a> [[epub-multi-rend-11]] of the publication.</p>
@@ -1674,8 +1679,8 @@
 				<section id="sec-container-filenames">
 					<h4>File paths and file names</h4>
 
-					<p id="ocf-fn-cs">In the context of the OCF abstract container, [=file paths=] and <a>file names</a>
-						are case sensitive.</p>
+					<p id="ocf-fn-cs">In the context of the [=OCF abstract container=], [=file paths=] and [=file
+						names=] are case sensitive.</p>
 
 					<p>In addition, the following restrictions are designed to allow file paths and file names to be
 						used without modification on most operating systems:</p>
@@ -1777,13 +1782,13 @@
 						</li>
 					</ul>
 					<div class="note">
-						<p> If EPUB creators dynamically integrate resources (i.e., where the naming is beyond their
+						<p>If [=EPUB creators=] dynamically integrate resources (i.e., where the naming is beyond their
 							control), they should be aware that automatic truncation of file names to keep them within
 							the 255 bytes limit can lead to corruption. This is due to the difference between bytes and
 							characters in multibyte encodings such as UTF-8; it is, therefore, important to avoid
 							mid-character truncation. See the section on <a
 								data-cite="international-specs/#char_truncation">"Truncating or limiting the length of
-								strings"</a> in [[international-specs]] for more information. </p>
+								strings"</a> in [[international-specs]] for more information.</p>
 					</div>
 
 					<div class="note">
@@ -1794,10 +1799,9 @@
 							iterations of EPUB, older tools and toolchains may still be encountered (e.g., ZIP tools
 							that only support [[us-ascii]]).</p>
 
-
-						<p>If EPUB creators need to ensure compatibility with EPUB 2 reading systems that only accept
-							URIs [[rfc3986]], they should further consider restricting resource names to the ASCII
-							character set [[us-ascii]].</p>
+						<p>If EPUB creators need to ensure compatibility with EPUB 2 [=reading systems=] that only
+							accept URIs [[rfc3986]], they should further consider restricting resource names to the
+							ASCII character set [[us-ascii]].</p>
 					</div>
 				</section>
 
@@ -1809,7 +1813,6 @@
 						(expressed using the terminology of [[infra]]):</p>
 
 					<ol class="algorithm">
-						<!-- <li>Let <var>file</var> be the directory or file to parse</li> -->
 						<li>Let <var>path</var> be an empty [=list=].</li>
 						<li>Let <var>current</var> be <var>file</var>.</li>
 						<li>While <var>current</var> is not the [=root directory=]: <ol>
@@ -1817,8 +1820,8 @@
 								<li>set <var>current</var> to the parent directory of <var>current</var>.</li>
 							</ol>
 						</li>
-						<li> Return the <a data-cite="infra#string-concatenate">concatenation</a> of <var>path</var>
-							using the <code>U+002F (/)</code> character. </li>
+						<li>Return the <a data-cite="infra#string-concatenate">concatenation</a> of <var>path</var>
+							using the <code>U+002F (/)</code> character.</li>
 					</ol>
 				</section>
 
@@ -1826,99 +1829,102 @@
 					<h4>URLs in the OCF abstract container</h4>
 
 					<p id="sec-container-iri-root"
-						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">The <a>container root
-							URL</a> is the [=URL=] [[url]] of the [=root directory=]. It is implementation-specific, but
-						EPUB creators MUST assume it has the following properties:</p>
+						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">The [=container root
+						URL=] is the [=URL=] [[url]] of the [=root directory=]. It is implementation-specific, but
+						[=EPUB creators=] MUST assume it has the following properties:</p>
 
 					<ul id="sec-root-url-properties">
 						<li id="sec-container-iri-root-parse"
 							data-tests="#ocf-url_link-path-absolute,#ocf-url_parse-path-absolute">The result of <a
 								data-lt="url parser">parsing</a> "<code>/</code>" with the [=container root URL=] as <a
-								data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root
-							URL</a>.</li>
+								data-cite="url#concept-base-url"><var>base</var></a> is the [=container root URL=].</li>
 						<li id="sec-container-iri-step-parse"
 							data-tests="#ocf-url_link-leaking-relative,#ocf-url_parse-leaking-relative">The result of <a
 								data-lt="url parser">parsing</a> "<code>..</code>" with the [=container root URL=] as <a
-								data-cite="url#concept-base-url"><var>base</var></a> is the <a>container root
-							URL</a>.</li>
+								data-cite="url#concept-base-url"><var>base</var></a> is the [=container root URL=].</li>
 					</ul>
 
 					<p>The [=content URL=] of a file or directory in the [=OCF abstract container=] is the result of
-						[=url parser | parsing=] the file's [=file path=] with the <a>container root URL</a> as <a
+						[=url parser | parsing=] the file's [=file path=] with the container root URL as <a
 							data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 					<div class="note" id="note-cru-explanation">
-						<p> The [=container root URL=] is the URL assigned by the reading system to the root of the
-							container. It typically depends on how the reading system internally implements the
-							container file system. </p>
-						<p> However, a reading system cannot arbitrarily use any URL, but one that honors the
-							constraints defined above. These constraints ensure that any relative URL string found in
-							the EPUB will always be parsed to a URL of a resource within the container (which may or may
-							not exist). The primary reason for these constraints is to avoid potential run-time security
-							issues that would be caused by parsed URLs "leaking" outside the container files. </p>
-						<p> For example, URLs like <code>https://localhost:12345/</code> or
+						<p>The container root URL is the URL assigned by the [=reading system=] to the root of the
+							[=EPUB container=]. It typically depends on how the reading system internally implements the
+							container file system.</p>
+
+						<p>However, a reading system cannot arbitrarily use any URL, but one that honors the constraints
+							defined above. These constraints ensure that any relative URL string found in the EPUB will
+							always be parsed to a URL of a resource within the container (which may or may not exist).
+							The primary reason for these constraints is to avoid potential run-time security issues that
+							would be caused by parsed URLs "leaking" outside the container files.</p>
+
+						<p>For example, URLs like <code>https://localhost:12345/</code> or
 								<code>https://www.example.org:12345/</code> honor these properties. But URLs like
 								<code>https://localhost:12345/path/to.epub/</code>,
 								<code>file:///path/to.epub#path=/</code>, or <code>jar:file:/path/to.epub!/EPUB/</code>
 							do not (parsing the URL string "<code>..</code>" with these three examples as base would
 							return <code>https://localhost:12345/path/</code>, <code>file:///path/</code>, and a parsing
 							error, respectively). It is the responsibility of the reading system to assign a URL to the
-							root directory that complies with the properties defined above. </p>
+							root directory that complies with the properties defined above.</p>
 					</div>
 
 					<div class="note">
-						<p> [=url parser | Parsing=] may replace some characters in the file path by their <a
+						<p>Parsing may replace some characters in the file path by their <a
 								data-cite="url#percent-encode">percent encoded</a> alternative. For example,
 								<code>A/B/C/file&#160;name.xhtml</code> becomes <code>A/B/C/file%20name.xhtml</code>.
 						</p>
 					</div>
 
-					<p> A string <var>url</var> is a <dfn class="export"
+					<p>A string <var>url</var> is a <dfn class="export"
 							id="dfn-valid-relative-container-url-with-fragment-string"
 							>valid-relative-ocf-URL-with-fragment string</dfn> if it is a
 						[=path-relative-scheme-less-url string=], optionally followed by <code>U+0023 (#)</code> and a
-						[=url-fragment string=], and if the following steps return <var>true</var>: </p>
+						[=url-fragment string=], and if the following steps return <var>true</var>:</p>
 
 					<ol class="algorithm" id="algo-out-of-container">
-						<li> Set the [=container root URL=] to <code>https://a.example.org/A/</code>. <details
-								class="explanation">
+						<li>
+							<p>Set the [=container root URL=] to <code>https://a.example.org/A/</code>.</p>
+							<details class="explanation">
 								<summary>Explanation</summary>
-								<p> The goal of the algorithm is to detect whether <var>url</var> could be seen as
-									"leaking" outside the container. To do that, the standard <a data-lt="url parser"
-										>URL parsing algorithm</a> is used with an artificial root URL; the detection of
-									the "leak" is done by comparing the result of the parsing with the presence of the
-									first test path segment (<code>A</code>). (Note that the artificial container root
-									URL wilfully violates, for the purpose of this algorithm, the <a
-										href="#sec-root-url-properties">required properties</a> by using that first test
-									path segment.) </p>
+								<p>The goal of the algorithm is to detect whether <var>url</var> could be seen as
+									"leaking" outside the container. To do that, the standard [=url parser | URL parsing
+									algorithm=] is used with an artificial root URL; the detection of the "leak" is done
+									by comparing the result of the parsing with the presence of the first test path
+									segment (<code>A</code>). (Note that the artificial container root URL wilfully
+									violates, for the purpose of this algorithm, the <a href="#sec-root-url-properties"
+										>required properties</a> by using that first test path segment.)</p>
 							</details>
 						</li>
 
-						<li> Let <var>base</var> be the <a data-cite="url#concept-base-url">base URL</a> that must be
-							used to parse <var>url</var> as defined by the context (document or environment) where
-								<var>url</var> is used, and according to the [=content URL=] of the <a>package
-								document</a> (see <a href="#sec-parse-package-urls"></a>). <details class="explanation">
+						<li>
+							<p>Let <var>base</var> be the <a data-cite="url#concept-base-url">base URL</a> that must be
+								used to parse <var>url</var> as defined by the context (document or environment) where
+									<var>url</var> is used, and according to the content URL of the [=package document=]
+								(see <a href="#sec-parse-package-urls"></a>).</p>
+							<details class="explanation">
 								<summary>Explanation</summary>
-								<p> In the case of a URL in the package document the <var>base</var> variable is set to
-									the [=content URL=] of the [=package document=]. In the case of a document within
-									the <code>META-INF</code> directory, the <var>base</var> variable is set to the
-									[=container root URL=] (see <a href="#sec-parsing-urls-metainf"></a>). In the case
-									of a URL in an XHTML content document, the base URL used for parsing is defined by
+								<p>In the case of a URL in the package document the <var>base</var> variable is set to
+									the content URL of the package document. In the case of a document within the
+										<code>META-INF</code> directory, the <var>base</var> variable is set to the
+									container root URL (see <a href="#sec-parsing-urls-metainf"></a>). In the case of a
+									URL in an [=XHTML content document=], the base URL used for parsing is defined by
 									the <a data-cite="html#resolving-urls">HTML standard</a>. Typically, it will be the
-									[=content URL=] of the content document (unless the <a
-										href="#sec-xhtml-deviations-base">discouraged</a>
-									<code>base</code> element is used). </p>
+									content URL of the content document (unless the <a href="#sec-xhtml-deviations-base"
+										>discouraged</a>
+									<code>base</code> element is used).</p>
 							</details>
 						</li>
 
-						<li> Let <var>testURLRecord</var> be the result of applying the [=URL parser=] to
-							<var>url</var>, with <var>base</var>. </li>
+						<li>Let <var>testURLRecord</var> be the result of applying the [=URL parser=] to <var>url</var>,
+							with <var>base</var>.</li>
 
-						<li> Let <var>testURLStringA</var> be the result of applying the [=URL Serializer=] to
+						<li>Let <var>testURLStringA</var> be the result of applying the [=URL Serializer=] to
 								<var>testURLRecord</var>. </li>
 
-						<li> Set the [=container root URL=] to <code>https://b.example.org/B/</code>. <details
-								class="explanation">
+						<li>
+							<p>Set the [=container root URL=] to <code>https://b.example.org/B/</code>.</p>
+							<details class="explanation">
 								<summary>Explanation</summary>
 								<p>The reasons to repeat the same steps twice with different, and artificial, settings
 									of the container root URL is to avoid collision which may occur if the
@@ -1927,31 +1933,35 @@
 							</details>
 						</li>
 
-						<li> Set <var>base</var> to be the <a data-cite="url#concept-base-url">base URL</a> that must be
+						<li>Set <var>base</var> to be the <a data-cite="url#concept-base-url">base URL</a> that must be
 							used to parse <var>url</var> as defined by the context (document or environment) where
-								<var>url</var> is used, and according to the [=content URL=] of the <a>package
-								document</a> (see <a href="#sec-parse-package-urls"></a>). </li>
+								<var>url</var> is used, and according to the content URL of the package document (see <a
+								href="#sec-parse-package-urls"></a>).</li>
 
-						<li> Set <var>testURLRecord</var> to be the result of applying the [=URL parser=] to
+						<li>Set <var>testURLRecord</var> to be the result of applying the [=URL parser=] to
 								<var>url</var>, with <var>base</var>. </li>
 
-						<li> Let <var>testURLStringB</var> be the result of applying the [=URL Serializer=] to
-								<var>testURLRecord</var>. </li>
+						<li>Let <var>testURLStringB</var> be the result of applying the [=URL Serializer=] to
+								<var>testURLRecord</var>.</li>
 
-						<li> If <var>testURLStringA</var> does not start with <code>https://a.example.org/</code> or
-								<var>testURLStringB</var> does not start with <code>https://b.example.org/</code>,
-							return <var>true</var>. <details class="explanation">
+						<li>
+							<p>If <var>testURLStringA</var> does not start with <code>https://a.example.org/</code> or
+									<var>testURLStringB</var> does not start with <code>https://b.example.org/</code>,
+								return <var>true</var>.</p>
+							<details class="explanation">
 								<summary>Explanation</summary>
-								<p> If any of the result does not share the test URL host, it means that <var>url</var>,
+								<p>If any of the result does not share the test URL host, it means that <var>url</var>,
 									or its base URL (for example, in HTML, if it is explicitly set with the
 										<code>base</code> element), was <em>absolute</em> and points outside the
-									container. This is acceptable. </p>
+									container. This is acceptable.</p>
 							</details>
 						</li>
 
-						<li> If <var>testURLStringA</var> starts with <code>https://a.example.org/A/</code> and
-								<var>testURLStringB</var> starts with <code>https://b.example.org/B/</code>, return
-								<var>true</var>. <details class="explanation">
+						<li>
+							<p>If <var>testURLStringA</var> starts with <code>https://a.example.org/A/</code> and
+									<var>testURLStringB</var> starts with <code>https://b.example.org/B/</code>, return
+									<var>true</var>.</p>
+							<details class="explanation">
 								<summary>Explanation</summary>
 								<p>The presence of the first test path segments (<code>A</code>, respectively
 										<code>B</code>) indicate that the URL doesn't leak outside the container.</p>
@@ -1961,13 +1971,12 @@
 						<li>Return <var>false</var>.</li>
 					</ol>
 
-					<p id="urls-in-ocf-constraints"> In the [=OCF abstract container=], any URL string MUST be an
-						[=absolute-url-with-fragment string=] or a <a>valid-relative-ocf-URL-with-fragment
-						string</a>.</p>
+					<p id="urls-in-ocf-constraints">In the OCF abstract container, any URL string MUST be an
+						[=absolute-url-with-fragment string=] or a [=valid-relative-ocf-URL-with-fragment string=].</p>
 
 					<p>In addition, all [=relative-URL-with-fragment strings=] [[url]] MUST, after <a
-							data-lt="url parser">parsing</a>, be equal to the [=content URL=] of an existing file in the
-						OCF abstract container.</p>
+							data-lt="url parser">parsing</a>, be equal to the content URL of an existing file in the OCF
+						abstract container.</p>
 
 					<div class="note">
 						<p>These constraints on URL strings mean that:</p>
@@ -1980,15 +1989,15 @@
 							<li>any other absolute or relative URL string is allowed.</li>
 						</ul>
 
-						<p> Note that in any case, even the disallowed URL strings described above will not "leak"
+						<p>Note that in any case, even the disallowed URL strings described above will not "leak"
 							outside the container after parsing (as explained in the <a href="#note-cru-explanation"
 								>first note</a> of this section). They are nevertheless disallowed for better
-							interoperability with non-conforming or legacy reading systems and toolchains. </p>
+							interoperability with non-conforming or legacy reading systems and toolchains.</p>
 					</div>
 
 					<aside class="example" title="Referencing a file in the same directory">
-						<p>In this example, the file <code>image1.jpg</code> is in the same directory as the <a>XHTML
-								content document</a>.</p>
+						<p>In this example, the file <code>image1.jpg</code> is in the same directory as the XHTML
+							content document.</p>
 
 						<pre>&lt;html …>
    …
@@ -2014,10 +2023,10 @@
 						</pre>
 
 						<p> A URL `../../../../EPUB/secret.xhtml` appearing in `content.xhtml` would be parsed by a
-							reading system into a [=content URL=] with a path `EPUB/secret.xhtml`, following the
-							constraints on the [=container root URL=]. However, as the URL could be perceived as one of
-							a resource outside the container, and create interoperability issues; it would be reported
-							as an error by a checker tool. </p>
+							reading system into a content URL with a path `EPUB/secret.xhtml`, following the constraints
+							on the container root URL. However, as the URL could be perceived as one of a resource
+							outside the container, and create interoperability issues; it would be reported as an error
+							by a checker tool. </p>
 					</aside>
 				</section>
 
@@ -2054,9 +2063,9 @@
    &lt;/rootfiles>
 &lt;/container></pre>
 
-							<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the root directory
-								for the OCF abstract container and not relative to the <code>META-INF</code>
-								directory.</p>
+							<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the [=root
+								directory=] for the [=OCF abstract container=] and not relative to the
+									<code>META-INF</code> directory.</p>
 						</aside>
 					</section>
 
@@ -2067,7 +2076,7 @@
 							<h6>Container file (<code>container.xml</code>)</h6>
 
 							<p>The REQUIRED <code>container.xml</code> file in the <code>META-INF</code> directory
-								identifies the [=package documents=] available in the <a>OCF abstract container</a>.</p>
+								identifies the [=package documents=] available in the [=OCF abstract container=].</p>
 
 							<p>All [[xml]] elements defined in this section are in the
 									<code>urn:oasis:names:tc:opendocument:xmlns:container</code> namespace [[xml-names]]
@@ -2083,7 +2092,7 @@
 							<section id="sec-container.xml-container-elem">
 								<h6>The <code>container</code> element</h6>
 
-								<p>The <code>container</code> element is the root element of the
+								<p>The <code>container</code> element encapsulates all the information in the
 										<code>container.xml</code> file.</p>
 
 								<dl id="elemdef-container" class="elemdef">
@@ -2097,7 +2106,8 @@
 
 									<dt>Usage:</dt>
 									<dd>
-										<p>Root element of the <code>container.xml</code> file.</p>
+										<p>REQUIRED <a data-cite="xml#dt-root">root element</a> [[xml]] of the
+												<code>container.xml</code> file.</p>
 									</dd>
 
 									<dt>Attributes:</dt>
@@ -2160,8 +2170,8 @@
 							<section id="sec-container.xml-rootfile-elem">
 								<h6>The <code>rootfile</code> element</h6>
 
-								<p>Each <code>rootfile</code> element identifies the location of one <a>package
-										document</a> in the [=EPUB container=].</p>
+								<p>Each <code>rootfile</code> element identifies the location of one [=package
+									document=] in the [=EPUB container=].</p>
 
 								<dl id="elemdef-rootfile" class="elemdef">
 									<dt>Element Name:</dt>
@@ -2185,10 +2195,10 @@
 												<code>[required]</code>
 											</dt>
 											<dd>
-												<p>Identifies the location of a [=package document=].</p>
-												<p>The value of the attribute MUST be a <a>path-relative-scheme-less-URL
-														string</a> [[url]]. The path is relative to the <a>root
-														directory</a>.</p>
+												<p>Identifies the location of a package document.</p>
+												<p>The value of the attribute MUST be a [=path-relative-scheme-less-URL
+													string=] [[url]]. The path is relative to the [=root
+													directory=].</p>
 											</dd>
 
 											<dt>
@@ -2209,9 +2219,9 @@
 									</dd>
 								</dl>
 
-								<p>If an EPUB creator defines more than one <code>rootfile</code> element, each MUST
+								<p>If an [=EPUB creator=] defines more than one <code>rootfile</code> element, each MUST
 									reference a package document that conforms to the same version of EPUB. Each package
-									document represents one rendering of the EPUB publication.</p>
+									document represents one rendering of the [=EPUB publication=].</p>
 
 								<div class="note">
 									<p>Although the EPUB container provides the ability to reference more than one
@@ -2338,8 +2348,8 @@
 							<h6>Encryption file (<code>encryption.xml</code>)</h6>
 
 							<p>The OPTIONAL <code>encryption.xml</code> file in the <code>META-INF</code> directory
-								holds all encryption information on the contents of the container. If an EPUB creator
-								encrypts any resources within the container, they MUST include an
+								holds all encryption information on the contents of the container. If an [=EPUB
+								creator=] encrypts any resources within the container, they MUST include an
 									<code>encryption.xml</code> file to provide information about the encryption
 								used.</p>
 
@@ -2362,7 +2372,8 @@
 
 									<dt>Usage:</dt>
 									<dd>
-										<p>Root element of the <code>encryption.xml</code> file.</p>
+										<p>REQUIRED <a data-cite="xml#dt-root">root element</a> [[xml]] of the
+												<code>encryption.xml</code> file.</p>
 									</dd>
 
 									<dt>Attributes:</dt>
@@ -2401,17 +2412,19 @@
 
 								<p>OCF uses XML Encryption [[xmlenc-core1]] to provide a framework for encryption,
 									allowing a variety of algorithms to be used. XML Encryption specifies a process for
-									encrypting arbitrary data and representing the result in XML. Even though an <a>OCF
-										abstract container</a> may contain non-XML data, EPUB creators can use XML
-									Encryption to encrypt all data in an OCF abstract container. OCF encryption supports
-									only the encryption of entire files within the container, not parts of files. EPUB
-									creators MUST NOT encrypt the <code>encryption.xml</code> file when present.</p>
+									encrypting arbitrary data and representing the result in XML. Even though an [=OCF
+									abstract container=] may contain non-XML data, [=EPUB creators=] can use XML
+									Encryption to encrypt all data in an [=OCF abstract container=]. OCF encryption
+									supports only the encryption of entire files within the container, not parts of
+									files. EPUB creators MUST NOT encrypt the <code>encryption.xml</code> file when
+									present.</p>
 
 								<p>Encrypted data replaces unencrypted data in an OCF abstract container. For example,
 									if an EPUB creator encrypts an image named <code>photo.jpeg</code>, they should
 									replace the contents of the <code>photo.jpeg</code> resource with its encrypted
 									contents. Within the ZIP directory, EPUB creators SHOULD store encrypted files
 									rather than Deflate-compress them.</p>
+
 								<p id="encryption-obfuscation">Note that some situations require obfuscating the storage
 									of embedded fonts referenced by an [=EPUB publication=] to make them more difficult
 									to extract for unrestricted use. Although obfuscation is not encryption, reading
@@ -2443,16 +2456,12 @@
 									<li>
 										<code>META-INF/signatures.xml</code>
 									</li>
-									<li>
-										<a>
-											<code>package document</code>
-										</a>
-									</li>
+									<li> [= <code>package document</code> =] </li>
 								</ul>
 
 								<p>EPUB creators MAY subsequently encrypt signed resources using the Decryption
-									Transform for XML Signature [[xmlenc-decrypt]]. This feature enables a reading
-									system to distinguish data encrypted before signing from data encrypted after
+									Transform for XML Signature [[xmlenc-decrypt]]. This feature enables a [=reading
+									system=] to distinguish data encrypted before signing from data encrypted after
 									signing.</p>
 
 								<aside class="example" title="An encrypted image">
@@ -2500,17 +2509,17 @@
 							<section id="sec-enc-compression">
 								<h6>Order of compression and encryption</h6>
 
-								<p>When stored in a ZIP container, EPUB creators SHOULD compress streams of data with
-									[=non-codec=] content types before encrypting them. EPUB creators MUST use Deflate
-									compression. This practice ensures that file entries stored in the ZIP container
-									have a smaller size.</p>
+								<p>When stored in an [=OCF ZIP container=], [=EPUB creators=] SHOULD compress streams of
+									data with [=non-codec=] content types before encrypting them. EPUB creators MUST use
+									Deflate compression. This practice ensures that file entries stored in the ZIP
+									container have a smaller size.</p>
 
 								<p>EPUB creators SHOULD NOT compress streams of data with [=codec=] content types before
 									encrypting them. In such cases, additional compression introduces unnecessary
 									processing overhead at production time (especially with large resource files) and
 									impacts audio/video playback performance at consumption time. In some cases, the
 									combination of compression with some encryption schemes might even compromise the
-									ability of reading systems to handle partial content requests (e.g. HTTP byte
+									ability of [=reading systems=] to handle partial content requests (e.g. HTTP byte
 									ranges), due to the technical impossibility to determine the length of the full
 									resource ahead of media playback (e.g. HTTP Content-Length header).</p>
 
@@ -2603,8 +2612,8 @@
 
 							<p>The OCF specification does not mandate a format for the manifest.</p>
 
-							<p>Note that [=package documents=] specify the only manifests used for processing <a>EPUB
-									publications</a>. Reading systems do not use this file.</p>
+							<p>Note that [=package documents=] specify the only manifests used for processing [=EPUB
+								publications=]. Reading systems do not use this file.</p>
 
 							<div class="note">This feature exists only for compatibility with [[odf]].</div>
 						</section>
@@ -2615,11 +2624,11 @@
 							<p>The OPTIONAL <code>metadata.xml</code> file in the <code>META-INF</code> directory is
 								only for container-level metadata.</p>
 
-							<p>If EPUB creators include a <code>metadata.xml</code> file, they SHOULD use only
-								namespace-qualified elements [[xml-names]] in it. The file SHOULD contain the root
-								element <code>metadata</code> in the namespace
-									<code>http://www.idpf.org/2013/metadata</code>, but this specification allows other
-								root elements for backwards compatibility.</p>
+							<p>If [=EPUB creators=] include a <code>metadata.xml</code> file, they SHOULD use only
+								namespace-qualified elements [[xml-names]] in it. The file SHOULD contain the <a
+									data-cite="xml#dt-root">root element</a> [[xml]] <code>metadata</code> in the
+								namespace <code>http://www.idpf.org/2013/metadata</code>, but this specification allows
+								other root elements for backwards compatibility.</p>
 
 							<p>This version of the specification does not define metadata for use in the
 									<code>metadata.xml</code> file. Future versions of this specification MAY define
@@ -2631,15 +2640,12 @@
 
 							<p>This specification reserves the OPTIONAL <code>rights.xml</code> file in the
 									<code>META-INF</code> directory for digital rights management (DRM) information for
-								trusted exchange of EPUB publications among rights holders, intermediaries, and
+								trusted exchange of [=EPUB publications=] among rights holders, intermediaries, and
 								users.</p>
 
-							<p>When EPUB creators do not include a <code>rights.xml</code> file, no part of the
-								container is rights governed at the container level. Rights expressions might exist
-								within the EPUB publications.</p>
-
-							<p>If EPUB creators do not include a <code>rights.xml</code> file, no part of the OCF
-								abstract container is rights governed.</p>
+							<p>When [=EPUB creators=] do not include a <code>rights.xml</code> file, no part of the
+								[=OCF abstract container=] is rights governed at the container level. Rights expressions
+								might exist within the EPUB publications.</p>
 						</section>
 
 						<section id="sec-container-metainf-signatures.xml">
@@ -2647,7 +2653,8 @@
 
 							<div class="note">
 								<p>Adding a digital signature is not a guarantee that a malicious actor cannot tamper
-									with an EPUB publication as reading systems do not have to check signatures.</p>
+									with an [=EPUB publication=] as [=reading systems=] do not have to check
+									signatures.</p>
 							</div>
 
 							<p>The OPTIONAL <code>signatures.xml</code> file in the <code>META-INF</code> directory
@@ -2672,7 +2679,8 @@
 
 									<dt>Usage:</dt>
 									<dd>
-										<p>Root element of the <code>signature.xml</code> file.</p>
+										<p>REQUIRED <a data-cite="xml#dt-root">root element</a> [[xml]] of the
+												<code>signature.xml</code> file.</p>
 									</dd>
 
 									<dt>Attributes:</dt>
@@ -2689,20 +2697,20 @@
 								</dl>
 
 								<p>The <code>signature</code> element contains child elements of type
-										<code>Signature</code>, as defined by [[xmldsig-core1]]. EPUB creators can apply
-									signatures to an EPUB publication as a whole or to its parts, and can specify the
-									signing of any kind of data (i.e., not just XML).</p>
+										<code>Signature</code>, as defined by [[xmldsig-core1]]. [=EPUB creators=] can
+									apply signatures to an EPUB publication as a whole or to its parts, and can specify
+									the signing of any kind of data (i.e., not just XML).</p>
 
 								<p class="note">An <a href="#app-schema-signatures">XML Schema</a> also informally
 									defines the content of the <code>signatures.xml</code> file.</p>
 
 								<p>When an EPUB creator does not include a <code>signatures.xml</code> file, they are
-									not signing any part of the container at the container level. Digital signing might
-									exist within the [=EPUB publication=].</p>
+									not signing any part of the [=OCF abstract container=] at the container level.
+									Digital signing might exist within the EPUB publication.</p>
 
-								<p id="sig-container">When an EPUB creator creates a data signature for the container,
-									they SHOULD add the signature as the last child <code>Signature</code> element of
-									the <code>signatures</code> element.</p>
+								<p id="sig-container">When an EPUB creator creates a data signature for the OCF abstact
+									container, they SHOULD add the signature as the last child <code>Signature</code>
+									element of the <code>signatures</code> element.</p>
 
 								<div class="note">
 									<p>Each <code>Signature</code> in the <code>signatures.xml</code> file identifies by
@@ -2716,13 +2724,13 @@
 										reference them by one or more <code>Signature</code> elements.</p>
 								</div>
 
-								<p id="sig-restrictions">EPUB creators can sign any or all files in the container in
-									their entirety, except for the <code>signatures.xml</code> file since that file will
-									contain the computed signature information. Whether and how EPUB creators sign the
-										<code>signatures.xml</code> file depends on their objective.</p>
+								<p id="sig-restrictions">EPUB creators can sign any or all files in the OCF abstract
+									container in their entirety, except for the <code>signatures.xml</code> file since
+									that file will contain the computed signature information. Whether and how EPUB
+									creators sign the <code>signatures.xml</code> file depends on their objective.</p>
 
-								<p>If the EPUB creator wants to allow signatures to be added or removed from the
-									container without invalidating their signature, they SHOULD NOT sign the
+								<p>If the EPUB creator wants to allow signatures to be added or removed from the OCF
+									abstract container without invalidating their signature, they SHOULD NOT sign the
 										<code>signatures.xml</code> file.</p>
 
 								<p>If the EPUB creator wants any addition or removal of a signature to invalidate their
@@ -2821,8 +2829,8 @@
 				<section id="sec-container-zip-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>An [=OCF ZIP container=] is a physical single-file manifestation of an <a>OCF abstract
-							container</a>. The container allows:</p>
+					<p>An [=OCF ZIP container=] is a physical single-file manifestation of an [=OCF abstract
+						container=]. The container allows:</p>
 
 					<ul>
 						<li>
@@ -2874,12 +2882,13 @@
 								[[unicode]].</p>
 						</li>
 					</ul>
+
 					<p>The following constraints apply to specific fields in the OCF ZIP container archive:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-zip-fld-version">In the local file header table, EPUB creators MUST set the
-									<code>version needed to extract</code> fields to the values <code>10</code>,
+							<p id="confreq-zip-fld-version">In the local file header table, [=EPUB creators=] MUST set
+								the <code>version needed to extract</code> fields to the values <code>10</code>,
 									<code>20</code> or <code>45</code> to match the maximum version level needed by the
 								given file (e.g., <code>20</code> for Deflate, <code>45</code> for ZIP64).</p>
 						</li>
@@ -2894,8 +2903,8 @@
 				<section id="sec-zip-container-mime">
 					<h4>OCF ZIP container media type identification</h4>
 
-					<p>EPUB creators MUST include the <code>mimetype</code> file as the first file in the <a>OCF ZIP
-							container</a>. In addition:</p>
+					<p>[=EPUB creators=] MUST include the <code>mimetype</code> file as the first file in the [=OCF ZIP
+						container=]. In addition:</p>
 
 					<ul>
 						<li>The contents of the <code>mimetype</code> file MUST be the MIME media type [[rfc2046]]
@@ -2920,8 +2929,8 @@
 				<div class="caution">
 					<p>Better methods of protecting fonts exist. Both [[woff]] and [[woff2]] fonts, for example, allow
 						the embedding of licensing information and provide some protection through font table
-						compression. The use of remotely hosted fonts also allows for font subsetting. EPUB creators are
-						advised to use font obfuscation as defined in this section only when no other options are
+						compression. The use of remotely hosted fonts also allows for font subsetting. [=EPUB creators=]
+						are advised to use font obfuscation as defined in this section only when no other options are
 						available to them. See also the <a href="#fobfus-limitations">limitations of
 						obfuscation</a>.</p>
 				</div>
@@ -2938,12 +2947,12 @@
 						extraction of fonts is not a desired side-effect of not encrypting them. An [=EPUB creator=] who
 						wishes to include a third-party font, for example, typically does not want that font extracted
 						and re-used by others. More critically, many commercial fonts allow embedding, but embedding a
-						font implies making it an integral part of the EPUB publication, not just providing the original
-						font file along with the content.</p>
+						font implies making it an integral part of the [=EPUB publication=], not just providing the
+						original font file along with the content.</p>
 
 					<p>Since integrated ZIP support is so ubiquitous in modern operating systems, simply placing a font
-						in the ZIP archive is insufficient to signify that the font cannot be reused in other contexts.
-						This uncertainty can undermine the otherwise useful font embedding capability of EPUB
+						in the [=OCF ZIP container=] is insufficient to signify that the font cannot be reused in other
+						contexts. This uncertainty can undermine the otherwise useful font embedding capability of EPUB
 						publications.</p>
 
 					<p>To discourage reuse of their fonts, some font vendors might only allow their use in EPUB
@@ -2963,7 +2972,7 @@
 					<p>This specification does not claim that obfuscation constitutes encryption, nor does it guarantee
 						that the resource will be secure from copyright infringement. The hope is only that this
 						algorithm will meet the requirements of vendors who require some assurance that their fonts
-						cannot be extracted simply by unzipping the OCF ZIP container and copying the resource.</p>
+						cannot be extracted simply by unzipping the [=OCF ZIP container=] and copying the resource.</p>
 
 					<p>Obfuscation, like any protection scheme, cannot fully protect fonts from being accessed in their
 						deobfuscated state. The mechanism only provides an obstacle for those who are unaware of the
@@ -2972,15 +2981,15 @@
 
 					<ul>
 						<li>applying the deobfuscation algorithm to extract the raw font file;</li>
-						<li>accessing the deobfuscated font through a reading system that must dedobfuscate it to render
-							the content (e.g., by accessing the resources through a browser-based reading system);
-							or</li>
+						<li>accessing the deobfuscated font through a [=reading system=] that must dedobfuscate it to
+							render the content (e.g., by accessing the resources through a browser-based reading
+							system); or</li>
 						<li>accessing the deobfuscated font through authoring tools that provide the visual rendering of
 							the content.</li>
 					</ul>
 
 					<p>As a result, whether this method of obfuscation satisfies the requirements of individual font
-						licenses remains a question for the licensor and licensee. EPUB creators are responsible for
+						licenses remains a question for the licensor and licensee. [=EPUB creators=] are responsible for
 						ensuring their use of obfuscation meets font licensing requirements.</p>
 
 					<p>EPUB creators should also be aware that obfuscation may lead to interoperability issues in
@@ -2994,8 +3003,8 @@
 				<section id="obfus-keygen">
 					<h4>Obfuscation key</h4>
 
-					<p>EPUB creators MUST derive the key used in the obfuscation algorithm from the <a>unique
-							identifier</a>.</p>
+					<p>[=EPUB creators=] MUST derive the key used in the obfuscation algorithm from the [=unique
+						identifier=].</p>
 
 					<p>All white space characters, as defined in <a data-cite="xml#sec-common-syn">section 2.3 of the
 							XML 1.0 specification</a> [[xml]], MUST be removed from this identifier — specifically, the
@@ -3023,10 +3032,10 @@
 						the source. Once 1040 bytes are encoded in this way (or the end of the source is reached),
 						directly copy any remaining data in the source to the destination.</p>
 
-					<p>EPUB creators MUST obfuscate fonts before compressing and adding them to the OCF ZIP container.
-						Note that as obfuscation is not encryption, this requirement is not a violation of the one in <a
-							href="#sec-container-metainf-encryption.xml"></a> to compress fonts before encrypting
-						them.</p>
+					<p>[=EPUB creators=] MUST obfuscate fonts before compressing and adding them to the [=OCF ZIP
+						container=]. Note that as obfuscation is not encryption, this requirement is not a violation of
+						the one in <a href="#sec-container-metainf-encryption.xml"></a> to compress fonts before
+						encrypting them.</p>
 
 					<p>The following pseudo-code exemplifies the obfuscation algorithm.</p>
 
@@ -3075,11 +3084,11 @@
 					<h4>Specifying obfuscated fonts</h4>
 
 					<p>Although not technically encrypted data, all obfuscated fonts MUST have an entry in the <code
-							class="filename">encryption.xml</code> file accompanying the EPUB publication (see <a
+							class="filename">encryption.xml</code> file accompanying the [=EPUB publication=] (see <a
 							href="#sec-container-metainf-encryption.xml"></a>).</p>
 
-					<p>EPUB creators MUST specify an <code>EncryptedData</code> element for each obfuscated font. Each
-							<code>EncryptedData</code> element MUST contain a child <code>EncryptionMethod</code>
+					<p>[=EPUB creators=] MUST specify an <code>EncryptedData</code> element for each obfuscated font.
+						Each <code>EncryptedData</code> element MUST contain a child <code>EncryptionMethod</code>
 						element whose <code>Algorithm</code> attribute has the value
 							<code>http://www.idpf.org/2008/embedding</code>. The presence of this attribute signals the
 						use of the algorithm described in this specification.</p>
@@ -3137,12 +3146,12 @@
 					</li>
 					<li>
 						<p>A <a href="#sec-spine-elem">spine</a> — an ordered sequence of ID references to top-level
-							resources in the manifest from which reading systems can reach or utilize all other
+							resources in the manifest from which [=reading systems=] can reach or utilize all other
 							resources in the set. The spine defines the default reading order.</p>
 					</li>
 					<li>
 						<p><a href="#sec-collection-elem">Collections</a> — a method of encapsulating and identifying
-							subcomponents within the Package.</p>
+							subcomponents within the EPUB publication.</p>
 					</li>
 					<li>
 						<p>[=Manifest fallback chains=] — a mechanism that defines an ordered list of top-level
@@ -3167,7 +3176,7 @@
 				<h3>Parsing URLs in the package document</h3>
 
 				<p id="pkg-parse-package-url" data-tests="#ocf-url_link-relative,#ocf-url_relative"> To parse a URL
-					string <var>url</var> used in the package document, the <a data-lt="url parser">URL
+					string <var>url</var> used in the [=package document=], the <a data-lt="url parser">URL
 					parser</a> [[url]] MUST be applied to <var>url</var>, with the [=content URL=] of the package
 					document as <var>base</var>.</p>
 			</section>
@@ -3195,8 +3204,8 @@
 							[[bidi]].</li>
 					</ul>
 
-					<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading systems will assume the
-						value <code>auto</code> when EPUB creators omit the attribute or use an invalid value.</p>
+					<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">[=Reading systems=] will assume the
+						value <code>auto</code> when [=EPUB creators=] omit the attribute or use an invalid value.</p>
 
 					<div class="note">
 						<p>The base direction specified in the <code>dir</code> attribute does not affect the ordering
@@ -3244,7 +3253,8 @@
 				<section id="attrdef-id">
 					<h4>The <code>id</code> attribute</h4>
 
-					<p>The ID [[xml]] of the element, which MUST be unique within the document scope.</p>
+					<p>The <a data-cite="xml#id">ID</a> [[xml]] of the element, which MUST be unique within the document
+						scope.</p>
 
 					<aside class="example" title="Adding an identifier attribute">
 						<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
@@ -3316,9 +3326,9 @@
 					<h4>The <code>refines</code> attribute</h4>
 
 					<p>Establishes an association between the current expression and the element or resource identified
-						by its value. EPUB creators MUST use as the value a [=path-relative-scheme-less-URL string=],
-						optionally followed by <code>U+0023 (#)</code> and a [=URL-fragment string=] that references the
-						resource or element they are describing.</p>
+						by its value. [=EPUB creators=] MUST use as the value a [=path-relative-scheme-less-URL
+						string=], optionally followed by <code>U+0023 (#)</code> and a [=URL-fragment string=] that
+						references the resource or element they are describing.</p>
 
 					<aside class="example" title="Specifying that a creator is the illustrator">
 						<pre>&lt;package …>
@@ -3343,8 +3353,8 @@
 						omitted, the element defines a <a href="#primary-expression">primary expression</a>.</p>
 
 					<p>When creating expressions about a [=publication resource=], the <code>refines</code> attribute
-						SHOULD specify a fragment identifier that references the ID of the resource's <a
-							href="#sec-item-elem">manifest entry</a>.</p>
+						SHOULD specify a fragment identifier that references the <a data-cite="xml#id">ID</a> [[xml]] of
+						the resource's <a href="#sec-item-elem">manifest entry</a>.</p>
 
 					<p>Refinement chains MUST NOT contain circular references or self-references.</p>
 
@@ -3400,7 +3410,8 @@
 			<section id="sec-package-elem">
 				<h3>The <code>package</code> element</h3>
 
-				<p>The <code>package</code> element is the root element of the [=package document=].</p>
+				<p>The <code>package</code> element encapsulates all the information expressed in the [=package
+					document=].</p>
 
 				<dl id="elemdef-opf-package" class="elemdef">
 					<dt>Element Name:</dt>
@@ -3412,7 +3423,7 @@
 
 					<dt>Usage:</dt>
 					<dd>
-						<p>The <code>package</code> element is the root element of the package document.</p>
+						<p>REQUIRED <a data-cite="xml#dt-root">root element</a> [[xml]] of the package document.</p>
 					</dd>
 
 					<dt>Attributes:</dt>
@@ -3512,7 +3523,7 @@
 				</dl>
 
 				<p id="attrdef-package-version">The <code>version</code> attribute specifies the EPUB specification
-					version to which the given EPUB publication conforms. The attribute MUST have the value
+					version to which the given [=EPUB publication=] conforms. The attribute MUST have the value
 						"<code>3.0</code>" to indicate conformance with EPUB 3.</p>
 
 				<div class="note">
@@ -3601,11 +3612,11 @@
 						</dd>
 					</dl>
 
-					<p>The package document <code>metadata</code> element has two primary functions:</p>
+					<p>The [=package document=] <code>metadata</code> element has two primary functions:</p>
 
 					<ol>
 						<li>
-							<p>to provide a minimal set of meta information for reading systems to use to internally
+							<p>to provide a minimal set of meta information for [=reading systems=] to use to internally
 								catalogue an [=EPUB publication=] and make it available to a user (e.g., to present in a
 								bookshelf).</p>
 						</li>
@@ -3615,12 +3626,12 @@
 						</li>
 					</ol>
 
-					<p>The package document does not provide complex metadata encoding capabilities. If EPUB creators
-						need to provide more detailed information, they can associate metadata records (e.g., that
-						conform to an international standard such as [[onix]] or are created for custom purposes) using
-						the [^link^] element. This approach allows reading systems to process the metadata in its native
-						form, avoiding the potential problems and information loss caused by translating to use the
-						minimal package document structure.</p>
+					<p>The package document does not provide complex metadata encoding capabilities. If [=EPUB
+						creators=] need to provide more detailed information, they can associate metadata records (e.g.,
+						that conform to an international standard such as [[onix]] or are created for custom purposes)
+						using the [^link^] element. This approach allows reading systems to process the metadata in its
+						native form, avoiding the potential problems and information loss caused by translating to use
+						the minimal package document structure.</p>
 
 					<p id="core-metadata-reqs">In keeping with this philosophy, the package document only has the
 						following minimal metadata requirements: it MUST contain the [[dcterms]] [^dc:title^],
@@ -3664,9 +3675,9 @@
 				<section id="sec-metadata-values">
 					<h4>Metadata values</h4>
 
-					<p>The Dublin Core elements [[dcterms]] and [^meta^] element have mandatory <a>child text
-							content</a> [[dom]]. This specification refers to this content as the <dfn>value</dfn> of
-						the element in their descriptions.</p>
+					<p>The Dublin Core elements [[dcterms]] and [^meta^] element have mandatory [=child text content=]
+						[[dom]]. In the descriptions for these elements, this specification refers to this content as
+						the element's <dfn>value</dfn>.</p>
 
 					<p>These elements MUST have non-empty values after <a
 							data-lt="strip leading and trailing ascii whitespace">leading and trailing ASCII
@@ -3730,10 +3741,10 @@
 							</dd>
 						</dl>
 
-						<p>The [=EPUB creator=] MUST provide an identifier that is unique to one and only one <a>EPUB
-								publication</a> &#8212; its [=unique identifier=] &#8212; in an
-								<code>dc:identifier</code> element. This <code>dc:identifier</code> element MUST specify
-							an <code>id</code> attribute whose value is referenced from the [^package^] element's <a
+						<p>The [=EPUB creator=] MUST provide an identifier that is unique to one and only one [=EPUB
+							publication=] &#8212; its [=unique identifier=] &#8212; in an <code>dc:identifier</code>
+							element. This <code>dc:identifier</code> element MUST specify an <code>id</code> attribute
+							whose value is referenced from the [^package^] element's <a
 								href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
 							attribute</a>.</p>
 
@@ -3859,8 +3870,8 @@
 </pre>
 						</aside>
 
-						<p>EPUB creators should use only a single <code>dc:title</code> element to ensure consistent
-							rendering of the title in reading systems.</p>
+						<p>[=EPUB creators=] should use only a single <code>dc:title</code> element to ensure consistent
+							rendering of the title in [=reading systems=].</p>
 
 						<div class="note">
 							<p>Although it is possible to include more than one <code>dc:title</code> element for
@@ -3957,8 +3968,8 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<p>Although EPUB creators MAY specify additional <code>dc:language</code> elements for
-							multilingual Publications, reading systems will treat the first <code>dc:language</code>
+						<p>Although [=EPUB creators=] MAY specify additional <code>dc:language</code> elements for
+							multilingual Publications, [=reading systems=] will treat the first <code>dc:language</code>
 							element in document order as the primary language of the EPUB publication.</p>
 
 						<div class="note">
@@ -4053,7 +4064,7 @@
 
 						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
 								><code>dc:creator</code></dfn> element [[dcterms]] represents the name of a person,
-							organization, etc. responsible for the creation of the content. EPUB creators MAY <a
+							organization, etc. responsible for the creation of the content. [=EPUB creators=] MAY <a
 								href="#subexpression">associate</a> a <a href="#role"><code>role</code> property</a>
 							with the element to indicate the function the creator played.</p>
 
@@ -4080,7 +4091,7 @@
 						</aside>
 
 						<p>The <code>dc:creator</code> element should contain the name of the creator as EPUB creators
-							intend reading systems to display it to users.</p>
+							intend [=reading systems=] to display it to users.</p>
 
 						<p>EPUB creators MAY use the <a href="#file-as"><code>file-as</code> property</a>
 							<a href="#subexpression">to associate</a> a normalized form of the creator's name, and the
@@ -4109,7 +4120,7 @@
 &lt;/metadata></pre>
 						</aside>
 
-						<p>If an EPUB publication has more than one creator, EPUB creators should specify each in a
+						<p>If an [=EPUB publication=] has more than one creator, EPUB creators should specify each in a
 							separate <code>dc:creator</code> element.</p>
 
 						<p>The document order of <code>dc:creator</code> elements in the <code>metadata</code> section
@@ -4143,7 +4154,7 @@
 						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
 								><code>dc:date</code></dfn> element [[dcterms]] defines the publication date of the
 							[=EPUB publication=]. The publication date is not the same as the <a
-								href="#last-modified-date">last modified date</a> (the last time the EPUB creator
+								href="#last-modified-date">last modified date</a> (the last time the [=EPUB creator=]
 							changed the EPUB publication).</p>
 
 						<p>It is RECOMMENDED that the date string conform to [[iso8601]], particularly the subset
@@ -4170,10 +4181,10 @@
 						<h5>The <code>dc:subject</code> element</h5>
 
 						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-								><code>dc:subject</code></dfn> element [[dcterms]] identifies the subject of the EPUB
-							publication. EPUB creators should set the [=value=] of the element to the human-readable
-							heading or label, but may use a code value if the subject taxonomy does not provide a
-							separate descriptive label.</p>
+								><code>dc:subject</code></dfn> element [[dcterms]] identifies the subject of the [=EPUB
+							publication=]. [=EPUB creators=] should set the [=value=] of the element to the
+							human-readable heading or label, but may use a code value if the subject taxonomy does not
+							provide a separate descriptive label.</p>
 
 						<p>EPUB creators MAY identify the system or scheme they drew the element's [=value=] from using
 							the <a href="#authority"><code>authority</code> property</a>.</p>
@@ -4228,11 +4239,11 @@
 						<h5>The <code>dc:type</code> element</h5>
 
 						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-								><code>dc:type</code></dfn> element [[dcterms]] is used to indicate that the EPUB
-							publication is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
+								><code>dc:type</code></dfn> element [[dcterms]] is used to indicate that the [=EPUB
+							publication=] is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
 							format).</p>
 
-						<p>EPUB creators MAY use any text string as a [=value=].</p>
+						<p>[=EPUB creators=] MAY use any text string as a [=value=].</p>
 
 						<div class="note">
 							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
@@ -4328,8 +4339,8 @@
 						of the element represents the assertion. (Refer to <a href="#sec-vocab-assoc"></a> for more
 						information.)</p>
 
-					<p id="meta-expr-types">This specification defines two types of metadata expressions that EPUB
-						creators can define using the <code>meta</code> element:</p>
+					<p id="meta-expr-types">This specification defines two types of metadata expressions that [=EPUB
+						creators=] can define using the <code>meta</code> element:</p>
 
 					<ul>
 						<li id="primary-expression">A <em>primary expression</em> is one in which the expression defined
@@ -4406,7 +4417,7 @@
 						containing the last modification date. The [=value=] of this property MUST be an [[xmlschema-2]]
 						dateTime conformant date of the form: <code>CCYY-MM-DDThh:mm:ssZ</code></p>
 
-					<p>EPUB creators MUST express the last modification date in Coordinated Universal Time (UTC) and
+					<p>[=EPUB creators=] MUST express the last modification date in Coordinated Universal Time (UTC) and
 						MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>
 
 					<aside class="example" title="Expressing a last modification date">
@@ -4420,11 +4431,11 @@
 &lt;/metadata></pre>
 					</aside>
 
-					<p>EPUB creators should update the last modified date whenever they make changes to the EPUB
-						publication.</p>
+					<p>EPUB creators should update the last modified date whenever they make changes to the [=EPUB
+						publication=].</p>
 
-					<p>EPUB creators MAY specify additional modified properties in the package document metadata, but
-						they MUST have a different subject (i.e., they require a <code>refines</code> attribute that
+					<p>EPUB creators MAY specify additional modified properties in the [=package document=] metadata,
+						but they MUST have a different subject (i.e., they require a <code>refines</code> attribute that
 						references an element or resource).</p>
 
 					<div class="note">
@@ -4532,16 +4543,16 @@
 							<p>referenced from the [=EPUB spine | spine=]; or</p>
 						</li>
 						<li>
-							<p>included or embedded in an EPUB content document (e.g., a metadata record serialized as
-								RDFa [[?rdfa-core]] or JSON-LD [[?json-ld11]] embedded in an [[html]] [^script^]
+							<p>included or embedded in an [=EPUB content document=] (e.g., a metadata record serialized
+								as RDFa [[?rdfa-core]] or JSON-LD [[?json-ld11]] embedded in an [[html]] [^script^]
 								element).</p>
 						</li>
 					</ul>
 
 					<p>In all other cases (e.g., when linking to standalone [[?onix]] or [[?xmp]] records), the linked
-						resources are not publication resources (i.e., are not subject to <a
-							href="#sec-core-media-types">core media type requirements</a>) and EPUB creators MUST NOT
-						list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
+						resources are not [=publication resources=] (i.e., are not subject to <a
+							href="#sec-core-media-types">core media type requirements</a>) and [=EPUB creators=] MUST
+						NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
 
 					<aside class="example" title="Reference to a record embedded in an XHTML content document">
 						<p>In this example, the metadata record is embedded in a <code>script</code> element. Note that
@@ -4581,9 +4592,9 @@ XHTML:
 &lt;/html></pre>
 					</aside>
 
-					<p id="linked-res-location">EPUB creators MAY locate linked resources within the <a>EPUB
-							container</a> or externally, but should consider that [=reading systems=] are not required
-						to retrieve resources outside the EPUB container.</p>
+					<p id="linked-res-location">EPUB creators MAY locate linked resources within the [=EPUB container=]
+						or externally, but should consider that [=reading systems=] are not required to retrieve
+						resources outside the EPUB container.</p>
 
 					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
 							attribute</a> is OPTIONAL when a linked resource is located outside the EPUB container, as
@@ -4632,7 +4643,7 @@ XHTML:
 					<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a href="#sec-default-vocab"
 							>default vocabulary</a> for the <code>rel</code> and <code>properties</code> attributes.</p>
 
-					<p>[=EPUB creators=] MAY add relationships and properties from other vocabularies as defined in <a
+					<p>EPUB creators MAY add relationships and properties from other vocabularies as defined in <a
 							href="#sec-vocab-assoc"></a>.</p>
 
 					<aside class="example" title="Declaring a new link relationship">
@@ -4661,10 +4672,11 @@ XHTML:
 							href="#record">linked metadata records</a> to enhance the information available to reading
 						systems, but reading systems may ignore these records.</p>
 
-					<p id="sec-linked-records-priority" data-tests="#pkg-linked-records_link-priority,#pkg-linked-records_link-order">When a reading system <a data-cite="epub-rs-33#sec-linked-records">processes linked records</a>
-						[[epub-rs-33]], the document order of <code>link</code> elements is used to determine which has
-						the highest priority in the case of conflicts (i.e., first in document order has the highest
-						priority).</p>
+					<p id="sec-linked-records-priority"
+						data-tests="#pkg-linked-records_link-priority,#pkg-linked-records_link-order">When a reading
+						system <a data-cite="epub-rs-33#sec-linked-records">processes linked records</a> [[epub-rs-33]],
+						the document order of <code>link</code> elements is used to determine which has the highest
+						priority in the case of conflicts (i.e., first in document order has the highest priority).</p>
 
 					<aside class="example" title="Specifying metadata precedence">
 						<p>In this example, the first remote record has the highest precedence, the local record has the
@@ -4752,16 +4764,16 @@ XHTML:
 						</dd>
 					</dl>
 
-					<p id="confreq-rendition-manifest">EPUB creators MUST list all [=publication resources=] in the
+					<p id="confreq-rendition-manifest">[=EPUB creators=] MUST list all publication resources in the
 							<code>manifest</code>, regardless of whether they are [=container resources=] or [=remote
 						resources=], using [^item^] elements.</p>
 
 					<p>Note that the <code>manifest</code> is not self-referencing: EPUB creators MUST NOT specify an
-							<code>item</code> element that refers to the package document itself.</p>
+							<code>item</code> element that refers to the [=package document=] itself.</p>
 
 					<div class="note">
-						<p>Failure to provide a complete manifest of resources may lead to rendering issues. Reading
-							systems might not unzip such resources or could prevent access to them for security
+						<p>Failure to provide a complete manifest of resources may lead to rendering issues. [=Reading
+							systems=] might not unzip such resources or could prevent access to them for security
 							reasons.</p>
 					</div>
 				</section>
@@ -4843,22 +4855,23 @@ XHTML:
 						</dd>
 					</dl>
 
-					<p>Each <code>item</code> element identifies a [=publication resource=] by the URL [[url]] in its
+					<p>Each <code>item</code> element identifies a publication resource by the URL [[url]] in its
 							<code>href</code> attribute. The value MUST be an <a data-lt="absolute-url string"
 							>absolute-</a> or <a data-lt="path-relative-scheme-less-url string"
-							>path-relative-scheme-less-URL</a> string [[url]]. EPUB creators MUST ensure each URL is
+							>path-relative-scheme-less-URL</a> string [[url]]. [=EPUB creators=] MUST ensure each URL is
 						unique within the <code>manifest</code> scope after <a href="#sec-parse-package-urls"
 							>parsing</a>.</p>
 
 					<p id="attrdef-item-media-type">The publication resource identified by an <code>item</code> element
-						MUST conform to the applicable specification(s) as inferred from the MIME media type provided in
-						the <a href="#attrdef-media-type"><code>media-type</code> attribute</a>. For <a>core media type
-							resources</a>, EPUB creators MUST use the media type designated in <a
+						MUST conform to the applicable specification(s) as inferred from the MIME media type [[rfc2046]]
+						provided in the <a href="#attrdef-media-type"><code>media-type</code> attribute</a>. For [=core
+						media type resources=], EPUB creators MUST use the media type designated in <a
 							href="#sec-core-media-types"></a>.</p>
 
 					<p id="attrdef-item-fallback">The <code>fallback</code> attribute specifies the fallback for the
-						referenced publication resource. The <code>fallback</code> attribute's IDREF [[xml]] value MUST
-						resolve to another <code>item</code> in the <code>manifest</code>.</p>
+						referenced publication resource. The <code>fallback</code> attribute's <a data-cite="xml#idref"
+							>IDREF</a> [[xml]] value MUST resolve to another <code>item</code> in the
+							<code>manifest</code>.</p>
 
 					<p>The fallback for one <code>item</code> MAY specify a fallback to another <code>item</code>, and
 						so on, creating a chain of fallback options. Refer to <a href="#sec-manifest-fallbacks"></a> for
@@ -4886,7 +4899,7 @@ XHTML:
 								Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
 								<code>properties</code> attribute.</p>
 
-						<p>EPUB creators MUST set the following properties whenever a resource referenced by an
+						<p>[=EPUB creators=] MUST set the following properties whenever a resource referenced by an
 								<code>item</code> element matches their respective definitions:</p>
 
 						<ul>
@@ -4908,8 +4921,9 @@ XHTML:
 						</aside>
 
 						<p>These properties do not apply recursively to content included into a resource (e.g., via the
-							HTML <code>iframe</code> element). For example, if a non-scripted XHTML content document
-							embeds a scripted content document, only the embedded document's manifest <code>item</code>
+							[[html]] [^iframe^] element). For example, if a non-scripted [=XHTML content document=]
+							embeds a [=scripted content document=], only the embedded document's manifest
+								<code>item</code>
 							<code>properties</code> attribute will have the <code>scripted</code> value.</p>
 
 						<p>EPUB creators MUST declare exactly one <code>item</code> as the EPUB navigation document
@@ -5010,8 +5024,8 @@ XHTML:
 
 						<aside class="example" id="example-manifest-flbk"
 							title="Foreign content document in spine with fallback">
-							<p>The following example shows the [=manifest fallback chain=] allowing a <a>foreign content
-									document</a> (JPEG) to be listed in the spine with fallback to an SVG content
+							<p>The following example shows the [=manifest fallback chain=] allowing a [=foreign content
+								document=] (JPEG) to be listed in the spine with fallback to an SVG content
 								document.</p>
 
 							<pre>&lt;package …>
@@ -5041,12 +5055,12 @@ XHTML:
 
 						<aside class="example"
 							title="Embedded core media type resource with Link to View as top-level content document">
-							<p>The following example shows a JPEG embedded in an EPUB content document (via the
+							<p>The following example shows a JPEG embedded in an [=EPUB content document=] (via the
 									<code>img</code> tag) with a hyperlink that allows it to open as a separate page
 								(e.g., for easier zooming). Although embedding the image using the <code>img</code> tag
 								does not require it to be listed in the [=EPUB spine | spine=] or have a fallback,
-								adding the hyperlink causes the document to open as a <a>top-level content document</a>.
-								As its use in the spine makes it a [=foreign content document=], the EPUB creator must
+								adding the hyperlink causes the document to open as a [=top-level content document=]. As
+								its use in the spine makes it a [=foreign content document=], the [=EPUB creator=] must
 								include a fallback to an EPUB content document.</p>
 
 							<pre>XHTML:
@@ -5094,12 +5108,12 @@ Package document:
 						</aside>
 
 						<aside class="example" title="Link to View foreign resource as top-level content document">
-							<p>The following example shows a link to the raw CSV data file. The data will open in the
-								reading system as a [=top-level content document=] the EPUB creator must list it in the
-								spine. As its use in the spine makes it a [=foreign content document=], the EPUB creator
-								must also provide a fallback to an [=EPUB content document=]. Because there is no
-								guarantee users will be able to access the data in its raw form, instructions on how to
-								extract the file from the [=EPUB container=] are also provided.</p>
+							<p>The following example shows a link to the raw CSV data file. As the data will open in the
+								[=reading system=] as a [=top-level content document=], the [=EPUB creator=] must list
+								it in the spine. As its use in the spine makes it a [=foreign content document=], the
+								EPUB creator must also provide a fallback to an [=EPUB content document=]. Because there
+								is no guarantee users will be able to access the data in its raw form, instructions on
+								how to extract the file from the [=EPUB container=] are also provided.</p>
 
 							<pre>XHTML:
 &lt;html …>
@@ -5149,10 +5163,10 @@ Package document:
 
 						<aside class="example" title="Remote resources that are publication resources">
 							<p>The following example shows a reference to a remote audio file. Because the
-									<code>audio</code> element embeds the audio in its EPUB content document, the file
-								is considered a publication resource. The EPUB creator therefore must list the audio
-								file in the manifest and indicate that its host EPUB content document contains a
-								[=remote resource=].</p>
+									<code>audio</code> element embeds the audio in its [=EPUB content document=], the
+								file is considered a [=publication resource=]. The [=EPUB creator=] therefore must list
+								the audio file in the manifest and indicate that its host EPUB content document contains
+								a [=remote resource=].</p>
 
 							<pre>XHTML:
 &lt;html …>
@@ -5188,10 +5202,10 @@ Package document:
 						</aside>
 
 						<aside class="example" title="External Resources that are not publication resources">
-							<p>The following example shows a hyperlink to an audio file hosted on the web. Reading
-								systems will open such external content in a new browser window; it is not rendered
-								within the publication. In this case, the EPUB creator does not list the file in the
-								manifest because it is not a publication resource.</p>
+							<p>The following example shows a hyperlink to an audio file hosted on the web. [=Reading
+								systems=] will open such external content in a new browser window; the audio file is not
+								rendered within the publication. In this case, the [=EPUB creator=] does not list the
+								file in the manifest because it is not a [=publication resource=].</p>
 
 							<pre>XHTML:
 &lt;html …>
@@ -5288,25 +5302,25 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p id="confreq-pub-resource">The <code>spine</code> MUST specify at least one <a>EPUB content
-							document</a> or [=foreign content document=].</p>
+					<p id="confreq-pub-resource">The <code>spine</code> MUST specify at least one [=EPUB content
+						document=] or [=foreign content document=].</p>
 
-					<p id="spine-inclusion-req">EPUB creators MUST list in the <code>spine</code> all EPUB and foreign
-						content documents that are hyperlinked to from publication resources in the <code>spine</code>,
-						where hyperlinking encompasses any linking mechanism that requires the user to navigate away
-						from the current resource. Common hyperlinking mechanisms include the [^a/href^] attribute of
-						the [[html]] [^a^] and [^area^] elements and scripted links (e.g., using DOM Events and/or form
-						elements). The requirement to list hyperlinked resources applies recursively (i.e., EPUB
-						creators must list all EPUB and foreign content documents hyperlinked to from hyperlinked
-						documents, and so on.).</p>
+					<p id="spine-inclusion-req">[=EPUB creators=] MUST list in the <code>spine</code> all EPUB and
+						foreign content documents that are hyperlinked to from publication resources in the
+							<code>spine</code>, where hyperlinking encompasses any linking mechanism that requires the
+						user to navigate away from the current resource. Common hyperlinking mechanisms include the
+						[^a/href^] attribute of the [[html]] [^a^] and [^area^] elements and scripted links (e.g., using
+						DOM Events and/or form elements). The requirement to list hyperlinked resources applies
+						recursively (i.e., EPUB creators must list all EPUB and foreign content documents hyperlinked to
+						from hyperlinked documents, and so on.).</p>
 
 					<p>EPUB creators also MUST list in the <code>spine</code> all EPUB and foreign content documents
 						hyperlinked to from the [=EPUB navigation document=], regardless of whether EPUB creators
 						include the EPUB navigation document in the <code>spine</code>.</p>
 
 					<div class="note">
-						<p>As hyperlinks to resources outside the EPUB container are not publication resources, they are
-							not subject to the requirement to include in the spine (e.g., web pages and web-hosted
+						<p>As hyperlinks to resources outside the EPUB container are not [=publication resources=], they
+							are not subject to the requirement to include in the spine (e.g., web pages and web-hosted
 							resources).</p>
 
 						<p>Publication resources used in the rendering of spine items (e.g., referenced from [[html]]
@@ -5317,7 +5331,7 @@ No Entry</pre>
 						attribute sets the global direction in which the content flows. Allowed values are
 							<code>ltr</code> (left-to-right), <code>rtl</code> (right-to-left) and <code>default</code>.
 						When EPUB creators specify the <code>default</code> value, they are expressing no preference and
-						the reading system can choose the rendering direction.</p>
+						the [=reading system=] can choose the rendering direction.</p>
 
 					<p>Although the <code>page-progression-direction</code> attribute sets the global flow direction,
 						individual EPUB content documents and parts of EPUB content documents MAY override this setting
@@ -5326,15 +5340,15 @@ No Entry</pre>
 						application of alternate style sheets).</p>
 
 					<p>The <a href="#legacy">legacy</a>
-						<code>toc</code> attribute takes an IDREF [[xml]] that identifies the manifest item that
-						represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
+						<code>toc</code> attribute takes an <a data-cite="xml#idref">IDREF</a> [[xml]] that identifies
+						the manifest item that represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
 				</section>
 
 				<section id="sec-itemref-elem">
 					<h4>The <code>itemref</code> element</h4>
 
-					<p>The <code>itemref</code> element identifies an [=EPUB content document=] or <a>foreign content
-							document</a> in the default reading order.</p>
+					<p>The <code>itemref</code> element identifies an [=EPUB content document=] or [=foreign content
+						document=] in the default reading order.</p>
 
 					<dl id="elemdef-spine-itemref" class="elemdef">
 						<dt>Element Name:</dt>
@@ -5394,23 +5408,24 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p id="attrdef-itemref-idref">Each itemref element MUST reference the ID of an [^item^] in the
-						[=EPUB manifest | manifest=] via the IDREF [[xml]] in its <code>idref</code> attribute, and item
-						IDs MUST NOT be referenced more than once. </p>
+					<p id="attrdef-itemref-idref">Each <code>itemref</code> element MUST reference the <a
+							data-cite="xml#id">ID</a> [[xml]] of an [^item^] in the [=EPUB manifest | manifest=] via the
+							<a data-cite="xml#idref">IDREF</a> [[xml]] in its <code>idref</code> attribute.
+							<code>item</code> element IDs MUST NOT be referenced more than once. </p>
 
 					<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a) an
 						[=EPUB content document=] or b) a [=foreign content document=] that includes an EPUB content
 						document in its [=manifest fallback chain=].</p>
 
 					<div class="note">
-						<p>Although EPUB publications <a href="#confreq-nav">require an EPUB navigation document</a>, it
-							is not mandatory to include it in the <code>spine</code>.</p>
+						<p>Although [=EPUB publications=] <a href="#confreq-nav">require an EPUB navigation
+							document</a>, it is not mandatory to include it in the [=EPUB spine | spine=].</p>
 					</div>
 
 					<p id="attrdef-itemref-linear">The <code>linear</code> attribute indicates whether the referenced
 							<code>item</code> contains content that contributes to the primary reading order and that
-						reading systems must read sequentially ("<code>yes</code>"), or auxiliary content that enhances
-						or augments the primary content that reading systems can access out of sequence
+						[=reading systems=] must read sequentially ("<code>yes</code>"), or auxiliary content that
+						enhances or augments the primary content that reading systems can access out of sequence
 							("<code>no</code>"). Examples of auxiliary content include notes, descriptions, and answer
 						keys.</p>
 
@@ -5424,14 +5439,14 @@ No Entry</pre>
 						the spine.</p>
 
 					<div class="note">
-						<p>EPUB creators should list non-linear content at the end of the spine except when it makes
+						<p>[=EPUB creators=] should list non-linear content at the end of the spine except when it makes
 							sense for users to encounter it between linear spine items.</p>
 					</div>
 
-					<p id="linear-itemrefs"> A linear <code>itemref</code> element is one whose <code>linear</code>
+					<p id="linear-itemrefs">A linear <code>itemref</code> element is one whose <code>linear</code>
 						attribute value is explicitly set to "<code>yes</code>" or that omits the attribute — reading
 						systems will assume the value "<code>yes</code>" for <code>itemref</code> elements without the
-						attribute. The spine MUST contain at least one linear <code>itemref</code> element. </p>
+						attribute. The spine MUST contain at least one linear <code>itemref</code> element.</p>
 
 					<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB creators MUST provide a means
 						of accessing all non-linear content (e.g., hyperlinks in the content or from the <a
@@ -5545,12 +5560,12 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p>The <code>collection</code> element allows EPUB creators to assemble resources into logical
+					<p>The <code>collection</code> element allows [=EPUB creators=] to assemble resources into logical
 						groups for a variety of potential uses: enabling reassembly into a meaningful unit of content
 						split across multiple [=EPUB content documents=] (e.g., an index split across multiple
 						documents), identifying resources for specialized purposes (e.g., preview content), or
-						collecting together resources that present additional information about the <a>EPUB
-							publication</a>.</p>
+						collecting together resources that present additional information about the [=EPUB
+						publication=].</p>
 
 					<p id="attrdef-collection-role">EPUB creators MUST identify the role of each <code>collection</code>
 						element in its <code>role</code> attribute, whose value MUST be one or more NMTOKENs
@@ -5596,17 +5611,17 @@ No Entry</pre>
 					<h4>The <code>meta</code> element</h4>
 
 					<p>The <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"><code>meta</code>
-							element</a> [[opf-201]] is a <a href="#legacy">legacy</a> feature that previously provided a
-						means of including generic metadata. The EPUB 3 [^meta^] element, which uses different
+							element</a> [[opf-201]] is a <a href="#legacy">legacy</a> feature that provided a means of
+						including generic metadata in EPUB 2. The EPUB 3 [^meta^] element, which uses different
 						attributes and requires text content, replaces this element.</p>
 
 					<p>Refer to the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
 								><code>meta</code> element definition</a> in [[opf-201]] for more information.</p>
 
 					<div class="note">
-						<p>The [[opf-201]] <code>meta</code> element is retained in EPUB 3 primarily so that EPUB
-							creators can identify the cover image for compatibility with EPUB 2 reading systems. In EPUB
-							3, the cover image must be identified using the <a href="#sec-cover-image"
+						<p>The [[opf-201]] <code>meta</code> element is retained in EPUB 3 primarily so that [=EPUB
+							creators=] can identify the cover image for compatibility with EPUB 2 [=reading systems=].
+							In EPUB 3, the cover image must be identified using the <a href="#sec-cover-image"
 									><code>cover-image</code> property</a> on the manifest [^item^] for the image.</p>
 					</div>
 				</section>
@@ -5615,9 +5630,9 @@ No Entry</pre>
 					<h4>The <code>guide</code> element</h4>
 
 					<p>The <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code>
-							element</a> [[opf-201]] is a <a href="#legacy">legacy</a> feature that previously provided
-						machine-processable navigation to key structures. The <a href="#sec-nav-landmarks">landmarks
-							nav</a> in the [=EPUB navigation document=] replaces this element.</p>
+							element</a> [[opf-201]] is a <a href="#legacy">legacy</a> feature that provided
+						machine-processable navigation to key structures in EPUB 2. The <a href="#sec-nav-landmarks"
+							>landmarks nav</a> in the [=EPUB navigation document=] replaces this element.</p>
 
 					<p>Refer to the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
 								><code>guide</code> element definition</a> in [[opf-201]] for more information.</p>
@@ -5627,7 +5642,7 @@ No Entry</pre>
 					<h4>NCX</h4>
 
 					<p>The <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a> [[opf-201]]
-						is a <a href="#legacy">legacy</a> feature that previously provided the table of contents. The <a
+						is a <a href="#legacy">legacy</a> feature that provided the table of contents in EPUB 2. The <a
 							href="#sec-nav">EPUB navigation document</a> replaces this document.</p>
 
 					<p>Refer to the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
@@ -5644,15 +5659,15 @@ No Entry</pre>
 				<section id="sec-xhtml-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>This section defines a profile of [[html]] for creating XHTML content documents. An instance of
-						an XML document that conforms to this profile is a [=core media type resource=] and is referred
-						to in this specification as an [=XHTML content document=].</p>
+					<p>This section defines a profile of [[html]] for creating [=XHTML content documents=]. An instance
+						of an XML document that conforms to this profile is a [=core media type resource=] and is
+						referred to in this specification as an XHTML content document.</p>
 				</section>
 
 				<section id="sec-xhtml-req">
 					<h4>XHTML requirements</h4>
 
-					<p>An XHTML content document:</p>
+					<p>An [=XHTML content document=]:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -5670,11 +5685,12 @@ No Entry</pre>
 								conformance constraints defined therein.</p>
 						</li>
 					</ul>
+
 					<p>Unless specified otherwise, XHTML content documents inherit all definitions of semantics,
 						structure, and processing behaviors from the [[html]] specification.</p>
 
 					<div class="note">
-						<p>The recommendation that EPUB publications follow the accessibility requirements in
+						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
 							[[epub-a11y-11]] applies to XHTML content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
@@ -5695,7 +5711,7 @@ No Entry</pre>
 					<section id="sec-xhtml-structural-semantics">
 						<h5>Structural semantics</h5>
 
-						<p>EPUB creators MAY use the [^/epub:type^] attribute in <a>XHTML content documents</a> to
+						<p>[=EPUB creators=] MAY use the [^/epub:type^] attribute in [=XHTML content documents=] to
 							express <a href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
 						<p>As the [[html]] <a data-cite="html#the-head-element"><code>head</code></a> element contains
@@ -5706,7 +5722,7 @@ No Entry</pre>
 					<section id="sec-xhtml-rdfa">
 						<h5>RDFa</h5>
 
-						<p>The [[html-rdfa]] specification defines a set of attributes that EPUB creators MAY use in
+						<p>The [[html-rdfa]] specification defines a set of attributes that [=EPUB creators=] MAY use in
 							[=XHTML content documents=] to semantically enrich the content. The use of these attributes
 							MUST conform to the requirements defined in [[html-rdfa]].</p>
 
@@ -5725,9 +5741,9 @@ No Entry</pre>
 					<section id="sec-xhtml-content-switch">
 						<h5>Content switching (deprecated)</h5>
 
-						<p>The <code>switch</code> element provides a simple mechanism through which <a>EPUB
-								creators</a> can tailor the content displayed to users, one that is not dependent on the
-							scripting capabilities of the [=EPUB reading system=].</p>
+						<p>The <code>switch</code> element provides a simple mechanism through which [=EPUB creators=]
+							can tailor the content displayed to users, one that is not dependent on the scripting
+							capabilities of the [=EPUB reading system=].</p>
 
 						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
 
@@ -5763,9 +5779,10 @@ No Entry</pre>
 							<li><code>w3.org</code></li>
 							<li><code>idpf.org</code></li>
 						</ul>
+
 						<p>When using custom attributes, the content MUST remain consumable by a user without any
-							information loss or other significant deterioration, regardless of the reading system it is
-							rendered on.</p>
+							information loss or other significant deterioration, regardless of the [=reading system=] it
+							is rendered on.</p>
 
 						<div class="note">
 							<p>Custom attributes are usually defined in a reading system-specific manner and are not
@@ -5784,7 +5801,7 @@ No Entry</pre>
 					<section id="sec-xhtml-mathml">
 						<h5>Embedded MathML</h5>
 
-						<p>XHTML content documents support embedded [[mathml3]]. Occurrences of MathML markup MUST
+						<p>[=XHTML content documents=] support embedded [[mathml3]]. Occurrences of MathML markup MUST
 							conform to the constraints expressed in the MathML specification [[mathml3]], with the
 							following additional restrictions:</p>
 
@@ -5798,7 +5815,7 @@ No Entry</pre>
 
 							<dt id="math-cont">Content MathML</dt>
 							<dd>
-								<p id="confreq-mathml-annot-cont">EPUB creators MAY include <a
+								<p id="confreq-mathml-annot-cont">[=EPUB creators=] MAY include <a
 										data-cite="mathml3/chapter4.html#">Content MathML</a> within MathML markup in
 									XHTML content documents, and, when present, MUST include it within an
 										<code>annotation-xml</code> child element of a <code>semantics</code>
@@ -5811,8 +5828,8 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p>This subset eases the implementation burden on reading systems and promotes accessibility,
-							while retaining compatibility with [[html]] user agents.</p>
+						<p>This subset eases the implementation burden on [=reading systems=] and promotes
+							accessibility, while retaining compatibility with [[html]] user agents.</p>
 
 						<div class="note">
 							<p>The <a href="#mathml"><code>mathml</code> property</a> of the [=EPUB manifest |
@@ -5848,11 +5865,11 @@ No Entry</pre>
 							<p id="confreq-html-vocab-base"> The [[html]] <a data-lt="base"><code>base</code>
 									element</a> can be used to specify the [=document base URL=] for the purposes of
 								parsing URLs. When using it in an [=EPUB publication=], the interpretation of the
-									<code>base</code> element may inadvertently result in references to <a>remote
-									resources</a>. It may also cause reading systems to misinterpret the location of
+									<code>base</code> element may inadvertently result in references to [=remote
+								resources=]. It may also cause [=reading systems=] to misinterpret the location of
 								hyperlinks (e.g., relative links to other documents in the publication might appear as
 								links to a web site if the <code>base</code> element specifies an absolute URL). To
-								avoid significant interoperability issues, EPUB creators should not use the
+								avoid significant interoperability issues, [=EPUB creators=] should not use the
 									<code>base</code> element. </p>
 						</section>
 
@@ -5862,7 +5879,7 @@ No Entry</pre>
 							<p id="confreq-html-vocab-rp">The [[html]] [^rp^] element is intended to provide a fallback
 								for older [=reading systems=] that do not recognize ruby markup (i.e., a parenthesis
 								display around <code>ruby</code> markup). As EPUB 3 reading systems are ruby-aware, and
-								can provide fallbacks, EPUB creators should not use <code>rp</code> elements.</p>
+								can provide fallbacks, [=EPUB creators=] should not use <code>rp</code> elements.</p>
 						</section>
 
 						<section id="sec-xhtml-deviations-embed">
@@ -5870,7 +5887,7 @@ No Entry</pre>
 
 							<p id="confreq-html-vocab-embed">Since the [[html]] <a data-lt="embed"><code>embed</code>
 									element</a> element does not include intrinsic facilities to provide fallback
-								content for reading systems that do not support scripting, [=EPUB creators=] are
+								content for [=reading systems=] that do not support scripting, [=EPUB creators=] are
 								discouraged from using the element when the referenced resource includes scripting. The
 								[[html]] [^object^] element is a better alternative, as it includes intrinsic fallback
 								capabilities.</p>
@@ -5895,17 +5912,17 @@ No Entry</pre>
 						final-form vector graphics and text.</p>
 
 					<p>Although [=EPUB creators=] typically use <a href="#sec-xhtml">XHTML content documents</a> as the
-						[=top-level content document | top-level=] document type, the use of <a>SVG content
-							documents</a> is also permitted. EPUB creators will typically only need SVGs for certain
-						special cases, such as when final-form page images are the only suitable representation of the
-						content (e.g., for cover art or in the context of manga or comic books).</p>
+						[=top-level content document | top-level=] document type, the use of [=SVG content documents=]
+						is also permitted. EPUB creators will typically only need SVGs for certain special cases, such
+						as when final-form page images are the only suitable representation of the content (e.g., for
+						cover art or in the context of manga or comic books).</p>
 
 					<p>This section defines a profile for [[svg]] documents. An instance of an XML document that
 						conforms to this profile is a [=core media type resource=] and is referred to in this
 						specification as an [=SVG content document=].</p>
 
 					<div class="note">
-						<p>This section defines conformance requirements for [=SVG content documents=]. Refer to <a
+						<p>This section defines conformance requirements for SVG content documents. Refer to <a
 								href="#sec-xhtml-svg"></a> for the conformance requirements for SVG embedded in XHTML
 							content documents.</p>
 					</div>
@@ -5914,7 +5931,7 @@ No Entry</pre>
 				<section id="sec-svg-req">
 					<h4>SVG requirements</h4>
 
-					<p>An SVG content document:</p>
+					<p>An [=SVG content document=]:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -5930,7 +5947,7 @@ No Entry</pre>
 						</li>
 					</ul>
 					<div class="note">
-						<p>The recommendation that EPUB publications follow the accessibility requirements in
+						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
 							[[epub-a11y-11]] applies to SVG content documents. See <a href="#confreq-a11y"
 								>Accessibility</a>.</p>
 					</div>
@@ -5949,8 +5966,8 @@ No Entry</pre>
 										><code>foreignObject</code></a> element:</p>
 							<ul class="conformance-list">
 								<li>
-									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[html]] <a>flow
-											content</a> or exactly one [[html]] <a data-cite="html#the-body-element"
+									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[html]] [=flow
+										content=] or exactly one [[html]] <a data-cite="html#the-body-element"
 												><code>body</code></a> element.</p>
 									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
 											<code>body</code> element is not permitted per the <a data-cite="html#svg-0"
@@ -5976,8 +5993,8 @@ No Entry</pre>
 			<section id="sec-common-resource-req">
 				<h3>Common resource requirements</h3>
 
-				<p>This section defines requirements for technologies usable in both XHTML and SVG content
-					documents.</p>
+				<p>This section defines requirements for technologies usable in both [=XHTML content documents | XHTML=]
+					and [=SVG content documents=].</p>
 
 				<section id="sec-css">
 					<h3>Cascading Style Sheets (CSS)</h3>
@@ -6046,9 +6063,9 @@ No Entry</pre>
 						</ul>
 						<div class="note">
 							<p>This specification restricts the use of the <code>direction</code> and
-									<code>unicode-bidi</code> properties because reading systems may not implement, or
-								may switch off, CSS processing. EPUB creators must use the following format-specific
-								methods when they need control over these aspects of the rendering:</p>
+									<code>unicode-bidi</code> properties because [=reading systems=] might not
+								implement, or might switch off, CSS processing. [=EPUB creators=] must use the following
+								format-specific methods when they need control over these aspects of the rendering:</p>
 
 							<ul>
 								<li>
@@ -6099,13 +6116,13 @@ No Entry</pre>
 
 						<p>[=EPUB content documents=] MAY contain scripting using the facilities defined for this in the
 							respective underlying specifications ([[html]] and [[svg]]). When an EPUB content document
-							contains scripting, this specification refers to it as a <a>scripted content document</a>.
-							This label also applies to [=XHTML content documents=] when they contain instances of
-							[[html]] [=forms=].</p>
+							contains scripting, this specification refers to it as a [=scripted content document=]. This
+							label also applies to [=XHTML content documents=] when they contain instances of [[html]]
+							[=forms=].</p>
 
 						<p>The <a href="#scripted"><code>scripted</code> property</a> of the [=EPUB manifest |
 							manifest=] <code>item</code> element is used to indicate that an EPUB content document is a
-								<a>scripted content document</a>.</p>
+							scripted content document.</p>
 
 						<p>When an [[html]] <code>script</code> element contains a <a data-cite="html#data-block">data
 								block</a> [[html]], it does not represent scripted content.</p>
@@ -6115,9 +6132,9 @@ No Entry</pre>
 								if a future update adds the concept.</p>
 						</div>
 
-						<p>EPUB creators should note that reading systems are required to behave as though a unique
-							[=origin=] [[url]] has been assigned to each EPUB publication. In practice, this means that
-							it is not possible for scripts to share data between EPUB publications.</p>
+						<p>[=EPUB creators=] should note that [=reading systems=] are required to behave as though a
+							unique [=origin=] [[url]] has been assigned to each [=EPUB publication=]. In practice, this
+							means that it is not possible for scripts to share data between EPUB publications.</p>
 
 						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
 							rights and restrictions that a reading system places on it (refer to <a
@@ -6138,22 +6155,22 @@ No Entry</pre>
 
 						<ul>
 							<li><a href="#sec-scripted-container-constrained">container constrained</a> &#8212; when the
-								execution of a script occurs within an <code>iframe</code>; and</li>
+								execution of a script occurs within an [[html]] [^iframe^] element; and</li>
 							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a script
 								occurs directly within a [=top-level content document=].</li>
 						</ul>
 
 						<div class="note">
-							<p>Scripts may execute in other contexts, but reading system support for these contexts is
-								optional. For example, a scripted SVG document may be referenced from an [[html]]
+							<p>Scripts may execute in other contexts, but [=reading system=] support for these contexts
+								is optional. For example, a scripted SVG document may be referenced from an [[html]]
 								[^object^] element.</p>
 							<p>Refer to the <a data-cite="epub-rs-33#sec-scripted-content">processing of scripts</a>
 								[[epub-rs-33]] for more information.</p>
 						</div>
 
-						<p>Whether EPUB creators embed the code directly in the <code>script</code> element or reference
-							it via the element's <code>src</code> attribute makes no difference to its executing
-							context.</p>
+						<p>Whether [=EPUB creators=] embed the code directly in a <code>script</code> element or
+							reference it via the element's <code>src</code> attribute makes no difference to its
+							executing context.</p>
 
 						<p>Which context EPUB creators use for their scripts affects both what actions the scripts can
 							perform and the likelihood of support in reading systems, as described in the following
@@ -6166,31 +6183,33 @@ No Entry</pre>
 
 						<section id="sec-scripted-container-constrained">
 							<h5>Container-constrained scripts</h5>
+
 							<p>A <em>container-constrained script</em> is either of the following:</p>
+
 							<ul>
 								<li>
-									<p>An instance of the [[html]] [^script^] element contained in an <a>XHTML content
-											document</a> that is embedded in an XHTML content document using the
-										[[html]] [^iframe^] element.</p>
+									<p>An instance of the [[html]] [^script^] element contained in an [=XHTML content
+										document=] that is embedded in an XHTML content document using the [[html]]
+										[^iframe^] element.</p>
 								</li>
 								<li>
 									<p>An instance of the [[svg]] <a
 											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
-												><code>script</code></a> element contained in an <a>SVG content
-											document</a> that is embedded in a XHTML content document using the [[html]]
+												><code>script</code></a> element contained in an [=SVG content
+										document=] that is embedded in a XHTML content document using the [[html]]
 										[^iframe^] element.</p>
 								</li>
 							</ul>
 
 							<p id="confreq-cd-scripted-container">A container-constrained script MUST NOT contain
-								instructions for modifying the DOM of the EPUB content document that embeds it (i.e.,
-								the one that contains the <code>iframe</code> element). It also MUST NOT contain
+								instructions for modifying the DOM of the [=EPUB content document=] that embeds it
+								(i.e., the one that contains the <code>iframe</code> element). It also MUST NOT contain
 								instructions for manipulating the size of its containing rectangle.</p>
 
-							<p>EPUB creators should note that <a data-cite="epub-rs-33#sec-scripted-content">support for
-									container-constrained scripting in reading systems</a> is only recommended in
-								reflowable documents [[epub-rs-33]]. Furthermore, reading system support in
-								fixed-layouts EPUBs is optional.</p>
+							<p>[=EPUB creators=] should note that <a data-cite="epub-rs-33#sec-scripted-content">support
+									for container-constrained scripting in reading systems</a> is only recommended in
+								reflowable documents [[epub-rs-33]]. Furthermore, [=reading system=] support in
+								[=fixed-layout documents=] is optional.</p>
 
 							<p>EPUB creators should ensure container-constrained scripts degrade gracefully in reading
 								systems without scripting support (see <a href="#sec-scripted-fallbacks"></a>).</p>
@@ -6209,10 +6228,10 @@ No Entry</pre>
 									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 								element contained in a [=top-level content document=].</p>
 
-							<p>EPUB creators should note that support for spine-level scripting in reading systems is
-								only recommended in <a data-cite="epub-rs-33#confreq-rs-scripted-fxl-support"
-									>fixed-layout documents</a> and <a
-									data-cite="epub-rs-33#confreq-rs-scripted-scrolled">reflowable documents set to
+							<p>[=EPUB creators=] should note that support for spine-level scripting in [=reading
+								systems=] is only recommended in <a
+									data-cite="epub-rs-33#confreq-rs-scripted-fxl-support">fixed-layout documents</a>
+								and <a data-cite="epub-rs-33#confreq-rs-scripted-scrolled">reflowable documents set to
 									scroll</a> [[epub-rs-33]]. Furthermore, reading system support in all other contexts
 								is optional.</p>
 
@@ -6221,24 +6240,24 @@ No Entry</pre>
 								significant deterioration when scripting is disabled or not available (e.g., by
 								employing progressive enhancement techniques or <a href="#sec-scripted-fallbacks"
 									>fallbacks</a>). Failing to account for non-scripted environments in top-level
-								content documents can result in EPUB publications being unreadable.</p>
+								content documents can result in [=EPUB publications=] being unreadable.</p>
 						</section>
 					</section>
 
 					<section id="sec-scripted-content-events" class="informative">
 						<h4>Event model</h4>
 
-						<p>[=EPUB creators=] should consider the wide variety of possible reading system implementations
-							when adding scripting functionality to their EPUB publications (e.g., not all devices have
-							physical keyboards, and in many cases a soft keyboard is activated only for text input
-							elements). Consequently, EPUB creators should not rely on keyboard events alone; they should
-							always provide alternative ways to trigger a desired action.</p>
+						<p>[=EPUB creators=] should consider the wide variety of possible [=reading system=]
+							implementations when adding scripting functionality to their [=EPUB publications=] (e.g.,
+							not all devices have physical keyboards, and in many cases a soft keyboard is activated only
+							for text input elements). Consequently, EPUB creators should not rely on keyboard events
+							alone; they should always provide alternative ways to trigger a desired action.</p>
 					</section>
 
 					<section id="sec-scripted-a11y">
 						<h4>Scripting accessibility</h4>
 
-						<p id="confreq-cd-scripted-a11y">EPUB content documents that contain scripting SHOULD employ
+						<p id="confreq-cd-scripted-a11y">[=EPUB content documents=] that contain scripting SHOULD employ
 							relevant [[wai-aria]] accessibility techniques to ensure that the content remains consumable
 							by all users.</p>
 					</section>
@@ -6246,13 +6265,13 @@ No Entry</pre>
 					<section id="sec-scripted-fallbacks">
 						<h4 id="confreq-cd-scripted-flbk">Scripting fallbacks</h4>
 
-						<p id="confreq-cd-scripted-fallback">EPUB content documents that contain scripting MAY provide
-							fallbacks for such content, either by using intrinsic fallback mechanisms (such as those
-							available for the [[html]] [^object^] and [^canvas^] elements) or, when an intrinsic
+						<p id="confreq-cd-scripted-fallback">[=EPUB content documents=] that contain scripting MAY
+							provide fallbacks for such content, either by using intrinsic fallback mechanisms (such as
+							those available for the [[html]] [^object^] and [^canvas^] elements) or, when an intrinsic
 							fallback is not applicable, by using a <a href="#sec-manifest-fallbacks">manifest-level
 								fallback</a>.</p>
 
-						<p id="confreq-cd-scripted-foreign-resources">EPUB creators MUST ensure that scripts only
+						<p id="confreq-cd-scripted-foreign-resources">[=EPUB creators=] MUST ensure that scripts only
 							generate <a href="#sec-core-media-types">core media type resources</a> or fragments
 							thereof.</p>
 					</section>
@@ -6265,8 +6284,8 @@ No Entry</pre>
 			<section id="sec-nav-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>The EPUB navigation document is a <a href="#confreq-nav">mandatory component</a> of an <a>EPUB
-						publication</a>. It allows [=EPUB creators=] to include a human- and machine-readable global
+				<p>The [=EPUB navigation document=] is a <a href="#confreq-nav">mandatory component</a> of an [=EPUB
+					publication=]. It allows [=EPUB creators=] to include a human- and machine-readable global
 					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
 
 				<p>The EPUB navigation document is a special type of [=XHTML content document=] that defines the <a
@@ -6295,15 +6314,15 @@ No Entry</pre>
 			<section id="sec-nav-def-model">
 				<h3>The <code>nav</code> element: restrictions</h3>
 
-				<p>When a <code>nav</code> element carries the [^/epub:type^] attribute in an <a>EPUB navigation
-						document</a>, this specification restricts the content model of the element and its descendants
-					as follows:</p>
+				<p>When a <code>nav</code> element carries the [^/epub:type^] attribute in an [=EPUB navigation
+					document=], this specification restricts the content model of the element and its descendants as
+					follows:</p>
 
 				<dl class="elemdef">
 					<dt>Content Model:</dt>
 					<dd>
 						<dl class="variablelist">
-							<dt> [^nav^] </dt>
+							<dt>[^nav^]</dt>
 							<dd>
 								<p>In this order:</p>
 								<ul class="nomark">
@@ -6316,38 +6335,32 @@ No Entry</pre>
 										</p>
 									</li>
 									<li>
-										<p>
-											<code>ol</code>
-											<code>[exactly 1]</code>
+										<p> [^ol^] <code>[exactly 1]</code>
 										</p>
 									</li>
 								</ul>
 							</dd>
 
-							<dt> [^ol^] </dt>
+							<dt>[^ol^]</dt>
 							<dd>
 								<p>In this order:</p>
 								<ul class="nomark">
 									<li>
-										<p>
-											<code>li</code>
-											<code>[1 or more]</code>
+										<p> [^li^] <code>[1 or more]</code>
 										</p>
 									</li>
 								</ul>
 							</dd>
 
-							<dt> [^li^] </dt>
+							<dt>[^li^]</dt>
 							<dd>
 								<p>In this order:</p>
 								<ul class="nomark">
 									<li>
-										<p> (<code>span</code> or <code>a</code>) <code>[exactly 1]</code></p>
+										<p> ([^span^] or [^a^]) <code>[exactly 1]</code></p>
 									</li>
 									<li>
-										<p>
-											<code>ol</code>
-											<code>[conditionally required]</code>
+										<p> [^ol^] <code>[conditionally required]</code>
 										</p>
 									</li>
 								</ul>
@@ -6358,9 +6371,7 @@ No Entry</pre>
 								<p>In any order:</p>
 								<ul class="nomark">
 									<li>
-										<p>
-											<a data-lt="phrasing content"><code>HTML Phrasing content</code></a>
-											<code>[1 or more]</code>
+										<p> [=phrasing content | HTML Phrasing content=] <code>[1 or more]</code>
 										</p>
 									</li>
 								</ul>
@@ -6383,7 +6394,7 @@ No Entry</pre>
 						<p id="confreq-nav-a">Each list item of the ordered list represents a heading, structure, or
 							other item of interest. A child <code>a</code> element describes the target that the link
 							points to, while a <code>span</code> element serves as a heading for breaking down lists
-							into distinct groups (for example, an EPUB creator could segment a large list of
+							into distinct groups (for example, an [=EPUB creator=] could segment a large list of
 							illustrations into several lists, one for each chapter).</p>
 					</li>
 					<li>
@@ -6395,7 +6406,7 @@ No Entry</pre>
 					</li>
 					<li>
 						<p id="confreq-nav-a-title">If an <code>a</code> or <code>span</code> element contains instances
-							of [=embedded content | HTML embedded content=] that do not provide intrinsic text
+							of [=embedded content | HTML embedded content=] [[html]] that do not provide intrinsic text
 							alternatives, the element MUST also contain a <code>title</code> attribute with an alternate
 							text rendering of the link label.</p>
 					</li>
@@ -6459,14 +6470,14 @@ No Entry</pre>
 &lt;/nav></pre>
 				</aside>
 
-				<p id="confreq-cd-nav-docprops-spine">As a conforming XHTML content document, EPUB creators MAY include
-					the EPUB navigation document in the [=EPUB spine | spine=].</p>
+				<p id="confreq-cd-nav-docprops-spine">As a conforming [=XHTML content document=], EPUB creators MAY
+					include the EPUB navigation document in the [=EPUB spine | spine=].</p>
 
 				<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
 					items within <code>nav</code> elements is equivalent to the <a
 						href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:</code>
-						<code>none</code> property</a> [[csssnapshot]]. [=EPUB creators=] MAY specify alternative list
-					styling using CSS for rendering of the document in the [=EPUB spine | spine=].</p>
+						<code>none</code> property</a> [[csssnapshot]]. EPUB creators MAY specify alternative list
+					styling using CSS for rendering of the document in the spine.</p>
 			</section>
 
 			<section id="sec-nav-def-types">
@@ -6475,7 +6486,7 @@ No Entry</pre>
 				<section id="sec-nav-def-types-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>The <code>nav</code> elements defined in an EPUB navigation document are distinguished
+					<p>The <code>nav</code> elements defined in an [=EPUB navigation document=] are distinguished
 						semantically by the value of their [^/epub:type^] attribute.</p>
 
 					<p>This specification defines three types of navigation aid:</p>
@@ -6489,8 +6500,8 @@ No Entry</pre>
 						<dd>
 							<p>Identifies the <code>nav</code> element that contains the table of contents. The
 									<code>toc</code>
-								<code>nav</code> is the only navigation aid that EPUB creators must include in the EPUB
-								navigation document.</p>
+								<code>nav</code> is the only navigation aid that [=EPUB creators=] must include in the
+								EPUB navigation document.</p>
 						</dd>
 
 						<dt>
@@ -6528,9 +6539,9 @@ No Entry</pre>
 						sections of the publication).</p>
 
 					<p>The <code>toc</code>
-						<code>nav</code> element MUST occur exactly once in an EPUB navigation document.</p>
+						<code>nav</code> element MUST occur exactly once in an [=EPUB navigation document=].</p>
 
-					<p>EPUB creators SHOULD order the references in the <code>toc</code>
+					<p>[=EPUB creators=] SHOULD order the references in the <code>toc</code>
 						<code>nav</code> element such that they reflect both:</p>
 
 					<ul>
@@ -6539,7 +6550,8 @@ No Entry</pre>
 								the [=EPUB spine | spine=]; and</p>
 						</li>
 						<li>
-							<p>the order of the targeted elements within their respective EPUB content documents.</p>
+							<p>the order of the targeted elements within their respective [=EPUB content
+								documents=].</p>
 						</li>
 					</ul>
 				</section>
@@ -6552,15 +6564,15 @@ No Entry</pre>
 						exclusively for the [=EPUB publication=].</p>
 
 					<p>The <code>page-list</code>
-						<code>nav</code> element is OPTIONAL in EPUB navigation documents and MUST NOT occur more than
-						once.</p>
+						<code>nav</code> element is OPTIONAL in [=EPUB navigation documents=] and MUST NOT occur more
+						than once.</p>
 
 					<p>The <code>page-list</code>
 						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
 						nested sublists).</p>
 
-					<p>EPUB creators MAY identify the destinations of the <code>page-list</code> references in their
-						respective EPUB content documents using the <a data-cite="epub-ssv-11/#pagebreak"
+					<p>[=EPUB creators=] MAY identify the destinations of the <code>page-list</code> references in their
+						respective [=EPUB content documents=] using the <a data-cite="epub-ssv-11/#pagebreak"
 								><code>pagebreak</code> term</a> [[epub-ssv-11]].</p>
 				</section>
 
@@ -6569,12 +6581,12 @@ No Entry</pre>
 
 					<p>The <code>landmarks</code>
 						<code>nav</code> element identifies fundamental structural components in the content to enable
-						reading systems to provide the user efficient access to them (e.g., through a dedicated button
-						in the user interface).</p>
+						[=reading systems=] to provide the user efficient access to them (e.g., through a dedicated
+						button in the user interface).</p>
 
 					<p>The <code>landmarks</code>
-						<code>nav</code> element is OPTIONAL in EPUB navigation documents and MUST NOT occur more than
-						once.</p>
+						<code>nav</code> element is OPTIONAL in [=EPUB navigation documents=] and MUST NOT occur more
+						than once.</p>
 
 					<p>The <code>landmarks</code>
 						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
@@ -6619,7 +6631,7 @@ No Entry</pre>
 						<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code> value
 						that reference the same resource, or fragment thereof.</p>
 
-					<p>EPUB creators should limit the number of items they define in the <code>landmarks</code>
+					<p>[=EPUB creators=] should limit the number of items they define in the <code>landmarks</code>
 						<code>nav</code> to only items that a reading system is likely to use in its user interface. The
 						element is not meant to repeat the table of contents.</p>
 
@@ -6646,11 +6658,11 @@ No Entry</pre>
 				<section id="sec-nav-def-types-other">
 					<h4>Other <code>nav</code> elements</h4>
 
-					<p>EPUB navigation documents MAY contain one or more <code>nav</code> elements in addition to the
-							<code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
+					<p>[=EPUB navigation documents=] MAY contain one or more <code>nav</code> elements in addition to
+						the <code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
 						<code>nav</code> elements defined in the preceding sections. If these <code>nav</code> elements
-						are intended for reading system processing, they MUST have an [^/epub:type^] attribute and are
-						subject to the content model restrictions defined in <a href="#sec-nav-def-model"></a>.</p>
+						are intended for [=reading system=] processing, they MUST have an [^/epub:type^] attribute and
+						are subject to the content model restrictions defined in <a href="#sec-nav-def-model"></a>.</p>
 
 					<p>This specification imposes no restrictions on the semantics of any additional <code>nav</code>
 						elements: they MAY represent navigational semantics for any information domain, and they MAY
@@ -6690,16 +6702,16 @@ No Entry</pre>
 			<section id="sec-nav-doc-use-spine" class="informative">
 				<h3>Using in the spine</h3>
 
-				<p>Although it is possible to reuse the EPUB navigation document in the [=EPUB spine | spine=], it is
-					often the case that not all of the navigation structures, or branches within them, are needed.
+				<p>Although it is possible to reuse the [=EPUB navigation document=] in the [=EPUB spine | spine=], it
+					is often the case that not all of the navigation structures, or branches within them, are needed.
 					[=EPUB creators=] will often want to hide the <a href="#sec-nav-pagelist">page list</a> and <a
 						href="#sec-nav-landmarks">landmarks</a> navigation elements or trim the branches of the table of
 					contents for books that have many levels of subsections.</p>
 
 				<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
 						property</a> [[csssnapshot]] controls the visual rendering of EPUB navigation documents in
-					reading systems with [=viewports=], reading systems without viewports may not support CSS. To better
-					ensure the proper rendering in these reading systems, EPUB creators should use the [[html]]
+					[=reading systems=] with [=viewports=], reading systems without viewports may not support CSS. To
+					better ensure the proper rendering in these reading systems, EPUB creators should use the [[html]]
 					[^html-global/hidden^] attribute to indicate which (if any) portions of the navigation data are
 					excluded from rendering in the content flow.</p>
 
@@ -6780,7 +6792,7 @@ No Entry</pre>
 					upon. For example, although HTML with CSS provides powerful layout capabilities, those capabilities
 					are limited to the scope of the document being rendered.</p>
 
-				<p>This section defines properties that allow EPUB creators to express package-level rendering
+				<p>This section defines properties that allow [=EPUB creators=] to express package-level rendering
 					intentions (i.e., functionality that can only be implemented by the [=EPUB reading system=]). If a
 					reading system supports the desired rendering, these properties enable the user to be presented the
 					content as the EPUB creator optimally designed it.</p>
@@ -6792,21 +6804,21 @@ No Entry</pre>
 				<section id="fxl-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>EPUB documents, unlike print books or PDF files, are designed to change. The content flows, or
-						reflows, to fit the screen and to fit the needs of the user. As noted in <a
+					<p>[=EPUB publications=], unlike print books or PDF files, are designed to change. The content
+						flows, or reflows, to fit the screen and to fit the needs of the user. As noted in <a
 							data-cite="epub-overview-33#sec-rendering">Rendering and CSS</a> "content presentation
 						adapts to the user, rather than the user having to adapt to a particular presentation of
 						content." [[epub-overview-33]]</p>
 
 					<p>But this principle does not work for all types of documents. Sometimes content and design are so
 						intertwined it is not possible to separate them. Any change in appearance risks changing the
-						meaning or losing all meaning. [=fixed-layout documents=] give [=EPUB creators=] greater control
+						meaning or losing all meaning. [=Fixed-layout documents=] give [=EPUB creators=] greater control
 						over presentation when a reflowable EPUB is not suitable for the content.</p>
 
 					<p>EPUB creators define fixed layouts using a <a href="#sec-fxl-package">set of package document
 							properties</a> to control the rendering in [=reading systems=]. In addition, they set <a
 							href="#sec-fxl-package">the dimensions of each fixed-layout document</a> in its respective
-						EPUB content document.</p>
+						[=EPUB content document=].</p>
 
 					<div class="note" id="note-mechanisms">
 						<p>EPUB 3 affords multiple mechanisms for representing fixed-layout content. When fixed-layout
@@ -6829,20 +6841,20 @@ No Entry</pre>
 								property</a> is specified on a <code>meta</code> element, it indicates that the
 							paginated or reflowable layout style applies globally (i.e., for all spine items).</p>
 
-						<p>EPUB creators MUST use one of the following values with the <code>rendition:layout</code>
+						<p>[=EPUB creators=] MUST use one of the following values with the <code>rendition:layout</code>
 							property:</p>
 
 						<dl class="variablelist">
 							<dt id="def-layout-reflowable">reflowable</dt>
 							<dd>
-								<p>The content is not pre-paginated (i.e., reading systems apply dynamic pagination when
-									rendering). Default value.</p>
+								<p>The content is not pre-paginated (i.e., [=reading systems=] apply dynamic pagination
+									when rendering). Default value.</p>
 							</dd>
 
 							<dt id="def-layout-pre-paginated">pre-paginated</dt>
 							<dd>
 								<p>The content is pre-paginated (i.e., reading systems produce exactly one page per
-									spine [^itemref^] when rendering).</p>
+									[=EPUB spine | spine=] [^itemref^] when rendering).</p>
 							</dd>
 						</dl>
 
@@ -6867,11 +6879,11 @@ No Entry</pre>
 							setting the property for individual [=EPUB content documents=].</p>
 
 						<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
-							<p>In this example, the document's layout is set to <code>pre-paginated</code>, i.e., it is
-								defined to be a fixed layout document. Furthermore, media queries [[mediaqueries-3]] are
-								used to apply different style sheets for three different device categories. Note that
-								the media queries only affect the style sheet applied to the document; the size of the
-								content area set in the <code>viewport</code>
+							<p>In this example, the document's layout is set to <code>pre-paginated</code> (i.e., it is
+								defined to be a [=fixed-layout document=]). Furthermore, media queries
+								[[mediaqueries-3]] are used to apply different style sheets for three different device
+								categories. Note that the media queries only affect the style sheet applied to the
+								document; the size of the content area set in the <code>viewport</code>
 								<code>meta</code> tag is static.</p>
 
 							<p>Package document:</p>
@@ -6921,9 +6933,9 @@ No Entry</pre>
 						<section id="layout-overrides">
 							<h6>Layout overrides</h6>
 
-							<p id="property-layout-local">EPUB creators MAY specify the following properties locally on
-								spine [^itemref^] elements to override the <a href="#property-layout-global">global
-									value</a> for the given spine item:</p>
+							<p id="property-layout-local">[=EPUB creators=] MAY specify the following properties locally
+								on [=EPUB spine | spine=] [^itemref^] elements to override the <a
+									href="#property-layout-global">global value</a> for the given spine item:</p>
 
 							<dl>
 								<dt id="layout-pre-paginated">rendition:layout-pre-paginated</dt>
@@ -6940,21 +6952,21 @@ No Entry</pre>
 					<section id="orientation">
 						<h5>Orientation</h5>
 
-						<p>The <code>rendition:orientation</code> property specifies which orientation the EPUB creator
-							intends the content to be rendered in. </p>
+						<p>The <code>rendition:orientation</code> property specifies which orientation the [=EPUB
+							creator=] intends the content to be rendered in. </p>
 
 						<p id="property-orientation-global">When the <a href="#orientation"
-									><code>rendition:orientation</code> property</a> is specified on a <code>meta</code>
-							element, it indicates that the intended orientation applies globally (i.e., for all spine
-							items).</p>
+									><code>rendition:orientation</code> property</a> is specified on a [^meta^] element,
+							it indicates that the intended orientation applies globally (i.e., for all [=EPUB spine |
+							spine=] items).</p>
 
-						<p>EPUB creators MUST use one of the following values with the
+						<p>[=EPUB creators=] MUST use one of the following values with the
 								<code>rendition:orientation</code> property:</p>
 
 						<dl class="variablelist">
 							<dt>landscape</dt>
 							<dd>
-								<p>Reading systems should render the content in landscape orientation.</p>
+								<p>[=Reading systems=] should render the content in landscape orientation.</p>
 							</dd>
 
 							<dt>portrait</dt>
@@ -6998,13 +7010,13 @@ No Entry</pre>
 						<section id="orientation-overrides">
 							<h6>Orientation overrides</h6>
 
-							<p id="property-orientation-local">EPUB creators MAY specify the following properties
-								locally on spine [^itemref^] elements to override the <a
+							<p id="property-orientation-local">[=EPUB creators=] MAY specify the following properties
+								locally on [=EPUB spine | spine=] [^itemref^] elements to override the <a
 									href="#property-orientation-global">global value</a> for the given spine item:</p>
 
 							<dl>
 								<dt id="orientation-auto">rendition:orientation-auto</dt>
-								<dd>Specifies that the reading system determines the orientation to render the spine
+								<dd>Specifies that the [=reading system=] determines the orientation to render the spine
 									item in.</dd>
 
 								<dt id="orientation-landscape">rendition:orientation-landscape</dt>
@@ -7023,21 +7035,21 @@ No Entry</pre>
 					<section id="spread">
 						<h5>Synthetic spreads</h5>
 
-						<p>The <code>rendition:spread</code> property specifies the intended reading system synthetic
-							spread behavior.</p>
+						<p>The <code>rendition:spread</code> property specifies the intended [=reading system=]
+							synthetic spread behavior.</p>
 
 						<p id="property-spread-global">When the <code>rendition:spread</code> property is specified on a
 								<code>meta</code> element, it indicates that the intended [=synthetic spread=] behavior
 							applies globally (i.e., for all spine items).</p>
 
-						<p>EPUB creators MUST use one of the following values with the <code>rendition:spread</code>
+						<p>[=EPUB creators=] MUST use one of the following values with the <code>rendition:spread</code>
 							property:</p>
 
 						<dl class="variablelist">
 							<dt>none</dt>
 							<dd>
 								<p>Do not incorporate spine items in a synthetic spread. Reading systems should display
-									the items in a single viewport positioned at the center of the screen.</p>
+									the items in a single [=viewport=] positioned at the center of the screen.</p>
 							</dd>
 
 							<dt>landscape</dt>
@@ -7073,8 +7085,9 @@ No Entry</pre>
 							setting the property for individual [=EPUB content documents=].</p>
 
 						<div class="note">
-							<p>When synthetic spreads are used in the context of HTML and SVG content documents, the
-								dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport</code>
+							<p>When synthetic spreads are used in the context of [=XHTML content document | XHTML=] and
+								[=SVG content documents=], the dimensions given via the <a href="#sec-fxl-icb-html"
+										><code>viewport</code>
 									<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"><code>viewBox</code>
 									attribute</a> represents the size of one page in the spread, respectively.</p>
 						</div>
@@ -7117,11 +7130,11 @@ No Entry</pre>
 
 							<details id="spread-none-diagram" class="desc">
 								<summary>Image description</summary>
-								<p> Two rows of schematic views of tablets (three in each row). The tablets in the top
+								<p>Two rows of schematic views of tablets (three in each row). The tablets in the top
 									row are in portrait mode, and in landscape mode in the bottom one. The schematic
-									views of the tablets within a row are linked with left-to-right arrows. </p>
-								<p> In the tablets of each row the consecutive panels of a comics are displayed; the
-									panels are centered in their respective tablets. </p>
+									views of the tablets within a row are linked with left-to-right arrows.</p>
+								<p>In the tablets of each row the consecutive panels of a comics are displayed; the
+									panels are centered in their respective tablets.</p>
 							</details>
 						</aside>
 
@@ -7160,14 +7173,14 @@ No Entry</pre>
 
 							<details id="spread-landscape-diagram" class="desc">
 								<summary>Image description</summary>
-								<p> Two rows of schematic views of tablets (three in top row, and two in the bottom).
-									The tablets in the top row are in portrait mode, and in landscape mode in the bottom
+								<p>Two rows of schematic views of tablets (three in top row, and two in the bottom). The
+									tablets in the top row are in portrait mode, and in landscape mode in the bottom
 									one. The schematic views of the tablets within a row are linked with left-to-right
-									arrows. </p>
-								<p> In both rows three panels of a comics are displayed. In the top row the panels are
+									arrows.</p>
+								<p>In both rows three panels of a comics are displayed. In the top row the panels are
 									centered in their respective tablets. In the bottom row, the first tablet contains
 									the first and second panels of the comics side by side; the second tablet contains
-									the second and third panels of the comics side-by-side. </p>
+									the second and third panels of the comics side-by-side.</p>
 							</details>
 						</aside>
 
@@ -7205,12 +7218,12 @@ No Entry</pre>
 
 							<details id="spread-both-diagram" class="desc">
 								<summary>Image description</summary>
-								<p> Two rows of schematic views of tablets (two in each row). The tablets in the top row
+								<p>Two rows of schematic views of tablets (two in each row). The tablets in the top row
 									are in portrait mode, and in landscape mode in the bottom one. The schematic views
-									of the tablets within a row are linked with left-to-right arrows. </p>
-								<p> In both rows three panels of a comics are displayed. The first tablet in a row
+									of the tablets within a row are linked with left-to-right arrows.</p>
+								<p>In both rows three panels of a comics are displayed. The first tablet in a row
 									contains the first and second panels of the comics side by side; the second tablet
-									contains the second and third panels of the comics side-by-side. </p>
+									contains the second and third panels of the comics side-by-side.</p>
 							</details>
 						</aside>
 
@@ -7244,7 +7257,7 @@ No Entry</pre>
 &lt;/package></pre>
 
 							<figure id="spread-both-with-intro-figure">
-								<figcaption> Rendering of an introduction document in reflowable layout, followed by
+								<figcaption>Rendering of an introduction document in reflowable layout, followed by
 									three fixed-layout documents with synthetic spread in portrait orientation.
 										<br /><span class="attribution">(Comics courtesy of <a
 											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
@@ -7259,28 +7272,28 @@ No Entry</pre>
 
 							<details id="spread-both-with-intro-diagram" class="desc">
 								<summary>Image description</summary>
-								<p> A row of schematic views of three tablets in portrait mode, and linked with
-									left-to-right arrows. </p>
-								<p> The first tablet views includes a single, column-like strip (i.e., a rectangle
+								<p>A row of schematic views of three tablets in portrait mode, and linked with
+									left-to-right arrows.</p>
+								<p>The first tablet views includes a single, column-like strip (i.e., a rectangle
 									without a bottom edge following beyond the bottom of the tablet) with a text flowing
 									down the strip, and starting with the word "Introduction". This is followed by two
 									schematic tablets with three panels of comics displayed. The first tablet in the row
 									contains the first and second panels of the comics side by side; the second tablet
-									contains the second and third panels of the comics side-by-side. </p>
+									contains the second and third panels of the comics side-by-side.</p>
 							</details>
 						</aside>
 
 						<section id="spread-overrides">
 							<h6>Synthetic spread overrides</h6>
 
-							<p id="property-spread-local">EPUB creators MAY specify the following properties locally on
-								spine [^itemref^] elements to override the <a href="#property-spread-global">global
-									value</a> for the given spine item:</p>
+							<p id="property-spread-local">[=EPUB creators=] MAY specify the following properties locally
+								on [=EPUB spine | spine=] [^itemref^] elements to override the <a
+									href="#property-spread-global">global value</a> for the given spine item:</p>
 
 							<dl>
 								<dt id="spread-auto">rendition:spread-auto</dt>
-								<dd>Specifies the reading system determines when to render a synthetic spread for the
-									spine item. </dd>
+								<dd>Specifies the [=reading system=] determines when to render a synthetic spread for
+									the spine item. </dd>
 
 								<dt id="spread-both">rendition:spread-both</dt>
 								<dd>Specifies the reading system should render a synthetic spread for the spine item in
@@ -7311,11 +7324,11 @@ No Entry</pre>
 					<section id="page-spread">
 						<h5>Spread placement</h5>
 
-						<p>When a reading system renders a [=synthetic spread=], the default behavior is to populate the
-							spread by rendering the next [=EPUB content document=] in the next available unpopulated
-							viewport, where the next available viewport is determined by the given <a
+						<p>When a [=reading system=] renders a [=synthetic spread=], the default behavior is to populate
+							the spread by rendering the next [=EPUB content document=] in the next available unpopulated
+							[=viewport=], where the next available viewport is determined by the given <a
 								href="#attrdef-spine-page-progression-direction">page progression direction</a> or by
-							local declarations within EPUB content documents. An EPUB creator MAY override this
+							local declarations within [=EPUB content documents=]. An [=EPUB creator=] MAY override this
 							automatic population behavior and force reading systems to place a document in a particular
 							viewport by specifying one of the following properties on its spine <code>itemref</code>
 							element:</p>
@@ -7352,8 +7365,9 @@ No Entry</pre>
 							systems must render side-by-side for readability, such as a two-page map). To indicate that
 							two consecutive pages represent a true spread, EPUB creators SHOULD use the
 								<code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-							properties on the spine items for the two adjacent EPUB content documents, and omit the
-							properties on spine items where one-up or two-up presentation is equally acceptable.</p>
+							properties on the [=EPUB spine | spine=] items for the two adjacent EPUB content documents,
+							and omit the properties on spine items where one-up or two-up presentation is equally
+							acceptable.</p>
 
 						<p>EPUB creators MUST NOT declare more than one <code>page-spread-*</code> property on any given
 							spine item.</p>
@@ -7396,7 +7410,7 @@ No Entry</pre>
 &lt;/package></pre>
 
 							<figure id="spread-page-spread-right-figure">
-								<figcaption> Rendering of three fixed-layout documents, with synthetic spread in
+								<figcaption>Rendering of three fixed-layout documents, with synthetic spread in
 									landscape orientation starting on the right. <br /><span class="attribution">(Comics
 										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
 											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
@@ -7410,12 +7424,12 @@ No Entry</pre>
 
 							<details id="spread-page-spread-right-diagram" class="desc">
 								<summary>Image description</summary>
-								<p> A row of schematic views of two tablets in landscape mode, and linked with a
-									left-to-right arrow. </p>
-								<p> Three panels of a comics are displayed in the tablets. The first tablet in the row
+								<p>A row of schematic views of two tablets in landscape mode, and linked with a
+									left-to-right arrow.</p>
+								<p>Three panels of a comics are displayed in the tablets. The first tablet in the row
 									contains the first panels of the comics on the right hand of the tablet, with the
 									left side empty; the second tablet contains the second and third panels of the
-									comics side-by-side. </p>
+									comics side-by-side.</p>
 							</details>
 						</aside>
 
@@ -7470,8 +7484,9 @@ No Entry</pre>
 						<h5>Viewport dimensions (deprecated)</h5>
 
 						<p>The <code>rendition:viewport</code> property allows [=EPUB creators=] to express the CSS
-							initial containing block (ICB) [[css2]] for XHTML and SVG content documents whose
-								<code>rendition:layout</code> property has been set to <code>pre-paginated</code>.</p>
+							initial containing block (ICB) [[css2]] for [=XHTML content document | XHTML=] and [=SVG
+							content documents=] whose <code>rendition:layout</code> property has been set to
+								<code>pre-paginated</code>.</p>
 
 						<p>Use of the property is <a href="#deprecated">deprecated</a>.</p>
 
@@ -7543,22 +7558,23 @@ No Entry</pre>
 
 				<p>Although control over the rendering of [=EPUB content documents=] to create <a
 						href="#sec-fixed-layouts">fixed layouts</a> is an obvious need not handled by other
-					technologies, there are also considerations for reflowable content that are unique to EPUB
-					publications (e.g., how to handle the flow of content in the [=viewport=]). This section defines
+					technologies, there are also considerations for reflowable content that are unique to [=EPUB
+					publications=] (e.g., how to handle the flow of content in the [=viewport=]). This section defines
 					properties that allow [=EPUB creators=] to control presentation aspects of reflowable content.</p>
 
 				<section id="flow">
 					<h4>The <code>rendition:flow</code> property</h4>
 
-					<p>The <code>rendition:flow</code> property specifies the EPUB creator preference for how reading
-						systems should handle content overflow. </p>
+					<p>The <code>rendition:flow</code> property specifies the [=EPUB creator=] preference for how
+						[=reading systems=] should handle content overflow. </p>
 
 					<p id="property-flow-global">When the <a href="#flow"><code>rendition:flow</code> property</a> is
 						specified on a <code>meta</code> element, it indicates the EPUB creator's global preference for
-						overflow content handling (i.e., for all spine items). EPUB creators MAY indicate a preference
-						for dynamic pagination or scrolling. For scrolled content, it is also possible to specify
-						whether consecutive [=EPUB content documents=] are to be rendered as a continuous scrolling view
-						or whether each is to be rendered separately (i.e., with a dynamic page break between each).</p>
+						overflow content handling (i.e., for all [=EPUB spine | spine=] items). EPUB creators MAY
+						indicate a preference for dynamic pagination or scrolling. For scrolled content, it is also
+						possible to specify whether consecutive [=EPUB content documents=] are to be rendered as a
+						continuous scrolling view or whether each is to be rendered separately (i.e., with a dynamic
+						page break between each).</p>
 
 					<p>EPUB creators MUST use one of the following values with the <code>rendition:flow</code>
 						property:</p>
@@ -7571,9 +7587,9 @@ No Entry</pre>
 
 						<dt id="scrolled-continuous">scrolled-continuous</dt>
 						<dd id="scrolled-continuous-dd" data-tests="#pkg-flow-scrolled-continuous">
-							<p>Render all EPUB content documents such that overflow content is scrollable, and the EPUB
-								publication is presented as one continuous scroll from spine item to spine item (except
-								where <a href="#layout-property-flow-overrides">locally overridden</a>).</p>
+							<p>Render all EPUB content documents such that overflow content is scrollable, and the
+								[=EPUB publication=] is presented as one continuous scroll from spine item to spine item
+								(except where <a href="#layout-property-flow-overrides">locally overridden</a>).</p>
 							<p>Note that EPUB creators SHOULD NOT create publications in which different resources have
 								different block flow directions, as continuous scrolled rendition in EPUB reading
 								systems would be problematic.</p>
@@ -7605,7 +7621,7 @@ No Entry</pre>
 
 					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
 							attribute</a>. Refer to <a href="#layout-property-flow-overrides"></a> for setting the
-						property for individual [=EPUB content documents=].</p>
+						property for individual EPUB content documents.</p>
 
 					<figure id="fig-flow-paginated-single">
 						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
@@ -7678,9 +7694,9 @@ No Entry</pre>
 					<section id="layout-property-flow-overrides">
 						<h5>Spine overrides</h5>
 
-						<p id="layout-property-flow-local">EPUB creators MAY specify the following properties locally on
-							spine [^itemref^] elements to override the <a href="#property-flow-global">global value</a>
-							for the given spine item:</p>
+						<p id="layout-property-flow-local">[=EPUB creators=] MAY specify the following properties
+							locally on [=EPUB spine | spine=] [^itemref^] elements to override the <a
+								href="#property-flow-global">global value</a> for the given spine item:</p>
 
 						<dl>
 							<dt id="flow-auto">rendition:flow-auto</dt>
@@ -7704,8 +7720,8 @@ No Entry</pre>
 
 						<aside class="example" id="property-flow-ex1"
 							title="Overriding a global paginated flow declaration">
-							<p>In this example, the EPUB creator's intent is to have a paginated EPUB publication with a
-								scrollable table of contents.</p>
+							<p>In this example, the EPUB creator's intent is to have a paginated [=EPUB publication=]
+								with a scrollable table of contents.</p>
 							<pre>&lt;package …>
 &lt;metadata …&gt;
 	…
@@ -7733,19 +7749,19 @@ No Entry</pre>
 				<section id="align-x-center">
 					<h4>The <code>rendition:align-x-center</code> property</h4>
 
-					<p>The <code>rendition:align-x-center</code> property specifies that the given spine item should be
-						centered horizontally in the viewport or spread.</p>
+					<p>The <code>rendition:align-x-center</code> property specifies that the given [=EPUB spine |
+						spine=] item should be centered horizontally in the [=viewport=] or spread.</p>
 
-					<p>The property MUST NOT be set globally for all EPUB content documents (i.e., in a [^meta^] element
-						without a <a href="#attrdef-refines"><code>refines</code> attribute</a>). It is only available
-						as a spine override for individual EPUB content documents via the [^itemref^] element's
-							<code>properties</code> attribute.</p>
+					<p>The property MUST NOT be set globally for all [=EPUB content documents=] (i.e., in a [^meta^]
+						element without a <a href="#attrdef-refines"><code>refines</code> attribute</a>). It is only
+						available as a spine override for individual EPUB content documents via the [^itemref^]
+						element's <code>properties</code> attribute.</p>
 
 					<div class="note">
 						<p>This property was developed primarily to handle "Naka-Tobira (中扉)" (sectional title pages),
 							in the absence of reliable centering control within the content rendering. As support for
-							paged media evolves in CSS, however, this property is expected to be deprecated. EPUB
-							creators are encouraged to use CSS solutions when effective.</p>
+							paged media evolves in CSS, however, this property is expected to be deprecated. [=EPUB
+							creators=] are encouraged to use CSS solutions when effective.</p>
 					</div>
 				</section>
 			</section>
@@ -7757,9 +7773,9 @@ No Entry</pre>
 				<h4>Introduction</h4>
 
 				<p>Mainstream ebooks, educational tools and ebooks formatted for persons with print disabilities are
-					some examples of works that contain synchronized audio narration. In EPUB 3, EPUB creators can
+					some examples of works that contain synchronized audio narration. In EPUB 3, [=EPUB creators=] can
 					create these types of books using media overlay documents to describe the timing for the
-					pre-recorded audio narration and how it relates to the EPUB content document markup. The
+					pre-recorded audio narration and how it relates to the [=EPUB content document=] markup. The
 					specification defines the file format for media overlays as a subset of [[smil3]], a W3C
 					recommendation for representing synchronized multimedia information in XML.</p>
 
@@ -7770,7 +7786,7 @@ No Entry</pre>
 					purposes not traditionally considered accessibility concerns (e.g., for language learning).</p>
 
 				<p>The media overlays feature is transparent to [=EPUB reading systems=] that do not support the
-					feature. The inclusion of media overlays in an EPUB publication has no impact on the ability of
+					feature. The inclusion of media overlays in an [=EPUB publication=] has no impact on the ability of
 					media overlay-unaware reading systems to render the EPUB publication as though the media overlays
 					are not present.</p>
 
@@ -7798,8 +7814,8 @@ No Entry</pre>
 								constraints expressed in <a href="#sec-overlays-def"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-mo-docprops-references">MAY refer to more than one EPUB content document, but
-								more than one media overlay document MUST NOT reference the same EPUB content
+							<p id="confreq-mo-docprops-references">MAY refer to more than one [=EPUB content document=],
+								but more than one media overlay document MUST NOT reference the same EPUB content
 								document.</p>
 						</li>
 					</ul>
@@ -7814,7 +7830,8 @@ No Entry</pre>
 					<section id="sec-smil-smil-elem">
 						<h5>The <code>smil</code> element</h5>
 
-						<p>The <code>smil</code> element is the root element of all media overlay documents.</p>
+						<p>The <code>smil</code> element encapsulates all the information in an [=media overlay
+							document=].</p>
 
 						<dl class="elemdef" id="elemdef-smil">
 							<dt>Element Name:</dt>
@@ -7827,7 +7844,8 @@ No Entry</pre>
 
 							<dt>Usage:</dt>
 							<dd>
-								<p>The <code>smil</code> element is the root element of the media overlay document.</p>
+								<p>REQUIRED <a data-cite="xml#dt-root">root element</a> [[xml]] of the media overlay
+									document.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -7839,7 +7857,7 @@ No Entry</pre>
 									</dt>
 									<dd>
 										<p>Specifies the version number of the [[smil3]] specification to which the
-											media overlay adheres.</p>
+											media overlay document adheres.</p>
 										<p>This attribute MUST have the value "<code>3.0</code>".</p>
 									</dd>
 
@@ -7848,8 +7866,8 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[xml]] of the element, which MUST be unique within the document
-											scope.</p>
+										<p>The <a data-cite="xml#id">ID</a> [[xml]] of the element, which MUST be unique
+											within the document scope.</p>
 									</dd>
 
 									<dt id="attrdef-smil-prefix">
@@ -7884,8 +7902,8 @@ No Entry</pre>
 					<section id="sec-smil-head-elem">
 						<h5>The <code>head</code> element</h5>
 
-						<p>The <code>head</code> element is the container for metadata in the media overlay
-							document.</p>
+						<p>The <code>head</code> element is the container for metadata in the [=media overlay
+							document=].</p>
 
 						<dl class="elemdef" id="elemdef-smil-head">
 							<dt>Element Name:</dt>
@@ -7921,7 +7939,7 @@ No Entry</pre>
 					<section id="sec-smil-metadata-elem">
 						<h5>The <code>metadata</code> element</h5>
 
-						<p>The <code>metadata</code> element represents metadata for the media overlay document. The
+						<p>The <code>metadata</code> element represents metadata for the [=media overlay document=]. The
 								<code>metadata</code> element is an extension point that allows the inclusion of
 							metadata from any metainformation structuring language.</p>
 
@@ -7957,8 +7975,8 @@ No Entry</pre>
 						<h5>The <code>body</code> element</h5>
 
 						<p>The <code>body</code> element is the starting point for the presentation contained in the
-							media overlay document. It contains the main sequence of <code>par</code> and
-								<code>seq</code> elements.</p>
+							[=media overlay document=]. It contains the main sequence of [^par^] and [^seq^]
+							elements.</p>
 
 						<dl class="elemdef" id="elemdef-smil-body">
 							<dt>Element Name:</dt>
@@ -7995,8 +8013,8 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[xml]] of the element, which MUST be unique within the document
-											scope.</p>
+										<p>The <a data-cite="xml#id">ID</a> [[xml]] of the element, which MUST be unique
+											within the document scope.</p>
 									</dd>
 
 									<dt id="attrdef-body-textref">
@@ -8071,8 +8089,8 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[xml]] of the element, which MUST be unique within the document
-											scope.</p>
+										<p>The <a data-cite="xml#id">ID</a> [[xml]] of the element, which MUST be unique
+											within the document scope.</p>
 									</dd>
 
 									<dt id="attrdef-seq-textref">
@@ -8080,8 +8098,8 @@ No Entry</pre>
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>Refers to the associated EPUB content document and, optionally, identifies a
-											specific part of it.</p>
+										<p>Refers to the associated [=EPUB content document=] and, optionally,
+											identifies a specific part of it.</p>
 										<p>The value MUST be a [=path-relative-scheme-less-URL string=], optionally
 											followed by <code>U+0023 (#)</code> and a [=URL-fragment string=].</p>
 										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
@@ -8148,8 +8166,8 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[xml]] of the element, which MUST be unique within the document
-											scope.</p>
+										<p>The <a data-cite="xml#id">ID</a> [[xml]] of the element, which MUST be unique
+											within the document scope.</p>
 									</dd>
 								</dl>
 							</dd>
@@ -8176,9 +8194,9 @@ No Entry</pre>
 
 						<p>The <code>text</code> element references an element in an [=EPUB content document=]. A
 								<code>text</code> element typically refers to a textual element but can also refer to
-							other EPUB content document media elements (see <a href="#sec-embedded-media"></a>). In the
-							absence of a sibling <code>audio</code> element textual content referred to by this element
-							may be rendered via <a href="#sec-tts">text-to-speech</a>.</p>
+							other [=EPUB content document=] media elements (see <a href="#sec-embedded-media"></a>). In
+							the absence of a sibling [^audio^] element, textual content referred to by this element may
+							be rendered via <a href="#sec-tts">text-to-speech</a>.</p>
 
 						<dl class="elemdef" id="elemdef-smil-text">
 							<dt>Element Name:</dt>
@@ -8213,8 +8231,8 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[xml]] of the element, which MUST be unique within the document
-											scope.</p>
+										<p>The <a data-cite="xml#id">ID</a> [[xml]] of the element, which MUST be unique
+											within the document scope.</p>
 									</dd>
 								</dl>
 							</dd>
@@ -8225,13 +8243,13 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p class="note"> This specification places no restriction on the <code>src</code> attribute of a
-								<code>text</code> element. Authors should, however, refer to a content that can be
-							styled with CSS to make the <a href="#sec-docs-assoc-style">association with style
-								information</a> effective, i.e., [=palpable content=] for XHTML or <a
+						<p class="note">This specification places no restriction on the <code>src</code> attribute of a
+								<code>text</code> element. [=EPUB creators=] should, however, refer to a content that
+							can be styled with CSS to make the <a href="#sec-docs-assoc-style">association with style
+								information</a> effective (i.e., [=palpable content=] for XHTML or <a
 								href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a
 								href="https://www.w3.org/TR/SVG11/shapes.html">basic shapes</a>, or <a
-								href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG. </p>
+								href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG). </p>
 					</section>
 
 					<section id="sec-smil-audio-elem">
@@ -8261,8 +8279,8 @@ No Entry</pre>
 										<code>[optional]</code>
 									</dt>
 									<dd>
-										<p>The ID [[xml]] of the element, which MUST be unique within the document
-											scope.</p>
+										<p>The <a data-cite="xml#id">ID</a> [[xml]] of the element, which MUST be unique
+											within the document scope.</p>
 									</dd>
 
 									<dt>
@@ -8319,11 +8337,11 @@ No Entry</pre>
 				<section id="sec-docs-intro" class="informative">
 					<h4>Introduction</h4>
 
-					<p>EPUB creators can represent a pre-recorded narration of a publication as a series of audio clips,
-						each corresponding to part of an [=EPUB content document=]. A single audio clip, for example,
-						typically represents a single phrase or paragraph, but infers no order relative to the other
-						clips or to the text of a document. Media overlays solve this problem of synchronization by
-						tying the structured audio narration to its corresponding text (or other media) in the EPUB
+					<p>[=EPUB creators=] can represent a pre-recorded narration of a publication as a series of audio
+						clips, each corresponding to part of an [=EPUB content document=]. A single audio clip, for
+						example, typically represents a single phrase or paragraph, but infers no order relative to the
+						other clips or to the text of a document. Media overlays solve this problem of synchronization
+						by tying the structured audio narration to its corresponding text (or other media) in the EPUB
 						content document using [[smil3]] markup. Media overlays are, in fact, a simplified subset of
 						SMIL 3.0 that define the playback sequence of these clips.</p>
 
@@ -8331,7 +8349,7 @@ No Entry</pre>
 						sequence), [^seq^] (sequence) and [^par^] (parallel). (Refer to <a href="#sec-overlays-def"></a>
 						for more information on these and other SMIL elements.)</p>
 
-					<p>The <code>par</code> element is the basic building block of an Overlay and corresponds to a
+					<p>The <code>par</code> element is the basic building block of a media overlay and corresponds to a
 						phrase in the EPUB content document. The element provides two key pieces of information for
 						synchronizing content: 1) the audio clip containing the narration for the phrase; and 2) a
 						pointer to the associated EPUB content document fragment. The <code>par</code> element uses two
@@ -8398,6 +8416,7 @@ No Entry</pre>
    &lt;/body>
 &lt;/smil></pre>
 					</aside>
+
 					<p>EPUB creators can also add <code>par</code> elements to <code>seq</code> elements to define more
 						complex structures such as parts and chapters (see <a href="#sec-media-overlays-structure"
 						></a>).</p>
@@ -8407,18 +8426,18 @@ No Entry</pre>
 					<h4>Relationship to the EPUB content document</h4>
 
 					<div class="note">
-						<p>In this section, the [=EPUB content document=] is assumed to be an <a>XHTML content
-								document</a>. While EPUB creators may use media overlays with <a>SVG content
-								documents</a>, playback behavior might not be consistent and therefore interoperability
-							is not guaranteed.</p>
+						<p>In this section, the [=EPUB content document=] is assumed to be an [=XHTML content
+							document=]. While [=EPUB creators=] may use media overlays with [=SVG content documents=],
+							playback behavior might not be consistent and therefore interoperability is not
+							guaranteed.</p>
 					</div>
 
 					<section id="sec-media-overlays-structure">
 						<h5>Overlay structure</h5>
 
-						<p>The [^body^] of a media overlay document consists of two elements: the [^par^] element and
-							the [^seq^] element. The ordering of these elements represents how reading systems render
-							the content in the corresponding EPUB content documents during playback.</p>
+						<p>The [^body^] of a [=media overlay document=] consists of two elements: the [^par^] element
+							and the [^seq^] element. The ordering of these elements represents how [=reading systems=]
+							render the content in the corresponding [=EPUB content documents=] during playback.</p>
 
 						<p>The <code>par</code> element represents a segment of content, such as a word, phrase,
 							sentence, table cell, list item, image, or other identifiable piece of content in the
@@ -8427,14 +8446,14 @@ No Entry</pre>
 
 						<p>The <code>seq</code> element represents sequences &#8212; sets of <code>seq</code> and/or
 								<code>par</code> elements that together represent a logical component of the content.
-							EPUB creators can use it to represent nested containers such as sections, asides, headers,
-							tables, lists, and footnotes. It allows EPUB creators to retain the structure inherent in
-							these containers in the media overlay document.</p>
+							[=EPUB creators=] can use it to represent nested containers such as sections, asides,
+							headers, tables, lists, and footnotes. It allows EPUB creators to retain the structure
+							inherent in these containers in the media overlay document.</p>
 
 						<p>The <code>seq</code> element MUST contain an <a href="#attrdef-body-textref"
 									><code>epub:textref</code> attribute</a>. As <code>seq</code> elements do not
-							provide synchronization instructions, this attribute allows a reading system to match the
-							fragment to a location in the text.</p>
+							provide synchronization instructions, this attribute allows a [=reading system=] to match
+							the fragment to a location in the text.</p>
 
 						<div class="note">
 							<p>The reason for grouping structures like sections, figures, tables, and footnotes in a
@@ -8593,30 +8612,30 @@ No Entry</pre>
 
 						<p>Both the <code>epub:textref</code> attribute and the [^text^] element's <code>src</code>
 							attribute may contain a [=URL-fragment string=] that references a specific part (e.g., an
-							element via its ID) of the associated <a>EPUB content document</a>.</p>
+							element via its ID) of the associated [=EPUB content document=].</p>
 
-						<p>For XHTML and SVG content documents, the URL-fragment string SHOULD be a reference to a
-							specific element via its ID, or an <a
+						<p>For [=XHTML content document | XHTML=] and [=SVG content documents=], the URL-fragment string
+							SHOULD be a reference to a specific element via its ID, or an <a
 								href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
 								Identifier</a> [[svg]], respectively.</p>
 
-						<p>EPUB creators MAY use other fragment identifier schemes, but reading systems may not support
-							such identifiers.</p>
+						<p>EPUB creators MAY use other fragment identifier schemes, but [=reading systems=] may not
+							support such identifiers.</p>
 					</section>
 
 					<section id="sec-media-overlays-granularity" class="informative">
 						<h5>Overlay granularity</h5>
 
-						<p>The granularity level of the media overlay depends on how EPUB creators mark up the EPUB
-							content document and the type of fragment identifier they use in the [^text^] elements'
-								<code>src</code> attributes and the [^seq^] elements' <code>epub:textref</code>
+						<p>The granularity level of the media overlay depends on how [=EPUB creators=] mark up the
+							[=EPUB content document=] and the type of fragment identifier they use in the [^text^]
+							elements' <code>src</code> attributes and the [^seq^] elements' <code>epub:textref</code>
 							attrbutes. For example, when referencing [[html]] elements, if the finest level of markup is
 							at the paragraph level, then that is the finest possible level for media overlay
 							synchronization. Likewise, if sub-paragraph markup is available, such as [[html]] [^span^]
 							element representing phrases or sentences, then finer granularity is possible in the media
 							overlay. Finer granularity gives users more precise results for synchronized playback when
 							navigating by word or phrase and when searching the text but increases the file size of the
-							media overlay documents. Fragment identifier schemes that do not rely on the presence of
+							[=media overlay documents=]. Fragment identifier schemes that do not rely on the presence of
 							elements could provide even finer granularity, where supported.</p>
 					</section>
 
@@ -8624,18 +8643,18 @@ No Entry</pre>
 						<h5>Embedded media</h5>
 
 						<p>Any [=EPUB content document=] associated with a [=media overlay document=] MAY contain
-							embedded media such as video, audio, and images. EPUB creators MAY use the media overlay
+							embedded media such as video, audio, and images. [=EPUB creators=] MAY use the media overlay
 							[^text^] element in such instances to reference the embedded media by its element's
 								<code>id</code> attribute value.</p>
 
 						<section id="sec-emb-audio-video">
 							<h6>Embedded audio and video</h6>
 
-							<p> When a [^text^] element references embedded audio or video, reading systems will
+							<p> When a [^text^] element references embedded audio or video, [=reading systems=] will
 								initiate playback of the media in the absence of an [^audio^] element sibling. </p>
 
 							<p>[=EPUB creators=] SHOULD avoid using scripts to control playback of referenced embedded
-								EPUB content document media, as this might conflict with media overlays playback
+								[=EPUB content document=] media, as this might conflict with media overlays playback
 								behavior.</p>
 
 							<p>EPUB creators should carefully examine any overlapping audio situations and deal with
@@ -8647,10 +8666,11 @@ No Entry</pre>
 							<h6>Embedded images</h6>
 
 							<p>When a <code>text</code> element references an embedded image, the [^audio^] sibling
-								element is OPTIONAL. In the absence of an <code>audio</code> element, reading systems
-								will voice the image using <a href="#sec-tts">Text-to-Speech rendering</a>.</p>
+								element is OPTIONAL. In the absence of an <code>audio</code> element, [=reading
+								systems=] will voice the image using <a href="#sec-tts">text-to-speech
+								rendering</a>.</p>
 
-							<p>EPUB creators MUST ensure they provide fallback text for an image when an omitting an
+							<p>[=EPUB creators=] MUST ensure they provide fallback text for an image when an omitting an
 									<code>audio</code> element (e.g., using the [[html]] <code>alt</code>
 								attribute).</p>
 						</section>
@@ -8678,17 +8698,18 @@ No Entry</pre>
 				<section id="sec-docs-structural-semantic">
 					<h4>Structural semantics in overlays</h4>
 
-					<p>To express <a href="#app-structural-semantics">structural semantics</a> in <a>media overlay
-							documents</a>, EPUB creators MAY specify the [^/epub:type^] attribute on [^par^], [^seq^],
-						and [^body^] elements.</p>
+					<p>To express <a href="#app-structural-semantics">structural semantics</a> in [=media overlay
+						documents=], [=EPUB creators=] MAY specify the [^/epub:type^] attribute on [^par^], [^seq^], and
+						[^body^] elements.</p>
 
-					<p>The <code>epub:type</code> attribute facilitates reading system behavior appropriate for the
+					<p>The <code>epub:type</code> attribute facilitates [=reading system=] behavior appropriate for the
 						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
 							>skippability and escapability</a> and <a data-cite="epub-rs-33#note-table-reading-mode"
 							>table reading mode</a> [[?epub-rs-33]].</p>
 
-					<p>Media overlay documents MAY use the applicable <a href="#sec-vocab-assoc">vocabulary association
-							mechanisms</a> for the <code>epub:type</code> attribute to define additional semantics.</p>
+					<p>[=Media overlay documents=] MAY use the applicable <a href="#sec-vocab-assoc">vocabulary
+							association mechanisms</a> for the <code>epub:type</code> attribute to define additional
+						semantics.</p>
 
 					<aside class="example" title="Semantic markup for a media overlay document containing a figure">
 						<pre>&lt;smil
@@ -8733,10 +8754,10 @@ No Entry</pre>
 				<section id="sec-docs-assoc-style">
 					<h4>Associating style information</h4>
 
-					<p>EPUB creators MAY express visual rendering information for the currently playing <a>EPUB content
-							document</a> element in a CSS Style Sheet using author-defined classes.</p>
+					<p>[=EPUB creators=] MAY express visual rendering information for the currently playing [=EPUB
+						content document=] element in a CSS Style Sheet using author-defined classes.</p>
 
-					<p>When used, EPUB creators MUST declare the class names in the package document using the <a
+					<p>When used, EPUB creators MUST declare the class names in the [=package document=] using the <a
 							href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
 								><code>playback-active-class</code></a> properties.</p>
 
@@ -8747,9 +8768,9 @@ No Entry</pre>
 						properties.</p>
 
 					<p>EPUB creators MAY define any CSS properties for the specified CSS classes but must ensure that
-						each EPUB content document with an associated media overlay document includes a CSS stylesheet
-						(either embedded or linked) containing the class definitions. In the absence of such definitions
-						reading systems might provide their own styling, or no styling at all.</p>
+						each EPUB content document with an associated [=media overlay document=] includes a CSS
+						stylesheet (either embedded or linked) containing the class definitions. In the absence of such
+						definitions [=reading systems=] might provide their own styling, or no styling at all.</p>
 
 					<p>EPUB creators MUST NOT use the <code>active-class</code> and <code>playback-active-class</code>
 						properties in conjunction with a <a href="#attrdef-refines"><code>refines</code> attribute</a>
@@ -8819,13 +8840,12 @@ html.my-document-playing * {
 
 						<p>The reading system would also apply the author-defined <code>my-document-playing</code> class
 							to the document element of the EPUB content document when media overlays playback begins.
-							The reading system would remove the class name when playback stops. In the case of an XHTML
-							content document, the reading system would apply the class name to the <code>html</code>
-							element. In the case of an SVG content document, the reading system would apply the class
-							name to the <code>svg</code> element. The user would see all the inactive text elements turn
-							gray during media overlays playback. When playback stopped, the elements' colors would
-							return to their defaults.</p>
-
+							The reading system would remove the class name when playback stops. In the case of an
+							[=XHTML content document=], the reading system would apply the class name to the [^html^]
+							element [[?html]]. In the case of an [=SVG content document=], the reading system would
+							apply the class name to the [^svg^] element [[svg]]. The user would see all the inactive
+							text elements turn gray during media overlays playback. When playback stopped, the elements'
+							colors would return to their defaults.</p>
 					</aside>
 				</section>
 
@@ -8835,13 +8855,14 @@ html.my-document-playing * {
 					<section id="sec-package-including">
 						<h5>Including media overlays</h5>
 
-						<p>If an [=EPUB content document=] is wholly or partially referenced by a <a>media overlay
-								document</a>, then its [=EPUB manifest | manifest=] [^item^] element MUST specify a
-								<code>media-overlay</code> attribute. The attribute MUST reference the ID [[xml]] of the
-							manifest <code>item</code> for the corresponding media overlay document.</p>
+						<p>If an [=EPUB content document=] is wholly or partially referenced by a [=media overlay
+							document=], then its [=EPUB manifest | manifest=] [^item^] element MUST specify a
+								<code>media-overlay</code> attribute. The attribute MUST reference the <a
+								data-cite="xml#id">ID</a> [[xml]] of the manifest <code>item</code> for the
+							corresponding media overlay document.</p>
 
-						<p>EPUB creators MUST only specify the <code>media-overlay</code> attribute on manifest
-								<code>item</code> elements that reference [=EPUB content documents=].</p>
+						<p>[=EPUB creators=] MUST only specify the <code>media-overlay</code> attribute on manifest
+								<code>item</code> elements that reference EPUB content documents.</p>
 
 						<p>Manifest items for media overlay documents MUST have the media type
 								<code>application/smil+xml</code>.</p>
@@ -8870,11 +8891,11 @@ html.my-document-playing * {
 					<section id="sec-mo-package-metadata">
 						<h5>Overlays package metadata</h5>
 
-						<p id="total-duration">EPUB creators MUST specify the duration of the entire <a>EPUB
-								publication</a> in the [=package document=] using a [^meta^] element with the <a
+						<p id="total-duration">[=EPUB creators=] MUST specify the duration of the entire [=EPUB
+							publication=] in the [=package document=] using a [^meta^] element with the <a
 								href="#duration"><code>duration</code> property</a>.</p>
 
-						<p>In addition, EPUB creators MUST provide the duration of each media overlay document. EPUB
+						<p>In addition, EPUB creators MUST provide the duration of each [=media overlay document=]. EPUB
 							creators MUST use the <a href="#attrdef-refines"><code>refines</code> attribute</a> to
 							associate each duration declaration to the corresponding [=EPUB manifest | manifest=]
 							[^item^].</p>
@@ -8890,7 +8911,7 @@ html.my-document-playing * {
 
 						<p>[=EPUB creators=] MAY also specify <a href="#narrator"><code>narrator</code></a> information
 							in the package document, as well as <a href="#sec-docs-assoc-style">author-defined CSS class
-								names</a> to apply to the currently playing EPUB content document element.</p>
+								names</a> to apply to the currently playing [=EPUB content document=] element.</p>
 
 						<div class="note">
 							<p>The <code>media:</code> prefix is <a href="#sec-metadata-reserved-prefixes">reserved</a>
@@ -8954,11 +8975,11 @@ html.my-document-playing * {
 
 					<p>While reading, users may want to turn on or off certain features of the content, such as
 						footnotes, page numbers, or other types of secondary content. This feature is called
-						skippability. Reading systems use the semantic information provided by media overlay elements'
-							<a href="#sec-docs-structural-semantic"><code>epub:type</code></a> attribute to determine
-						when to offer users the option of skippable features.</p>
+						skippability. [=Reading systems=] use the semantic information provided by media overlay
+						elements' <a href="#sec-docs-structural-semantic"><code>epub:type</code></a> attribute to
+						determine when to offer users the option of skippable features.</p>
 
-					<p>EPUB creators MAY use the following semantics to enable skippability:</p>
+					<p>[=EPUB creators=] MAY use the following semantics to enable skippability:</p>
 
 					<ul>
 						<li>
@@ -9053,7 +9074,7 @@ html.my-document-playing * {
 						of items, but provides an exit from them (e.g., a user can listen to some of the content before
 						choosing to escape).</p>
 
-					<p>EPUB creators MAY use the following semantics to enable escapability:</p>
+					<p>[=EPUB creators=] MAY use the following semantics to enable escapability:</p>
 
 					<ul>
 						<li>
@@ -9071,7 +9092,7 @@ html.my-document-playing * {
 					</ul>
 
 					<p>This list is non-exhaustive list, however. It represents terms from the Structural Semantics
-						Vocabulary [[?epub-ssv-11]] for which reading systems are most likely to offer the option of
+						Vocabulary [[?epub-ssv-11]] for which [=reading systems=] are most likely to offer the option of
 						escapability.</p>
 
 					<div class="note">
@@ -9083,7 +9104,7 @@ html.my-document-playing * {
 					</div>
 
 					<aside class="example" title="Escapable structures">
-						<p>In this example, the media overlay document for an EPUB content document contains a
+						<p>In this example, the [=media overlay document=] for an [=EPUB content document=] contains a
 							paragraph, a table, and another paragraph. A reading system that supported escapability
 							would give the user the option to interrupt playback of the table to continue playing the
 							next paragraph.</p>
@@ -9207,10 +9228,10 @@ html.my-document-playing * {
 				<h3>Navigation document overlays</h3>
 
 				<p>As the [=EPUB navigation document=] is an [=XHTML content document=], [=EPUB creators=] may associate
-					a media overlay document with it. Unlike traditional XHTML content documents, however, [=reading
+					a [=media overlay document=] with it. Unlike traditional XHTML content documents, however, [=reading
 					systems=] must present the EPUB navigation document to users even when it is not included in the
 					[=EPUB spine | spine=] (see <a data-cite="epub-rs-33#sec-nav">Navigation document processing</a>
-					[[epub-rs-33]]). As a result, the method in which an associated Media Overlay behaves can change
+					[[epub-rs-33]]). As a result, the method in which an associated media overlay behaves can change
 					depending on the context:</p>
 
 				<ul>
@@ -9227,8 +9248,8 @@ html.my-document-playing * {
 				<div class="note">
 					<p>Specific implementation details are beyond the scope of this specification. The <a
 							href="https://daisy.org/info-help/document-archive/archived-publications/media-overlays-playback-requirements/"
-							>DAISY Media Overlays Playback Requirements</a> document describes best practices for EPUB
-						creators and provides recommendations for reading system developers.</p>
+							>DAISY Media Overlays Playback Requirements</a> document describes best practices for [=EPUB
+						creators=] and provides recommendations for reading system developers.</p>
 				</div>
 			</section>
 		</section>
@@ -9240,11 +9261,11 @@ html.my-document-playing * {
 
 			<p>The requirements and practices for creating accessible web content have already been documented in the
 				W3C's <a href="https://www.w3.org/TR/WCAG2/">Web Content Accessibility Guidelines (WCAG)</a> [[wcag2]].
-				These guidelines also form the basis for defining accessibility in EPUB publications.</p>
+				These guidelines also form the basis for defining accessibility in [=EPUB publications=].</p>
 
 			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, <a
 					data-cite="epub-a11y-11#">EPUB Accessibility</a> [[epub-a11y-11]], defines how to apply the standard
-				to [=EPUB publications=]. It also adds EPUB-specific requirements and recommendations for metadata,
+				to EPUB publications. It also adds EPUB-specific requirements and recommendations for metadata,
 				pagination, and media overlays.</p>
 
 			<p>This specification recommends that EPUB publications <a href="#confreq-a11y">conform to the accessibility
@@ -9278,13 +9299,13 @@ html.my-document-playing * {
 				<p>This means that EPUB 3's security and privacy issues are primarily linked to the features of those
 					formats, and closely mirror the threats presented by web content.</p>
 
-				<p>Although content risks are often equated with deliberately malicious authoring intent, EPUB creators
-					need to be aware that many practices followed with the best of intentions may expose users to
-					privacy and security issues. The rest of this section explores the risk model of EPUB 3 with the aim
-					of helping EPUB creators recognize and mitigate these risks.</p>
+				<p>Although content risks are often equated with deliberately malicious authoring intent, [=EPUB
+					creators=] need to be aware that many practices followed with the best of intentions may expose
+					users to privacy and security issues. The rest of this section explores the risk model of EPUB 3
+					with the aim of helping EPUB creators recognize and mitigate these risks.</p>
 
 				<div class="note">
-					<p>For the risks associated with reading systems, refer to the <a
+					<p>For the risks associated with [=reading systems=], refer to the <a
 							data-cite="epub-rs-33#sec-security-privacy">security and privacy section</a> of
 						[[epub-rs-33]].</p>
 				</div>
@@ -9293,11 +9314,11 @@ html.my-document-playing * {
 			<section id="epub-threat-model" class="informative">
 				<h3>Threat model</h3>
 
-				<p>EPUB publications pose a variety of privacy and security threats to unsuspecting users. Many of these
-					threats intersect with web content, but EPUB also introduces its own unique methods of attack that
-					can be used to trick users into accessing malicious content or into providing sensitive information.
-					Some of the more important attack vectors that EPUB creators and users need to be aware of
-					include:</p>
+				<p>[=EPUB publications=] pose a variety of privacy and security threats to unsuspecting users. Many of
+					these threats intersect with web content, but EPUB also introduces its own unique methods of attack
+					that can be used to trick users into accessing malicious content or into providing sensitive
+					information. Some of the more important attack vectors that [=EPUB creators=] and users need to be
+					aware of include:</p>
 
 				<dl>
 					<dt>Embedding of remote resources</dt>
@@ -9312,11 +9333,11 @@ html.my-document-playing * {
 							always the possibility that users may receive compromised resources.</p>
 						<p>Checking for malware and exploits at distribution time is not always reliable, either, as the
 							malicious content can be swapped in any time after publication, unlike resources that come
-							embedded in the EPUB container.</p>
+							embedded in the [=EPUB container=].</p>
 						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB creator
 							and specific to each reading system implementation. Consequently, if the EPUB creator hosts
-							remote resources on a web server they control, the server effectively cannot use security
-							features that require specifying allowable origins, such as headers for <a
+							[=remote resources=] on a web server they control, the server effectively cannot use
+							security features that require specifying allowable origins, such as headers for <a
 								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
 								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
 									><code>Content-Security-Policy</code></a>, or <a
@@ -9356,8 +9377,8 @@ html.my-document-playing * {
 							<li>collecting information about the user and their activities, whether malicious or
 								not;</li>
 							<li>attempting to access the file system and local storage to harvest information;</li>
-							<li>phishing attempts (e.g., making an EPUB content document appear like a trusted web site
-								to get the user to submit login information); and</li>
+							<li>phishing attempts (e.g., making an [=EPUB content document=] appear like a trusted web
+								site to get the user to submit login information); and</li>
 							<li>injecting malicious content from external sites into the EPUB publication.</li>
 						</ul>
 						<p>Network access may allow third-party content to exploit the user even if it was not the EPUB
@@ -9416,19 +9437,19 @@ html.my-document-playing * {
 					</ul>
 
 					<p>The one potential exception is the <a data-cite="epub-rs-33#app-epubReadingSystem"
-								><code>epubReadingSystem</code> object</a> [[epub-rs-33]] that allows EPUB creators to
-						query information about the current reading system. EPUB creators need to be mindful that they
-						only use the information exposed by this object to improve the rendering of their content (i.e.,
-						avoid using the information to profile the user and their environment).</p>
+								><code>epubReadingSystem</code> object</a> [[epub-rs-33]] that allows [=EPUB creators=]
+						to query information about the current [=reading system=]. EPUB creators need to be mindful that
+						they only use the information exposed by this object to improve the rendering of their content
+						(i.e., avoid using the information to profile the user and their environment).</p>
 				</section>
 			</section>
 
 			<section id="security-privacy-recommendations">
 				<h3>Recommendations</h3>
 
-				<p>Although EPUB creators cannot prevent every method of exploiting users, they are ultimately
+				<p>Although [=EPUB creators=] cannot prevent every method of exploiting users, they are ultimately
 					responsible for the secure construction of their content. That means that they need to take
-					precautions to limit the exposure of their EPUB publications to the types of <a
+					precautions to limit the exposure of their [=EPUB publications=] to the types of <a
 						href="#epub-threat-model">malicious exploits</a> described in the previous section.</p>
 
 				<p>Some practical steps include:</p>
@@ -9465,7 +9486,7 @@ html.my-document-playing * {
 				<p>When collecting and storing user information within an EPUB publication (e.g., through the use of <a
 						data-cite="html#dom-document-cookie">cookies</a> and <a data-cite="html#webstorage">web
 						storage</a> [[?html]]), EPUB creators need to consider to potential for data theft by other EPUB
-					publications on a reading system. Although [[epub-rs-33]] introduces a <a
+					publications on a [=reading system=]. Although [[epub-rs-33]] introduces a <a
 						data-cite="epub-rs-33#sec-container-iri">unique origin requirement</a> for EPUB publications,
 					which limits the potential for attacks, there is still a risk that reading systems will allow EPUB
 					publications access to shared persistent storage (e.g., older reading systems that have not been
@@ -9489,10 +9510,10 @@ html.my-document-playing * {
 		<section id="app-overview-unsupported" class="appendix">
 			<h2>Unsupported features</h2>
 
-			<p>This specification contains certain features that are not yet fully supported in reading systems, that
-				the Working Group no longer recommends for use, or that are only retained for interoperability with EPUB
-				2 reading systems. This section defines the meanings of the designations attached to these features and
-				their support expectations.</p>
+			<p>This specification contains certain features that are not yet fully supported in [=reading systems=],
+				that the Working Group no longer recommends for use, or that are only retained for interoperability with
+				EPUB 2 reading systems. This section defines the meanings of the designations attached to these features
+				and their support expectations.</p>
 
 			<section id="under-implemented">
 				<h3>Under-implemented features</h3>
@@ -9503,14 +9524,14 @@ html.my-document-playing * {
 						experience</a>.</p>
 
 				<p>These features are considered important to retain despite this limitation because they are known to
-					be implemented by EPUB creators (i.e., their deprecation would invalidate existing content) and/or
-					they are integral to the content model on which EPUB is built.</p>
+					be implemented by [=EPUB creators=] (i.e., their deprecation would invalidate existing content)
+					and/or they are integral to the content model on which EPUB is built.</p>
 
 				<p>If this specification designates a feature as under-implemented, the following hold true:</p>
 
 				<ul>
 					<li>
-						<p>[=EPUB creators=] MAY use the features as described.</p>
+						<p>EPUB creators MAY use the features as described.</p>
 					</li>
 					<li>
 						<p>[=Reading systems=] SHOULD support the feature as described.</p>
@@ -9541,16 +9562,16 @@ html.my-document-playing * {
 				<h3>Deprecated features</h3>
 
 				<p>A <strong>deprecated</strong> feature is one the Working Group no longer recommends for use in this
-					version of the specification. Deprecated features typically have limited or no support in reading
-					systems and/or usage in EPUB publications. If this specification designates a feature as deprecated,
-					the following hold true:</p>
+					version of the specification. Deprecated features typically have limited or no support in [=reading
+					systems=] and/or usage in [=EPUB publications=]. If this specification designates a feature as
+					deprecated, the following hold true:</p>
 
 				<ul>
 					<li>
-						<p>[=EPUB creators=] SHOULD NOT use the feature in their [=EPUB publications=].</p>
+						<p>[=EPUB creators=] SHOULD NOT use the feature in their EPUB publications.</p>
 					</li>
 					<li>
-						<p>[=Reading systems=] MAY support the feature.</p>
+						<p>Reading systems MAY support the feature.</p>
 						<p class="note">Developers should consider the unlikelihood of encountering content with
 							deprecated features before adding new support for them.</p>
 					</li>
@@ -9594,8 +9615,8 @@ html.my-document-playing * {
 					<a data-cite="xml#dt-sysid">system identifiers</a> [[xml]] allowed in <a data-cite="xml#dt-doctype"
 					>document type declarations</a>. [[xml]]</p>
 
-			<p>EPUB creators MAY use these external identifiers only in [=publication resources=] with the listed media
-				types specified in their [=EPUB manifest | manifest=] declarations. (Refer to <a
+			<p>[=EPUB creators=] MAY use these external identifiers only in [=publication resources=] with the listed
+				media types [[rfc2046]] specified in their [=EPUB manifest | manifest=] declarations. (Refer to <a
 					href="#sec-xml-constraints"></a> for more information.)</p>
 
 			<table class="zebra">
@@ -9660,22 +9681,22 @@ html.my-document-playing * {
 				<h3>Introduction</h3>
 
 				<p>Structural semantics add additional meaning about the specific structural purpose an element plays.
-					The [^/epub:type^] attribute is used to express domain-specific semantics in <a>EPUB content
-						documents</a> and [=media overlay documents=], with the structural information it carries
+					The [^/epub:type^] attribute is used to express domain-specific semantics in [=EPUB content
+					documents=] and [=media overlay documents=], with the structural information it carries
 					complementing the underlying vocabulary.</p>
 
 				<p>The applied semantics refine the meaning of their containing elements without changing their nature
 					for assistive technologies, as happens when using the similar [^/role^] attribute [[html]]. The
-					attribute does not enhance the accessibility of the content, in other words, only provides hints
+					attribute does not enhance the accessibility of the content, in other words; it only provides hints
 					about the purpose.</p>
 
 				<p>Semantic metadata enriches content for use in publishing workflows and for author-defined purposes.
-					It also allows reading systems to learn more about the structure and content of a document (e.g., to
-					enable <a href="#sec-behaviors-skip-escape">skippability and escapability</a> in media
+					It also allows [=reading systems=] to learn more about the structure and content of a document
+					(e.g., to enable <a href="#sec-behaviors-skip-escape">skippability and escapability</a> in media
 					overlays).</p>
 
 				<p>This specification defines a method for adding structural semantics using <em>the attribute
-					axis</em>: instead of adding new elements, EPUB creators can append the <code>epub:type</code>
+					axis</em>: instead of adding new elements, [=EPUB creators=] can append the <code>epub:type</code>
 					attribute to existing elements to add the desired semantics.</p>
 			</section>
 
@@ -9700,8 +9721,8 @@ html.my-document-playing * {
 
 					<dt>Usage:</dt>
 					<dd>
-						<p><a data-cite="html#global-attributes">Global attribute</a>. EPUB creators MAY specify on all
-							elements.</p>
+						<p><a data-cite="html#global-attributes">Global attribute</a>. [=EPUB creators=] MAY specify on
+							all elements.</p>
 					</dd>
 
 					<dt>Value:</dt>
@@ -9723,9 +9744,9 @@ html.my-document-playing * {
 						roles influence how assistive technologies understand such elements.</p>
 
 					<p>The <code>epub:type</code> attribute is consequently only intended for publishing semantics and
-						reading system enhancements. Reading systems may use <code>epub:type</code> values to provide
-						accessibility enhancements like built-in read aloud or media overlays functionality where
-						interaction with assistive technologies is not essential.</p>
+						[=reading system=] enhancements. Reading systems may use <code>epub:type</code> values to
+						provide accessibility enhancements like built-in read aloud or media overlays functionality
+						where interaction with assistive technologies is not essential.</p>
 
 					<p>Refer to <a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA
 						Module</a> [[?dpub-aria]] for more information about accessible publishing roles.</p>
@@ -9815,18 +9836,18 @@ html.my-document-playing * {
 					<p>A <var>property</var> value is like a CURIE [[rdfa-core]] &#8212; it represents a URL [[url]] in
 						compact form. The expression consists of a prefix and a reference, where the prefix — whether
 						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
-						vocabulary. When a reading system converts the prefix to its URL representation and combines
+						vocabulary. When a [=reading system=] converts the prefix to its URL representation and combines
 						with the reference, the resulting URL normally resolves to a fragment within that vocabulary
 						that contains human- and/or machine-readable information about the term.</p>
 
 					<p>To reduce the complexity for authoring, each attribute that takes a <var>property</var> data type
 						also defines a <a href="#sec-default-vocab">default vocabulary</a>. Terms and properties
-						referenced from the default vocabularies do not include a prefix as the mapping <a>reading
-							systems</a> use to map to a URL is predefined.</p>
+						referenced from the default vocabularies do not include a prefix as the mapping reading systems
+						use to map to a URL is predefined.</p>
 
 					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
-						terms and properties, EPUB creators only need to declare a <a href="#sec-prefix-attr"
-						>prefix</a>. In another authoring convenience, this specification also <a
+						terms and properties, [=EPUB creators=] only need to declare a <a href="#sec-prefix-attr"
+							>prefix</a>. In another authoring convenience, this specification also <a
 							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
 						publishing vocabularies (i.e., their declaration is optional).</p>
 
@@ -9895,7 +9916,7 @@ html.my-document-playing * {
 								prefix</a> that maps to the URL "<code>http://purl.org/dc/terms/</code>".</p>
 					</aside>
 
-					<p>When an EPUB creator omits a prefix from a <var>property</var> value, the expressed reference
+					<p>When an [=EPUB creator=] omits a prefix from a <var>property</var> value, the expressed reference
 						represents a term from the <a href="#sec-default-vocab">default vocabulary</a> for that
 						attribute.</p>
 
@@ -9919,7 +9940,7 @@ html.my-document-playing * {
 				<section id="sec-default-vocab">
 					<h5>Default vocabularies</h5>
 
-					<p>A default vocabulary is one that EPUB creators do not have to declare a <a
+					<p>A default vocabulary is one that [=EPUB creators=] do not have to declare a <a
 							href="#sec-prefix-attr">prefix</a> for in order to use its terms and properties where a <a
 							href="#sec-property-datatype"><var>property</var> value</a> is expected. EPUB creators MUST
 						NOT add a prefix to terms and properties from a default vocabulary.</p>
@@ -10002,8 +10023,8 @@ html.my-document-playing * {
 						</tr>
 					</table>
 
-					<p>EPUB creators MUST only specify the <code>prefix</code> attribute on the root element of the
-						respective format.</p>
+					<p>[=EPUB creators=] MUST only specify the <code>prefix</code> attribute on the <a
+							data-cite="xml#dt-root">root element</a> [[xml]] of the respective format.</p>
 
 					<p>The attribute is not namespaced when used in the [=package document=].</p>
 
@@ -10020,8 +10041,8 @@ html.my-document-playing * {
 					</aside>
 
 					<p>EPUB creators MUST declare the attribute in the namespace
-							<code>http://www.idpf.org/2007/ops</code> in [=EPUB content documents=] and <a>media overlay
-							documents</a>.</p>
+							<code>http://www.idpf.org/2007/ops</code> in [=EPUB content documents=] and [=media overlay
+						documents=].</p>
 
 					<aside class="example" title="Declaring prefixes in an XHTML content document">
 						<p>In this example, the EPUB creator declares a prefix for the Z39.98 Structural Semantics
@@ -10068,11 +10089,11 @@ html.my-document-playing * {
 					<h4>Reserved prefixes</h4>
 
 					<div class="caution">
-						<p>Although reserved prefixes are an authoring convenience, EPUB creators should avoid relying
-							on them as they may cause interoperability issues. [=EPUB conformance checkers=] will often
-							reject new prefixes until their developers update the tools to the latest version of the
-							specification, for example. EPUB creators should declare all prefixes they use to avoid such
-							issues.</p>
+						<p>Although reserved prefixes are an authoring convenience, [=EPUB creators=] should avoid
+							relying on them as they may cause interoperability issues. [=EPUB conformance checkers=]
+							will often reject new prefixes until their developers update the tools to the latest version
+							of the specification, for example. EPUB creators should declare all prefixes they use to
+							avoid such issues.</p>
 					</div>
 
 					<p>[=EPUB creators=] MAY use reserved prefixes in attributes that expect a <a
@@ -10175,7 +10196,8 @@ html.my-document-playing * {
 
 					<dt>Applies To</dt>
 					<dd>
-						<p>Specifies which publication resource type(s) EPUB creators MAY specify the property on.</p>
+						<p>Specifies which publication resource type(s) [=EPUB creators=] MAY specify the property
+							on.</p>
 						<p>This field appears for properties used in the <a href="#attrdef-properties"
 									><code>properties</code> attribute</a>.</p>
 					</dd>
@@ -10230,8 +10252,8 @@ html.my-document-playing * {
 			<p>This appendix describes the prefixed CSS properties supported by EPUB. </p>
 
 			<p class="note">The prefix definitions are no longer being synchronized with their CSS counterparts. In some
-				cases, the unprefixed versions of these properties now support additional values. Reading systems may
-				not support the new syntax with the prefixed properties, so EPUB creators are advised to use the
+				cases, the unprefixed versions of these properties now support additional values. [=Reading systems=]
+				may not support the new syntax with the prefixed properties, so [=EPUB creators=] are advised to use the
 				unprefixed versions for newer features.</p>
 
 			<section id="sec-css-prefixed-writing-modes">
@@ -10598,7 +10620,7 @@ html.my-document-playing * {
 			<section id="app-package-schema">
 				<h3>Package document schema</h3>
 
-				<p>A schema for package documents is available at <a
+				<p>A schema for [=package documents=] is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
 						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.</p>
 
@@ -10622,7 +10644,8 @@ html.my-document-playing * {
 				<section id="app-schema-container">
 					<h4>Schema for <code>container.xml</code></h4>
 
-					<p>A schema for <code>container.xml</code> files is available at <a
+					<p>A schema for <a href="#sec-container-metainf-container.xml"><code>container.xml</code> files</a>
+						is available at <a
 							href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl">
 							<code>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl</code></a>.</p>
 
@@ -10633,22 +10656,22 @@ html.my-document-playing * {
 				<section id="app-schema-encryption">
 					<h4>Schema for <code>encryption.xml</code></h4>
 
-					<p>The schema for <code>encryption.xml</code> files is included in
-						[[xmlsec-rngschema-20130411]].</p>
+					<p>The schema for <a href="#sec-container-metainf-encryption.xml"><code>encryption.xml</code>
+							files</a> is included in [[xmlsec-rngschema-20130411]].</p>
 				</section>
 
 				<section id="app-schema-signatures">
 					<h4>Schema for <code>signatures.xml</code></h4>
 
-					<p>The schema for <code>signatures.xml</code> files is included in
-						[[xmlsec-rngschema-20130411]].</p>
+					<p>The schema for <a href="#sec-container-metainf-signatures.xml"><code>signatures.xml</code>
+							files</a> is included in [[xmlsec-rngschema-20130411]].</p>
 				</section>
 			</section>
 
 			<section id="app-schema-overlays">
 				<h3>Media overlays schema</h3>
 
-				<p>A schema for media overlay documents is available at <a
+				<p>A schema for [=media overlay documents=] is available at <a
 						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl"
 						>https://github.com/w3c/epubcheck/tree/main/src/master/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl</a>.</p>
 
@@ -10667,7 +10690,7 @@ html.my-document-playing * {
 			<section id="publication-resources-example">
 				<h3>Resources</h3>
 
-				<p>Consider the following extracts of a [=package document=] and an <a>XHTML content document</a>:</p>
+				<p>Consider the following extracts of a [=package document=] and an [=XHTML content document=]:</p>
 
 				<pre>&lt;package …>
     &lt;metadata …>
@@ -10763,141 +10786,135 @@ html.my-document-playing * {
 				<dl>
 					<dt><code>meta/data.xml</code></dt>
 					<dd>
-						<p>The resource is a metadata record, stored in the container. It is linked via a [^link^]
-							element in the package document metadata. It is therefore a [=linked resource=] on the
-							[=manifest plane=], i.e., is not listed in the [=EPUB manifest | manifest=]. It is not part
-							on any other planes. </p>
+						<p>The resource is a metadata record, stored in the [=EPUB container=]. It is linked via a
+							[^link^] element in the package document metadata. It is therefore a [=linked resource=] on
+							the [=manifest plane=] (i.e., is not listed in the [=EPUB manifest | manifest=]). It is not
+							part on any other planes. </p>
 					</dd>
 
 					<dt><code>https://www.example.org/meta/data2.xml</code></dt>
 					<dd>
 						<p>The resource is a metadata record, stored remotely. It is linked via a [^link^] element in
-							the package document metadata. It is therefore a [=linked resource=] on the [=manifest
-							plane=], i.e., is not listed in the [=EPUB manifest | manifest=]. It is not part on any
-							other planes.</p>
+							the package document metadata. It is therefore a linked resource on the manifest plane,
+							(i.e., it is not listed in the manifest). It is not part on any other planes.</p>
 					</dd>
 
 					<dt><code>page.xhtml</code></dt>
 					<dd>
-						<p>The resource is an XHTML document. It is listed in the spine. It is a <a>publication
-								resource</a> on the [=manifest plane=], a [=container resource=], an <a>EPUB content
-								document</a> on the [=spine plane=], and is not present on the <a>content plane</a>. No
-							fallback is necessary.</p>
+						<p>The resource is an XHTML document. It is listed in the [[EPUB spine | spine=]. It is a
+							[=publication resource=] on the manifest plane, a [=container resource=], an [=EPUB content
+							document=] on the [=spine plane=], and is not present on the [=content plane=]. No fallback
+							is necessary.</p>
 					</dd>
 
 					<dt><code>nav.xhtml</code></dt>
 					<dd>
 						<p>The resource is the [=EPUB navigation document=]. It is not listed in the spine. It is a
-							[=publication resource=] on the [=manifest plane=], a [=container resource=], and is not
-							present on either the [=spine plane=] or the [=content plane=]. No fallback is
-							necessary.</p>
+							publication resource on the manifest plane, a container resource, and is not present on
+							either the spine plane or the content plane. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>style.css</code></dt>
 					<dd>
 						<p>The resource is a CSS file. It is not listed in the spine but is referenced from an [[html]]
-								<a data-cite="html#the-link-element"><code>link</code></a> element. It is a
-							[=publication resource=] on the [=manifest plane=], a [=container resource=], is not present
-							on the <a>spine plane</a>, and is a [=core media type resource=] on the [=content plane=].
-							No fallback is necessary.</p>
+								<a data-cite="html#the-link-element"><code>link</code></a> element. It is a publication
+							resource on the manifest plane, a container resource, is not present on the spine plane, and
+							is a [=core media type resource=] on the content plane. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.otf</code></dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
-							CSS file. It is a [=publication resource=] on the [=manifest plane=], is a [=container
-							resource=], is not present on the [=spine plane=], and is a <a>core media type resource</a>
-							on the [=content plane=]. No fallback is necessary.</p>
+							CSS file. It is a publication resource on the manifest plane, is a container resource, is
+							not present on the spine plane, and is a core media type resource on the content plane. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>https://www.example.org/fonts/font-file2.otf</code></dt>
 					<dd>
 						<p>The resource is a TrueType font file. It is not listed in the spine but is referenced from a
-							CSS file. It is a [=publication resource=] on the [=manifest plane=], is a <a>remote
-								resource</a>, is not present on the [=spine plane=], and is a <a>core media type
-								resource</a> on the [=content plane=]. No fallback is necessary.</p>
+							CSS file. It is a publication resource on the manifest plane, is a [=remote resource=], is
+							not present on the spine plane, and is a core media type resource on the content plane. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>font/font-file.cff</code></dt>
 					<dd>
 						<p>The resource is a font file in Compact Font Format. It is not listed in the spine but is
 							referenced from a CSS file. Its media type is not listed as a <a
-								href="#sec-core-media-types">core media type</a>. It is a [=publication resource=] on
-							the [=manifest plane=], a [=container resource=], is not present on the <a>spine plane</a>,
-							and is an [=exempt resource=] on the [=content plane=]. No fallback is necessary.</p>
+								href="#sec-core-media-types">core media type</a>. It is a publication resource on the
+							manifest plane, a container resource, is not present on the spine plane, and is an [=exempt
+							resource=] on the content plane. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>speech/cmn.pls</code></dt>
 					<dd>
 						<p>The resource is a Pronunciation Lexicon file. It is not listed in the spine but is referenced
 							from an [[html]] <a data-cite="html#the-link-element"><code>link</code></a> element. It is a
-								<a>publication resource</a> on the [=manifest plane=], a [=container resource=], not
-							present on the [=spine plane=], and is an [=exempt resource=] on the [=content plane=]. No
-							fallback is necessary.</p>
+							publication resource on the manifest plane, a container resource, not present on the spine
+							plane, and is an exempt resource on the content plane. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_1.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
-							[[html]] [^img^] element. It is a [=publication resource=] on the [=manifest plane=], a
-							[=container resource=], is not present on the <a>spine plane</a>, and is a [=core media type
-							resource=] on the [=content plane=]. No fallback is necessary.</p>
+							[[html]] [^img^] element. It is a publication resource on the manifest plane, a container
+							resource, is not present on the spine plane, and is a core media type resource on the
+							content plane. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_2.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is referenced via an [[html]] [^a^] element. Because it
-							is referenced from a hyperlink, it <em>must</em> be listed in the spine. It is a
-							[=publication resource=] on the [=manifest plane=], a [=container resource=], a [=foreign
-							content document=] on the [=spine plane=], and a [=core media type resource=] on the
-							[=content plane=]. As a [=foreign content document=] a fallback is required, which is
-							provided via a <a href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
+							is referenced from a hyperlink, it <em>must</em> be listed in the spine. It is a publication
+							resource on the manifest plane, a container resource, a [=foreign content document=] on the
+							spine plane, and a core media type resource on the content plane. As a foreign content
+							document, a fallback is required, which is provided via a <a href="#sec-manifest-fallbacks"
+								>manifest fallback</a>.</p>
 					</dd>
 
 					<dt><code>image_desc.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is the "target" of a manifest fallback so is not
 							explicitly listed in the spine (but it "replaces" the existing spine item when needed). It
-							is a [=publication resource=] on the [=manifest plane=], a [=container resource=], an EPUB
-							content document on [=spine plane=], and, because it is not "used" when rendering another
-							EPUB content document, it is not present on the [=content plane=]. No fallback is
-							necessary.</p>
+							is a publication resource on the manifest plane, a container resource, an EPUB content
+							document on spine plane, and, because it is not "used" when rendering another EPUB content
+							document, it is not present on the content plane. No fallback is necessary.</p>
 					</dd>
 
 					<dt><code>image/image_3.heic</code></dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
 							referenced from an [[html]] [^source^] element. Its media type is not listed as a <a
-								href="#sec-core-media-types">core media type</a>. It is a [=publication resource=] on
-							the [=manifest plane=], a [=container resource=], is not present on the [=spine plane=], and
-							is a [=foreign resource=] on the <a>content plane</a>. As a [=foreign resource=], a fallback
-							is required, which is provided via the sibling [[html]] [^img^] element in an [[html]]
-							[^picture^] element.</p>
+								href="#sec-core-media-types">core media type</a>. It is a publication resource on the
+							manifest plane, a container resource, is not present on the spine plane, and is a foreign
+							resource on the content plane. As a foreign resource, a fallback is required, which is
+							provided via the sibling [[html]] [^img^] element in an [[html]] [^picture^] element.</p>
 					</dd>
 
 					<dt><code>image/image_3.png</code></dt>
 					<dd>
 						<p>The resource is a PNG image file. It is not listed in the spine but is referenced from an
 							[[html]] [^img^] element that is used as an intrinsic fallback of the [[html]] [^picture^]
-							element. It is a [=publication resource=] on the [=manifest plane=], a [=container
-							resource=], is not present on the [=spine plane=], and is a [=core media type resource=] on
-							the [=content plane=]. No fallback is necessary.</p>
+							element. It is a publication resource on the manifest plane, a container resource, is not
+							present on the spine plane, and is a core media type resource on the content plane. No
+							fallback is necessary.</p>
 					</dd>
 
 					<dt><code>widget.xhtml</code></dt>
 					<dd>
 						<p>The resource is an XHTML document. It is not listed in the spine but is referenced from an
-							[[html]] [^iframe^] element. It is a <a>publication resource</a> on the [=manifest plane=],
-							a [=container resource=], is not present on [=spine plane=], and, because it is "used" when
-							rendering another EPUB content document, a [=core media type resource=] on the [=content
-							plane=]. No fallback is necessary.</p>
+							[[html]] [^iframe^] element. It is a publication resource on the manifest plane, a container
+							resource, is not present on spine plane, and, because it is "used" when rendering another
+							EPUB content document, a core media type resource on the content plane. No fallback is
+							necessary.</p>
 					</dd>
 
 					<dt><code>https://www.example.org/some_content</code></dt>
 					<dd>
-						<p>The resource is referenced via an [[html]] [^a^] element and is not stored in the [=EPUB
-							container=]. Reading systems will normally open this link via a separate browser instance.
-							It is not on any planes defined by this specification.</p>
+						<p>The resource is referenced via an [[html]] [^a^] element and is not stored in the EPUB
+							container. Reading systems will normally open this link via a separate browser instance. It
+							is not on any planes defined by this specification.</p>
 					</dd>
 				</dl>
 
@@ -10908,7 +10925,7 @@ html.my-document-playing * {
 			<section id="scripted-contexts-example">
 				<h3>Scripting contexts</h3>
 
-				<p>Consider the following example package document:</p>
+				<p>Consider the following example [=package document=]:</p>
 
 				<pre>&lt;package …>
     …
@@ -10933,6 +10950,7 @@ html.my-document-playing * {
     &lt;/spine>
     …
 &lt;/package></pre>
+
 				<p>and the following file <code>scripted01.xhtml</code>:</p>
 
 				<pre>&lt;html …>
@@ -10948,6 +10966,7 @@ html.my-document-playing * {
         …
     &lt;/body>
 &lt;/html></pre>
+
 				<p>and the following file <code>scripted02.xhtml</code>:</p>
 
 				<pre>&lt;html …>
@@ -10959,6 +10978,7 @@ html.my-document-playing * {
         …
     &lt;/body>
 &lt;/html></pre>
+
 				<p>From these examples, it is true that:</p>
 
 				<ul>
@@ -10970,7 +10990,7 @@ html.my-document-playing * {
 					<li>
 						<p>the code in the <code>script</code> element in <code>scripted02.xhtml</code> is a <a
 								href="#sec-scripted-container-constrained">container-constrained script</a> because the
-							HTML file it occurs in is included in <code>scripted01.xhtml</code> via the
+							XHTML document it occurs in is included in <code>scripted01.xhtml</code> via the
 								<code>iframe</code> element.</p>
 					</li>
 				</ul>
@@ -10979,8 +10999,8 @@ html.my-document-playing * {
 			<section id="ocf-example">
 				<h3>Packaged EPUB</h3>
 
-				<p>This example demonstrates the use of the OCF format to contain a signed and encrypted EPUB
-					publication within an [=OCF ZIP container=].</p>
+				<p>This example demonstrates the use of the OCF format to contain a signed and encrypted [=EPUB
+					publication=] within an [=OCF ZIP container=].</p>
 
 				<p>Ordered list of files in the OCF ZIP container:</p>
 
@@ -11420,7 +11440,7 @@ EPUB/images/cover.png</pre>
 				<p>This appendix registers the media type <code>application/epub+zip</code> for the EPUB Open Container
 					Format (OCF).</p>
 
-				<p>An [=OCF ZIP container=], or [=EPUB container=], file is a container technology based on the [[zip]]
+				<p>An OCF ZIP container, or EPUB container, file is a container technology based on the [[zip]]
 					archive format. It is used to encapsulate the EPUB publication. OCF and its related standards are
 					maintained and defined by the <a href="https://www.w3.org">World Wide Web Consortium</a> (W3C).</p>
 

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -9,6 +9,7 @@
 	
 	<section id="sec-cover-image">
 		<h4>cover-image</h4>
+		
 		<table class="tabledef" id="cover-image">
 			<tbody>
 				<tr>
@@ -19,8 +20,8 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>The <code>cover-image</code> property identifies the described publication resource as
-						the cover image for the Publication.</td>
+					<td>The <code>cover-image</code> property identifies the described [=publication resource=] as
+						the cover image for the [=EPUB publication=].</td>
 				</tr>
 				<tr>
 					<th>Applies to:</th>
@@ -35,8 +36,10 @@
 			</tbody>
 		</table>
 	</section>
+	
 	<section id="sec-mathml">
 		<h4>mathml</h4>
+		
 		<table class="tabledef" id="mathml">
 			<tbody>
 				<tr>
@@ -47,7 +50,7 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>The <code>mathml</code> property indicates that the described publication resource
+					<td>The <code>mathml</code> property indicates that the described [=publication resource=]
 						contains one or more instances of MathML markup.</td>
 				</tr>
 				<tr>
@@ -65,8 +68,10 @@
 			</tbody>
 		</table>
 	</section>
+	
 	<section id="sec-nav-prop">
 		<h4>nav</h4>
+		
 		<table class="tabledef" id="nav">
 			<tbody>
 				<tr>
@@ -82,8 +87,7 @@
 				</tr>
 				<tr>
 					<th>Applies to:</th>
-					<td>The [=EPUB navigation document=]
-					</td>
+					<td>The EPUB navigation document</td>
 				</tr>
 				<tr>
 					<th>Cardinality:</th>
@@ -94,8 +98,10 @@
 			</tbody>
 		</table>
 	</section>
+	
 	<section id="sec-remote-resources">
 		<h4>remote-resources</h4>
+		
 		<table class="tabledef" id="remote-resources">
 			<tbody>
 				<tr>
@@ -107,7 +113,8 @@
 				<tr>
 					<th>Description:</th>
 					<td>
-						<p>The <code>remote-resources</code> property indicates that the described publication resource contains one or more internal references to other publication resources
+						<p>The <code>remote-resources</code> property indicates that the described [=publication
+							resource=] contains one or more internal references to other publication resources
 							that are located outside of the [=EPUB container=].</p>
 						<p>Refer to <a href="#sec-resource-locations"></a> for more information.</p>
 					</td>
@@ -127,8 +134,10 @@
 			</tbody>
 		</table>
 	</section>
+	
 	<section id="sec-scripted">
 		<h4>scripted</h4>
+		
 		<table class="tabledef" id="scripted">
 			<tbody>
 				<tr>
@@ -139,7 +148,7 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>The <code>scripted</code> property indicates that the described publication resource is
+					<td>The <code>scripted</code> property indicates that the described [=publication resource=] is
 						a [=scripted content document=] (i.e., contains scripted content and/or HTML form
 						elements).</td>
 				</tr>
@@ -158,8 +167,10 @@
 			</tbody>
 		</table>
 	</section>
+	
 	<section id="sec-svg-prop">
 		<h4>svg</h4>
+		
 		<table class="tabledef" id="svg">
 			<tbody>
 				<tr>
@@ -171,7 +182,7 @@
 				<tr>
 					<th>Description:</th>
 					<td>
-						<p>The <code>svg</code> property indicates that the described publication resource
+						<p>The <code>svg</code> property indicates that the described [=publication resource=]
 							embeds one or more instances of SVG markup.</p>
 						<p>This property MUST be set when SVG markup is included directly in the resource and
 							MAY be set when the SVG is referenced from the resource (e.g., from an [[html]]
@@ -191,8 +202,10 @@
 			</tbody>
 		</table>
 	</section>
+	
 	<section id="sec-switch">
 		<h4>switch</h4>
+		
 		<table class="tabledef" id="switch">
 			<tbody>
 				<tr>
@@ -204,7 +217,7 @@
 				<tr>
 					<th>Description:</th>
 					<td>
-						<p>The <code>switch</code> property indicates that the described publication resource
+						<p>The <code>switch</code> property indicates that the described [=publication resource=]
 							contains one or more instances of the <a href="#sec-xhtml-content-switch"
 									>deprecated <code>epub:switch</code> element</a>.</p>
 					</td>

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -10,6 +10,7 @@
 
 	<section id="sec-page-spread-left">
 		<h4>page-spread-left</h4>
+		
 		<table class="tabledef" id="page-spread-left">
 			<tbody>
 				<tr>
@@ -27,8 +28,10 @@
 			</tbody>
 		</table>
 	</section>
+	
 	<section id="sec-page-spread-right">
 		<h4>page-spread-right</h4>
+		
 		<table class="tabledef" id="page-spread-right">
 			<tbody>
 				<tr>
@@ -46,8 +49,10 @@
 			</tbody>
 		</table>
 	</section>
+	
 	<section id="examples-itemref-properties">
 		<h4>Examples</h4>
+		
 		<aside class="example" id="example-itemref-multicol" title="Identifying a two-page spread in the spine">
 			<pre class="synopsis">&lt;spine&gt;
 &lt;itemref

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -17,6 +17,7 @@
 		
 		<section id="sec-acquire">
 			<h5>acquire</h5>
+			
 			<table class="tabledef" id="acquire">
 				<tbody>
 					<tr>
@@ -52,8 +53,10 @@
 				</tbody>
 			</table>
 		</section>
+		
 		<section id="sec-alternate">
 			<h5>alternate</h5>
+			
 			<table class="tabledef" id="alternate">
 				<tbody>
 					<tr>
@@ -70,13 +73,13 @@
 										<code>alternate</code> keyword</a> for links. It differs as follows:</p>
 							<ul>
 								<li>It cannot be paired with other keywords.</li>
-								<li>If an alternate link is included in the package document metadata, it
+								<li>If an alternate link is included in the [=package document=] metadata, it
 									identifies an alternate representation of the package document in the format
 									specified in the <code>media-type</code> attribute.</li>
 								<li>If an alternate link is included in a [^collection^] element's
 									metadata, it identifies an alternate representation of the <code>collection</code>
 									in the format specified in the <code>media-type</code> attribute.</li>
-								<li>Reading systems do not have to generate hyperlinks for alternate links.</li>
+								<li>[=Reading systems=] do not have to generate hyperlinks for alternate links.</li>
 							</ul>
 						</td>
 					</tr>
@@ -101,6 +104,7 @@
 				</tbody>
 			</table>
 		</section>
+		
 		<section id="sec-marc21xml-record">
 			<h5>marc21xml-record (deprecated)</h5>
 			
@@ -113,6 +117,7 @@
 				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"><code>marc21xml-record</code>
 				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
+		
 		<section id="sec-mods-record">
 			<h5>mods-record (deprecated)</h5>
 			
@@ -125,6 +130,7 @@
 				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"><code>mods-record</code>
 				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
+		
 		<section id="sec-onix-record">
 			<h5>onix-record (deprecated)</h5>
 			
@@ -137,8 +143,10 @@
 				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"><code>onix-record</code>
 				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
+		
 		<section id="sec-record">
 			<h5>record</h5>
+			
 			<table class="tabledef" id="record">
 				<tbody>
 					<tr>
@@ -170,7 +178,7 @@
 					</tr>
 					<tr>
 						<th>Extends:</th>
-						<td>Only applies to the EPUB publication or collection. MUST NOT be used when the <a
+						<td>Only applies to the [=EPUB publication=] or collection. MUST NOT be used when the <a
 								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
 					</tr>
 					<tr>
@@ -183,8 +191,10 @@
 				</tbody>
 			</table>
 		</section>
+		
 		<section id="sec-voicing">
 			<h5>voicing</h5>
+			
 			<table class="tabledef" id="voicing">
 				<tbody>
 					<tr>
@@ -225,6 +235,7 @@
 				</tbody>
 			</table>
 		</section>
+		
 		<section id="sec-xml-signature">
 			<h5>xml-signature (deprecated)</h5>
 			
@@ -235,6 +246,7 @@
 				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"><code>xml-signature</code>
 				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
+		
 		<section id="sec-xmp-record">
 			<h5>xmp-record (deprecated)</h5>
 			
@@ -248,14 +260,18 @@
 				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 	</section>
+	
 	<section id="sec-link-properties">
 		<h4>Link properties</h4>
+		
 		<p>The following values can be used in the [^link^] element's
 			<code>properties</code> attribute to establish the type of record a referenced resource represents.
 			These values are provided for record formats that cannot be uniquely identified by their media
 			type.</p>
+		
 		<section id="sec-onix">
 			<h5>onix</h5>
+			
 			<table class="tabledef" id="onix">
 				<tbody>
 					<tr>
@@ -279,8 +295,10 @@
 				</tbody>
 			</table>
 		</section>
+		
 		<section id="sec-xmp">
 			<h5>xmp</h5>
+			
 			<table class="tabledef" id="xmp">
 				<tbody>
 					<tr>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -142,14 +142,14 @@
 					<th>Description:</th>
 					<td>
 						<p>The <code>belongs-to-collection</code> property identifies the name of a collection
-							to which the EPUB publication belongs. An EPUB publication MAY belong to one or more
+							to which the [=EPUB publication=] belongs. An EPUB publication MAY belong to one or more
 							collections.</p>
 						<p>It is also possible to chain these properties using the <a href="#attrdef-refines"
 									><code>refines</code> attribute</a> to indicate that one collection is
 							itself a member of another collection.</p>
-						<p>To allow reading systems to organize collections and avoid naming collisions (e.g.,
+						<p>To allow [=reading systems=] to organize collections and avoid naming collisions (e.g.,
 							unrelated collections might share a similar name, or different editions of a
-							collection could be released), an identifier SHOULD be provided that uniquely
+							collection could be released), [=EPUB creators=] SHOULD provide an identifier that uniquely
 							identifies the instance of the collection. The <code>dcterms:identifier</code>
 							property must carry this identifier.</p>
 						<p>The collection MAY more precisely define its nature by attaching a <a
@@ -210,8 +210,8 @@
 						<p>The <code>collection-type</code> property indicates the form or nature of a
 							collection.</p>
 						<p>When the <code>collection-type</code> value is drawn from a code list or other formal
-							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
-							be attached to identify its source.</p>
+							enumeration, [=EPUB creators=] SHOULD attach a <a href="#attrdef-scheme"><code>scheme</code>
+								attribute</a> to identify its source.</p>
 						<p>This specification also defines the following collection types when no scheme is
 							specified:</p>
 						<dl>
@@ -231,8 +231,8 @@
 							</dd>
 						</dl>
 						<div class="note">
-							<p>Although reading systems are not required to support these values, specifying
-								them provides the option to group related EPUB publications in more meaningful
+							<p>Although [=reading systems=] are not required to support these values, specifying
+								them provides the option to group related [=EPUB publications=] in more meaningful
 								ways.</p>
 						</div>
 					</td>
@@ -380,10 +380,10 @@
 					<th>Description:</th>
 					<td>
 						<p>The <code>group-position</code> property indicates the numeric position in which the
-							EPUB publication is ordered relative to other works belonging to the same group
+							[=EPUB publication=] is ordered relative to other works belonging to the same group
 							(whether all EPUB publications or not).</p>
-						<p>The <code>group-position</code> property can be attached to any metadata property
-							that establishes the group but is typically associated with the <a
+						<p>[=EPUB creators=] can attach the <code>group-position</code> property to any metadata
+							property that establishes the group but it is typically associated with the <a
 								href="#belongs-to-collection"><code>belongs-to-collection</code>
 							property</a>.</p>
 						<p>An EPUB publication can belong to more than one group.</p>
@@ -466,8 +466,8 @@
 						<p>The <code>identifier-type</code> property indicates the form or nature of an
 								<code>identifier</code>.</p>
 						<p>When the <code>identifier-type</code> value is drawn from a code list or other formal
-							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
-							be attached to identify its source.</p>
+							enumeration, [=EPUB creators=] SHOULD attach a <a href="#attrdef-scheme"><code>scheme</code>
+								attribute</a> to identify its source.</p>
 					</td>
 				</tr>
 				<tr>
@@ -536,8 +536,8 @@
 								<code>contributor</code> or <code>publisher</code> in the creation of an EPUB
 							publication.</p>
 						<p>When the <code>role</code> value is drawn from a code list or other formal
-							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
-							be attached to identify its source.</p>
+							enumeration, [=EPUB creators=] SHOULD attach a <a href="#attrdef-scheme"><code>scheme</code>
+								attribute</a> to identify its source.</p>
 						<p>When attaching multiple roles to an individual or organization, the importance of the
 							roles should match the document order of their containing <code>meta</code> elements
 							(i.e., the first <code>meta</code> element encountered should contain the most
@@ -772,9 +772,9 @@
 						<p>The <code>title-type</code> property indicates the form or nature of a
 								<code>title</code>.</p>
 						<p>When the <code>title-type</code> value is drawn from a code list or other formal
-							enumeration, the <a href="#attrdef-scheme"><code>scheme</code> attribute</a> SHOULD
-							be attached to identify its source. When a scheme is not specified, reading systems
-								<span class="rfc2119">should</span> recognize the following title type values:
+							enumeration, [=EPUB creators=] SHOULD attach a <a href="#attrdef-scheme"><code>scheme</code>
+								attribute</a> to identify its source. When a scheme is not specified, [=reading systems=]
+								SHOULD recognize the following title type values:
 								<code>main</code>, <code>subtitle</code>, <code class="value">short</code>,
 								<code>collection</code>, <code class="value">edition</code> and
 								<code>expanded</code>. </p>

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -5,7 +5,7 @@
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
 			<code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>
 	<p>The prefix "<code>media:</code>" is <a href="#sec-metadata-reserved-prefixes">reserved for use</a> with
-		properties in this vocabulary and does not have to be declared in the package document.</p>
+		properties in this vocabulary and does not have to be declared in the [=package document=].</p>
 	<section id="sec-active-class">
 		<h4>active-class</h4>
 		<table class="tabledef" id="active-class">
@@ -18,7 +18,7 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>Author-defined CSS class name to apply to the currently playing EPUB content document
+					<td>[=EPUB creator=]-defined CSS class name to apply to the currently playing [=EPUB content document=]
 						element.</td>
 				</tr>
 				<tr>
@@ -126,8 +126,8 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>Author-defined CSS class name to apply to the EPUB content document's document element
-						when playback is active.</td>
+					<td>Author-defined CSS class name to apply to the [=EPUB content document | EPUB content document's=]
+						document element when playback is active.</td>
 				</tr>
 				<tr>
 					<th>Allowed value(s):</th>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -6,12 +6,12 @@
 	
 	<p>The "<code>rendition:</code>" prefix is <a href="#sec-metadata-reserved-prefixes">reserved for
 		use</a> with the package rendering properties and does not have to be declared in the
-		package document.</p>
+		[=package document=].</p>
 	
 	<div class="note">
 		<p>Unlike the other vocabularies in this appendix, the properties in the Package Rendering Vocabulary
 			consist of a mix of properties (expressed in [^meta^] elements)
-			and spine overrides (expressed on [^itemref^] elements).</p>
+			and [=EPUB spine | spine=] overrides (expressed on [^itemref^] elements).</p>
 		
 		<p>The usage requirements are also defined in <a href="#sec-rendering-control"></a> not in this appendix.
 			The following table provides a map to the properties, overrides, and where they are defined.</p>
@@ -103,15 +103,17 @@
 	<section id="sec-rendering-custom-properties">
 		<h4>Custom rendering properties</h4>
 		
-		<p>Reading system developers may introduce functionality not defined in this specification to address reading system-specific issues rendering [=EPUB content documents=].</p>
+		<p>[=Reading system=] developers may introduce functionality not defined in this specification to address 
+			reading system-specific issues rendering [=EPUB content documents=].</p>
 		
-		<p>To facilitate this experimentation, EPUB creators MAY include custom properties and spine overrides for
-			use in the [=package document=] provided they do not use the <code>rendition:</code>
+		<p>To facilitate this experimentation, [=EPUB creators=] MAY include custom properties and [=EPUB spine | spine=]
+			overrides for use in the [=package document=] provided they do not use the <code>rendition:</code>
 			prefix.</p>
 		
 		<div class="note">
-			<p>Custom properties should only address rendering issues specific to a particular reading system. This specification should be extended to provide extensions that multiple
-				independent reading systems can use.</p>
+			<p>Custom properties should only address rendering issues specific to a particular reading system. This
+				specification should be extended to provide extensions that multiple independent reading systems can
+				use.</p>
 		</div>
 	</section>
 </section>


### PR DESCRIPTION
I've gone through the core spec with this PR and checked all the terminology linking. That covers all the specs on REC track, so fixes #2241.

It also fixes #2353 by removing the second redundant paragraph.

And it fixes #2354 by changing the descriptions to say that they "encapsulate information for" their respective document format and changing the usage sections to add a normative "REQUIRED" statement (e.g. "REQUIRED root element [[xml]] for the package document". This matches all the other usage definitions where we say whether the element is required or optional, and avoids any ambiguity as for some files the root element we define is optional.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2357.html" title="Last updated on Jul 12, 2022, 11:06 AM UTC (1d80abf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2357/5f207b0...1d80abf.html" title="Last updated on Jul 12, 2022, 11:06 AM UTC (1d80abf)">Diff</a>