### PR TITLE
Add error handling and reporting subsections

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -221,7 +221,7 @@
 			</section>
 		</section>
 		<section id="sec-rs-conformance">
-			<h3>Reading system conformance</h3>
+			<h2>Reading system conformance</h2>
 
 			<p>Whether a [=reading system=] has to support a feature is mentioned at the beginning of its section. To be
 				conformant with this specification, reading systems MUST support all required features as well as all
@@ -242,6 +242,24 @@
 					document=] metadata). Reading systems may use this additional information for any purposes (e.g., to
 					improve the user interface).</p>
 			</div>
+
+			<section id="rs-conf-error-handling">
+				<h3>Error handling</h3>
+
+				<p>Reading systems are not required to load [=EPUB publications=], or resources within them, when they
+					violate content authoring or processing requirements.</p>
+			</section>
+
+			<section id="rs-conf-error-reporting" class="informative">
+				<h3>Error reporting</h3>
+
+				<p>Although reading systems are not required to report errors encountered while processing and rendering
+					[=EPUB publications=] (e.g., if the dimensions of a [=fixed-layout document=] have been inferred),
+					they are strongly encouraged to provide users a means of accessing this information.</p>
+
+				<p>Allowing access to processing errors can help users determine whether problems with their EPUB
+					publications should be reported to the reading system developer or to the EPUB creators.</p>
+			</section>
 		</section>
 		<section id="sec-pub-resources">
 			<h3>Publication resource processing</h3>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -267,7 +267,8 @@
 					(e.g., to efficiently debug their EPUB publications). For maximum use in debugging, it is
 					recommended that reading systems not only report issues they directly encounter but also issues
 					reported by any applications they use (e.g., HTML, CSS, and JavaScript errors reported from a
-					browser core used to render the content).</p>
+					browser core used to render the content, or validation issues reported by <a
+						href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>).</p>
 
 				<p>It is not expected that error reporting will be an intrusive experience that affects the general
 					reading experience for users. Rather, reporting information could, for example, be selectively

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -223,9 +223,8 @@
 		<section id="sec-rs-conformance">
 			<h2>Reading system conformance</h2>
 
-			<section id="rs-conf-conf-req">
+			<section id="rs-conf-req">
 				<h3>Requirements</h3>
-
 
 				<p>Whether a [=reading system=] has to support a feature is mentioned at the beginning of its section.
 					To be conformant with this specification, reading systems MUST support all required features as well

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -223,25 +223,30 @@
 		<section id="sec-rs-conformance">
 			<h2>Reading system conformance</h2>
 
-			<p>Whether a [=reading system=] has to support a feature is mentioned at the beginning of its section. To be
-				conformant with this specification, reading systems MUST support all required features as well as all
-				applicable conditionally-required features (e.g., to support image rendering if the reading system has a
-				[=viewport=]) as defined in their respective sections.</p>
+			<section id="rs-conf-conf-req">
+				<h3>Requirements</h3>
 
-			<p>When supporting recommended and optional features, reading systems MUST meet all normative requirements
-				as defined in their respective sections.</p>
 
-			<p>When reading system developers opt not to support a recommended or optional feature, it does not always
-				mean none of the normative requirements of the section apply. In some cases, there may be alternative
-				requirements when not implementing a feature (e.g., to <a href="#confreq-rs-scripted-flbk">process
-					fallbacks</a> when scripting is not supported). Reading systems MUST meet these alternative
-				requirements when not supporting a feature.</p>
+				<p>Whether a [=reading system=] has to support a feature is mentioned at the beginning of its section.
+					To be conformant with this specification, reading systems MUST support all required features as well
+					as all applicable conditionally-required features (e.g., to support image rendering if the reading
+					system has a [=viewport=]) as defined in their respective sections.</p>
 
-			<div class="note">
-				<p>EPUB publications frequently contain information not required by this specification (e.g., [=package
-					document=] metadata). Reading systems may use this additional information for any purposes (e.g., to
-					improve the user interface).</p>
-			</div>
+				<p>When supporting recommended and optional features, reading systems MUST meet all normative
+					requirements as defined in their respective sections.</p>
+
+				<p>When reading system developers opt not to support a recommended or optional feature, it does not
+					always mean none of the normative requirements of the section apply. In some cases, there may be
+					alternative requirements when not implementing a feature (e.g., to <a
+						href="#confreq-rs-scripted-flbk">process fallbacks</a> when scripting is not supported). Reading
+					systems MUST meet these alternative requirements when not supporting a feature.</p>
+
+				<div class="note">
+					<p>EPUB publications frequently contain information not required by this specification (e.g.,
+						[=package document=] metadata). Reading systems may use this additional information for any
+						purposes (e.g., to improve the user interface).</p>
+				</div>
+			</section>
 
 			<section id="rs-conf-error-handling">
 				<h3>Error handling</h3>
@@ -255,10 +260,18 @@
 
 				<p>Although reading systems are not required to report errors encountered while processing and rendering
 					[=EPUB publications=] (e.g., if the dimensions of a [=fixed-layout document=] have been inferred),
-					they are strongly encouraged to provide users a means of accessing this information.</p>
+					they are strongly encouraged to provide a means of accessing this information. A comparable example
+					are the developer tools that web browsers provide for debugging HTML pages and applications.</p>
 
-				<p>Allowing access to processing errors can help users determine whether problems with their EPUB
-					publications should be reported to the reading system developer or to the [=EPUB creators=].</p>
+				<p>[=EPUB creators=], for example, can greatly benefit from having access to such processing information
+					(e.g., to efficiently debug their EPUB publications). For maximum use in debugging, it is
+					recommended that reading systems not only report issues they directly encounter but also issues
+					reported by any applications they use (e.g., HTML, CSS, and JavaScript errors reported from a
+					browser core used to render the content).</p>
+
+				<p>It is not expected that error reporting will be an intrusive experience that affects the general
+					reading experience for users. Rather, reporting information could, for example, be selectively
+					activated from a settings menu so that it does not bother users unnecessarily.</p>
 			</section>
 		</section>
 		<section id="sec-pub-resources">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -258,7 +258,7 @@
 					they are strongly encouraged to provide users a means of accessing this information.</p>
 
 				<p>Allowing access to processing errors can help users determine whether problems with their EPUB
-					publications should be reported to the reading system developer or to the EPUB creators.</p>
+					publications should be reported to the reading system developer or to the [=EPUB creators=].</p>
 			</section>
 		</section>
 		<section id="sec-pub-resources">

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -2664,9 +2664,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>23-Sep-2023: Added a note on a possible future feature, whereby the value of
+					<li>13-Oct-2022: Added sections to explain expectations for error handling and reporting. See <a
+							href="https://github.com/w3c/epub-specs/issues/2454">issue 2454</a>.</li>
+					<li>23-Sep-2022: Added a note on a possible future feature, whereby the value of
 							<code>rendition:flow</code> would control the publication of webtoon-like publications. See
-							<a href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>. </li>
+							<a href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>.</li>
 					<li>19-Sept-2022: Removed ARIA extension section as the HTML specification already contains <a
 							href="https://html.spec.whatwg.org/multipage/dom.html#wai-aria">ARIA support
 							requirements</a>. See <a href="https://github.com/w3c/epub-specs/issues/2431">issue


### PR DESCRIPTION
I've made the error reporting section informative since we're not recommending or requiring it.

Fixes #2454 

* Reading Systems:
    * [Preview](https://raw.githack.com/w3c/epub-specs/fix/issue-2454/epub33/rs/index.html)
    * [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/fix/issue-2454/epub33/rs/index.html)
