### PR TITLE
Typos

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4522,9 +4522,10 @@
 					</dl>
 
 					<p>The [^metadata^] element MAY contain zero or more <code>link</code> elements, each of which
-						identifies the location of a [=linked resource=] in its REQUIRED <code>href</code> attribute</p>
+						identifies the location of a [=linked resource=] in its REQUIRED <code>href</code>
+						attribute.</p>
 
-					<p id="linked-res-manifest">linked resources are [=publication resources=] only when they are:</p>
+					<p id="linked-res-manifest">Linked resources are [=publication resources=] only when they are:</p>
 
 					<ul>
 						<li>


### PR DESCRIPTION
I didn't try to track the full history down, but there used to only be a missing period in very old drafts. At some point, the next paragraph lost its capital, but there wasn't any other text between. Probably just a weird coincidence related to our lowercasing of terminology.

Fixes #2418


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2419.html" title="Last updated on Sep 13, 2022, 3:44 PM UTC (3004d19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2419/f16eb51...3004d19.html" title="Last updated on Sep 13, 2022, 3:44 PM UTC (3004d19)">Diff</a>