### PR TITLE
Allow properties without values in viewport meta tags

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7575,6 +7575,9 @@ No Entry</pre>
 								</ul>
 								<p>The <code>device-width</code> and <code>device-height</code> values refer to the 100%
 									of the width and height, respectively, of the reading system's [=viewport=].</p>
+								<p>EPUB creators MUST NOT specify duplicate <code>height</code> or <code>width</code>
+									definitions either within a single <code>viewport meta</code> tag or by specifying
+									multiple <code>viewport meta</code> tags.</p>
 								<aside class="example"
 									title="Specifying the initial containing block in a viewport meta tag">
 									<pre>&lt;html …>
@@ -10732,9 +10735,6 @@ html.my-document-playing * {
 						href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign"
 						>assignment character</a>.</p>
 
-				<p>The [^meta/content^] attribute MUST NOT include duplicate property assignments (e.g., two or more
-          <code>height</code> or <code>width</code> definitions).</p>
-
 				<p>The authoring requirements in this section apply <em>after</em>
 					<a data-cite="xml#AVNormalize">whitespace normalization</a> [[xml]] (i.e., after a reading system
 					strips leading and trailing whitespace and compacts all instances of multiple whitespace within the
@@ -11783,9 +11783,8 @@ EPUB/images/cover.png</pre>
 				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub32/">EPUB 3.2</a></h3>
 
 				<ul>
-					<li>11-Oct-2023: Additional text on ICB setting when dimensions are set multiple times.
-						See <a href="https://github.com/w3c/epub-specs/issues/2442">issue 2442</a>.
-					</li>
+					<li>11-Oct-2023: Additional text on ICB setting when dimensions are set multiple times. See <a
+							href="https://github.com/w3c/epub-specs/issues/2442">issue 2442</a>. </li>
 					<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and
 						updated the list of semantics to use for escaping to match the guidance. See <a
 							href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10674,8 +10674,8 @@ html.my-document-playing * {
 									<a href="#viewport.ebnf.property">property</a>
 								</td>
 								<td>=</td>
-								<td><a href="viewport.ebnf.name">name</a>, <a href="viewport.ebnf.assign">assign</a>, <a
-										href="viewport.ebnf.value">value</a> ;</td>
+								<td><a href="viewport.ebnf.name">name</a>, [ <a href="viewport.ebnf.assign">assign</a>,
+										<a href="viewport.ebnf.value">value</a> ] ;</td>
 							</tr>
 							<tr>
 								<td id="viewport.ebnf.name">
@@ -11724,6 +11724,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>15-Oct-2023: Allow properties without values in <code>viewport meta</code> tag definition. See
+							<a href="https://github.com/w3c/epub-specs/pull/2457">pull request 2457</a>.</li>
 					<li>21-Sept-2022: Made the requirement to declare property prefixes explicit. See <a
 							href="https://github.com/w3c/epub-specs/issues/2438">issue 2438</a>.</li>
 					<li>19-Sept-2022: Removed minor contradictions in the <code>epub:type</code> attribute usage

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -10644,8 +10644,9 @@ html.my-document-playing * {
 			<section id="app-viewport-meta-syntax">
 				<h3>Syntax</h3>
 
-				<p>A <code>viewport</code> [^meta^] tag [[html]] MUST have <code>name</code> and <code>content</code>
-					attributes that conform to the following definition:</p>
+				<p>For [=fixed-layout documents=], a <code>viewport</code> [^meta^] tag [[html]] MUST have
+						<code>name</code> and <code>content</code> attributes that conform to the following
+					definition:</p>
 
 				<dl>
 					<dt id="viewport-name-attr">name</dt>
@@ -10666,16 +10667,16 @@ html.my-document-playing * {
 									<a href="#viewport.ebnf.def">viewport</a>
 								</td>
 								<td>=</td>
-								<td><a href="#viewport.ebnf.property">property</a>, {<a href="#viewport.ebnf.sep"
-										>sep</a>, <a href="#viewport.ebnf.property">property</a>} ;</td>
+								<td><a href="#viewport.ebnf.property">property</a>, { <a href="#viewport.ebnf.sep"
+										>sep</a>, <a href="#viewport.ebnf.property">property</a> } ;</td>
 							</tr>
 							<tr>
 								<td id="viewport.ebnf.property">
 									<a href="#viewport.ebnf.property">property</a>
 								</td>
 								<td>=</td>
-								<td><a href="viewport.ebnf.name">name</a>, [ <a href="viewport.ebnf.assign">assign</a>,
-										<a href="viewport.ebnf.value">value</a> ] ;</td>
+								<td><a href="#viewport.ebnf.name">name</a>, [ <a href="#viewport.ebnf.assign"
+									>assign</a>, <a href="#viewport.ebnf.value">value</a> ] ;</td>
 							</tr>
 							<tr>
 								<td id="viewport.ebnf.name">
@@ -10712,8 +10713,8 @@ html.my-document-playing * {
 									<a href="#viewport.ebnf.assign">assign</a>
 								</td>
 								<td>=</td>
-								<td>[<a href="#viewport.ebnf.space">space</a>], "=", [<a href="#viewport.ebnf.space"
-										>space</a>] ;</td>
+								<td>[ <a href="#viewport.ebnf.space">space</a> ], "=", [ <a href="#viewport.ebnf.space"
+										>space</a> ] ;</td>
 							</tr>
 							<tr>
 								<td id="viewport.ebnf.space">
@@ -10726,28 +10727,28 @@ html.my-document-playing * {
 					</dd>
 				</dl>
 
-				<p>This specification only defines <a href="#viewport.ebnf.value">value</a> requirements for the
-						<code>height</code> and <code>width</code> properties (see <a href="#sec-fxl-content-dimensions"
-					></a>). It imposes no restrictions on other property names and values except that they MUST NOT
-					contain <a href="#viewport.ebnf.sep-char">separator characters</a> or the <a
-						href="#viewport.ebnf.assign">assignment character</a>.</p>
+				<p>The only restriction on property <a href="#viewport.ebnf.name">names</a> and <a
+						href="#viewport.ebnf.value">values</a> is that they MUST NOT contain <a
+						href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign"
+						>assignment character</a>.</p>
+
+				<p>The authoring requirements in this section apply <em>after</em>
+					<a data-cite="xml#AVNormalize">whitespace normalization</a> [[xml]] (i.e., after a reading system
+					strips leading and trailing whitespace and compacts all instances of multiple whitespace within the
+					attribute to single spaces). EPUB creators MAY include any valid [=ascii whitespace=] [[infra]] in
+					the authored tag so long as the result is valid to this definition.</p>
 
 				<p>There are no restrictions on any other attributes allowed on the [^meta^] element by the [[html]]
 					grammar.</p>
 
 				<div class="note">
-					<p>Although the <code>viewport meta</code> tag allows EPUB creators to use properties other than
-							<code>height</code> and <code>width</code>, such use is strongly discouraged. Setting other
-						properties may have unintended consequences on the rendering of [=fixed-layout documents=].</p>
-				</div>
+					<p>For more information about specifying the required <code>height</code> and <code>width</code>
+						properties, and their required values, refer to <a href="#sec-fxl-content-dimensions"></a>.</p>
 
-				<div class="note">
-					<p>The authoring requirements in this section apply <em>after</em>
-						<a data-cite="xml#AVNormalize">whitespace normalization</a> [[xml]] (i.e., after a reading
-						system strips leading and trailing whitespace and compacts all instances of multiple whitespace
-						within the attribute to single spaces). EPUB creators can include any valid HTML whitespace
-						characters (e.g., tabs, line feeds) in the authored tag so long as the result is valid to this
-						definition.</p>
+					<p>Although the <code>viewport meta</code> tag allows EPUB creators to use properties other than
+							<code>height</code> and <code>width</code>, and to not include values for these properties,
+						such use is strongly discouraged. Setting other properties may have unintended consequences on
+						the rendering of fixed-layout documents.</p>
 				</div>
 			</section>
 		</section>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11724,7 +11724,7 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>15-Oct-2023: Allow properties without values in <code>viewport meta</code> tag definition. See
+					<li>15-Oct-2022: Allow properties without values in <code>viewport meta</code> tag definition. See
 							<a href="https://github.com/w3c/epub-specs/pull/2457">pull request 2457</a>.</li>
 					<li>21-Sept-2022: Made the requirement to declare property prefixes explicit. See <a
 							href="https://github.com/w3c/epub-specs/issues/2438">issue 2438</a>.</li>


### PR DESCRIPTION
@rdeltour would this solve your concerns about not blocking EPUB publications with (potentially) invalid property definitions because epubcheck will complain?

Really, what other data is in the tag isn't our concern since it isn't even supposed to be used, so by making the assignment operator and value optional, that should allow any weird combinations through (or future valid declarations that don't require a value, if such things ever come to pass).

Our requirement for a valid height and width declaration will still capture what we need even with this change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2457.html" title="Last updated on Oct 17, 2022, 12:34 PM UTC (131a4c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2457/032fcce...131a4c3.html" title="Last updated on Oct 17, 2022, 12:34 PM UTC (131a4c3)">Diff</a>