### PR TITLE
Add note for summaries

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -352,6 +352,14 @@
 					[[schema-org]] accessibility metadata not specified in this section.</p>
 
 				<div class="note">
+					<p>This specification assumes that conformance and discoverability metadata will be processed and
+						presented in a human-readable manner, removing the need for a summary unless there is additional
+						information to express. Such processing is not available in all market segments, however,
+						particularly in library systems. Publishers should consider this limitation when deciding
+						whether to include a summary and what to state in it.</p>
+				</div>
+
+				<div class="note">
 					<p>For the complete list of approved terms to use with these properties, refer to the <a
 							href="https://www.w3.org/2021/a11y-discov-vocab/latest/">Schema.org Accessibility Properties
 							for Discoverability Vocabulary</a> [[a11y-discov-vocab]].</p>


### PR DESCRIPTION
This is an update for #2401. Part of the resolution for the issue was to add a note explaining that summaries will still be useful for market segments where automated processing and display of metadata are not expected - library systems, in particular, as we've discussed. This PR adds the missing note.

- Accessibility [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/summary-use-note/epub33/a11y/index.html)
- Accessibility [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/summary-use-note/epub33/a11y/index.html)

