### PR TITLE
Add nav doc requirements section

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11719,6 +11719,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>14-September-2022: Added a new section for expressing all the primary navigation document
+						content requirements. See <a href="https://github.com/w3c/epub-specs/issues/2421">issue
+						2421</a>.</li>
 					<li>7-September-2022: Added clarifying requirement that the manifest only list publication
 						resources. See <a href="https://github.com/w3c/epub-specs/issues/2413">issue 2413</a>.</li>
 					<li>28-August-2022: Added a note to Media Overlays <code>text</code> element definition regarding

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6308,13 +6308,19 @@ No Entry</pre>
 
 				<p>A valid EPUB navigation document:</p>
 
-				<ul class="conformance">
-					<li>MUST conform to the content conformance constraints for [=XHTML content documents=] defined in
-							<a href="#sec-xhtml-req"></a>;</li>
-					<li>MUST conform to the <code>nav</code> element constraints defined <a href="#sec-nav-def-model"
-						></a>;</li>
-					<li>MUST include exactly one <code>toc</code>
-						<code>nav</code> element as defined in <a href="#sec-nav-toc"></a>.</li>
+				<ul class="conformance-list">
+					<li>
+						<p id="confreq-navdoc-xhtml">MUST conform to the content conformance constraints for [=XHTML
+							content documents=] defined in <a href="#sec-xhtml-req"></a>;</p>
+					</li>
+					<li>
+						<p id="confreq-navdoc-navs">MUST conform to the <code>nav</code> element constraints defined <a
+								href="#sec-nav-def-model"></a>;</p>
+					</li>
+					<li>
+						<p id="confreq-navdoc-toc">MUST include exactly one <code>toc</code>
+							<code>nav</code> element as defined in <a href="#sec-nav-toc"></a>.</p>
+					</li>
 				</ul>
 			</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11714,15 +11714,15 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>14-September-2022: Added a new section for expressing all the primary navigation document
+					<li>14-Sept-2022: Added a new section for expressing all the primary navigation document
 						content requirements. See <a href="https://github.com/w3c/epub-specs/issues/2421">issue
 						2421</a>.</li>
-					<li>7-September-2022: Added clarifying requirement that the manifest only list publication
+					<li>7-Sept-2022: Added clarifying requirement that the manifest only list publication
 						resources. See <a href="https://github.com/w3c/epub-specs/issues/2413">issue 2413</a>.</li>
-					<li>28-August-2022: Added a note to Media Overlays <code>text</code> element definition regarding
+					<li>28-Aug-2022: Added a note to Media Overlays <code>text</code> element definition regarding
 						using embedded timed media. See <a href="https://github.com/w3c/epub-specs/issues/2397">issue
 							2397</a>.</li>
-					<li>02-August-2022: Updated the media type registrations, following the <a
+					<li>02-Aug-2022: Updated the media type registrations, following the <a
 							href="https://lists.w3.org/Archives/Public/public-epub-wg/2022Aug/0000.html">official IANA
 							review comments</a> on updating the previous registrations. See <a
 							href="https://github.com/w3c/epub-specs/issues/1398">issue 1398</a>. </li>
@@ -11810,7 +11810,7 @@ EPUB/images/cover.png</pre>
 							href="https://github.com/w3c/epub-specs/issues/1872">issue 1872</a>, <a
 							href="https://github.com/w3c/epub-specs/issues/1875">issue 1875</a> and <a
 							href="https://github.com/w3c/epub-specs/issues/1876">issue 1876</a>.</li>
-					<li>21-January-2022: term "risky", used for the class of unsupported features, has been renamed to
+					<li>21-Jan-2022: term "risky", used for the class of unsupported features, has been renamed to
 						"under-implemented". See the <a
 							href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-01-20-epub#resolution1"
 							>WG resolution</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6303,6 +6303,21 @@ No Entry</pre>
 					ensure the content will retain its integrity when rendered in a non-browser context.</p>
 			</section>
 
+			<section id="sec-nav-content-req">
+				<h3>Navigation document requirements</h3>
+
+				<p>A valid EPUB navigation document:</p>
+
+				<ul class="conformance">
+					<li>MUST conform to the content conformance constraints for [=XHTML content documents=] defined in
+							<a href="#sec-xhtml-req"></a>;</li>
+					<li>MUST conform to the <code>nav</code> element constraints defined <a href="#sec-nav-def-model"
+						></a>;</li>
+					<li>MUST include exactly one <code>toc</code>
+						<code>nav</code> element as defined in <a href="#sec-nav-toc"></a>.</li>
+				</ul>
+			</section>
+
 			<section id="sec-nav-def-model">
 				<h3>The <code>nav</code> element: restrictions</h3>
 
@@ -6529,9 +6544,6 @@ No Entry</pre>
 						<code>nav</code> element defines the primary navigational hierarchy. It conceptually corresponds
 						to a table of contents in a printed work (i.e., it provides navigation to the major structural
 						sections of the publication).</p>
-
-					<p>The <code>toc</code>
-						<code>nav</code> element MUST occur exactly once in an [=EPUB navigation document=].</p>
 
 					<p>[=EPUB creators=] SHOULD order the references in the <code>toc</code>
 						<code>nav</code> element such that they reflect both:</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6318,8 +6318,8 @@ No Entry</pre>
 								href="#sec-nav-def-model"></a>;</p>
 					</li>
 					<li>
-						<p id="confreq-navdoc-toc">MUST include exactly one <code>toc</code>
-							<code>nav</code> element as defined in <a href="#sec-nav-toc"></a>.</p>
+						<p id="confreq-navdoc-toc">MUST include exactly one <code>toc nav</code> element as defined in
+								<a href="#sec-nav-toc"></a>.</p>
 					</li>
 				</ul>
 			</section>
@@ -6512,9 +6512,8 @@ No Entry</pre>
 						</dt>
 						<dd>
 							<p>Identifies the <code>nav</code> element that contains the table of contents. The
-									<code>toc</code>
-								<code>nav</code> is the only navigation aid that [=EPUB creators=] must include in the
-								EPUB navigation document.</p>
+									<code>toc nav</code> is the only navigation aid that [=EPUB creators=] must include
+								in the EPUB navigation document.</p>
 						</dd>
 
 						<dt>
@@ -6546,13 +6545,12 @@ No Entry</pre>
 				<section id="sec-nav-toc">
 					<h4>The <code>toc nav</code> element </h4>
 
-					<p>The <code>toc</code>
-						<code>nav</code> element defines the primary navigational hierarchy. It conceptually corresponds
-						to a table of contents in a printed work (i.e., it provides navigation to the major structural
-						sections of the publication).</p>
+					<p>The <code>toc nav</code> element defines the primary navigational hierarchy. It conceptually
+						corresponds to a table of contents in a printed work (i.e., it provides navigation to the major
+						structural sections of the publication).</p>
 
-					<p>[=EPUB creators=] SHOULD order the references in the <code>toc</code>
-						<code>nav</code> element such that they reflect both:</p>
+					<p>[=EPUB creators=] SHOULD order the references in the <code>toc nav</code> element such that they
+						reflect both:</p>
 
 					<ul>
 						<li>
@@ -6573,13 +6571,11 @@ No Entry</pre>
 						These boundaries may correspond to a statically paginated source such as print or may be defined
 						exclusively for the [=EPUB publication=].</p>
 
-					<p>The <code>page-list</code>
-						<code>nav</code> element is OPTIONAL in [=EPUB navigation documents=] and MUST NOT occur more
-						than once.</p>
+					<p>The <code>page-list nav</code> element is OPTIONAL in [=EPUB navigation documents=] and MUST NOT
+						occur more than once.</p>
 
-					<p>The <code>page-list</code>
-						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
-						nested sublists).</p>
+					<p>The <code>page-list nav</code> element SHOULD contain only a single <code>ol</code> descendant
+						(i.e., no nested sublists).</p>
 
 					<p>[=EPUB creators=] MAY identify the destinations of the <code>page-list</code> references in their
 						respective [=EPUB content documents=] using the <a data-cite="epub-ssv-11/#pagebreak"
@@ -6589,24 +6585,19 @@ No Entry</pre>
 				<section id="sec-nav-landmarks">
 					<h4>The <code>landmarks nav</code> element</h4>
 
-					<p>The <code>landmarks</code>
-						<code>nav</code> element identifies fundamental structural components in the content to enable
-						[=reading systems=] to provide the user efficient access to them (e.g., through a dedicated
-						button in the user interface).</p>
+					<p>The <code>landmarks nav</code> element identifies fundamental structural components in the
+						content to enable [=reading systems=] to provide the user efficient access to them (e.g.,
+						through a dedicated button in the user interface).</p>
 
-					<p>The <code>landmarks</code>
-						<code>nav</code> element is OPTIONAL in [=EPUB navigation documents=] and MUST NOT occur more
-						than once.</p>
+					<p>The <code>landmarks nav</code> element is OPTIONAL in [=EPUB navigation documents=] and MUST NOT
+						occur more than once.</p>
 
-					<p>The <code>landmarks</code>
-						<code>nav</code> element SHOULD contain only a single <code>ol</code> descendant (i.e., no
-						nested sublists).</p>
+					<p>The <code>landmarks nav</code> element SHOULD contain only a single <code>ol</code> descendant
+						(i.e., no nested sublists).</p>
 
 					<p>The [^/epub:type^] attribute is REQUIRED on <code>a</code> element descendants of the
-							<code>landmarks</code>
-						<code>nav</code> element. The structural semantics of each link target within the
-							<code>landmarks</code>
-						<code>nav</code> element is determined by the value of this attribute.</p>
+							<code>landmarks nav</code> element. The structural semantics of each link target within the
+							<code>landmarks nav</code> element is determined by the value of this attribute.</p>
 
 					<aside class="example" title="A basic landmarks nav">
 						<p>In this example, the <code>epub:type</code> attribute value are drawn from structural
@@ -6637,13 +6628,12 @@ No Entry</pre>
 &lt;/nav></pre>
 					</aside>
 
-					<p>The <code>landmarks</code>
-						<code>nav</code> MUST NOT include multiple entries with the same <code>epub:type</code> value
-						that reference the same resource, or fragment thereof.</p>
+					<p>The <code>landmarks nav</code> MUST NOT include multiple entries with the same
+							<code>epub:type</code> value that reference the same resource, or fragment thereof.</p>
 
-					<p>[=EPUB creators=] should limit the number of items they define in the <code>landmarks</code>
-						<code>nav</code> to only items that a reading system is likely to use in its user interface. The
-						element is not meant to repeat the table of contents.</p>
+					<p>[=EPUB creators=] should limit the number of items they define in the <code>landmarks nav</code>
+						to only items that a reading system is likely to use in its user interface. The element is not
+						meant to repeat the table of contents.</p>
 
 					<p>The following landmarks are recommended to include when available:</p>
 
@@ -6656,23 +6646,22 @@ No Entry</pre>
 							to the document containing it.</li>
 					</ul>
 
-					<p>Other possibilities for inclusion in the <code>landmarks</code>
-						<code>nav</code> are key reference sections such as indexes and glossaries.</p>
+					<p>Other possibilities for inclusion in the <code>landmarks nav</code> are key reference sections
+						such as indexes and glossaries.</p>
 
-					<p>Although the <code>landmarks</code>
-						<code>nav</code> is intended for reading system use, EPUB creators should still ensure that the
-						labels for the <code>landmarks</code>
-						<code>nav</code> are human readable. Reading systems may expose the links directly to users.</p>
+					<p>Although the <code>landmarks nav</code> is intended for reading system use, EPUB creators should
+						still ensure that the labels for the <code>landmarks nav</code> are human readable. Reading
+						systems may expose the links directly to users.</p>
 				</section>
 
 				<section id="sec-nav-def-types-other">
 					<h4>Other <code>nav</code> elements</h4>
 
 					<p>[=EPUB navigation documents=] MAY contain one or more <code>nav</code> elements in addition to
-						the <code>toc</code>, <code>page-list</code>, and <code>landmarks</code>
-						<code>nav</code> elements defined in the preceding sections. If these <code>nav</code> elements
-						are intended for [=reading system=] processing, they MUST have an [^/epub:type^] attribute and
-						are subject to the content model restrictions defined in <a href="#sec-nav-def-model"></a>.</p>
+						the <code>toc</code>, <code>page-list</code>, and <code>landmarks nav</code> elements defined in
+						the preceding sections. If these <code>nav</code> elements are intended for [=reading system=]
+						processing, they MUST have an [^/epub:type^] attribute and are subject to the content model
+						restrictions defined in <a href="#sec-nav-def-model"></a>.</p>
 
 					<p>This specification imposes no restrictions on the semantics of any additional <code>nav</code>
 						elements: they MAY represent navigational semantics for any information domain, and they MAY


### PR DESCRIPTION
I've added a new section to collect the main requirements for the nav doc: that it be a conforming xhtml content document, that it conform to the nav element restrictions and that there be exactly one toc nav. None of these are new, although the first went astray.

This should make reading the section clearer.

Fixes #2421


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2422.html" title="Last updated on Sep 14, 2022, 11:59 AM UTC (93ea17f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2422/f16eb51...93ea17f.html" title="Last updated on Sep 14, 2022, 11:59 AM UTC (93ea17f)">Diff</a>