### PR TITLE
Made the XML conformance section more succinct

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -309,24 +309,14 @@
 			<section id="sec-epub-rs-conf-xml">
 				<h4>XML processing</h4>
 
-				<p>A reading system MUST be both of the following:</p>
+				<p  id="confreq-rs-xml-nval"
+				data-tests="#pub-xml-non-validating_invalid,#pub-xml-non-validating_unclosed">A [= reading system =] MUST use a 
+				non-validating XML processor [[xml]] that:</p>
 
 				<ul class="conformance-list">
-					<li>
-						<p id="confreq-rs-xml-nval"
-							data-tests="#pub-xml-non-validating_invalid,#pub-xml-non-validating_unclosed">a <a
-								data-cite="xml#proc-types">conformant non-validating XML processor</a> [[xml]].</p>
-					</li>
-					<li>
-						<p id="confreq-rs-xml-ns" data-tests="#pub-xml-names">a <a
-								data-cite="xml-names#ProcessorConformance">conformant processor</a> as defined in
-							[[xml-names]].</p>
-					</li>
+					<li id="confreq-rs-xml-extid" data-tests="#pub-xml-external-id">does not read external DTD subsets [[xml]];</li>
+					<li id="confreq-rs-xml-ns" data-tests="#pub-xml-names">conforms to [[xml-names]].</li>
 				</ul>
-
-				<p id="confreq-rs-xml-extid" data-tests="#pub-xml-external-id">In addition, when processing XML
-					documents, a reading system MUST NOT resolve <a data-cite="xml#NT-ExternalID">external
-						identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[xml]].</p>
 			</section>
 
 			<section id="sec-epub-rs-i18n">
@@ -2426,6 +2416,14 @@
 					publications through the process of "sideloading") SHOULD treat such content as insecure (e.g.,
 					prompt users to allow scripting and network access).</p>
 
+				<p >When processing XML documents, a reading system SHOULD NOT resolve 
+					<a data-cite="xml#NT-ExternalID">external identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[xml]].
+					Reading systems SHOULD also consider security risks related to <a data-cite="xml#sec-internal-ent">internal</a> or 
+					<a data-cite="xml#sec-external-ent">external</a> XML entities like, for example, DoS attacks 
+					also known as <a href="https://en.wikipedia.org/wiki/Billion_laughs_attack">"Billion laughs attacks"</a>
+					or <a href="https://en.wikipedia.org/wiki/XML_external_entity_attack">"XML external entity attacks"</a>.
+				</p>
+	
 				<div class="note">
 					<p>Additional security recommendations for external links, network access and scripting are
 						available in <a href="#sec-epub-rs-external-links"></a>, <a href="#sec-epub-rs-network-access"
@@ -2646,6 +2644,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>06-10-2022: Moved the restriction on XML external identifiers from the XML conformance clause to 
+						the security and privacy section, adding an additional note on security risks on 
+						internal or external entities. See <a href="https://github.com/w3c/epub-specs/issues/2433">issue 2433</a>
+						and <a href="https://github.com/w3c/epub-specs/issues/2447">issue 2477</a>.
+					</li>
 					<li>23-Sep-2023: Added a note on a possible future feature, whereby the value of
 							<code>rendition:flow</code> would control the publication of webtoon-like publications. See
 							<a href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>. </li>


### PR DESCRIPTION
This PR is a replacement for #2450, which was mistakenly branched off on an earlier state of the spec.

The PR also adds some text to the security section (also anticipating some WG discussion on #2447 to happen on 2022-10-06).


See:

* For EPUB 3.3 Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/makoto-xml-conformance-change/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/makoto-xml-conformance-change/epub33/rs/index.html)
