### PR TITLE
Update viewport meta intro

### DIFF
--- a/epub33/core/biblio.js
+++ b/epub33/core/biblio.js
@@ -3,6 +3,11 @@ var biblio = {
 		"title": "CSS Snapshot",
 		"href": "https://www.w3.org/TR/CSS/"
 	},
+	"css-viewport-1": {
+		"title": "CSS Viewport Module Level 1",
+		"href": "https://drafts.csswg.org/css-viewport/",
+		"publisher": "W3C"
+	},
 	"dpub-aria" : {
 		"title": "Digital Publishing WAI-ARIA Module",
 		"href": "https://www.w3.org/TR/dpub-aria/",

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10635,9 +10635,8 @@ html.my-document-playing * {
 						<a href="#sec-fxl-icb-html">width and height dimensions</a> for use rendering [=fixed-layout
 					documents=].</p>
 
-				<p>The syntax of this grammar is also influenced by the processing model for transforming
-						<code>viewport</code>
-					<code>meta</code> tags to <code>@viewport</code> CSS rules, as defined in [[css-device-adapt]].</p>
+				<p>The syntax of this grammar is also influenced by the parsing algorithm for the <code>viewport</code>
+					<code>meta</code> tag, as defined in [[css-viewport-1]].</p>
 
 				<p>The syntax is intentionally left as generic as possible as it is not in this specification's scope to
 					define all the possible properties and values. It only defines the basic requirements for defining a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6918,8 +6918,8 @@ No Entry</pre>
 									configuration</a> [[uaag20]] for related information.</p>
 						</div>
 
-						<p id="fxl-layout-duplication" data-tests="#lay-fxl-layout-duplication">When the property is set to
-								<code>pre-paginated</code> for a spine item, its content dimensions MUST be set as
+						<p id="fxl-layout-duplication" data-tests="#lay-fxl-layout-duplication">When the property is set
+							to <code>pre-paginated</code> for a spine item, its content dimensions MUST be set as
 							defined in <a href="#sec-fxl-content-dimensions"></a>.</p>
 
 						<p>EPUB creators MUST NOT declare the <code>rendition:layout</code> property more than once.</p>
@@ -6933,8 +6933,8 @@ No Entry</pre>
 								defined to be a [=fixed-layout document=]). Furthermore, media queries
 								[[mediaqueries-3]] are used to apply different style sheets for three different device
 								categories. Note that the media queries only affect the style sheet applied to the
-								document; the size of the content area set in the <code>viewport</code>
-								<code>meta</code> tag is static.</p>
+								document; the size of the content area set in the <code>viewport meta</code> tag is
+								static.</p>
 
 							<p>Package document:</p>
 
@@ -7030,8 +7030,8 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p id="fxl-orientation-duplication" data-tests="#lay-fxl-orientation-duplication">EPUB creators MUST
-							NOT declare the <code>rendition:orientation</code> property more than once.</p>
+						<p id="fxl-orientation-duplication" data-tests="#lay-fxl-orientation-duplication">EPUB creators
+							MUST NOT declare the <code>rendition:orientation</code> property more than once.</p>
 
 						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
 									><code>refines</code> attribute</a>. Refer to <a href="#orientation-overrides"></a>
@@ -7137,9 +7137,9 @@ No Entry</pre>
 						<div class="note">
 							<p>When synthetic spreads are used in the context of [=XHTML content document | XHTML=] and
 								[=SVG content documents=], the dimensions given via the <a href="#sec-fxl-icb-html"
-										><code>viewport</code>
-									<code>meta</code> element</a> and <a href="#sec-fxl-icb-svg"><code>viewBox</code>
-									attribute</a> represents the size of one page in the spread, respectively.</p>
+										><code>viewport meta</code> element</a> and <a href="#sec-fxl-icb-svg"
+										><code>viewBox</code> attribute</a> represents the size of one page in the
+								spread, respectively.</p>
 						</div>
 
 						<div class="note">
@@ -7557,14 +7557,14 @@ No Entry</pre>
 								containing block</a> [[css2]] in the manner applicable to their format:</p>
 
 						<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
-							<dt id="sec-fxl-icb-html" data-tests="#lay-fxl-xhtml-icb,#lay-fxl-xhtml-icb_multi">Expressing in
-								XHTML</dt>
+							<dt id="sec-fxl-icb-html" data-tests="#lay-fxl-xhtml-icb,#lay-fxl-xhtml-icb_multi"
+								>Expressing in XHTML</dt>
 							<dd>
 								<p>For XHTML [=fixed-layout documents=], the <a
 										href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
 										containing block</a> [[css2]] is obtained from the REQUIRED <code>height</code>
-									and <code>width</code> definitions in a <a href="#app-viewport-meta"
-											><code>viewport</code> meta tag</a>, where:</p>
+									and <code>width</code> definitions in a <a href="#app-viewport-meta"><code>viewport
+											meta</code> tag</a>, where:</p>
 								<ul>
 									<li>the <code>height</code>
 										<a href="#viewport.ebnf.property">property</a> MUST have as its <a
@@ -10621,22 +10621,20 @@ html.my-document-playing * {
 			</section>
 		</section>
 		<section id="app-viewport-meta" class="appendix">
-			<h2>The <code>viewport</code>
-				<code>meta</code> tag</h2>
+			<h2>The <code>viewport meta</code> tag</h2>
 
 			<section id="app-viewport-meta-intro" class="informative">
 				<h3>Introduction</h3>
 
 				<p>As the <a
 						href="https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW6"
-						>Safari HTML definition</a> of the <code>viewport</code>
-					<code>meta</code> tag, that was used in earlier versions of EPUB 3, is not an officially recognized
-					standard, this specification defines a basic syntax in order to allow [=EPUB creators=] to express
-						<a href="#sec-fxl-icb-html">width and height dimensions</a> for use rendering [=fixed-layout
-					documents=].</p>
+						>Safari HTML definition</a> of the <code>viewport meta</code> tag, that was used in earlier
+					versions of EPUB 3, is not an officially recognized standard, this specification defines a basic
+					syntax in order to allow [=EPUB creators=] to express <a href="#sec-fxl-icb-html">width and height
+						dimensions</a> for use rendering [=fixed-layout documents=].</p>
 
-				<p>The syntax of this grammar is also influenced by the parsing algorithm for the <code>viewport</code>
-					<code>meta</code> tag, as defined in [[css-viewport-1]].</p>
+				<p>The syntax of this grammar is also influenced by the parsing algorithm for the <code>viewport
+						meta</code> tag, as defined in [[css-viewport-1]].</p>
 
 				<p>The syntax is intentionally left as generic as possible as it is not in this specification's scope to
 					define all the possible properties and values. It only defines the basic requirements for defining a
@@ -10738,10 +10736,9 @@ html.my-document-playing * {
 					grammar.</p>
 
 				<div class="note">
-					<p>Although the <code>viewport</code>
-						<code>meta</code> tag allows EPUB creators to use properties other than <code>height</code> and
-							<code>width</code>, such use is strongly discouraged. Setting other properties may have
-						unintended consequences on the rendering of [=fixed-layout documents=].</p>
+					<p>Although the <code>viewport meta</code> tag allows EPUB creators to use properties other than
+							<code>height</code> and <code>width</code>, such use is strongly discouraged. Setting other
+						properties may have unintended consequences on the rendering of [=fixed-layout documents=].</p>
 				</div>
 
 				<div class="note">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1434,8 +1434,8 @@
 					<section id="layout">
 						<h5>The <code>rendition:layout</code> property</h5>
 
-						<p id="layout-default" data-cite="epub-33" data-tests="#lay-fxl-layout-default"> The default value
-								<code>reflowable</code> MUST be assumed by EPUB reading systems as the global value if
+						<p id="layout-default" data-cite="epub-33" data-tests="#lay-fxl-layout-default"> The default
+							value <code>reflowable</code> MUST be assumed by EPUB reading systems as the global value if
 							no [^meta^] element carrying the <a data-cite="epub-33#layout"><code>rendition:layout</code>
 								property</a> occurs in the <a data-cite="epub-33#elemdef-opf-metadata">package document
 								metadata</a> [[epub-33]].</p>
@@ -1453,7 +1453,8 @@
 							<dd>
 								<p>Reading systems MAY apply dynamic pagination when rendering.</p>
 							</dd>
-							<dt id="def-layout-pre-paginated" data-tests="#lay-fxl-layout-pre-paginated">pre-paginated</dt>
+							<dt id="def-layout-pre-paginated" data-tests="#lay-fxl-layout-pre-paginated"
+								>pre-paginated</dt>
 							<dd>
 								<p>Reading systems MUST produce exactly one page per spine [^itemref^] [[epub-33]] when
 									rendering.</p>
@@ -1464,9 +1465,9 @@
 					<section id="orientation">
 						<h5>The <code>rendition:orientation</code> property</h5>
 
-						<p id="fxl-orientation-default" data-tests="#lay-fxl-orientation-default" data-cite="epub-33">The
-							default value <code>auto</code> MUST be assumed by EPUB reading systems as the global value
-							if no [^meta^] element carrying the <a data-cite="epub-33#orientation"
+						<p id="fxl-orientation-default" data-tests="#lay-fxl-orientation-default" data-cite="epub-33"
+							>The default value <code>auto</code> MUST be assumed by EPUB reading systems as the global
+							value if no [^meta^] element carrying the <a data-cite="epub-33#orientation"
 									><code>rendition:orientation</code> property</a> occurs in the <a
 								data-cite="epub-33#elemdef-opf-metadata">package document metadata</a> [[epub-33]].</p>
 
@@ -1480,7 +1481,8 @@
 									documents=].</p>
 							</dd>
 
-							<dt id="def-orientation-landscape" data-tests="#lay-fxl-orientation-landscape">landscape</dt>
+							<dt id="def-orientation-landscape" data-tests="#lay-fxl-orientation-landscape"
+								>landscape</dt>
 							<dd>
 								<p>Reading systems that support multiple orientations SHOULD render EPUB content
 									documents in landscape orientation.</p>
@@ -1499,11 +1501,11 @@
 					<section id="spread">
 						<h5>The <code>rendition:spread</code> property</h5>
 
-						<p id="fxl-spread-default" data-tests="#lay-fxl-spread-default" data-cite="epub-33">Reading Systems
-							MUSt assume the default value <code>auto</code> as the global value if no [^meta^] element
-							carrying the <a data-cite="epub-33#spread"><code>rendition:spread</code></a> property occurs
-							in the <a data-cite="epub-33#elemdef-opf-metadata">package document metadata</a>
-							[[epub-33]].</p>
+						<p id="fxl-spread-default" data-tests="#lay-fxl-spread-default" data-cite="epub-33">Reading
+							Systems MUSt assume the default value <code>auto</code> as the global value if no [^meta^]
+							element carrying the <a data-cite="epub-33#spread"><code>rendition:spread</code></a>
+							property occurs in the <a data-cite="epub-33#elemdef-opf-metadata">package document
+								metadata</a> [[epub-33]].</p>
 
 						<p>The <code>rendition:spread</code> property values have the following processing
 							requirements:</p>
@@ -1556,16 +1558,17 @@
 							properties apply to both pre-paginated and reflowable content, and they only apply when the
 							reading system is creating [=synthetic spreads=].</p>
 
-						<p id="page-break-precedence" data-tests="#lay-rendition-flow-pre-pag">The <code>rendition:page-spread-*</code> properties MUST take
-							precedence over whatever value of the <a
-								href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
+						<p id="page-break-precedence" data-tests="#lay-rendition-flow-pre-pag">The
+								<code>rendition:page-spread-*</code> properties MUST take precedence over whatever value
+							of the <a href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
 									><code>page-break-before</code> property</a> [[csssnapshot]] has been set for an
 							[=XHTML content document=].</p>
 
-						<p id="page-layout-both" data-tests="#lay-page-layout-both">When a <a href="#def-layout-reflowable"
-								>reflowable</a> spine item follows a <a href="#def-layout-pre-paginated"
-								>pre-paginated</a> one, the reflowable one SHOULD start on the next page &#8212; as
-							defined by the <a data-cite="epub-33#attrdef-spine-page-progression-direction"
+						<p id="page-layout-both" data-tests="#lay-page-layout-both">When a <a
+								href="#def-layout-reflowable">reflowable</a> spine item follows a <a
+								href="#def-layout-pre-paginated">pre-paginated</a> one, the reflowable one SHOULD start
+							on the next page &#8212; as defined by the <a
+								data-cite="epub-33#attrdef-spine-page-progression-direction"
 									><code>page-progression-direction</code> attribute</a> [[epub-33]] &#8212; when it
 							lacks a <code>rendition:page-spread-*</code> property value.</p>
 
@@ -1578,10 +1581,11 @@
 							defined by the <code>page-progression-direction</code> attribute) when it lacks a
 								<code>rendition:page-spread-*</code> property value.</p>
 
-						<p id="fxl-page-spread-combined" data-tests="#lay-fxl-page-spread-combined">When a reading system
-							encounters two spine items that represent a true spread (i.e., two adjacent spine items with
-							the <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>
-							properties), it SHOULD create the spread with no space between the adjacent pages.</p>
+						<p id="fxl-page-spread-combined" data-tests="#lay-fxl-page-spread-combined">When a reading
+							system encounters two spine items that represent a true spread (i.e., two adjacent spine
+							items with the <code>rendition:page-spread-left</code> and
+								<code>rendition:page-spread-right</code> properties), it SHOULD create the spread with
+							no space between the adjacent pages.</p>
 					</section>
 				</section>
 
@@ -1594,25 +1598,25 @@
 							<p>
 								<span id="confreq-fxl-rs-xhtml-icb-def">Reading systems MUST create the initial
 									containing block (ICB) using the width and height expressions declared in the
-										<code>viewport</code>
-									<code>meta</code> tag for [=XHTML content documents=], as defined in <a
+										<code>viewport meta</code> tag for [=XHTML content documents=], as defined in <a
 										data-cite="epub-33#sec-fxl-icb-html">Expressing in HTML</a> [[epub-33]].</span>
-								<span id="confreq-fxl-rs-xhtml-icb" data-tests="#lay-fxl-xhtml-icb,#lay-fxl-xhtml-icb_multi"
-									>They MUST clip content positioned outside of the ICB.</span>
+								<span id="confreq-fxl-rs-xhtml-icb"
+									data-tests="#lay-fxl-xhtml-icb,#lay-fxl-xhtml-icb_multi">They MUST clip content
+									positioned outside of the ICB.</span>
 							</p>
 							<p id="confreq-fxl-rs-xhtml-icb-units" data-tests="#lay-fxl-xhtml-icb_units">If the width or
-								height values in the <code>viewport</code>
-								<code>meta</code> tag contain a non-numeric character but start with a number (e.g., the
-								value includes a unit of length declaration such as "500px"), the number prefix SHOULD
-								be used as the pixel value, otherwise the value MUST be treated as invalid.</p>
-							<p>If the <code>viewport</code>
-								<code>meta</code> does not contain a width or a height value, or if these values are
-								invalid, reading systems SHOULD consider these as having the values
+								height values in the <code>viewport meta</code> tag contain a non-numeric character but
+								start with a number (e.g., the value includes a unit of length declaration such as
+								"500px"), the number prefix SHOULD be used as the pixel value, otherwise the value MUST
+								be treated as invalid.</p>
+							<p>If the <code>viewport meta</code> does not contain a width or a height value, or if these
+								values are invalid, reading systems SHOULD consider these as having the values
 									<code>device-width</code> and <code>device-height</code>, respectively.</p>
-							<p id="confreq-fxl-rs-xhtml-multiple-icb-def" data-tests="#lay-fxl-xhtml-icb_multi_declarations"
-								>If an XHTML content document contains more than one <code>viewport</code>
-								<code>meta</code> tag, reading systems MUST use the first in document order to obtain
-								the height and width dimensions. Subsequent declarations MUST be ignored.</p>
+							<p id="confreq-fxl-rs-xhtml-multiple-icb-def"
+								data-tests="#lay-fxl-xhtml-icb_multi_declarations">If an XHTML content document contains
+								more than one <code>viewport meta</code> tag, reading systems MUST use the first in
+								document order to obtain the height and width dimensions. Subsequent declarations MUST
+								be ignored.</p>
 							<p id="confreq-fxl-rs-xhtml-icb-ratio">When the ICB aspect ratio does not match the aspect
 								ratio of the reading system [=content display area=], reading systems MAY position the
 								ICB inside the area to accommodate the user interface; in other words, added
@@ -1621,8 +1625,8 @@
 
 						<dt>SVG</dt>
 						<dd>
-							<p id="confreq-fxl-rs-svg" data-tests="#lay-fxl-svg-icb_multi">Reading systems MUST create the
-								initial containing block (ICB) using the dimensions as defined in <a
+							<p id="confreq-fxl-rs-svg" data-tests="#lay-fxl-svg-icb_multi">Reading systems MUST create
+								the initial containing block (ICB) using the dimensions as defined in <a
 									data-cite="epub-33#sec-fxl-icb-svg">Expressing the ICB in SVG</a> [[epub-33]] to
 								render [=SVG content documents=]. </p>
 							<p id="confreq-fxl-rs-svg-icb-ratio" class="note"> When the ICB aspect ratio does not match
@@ -1686,9 +1690,8 @@
 						<dd id="scrolled-continuous-dd" data-tests="#lay-pkg-flow-scrolled-continuous">
 							<p>The reading system SHOULD render all [=EPUB content documents=] such that overflow
 								content is scrollable, and SHOULD present the [=EPUB publication=] as one continuous
-								scroll from spine item to spine item (except where <a
-									data-cite="epub-33#flow-overrides">locally overridden</a>
-								[[epub-33]]).</p>
+								scroll from spine item to spine item (except where <a data-cite="epub-33#flow-overrides"
+									>locally overridden</a> [[epub-33]]).</p>
 						</dd>
 
 						<dt id="scrolled-doc">scrolled-doc</dt>
@@ -1716,16 +1719,15 @@
 						processing <a href="https://www.w3.org/TR/epub-33/#def-layout-pre-paginated">pre-paginated spine
 							items</a> [[epub-33]].</p>
 
-					<p class="note">
-						Reading system developers may decide to disregard this restriction, and accept 
-						the <code>scrolled-continuous</code> value of <code>rendition:flow</code> as a switch
-						to display each pre-paginated spine item on a long, vertical strip (making it is easier to read on a 
-						smartphone or computer). This type of presentation is 
-						often referred to  as <a href="https://medium.com/mrcomics/what-is-webtoon-4926929b20d8">"webtoons"</a>.
-						Some publishers already use this possibility. After some further experimentation and incubation,
-						a future version of this specification may introduce this approach as a standard feature 
-						for fixed-layout documents. See also the (deferred) github <a href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>.
-					</p>
+					<p class="note"> Reading system developers may decide to disregard this restriction, and accept the
+							<code>scrolled-continuous</code> value of <code>rendition:flow</code> as a switch to display
+						each pre-paginated spine item on a long, vertical strip (making it is easier to read on a
+						smartphone or computer). This type of presentation is often referred to as <a
+							href="https://medium.com/mrcomics/what-is-webtoon-4926929b20d8">"webtoons"</a>. Some
+						publishers already use this possibility. After some further experimentation and incubation, a
+						future version of this specification may introduce this approach as a standard feature for
+						fixed-layout documents. See also the (deferred) github <a
+							href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>. </p>
 				</section>
 
 				<section id="align-x-center">
@@ -1736,8 +1738,8 @@
 						[=viewport=] or spread, as applicable. This property does not affect the rendering of the spine
 						item, only the placement of the resulting content box.</p>
 
-					<p id="reflow-align-x-center" data-tests="#lay-reflow-align-x-center">For reflowable content, reading systems that support this property MUST center each virtual
-						page.</p>
+					<p id="reflow-align-x-center" data-tests="#lay-reflow-align-x-center">For reflowable content,
+						reading systems that support this property MUST center each virtual page.</p>
 
 					<p>This specification does not define a default rendering behavior when reading systems do not
 						support this property or [=EPUB creators=] do not specify it. Reading systems MAY render spine
@@ -1746,13 +1748,12 @@
 			</section>
 
 			<section id="sec-viewport-meta">
-				<h3>The <code>viewport</code>
-					<code>meta</code> tag</h3>
+				<h3>The <code>viewport meta</code> tag</h3>
 
-				<p id="viewport-meta-prop" data-tests="#lay-viewport-meta-prop">Except when obtaining the initial containing block dimensions for [=fixed-layout documents=], reading
-					systems MUST ignore rendering instructions in <a data-cite="epub-33#app-viewport-meta"
-							><code>viewport</code>
-						<code>meta</code> declarations</a>.</p>
+				<p id="viewport-meta-prop" data-tests="#lay-viewport-meta-prop">Except when obtaining the initial
+					containing block dimensions for [=fixed-layout documents=], reading systems MUST ignore rendering
+					instructions in <a data-cite="epub-33#app-viewport-meta"><code>viewport meta</code>
+					declarations</a>.</p>
 
 				<p>This restriction applies to both fixed-layout and reflowable documents.</p>
 			</section>
@@ -2645,10 +2646,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>23-Sep-2023: Added a note on a possible future feature, whereby the value of 
-						<code>rendition:flow</code> would control the publication of webtoon-like publications.
-						See <a href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>.
-					</li>
+					<li>23-Sep-2023: Added a note on a possible future feature, whereby the value of
+							<code>rendition:flow</code> would control the publication of webtoon-like publications. See
+							<a href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>. </li>
 					<li>19-Sept-2022: Removed ARIA extension section as the HTML specification already contains <a
 							href="https://html.spec.whatwg.org/multipage/dom.html#wai-aria">ARIA support
 							requirements</a>. See <a href="https://github.com/w3c/epub-specs/issues/2431">issue


### PR DESCRIPTION
Adopts the language in https://github.com/w3c/epub-specs/issues/2442#issue-1389469990 and switches the reference from css-device-adapt to css-viewport-1.

Note that I had to add a custom biblio entry as the new spec hasn't been published at its listed TR address (i.e., it's also not in specref yet). Will have to remember to delete this once it is.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2443.html" title="Last updated on Sep 29, 2022, 10:59 AM UTC (ecd9ec3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2443/093b9a1...ecd9ec3.html" title="Last updated on Sep 29, 2022, 10:59 AM UTC (ecd9ec3)">Diff</a>