### PR TITLE
Added test references for spine overrides

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -923,7 +923,7 @@
 				<section id="spine-overrides">
 					<h4>Spine overrides</h4>
 
-					<p id="confreq-rs-pkg-spine-override">When a [=spine=] [^itemref^] element's <a
+					<p id="confreq-rs-pkg-spine-override" data-tests="#fxl-spine-overrides_behave-as-global">When a [=spine=] [^itemref^] element's <a
 							data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a <a
 							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
 						systems MUST follow the requirements for the override's global value to display that spine
@@ -934,7 +934,7 @@
 						requirements of the global <a href="#def-layout-pre-paginated"><code>pre-paginated</code>
 							value</a>.</p>
 
-					<p id="confreq-rs-pkg-spine-override-first">If more than one override for the same property is
+					<p id="confreq-rs-pkg-spine-override-first" data-tests="#fxl-spine-overrides_behave-as-global">If more than one override for the same property is
 						specified in a <code>properties</code> attribute, reading systems MUST use only the first
 						value.</p>
 				</section>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -923,7 +923,7 @@
 				<section id="spine-overrides">
 					<h4>Spine overrides</h4>
 
-					<p id="confreq-rs-pkg-spine-override" data-tests="#fxl-spine-overrides_behave-as-global">When a [=spine=] [^itemref^] element's <a
+					<p id="confreq-rs-pkg-spine-override" data-tests="#fxl-spine-overrides_behave-as-global,#fxl-spine-overrides_behave-as-global-bis">When a [=spine=] [^itemref^] element's <a
 							data-cite="epub-33#attrdef-properties"><code>properties</code> attribute</a> overrides a <a
 							data-cite="epub-33#app-rendering-vocab">global rendering property</a> [[epub-33]], reading
 						systems MUST follow the requirements for the override's global value to display that spine


### PR DESCRIPTION
Added references to tests in https://github.com/w3c/epub-tests/pull/184. PR to be merged when that one is merged