### PR TITLE
Remove contradictions in epub:type usage sections

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9714,7 +9714,8 @@ html.my-document-playing * {
 					<dt>Usage:</dt>
 					<dd>
 						<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">XHTML</a>, <a
-								href="#sec-svg-req">SVG</a>, and <a href="#sec-overlays-def">media overlays</a>.</p>
+								href="#confreq-svg-structural-semantics">SVG</a>, and <a href="#sec-overlays-def">media
+								overlays</a>.</p>
 					</dd>
 
 					<dt>Value:</dt>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -9713,8 +9713,8 @@ html.my-document-playing * {
 
 					<dt>Usage:</dt>
 					<dd>
-						<p>Refer to the requirements for <a>XHTML</a>, <a>SVG</a>, and <a href="#sec-overlays-def">media
-								overlays</a></p>
+						<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">XHTML</a>, <a
+								href="#sec-svg-req">SVG</a>, and <a href="#sec-overlays-def">media overlays</a>.</p>
 					</dd>
 
 					<dt>Value:</dt>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5748,7 +5748,7 @@ No Entry</pre>
 						<p>[=EPUB creators=] MAY use the [^/epub:type^] attribute in [=XHTML content documents=] to
 							express <a href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
-						<p>The attribute MUST only be used on [=palpable content=].</p>
+						<p>The attribute MUST only be used on [=palpable content=] [[html]].</p>
 					</section>
 
 					<section id="sec-xhtml-rdfa">
@@ -5978,7 +5978,7 @@ No Entry</pre>
 								the attribute MUST only be included on <a
 									href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
 									<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
-									href="https://www.w3.org/TR/SVG11/text.html">text</a> elements.</p>
+									href="https://www.w3.org/TR/SVG11/text.html">text</a> elements [[svg]].</p>
 						</li>
 						<li>
 							<p id="confreq-svg-vocab-assoc">MAY include all applicable <a href="#sec-vocab-assoc"

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5748,9 +5748,7 @@ No Entry</pre>
 						<p>[=EPUB creators=] MAY use the [^/epub:type^] attribute in [=XHTML content documents=] to
 							express <a href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
-						<p>As the [[html]] <a data-cite="html#the-head-element"><code>head</code></a> element contains
-							metadata for the document, structural semantics expressed on this element or any descendant
-							of it have no meaning.</p>
+						<p>The attribute MUST only be used on [=palpable content=].</p>
 					</section>
 
 					<section id="sec-xhtml-rdfa">
@@ -5975,9 +5973,16 @@ No Entry</pre>
 								constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-svg-structural-semantics">MAY specify the [^/epub:type^] attribute for
-								expressing <a href="#app-structural-semantics">structural semantics</a> and use all
-								applicable <a href="#sec-vocab-assoc">vocabulary association mechanisms</a>.</p>
+							<p id="confreq-svg-structural-semantics">MAY include the [^/epub:type^] attribute for
+								expressing <a href="#app-structural-semantics">structural semantics</a>. When specified,
+								the attribute MUST only be included on <a
+									href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
+									<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
+									href="https://www.w3.org/TR/SVG11/text.html">text</a> elements.</p>
+						</li>
+						<li>
+							<p id="confreq-svg-vocab-assoc">MAY include all applicable <a href="#sec-vocab-assoc"
+									>vocabulary association mechanisms</a>.</p>
 						</li>
 					</ul>
 					<div class="note">
@@ -9708,16 +9713,8 @@ html.my-document-playing * {
 
 					<dt>Usage:</dt>
 					<dd>
-						<p><a data-cite="html#global-attributes">Global attribute</a>. It MAY be used in [[html]] and
-							[[svg]] with the following restrictions:</p>
-						<ul>
-							<li>For [[html]] content: it MUST be used on [=palpable content=].</li>
-							<li>For [[svg]] content: it MUST be used on <a
-									href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
-									<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
-									href="https://www.w3.org/TR/SVG11/text.html">text</a> elements.</li>
-						</ul>
-						<p>For use in [=media overlay documents=] refer to <a href="#sec-overlays-def"></a>.</p>
+						<p>Refer to the requirements for <a>XHTML</a>, <a>SVG</a>, and <a href="#sec-overlays-def">media
+								overlays</a></p>
 					</dd>
 
 					<dt>Value:</dt>
@@ -11728,6 +11725,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>19-Sept-2022: Removed minor contradictions in the <code>epub:type</code> attribute usage
+						definitions. See <a href="https://github.com/w3c/epub-specs/issues/2434">issue 2434</a>.</li>
 					<li>14-Sept-2022: Combined the legacy feature section into the package document definition. See <a
 							href="https://github.com/w3c/epub-specs/issues/2423">issue 2423</a>.</li>
 					<li>14-Sept-2022: Clarified that the <code>href</code> attribute in the package document must not be
@@ -11737,14 +11736,13 @@ EPUB/images/cover.png</pre>
 					<li>14-Sept-2022: Re-establish that empty reference and property values are not valid to ensure that
 						metadata properties do not consist only of prefixes. See <a
 							href="https://github.com/w3c/epub-specs/issues/2417">issue 2417</a>.</li>
-					<li>14-Sept-2022: Added a new section for expressing all the primary navigation document
-						content requirements. See <a href="https://github.com/w3c/epub-specs/issues/2421">issue
-						2421</a>.</li>
-					<li>7-Sept-2022: Added clarifying requirement that the manifest only list publication
-						resources. See <a href="https://github.com/w3c/epub-specs/issues/2413">issue 2413</a>.</li>
-					<li>28-Aug-2022: Added a note to Media Overlays <code>text</code> element definition regarding
-						using embedded timed media. See <a href="https://github.com/w3c/epub-specs/issues/2397">issue
-							2397</a>.</li>
+					<li>14-Sept-2022: Added a new section for expressing all the primary navigation document content
+						requirements. See <a href="https://github.com/w3c/epub-specs/issues/2421">issue 2421</a>.</li>
+					<li>7-Sept-2022: Added clarifying requirement that the manifest only list publication resources. See
+							<a href="https://github.com/w3c/epub-specs/issues/2413">issue 2413</a>.</li>
+					<li>28-Aug-2022: Added a note to Media Overlays <code>text</code> element definition regarding using
+						embedded timed media. See <a href="https://github.com/w3c/epub-specs/issues/2397">issue
+						2397</a>.</li>
 					<li>02-Aug-2022: Updated the media type registrations, following the <a
 							href="https://lists.w3.org/Archives/Public/public-epub-wg/2022Aug/0000.html">official IANA
 							review comments</a> on updating the previous registrations. See <a


### PR DESCRIPTION
This pull request makes the following changes:

- the claim of epub:type being a global attribute is removed
- instead of embedding format-specific usage restrictions in the generic attribute definition, these are moved to the corresponding xhtml and svg sections where the attribute is defined
- the prose about ignoring epub:type in the HTML `head` element is removed since the usage restrictions now disallow this

Fixes #2434


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2436.html" title="Last updated on Sep 20, 2022, 11:10 AM UTC (8e99627)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2436/3f97cdb...8e99627.html" title="Last updated on Sep 20, 2022, 11:10 AM UTC (8e99627)">Diff</a>