### PR TITLE
Extra note on RS conformance

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -224,16 +224,18 @@
 			<h3>Reading system conformance</h3>
 
 			<p>Whether a [=reading system=] has to support a feature is mentioned at the beginning of its section. To be
-				conformant with this specification, reading systems MUST, with one exception, support all required features as well as all
+				conformant with this specification, reading systems MUST support all required features as well as all
 				applicable conditionally-required features (e.g., to support image rendering if the reading system has a
 				[=viewport=]) as defined in their respective sections.</p>
 
-			<p>
-				The one exception to the conformance requirement stated above is for reading systems that do not allow
-				users to load their own EPUB publications (e.g., all content is controlled and delivered from a bookstore or
-				library system). In this case, if a reading system developer can demonstrate that a requirement is handled
-				in an upstream process (e.g., EPUB publications with duplicate [^itemref^] entries [[epub-33]] cannot enter
-				the system), the reading system is still considered conforming.
+			<p class="note">
+				As a reading system is not necessarily a single application, but may exist as a distributed system,
+				it is not always the case that reading system requirements will be met in the application that 
+				renders EPUB publications to users. An example is a reading system that solely interacts with a
+				controlled content repository (e.g., a bookstore or library system). In this case, if a reading
+				system developer can demonstrate that requirements are not applicable to the application
+				(e.g., EPUB publications with duplicate [^itemref^] entries [[epub-33]] cannot enter the system),
+				the reading system as a whole is still considered conforming.
 			</p>
 
 			<p>When supporting recommended and optional features, reading systems MUST meet all normative requirements

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -224,9 +224,18 @@
 			<h3>Reading system conformance</h3>
 
 			<p>Whether a [=reading system=] has to support a feature is mentioned at the beginning of its section. To be
-				conformant with this specification, reading systems MUST support all required features as well as all
+				conformant with this specification, reading systems MUST, in general, support all required features as well as all
 				applicable conditionally-required features (e.g., to support image rendering if the reading system has a
 				[=viewport=]) as defined in their respective sections.</p>
+
+			<p>
+				There is one exception to the conformance requirement as stated above. Not all reading systems offer the possibility
+				to load an EPUB publication directly (a feature often referred to as "side-loading"); instead, the reading 
+				system is part of a larger publishing workflow which automatically filters out non-conformant EPUB publications 
+				(e.g., whether the publication contains duplicate <a data-cite="epub-33#itemref"><code>itemref</code></a> entries in 
+				its <a data-cite="epub-33#spine">spine</a> [[epub-33]]). It is reasonable for such reading systems not to implement
+				strong checks for those cases. This decision does <em>not</em> affect the conformance of such reading systems.
+			</p>
 
 			<p>When supporting recommended and optional features, reading systems MUST meet all normative requirements
 				as defined in their respective sections.</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -224,17 +224,16 @@
 			<h3>Reading system conformance</h3>
 
 			<p>Whether a [=reading system=] has to support a feature is mentioned at the beginning of its section. To be
-				conformant with this specification, reading systems MUST, in general, support all required features as well as all
+				conformant with this specification, reading systems MUST, with one exception, support all required features as well as all
 				applicable conditionally-required features (e.g., to support image rendering if the reading system has a
 				[=viewport=]) as defined in their respective sections.</p>
 
 			<p>
-				There is one exception to the conformance requirement as stated above. Not all reading systems offer the possibility
-				to load an EPUB publication directly (a feature often referred to as "side-loading"); instead, the reading 
-				system is part of a larger publishing workflow which automatically filters out non-conformant EPUB publications 
-				(e.g., whether the publication contains duplicate <a data-cite="epub-33#itemref"><code>itemref</code></a> entries in 
-				its <a data-cite="epub-33#spine">spine</a> [[epub-33]]). It is reasonable for such reading systems not to implement
-				strong checks for those cases. This decision does <em>not</em> affect the conformance of such reading systems.
+				The one exception to the conformance requirement stated above is for reading systems that do not allow
+				users to load their own EPUB publications (e.g., all content is controlled and delivered from a bookstore or
+				library system). In this case, if a reading system developer can demonstrate that a requirement is handled
+				in an upstream process (e.g., EPUB publications with duplicate [^itemref^] entries [[epub-33]] cannot enter
+				the system), the reading system is still considered conforming.
 			</p>
 
 			<p>When supporting recommended and optional features, reading systems MUST meet all normative requirements


### PR DESCRIPTION
This PR offers a solution for the core issue raised in #2433.

Fix #2433.


For preview see:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/note-on-rs-conformance/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/note-on-rs-conformance/epub33/rs/index.html)
