### PR TITLE
Deprecating the name and version properties for epubReadingSystem objects

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2584,6 +2584,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>
+						22-July-2022: The <code>name</code> and <code>version</code> properties of the 
+						<code>epubReadingSystem</code> object have been deprecated. 
+						See <a href="https://github.com/w3c/epub-specs/issues/1872">issue 1872</a>.
+					</li>
 					<li>19-July-2022: ZIP containers with content split into segments have been disallowed in general.
 						See <a href="https://github.com/w3c/epub-specs/issues/2360">issue 2360</a>.
 					</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2456,8 +2456,8 @@ partial interface Navigator {
 
 				<p>This specification used to define the <code>name</code>, <code>version</code>, and the <code>layoutStyle</code> properties, 
 					but these are now <a data-cite="epub-33#deprecated">deprecated</a> [[epub-33]]. For more information refer
-					to their definitions in [[epubcontentdocs-32]] (for <code>name</code> and <code>version</code>) 
-					and in [[epubcontentdocs-301]] (for <code>layoutStyle</code>).</p>
+					to their definitions in [[epubcontentdocs-32]] (for <a href="https://www.w3.org/publishing/epub3/epub-contentdocs.html#app-ers-properties"><code>name</code> and <code>version</code></a>) 
+					and in [[epubcontentdocs-301]] (for <a href="https://idpf.org/epub/301/spec/epub-contentdocs.html#app-ers-properties"><code>layoutStyle</code></a>).</p>
 			</section>
 
 			<section id="app-ers-methods">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -81,6 +81,15 @@
 						"date": "26 June 2014",
 						"publisher": "IDPF"
 					},
+					"epubcontentdocs-32": {
+						"authors":[
+						"Dave Cramer",
+						"Matt Garrish"],
+						"title": "EPUB Content Documents 3.2",
+						"href": "https://www.w3.org/publishing/epub32/epub-contentdocs.html",
+						"date": "08 May 2019",
+						"publisher": "W3C"
+					},
 					"epubpackages-32": {
 						"authors":[
 						"Matt Garrish",
@@ -2402,8 +2411,6 @@
 
 				<pre class="idl">[Exposed=(Window)]
 interface EpubReadingSystem {
-    [LegacyUnforgeable] readonly attribute DOMString name;
-    [LegacyUnforgeable] readonly attribute DOMString version;
     boolean hasFeature(DOMString feature, optional DOMString version);
 };
 
@@ -2426,16 +2433,9 @@ partial interface Navigator {
 					through which a [=scripted content document=] can query information about a user's reading
 					system.</p>
 
-				<p>The object exposes <a href="#app-ers-properties">properties</a> of the reading system (its name and
-					version), and provides the <a href="#app-ers-hasFeature"><code>hasFeature</code> method</a> which
-					can be invoked to determine the features it supports.</p>
-
-				<aside class="example" title="JavaScript function to display the name of the current reading system">
-					<pre>alert("Reading system name: " + navigator.epubReadingSystem.name);</pre>
-				</aside>
 
 				<p id="scripting-req-readingsystem"
-					data-tests="#scr-readingsystem-support,#scr-readingsystem-support_svg,#scr-readingsystem-support_iframe,#scr-readingsystem-support_iframe_svg"
+					data-tests="#scr-readingsystem-features,#scr-readingsystem-support_svg,#scr-readingsystem-support_iframe,#scr-readingsystem-support_iframe_svg"
 					>Reading systems MUST expose the <code>epubReadingSystem</code> object on the <code>navigator</code>
 					object of all loaded scripted content documents, including any nested <a
 						data-cite="epub-33#sec-scripted-container-constrained">container-constrained scripting
@@ -2454,43 +2454,10 @@ partial interface Navigator {
 			<section id="app-ers-properties">
 				<h3>Properties</h3>
 
-				<p id="scripting-req-readingsystem-properties"
-					data-tests="#scr-readingsystem-support,#scr-readingsystem-support_svg,#scr-readingsystem-support_iframe,#scr-readingsystem-support_iframe_svg"
-					>The reading system MUST make the following properties available for retrieving information about
-					it.</p>
-
-				<table data-dfn-for="EpubReadingSystem">
-					<thead>
-						<tr>
-							<th>Name</th>
-							<th>Description</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td id="propdef-name">
-								<code>
-									<dfn>name</dfn>
-								</code>
-							</td>
-							<td>Returns a <code>String</code> value representing the name of the reading system (e.g.,
-									"<code>iBooks</code>", "<code>Kindle</code>").</td>
-						</tr>
-						<tr>
-							<td id="propdef-version">
-								<code>
-									<dfn>version</dfn>
-								</code>
-							</td>
-							<td>Returns a <code>String</code> value representing the version of the reading system
-								(e.g., "<code>1.0</code>", "<code>2.1.1</code>").</td>
-						</tr>
-					</tbody>
-				</table>
-
-				<p>This specification used to define a <code>layoutStyle</code> property, but it is now <a
-						data-cite="epub-33#deprecated">deprecated</a> [[epub-33]]. Refer to its definition in
-					[[epubcontentdocs-301]] for more information.</p>
+				<p>This specification used to define the <code>name</code>, <code>version</code>, and the <code>layoutStyle</code> properties, 
+					but these are now <a data-cite="epub-33#deprecated">deprecated</a> [[epub-33]]. For more information refer
+					to their definitions in [[epubcontentdocs-32]] (for <code>name</code> and <code>version</code>) 
+					and in [[epubcontentdocs-301]] (for <code>layoutStyle</code>).</p>
 			</section>
 
 			<section id="app-ers-methods">


### PR DESCRIPTION
The PR implements the [WG Resolution](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-07-21-epub#resolution1) on 2022-07-21.

Fix #1872

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/deprecate-epubReadingSystem/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/deprecate-epubReadingSystem/epub33/rs/index.html)
