### PR TITLE
Missing fullstop

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3179,7 +3179,7 @@
 					<p
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
 						>Specifies the <a data-cite="bidi#BD5">base direction</a> [[bidi]] of the textual content and
-						attribute values of the carrying element and its descendants</p>
+						attribute values of the carrying element and its descendants.</p>
 
 					<p>Allowed values are:</p>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2444.html" title="Last updated on Oct 1, 2022, 3:44 PM UTC (52196f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2444/093b9a1...52196f1.html" title="Last updated on Oct 1, 2022, 3:44 PM UTC (52196f1)">Diff</a>