### PR TITLE
Spine vocabulary improvement on the usage of page-spread-*

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7445,8 +7445,8 @@ No Entry</pre>
 							and omit the properties on spine items where one-up or two-up presentation is equally
 							acceptable.</p>
 
-						<p>EPUB creators MUST NOT declare more than one <code>page-spread-*</code> property on any given
-							spine item.</p>
+						<p>EPUB creators MUST NOT declare more than one <code>rendition:page-spread-*</code> property,
+							or their unprefixed equivalents, on any given spine item.</p>
 
 						<div class="note" id="note-page-spread-aliases">
 							<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7446,7 +7446,9 @@ No Entry</pre>
 							acceptable.</p>
 
 						<p>EPUB creators MUST NOT declare more than one <code>rendition:page-spread-*</code> property,
-							or their unprefixed equivalents, on any given spine item.</p>
+							and/or their unprefixed equivalents, on any given spine item (e.g., it is valid to specify
+							both "<code>rendition:page-spread-left page-spread-left</code>" in case reading systems only
+							support one of properties).</p>
 
 						<div class="note" id="note-page-spread-aliases">
 							<p>The <code>rendition:page-spread-left</code> and <code>rendition:page-spread-right</code>

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -21,9 +21,14 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>The <code>page-spread-left</code> property indicates that the first page of the
-						associated <code>item</code> element's [=EPUB content document=] represents the
-						left-hand side of a two-page spread.</td>
+					<td>
+						<p>The <code>page-spread-left</code> property indicates that the first page of the
+							associated <code>item</code> element's [=EPUB content document=] represents the
+							left-hand side of a two-page spread.</p>
+						<p>The <a href="#fxl-page-spread-left"><code>rendition:page-spread-left</code> 
+							property</a> is an alias for this property. Refer to <a href="#page-spread"></a>
+							for more information about their use.</p>
+					</td>
 				</tr>
 			</tbody>
 		</table>
@@ -42,16 +47,18 @@
 				</tr>
 				<tr>
 					<th>Description:</th>
-					<td>The <code>page-spread-right</code> property indicates that the first page of the
-						associated <code>item</code> element's [=EPUB content document=]
-						represents the right-hand side of a two-page spread.</td>
+					<td>
+						<p>The <code>page-spread-right</code> property indicates that the first page of the
+							associated <code>item</code> element's [=EPUB content document=]
+							represents the right-hand side of a two-page spread.</p>
+						<p>The <a href="#fxl-page-spread-right"><code>rendition:page-spread-right</code> 
+							property</a> is an alias for this property. Refer to <a href="#page-spread"></a>
+							for more information about their use.</p>
+					</td>
 				</tr>
 			</tbody>
 		</table>
 	</section>
-
-	<p>EPUB creators MUST NOT declare more than one <code>page-spread-*</code> property on any given
-		spine item.</p>
 	
 	<section id="examples-itemref-properties">
 		<h4>Examples</h4>

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -49,6 +49,9 @@
 			</tbody>
 		</table>
 	</section>
+
+	<p>EPUB creators MUST NOT declare more than one <code>page-spread-*</code> property on any given
+		spine item.</p>
 	
 	<section id="examples-itemref-properties">
 		<h4>Examples</h4>


### PR DESCRIPTION
This is to fix #2468.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2470.html" title="Last updated on Nov 1, 2022, 11:27 AM UTC (67fa715)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2470/3340110...67fa715.html" title="Last updated on Nov 1, 2022, 11:27 AM UTC (67fa715)">Diff</a>