### PR TITLE
Rearrange unsupported features

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11707,9 +11707,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>14-Sep-2022: Combined the legacy feature section into the package document definition. See <a
+					<li>14-Sept-2022: Combined the legacy feature section into the package document definition. See <a
 							href="https://github.com/w3c/epub-specs/issues/2423">issue 2423</a>.</li>
-					<li>07-Sep-2022: Added clarifying requirement that the manifest only list publication resources. See
+					<li>07-Sept-2022: Added clarifying requirement that the manifest only list publication resources. See
 							<a href="https://github.com/w3c/epub-specs/issues/2413">issue 2413</a>.</li>
 					<li>28-Aug-2022: Added a note to Media Overlays <code>text</code> element definition regarding using
 						embedded timed media. See <a href="https://github.com/w3c/epub-specs/issues/2397">issue

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1106,7 +1106,7 @@
 								<code>application/x-dtbncx+xml</code>
 							</td>
 							<td> [[opf-201]] </td>
-							<td>The <a href="#legacy">legacy</a> NCX.</td>
+							<td>The <a href="#sec-pkg-legacy-intro">legacy</a> NCX.</td>
 						</tr>
 						<tr>
 							<td id="cmt-smil">
@@ -3488,7 +3488,7 @@
 										<code>guide</code>
 									</a>
 									<code>[0 or 1]</code>
-									<a href="#legacy" class="legacy">(legacy)</a>
+									<a href="#sec-pkg-legacy-intro" class="legacy">(legacy)</a>
 								</p>
 							</li>
 							<li>
@@ -3587,7 +3587,7 @@
 									<p>
 										<a href="#sec-opf2-meta">OPF2 <code>meta</code></a>
 										<code>[0 or more]</code>
-										<a href="#legacy" class="legacy">(legacy)</a>
+										<a href="#sec-pkg-legacy-intro" class="legacy">(legacy)</a>
 									</p>
 								</li>
 								<li>
@@ -5277,7 +5277,7 @@ No Entry</pre>
 											<code>toc</code>
 										</a>
 										<code>[optional]</code>
-										<a href="#legacy" class="legacy">(legacy)</a>
+										<a href="#sec-pkg-legacy-intro" class="legacy">(legacy)</a>
 									</p>
 								</li>
 							</ul>
@@ -5327,7 +5327,7 @@ No Entry</pre>
 						mechanisms to override the default direction (e.g., buttons or settings that allow the
 						application of alternate style sheets).</p>
 
-					<p>The <a href="#legacy">legacy</a>
+					<p>The <a href="#sec-pkg-legacy-intro">legacy</a>
 						<code>toc</code> attribute takes an <a data-cite="xml#idref">IDREF</a> [[xml]] that identifies
 						the manifest item that represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
 				</section>
@@ -5593,24 +5593,58 @@ No Entry</pre>
 			</section>
 
 			<section id="sec-pkg-legacy">
-				<h3>Legacy content</h3>
+				<h3>Legacy features</h3>
+
+				<section id="sec-pkg-legacy-intro">
+					<h4>Introduction</h4>
+
+					<p>The package document <strong>legacy</strong> features are retained from EPUB 2 only to allow
+						[=EPUB creators=] to author content that can function, to some degree, in [=reading systems=]
+						that only support EPUB 2 publications.</p>
+
+					<p>These features were added primarily to address the overlap period as EPUB 3 reading systems were
+						developed, as there was still a high probability at that time that users would be opening EPUB 3
+						publications on EPUB 2 reading systems.</p>
+
+					<p>As reading systems that only handle EPUB 2 publications are now rare, EPUB creators should
+						consider the likelihood of their publications still being opened on these types of older devices
+						before making the effort to add these legacy features.</p>
+				</section>
+
+				<section id="pkg-legacy-support">
+					<h4>Support</h4>
+
+					<p>[=EPUB creators=] MAY include the legacy features defined in this section for compatibility
+						purposes with EPUB 2 reading systems.</p>
+
+					<p>EPUB 3 reading systems will not use these features when presenting publications to users.</p>
+
+					<div class="note">
+						<p>[=EPUB conformance checkers=] should not alert EPUB creators about the presence of legacy
+							features in an [=EPUB publication=], as their inclusion is valid for backwards
+							compatibility. EPUB conformance checkers must alert EPUB creators if a legacy feature does
+							not conform to its definition or otherwise breaks a usage requirement.</p>
+					</div>
+				</section>
 
 				<section id="sec-opf2-meta">
 					<h4>The <code>meta</code> element</h4>
 
 					<p>The <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"><code>meta</code>
-							element</a> [[opf-201]] is a <a href="#legacy">legacy</a> feature that provided a means of
-						including generic metadata in EPUB 2. The EPUB 3 [^meta^] element, which uses different
-						attributes and requires text content, replaces this element.</p>
+							element</a> [[opf-201]] provides a means of including generic metadata for EPUB 2 [=reading
+						systems=].</p>
 
 					<p>Refer to the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
 								><code>meta</code> element definition</a> in [[opf-201]] for more information.</p>
 
 					<div class="note">
-						<p>The [[opf-201]] <code>meta</code> element is retained in EPUB 3 primarily so that [=EPUB
-							creators=] can identify the cover image for compatibility with EPUB 2 [=reading systems=].
-							In EPUB 3, the cover image must be identified using the <a href="#sec-cover-image"
-									><code>cover-image</code> property</a> on the manifest [^item^] for the image.</p>
+						<p>The EPUB 3 [^meta^] element, which uses different attributes and requires text content,
+							provides metadata capabilities for EPUB 3 reading systems.</p>
+
+						<p>The [[opf-201]] <code>meta</code> element also allows [=EPUB creators=] to identify a cover
+							image for EPUB 2 reading systems. In EPUB 3, the cover image must be identified using the <a
+								href="#sec-cover-image"><code>cover-image</code> property</a> on the manifest [^item^]
+							for the image.</p>
 					</div>
 				</section>
 
@@ -5618,23 +5652,31 @@ No Entry</pre>
 					<h4>The <code>guide</code> element</h4>
 
 					<p>The <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code>
-							element</a> [[opf-201]] is a <a href="#legacy">legacy</a> feature that provided
-						machine-processable navigation to key structures in EPUB 2. The <a href="#sec-nav-landmarks"
-							>landmarks nav</a> in the [=EPUB navigation document=] replaces this element.</p>
+							element</a> [[opf-201]] provides machine-processable navigation to key structures in EPUB 2
+						[=reading systems=].</p>
 
 					<p>Refer to the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
 								><code>guide</code> element definition</a> in [[opf-201]] for more information.</p>
+
+					<div class="note">
+						<p>The <a href="#sec-nav-landmarks">landmarks nav</a> in the [=EPUB navigation document=]
+							provides this functionality in EPUB 3 reading systems.</p>
+					</div>
 				</section>
 
 				<section id="sec-opf2-ncx">
 					<h4>NCX</h4>
 
 					<p>The <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a> [[opf-201]]
-						is a <a href="#legacy">legacy</a> feature that provided the table of contents in EPUB 2. The <a
-							href="#sec-nav">EPUB navigation document</a> replaces this document.</p>
+						provides a table of contents for EPUB 2 [=reading systems=].</p>
 
 					<p>Refer to the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
 							definition</a> in [[opf-201]] for more information.</p>
+
+					<div class="note">
+						<p>The <a href="#sec-nav">EPUB navigation document</a> replaces the NCX for EPUB 3 reading
+							systems.</p>
+					</div>
 				</section>
 			</section>
 		</section>
@@ -9483,7 +9525,7 @@ html.my-document-playing * {
 					overall user privacy and security.</p>
 			</section>
 		</section>
-		<section id="app-overview-unsupported" class="appendix">
+		<section id="app-unsupported" class="appendix">
 			<h2>Unsupported features</h2>
 
 			<p>This specification contains certain features that are not yet fully supported in [=reading systems=],
@@ -9503,16 +9545,8 @@ html.my-document-playing * {
 					be implemented by [=EPUB creators=] (i.e., their deprecation would invalidate existing content)
 					and/or they are integral to the content model on which EPUB is built.</p>
 
-				<p>If this specification designates a feature as under-implemented, the following hold true:</p>
-
-				<ul>
-					<li>
-						<p>EPUB creators MAY use the features as described.</p>
-					</li>
-					<li>
-						<p>[=Reading systems=] SHOULD support the feature as described.</p>
-					</li>
-				</ul>
+				<p>If this specification designates a feature as under-implemented, EPUB creators MAY use the features
+					as described.</p>
 
 				<div class="note">
 					<p>[=EPUB conformance checkers=] should alert EPUB creators to the presence of under-implemented
@@ -9539,48 +9573,14 @@ html.my-document-playing * {
 
 				<p>A <strong>deprecated</strong> feature is one the Working Group no longer recommends for use in this
 					version of the specification. Deprecated features typically have limited or no support in [=reading
-					systems=] and/or usage in [=EPUB publications=]. If this specification designates a feature as
-					deprecated, the following hold true:</p>
+					systems=] and/or usage in [=EPUB publications=].</p>
 
-				<ul>
-					<li>
-						<p>[=EPUB creators=] SHOULD NOT use the feature in their EPUB publications.</p>
-					</li>
-					<li>
-						<p>Reading systems MAY support the feature.</p>
-						<p class="note">Developers should consider the unlikelihood of encountering content with
-							deprecated features before adding new support for them.</p>
-					</li>
-				</ul>
+				<p>If this specification designates a feature as deprecated, [=EPUB creators=] SHOULD NOT use the
+					feature in their EPUB publications.</p>
 
 				<div class="note">
 					<p>[=EPUB conformance checkers=] should alert EPUB creators to the presence of deprecated features
 						when encountered in EPUB publications.</p>
-				</div>
-			</section>
-
-			<section id="legacy">
-				<h3>Legacy features</h3>
-
-				<p>A <strong>legacy</strong> feature is one that the Working Group has retained only for authoring
-					content that is compatible with versions of EPUB prior to 3.0. If this specification designates a
-					feature as legacy, the following hold true:</p>
-
-				<ul>
-					<li>
-						<p>[=EPUB creators=] MAY include the legacy feature for compatibility purposes.</p>
-					</li>
-					<li>
-						<p>[=Reading systems=] MUST NOT support the legacy feature in content that conforms to this
-							version of EPUB.</p>
-					</li>
-				</ul>
-
-				<div class="note">
-					<p>[=EPUB conformance checkers=] should not alert EPUB creators about the presence of legacy
-						features in an [=EPUB publication=], as their inclusion is valid for backwards compatibility.
-						EPUB conformance checkers must alert EPUB creators if a legacy feature does not conform to its
-						definition or otherwise breaks a usage requirement.</p>
 				</div>
 			</section>
 		</section>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11707,12 +11707,14 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>7-September-2022: Added clarifying requirement that the manifest only list publication
-						resources. See <a href="https://github.com/w3c/epub-specs/issues/2413">issue 2413</a>.</li>
-					<li>28-August-2022: Added a note to Media Overlays <code>text</code> element definition regarding
-						using embedded timed media. See <a href="https://github.com/w3c/epub-specs/issues/2397">issue
-							2397</a>.</li>
-					<li>02-August-2022: Updated the media type registrations, following the <a
+					<li>14-Sep-2022: Combined the legacy feature section into the package document definition. See <a
+							href="https://github.com/w3c/epub-specs/issues/2423">issue 2423</a>.</li>
+					<li>07-Sep-2022: Added clarifying requirement that the manifest only list publication resources. See
+							<a href="https://github.com/w3c/epub-specs/issues/2413">issue 2413</a>.</li>
+					<li>28-Aug-2022: Added a note to Media Overlays <code>text</code> element definition regarding using
+						embedded timed media. See <a href="https://github.com/w3c/epub-specs/issues/2397">issue
+						2397</a>.</li>
+					<li>02-Aug-2022: Updated the media type registrations, following the <a
 							href="https://lists.w3.org/Archives/Public/public-epub-wg/2022Aug/0000.html">official IANA
 							review comments</a> on updating the previous registrations. See <a
 							href="https://github.com/w3c/epub-specs/issues/1398">issue 1398</a>. </li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2642,7 +2642,7 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>14-Sep-2022: Integrated the reading system support requirements for unsupported features that
+					<li>14-Sept-2022: Integrated the reading system support requirements for unsupported features that
 						were still in the EPUB 3.3 specification. See <a
 							href="https://github.com/w3c/epub-specs/issues/2424">issue 2424</a>.</li>
 					<li>28-Aug-2022: The guidelines for rendering embedded timed media in Media Overlays have been

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2642,7 +2642,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>28-August-2022: The guidelines for rendering embedded timed media in Media Overlays have been
+					<li>14-Sep-2022: Integrated the reading system support requirements for unsupported features that
+						were still in the EPUB 3.3 specification. See <a
+							href="https://github.com/w3c/epub-specs/issues/2424">issue 2424</a>.</li>
+					<li>28-Aug-2022: The guidelines for rendering embedded timed media in Media Overlays have been
 						deprecated. See <a href="https://github.com/w3c/epub-specs/issues/2397">issue 2397</a>.</li>
 					<li>28-July-2022: Restructured the vocabulary association mechanisms section as an algorithm for
 						obtaining an expanded URL. See <a href="https://github.com/w3c/epub-specs/issues/2378">issue

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -706,8 +706,9 @@
 			<section id="sec-container-fobfus">
 				<h3>Font obfuscation</h3>
 
-				<p id="confreq-ocf-fobfus" data-tests="#ocf-font_obfuscation,#ocf-font_obfuscation-bis">Reading systems SHOULD support deobfuscation of fonts as defined in <a
-						data-cite="epub-33#sec-font-obfuscation">Font obfuscation</a> [[epub-33]].</p>
+				<p id="confreq-ocf-fobfus" data-tests="#ocf-font_obfuscation,#ocf-font_obfuscation-bis">Reading systems
+					SHOULD support deobfuscation of fonts as defined in <a data-cite="epub-33#sec-font-obfuscation">Font
+						obfuscation</a> [[epub-33]].</p>
 
 				<p>To restore the original data, reading systems should simply reverse the process: the source file
 					becomes the obfuscated data, and the destination file contains the raw data.</p>
@@ -961,6 +962,14 @@
 						>collections</a> [[epub-33]] in reading systems is OPTIONAL. <span
 						id="confreq-rs-pkg-collections-unknown" data-tests="#pkg-collections-unknown">Reading systems
 						MUST ignore <code>collection</code> elements that define unrecognized roles.</span></p>
+			</section>
+
+			<section id="sec-pkg-doc-legacy">
+				<h3>Legacy features</h3>
+
+				<p id="confreq-rs-legacy">Reading systems MUST NOT support <a data-cite="epub-33#legacy">legacy
+						features</a> in content that conforms to <a data-cite="epub-33#attrdef-package-version">this
+						version of EPUB</a> [[epub-33]].</p>
 			</section>
 		</section>
 		<section id="sec-contentdocs">
@@ -2420,7 +2429,28 @@
 				</div>
 			</section>
 		</section>
-		<section id="app-epubReadingSystem">
+		<section id="app-unsupported" class="appendix">
+			<h2>Unsupported features</h2>
+
+			<p>For features marked as unsupported, [=reading systems=]:</p>
+
+			<ul class="conformance-list">
+				<li>
+					<p id="confreq-rs-under-implemented">SHOULD support <a data-cite="epub-33#under-implemented"
+							>under-implemented features</a> [[epub-33]] as described.</p>
+				</li>
+				<li>
+					<p id="confreq-rs-deprecated">MAY support <a data-cite="epub-33#deprecated">deprecated features</a>
+						[[epub-33]].</p>
+				</li>
+			</ul>
+
+			<div class="note">
+				<p>Developers should consider the unlikelihood of encountering content with deprecated features before
+					adding new support for them.</p>
+			</div>
+		</section>
+		<section id="app-epubReadingSystem" class="appendix">
 			<h2><dfn class="export">epubReadingSystem</dfn> object</h2>
 
 			<p class="note">[=Reading systems=] act as the core rendering engines of EPUB publications and provide a


### PR DESCRIPTION
This PR makes the following changes:

- the explanation of "legacy features" is integrated into the existing package document section as these are the only legacy features
- adds a new intro to try and explain that the legacy features only exist to allow epub 2 reading systems to open epub 3 content, and there probably isn't much use for them anymore
- makes some minor tweaks to the legacy feature descriptions to better highlight that they're only for epub 2 reading systems
- moves the reading system support requirement for legacy features to a new corresponding section in the reading system spec
- also moves the under-implemented and deprecated support requirements to the RS spec

Fixes #2423 
Fixes #2424 

* Preview for EPUB 3.3 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-2424/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-2424/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2425.html" title="Last updated on Sep 14, 2022, 11:45 PM UTC (5bedee4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2425/0792d0d...5bedee4.html" title="Last updated on Sep 14, 2022, 11:45 PM UTC (5bedee4)">Diff</a>