### PR TITLE
Update conformance identifiers to new expanded pattern

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1115,7 +1115,7 @@
 						after <a data-cite="xml#AVNormalize">whitespace normalization</a> [[xml]], exactly matches
 						(i.e., both in case and spacing) the following pattern:</p>
 
-					<p class="conf-pattern">EPUB Aceessibility <a href="#acc-ver"><var>A11Y-VER</var></a> - WCAG <a
+					<p class="conf-pattern">EPUB Accessibility <a href="#acc-ver"><var>A11Y-VER</var></a> - WCAG <a
 							href="#wcag-ver"><var>WCAG-VER</var></a> Level <a href="#wcag-lvl"
 						><var>WCAG-LVL</var></a></p>
 

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1150,7 +1150,7 @@
       &lt;meta 
           property="dcterms:conformsTo"
           id="conf">
-         EPUB Aceessibility 1.1 - WCAG 2.1 Level AA
+         EPUB Accessibility 1.1 - WCAG 2.1 Level AA
       &lt;/meta>
       …
    &lt;/metadata>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1161,12 +1161,12 @@
 					<p>The following conformance strings are valid as of publication of this specification:</p>
 
 					<ul>
-						<li>EPUB Aceessibility 1.1 - WCAG 2.0 Level A</li>
-						<li>EPUB Aceessibility 1.1 - WCAG 2.0 Level AA</li>
-						<li>EPUB Aceessibility 1.1 - WCAG 2.0 Level AAA</li>
-						<li>EPUB Aceessibility 1.1 - WCAG 2.1 Level A</li>
-						<li>EPUB Aceessibility 1.1 - WCAG 2.1 Level AA</li>
-						<li>EPUB Aceessibility 1.1 - WCAG 2.1 Level AAA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level A</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.0 Level AAA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level A</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AA</li>
+						<li>EPUB Accessibility 1.1 - WCAG 2.1 Level AAA</li>
 					</ul>
 
 					<div class="note">

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1859,7 +1859,7 @@
 				<ul>
 					<li>12-Aug-2022: Changed the conformance identifier for publications to be more human-readable while
 						still machine-processable so that the information is not needlessly duplicated in the summary.
-						See <a href="https://github.com/w3c/epub-specs/issues/#">issue #</a>.</li>
+						See <a href="https://github.com/w3c/epub-specs/issues/2398">issue 2398</a>.</li>
 					<li>07-June-2022: Updated privacy and security recommendations to use normative language.</li>
 					<li>17-May-2022: Added an index of terms. See <a
 							href="https://github.com/w3c/epub-specs/issues/2260">issue 2260</a>.</li>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1111,11 +1111,13 @@
 							href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publication</a> [[epub-3]] MUST
 						specify in its <a href="https://www.w3.org/TR/epub/#sec-pkg-metadata">metadata section</a> a <a
 							href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/conformsTo"
-								><code id="dcterms-conformsTo">conformsTo</code> property</a> [[dcterms]] exactly
-						matching (i.e., both in case and spacing) the following pattern:</p>
+								><code id="dcterms-conformsTo">conformsTo</code> property</a> [[dcterms]] whose value,
+						after <a data-cite="xml#AVNormalize">whitespace normalization</a> [[xml]], exactly matches
+						(i.e., both in case and spacing) the following pattern:</p>
 
-					<p class="conf-pattern">EPUB-A11Y-<a href="#acc-ver"><var>A11Y-VER</var></a>_WCAG-<a
-							href="#wcag-ver"><var>WCAG-VER</var></a>-<a href="#wcag-lvl"><var>WCAG-LVL</var></a></p>
+					<p class="conf-pattern">EPUB Aceessibility <a href="#acc-ver"><var>A11Y-VER</var></a> - WCAG <a
+							href="#wcag-ver"><var>WCAG-VER</var></a> Level <a href="#wcag-lvl"
+						><var>WCAG-LVL</var></a></p>
 
 					<p><i>where:</i></p>
 
@@ -1123,14 +1125,12 @@
 						<dt id="acc-ver"><var>A11Y-VER</var></dt>
 						<dd>
 							<p>Specifies the version number of the EPUB Accessibility specification the publication
-								conforms to. The value MUST NOT include decimal points (e.g., the value <code>11</code>
-								indicates this version of this specification).</p>
+								conforms to. The value MUST be <code>1.1</code> or higher.</p>
 						</dd>
 						<dt id="wcag-ver"><var>WCAG-VER</var></dt>
 						<dd>
-							<p>Specifies the version number of WCAG the publication conforms to. The value MUST NOT
-								include decimal points (e.g., <code>20</code> for WCAG 2.0 or <code>21</code> for WCAG
-								2.1).</p>
+							<p>Specifies the version number of WCAG the publication conforms to. The value MUST be
+									<code>2.0</code> or higher.</p>
 						</dd>
 						<dt id="wcag-lvl"><var>WCAG-LVL</var></dt>
 						<dd>
@@ -1150,7 +1150,7 @@
       &lt;meta 
           property="dcterms:conformsTo"
           id="conf">
-         EPUB-A11Y-11_WCAG-21-AA
+         EPUB Aceessibility 1.1 - WCAG 2.1 Level AA
       &lt;/meta>
       …
    &lt;/metadata>
@@ -1161,12 +1161,12 @@
 					<p>The following conformance strings are valid as of publication of this specification:</p>
 
 					<ul>
-						<li>EPUB-A11Y-11_WCAG-20-A</li>
-						<li>EPUB-A11Y-11_WCAG-20-AA</li>
-						<li>EPUB-A11Y-11_WCAG-20-AAA</li>
-						<li>EPUB-A11Y-11_WCAG-21-A</li>
-						<li>EPUB-A11Y-11_WCAG-21-AA</li>
-						<li>EPUB-A11Y-11_WCAG-21-AAA</li>
+						<li>EPUB Aceessibility 1.1 - WCAG 2.0 Level A</li>
+						<li>EPUB Aceessibility 1.1 - WCAG 2.0 Level AA</li>
+						<li>EPUB Aceessibility 1.1 - WCAG 2.0 Level AAA</li>
+						<li>EPUB Aceessibility 1.1 - WCAG 2.1 Level A</li>
+						<li>EPUB Aceessibility 1.1 - WCAG 2.1 Level AA</li>
+						<li>EPUB Aceessibility 1.1 - WCAG 2.1 Level AAA</li>
 					</ul>
 
 					<div class="note">
@@ -1230,7 +1230,7 @@
   &lt;meta
       property="dcterms:conformsTo"
       id="conf">
-     EPUB-A11Y-11_WCAG-21-AA
+     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
   &lt;/meta>
   
   &lt;meta
@@ -1255,7 +1255,7 @@
   &lt;meta
       property="dcterms:conformsTo"
       id="conf">
-     EPUB-A11Y-11_WCAG-21-AA
+     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
   &lt;/meta>
   &lt;meta
       property="a11y:certifiedBy"
@@ -1280,7 +1280,7 @@
   &lt;meta
       property="dcterms:conformsTo"
       id="conf">
-     EPUB-A11Y-11_WCAG-21-AA
+     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
   &lt;/meta>
   
   &lt;meta
@@ -1304,7 +1304,7 @@
   …
   &lt;meta
       name="dcterms:conformsTo"
-      content="EPUB-A11Y-11_WCAG-21-AA"/>
+      content="EPUB Accessibility 1.1 - WCAG 2.1 Level AA"/>
   
   &lt;meta
       name="a11y:certifiedBy"
@@ -1358,7 +1358,7 @@
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
-      EPUB-A11Y-11_WCAG-21-AA
+     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
    &lt;/meta>
    
    &lt;meta
@@ -1392,7 +1392,7 @@
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
-      EPUB-A11Y-11_WCAG-21-AA
+     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
    &lt;/meta>
 
    &lt;meta
@@ -1416,7 +1416,7 @@
    &lt;meta
        property="dcterms:conformsTo"
        id="conf">
-      EPUB-A11Y-11_WCAG-21-AA
+     EPUB Accessibility 1.1 - WCAG 2.1 Level AA
    &lt;/meta>
    
    &lt;meta
@@ -1857,7 +1857,10 @@
 						Recommendation</a></h3>
 
 				<ul>
-				  <li>07-June-2022: Updated privacy and security recommendations to use normative language.</li>
+					<li>12-Aug-2022: Changed the conformance identifier for publications to be more human-readable while
+						still machine-processable so that the information is not needlessly duplicated in the summary.
+						See <a href="https://github.com/w3c/epub-specs/issues/#">issue #</a>.</li>
+					<li>07-June-2022: Updated privacy and security recommendations to use normative language.</li>
 					<li>17-May-2022: Added an index of terms. See <a
 							href="https://github.com/w3c/epub-specs/issues/2260">issue 2260</a>.</li>
 				</ul>

--- a/epub33/reports/exit_criteria.html
+++ b/epub33/reports/exit_criteria.html
@@ -180,7 +180,7 @@
                 <ol>
                     <li id="exit-criteria-a11y-1">
                         <p>
-                          Testing the features in category 1 tests whether these restrictions are <em>feasible</em> and <em>used</em> in practice. This is achieved by the requirement that at least 5 publishers will produce at least 1 EPUB each that conform to <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting-pub">EPUB-A11Y-11_WCAG-20-AA</a>.
+                          Testing the features in category 1 tests whether these restrictions are <em>feasible</em> and <em>used</em> in practice. This is achieved by the requirement that at least 5 publishers will produce at least 1 EPUB each that conform to <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting-pub">EPUB Accessibility 1.1 - WCAG 2.0 Level AA</a>.
                         </p> 
                           
                         <p>


### PR DESCRIPTION
This pull request implements the new pattern for identifiers we discussed to make the metadata field more human readable.

Because the value now has whitespace in it, I added that the value must match our pattern string after xml whitespace normalization. This will allow the value to be brokan by line endings and indents but still be valid.

Other than that, it's a pretty basic expanding of a few abbreviations and removing the hyphenation and underscores that made it one contiguous string of characters.

Fixes #2398 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2398/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2398/epub33/a11y/index.html)

