### PR TITLE
Succinct wording for conformance requirements on XML processing

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -309,24 +309,14 @@
 			<section id="sec-epub-rs-conf-xml">
 				<h4>XML processing</h4>
 
-				<p>A reading system MUST be both of the following:</p>
+				<p id="confreq-rs-xml-nval" data-tests="#pub-xml-non-validating_invalid,#pub-xml-non-validating_unclosed">
+                                A reading system MUST use a non-validating XML processor [xml].</p>
 
-				<ul class="conformance-list">
-					<li>
-						<p id="confreq-rs-xml-nval"
-							data-tests="#pub-xml-non-validating_invalid,#pub-xml-non-validating_unclosed">a <a
-								data-cite="xml#proc-types">conformant non-validating XML processor</a> [[xml]].</p>
-					</li>
-					<li>
-						<p id="confreq-rs-xml-ns" data-tests="#pub-xml-names">a <a
-								data-cite="xml-names#ProcessorConformance">conformant processor</a> as defined in
-							[[xml-names]].</p>
-					</li>
-				</ul>
+				<p id="confreq-rs-xml-extid" data-tests="#pub-xml-external-id">It MUST NOT read <a data-cite="xml#dt-doctype>external 
+                                DTD subsets</a> [[xml]].</p>
 
-				<p id="confreq-rs-xml-extid" data-tests="#pub-xml-external-id">In addition, when processing XML
-					documents, a reading system MUST NOT resolve <a data-cite="xml#NT-ExternalID">external
-						identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[xml]].</p>
+				<p id="confreq-rs-xml-ns" data-tests="#pub-xml-names">It MUST conform to [[xml-names]].</p>
+
 			</section>
 
 			<section id="sec-epub-rs-i18n">


### PR DESCRIPTION
Here is my proposed rewrite of 3.6 XML processing in EPUB 3.3 RS.  It is intended to address #2433 at least partially.  But more wording about XML security issues is needed somewhere else.

See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/murata2makoto/epub-specs/xml-processing-conformance/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/murata2makoto/epub-specs/xml-processing-conformance/epub33/rs/index.html)
