### PR TITLE
Add dpub-aria reference

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -396,9 +396,9 @@
 					of accessibility through the application of established web accessibility techniques, such as using
 					native elements and controls whenever possible and enhancing custom interactive content with
 					[[wai-aria]] roles, states, and properties. Plus, whenever possible, the EPUB community adds
-					publishing accessibility needs to these standards, such as creating the [[dpub-aria]] role module.
-					It is not necessary for anyone familiar with web accessibility to learn a new accessibility
-					framework to make EPUB publications accessible.</p>
+					publishing accessibility needs to these standards &#8212; for example, through the creation of the
+					[[dpub-aria]] role module. It is not necessary for anyone familiar with web accessibility to learn a
+					new accessibility framework to make EPUB publications accessible.</p>
 
 				<p>The primary source for producing accessible web content is the W3C's Web Content Accessibility
 					Guidelines (WCAG) [[wcag2]], which establish benchmarks for accessible content. WCAG defines four

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -397,7 +397,7 @@
 					native elements and controls whenever possible and enhancing custom interactive content with
 					[[wai-aria]] roles, states, and properties. Plus, whenever possible, the EPUB community adds
 					publishing accessibility needs to these standards &#8212; for example, through the creation of the
-					[[dpub-aria]] role module. It is not necessary for anyone familiar with web accessibility to learn a
+					[[dpub-aria-1.0]] role module. It is not necessary for anyone familiar with web accessibility to learn a
 					new accessibility framework to make EPUB publications accessible.</p>
 
 				<p>The primary source for producing accessible web content is the W3C's Web Content Accessibility

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -395,8 +395,10 @@
 						href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> with a high degree
 					of accessibility through the application of established web accessibility techniques, such as using
 					native elements and controls whenever possible and enhancing custom interactive content with
-					[[wai-aria]] roles, states, and properties. It is not necessary for anyone familiar with web
-					accessibility to learn a new accessibility framework to make EPUB publications accessible.</p>
+					[[wai-aria]] roles, states, and properties. Plus, whenever possible, the EPUB community adds
+					publishing accessibility needs to these standards, such as creating the [[dpub-aria]] role module.
+					It is not necessary for anyone familiar with web accessibility to learn a new accessibility
+					framework to make EPUB publications accessible.</p>
 
 				<p>The primary source for producing accessible web content is the W3C's Web Content Accessibility
 					Guidelines (WCAG) [[wcag2]], which establish benchmarks for accessible content. WCAG defines four


### PR DESCRIPTION
@avneeshsingh The best I could find was to add the following sentence after mentioning aria:

> Plus, whenever possible, the EPUB community adds publishing accessibility needs to these standards — for example, through the creation of the [[dpub-aria-1.0](http://localhost:120/a11y/#bib-dpub-aria-1.0)] role module.

Let me know if this is sufficient.