### PR TITLE
Remove ARIA extension section from HTML

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -994,14 +994,6 @@
 				<section id="sec-xhtml-extensions">
 					<h4>HTML extensions</h4>
 
-					<section id="sec-xhtml-aria">
-						<h5>ARIA</h5>
-
-						<p id="confreq-html-rs-a11y">Reading systems SHOULD recognize embedded ARIA markup and support
-							exposure of any given ARIA roles, states and properties to platform accessibility APIs
-							[[wai-aria]].</p>
-					</section>
-
 					<section id="sec-xhtml-rdfa">
 						<h5>RDFa</h5>
 
@@ -1038,12 +1030,12 @@
 
 					<section id="sec-xhtml-microdata">
 						<h5>Microdata</h5>
-						
+
 						<p>Reading system support for the <a data-cite="html#encoding-microdata">attribute processing
-							model</a> is OPTIONAL, as is the <a data-cite="html#json">conversion to JSON</a>
+								model</a> is OPTIONAL, as is the <a data-cite="html#json">conversion to JSON</a>
 							[[html]].</p>
 					</section>
-					
+
 					<section id="sec-xhtml-mathml">
 						<h3>MathML</h3>
 
@@ -2642,6 +2634,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>19-Sept-2022: Removed ARIA extension section as the HTML specification already contains <a
+							href="https://html.spec.whatwg.org/multipage/dom.html#wai-aria">ARIA support
+							requirements</a>. See <a href="https://github.com/w3c/epub-specs/issues/2431">issue
+						2431</a>.</li>
 					<li>14-Sept-2022: Integrated the reading system support requirements for unsupported features that
 						were still in the EPUB 3.3 specification. See <a
 							href="https://github.com/w3c/epub-specs/issues/2424">issue 2424</a>.</li>


### PR DESCRIPTION
Note that we also mention exposing ARIA roles, states and properties in the new accessibility section, so between that and HTML already having an ARIA support section I don't see this removal changing anything.

Fixes #2431 

* EPUB 3.3 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-2431/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/issue-2431/epub33/rs/index.html)
