### PR TITLE
Tweak to rights.xml definition

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2639,9 +2639,8 @@
 							<h6>Rights management file (<code>rights.xml</code>)</h6>
 
 							<p>This specification reserves the OPTIONAL <code>rights.xml</code> file in the
-									<code>META-INF</code> directory for digital rights management (DRM) information for
-								trusted exchange of [=EPUB publications=] among rights holders, intermediaries, and
-								users.</p>
+									<code>META-INF</code> directory for the trusted exchange of [=EPUB publications=]
+								among rights holders, intermediaries, and users.</p>
 
 							<p>When [=EPUB creators=] do not include a <code>rights.xml</code> file, no part of the
 								[=OCF abstract container=] is rights governed at the container level. Rights expressions
@@ -10643,9 +10642,10 @@ html.my-document-playing * {
 				<p>As the <a
 						href="https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW6"
 						>Safari HTML definition</a> of the <code>viewport</code>
-					<code>meta</code> tag, that was used in earlier versions of EPUB 3, is not an officially recognized standard, this specification defines a basic
-					syntax in order to allow [=EPUB creators=] to express <a href="#sec-fxl-icb-html">width and height
-						dimensions</a> for use rendering [=fixed-layout documents=].</p>
+					<code>meta</code> tag, that was used in earlier versions of EPUB 3, is not an officially recognized
+					standard, this specification defines a basic syntax in order to allow [=EPUB creators=] to express
+						<a href="#sec-fxl-icb-html">width and height dimensions</a> for use rendering [=fixed-layout
+					documents=].</p>
 
 				<p>The syntax of this grammar is also influenced by the processing model for transforming
 						<code>viewport</code>
@@ -11729,8 +11729,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>18-July-2022: The viewport <code>meta</code> element for specifying the initial containing boundary
-						in fixed-layout documents is now formally defined. See <a
+					<li>18-July-2022: The viewport <code>meta</code> element for specifying the initial containing
+						boundary in fixed-layout documents is now formally defined. See <a
 							href="https://github.com/w3c/epub-specs/issues/2292">issue 2292</a>. </li>
 					<li>14-July-2022: Clarified that the markup in the SVG <code>title</code> element is restricted to
 						HTML elements. See <a href="https://github.com/w3c/epub-specs/issues/2355">issue 2355</a>.</li>


### PR DESCRIPTION
This PR is just a minor edit to remove everyone's favourite three-letter word from the rights.xml definition. It's not strictly necessary to call it out to explain the purpose of the file, and probably leads to questions like that in #2359 asking for examples of how to implement drm. We're not defining or restricting the information that goes in the file.

Fixes #2359


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2365.html" title="Last updated on Jul 22, 2022, 11:05 AM UTC (a499186)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2365/319d4cb...a499186.html" title="Last updated on Jul 22, 2022, 11:05 AM UTC (a499186)">Diff</a>