### PR TITLE
Adding test references for restrictions on container-constrained scripts

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1238,10 +1238,16 @@
 					</li>
 
 					<li>
-						<p id="confreq-rs-scripted-container">It MUST NOT allow a container-constrained script to modify
-							the [[dom]] of the host EPUB content document or other contents in the EPUB publication and
-							MUST NOT allow it to manipulate the size of its containing rectangle. (Note: Even if a
-							script is not container-constrained, a reading system might impose restrictions on
+						<p id="confreq-rs-scripted-container">
+							<span id="confreq-rs-scripted-container-dom" data-tests="#scr-not-support_ccscript-modify-host">
+								It MUST NOT allow a container-constrained script to modify
+								the [[dom]] of the host EPUB content document or other contents in the EPUB publication
+							</span> 
+							and
+							<span id="confreq-rs-scripted-container-size"  data-tests="#scr-not-support_ccscript-modify-size">
+								MUST NOT allow it to manipulate the size of its containing rectangle
+							</span>. 
+							(Note: Even if a script is not container-constrained, a reading system might impose restrictions on
 							modifications. See the <a href="#feature-dom-manipulation">dom-manipulation
 							feature</a>.)</p>
 					</li>


### PR DESCRIPTION
This corresponds to https://github.com/w3c/epub-tests/pull/194. To merged when that one is merged.