### PR TITLE
Removed the section on tts, and added references elsewhere

### DIFF
--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -303,7 +303,10 @@
 				<p id="para-media-overlay">Another key multimedia feature in EPUB 3 is the inclusion of <a>media overlay
 						documents</a> [[epub-33]]. When pre-recorded narration is available for an EPUB publication,
 					media overlays provide the ability to synchronize that audio with the text of a Content Document
-					(see also <a href="#sec-access-overlays"></a>).</p>
+					(see also <a href="#sec-access-overlays"></a>). It is also possible to use text-to-speech (TTS)
+					features (pronunciation lexicons or SSML phonemes) in addition to pre-recorded audio clips. These
+					facilities are described in more details in a separate Working Group Note [[epub-tts-10]].
+				</p>
 
 				<p>The <a data-cite="epub-33#sec-media-overlays">structure and semantics of media overlay documents</a>
 					are defined in [[epub-33]].</p>
@@ -351,38 +354,6 @@
 				<p>In other words, consider limiting scripting to cases where it is essential to the user experience,
 					since it greatly increases the likelihood that content will not be portable across all reading
 					systems and creates barriers to accessibility and content reusability.</p>
-
-			</section>
-
-			<section id="sec-tts">
-				<h2>Text-to-speech</h2>
-
-				<p>EPUB 3 provides the following text-to-speech (TTS) facilities for controlling aspects of speech
-					synthesis, such as pronunciation, prosody, and voice characteristics:</p>
-
-				<dl class="labels">
-					<dt>Pronunciation Lexicons</dt>
-					<dd>
-						<p>The inclusion of generic pronunciation lexicons using the W3C PLS format
-							[[pronunciation-lexicon]] enables EPUB creators to provide pronunciation rules that apply to
-							the entire EPUB publication. Refer to <a data-cite="epub-tts-10#pls">Pronunciation
-								Lexicons</a> [[epub-tts-10]] for more information.</p>
-					</dd>
-					<dt>Inline SSML Phonemes</dt>
-					<dd>
-						<p> The incorporation of SSML phonemes functionality [[ssml]] directly into a <a>EPUB content
-								document</a> enables fine-grained pronunciation control, taking precedence over default
-							pronunciation rules and/or referenced pronunciation lexicons (as provided by the PLS format
-							mentioned above). Refer to <a data-cite="epub-tts-10#ssml">SSML Attributes</a>
-							[[epub-tts-10]] for more information.</p>
-					</dd>
-				</dl>
-
-				<p>Note that EPUB creators may also rely on CSS Speech [[css-speech-1]] properties in their style sheet
-					definitions.</p>
-
-				<p>The authoring features for improving the voicing of EPUB 3 publication are described in the separate
-					Working Group Note on Text-to-Speech Enhancements [[epub-tts-10]].</p>
 
 			</section>
 
@@ -460,7 +431,8 @@
 
 				<p>EPUB 3's support for PLS documents and SSML attributes increases the pronunciation control that EPUB
 					creators have over the rendering of any natural language in text-to-speech-enabled reading systems.
-					Refer to <a href="#sec-tts"></a> in the Features section for more information on these
+					Refer to <a href="#sec-multimedia"></a> in the Features section as well as the separate Working
+					Group Note [[epub-tts-10]] for more information on these
 					capabilities.</p>
 
 			</section>
@@ -553,7 +525,7 @@
 
 				<p>Aural renderings of content are important for accessibility and are a desirable feature for many
 					users. A baseline to facilitate aural rendering is to utilize semantic HTML designed for dynamic
-					layout. Refer to <a href="#sec-tts"></a> for more information on how to use the native facilities
+					layout. Refer to [[epub-tts-10]] for more information on how to use the native facilities
 					that XHTML content documents include.</p>
 
 				<p><a data-cite="epub-33#sec-media-overlays">Media overlays</a> [[epub-33]] provide the ability to


### PR DESCRIPTION
This is to fix #2370

The PR removes the old section altogether; instead, it adds a reference to TTS in the multimedia (more exactly the MOL) section. (This is the only place where TTS is mentioned in the core spec.)

See:

* For EPUB 3 Overview:
    * [Preview](https://raw.githack.com/w3c/epub-specs/overview-tts-issue-2370/epub33/overview/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/overview/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/overview-tts-issue-2370/epub33/overview/index.html)
