### PR TITLE
Added the epubcfi reference to the media type registrations

### DIFF
--- a/epub33/core/biblio.js
+++ b/epub33/core/biblio.js
@@ -19,6 +19,22 @@ var biblio = {
 		"date": "26 June 2014",
 		"publisher": "IDPF"
 	},
+	"epubcfi" : {
+		"authors": [
+			"Peter Sorotokin",
+			"Garth Conboy",
+			"Brady Duga",
+			"John Rivlin",
+			"Don Beaver",
+			"Kevin Ballard",
+			"Alastair Fettes",
+			"Daniel Weck"
+		],
+		"title": "EPUB Canonical Fragment Identifier (epubcfi) Specification",
+		"href": "https://idpf.org/epub/linking/cfi/epub-cfi-20111011.html",
+		"publisher": "IDPF",
+		"date": "11 October 2011"
+	},
 	"epubpackages-32": {
 		"authors":[
 		"Matt Garrish",

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11564,7 +11564,7 @@ EPUB/images/cover.png</pre>
 
 							<dt>Fragment Identifiers:</dt>
 							<dd>
-								<p>EPUB Canonical Fragment Identifiers are custom fragment identifiers that can resolve
+								<p>EPUB Canonical Fragment Identifiers [[epubcfi]] are custom fragment identifiers that can resolve
 									to <code>application/oebps-package+xml</code> documents.</p>
 							</dd>
 						</dl>
@@ -11688,7 +11688,7 @@ EPUB/images/cover.png</pre>
 
 							<dt>Fragment identifiers:</dt>
 							<dd>
-								<p>EPUB Canonical Fragment Identifiers are custom fragment identifiers that can resolve
+								<p>EPUB Canonical Fragment Identifiers [[epubcfi]] are custom fragment identifiers that can resolve
 									to <code>application/epub+zip</code> and <code>application/oebps-package+xml</code>
 									documents.</p>
 							</dd>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11472,7 +11472,8 @@ EPUB/images/cover.png</pre>
 				<h3>The <code>application/oebps-package+xml</code> media type</h3>
 
 				<p>This appendix registers the media type <code>application/oebps-package+xml</code> for the EPUB
-					package document. This registration supersedes [[rfc4839]].</p>
+					package document. This registration supersedes RFC4839 (see 
+					<a href="https://www.rfc-editor.org/rfc/rfc4839">https://www.rfc-editor.org/rfc/rfc4839</a>).</p>
 
 				<p>The package document is an XML file that describes an EPUB publication. It identifies the resources
 					in the EPUB publication and provides metadata information. The package document and its related
@@ -11564,8 +11565,7 @@ EPUB/images/cover.png</pre>
 
 							<dt>Fragment Identifiers:</dt>
 							<dd>
-								<p>EPUB Canonical Fragment Identifiers [[epubcfi]] are custom fragment identifiers that can resolve
-									to <code>application/oebps-package+xml</code> documents.</p>
+								<p>EPUB Canonical Fragment Identifiers are custom fragment identifiers that can resolve to <code>application/epub+zip</code> and <code>application/oebps-package+xml</code> documents. These identifiers are defined at <a href="https://idpf.org/epub/linking/cfi/">https://idpf.org/epub/linking/cfi/</a>.</p>
 							</dd>
 						</dl>
 					</dd>
@@ -11593,8 +11593,9 @@ EPUB/images/cover.png</pre>
 				<p>This appendix registers the media type <code>application/epub+zip</code> for the EPUB Open Container
 					Format (OCF).</p>
 
-				<p>An OCF ZIP container, or EPUB container, file is a container technology based on the [[zip]] archive
-					format. It is used to encapsulate the EPUB publication. OCF and its related standards are maintained
+				<p>An OCF ZIP container, or EPUB container, file is a container technology based on the 
+					zip archive format (see <a href="https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT">https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT</a>). It is used to encapsulate the EPUB publication. 
+					OCF and its related standards are maintained
 					and defined by the <a href="https://www.w3.org">World Wide Web Consortium</a> (W3C).</p>
 
 				<dl class="variablelist">
@@ -11688,9 +11689,7 @@ EPUB/images/cover.png</pre>
 
 							<dt>Fragment identifiers:</dt>
 							<dd>
-								<p>EPUB Canonical Fragment Identifiers [[epubcfi]] are custom fragment identifiers that can resolve
-									to <code>application/epub+zip</code> and <code>application/oebps-package+xml</code>
-									documents.</p>
+								<p>EPUB Canonical Fragment Identifiers are custom fragment identifiers that can resolve to <code>application/epub+zip</code> and <code>application/oebps-package+xml</code> documents. These identifiers are defined at <a href="https://idpf.org/epub/linking/cfi/">https://idpf.org/epub/linking/cfi/</a>.</p>
 							</dd>
 						</dl>
 					</dd>


### PR DESCRIPTION
Fix #2367


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2369.html" title="Last updated on Jul 24, 2022, 4:03 AM UTC (0c611b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2369/a959518...0c611b8.html" title="Last updated on Jul 24, 2022, 4:03 AM UTC (0c611b8)">Diff</a>