### PR TITLE
Clarify link vocab requirements

### DIFF
--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -72,7 +72,7 @@
 								data-cite="html#link-type-alternate">HTML
 										<code>alternate</code> keyword</a> for links. It differs as follows:</p>
 							<ul>
-								<li>It cannot be paired with other keywords.</li>
+								<li>It MUST NOT be paired with other keywords.</li>
 								<li>If an alternate link is included in the [=package document=] metadata, it
 									identifies an alternate representation of the package document in the format
 									specified in the <code>media-type</code> attribute.</li>
@@ -159,7 +159,7 @@
 						<th>Description:</th>
 						<td>
 							<p>Indicates that the referenced resource is a metadata record.</p>
-							<p>The media type of the record is identified in the <a
+							<p>The media type of the record MUST be identified in the <a
 									href="#attrdef-link-media-type"><code>media-type</code> attribute</a> when
 								this keyword is specified.</p>
 							<p>For a list of commonly linked metadata record types, refer to the <a
@@ -209,7 +209,7 @@
 							<p>Indicates that the referenced audio file provides an aural representation of the
 								expression or resource (typically, the title or creator) specified by the
 								refines attribute.</p>
-							<p>The media type of the audio file is identified in the <a
+							<p>The media type of the audio file MUST be identified in the <a
 									href="#attrdef-link-media-type"><code>media-type</code> attribute</a> when
 								this keyword is specified.</p>
 						</td>


### PR DESCRIPTION
A few of the link properties had requirements expressed without using normative language - media types that must be specified and a ban on pairing with other keywords.