### PR TITLE
Add clarifying requirement that the manifest only list publication resources

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -2988,7 +2988,8 @@
 				<section id="obfus-keygen">
 					<h4>Obfuscation key</h4>
 
-					<p id="obfus-key-unique-id" data-tests="#ocf-font_obfuscation,#ocf-font_obfuscation-bis">[=EPUB creators=] MUST derive the key used in the obfuscation algorithm from the [=unique
+					<p id="obfus-key-unique-id" data-tests="#ocf-font_obfuscation,#ocf-font_obfuscation-bis">[=EPUB
+						creators=] MUST derive the key used in the obfuscation algorithm from the [=unique
 						identifier=].</p>
 
 					<p>All white space characters, as defined in <a data-cite="xml#sec-common-syn">section 2.3 of the
@@ -4753,7 +4754,7 @@ XHTML:
 
 					<p id="confreq-rendition-manifest">[=EPUB creators=] MUST list all publication resources in the
 							<code>manifest</code>, regardless of whether they are [=container resources=] or [=remote
-						resources=], using [^item^] elements.</p>
+						resources=]. Moreover, the <code>manifest</code> MUST only list publication resources.</p>
 
 					<p>Note that the <code>manifest</code> is not self-referencing: EPUB creators MUST NOT specify an
 							<code>item</code> element that refers to the [=package document=] itself.</p>
@@ -11706,6 +11707,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>7-September-2022: Added clarifying requirement that the manifest only list publication
+						resources. See <a href="https://github.com/w3c/epub-specs/issues/2413">issue 2413</a>.</li>
 					<li>28-August-2022: Added a note to Media Overlays <code>text</code> element definition regarding
 						using embedded timed media. See <a href="https://github.com/w3c/epub-specs/issues/2397">issue
 							2397</a>.</li>


### PR DESCRIPTION
Implements the text in #2413 

Fixes #2413


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2414.html" title="Last updated on Sep 7, 2022, 7:18 PM UTC (55f0307)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2414/32d72b1...55f0307.html" title="Last updated on Sep 7, 2022, 7:18 PM UTC (55f0307)">Diff</a>