### PR TITLE
Adding the value of "hidden" to the example

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6722,7 +6722,7 @@ No Entry</pre>
 
 					<pre>&lt;nav
     epub:type="page-list"
-    hidden="">
+    hidden="hidden">
    &lt;h2>Pagebreaks of the print version, third edition&lt;/h2>
    &lt;ol>
       &lt;li>


### PR DESCRIPTION
Although, per the [HTML spec](https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute), the empty string is valid and is equivalent to the value of `hidden`, it is probably a better practice to make it explicit (as for a number of attributes in the XHTML), so this PR does that.

Fix #2403


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2404.html" title="Last updated on Aug 25, 2022, 9:38 AM UTC (89a4c97)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2404/d9c0385...89a4c97.html" title="Last updated on Aug 25, 2022, 9:38 AM UTC (89a4c97)">Diff</a>