### PR TITLE
rendition:flow for webtoon-like publications

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1717,7 +1717,7 @@
 							items</a> [[epub-33]].</p>
 
 					<p class="note">
-						Reading system developers s may decide to disregard this restriction, and accept 
+						Reading system developers may decide to disregard this restriction, and accept 
 						the <code>scrolled-continuous</code> value of <code>rendition:flow</code> as a switch
 						to display each pre-paginated spine item on a long, vertical strip (making it is easier to read on a 
 						smartphone or computer). This type of presentation is 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1715,6 +1715,17 @@
 					<p>Reading systems MUST ignore the <code>rendition:flow</code> property and its overrides when
 						processing <a href="https://www.w3.org/TR/epub-33/#def-layout-pre-paginated">pre-paginated spine
 							items</a> [[epub-33]].</p>
+
+					<p class="note">
+						Reading systems may decide to disregard this restriction, and accept 
+						the <code>scrolled-continuous</code> value of <code>rendition:flow</code> as a switch
+						to display each pre-paginated spine item on a long, vertical strip (making it is easier to read on a 
+						smartphone or computer). This type of presentation is 
+						often referred to  as <a href="https://medium.com/mrcomics/what-is-webtoon-4926929b20d8">"webtoons"</a>.
+						Some publishers already use this possibility. After some further experimentation and incubation,
+						a future version of this specification may introduce this approach as a standard feature 
+						for fixed-layout documents.
+					</p>
 				</section>
 
 				<section id="align-x-center">
@@ -2634,6 +2645,10 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>23-Sep-2023: Added a note on a possible future feature, whereby the value of 
+						<code>rendition:flow</code> would control the publication of webtoon-like publications.
+						See <a href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>.
+					</li>
 					<li>19-Sept-2022: Removed ARIA extension section as the HTML specification already contains <a
 							href="https://html.spec.whatwg.org/multipage/dom.html#wai-aria">ARIA support
 							requirements</a>. See <a href="https://github.com/w3c/epub-specs/issues/2431">issue

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1717,14 +1717,14 @@
 							items</a> [[epub-33]].</p>
 
 					<p class="note">
-						Reading systems may decide to disregard this restriction, and accept 
+						Reading system developers s may decide to disregard this restriction, and accept 
 						the <code>scrolled-continuous</code> value of <code>rendition:flow</code> as a switch
 						to display each pre-paginated spine item on a long, vertical strip (making it is easier to read on a 
 						smartphone or computer). This type of presentation is 
 						often referred to  as <a href="https://medium.com/mrcomics/what-is-webtoon-4926929b20d8">"webtoons"</a>.
 						Some publishers already use this possibility. After some further experimentation and incubation,
 						a future version of this specification may introduce this approach as a standard feature 
-						for fixed-layout documents.
+						for fixed-layout documents. See also the (deferred) github <a href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>.
 					</p>
 				</section>
 


### PR DESCRIPTION
This is the implementation of the [WG resolution](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-09-13-epub#resolution1) (see #2412).

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/webtoon-note/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/webtoon-note/epub33/rs/index.html)
