### PR TITLE
Clarify that href attribute must not reference package document elements

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3219,6 +3219,9 @@
 
 					<p>A [=valid URL string=] [[url]] that references a resource.</p>
 
+					<p>The URL string MUST NOT reference resources via elements in the package document (e.g., via a
+						manifest [^item^] or spine [^itemref^] declaration).</p>
+
 					<aside class="example" title="Linking a metadata record">
 						<pre>&lt;package …>
    &lt;metadata …>
@@ -11708,6 +11711,10 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>14-Sept-2022: Clarified that the <code>href</code> attribute in the package document must not be
+						used to reference other package document elements (i.e., to indirectly reference a resource via
+						its manifest or spine entry). See <a href="https://github.com/w3c/epub-specs/issues/2420">issue
+							2420</a>.</li>
 					<li>7-September-2022: Added clarifying requirement that the manifest only list publication
 						resources. See <a href="https://github.com/w3c/epub-specs/issues/2413">issue 2413</a>.</li>
 					<li>28-August-2022: Added a note to Media Overlays <code>text</code> element definition regarding


### PR DESCRIPTION
Fixes #2420


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2428.html" title="Last updated on Sep 14, 2022, 3:58 PM UTC (3878c78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2428/e35924e...3878c78.html" title="Last updated on Sep 14, 2022, 3:58 PM UTC (3878c78)">Diff</a>