### PR TITLE
Re-establish that empty references are not valid

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9886,6 +9886,20 @@ html.my-document-playing * {
 					<p>This specification derives the <var>property</var> data type from the CURIE data type defined in
 						[[rdfa-core]]. A <var>property</var> represents a subset of CURIEs.</p>
 
+					<p>There are two key differences from CURIEs, however:</p>
+
+					<ul>
+						<li>
+							<p>an empty <var>reference</var> does not represent a valid <var>property</var> value even
+								though it is valid to the definition above (i.e., a <var>property</var> value that only
+								consists of a prefix and colon is invalid).</p>
+						</li>
+						<li>
+							<p>an empty string does not represent a valid <var>property</var> even though it is valid to
+								the definition above.</p>
+						</li>
+					</ul>
+
 					<aside class="example" title="Expanding a metadata property value">
 						<p>In this example, the <var>property</var> value is composed of the prefix <code>dcterms</code>
 							and the reference <code>modified</code>.</p>
@@ -9917,10 +9931,6 @@ html.my-document-playing * {
 
 						<p>when the prefix URL for the vocabulary is concatenated with the reference.</p>
 					</aside>
-
-					<p>An empty string does not represent a valid <var>property</var> value, even though it is valid to
-						the definition above. A <code>property</code> value that consists only of a prefix and colon is
-						valid, however (i.e., the reference can be an empty string when a prefix is defined).</p>
 				</section>
 
 				<section id="sec-default-vocab">
@@ -11708,6 +11718,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>14-Sept-2022: Re-establish that empty reference and property values are not valid to ensure that
+						metadata properties do not consist only of prefixes. See <a
+							href="https://github.com/w3c/epub-specs/issues/2417">issue 2417</a>.</li>
 					<li>7-September-2022: Added clarifying requirement that the manifest only list publication
 						resources. See <a href="https://github.com/w3c/epub-specs/issues/2413">issue 2413</a>.</li>
 					<li>28-August-2022: Added a note to Media Overlays <code>text</code> element definition regarding


### PR DESCRIPTION
Adds the requirements that although empty reference and property values are valid per the ebnf definition, they are not valid property values.

Fixes #2417


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2427.html" title="Last updated on Sep 14, 2022, 3:58 PM UTC (f50fbc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2427/ce738d1...f50fbc0.html" title="Last updated on Sep 14, 2022, 3:58 PM UTC (f50fbc0)">Diff</a>