### PR TITLE
Clarify not to set access modes for non-essential content

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -206,6 +206,14 @@
 &lt;/meta></pre>
 				</aside>
 
+				<p><strong>Do not</strong> list acess modes for content that does not contain information necessary to
+					understand to read a publication. Most EPUB publications contain cover images, for example, but it
+					is not necessary to see the cover image to read the publication. The same is true of publisher logos
+					and images in the content are only for presentational purposes (i.e., have no information so have
+					empty [[html]] <code>alt</code> attribute values). If these are the only visual content, then it is
+					not valid to list a visual access mode. Similarly, if the only audio an EPUB publication contains is
+					background mood music, listing an auditory access mode is not valid.</p>
+
 				<p>Note that the access modes of the content do not reflect any adaptations that have been provided. For
 					example, if a comic book also includes alternative text for each image, it does not have a textual
 					access mode. See the following section on <a href="#meta-002">sufficient access modes</a> for how to
@@ -244,8 +252,8 @@
 					<li><code>textual</code> &#8212; setting this value indicates that the publication is screen-reader
 						friendly (i.e., all the content is available for text-to-speech rendering by an assistive
 						technology). EPUB creators can set this value for EPUB publications that conform to [[WCAG2]] <a
-							href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a> or higher, for example, as there must
-						be textual alternatives for non-text content to meet these thresholds.</li>
+							href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a> or higher, for example, as there must be
+						textual alternatives for non-text content to meet these thresholds.</li>
 					<li><code>auditory</code> &#8212; setting this value indicates that pre-recorded audio is available
 						for the publication. EPUB creators can set this value for EPUB publications that provide media
 						overlays for all the content.</li>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -206,12 +206,12 @@
 &lt;/meta></pre>
 				</aside>
 
-				<p><strong>Do not</strong> list acess modes for content that does not contain information necessary to
-					understand to read a publication. Most EPUB publications contain cover images, for example, but it
-					is not necessary to see the cover image to read the publication. The same is true of publisher logos
-					and images in the content are only for presentational purposes (i.e., have no information so have
-					empty [[html]] <code>alt</code> attribute values). If these are the only visual content, then it is
-					not valid to list a visual access mode. Similarly, if the only audio an EPUB publication contains is
+				<p><strong>Do not</strong> list access modes for content that does not contain information necessary to
+					understand a publication. Most EPUB publications contain cover images, for example, but it is not
+					necessary to see the cover image to read the publication. The same is true of publisher logos and
+					images in the content are only for presentational purposes (i.e., have no information so have empty
+					[[html]] <code>alt</code> attribute values). If these are the only visual content, then it is not
+					valid to list a visual access mode. Similarly, if the only audio an EPUB publication contains is
 					background music (e.g., for an instructional video with text captions, or as mood music while
 					reading), listing an auditory access mode is not valid.</p>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -212,7 +212,8 @@
 					and images in the content are only for presentational purposes (i.e., have no information so have
 					empty [[html]] <code>alt</code> attribute values). If these are the only visual content, then it is
 					not valid to list a visual access mode. Similarly, if the only audio an EPUB publication contains is
-					background mood music, listing an auditory access mode is not valid.</p>
+					background music (e.g., for an instructional video with text captions, or as mood music while
+					reading), listing an auditory access mode is not valid.</p>
 
 				<p>Note that the access modes of the content do not reflect any adaptations that have been provided. For
 					example, if a comic book also includes alternative text for each image, it does not have a textual


### PR DESCRIPTION
This pull request adds a paragraph clarifying that you do not set access modes for content that does not contain information necessary to read a publication. For example, a book with only a cover image or publisher logo does not have a visual access mode, as these are not important to reading the book itself.

This change just reinforces what the schema.org [vocabulary definitions](https://w3c.github.io/a11y-discov-vocab/#auditory) already say.