### PR TITLE
Handling problematic viewport/ICB settings 

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10733,7 +10733,7 @@ html.my-document-playing * {
 						href="#viewport.ebnf.assign">assignment character</a>.</p>
 
 				<p>
-					The [^meta/content^] attribute SHOULD NOT include several <code>height</code>, respectively <code>width</code>,  assignments.
+					The [^meta/content^] attribute MUST NOT include several <code>height</code>, respectively <code>width</code>,  assignments.
 				</p>
 
 				<p>There are no restrictions on any other attributes allowed on the [^meta^] element by the [[html]]

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10732,6 +10732,12 @@ html.my-document-playing * {
 					contain <a href="#viewport.ebnf.sep-char">separator characters</a> or the <a
 						href="#viewport.ebnf.assign">assignment character</a>.</p>
 
+				<p>
+					If the <code>height</code> or the <code>width</code> assignments have multiple occurences whithin an otherwise
+					correct value of the [^meta/content^] attribute, only the first occurence of the <code>height</code>, respectively
+					<code>width</code>, definition counts, and all others MUST be ignored.
+				</p>
+
 				<p>There are no restrictions on any other attributes allowed on the [^meta^] element by the [[html]]
 					grammar.</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10733,9 +10733,7 @@ html.my-document-playing * {
 						href="#viewport.ebnf.assign">assignment character</a>.</p>
 
 				<p>
-					If the <code>height</code> or the <code>width</code> assignments have multiple occurences whithin an otherwise
-					correct value of the [^meta/content^] attribute, only the first occurence of the <code>height</code>, respectively
-					<code>width</code>, definition counts, and all others MUST be ignored.
+					The [^meta/content^] attribute SHOULD NOT include several <code>height</code>, respectively <code>width</code>,  assignments.
 				</p>
 
 				<p>There are no restrictions on any other attributes allowed on the [^meta^] element by the [[html]]

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10644,7 +10644,7 @@ html.my-document-playing * {
 			<section id="app-viewport-meta-syntax">
 				<h3>Syntax</h3>
 
-				<p>A <code>viewport</code> [^meta^] tag [[html]] MUST have <code>name</code> and <code>content</code>
+				<p>A <code>viewport</code> <a data-cite="html#meta"><code>meta</code></a> tag [[html]] MUST have <code>name</code> and <code>content</code>
 					attributes that conform to the following definition:</p>
 
 				<dl>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11783,6 +11783,9 @@ EPUB/images/cover.png</pre>
 				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub32/">EPUB 3.2</a></h3>
 
 				<ul>
+					<li>11-Oct-2023: Additional text on ICB setting when dimensions are set multiple times.
+						See <a href="https://github.com/w3c/epub-specs/issues/2442">issue 2442</a>.
+					</li>
 					<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and
 						updated the list of semantics to use for escaping to match the guidance. See <a
 							href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2669,6 +2669,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>11-Oct-2023: Additional text sketching the RS behavior in the case of erroneous ICB setting.
+						See <a href="https://github.com/w3c/epub-specs/issues/2442">issue 2442</a>.
+					</li>
 					<li>23-Sep-2023: Added a note on a possible future feature, whereby the value of
 							<code>rendition:flow</code> would control the publication of webtoon-like publications. See
 							<a href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>. </li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1611,17 +1611,19 @@
 								"500px"), the number prefix SHOULD be used as the pixel value, otherwise the value MUST
 								be treated as invalid.</p>
 
-							<p>
+							<p id="confreq-fxl-rs-xhtml-icb_invalid_meta"
+							   data-tests="#lay-fxl-xhtml-icb_invalid_meta">
 								Reading systems SHOULD attempt to extract <code>width</code> and <code>height</code> values from a <code>viewport meta</code> tag even if its syntax is invalid.
 							</p>
 
-							<p>
+							<p id="confreq-fxl-rs-xhtml-icb_repeated-in-meta"
+							   data-tests="#lay-fxl-xhtml-icb_repeated-in-meta">
 								Reading systems MUST use the first declaration of a <code>width</code> and <code>height</code> property in a <code>viewport meta</code> tag (i.e., ignore repeated declarations).
 							</p>
 							
 							<p>
 								If the <code>viewport meta</code> does not contain a width or a height value, or if these
-								values are invalid, reading systems MAY supply the values. For example, a reading system might:
+								values are invalid, reading systems MAY supply the values. For example, a reading system may:
 							</p>
 
 							<ul>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1604,23 +1604,46 @@
 									data-tests="#lay-fxl-xhtml-icb,#lay-fxl-xhtml-icb_multi">They MUST clip content
 									positioned outside of the ICB.</span>
 							</p>
+
 							<p id="confreq-fxl-rs-xhtml-icb-units" data-tests="#lay-fxl-xhtml-icb_units">If the width or
 								height values in the <code>viewport meta</code> tag contain a non-numeric character but
 								start with a number (e.g., the value includes a unit of length declaration such as
 								"500px"), the number prefix SHOULD be used as the pixel value, otherwise the value MUST
 								be treated as invalid.</p>
-							<p>If the <code>viewport meta</code> does not contain a width or a height value, or if these
-								values are invalid, reading systems SHOULD consider these as having the values
-									<code>device-width</code> and <code>device-height</code>, respectively.</p>
+
+							<p>
+								If the <code>viewport meta</code> tag is invalid, the reading system MAY attempt to
+								extract valid <code>width</code> and <code>height</code> values and, if successful, use those to establish
+								the initial containing block.
+							</p>
+							
+							<p>
+								If the <code>viewport meta</code> does not contain a width or a height value, or if these
+								values are invalid, reading systems MAY choose to:
+							</p>
+
+							<ul>
+								<li>consider these as having the values <code>device-width</code> and <code>device-height</code>, respectively; or</li>
+								<li>look for the previous content document in the [=spine=], if applicable, and use the ICB value defined there; or</li>
+								<li>consider the content document as erroneous XHTML content altogether.</li>
+							</ul>
+
 							<p id="confreq-fxl-rs-xhtml-multiple-icb-def"
 								data-tests="#lay-fxl-xhtml-icb_multi_declarations">If an XHTML content document contains
-								more than one <code>viewport meta</code> tag, reading systems MUST use the first in
+								more than one <code>viewport meta</code> tags, reading systems MUST use the first in
 								document order to obtain the height and width dimensions. Subsequent declarations MUST
 								be ignored.</p>
+
 							<p id="confreq-fxl-rs-xhtml-icb-ratio">When the ICB aspect ratio does not match the aspect
 								ratio of the reading system [=content display area=], reading systems MAY position the
 								ICB inside the area to accommodate the user interface; in other words, added
 								letter-boxing space MAY appear on either side (or both) of the content.</p>
+
+							<p>
+								In all cases when the <code>viewport meta</code> tag is invalid, the reading system MAY issue 
+								an error message visible to the reader and/or the EPUB creator.
+							</p>
+	
 						</dd>
 
 						<dt>SVG</dt>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1642,11 +1642,6 @@
 								ratio of the reading system [=content display area=], reading systems MAY position the
 								ICB inside the area to accommodate the user interface; in other words, added
 								letter-boxing space MAY appear on either side (or both) of the content.</p>
-
-							<p>
-								In all cases when the <code>viewport meta</code> tag is invalid, the reading system MAY issue 
-								an error message visible to the reader and/or the EPUB creator.
-							</p>
 	
 						</dd>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1612,9 +1612,7 @@
 								be treated as invalid.</p>
 
 							<p>
-								If the <code>viewport meta</code> tag is invalid, the reading system MAY attempt to
-								extract valid <code>width</code> and <code>height</code> values and, if successful, use those to establish
-								the initial containing block.
+								Reading systems SHOULD attempt to extract <code>width</code> and <code>height</code> values from a <code>viewport meta</code> tag even if its syntax is invalid.
 							</p>
 							
 							<p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1619,7 +1619,7 @@
 							
 							<p>
 								If the <code>viewport meta</code> does not contain a width or a height value, or if these
-								values are invalid, reading systems MAY choose to:
+								values are invalid, reading systems MAY supply the values. For example, a reading system might:
 							</p>
 
 							<ul>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1614,6 +1614,10 @@
 							<p>
 								Reading systems SHOULD attempt to extract <code>width</code> and <code>height</code> values from a <code>viewport meta</code> tag even if its syntax is invalid.
 							</p>
+
+							<p>
+								Reading systems MUST use the first declaration of a <code>width</code> and <code>height</code> property in a <code>viewport meta</code> tag (i.e., ignore repeated declarations).
+							</p>
 							
 							<p>
 								If the <code>viewport meta</code> does not contain a width or a height value, or if these


### PR DESCRIPTION
As agreed on the [WG call](https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-10-07-epub#resolution1) this is an attempt to fix #2442. Some notes:

- The case of repeated `width`/`height` setting within the `viewport` tag is now part of the `viewport` definition in the core spec. Having it there means that epubcheck can consider such a `viewport` setting as valid (although it may choose to issue a warning).
- Clearly, the reaction of various reading systems on the problematic cases is different, contrast, e.g., https://github.com/w3c/epub-specs/issues/2442#issuecomment-1271820337 and https://github.com/w3c/epub-specs/issues/2442#issuecomment-1268691239. My conclusion from this, but also of the discussion, is that the RS can only include non-binding solutions, in other words, _MAY_ statements. This is what is there. Maybe in the discussion we can agree to put a _SHOULD_ to one of these.
- There may have to be a more general statement in the RS spec on what happens if erronous content is met, e.g., an invalid XHTML content file. I believe a note or some sentence in §2 (Reading system conformance) would be in order which says something like 'the RS _MAY_ issue and error message'. I would let @mattgarrrish think about it before doing it. Note that, if we decide to put something there, the last (new) paragraph in the PR may become moot.

See:

* For EPUB 3.3:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/viewport-spec-issues/epub33/core/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/core/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/viewport-spec-issues/epub33/core/index.html)
* For EPUB 3.3 Reading Systems:
    * [Preview](https://cdn.statically.io/gh/w3c/epub-specs/viewport-spec-issues/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/viewport-spec-issues/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2453.html" title="Last updated on Oct 15, 2022, 4:10 AM UTC (f8b1398)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2453/2fb7a66...f8b1398.html" title="Last updated on Oct 15, 2022, 4:10 AM UTC (f8b1398)">Diff</a>