### PR TITLE
Clarify the purpose of the techniques 

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -108,18 +108,28 @@
 				Publications.</p>
 		</section>
 		<section id="sotd"></section>
-		<section id="sec-overview">
-			<h2>Overview</h2>
+		<section id="sec-intro">
+			<h2>Introduction</h2>
 
-			<section id="sec-purpose-scope">
-				<h3>Purpose and scope</h3>
+			<section id="sec-overview">
+				<h3>Overview</h3>
 
-				<p>This document, EPUB Accessibility Techniques, provides guidance on how to meet the
-					[[epub-a11y-11]] discovery and accessibility requirements for <a
+				<p>This document, EPUB Accessibility Techniques, provides informative guidance on how to understand and
+					apply the discovery and accessibility requirements defined in the EPUB Accessibility 1.1
+					specification [[epub-a11y-11]] that are unique to <a
 						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a>.</p>
 
-				<p>This document does not cover techniques and best practices already addressed in [[wcag2]] and
-					[[wai-aria]] for which no substantive differences in application exist.</p>
+				<p>This document does not cover general web accessibility techniques already addressed in [[wcag2]] and
+					[[wai-aria]], for example, for which no substantive differences in application exist. Following
+					those techniques, as applicable, is also essential to meeting the accessibility requirements of the
+					EPUB Accessibility 1.1 specification.</p>
+
+				<p>This document is not intended to be read in isolation, in other words, as it does not define
+					conformance requirements for making accessibility claims or cover every method for producing
+					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.1 in
+					order to make a claim of accessibility. Verifying only the techniques in this document does not mean
+					an <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> can claim conformance to
+					EPUB Accessibility 1.1.</p>
 			</section>
 
 			<section id="sec-terminology">
@@ -2336,6 +2346,9 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>08-Sept-2022: Clarified that only meeting the techniques in this document is not sufficient for
+					making claims of accessibility. <a href="https://github.com/w3c/epub-specs/issues/2407">issue
+						2407</a></li>
 				<li>12-Aug-2022: Clarified guidance that an <code>xml:lang</code> attribute on an
 						<code>accessibilitySummary</code> property does not represent a translation. See <a
 						href="https://github.com/w3c/epub-specs/pulls/2401">pull request 2401</a>.</li>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -126,9 +126,9 @@
 
 				<p>This document is not intended to be read in isolation, in other words, as it does not define
 					conformance requirements for making accessibility claims or cover every method for producing
-					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.1 in
-					order to make a claim of accessibility. Verifying only the techniques in this document does not mean
-					an <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> can claim conformance to
+					accessible content. An EPUB publication must meet all the requirements of EPUB Accessibility 1.1 to
+					make a claim of accessibility. Verifying only the techniques in this document does not mean an <a
+						href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creator</a> can claim conformance to
 					EPUB Accessibility 1.1.</p>
 			</section>
 


### PR DESCRIPTION
There are two parts to this pull request:

- the first renames a couple of sections that were still using the old IDPF conventions. Specifically, "Overview" is renamed to "Introduction" and "Purpose and Scope" is renamed to "Overview". This makes the naming consistent with the specifications.
- the second is to expand on the old "purpose and scope" section (now overview) to try and better explain how these techniques fit with the accessibility specification and also wcag and aria techniques.

Fixes #2407 

- Accessibility Techniques [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2407/epub33/a11y-tech/index.html)
- Accessibility Techniques [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/issue-2407/epub33/a11y-tech/index.html)
