### PR TITLE
Add recommendation against using spaces in file paths and names

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1761,7 +1761,7 @@
 							</ul>
 						</li>
 						<li>
-							<p id="ocf-fn-space">For compatibility with older reading systems, file names SHOULD NOT
+							<p id="ocf-fn-space">For compatibility with older [=reading systems=], file names SHOULD NOT
 								contain SPACE (U+0020) characters.</p>
 						</li>
 						<li>
@@ -1789,9 +1789,9 @@
 							iterations of EPUB, older tools and toolchains may still be encountered (e.g., ZIP tools
 							that only support [[us-ascii]]).</p>
 
-						<p>If EPUB creators need to ensure compatibility with EPUB 2 [=reading systems=] that only
-							accept URIs [[rfc3986]], they should further consider restricting resource names to the
-							ASCII character set [[us-ascii]].</p>
+						<p>If EPUB creators need to ensure compatibility with EPUB 2 reading systems that only accept
+							URIs [[rfc3986]], they should further consider restricting resource names to the ASCII
+							character set [[us-ascii]].</p>
 					</div>
 				</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1761,8 +1761,8 @@
 							</ul>
 						</li>
 						<li>
-							<p id="ocf-fn-space">For compatibility with older reading systems, file paths and names
-								SHOULD NOT contain SPACE (U+0020) characters.</p>
+							<p id="ocf-fn-space">For compatibility with older reading systems, file names SHOULD NOT
+								contain SPACE (U+0020) characters.</p>
 						</li>
 						<li>
 							<p id="ocf-fn-cn">All file names within the same directory MUST be unique following Unicode

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1673,17 +1673,17 @@
 
 					<ul class="conformance-list">
 						<li>
-							<p id="ocf-fn-encoding">file names and paths MUST be UTF-8 [[unicode]] encoded.</p>
+							<p id="ocf-fn-encoding">File paths and names MUST be UTF-8 [[unicode]] encoded.</p>
 						</li>
 						<li>
-							<p id="ocf-fn-length">file names MUST NOT exceed 255 bytes.</p>
+							<p id="ocf-fn-length">File names MUST NOT exceed 255 bytes.</p>
 						</li>
 						<li>
 							<p id="ocf-pn-length">The file paths for any directory or file within the OCF abstract
 								container MUST NOT exceed 65535 bytes.</p>
 						</li>
 						<li>
-							<p id="ocf-fn-chars">file names MUST NOT use the following [[unicode]] characters, as
+							<p id="ocf-fn-chars">File names MUST NOT use the following [[unicode]] characters, as
 								commonly used operating systems may not support these characters consistently:</p>
 							<ul>
 								<li>
@@ -1759,6 +1759,10 @@
 									<p>Supplementary Private Use Area-B (<code>U+100000 … U+10FFFF</code>)</p>
 								</li>
 							</ul>
+						</li>
+						<li>
+							<p id="ocf-fn-space">For compatibility with older reading systems, file paths and names
+								SHOULD NOT contain SPACE (U+0032) characters.</p>
 						</li>
 						<li>
 							<p id="ocf-fn-cn">All file names within the same directory MUST be unique following Unicode
@@ -10644,8 +10648,9 @@ html.my-document-playing * {
 			<section id="app-viewport-meta-syntax">
 				<h3>Syntax</h3>
 
-				<p>A <code>viewport</code> <a data-cite="html#meta"><code>meta</code></a> tag [[html]] MUST have <code>name</code> and <code>content</code>
-					attributes that conform to the following definition:</p>
+				<p>A <code>viewport</code>
+					<a data-cite="html#meta"><code>meta</code></a> tag [[html]] MUST have <code>name</code> and
+						<code>content</code> attributes that conform to the following definition:</p>
 
 				<dl>
 					<dt id="viewport-name-attr">name</dt>
@@ -10732,9 +10737,8 @@ html.my-document-playing * {
 					contain <a href="#viewport.ebnf.sep-char">separator characters</a> or the <a
 						href="#viewport.ebnf.assign">assignment character</a>.</p>
 
-				<p>
-					The [^meta/content^] attribute MUST NOT include several <code>height</code>, respectively <code>width</code>,  assignments.
-				</p>
+				<p> The [^meta/content^] attribute MUST NOT include several <code>height</code>, respectively
+						<code>width</code>, assignments. </p>
 
 				<p>There are no restrictions on any other attributes allowed on the [^meta^] element by the [[html]]
 					grammar.</p>
@@ -11728,6 +11732,10 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>17-Oct-2022: Added recommendation against using spaces in file paths and names. See <a
+							href="https://github.com/w3c/epub-specs/issues/2458">issue 2458</a>.</li>
+					<li>11-Oct-2022: Additional text on ICB setting when dimensions are set multiple times. See <a
+							href="https://github.com/w3c/epub-specs/issues/2442">issue 2442</a>.</li>
 					<li>21-Sept-2022: Made the requirement to declare property prefixes explicit. See <a
 							href="https://github.com/w3c/epub-specs/issues/2438">issue 2438</a>.</li>
 					<li>19-Sept-2022: Removed minor contradictions in the <code>epub:type</code> attribute usage
@@ -11781,9 +11789,6 @@ EPUB/images/cover.png</pre>
 				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub32/">EPUB 3.2</a></h3>
 
 				<ul>
-					<li>11-Oct-2023: Additional text on ICB setting when dimensions are set multiple times.
-						See <a href="https://github.com/w3c/epub-specs/issues/2442">issue 2442</a>.
-					</li>
 					<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and
 						updated the list of semantics to use for escaping to match the guidance. See <a
 							href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1762,7 +1762,7 @@
 						</li>
 						<li>
 							<p id="ocf-fn-space">For compatibility with older reading systems, file paths and names
-								SHOULD NOT contain SPACE (U+0032) characters.</p>
+								SHOULD NOT contain SPACE (U+0020) characters.</p>
 						</li>
 						<li>
 							<p id="ocf-fn-cn">All file names within the same directory MUST be unique following Unicode


### PR DESCRIPTION
Fixes #2458

Also makes some minor editorial tweaks:
- all bullets are capitalized for consistentcy
- s/file names and paths/file paths and names/ in one bullet to be consistent with section name and ordering in another bullet


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2459.html" title="Last updated on Oct 17, 2022, 7:07 PM UTC (b7b6a17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2459/f101c88...b7b6a17.html" title="Last updated on Oct 17, 2022, 7:07 PM UTC (b7b6a17)">Diff</a>