### PR TITLE
Changed the alternate-script definition on language tags.

### DIFF
--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -27,8 +27,9 @@
 					<th>Description:</th>
 					<td>
 						<p>The <code>alternate-script</code> property provides an alternate expression of the
-							associated property value in a language and script identified by the
-								<code>xml:lang</code> attribute.</p>
+							associated property value in a different language and/or script. 
+							The language tags of the alternate-script property and its associated property — as expressed 
+							by their respective in-scope xml:lang attributes — MUST NOT be the same.</p>
 						<p>This property is typically attached to <code>creator</code> and <code>title</code>
 							properties for internationalization purposes.</p>
 					</td>
@@ -62,7 +63,7 @@
        refines="#creator"
        property="alternate-script"
        xml:lang="ja">
-      村上 春樹
+      村上春樹
    &lt;/meta>
    …
 &lt;/metadata></pre>


### PR DESCRIPTION
This is to fix #2465, adopting the proposed text in https://github.com/w3c/epub-specs/issues/2465#issuecomment-1284257358.

Takes also care of the remark of @r12a in https://github.com/w3c/epub-specs/issues/2465#issuecomment-1291769787.