### PR TITLE
Update access mode sufficient technique to emphasize single values

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -244,8 +244,8 @@
 					<li><code>textual</code> &#8212; setting this value indicates that the publication is screen-reader
 						friendly (i.e., all the content is available for text-to-speech rendering by an assistive
 						technology). EPUB creators can set this value for EPUB publications that conform to [[WCAG2]] <a
-							href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a> as there have to be textual alternatives
-						for non-text content to meet this threshold.</li>
+							href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a>, for example, as there have to be
+						textual alternatives for non-text content to meet this threshold.</li>
 					<li><code>auditory</code> &#8212; setting this value indicates that pre-recorded audio is available
 						for the publication. EPUB creators can set this value for EPUB publications that provide media
 						overlays for all the content.</li>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -244,8 +244,8 @@
 					<li><code>textual</code> &#8212; setting this value indicates that the publication is screen-reader
 						friendly (i.e., all the content is available for text-to-speech rendering by an assistive
 						technology). EPUB creators can set this value for EPUB publications that conform to [[WCAG2]] <a
-							href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a>, for example, as there have to be
-						textual alternatives for non-text content to meet this threshold.</li>
+							href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a> or higher, for example, as there must
+						be textual alternatives for non-text content to meet these thresholds.</li>
 					<li><code>auditory</code> &#8212; setting this value indicates that pre-recorded audio is available
 						for the publication. EPUB creators can set this value for EPUB publications that provide media
 						overlays for all the content.</li>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -231,10 +231,30 @@
 						href="https://schema.org/accessModeSufficient"><code>accessModeSufficient</code> property</a>.
 					Repeat the property for each set of sufficient access modes.</p>
 
-				<p>For example, consider an EPUB publication that contains graphics and charts, as well as descriptions
-					for all these images. The publication has both textual and visual content, so the <a
-						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> will include the following
-						<code>schema:accessMode</code> metadata entries to indicate this:</p>
+				<p>The most strongly recommended sufficient access modes to list are the ones that consist of only a
+					single value. Users seeking alternatives to the default encoding of the information typically want
+					to read the content without switching reading modes (e.g., they want a purely textual alternative to
+					use text-to-speech playback or an auditory alternative to listen to prerecorded narration). Listing
+					the single value sets allows users to easily determine whether a publication will meet their reading
+					needs.</p>
+
+				<p>The most common single sufficient access modes for EPUB publications are:</p>
+
+				<ul>
+					<li><code>textual</code> &#8212; setting this value indicates that the publication is screen-reader
+						friendly (i.e., all the content is available for text-to-speech rendering by an assistive
+						technology). EPUB creators can set this value for EPUB publications that conform to [[WCAG2]] <a
+							href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a> as there have to be textual alternatives
+						for non-text content to meet this threshold.</li>
+					<li><code>auditory</code> &#8212; setting this value indicates that pre-recorded audio is available
+						for the publication. EPUB creators can set this value for EPUB publications that provide media
+						overlays for all the content.</li>
+				</ul>
+
+				<p>As an example of setting sufficient access modes, consider an EPUB publication that contains graphics
+					and charts, as well as descriptions for all these images. The publication has both textual and
+					visual content, so the <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> will
+					include the following <code>schema:accessMode</code> metadata entries to indicate this:</p>
 
 				<pre>&lt;meta
     property="schema:accessMode">
@@ -249,16 +269,9 @@
 					publication, or whether a visual one is, only that the user requires the ability to read in those
 					two modes by default. This discrepancy is why sufficiency is also important to know.</p>
 
-				<p>The most strongly recommended sufficient access modes to list are the ones that consist of only a
-					single value. Users seeking alternatives to the default encoding of the information typically want
-					to read the content without switching reading modes (e.g., they want a purely textual alternative to
-					use text-to-speech playback or an auditory alternative to listen to prerecorded narration). Listing
-					the single value sets allows users to easily determine whether a publication will meet their reading
-					needs.</p>
-
-				<p>Since the EPUB creator has also included descriptions for all the images in the example publication,
-					the metadata can also indicate that a purely textual access mode is sufficient to read the
-					content:</p>
+				<p>Since the EPUB creator has also included textual alternatives and/or descriptions for all the images
+					in the example publication, the metadata can also indicate that a purely textual access mode is
+					sufficient to read the content:</p>
 
 				<pre>&lt;meta
     property="schema:accessModeSufficient">
@@ -2288,6 +2301,9 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>20-July-2022: Added additional emphasis on setting single value access mode sufficient declarations
+					and also listed and explained when to apply the two most common for EPUBs. See <a
+						href="https://github.com/w3c/epub-specs/issues/2302">issue 2302</a>.</li>
 				<li>07-June-2022: Added a technique explaining how to set access modes and features when media overlays
 					are present. See <a href="https://github.com/w3c/epub-specs/issues/2303">issue 2303</a>.</li>
 				<li>07-June-2022: Prioritized single-value <code>accessModeSufficient</code> declarations. See <a


### PR DESCRIPTION
I took another look at the access mode sufficient technique and made a couple of minor changes to emphasize single-value declarations.

First, I've moved the paragraph that explains these are the most important up higher in the technique. You had to read through the example for a while before finding it, which was suboptimal.

Second, I've added a list of the two single-value modes that are most common for epubs: textual and auditory. I've also explained when these are set.

The only question I have @GeorgeKerscher is if I've got the right WCAG level for stating that a publication is screenreader friendly. If you meet WCAG Level A, you should be able to set "textual" as a single sufficient access mode, correct? I don't believe AA adds anything more for TTS playback, but if you can confirm that would be a big help.

Also, if anyone spots anything else that needs improving, please let me know now. Issue #2302 has been open for a long time now, so I'd like to close it off with this pull request.

Fixes #2302 