### PR TITLE
Minor rewrite of conformance intro

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -381,21 +381,25 @@
 			<section id="sec-accessible-pubs-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>EPUB builds on the Open Web Platform, with HTML, CSS, JavaScript and SVG, the core technologies used
-					for content authoring. The use of these technologies means that <a
-						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> can author <a
+				<p>EPUB builds on the Open Web Platform, with HTML, CSS, JavaScript, and SVG the core technologies used
+					for content authoring. Leveraging these technologies allows <a
+						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> to author <a
 						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> with a high degree
-					of accessibility simply through the proper application of established web accessibility
-					techniques.</p>
+					of accessibility through the application of established web accessibility techniques, such as using
+					native elements and controls whenever possible and enhancing custom interactive content with
+					[[wai-aria]] roles, states, and properties. It is not necessary for anyone familiar with web
+					accessibility to learn a new accessibility framework to make EPUB publications accessible.</p>
 
-				<p>The primary source producing accessible web content is the W3C Web Content Accessibility Guidelines
-					(WCAG) [[wcag2]]. This specification leverages the extensive work done in WCAG to establish
-					benchmarks for accessible content, and the same four high-level content principles — perceivable,
-					operable, understandable, and robust — are central to creating EPUB publications that are
-					accessible.</p>
+				<p>The primary source for producing accessible web content is the W3C's Web Content Accessibility
+					Guidelines (WCAG) [[wcag2]], which establish benchmarks for accessible content. WCAG defines four
+					high-level content principles — that content be perceivable, operable, understandable, and robust.
+					These principles are also central to creating accessible EPUB publications, so it is no surprise
+					that this specification builds on the extensive work done in WCAG.</p>
 
-				<p>This section defines how to apply the conformance criteria defined in WCAG and addresses qualities
-					unique to EPUB publications.</p>
+				<p>This section defines <a href="#sec-acc-pub-wcag">how to apply the conformance criteria defined in
+						WCAG</a> to EPUB publications. It also adds additional <a href="#sec-epub-req">requirements
+						unique to EPUB publications</a>, and defines <a href="#sec-conf-reporting">conformance reporting
+						requirements</a>.</p>
 
 				<p>EPUB publications authored to comply with the requirements in this section will have a high degree of
 					accessibility for users with a wide variety of reading needs and preferences.</p>
@@ -405,9 +409,9 @@
 				<h3>Relationship to WCAG</h3>
 
 				<p>WCAG [[wcag2]] and its <a href="https://www.w3.org/WAI/WCAG21/Techniques/">associated techniques</a>
-					provide extensive coverage of issues and solutions for web content accessibility — from tables to
-					embedded multimedia to rich semantics. They represent the foundation that this specification builds
-					upon.</p>
+					provide extensive coverage of issues and solutions for web content accessibility, covering
+					everything from multimedia to interactive content to structured markup and more. They represent the
+					foundation that this specification builds upon.</p>
 
 				<p>This specification does not repeat the requirements or techniques introduced in those documents, as
 					it risks breaking compatibility between the two standards (e.g., putting guidance out of sync, or in


### PR DESCRIPTION
Looking over the introduction to section 3.1 of the accessibility specification again to see if there was someplace there to mention ARIA, I noticed a typo and some unneeded verbosity in the language.

This pull request does some minor rewriting to try and improve it a bit. The most notable changes are probably:

- adding mention of ARIA roles, states and properties in giving examples of following established web accessibility practices;
- expanding the paragraph about how this section explains how to apply WCAG to EPUB - it now mentions the EPUB additions and conformance reporting. I've also added links to the subsections.

I also did a minor tweak to the list of examples of what WCAG covers. It was kind of an odd mix to have tables and rich semantics as two of only three examples of what WCAG covers. The list is now generalized to: " covering everything from multimedia to interactive content to structured markup and more."

Let me know if you spot anything you don't agree with or think could be added to enhance the section.

Fixes #2405 

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2405/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2405/epub33/a11y/index.html)
