### PR TITLE
Clarify svg title phrasing content restrictions

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5981,10 +5981,9 @@ No Entry</pre>
 							</ul>
 						</li>
 						<li>
-							<p id="confreq-svg-title">The [[svg]] <a
-									href="https://www.w3.org/TR/SVG/struct.html#TitleElement"><code>title</code></a>
-								element MUST contain only valid <a href="#sec-xhtml-req">XHTML content document Phrasing
-									content</a>.</p>
+							<p id="confreq-svg-title" data-cite="svg">The [[svg]] [^title^] element MAY contain [[html]]
+								[=phrasing content=] that conforms to <a href="#sec-xhtml-req"></a>. It MUST NOT contain
+								elements from other namespaces.</p>
 						</li>
 					</ul>
 				</section>
@@ -11440,9 +11439,9 @@ EPUB/images/cover.png</pre>
 				<p>This appendix registers the media type <code>application/epub+zip</code> for the EPUB Open Container
 					Format (OCF).</p>
 
-				<p>An OCF ZIP container, or EPUB container, file is a container technology based on the [[zip]]
-					archive format. It is used to encapsulate the EPUB publication. OCF and its related standards are
-					maintained and defined by the <a href="https://www.w3.org">World Wide Web Consortium</a> (W3C).</p>
+				<p>An OCF ZIP container, or EPUB container, file is a container technology based on the [[zip]] archive
+					format. It is used to encapsulate the EPUB publication. OCF and its related standards are maintained
+					and defined by the <a href="https://www.w3.org">World Wide Web Consortium</a> (W3C).</p>
 
 				<dl class="variablelist">
 					<dt>MIME media type name:</dt>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5982,8 +5982,7 @@ No Entry</pre>
 						</li>
 						<li>
 							<p id="confreq-svg-title" data-cite="svg">The [[svg]] [^title^] element MAY contain [[html]]
-								[=phrasing content=] that conforms to <a href="#sec-xhtml-req"></a>. It MUST NOT contain
-								elements from other namespaces.</p>
+								[=phrasing content=]. It MUST NOT contain elements from other namespaces.</p>
 						</li>
 					</ul>
 				</section>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5981,8 +5981,9 @@ No Entry</pre>
 							</ul>
 						</li>
 						<li>
-							<p id="confreq-svg-title" data-cite="svg">The [[svg]] [^title^] element MAY contain [[html]]
-								[=phrasing content=]. It MUST NOT contain elements from other namespaces.</p>
+							<p id="confreq-svg-title" data-cite="svg">If the [[svg]] <code>title</code> element contains
+								marked-up text, the markup MUST contain only elements declared in the <a
+									data-cite="dom#html-namespace">HTML namespace</a> [[dom]].</p>
 						</li>
 					</ul>
 				</section>
@@ -11574,6 +11575,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>14-July-2022: Clarified that the markup in the SVG <code>title</code> element is restricted to
+						HTML elements. See <a href="https://github.com/w3c/epub-specs/issues/2355">issue 2355</a>.</li>
 					<li>10-June-2022: Clarified that data blocks are exempt from fallback requirements. See <a
 							href="https://github.com/w3c/epub-specs/issues/2331">issue 2331</a>.</li>
 					<li>07-June-2022: The usage of File URLs has been disallowed. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5981,11 +5981,16 @@ No Entry</pre>
 							</ul>
 						</li>
 						<li>
-							<p id="confreq-svg-title" data-cite="svg">If the [[svg]] <code>title</code> element contains
+							<p id="confreq-svg-title" data-cite="svg">If the [[svg]] [^title^] element contains
 								marked-up text, the markup MUST contain only elements declared in the <a
 									data-cite="dom#html-namespace">HTML namespace</a> [[dom]].</p>
 						</li>
 					</ul>
+					<div class="note">
+						<p>Although the [[svg]] <code>title</code> element allows markup elements, support for this
+							feature is limited. [=EPUB creators=] are advised to use text-only titles for maximum
+							interoperability.</p>
+					</div>
 				</section>
 			</section>
 


### PR DESCRIPTION
This PR implements the text in https://github.com/w3c/epub-specs/issues/2355#issue-1301109618

I'm still not sure I see the point of the restriction, though.

Fixes #2355


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2358.html" title="Last updated on Jul 14, 2022, 10:22 AM UTC (1cfd608)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2358/df86d5a...1cfd608.html" title="Last updated on Jul 14, 2022, 10:22 AM UTC (1cfd608)">Diff</a>