### PR TITLE
Remove utf-8 encoding requirement for abstract container file names

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1699,9 +1699,6 @@
 
 					<ul class="conformance-list">
 						<li>
-							<p id="ocf-fn-encoding">File paths and names MUST be UTF-8 [[unicode]] encoded.</p>
-						</li>
-						<li>
 							<p id="ocf-fn-length">File names MUST NOT exceed 255 bytes.</p>
 						</li>
 						<li>
@@ -2889,7 +2886,7 @@
 									href="#sec-container-metainf-encryption.xml"></a>.</p>
 						</li>
 						<li>
-							<p id="confreq-zip-utf8">OCF ZIP containers MUST encode File System Names using UTF-8
+							<p id="confreq-zip-utf8">OCF ZIP containers MUST encode file system names using UTF-8
 								[[unicode]].</p>
 						</li>
 					</ul>
@@ -11754,6 +11751,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>20-Oct-2022: Removed requirement to encode file names in abstract container in UTF-8 as it is
+						not possible in the abstract and is already covered by a ZIP container requirement. See <a
+							href="https://github.com/w3c/epub-specs/issues/2461">issue 2461</a>.</li>
 					<li>17-Oct-2022: Added recommendation against using spaces in file paths and names. See <a
 							href="https://github.com/w3c/epub-specs/issues/2458">issue 2458</a>.</li>
 					<li>15-Oct-2022: Allow properties without values in <code>viewport meta</code> tag definition. See


### PR DESCRIPTION
I've only removed the encoding bullet and lowercased "File System Names" per #2461 with this pull request, as those are reasonably straightforward.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2466.html" title="Last updated on Oct 20, 2022, 1:24 PM UTC (be81cdd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2466/ea362bb...be81cdd.html" title="Last updated on Oct 20, 2022, 1:24 PM UTC (be81cdd)">Diff</a>