### PR TITLE
Added a reference to a font obfuscation test

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2988,7 +2988,7 @@
 				<section id="obfus-keygen">
 					<h4>Obfuscation key</h4>
 
-					<p>[=EPUB creators=] MUST derive the key used in the obfuscation algorithm from the [=unique
+					<p id="obfus-key-unique-id" data-tests="#ocf-font_obfuscation,#ocf-font_obfuscation-bis">[=EPUB creators=] MUST derive the key used in the obfuscation algorithm from the [=unique
 						identifier=].</p>
 
 					<p>All white space characters, as defined in <a data-cite="xml#sec-common-syn">section 2.3 of the

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -697,7 +697,7 @@
 			<section id="sec-container-fobfus">
 				<h3>Font obfuscation</h3>
 
-				<p id="confreq-ocf-fobfus">Reading systems SHOULD support deobfuscation of fonts as defined in <a
+				<p id="confreq-ocf-fobfus" data-tests="#ocf-font_obfuscation">Reading systems SHOULD support deobfuscation of fonts as defined in <a
 						data-cite="epub-33#sec-font-obfuscation">Font obfuscation</a> [[epub-33]].</p>
 
 				<p>To restore the original data, reading systems should simply reverse the process: the source file

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -697,7 +697,7 @@
 			<section id="sec-container-fobfus">
 				<h3>Font obfuscation</h3>
 
-				<p id="confreq-ocf-fobfus" data-tests="#ocf-font_obfuscation">Reading systems SHOULD support deobfuscation of fonts as defined in <a
+				<p id="confreq-ocf-fobfus" data-tests="#ocf-font_obfuscation,#ocf-font_obfuscation-bis">Reading systems SHOULD support deobfuscation of fonts as defined in <a
 						data-cite="epub-33#sec-font-obfuscation">Font obfuscation</a> [[epub-33]].</p>
 
 				<p>To restore the original data, reading systems should simply reverse the process: the source file


### PR DESCRIPTION
This is a counterpart to https://github.com/w3c/epub-tests/pull/201. To be merged when that one is merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2409.html" title="Last updated on Sep 6, 2022, 3:06 PM UTC (bd5d6c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2409/466cbd7...bd5d6c0.html" title="Last updated on Sep 6, 2022, 3:06 PM UTC (bd5d6c0)">Diff</a>