### PR TITLE
Made the epub:type restrictions explicit and adapted the RS

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9721,8 +9721,16 @@ html.my-document-playing * {
 
 					<dt>Usage:</dt>
 					<dd>
-						<p><a data-cite="html#global-attributes">Global attribute</a>. [=EPUB creators=] MAY specify on
-							all elements.</p>
+						<p><a data-cite="html#global-attributes">Global attribute</a>. It MAY be used
+							in [[html]], [[svg]], and on [=Media overlay documents=] with the following restrictions:</p>
+						<ul>
+							<li>For [[html]] content: it MUST be used on [=palpable content=].</li>
+							<li>For [[svg]] content: it MUST be used on 
+								<a href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
+								<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or
+								<a href="https://www.w3.org/TR/SVG11/text.html">text</a> elements.</li>
+							<li>For [=media overlay document=]: it MUST be used on the [^body^] element or its descendants.</li>
+						</ul>
 					</dd>
 
 					<dt>Value:</dt>
@@ -11710,6 +11718,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>28-July-2022: The restrictions on the elements where <code>epub:type</code> may be used 
+						has been made explicit. See <a href="https://github.com/w3c/epub-specs/issues/2377">issue 2377</a>.</li>
 					<li>18-July-2022: The viewport <code>meta</code> element for specifying the initial containing
 						boundary in fixed-layout documents is now formally defined. See <a
 							href="https://github.com/w3c/epub-specs/issues/2292">issue 2292</a>. </li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9722,15 +9722,15 @@ html.my-document-playing * {
 					<dt>Usage:</dt>
 					<dd>
 						<p><a data-cite="html#global-attributes">Global attribute</a>. It MAY be used
-							in [[html]], [[svg]], and on [=Media overlay documents=] with the following restrictions:</p>
+							in [[html]] and [[svg]] with the following restrictions:</p>
 						<ul>
 							<li>For [[html]] content: it MUST be used on [=palpable content=].</li>
 							<li>For [[svg]] content: it MUST be used on 
 								<a href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
 								<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or
 								<a href="https://www.w3.org/TR/SVG11/text.html">text</a> elements.</li>
-							<li>For [=media overlay document=]: it MUST be used on the [^body^] element or its descendants.</li>
 						</ul>
+						<p>For use in [=media overlay documents=] refer to <a href="#sec-overlays-def"></a>.</p>
 					</dd>
 
 					<dt>Value:</dt>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -979,14 +979,6 @@
 							[[wai-aria]].</p>
 					</section>
 
-					<section id="sec-xhtml-structural-semantics">
-						<h5>Structural semantics</h5>
-
-						<p id="confreq-rs-epubtype-head">In addition to the requirements in <a
-								href="#sec-structural-semantics"></a>, a reading system MUST ignore semantics expressed
-							on the [[html]] <span data-cite="html">[^head^]</span> element or its descendants.</p>
-					</section>
-
 					<section id="sec-xhtml-rdfa">
 						<h5>RDFa</h5>
 
@@ -2055,6 +2047,10 @@
 			<p>When processing the [^/epub:type^] attribute, a reading system:</p>
 
 			<ul class="conformance-list">
+				<li>
+					<p id="confreq-rs-epubtype-wrong-element">MUST ignore the terms if used on an element 
+					whose usage is not allowed in the <a data-cite="epub-33#sec-epub-type-attribute">definition of <code>epub:type</code></a> [[epub-33]].</p>
+				</li>
 				<li>
 					<p id="confreq-rs-epubtype-beh">MAY associate behaviors with none, some, or all of the terms defined
 						in the <a data-cite="epub-33#sec-epub-type-attribute">default vocabulary</a> [[epub-33]].</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2040,7 +2040,7 @@
 		<section id="sec-structural-semantics">
 			<h2>Processing structural semantics</h2>
 
-			<p id="confreq-rs-epub-epub-type" class="support">[=Reading systems=] MAY support <a
+			<p id="confreq-rs-epub-epub-type" class="support" data-tests="#pss-support">[=Reading systems=] MAY support <a
 					data-cite="epub-33#app-structural-semantics">structural semantics</a> [[epub-33]] in <a>EPUB content
 					documents</a>.</p>
 
@@ -2048,11 +2048,11 @@
 
 			<ul class="conformance-list">
 				<li>
-					<p id="confreq-rs-epubtype-wrong-element">MUST ignore the terms if used on an element 
+					<p id="confreq-rs-epubtype-ignore-element" data-tests="#pss-support_ignore-title">MUST ignore the terms if used on an element 
 					whose usage is not allowed in the <a data-cite="epub-33#sec-epub-type-attribute">definition of <code>epub:type</code></a> [[epub-33]].</p>
 				</li>
 				<li>
-					<p id="confreq-rs-epubtype-beh">MAY associate behaviors with none, some, or all of the terms defined
+					<p id="confreq-rs-epubtype-beh" data-tests="#pss-support">MAY associate behaviors with none, some, or all of the terms defined
 						in the <a data-cite="epub-33#sec-epub-type-attribute">default vocabulary</a> [[epub-33]].</p>
 				</li>
 				<li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2058,9 +2058,6 @@
 				<li>
 					<p id="confreq-rs-epubtype-oth">MAY associate behaviors with terms from other vocabularies.</p>
 				</li>
-				<li>
-					<p id="confreq-rs-epubtype-ign">MUST ignore terms that it does not recognize.</p>
-				</li>
 			</ul>
 		</section>
 		<section id="sec-vocab-assoc">


### PR DESCRIPTION
Went roughly along the line of https://github.com/w3c/epub-specs/issues/2377#issuecomment-1197985804.

In the §10 of the RS I was tempted to turn the two _MUST_-s into _SHOULD_-s; ignoring those terms is untestable in my view. But I did not do it for now

Fix: #2377

* Preview for EPUB 3.3 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/issue-2377-head-element-semantics/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/issue-2377-head-element-semantics/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2380.html" title="Last updated on Jul 29, 2022, 1:08 PM UTC (730bd2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2380/8b0feb6...730bd2d.html" title="Last updated on Jul 29, 2022, 1:08 PM UTC (730bd2d)">Diff</a>