### PR TITLE
Reformulated the zip file splitting ban

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -653,8 +653,8 @@
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-zip-mult">MUST treat any [=OCF ZIP container=] that specifies the [[zip]] file is
-							split across multiple storage media as in error.</p>
+						<p id="confreq-zip-mult">MUST treat any [=OCF ZIP container=] that splits the content into
+							segments [[zip]] as in error.</p>
 					</li>
 					<li>
 						<p id="confreq-zip-comp">MUST treat any OCF ZIP container that uses compression techniques other


### PR DESCRIPTION
I used the terminology of 'splitting the content into segments' that is used in the zip specification itself.

Fix #2360

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-2360/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-2360/epub33/rs/index.html)
