### PR TITLE
Add requirement that property prefixes be declared

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7685,8 +7685,8 @@ No Entry</pre>
 					<p>EPUB creators MUST NOT declare the <code>rendition:flow</code> property more than once.</p>
 
 					<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code>
-							attribute</a>. Refer to <a href="#flow-overrides"></a> for setting the
-						property for individual EPUB content documents.</p>
+							attribute</a>. Refer to <a href="#flow-overrides"></a> for setting the property for
+						individual EPUB content documents.</p>
 
 					<figure id="fig-flow-paginated-single">
 						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
@@ -10027,8 +10027,10 @@ html.my-document-playing * {
 						</tr>
 					</table>
 
-					<p>[=EPUB creators=] MUST only specify the <code>prefix</code> attribute on the <a
-							data-cite="xml#dt-root">root element</a> [[xml]] of the respective format.</p>
+					<p>With the exception of <a href="#sec-reserved-prefixes">reserved prefixes</a>, [=EPUB creators=]
+						MUST declare all prefixes used in a document. [=EPUB creators=] MUST only specify the
+							<code>prefix</code> attribute on the <a data-cite="xml#dt-root">root element</a> [[xml]] of
+						the respective format.</p>
 
 					<p>The attribute is not namespaced when used in the [=package document=].</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11728,6 +11728,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>21-Sept-2022: Made the requirement to declare property prefixes explicit. See <a
+							href="https://github.com/w3c/epub-specs/issues/2438">issue 2438</a>.</li>
 					<li>19-Sept-2022: Removed minor contradictions in the <code>epub:type</code> attribute usage
 						definitions. See <a href="https://github.com/w3c/epub-specs/issues/2434">issue 2434</a>.</li>
 					<li>14-Sept-2022: Combined the legacy feature section into the package document definition. See <a


### PR DESCRIPTION
Fixes #2438 by adding the following requirement to the prefix attribute section:

> With the exception of reserved prefixes, EPUB creators MUST declare all prefixes used in a document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2439.html" title="Last updated on Sep 21, 2022, 11:48 AM UTC (04e1f2a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2439/9b8c9d6...04e1f2a.html" title="Last updated on Sep 21, 2022, 11:48 AM UTC (04e1f2a)">Diff</a>