### PR TITLE
Deprecate Media Overlays embedded media

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8257,7 +8257,7 @@ No Entry</pre>
 								href="https://www.w3.org/TR/SVG11/shapes.html">basic shapes</a>, or <a
 								href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG). </p>
 						
-						<p class="note">While the <code>src</code> attribute of a <code>text</code> element may refer to embedded timed media, such as an [[html]] [^video^] element, this is atypical usage and, as Reading System behavior is unspecified, may produce unpredictable results.</p>
+						<p class="note">[[epub-rs-33]] no longer provides guidance for reading systems on the playback of timed media (i.e., the automatic starting of the referenced media). Although the <code>src</code> attribute of a <code>text</code> element may refer to embedded timed media (e.g., via an [[html]] [^video^] element), referencing such media may have unpredictable results.</p>
 					</section>
 
 					<section id="sec-smil-audio-elem">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11707,7 +11707,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>28-August-2022: Added a note to Media Overlays <code>text</code> element definition regarding using embedded timed media.</li>
+					<li>28-August-2022: Added a note to Media Overlays <code>text</code> element definition regarding using embedded timed media.
+						See <a href="https://github.com/w3c/epub-specs/issues/2397">issue 2397</a>.</li>
 					<li>02-August-2022: Updated the media type registrations, following the 
 						<a href="https://lists.w3.org/Archives/Public/public-epub-wg/2022Aug/0000.html">official IANA review comments</a>
 						on updating the previous registrations. 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8200,7 +8200,7 @@ No Entry</pre>
 
 						<p>The <code>text</code> element references an element in an [=EPUB content document=]. A
 								<code>text</code> element typically refers to a textual element but can also refer to
-							other [=EPUB content document=] media elements (see <a href="#sec-embedded-media"></a>). In
+							other [=EPUB content document=] media elements. In
 							the absence of a sibling [^audio^] element, textual content referred to by this element may
 							be rendered via <a href="#sec-tts">text-to-speech</a>.</p>
 
@@ -8256,6 +8256,8 @@ No Entry</pre>
 								href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a
 								href="https://www.w3.org/TR/SVG11/shapes.html">basic shapes</a>, or <a
 								href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG). </p>
+						
+						<p class="note">While the <code>src</code> attribute of a <code>text</code> element may refer to embedded timed media, such as an [[html]] [^video^] element, this is atypical usage and, as Reading System behavior is unspecified, may produce unpredictable results.</p>
 					</section>
 
 					<section id="sec-smil-audio-elem">
@@ -8643,43 +8645,6 @@ No Entry</pre>
 							navigating by word or phrase and when searching the text but increases the file size of the
 							[=media overlay documents=]. Fragment identifier schemes that do not rely on the presence of
 							elements could provide even finer granularity, where supported.</p>
-					</section>
-
-					<section id="sec-embedded-media">
-						<h5>Embedded media</h5>
-
-						<p>Any [=EPUB content document=] associated with a [=media overlay document=] MAY contain
-							embedded media such as video, audio, and images. [=EPUB creators=] MAY use the media overlay
-							[^text^] element in such instances to reference the embedded media by its element's
-								<code>id</code> attribute value.</p>
-
-						<section id="sec-emb-audio-video">
-							<h6>Embedded audio and video</h6>
-
-							<p> When a [^text^] element references embedded audio or video, [=reading systems=] will
-								initiate playback of the media in the absence of an [^audio^] element sibling. </p>
-
-							<p>[=EPUB creators=] SHOULD avoid using scripts to control playback of referenced embedded
-								[=EPUB content document=] media, as this might conflict with media overlays playback
-								behavior.</p>
-
-							<p>EPUB creators should carefully examine any overlapping audio situations and deal with
-								them at the production stage, as reading systems handling of simultaneous volume levels
-								is optional.</p>
-						</section>
-
-						<section id="sec-emb-img">
-							<h6>Embedded images</h6>
-
-							<p>When a <code>text</code> element references an embedded image, the [^audio^] sibling
-								element is OPTIONAL. In the absence of an <code>audio</code> element, [=reading
-								systems=] will voice the image using <a href="#sec-tts">text-to-speech
-								rendering</a>.</p>
-
-							<p>[=EPUB creators=] MUST ensure they provide fallback text for an image when an omitting an
-									<code>audio</code> element (e.g., using the [[html]] <code>alt</code>
-								attribute).</p>
-						</section>
 					</section>
 
 					<section id="sec-tts">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11707,6 +11707,7 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>28-August-2022: Added a note to Media Overlays <code>text</code> element definition regarding using embedded timed media.</li>
 					<li>02-August-2022: Updated the media type registrations, following the 
 						<a href="https://lists.w3.org/Archives/Public/public-epub-wg/2022Aug/0000.html">official IANA review comments</a>
 						on updating the previous registrations. 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1866,6 +1866,9 @@
 			<section id="sec-behaviors-interaction">
 				<h4>Interacting with the EPUB content document</h4>
 
+				<p class="note">Earlier versions of this specification included some information about embedded audio and 
+					video [epubmediaoverlays-32]. This feature has been deprecated.</p>
+
 				<section id="sec-rsconf-navigation">
 					<h5>Navigation</h5>
 
@@ -1896,113 +1899,6 @@
 							synchronized with user navigation of table rows and cells. The reading system might also
 							play the corresponding table header preceding the contents of the cell.</p>
 					</div>
-				</section>
-
-				<section id="sec-embedded-media">
-					<h5>Embedded audio and video</h5>
-
-					<p>An [=EPUB content document=] with which a media overlay is associated MAY itself contain embedded
-						video and audio media. The media overlay elements MAY point to these elements. Unlike text and
-						images, video and audio media have an intrinsic duration. <span id="mol-embed-override"
-							data-tests="#mol-embed,#mol-embed_fxl">Consequently, when a reading system renders the
-							synchronization described by a media overlay, it MUST override the default playback behavior
-							of audio and video media embedded within the associated EPUB content document.</span></p>
-
-					<p>Note that the rules below apply only to <em>referenced</em> [[html]] <span data-cite="html"
-							>[^video^] or [^audio^]</span> elements within the associated EPUB content document. That is
-						to say, the rules apply to only those elements pointed to by [^text^] elements [[epub-33]]
-						within the media overlay (i.e., via the <code>src</code> attribute). These rules do not apply to
-						embedded media not referenced by media overlay elements.</p>
-
-					<ul>
-						<li>
-							<p>
-								<span id="mol-embed-deactivate-playback"  data-tests="#mol-embed_deactivate_playback">Reading
-								systems MUST deactivate the public playback interface for all referenced audio and video
-								media embedded within an EPUB content document (typically: play/pause control, time
-								slider, volume level, etc.). 
-								</span>
-								This behavior avoids interference between the scheduled
-								playback sequence defined by the media overlay, and the arbitrary playback behavior due
-								to user interaction or script execution. As a result, when the reading system is in
-								playback mode, it SHOULD:</p>
-							<ul>
-								<li>
-									<p>Hide the individual video/audio UI controls from the page, which overrides the
-										default behavior defined by the [[html]] [^audio/controls^] attribute.</p>
-								</li>
-								<li>
-									<p>Prevent scripts embedded within the EPUB content document from invoking the
-										JavaScript audio/video playback API (i.e., authored as part of the default
-										behavior).</p>
-								</li>
-							</ul>
-						</li>
-						<li id="mol-embed-init-to-stop" data-tests="#mol-embed,#mol-embed_fxl">
-							<p>Reading systems MUST initialize all referenced audio and video media embedded within an
-								EPUB content document to their "stopped" state, and ready them to play from the
-								zero-position within their content stream (possibly displaying the image specified using
-								the [[html]] [^video/poster^] attribute). This requirement overrides the default behavior
-								defined by the [[html]] [^video/autoplay^] attribute.</p>
-						</li>
-						<li>
-							<p>When an EPUB content document element becomes active, the CSS Style Sheet visual
-								highlighting rules apply regardless of the content type referred to by that element's
-									<code>src</code> attribute (e.g., the CSS class name defined by the <a
-									data-cite="epub-33#active-class"><code>active-class</code> metadata property</a>
-								[[epub-33]] SHOULD be applied to visible video and audio player controls within the host
-								EPUB content document).</p>
-						</li>
-						<li>
-							<p id="mol-embed-start-and-stop" data-tests="#mol-embed,#mol-embed_fxl">In addition to the
-								default behavior of media overlay activation for textual fragments and images, audio and
-								video playback MUST be started and stopped according to the duration implied by the
-								authored media overlay synchronization (as per the standard [[smil3]] timing model).
-								There are two possible scenarios:</p>
-							<ul>
-								<li>
-									<p data-cite="epub-33">When a media overlay <code>text</code> element has no
-										[^audio^] [[epub-33]] sibling within its [^par^] [[epub-33]] parent container,
-										the referenced EPUB content document audio or video media MUST play until it
-										ends, at which point the <code>text</code> element's lifespan terminates. In
-										this case, the implicit duration of the <code>text</code> element (and by
-										inference, of the parent <code>par</code> container) is that of the referenced
-										audio or video clip.</p>
-								</li>
-								<li>
-									<p>When a media overlay <code>text</code> element has an <code>audio</code> sibling
-										within its <code>par</code> parent container, reading systems MUST constrain the
-										playback duration of the referenced EPUB content document audio or video media
-										by the duration of the <code>audio</code> sibling. In this case, the actual
-										duration of the parent <code>par</code> container is that of the child audio
-										clip, regardless of the duration of the video or audio media pointed to by the
-											<code>text</code> element. This behavior can result in embedded video or
-										audio media ending playback prematurely (before reaching its full duration), or
-										ending before the playback of the parallel media overlay <code>audio</code> is
-										finished (in which case the last-played video frame SHOULD remain visible until
-										the parent <code>par</code> container finally ends). This behavior is equivalent
-										of the media overlay <code>audio</code> element implicitly carrying the behavior
-										of the [[smil3]] <a data-cite="smil3/smil-timing.html#adef-endsync"
-												><code>endsync</code></a> attribute.</p>
-									<p>Furthermore, reading systems SHOULD expose user controls for the volume levels of
-										each independent audio track (i.e., from the <code>audio</code> element of the
-										media overlay, and from the embedded audio or video media within the EPUB
-										content document), so that users can adjust the audio output to match their
-										requirements. Note that having overlapping audio tracks is typically an
-										authoring-time concern: content producers usually add a layer of audio
-										information over a video track for description purposes. Reading systems
-										handling of simultaneous volume levels in any specific way is OPTIONAL.</p>
-								</li>
-							</ul>
-						</li>
-						<li>
-							<p id="mol-text-inactive">When a <code>text</code> element becomes inactive in the media
-								overlay, and when it points to embedded video or audio media, that referenced media MUST
-								be reset to its initial "stopped" state, ready to be played from the zero-position
-								within their content stream (possibly displaying the poster image specified using the
-								[[html]] markup).</p>
-						</li>
-					</ul>
 				</section>
 
 				<section id="sec-text-to-speech">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2598,6 +2598,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>28-August-2022: The guidelines for rendering embedded timed media in Media Overlays have been 
+						deprecated. See <a href="https://github.com/w3c/epub-specs/issues/2397">issue 2397</a>.</li>
 					<li>28-July-2022: Restructured the vocabulary association mechanisms section as an algorithm for
 						obtaining an expanded URL. See <a href="https://github.com/w3c/epub-specs/issues/2378">issue
 							2378</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1867,7 +1867,7 @@
 				<h4>Interacting with the EPUB content document</h4>
 
 				<p class="note">Earlier versions of this specification included some information about embedded audio and 
-					video [epubmediaoverlays-32]. This feature has been deprecated.</p>
+					video [[epubmediaoverlays-32]]. This feature has been deprecated.</p>
 
 				<section id="sec-rsconf-navigation">
 					<h5>Navigation</h5>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1901,6 +1901,12 @@
 					</div>
 				</section>
 
+				<section id="sec-embedded-media">
+					<h4>Embedded audio and video (deprecated)</h4>
+					<p>Guidance for automatic playback of embedded audio and video is now <a data-cite="epub-33#deprecated">deprecated</a>.</p>
+					<p>Refer to its definition in [[epubmediaoverlays-32]] for more information.</p>
+				</section>
+
 				<section id="sec-text-to-speech">
 					<h5>Text-to-speech</h5>
 


### PR DESCRIPTION
Fixes #2397 

In the core spec:

Removed 9.3.2.4 entirely, added note to MO text element about how referring to embedded timed media with the MO text element is possible but unspecified.

In the RS spec:

Removed 9.3.2 and added a note about deprecation to the top of 9.3.

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/marisademeglio/epub-specs/fix-issue-2397-mo-embed/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/marisademeglio/epub-specs/fix-issue-2397-mo-embed/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marisademeglio/epub-specs/pull/2402.html" title="Last updated on Aug 29, 2022, 3:42 PM UTC (76eb127)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2402/d9c0385...marisademeglio:76eb127.html" title="Last updated on Aug 29, 2022, 3:42 PM UTC (76eb127)">Diff</a>