### PR TITLE
IANA comments on the registrations.

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11497,7 +11497,13 @@ EPUB/images/cover.png</pre>
 
 					<dt>Encoding considerations:</dt>
 					<dd>
-						<p>Package documents are UTF-8 or UTF-16 encoded XML.</p>
+						<p>8bit if UTF-8; binary if UTF-16.</p>
+						<p>
+							Package documents are in XML, represented either in UTF-8 or UTF-16. When the 
+							package document is written in UTF-8, the file is 8bit compatible.  
+							When it is written in UTF-16, the binary content-transfer-encoding
+							must be used.
+						</p>
 					</dd>
 
 					<dt>Security considerations:</dt>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11559,10 +11559,6 @@ EPUB/images/cover.png</pre>
 								<p>TEXT</p>
 							</dd>
 
-							<dt>Fragment Identifiers:</dt>
-							<dd>
-								<p>EPUB Canonical Fragment Identifiers are custom fragment identifiers that can resolve to <code>application/epub+zip</code> and <code>application/oebps-package+xml</code> documents. These identifiers are defined at <a href="https://idpf.org/epub/linking/cfi/">https://idpf.org/epub/linking/cfi/</a>.</p>
-							</dd>
 						</dl>
 					</dd>
 
@@ -11685,9 +11681,14 @@ EPUB/images/cover.png</pre>
 
 							<dt>Fragment identifiers:</dt>
 							<dd>
-								<p>EPUB Canonical Fragment Identifiers are custom fragment identifiers that can resolve to <code>application/epub+zip</code> and <code>application/oebps-package+xml</code> documents. These identifiers are defined at <a href="https://idpf.org/epub/linking/cfi/">https://idpf.org/epub/linking/cfi/</a>.</p>
+								<p>
+									EPUB Canonical Fragment Identifiers are custom fragment identifiers defined for [= EPUB Publications =]. 
+									In combination with the URL of the publication, they may be used to refer to an arbitrary content within 
+									any [=publication resource=] defined for the publication.
+									These identifiers are defined at <a href="https://idpf.org/epub/linking/cfi/">https://idpf.org/epub/linking/cfi/</a>.
+								</p>	
 							</dd>
-						</dl>
+					</dl>
 					</dd>
 
 					<dt>Person &amp; email address to contact for further information:</dt>
@@ -11724,6 +11725,11 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>02-August-2022: Updated the media type registrations, following the 
+						<a href="https://lists.w3.org/Archives/Public/public-epub-wg/2022Aug/0000.html">official IANA review comments</a>
+						on updating the previous registrations. 
+						See <a href="https://github.com/w3c/epub-specs/issues/1398">issue 1398</a>.
+					</li>
 					<li>28-July-2022: The restrictions on the elements where <code>epub:type</code> may be used 
 						has been made explicit. See <a href="https://github.com/w3c/epub-specs/issues/2377">issue 2377</a>.</li>
 					<li>18-July-2022: The viewport <code>meta</code> element for specifying the initial containing

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11502,7 +11502,7 @@ EPUB/images/cover.png</pre>
 							Package documents are in XML, represented either in UTF-8 or UTF-16. When the 
 							package document is written in UTF-8, the file is 8bit compatible.  
 							When it is written in UTF-16, the binary content-transfer-encoding
-							must be used.
+							must be used. For further details, see [[rfc7303]].
 						</p>
 					</dd>
 
@@ -11557,6 +11557,16 @@ EPUB/images/cover.png</pre>
 							<dt>Macintosh File Type Code(s):</dt>
 							<dd>
 								<p>TEXT</p>
+							</dd>
+
+							<dt>Fragment identifiers:</dt>
+							<dd>
+								<p>
+									EPUB Canonical Fragment Identifiers are custom fragment identifiers defined for [= EPUB Publications =]. 
+									They may be used to refer to an arbitrary content within 
+									any [=publication resource=] defined for the publication.
+									These identifiers are defined at <a href="https://idpf.org/epub/linking/cfi/">https://idpf.org/epub/linking/cfi/</a>.
+								</p>	
 							</dd>
 
 						</dl>
@@ -11683,7 +11693,7 @@ EPUB/images/cover.png</pre>
 							<dd>
 								<p>
 									EPUB Canonical Fragment Identifiers are custom fragment identifiers defined for [= EPUB Publications =]. 
-									In combination with the URL of the publication, they may be used to refer to an arbitrary content within 
+									They may be used to refer to an arbitrary content within 
 									any [=publication resource=] defined for the publication.
 									These identifiers are defined at <a href="https://idpf.org/epub/linking/cfi/">https://idpf.org/epub/linking/cfi/</a>.
 								</p>	


### PR DESCRIPTION
This PR is a proposed answer to https://lists.w3.org/Archives/Public/public-epub-wg/2022Aug/0000.html

To directly answer to the comments

> It was wrong before and it is still a bit wrong, because this field can
> have only 1 of 4 values: 7bit/8bit/binary/framed.
> I think "binary" is suitable here, as UTF-16 always use "binary" encoding.

However, the package document may be in UTF-8 or UTF-16, i.e., if my understanding is correct, it should either in 8bit or binary encoding. I have therefore changed the text to make this explicit.

(I got inspired by some other registrations, like https://datatracker.ietf.org/doc/html/rfc4627)

> The newly added "Fragment Identifiers" says:
> EPUB Canonical Fragment Identifiers are custom fragment identifiers
> that can resolve to application/oebps-package+xml documents.
>
> I don't know what this means and the above doesn't give me enough
> information about where more information can be found.
> I found Section 9.3.2.2 in <https://www.w3.org/TR/epub-33/> and it seems
> to contain the text I expected here. I suggest the above text is
> replaced with the reference to this section.

It is correct that the current description of the EPUB Canonical Fragment Identifiers (epubcfi) is a by cryptic and is to be improved. Unfortunately, the section you refer to is not the right one, it refers to fragment identifiers for HTML, SVG, etc, files in a specific context. This Pull Request contains an alternative formulation; hopefully that would work. 

~Furthermore, the comment made me think that it was wrong to list epubcfi for the application/oebps-package+xml media type; it is a fragment that is to be used with the URL of the publication and not with the package document. Ie, it is valid for the application/epub+zip media type only.~


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2383.html" title="Last updated on Aug 5, 2022, 10:56 AM UTC (95746ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2383/c90ecf5...95746ae.html" title="Last updated on Aug 5, 2022, 10:56 AM UTC (95746ae)">Diff</a>