### PR TITLE
Counterpart to some MOL test cleanup

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1744,7 +1744,8 @@
 		<section id="sec-media-overlays">
 			<h2>Media overlays processing</h2>
 
-			<p id="confreq-rs-epub3-mo" class="support">[=Reading systems=] with the capability to render prerecorded
+			<p id="confreq-rs-epub3-mo" class="support" data-tests="#mol-css">[=Reading systems=] with the capability to 
+				render prerecorded
 				audio SHOULD support <a data-cite="epub-33#sec-media-overlays">media overlays</a> [[epub-33]].</p>
 
 			<p>If a reading system does not support media overlays, it MUST ignore both:</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1764,7 +1764,7 @@
 					media overlays for [=EPUB content documents=].</p>
 
 				<p id="confreq-rs-xhtml-svg">
-					<span id="mol-xhtml-support" data-tests="#mol-css">Reading systems MUST support playback for [=XHTML
+					<span id="mol-xhtml-support" data-tests="#mol-support_xhtml">Reading systems MUST support playback for [=XHTML
 						content documents=], and</span>
 					<span id="mol-svg-support">MAY support [=SVG content documents=].</span>
 				</p>
@@ -1784,7 +1784,7 @@
 					<h3>Timing and synchronization</h3>
 
 					<p id="mol-timing-sync" data-cite="epub-33"
-						data-tests="#mol-timing-synchronization,#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio"
+						data-tests="#mol-timing-synchronization,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_multiple_audio"
 						>Reading systems MUST render immediate children of the [^body^] element [[epub-33]] in a
 						sequence. A [^seq^] element's [[epub-33]] children MUST be rendered in sequence, and playback
 						completes when the last child finishes playing. Reading system MUST render a [^par^] element's
@@ -1906,10 +1906,13 @@
 
 					<ul>
 						<li>
-							<p id="mol-embed-deactivate-playback" data-tests="#mol-embed_deactivate_playback">Reading
+							<p>
+								<span id="mol-embed-deactivate-playback"  data-tests="#mol-embed_deactivate_playback">Reading
 								systems MUST deactivate the public playback interface for all referenced audio and video
 								media embedded within an EPUB content document (typically: play/pause control, time
-								slider, volume level, etc.). This behavior avoids interference between the scheduled
+								slider, volume level, etc.). 
+								</span>
+								This behavior avoids interference between the scheduled
 								playback sequence defined by the media overlay, and the arbitrary playback behavior due
 								to user interaction or script execution. As a result, when the reading system is in
 								playback mode, it SHOULD:</p>


### PR DESCRIPTION
This is the counterpart to https://github.com/w3c/epub-tests/pull/196 (see description there for `mol-css`.