### PR TITLE
Remove redundant paragraph about using us-ascii

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1810,10 +1810,6 @@
 							characters are supported. Although Unicode support is much better now than in earlier
 							iterations of EPUB, older tools and toolchains may still be encountered (e.g., ZIP tools
 							that only support [[us-ascii]]).</p>
-
-						<p>If EPUB creators need to ensure compatibility with EPUB 2 [=reading systems=] that only
-							accept URIs [[rfc3986]], they should further consider restricting resource names to the
-							ASCII character set [[us-ascii]].</p>
 					</div>
 				</section>
 


### PR DESCRIPTION
As noted in https://github.com/w3c/epub-specs/pull/2459#pullrequestreview-1144248244, the paragraph about using us ascii for epub 2 reading systems is confusing, and I'm not even sure is valid (OCF 2 supported IRIs).

At best it's just a redundancy with the paragraph above.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2464.html" title="Last updated on Oct 17, 2022, 4:37 PM UTC (82472e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2464/988334c...82472e4.html" title="Last updated on Oct 17, 2022, 4:37 PM UTC (82472e4)">Diff</a>