### PR TITLE
Change accessibilitySummary to a recommended field

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -2336,9 +2336,12 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>12-Aug-2022: Corrected the invalid guidance than an <code>xml:lang</code> attribute on an
+						<code>accessibilitySummary</code> property represents a translation. See <a
+						href="https://github.com/w3c/epub-specs/pulls/2401">pull request 2401</a>.</li>
 				<li>12-Aug-2022: Updated the <code>accessibilitySummary</code> explanation to avoid repeating
 					information available in the other metadata. See <a
-						href="https://github.com/w3c/epub-specs/issues/#2399">issue 2399</a>.</li>
+						href="https://github.com/w3c/epub-specs/issues/2399">issue 2399</a>.</li>
 				<li>20-July-2022: Added additional emphasis on setting single value access mode sufficient declarations
 					and also listed and explained when to apply the two most common for EPUBs. See <a
 						href="https://github.com/w3c/epub-specs/issues/2302">issue 2302</a>.</li>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -543,10 +543,34 @@
 
 				<p>An accessibility summary provides a brief, human-readable description of the accessibility
 					characteristics of an <a href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB
-						publication</a>, or lack thereof.</p>
+						publication</a> that cannot be expressed through the other discovery metadata.</p>
+
+				<p>The accessibility summary should not simply repeat the conformance information provided in the
+						<code>dcterms:conformsTo</code> property, for example, or the features listed in the
+						<code>schema:accessibilityFeature</code> properties. As this metadata is required by the EPUB
+					Accessibility specification, systems that process EPUB publications can already present it to users.
+					Repeating it in the summary only makes them hear the information again.</p>
+
+				<aside class="example" title="Accessibility summary that complements the conformance statement">
+					<pre>&lt;meta
+    property="dcterms:conformsTo">
+   EPUB Accessibility 1.1 - WCAG 2.1 Level AA
+&lt;/meta>
+&lt;meta
+    property="schema:accessibilitySummary">
+   In addition to the requirements of its conformance claim,
+   this publication includes sign language interpretation
+   for all audio content.&#8230;
+&lt;/meta>
+					</pre>
+				</aside>
+
+				<p>EPUB creators should not include an accessibility summary when they have nothing more to add to the
+					conformance claim and other discovery metadata.</p>
 
 				<p>If an EPUB publication does not meet the requirements for content accessibility in [[epub-a11y-11]],
-					the reason(s) it fails should be noted in the summary.</p>
+					the reason(s) it fails should be noted in the summary. Similarly, if an EPUB creator is hesitant to
+					make a formal claim of conformance, the reasons why can be explained in the summary.</p>
 
 				<p>An accessibility summary is provided using the [[schema-org]] <a
 						href="https://schema.org/accessibilitySummary"
@@ -564,19 +588,21 @@
 				<aside class="example" title="Accessibility summary for a publication with a motion simulation hazard">
 					<pre>&lt;meta3
     property="schema:accessibilitySummary">
-   Chapter four contains a first-person interactive game that could cause
-   motion sickness in certain individuals. The game is only provided for
-   illustrative purposes, so readers unable to interact with it will not
+   Although this publication meets the requirements of its accessibility
+   claim, chapter four contains a first-person interactive game that could
+   cause motion sickness in certain individuals. The game is only provided
+   for illustrative purposes, so readers unable to interact with it will not
    be at a disadvantage.
 &lt;/meta></pre>
 				</aside>
 
-				<p>Do not repeat this property unless it contains the summary in another language. In the case of
-					multiple summaries, use the <code>xml:lang</code> attribute to differentiate the language.</p>
+				<p>Do not repeat this property to provide translations of a summary. EPUB does not define a method for
+					including translations. Putting different <code>xml:lang</code> attributes on properties does not
+					indicate a translation and could lead to users hearing the wrong summary for their language.</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilitySummary">The
-							<code>accessibilitySummary</code> Property</a> [[a11y-discov-vocab]] for more information
-					about this property.</p>
+							<code>accessibilitySummary</code> property</a> [[a11y-discov-vocab]] for more
+					information.</p>
 			</section>
 
 			<section id="meta-006">
@@ -2310,6 +2336,9 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>12-Aug-2022: Updated the <code>accessibilitySummary</code> explanation to avoid repeating
+					information available in the other metadata. See <a
+						href="https://github.com/w3c/epub-specs/issues/#2399">issue 2399</a>.</li>
 				<li>20-July-2022: Added additional emphasis on setting single value access mode sufficient declarations
 					and also listed and explained when to apply the two most common for EPUBs. See <a
 						href="https://github.com/w3c/epub-specs/issues/2302">issue 2302</a>.</li>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -598,7 +598,7 @@
 
 				<p>Do not repeat this property to provide translations of a summary. EPUB does not define a method for
 					including translations. Putting different <code>xml:lang</code> attributes on properties does not
-					indicate a translation and could lead to users hearing the wrong summary for their language.</p>
+					indicate a translation and could lead to wrong summary being rendered to users.</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilitySummary">The
 							<code>accessibilitySummary</code> property</a> [[a11y-discov-vocab]] for more
@@ -2336,8 +2336,8 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
-				<li>12-Aug-2022: Corrected the invalid guidance than an <code>xml:lang</code> attribute on an
-						<code>accessibilitySummary</code> property represents a translation. See <a
+				<li>12-Aug-2022: Clarified guidance that an <code>xml:lang</code> attribute on an
+						<code>accessibilitySummary</code> property does not represent a translation. See <a
 						href="https://github.com/w3c/epub-specs/pulls/2401">pull request 2401</a>.</li>
 				<li>12-Aug-2022: Updated the <code>accessibilitySummary</code> explanation to avoid repeating
 					information available in the other metadata. See <a

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -324,18 +324,19 @@
 								>accessibilityHazard</a> — any potential hazards that the content presents (e.g.,
 							flashing, motion simulation, sound).</p>
 					</li>
-
-					<li>
-						<p id="confreq-schema-accessibilitySummary"><a href="https://schema.org/accessibilitySummary"
-								>accessibilitySummary</a> — a human-readable summary of the overall accessibility, which
-							includes a description of any known deficiencies (e.g., lack of extended descriptions,
-							specific hazards).</p>
-					</li>
 				</ul>
 
 				<p>EPUB publications SHOULD include the following [[schema-org]] accessibility metadata:</p>
 
 				<ul class="conformance-list">
+					<li>
+						<p id="confreq-schema-accessibilitySummary"><a href="https://schema.org/accessibilitySummary"
+								>accessibilitySummary</a> — a human-readable summary of the accessibility that
+							complements, but does not duplicate, the other discoverability metadata. The summary also
+							describes any known deficiencies (e.g., lack of extended descriptions, specific
+							hazards).</p>
+					</li>
+
 					<li>
 						<p id="confreq-schema-accessModeSufficient"><a href="https://schema.org/accessModeSufficient"
 								>accessModeSufficient</a> — a set of one or more access modes sufficient to consume the
@@ -1857,7 +1858,10 @@
 						Recommendation</a></h3>
 
 				<ul>
-				  <li>07-June-2022: Updated privacy and security recommendations to use normative language.</li>
+					<li>12-Aug-2022: Changed <code>accessibilitySummary</code> from a required to a recommended property
+						and updated its definition to focus less on repeating information available in the other
+						metadata. See <a href="https://github.com/w3c/epub-specs/issues/2399">issue 2399</a>.</li>
+					<li>07-June-2022: Updated privacy and security recommendations to use normative language.</li>
 					<li>17-May-2022: Added an index of terms. See <a
 							href="https://github.com/w3c/epub-specs/issues/2260">issue 2260</a>.</li>
 				</ul>


### PR DESCRIPTION
This pull request moves accssibilitySummary to the recommended metadata list with accessModeSufficient. The definition is also slightly tweaked to emphasize that it is not for duplicating information expressed elsewhere.

The techniques document section has also been rewritten to emphasize avoiding duplication.

Have a good look at these changes and let me know if there's anything else we should say.

Fixes #2399 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2399/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2399/epub33/a11y/index.html)

