### PR TITLE
Fix respec ambiguity errors around uses of "origin"

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6199,7 +6199,7 @@ No Entry</pre>
 						</div>
 
 						<p>[=EPUB creators=] should note that [=reading systems=] are required to behave as though a
-							unique [=origin=] [[url]] has been assigned to each [=EPUB publication=]. In practice, this
+							unique <a data-cite="html#origin">origin</a> [[html]] has been assigned to each [=EPUB publication=]. In practice, this
 							means that it is not possible for scripts to share data between EPUB publications.</p>
 
 						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -231,18 +231,16 @@
 					as all applicable conditionally-required features (e.g., to support image rendering if the reading
 					system has a [=viewport=]) as defined in their respective sections.</p>
 
-			<p class="note">
-				As a reading system is not necessarily a single application, but may exist as a distributed system,
-				it is not always the case that reading system requirements will be met in the application that 
-				renders EPUB publications to users. An example is a reading system that solely interacts with a
-				controlled content repository (e.g., a bookstore or library system). In this case, if a reading
-				system developer can demonstrate that requirements are not applicable to the application
-				(e.g., EPUB publications with duplicate [^itemref^] entries [[epub-33]] cannot enter the system),
-				the reading system as a whole is still considered conforming.
-			</p>
+				<p class="note"> As a reading system is not necessarily a single application, but may exist as a
+					distributed system, it is not always the case that reading system requirements will be met in the
+					application that renders EPUB publications to users. An example is a reading system that solely
+					interacts with a controlled content repository (e.g., a bookstore or library system). In this case,
+					if a reading system developer can demonstrate that requirements are not applicable to the
+					application (e.g., EPUB publications with duplicate [^itemref^] entries [[epub-33]] cannot enter the
+					system), the reading system as a whole is still considered conforming. </p>
 
-			<p>When supporting recommended and optional features, reading systems MUST meet all normative requirements
-				as defined in their respective sections.</p>
+				<p>When supporting recommended and optional features, reading systems MUST meet all normative
+					requirements as defined in their respective sections.</p>
 
 				<p>When supporting recommended and optional features, reading systems MUST meet all normative
 					requirements as defined in their respective sections.</p>
@@ -353,12 +351,13 @@
 			<section id="sec-epub-rs-conf-xml">
 				<h4>XML processing</h4>
 
-				<p  id="confreq-rs-xml-nval"
-				data-tests="#pub-xml-non-validating_invalid,#pub-xml-non-validating_unclosed">A [= reading system =] MUST use a 
-				non-validating XML processor [[xml]] that:</p>
+				<p id="confreq-rs-xml-nval"
+					data-tests="#pub-xml-non-validating_invalid,#pub-xml-non-validating_unclosed">A [= reading system =]
+					MUST use a non-validating XML processor [[xml]] that:</p>
 
 				<ul class="conformance-list">
-					<li id="confreq-rs-xml-extid" data-tests="#pub-xml-external-id">does not read external DTD subsets [[xml]];</li>
+					<li id="confreq-rs-xml-extid" data-tests="#pub-xml-external-id">does not read external DTD
+						subsets [[xml]];</li>
 					<li id="confreq-rs-xml-ns" data-tests="#pub-xml-names">conforms to [[xml-names]].</li>
 				</ul>
 			</section>
@@ -481,15 +480,15 @@
 								URL</a> as <a data-cite="url#concept-base-url"><var>base</var></a> is the <a>container
 								root URL</a>.</li>
 
-						<li id="sec-container-iri-origin" data-tests="#ocf-url_origin">The [=origin=] of the [=container
-							root URL=] is unique for each user-specific instance of an [=EPUB publication=] in a reading
-							system.</li>
+						<li id="sec-container-iri-origin" data-tests="#ocf-url_origin">The <a data-cite="url#origin"
+								>origin</a> [[url]] of the [=container root URL=] is unique for each user-specific
+							instance of an [=EPUB publication=] in a reading system.</li>
 					</ul>
 
-					<p class="note">The unicity of the [=origin=] per each user-specific instance of an EPUB publication
-						in a reading system means that if two different users acquire a copy of the same EPUB
-						publication, the origins will be different for the two users on those copies even if the same
-						reading system is used.</p>
+					<p class="note">The unicity of the <a data-cite="html#origin">origin</a> [[html]] per each
+						user-specific instance of an EPUB publication in a reading system means that if two different
+						users acquire a copy of the same EPUB publication, the origins will be different for the two
+						users on those copies even if the same reading system is used.</p>
 
 					<div class="note">
 						<p>The properties of the [=container root URL=] are such that a conforming reading system will
@@ -1279,11 +1278,12 @@
 					<li>
 						<p id="confreq-rs-scripted-origin">
 							<span id="confreq-rs-scripted-origin-shared" data-tests="#scr-support_origin">It MUST assign
-								a unique [=origin=] [[url]], shared by all <a data-cite="epub-33#sec-scripted-spine"
-									>spine-level scripts</a> of the [=EPUB publication=].</span>
-							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin">That
-								[=origin=] [[url]] MUST be <em>unique</em> for each user-specific instance of an EPUB
-								publication in a reading system.</span>
+								a unique <a data-cite="html#origin">origin</a> [[html]], shared by all <a
+									data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> of the [=EPUB
+								publication=].</span>
+							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin">That <a
+									data-cite="html#origin">origin</a> [[html]] MUST be <em>unique</em> for each
+								user-specific instance of an EPUB publication in a reading system.</span>
 						</p>
 					</li>
 
@@ -1381,10 +1381,10 @@
 					</ul>
 
 					<p>To limit the possible damage of untrusted scripts, this specification recommends that reading
-						systems establish a unique [=origin=] [[url]] allocated to each [=EPUB publication=] (see <a
-							href="#sec-container-iri"></a>). Assigning a unique origin ensures that <a
-							data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> [[epub-33]] are isolated from
-						other EPUB publications, and limits access to <a data-cite="html#dom-document-cookie"
+						systems establish a unique <a data-cite="html#origin">origin</a> [[html]] allocated to each
+						[=EPUB publication=] (see <a href="#sec-container-iri"></a>). Assigning a unique origin ensures
+						that <a data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> [[epub-33]] are isolated
+						from other EPUB publications, and limits access to <a data-cite="html#dom-document-cookie"
 							>cookies</a> [[html]], <a data-cite="html#webstorage">web storage</a> [[html]], etc.</p>
 
 					<p>Examples of web APIs that are tied to the concept of "origin" include web storage [[html]] and
@@ -1638,45 +1638,37 @@
 									data-tests="#lay-fxl-xhtml-icb,#lay-fxl-xhtml-icb_multi">They MUST clip content
 									positioned outside of the ICB.</span>
 							</p>
-
 							<p id="confreq-fxl-rs-xhtml-icb-units" data-tests="#lay-fxl-xhtml-icb_units">If the width or
 								height values in the <code>viewport meta</code> tag contain a non-numeric character but
 								start with a number (e.g., the value includes a unit of length declaration such as
 								"500px"), the number prefix SHOULD be used as the pixel value, otherwise the value MUST
 								be treated as invalid.</p>
-
-							<p id="confreq-fxl-rs-xhtml-icb_invalid_meta"
-							   data-tests="#lay-fxl-xhtml-icb_invalid_meta">
-								Reading systems SHOULD attempt to extract <code>width</code> and <code>height</code> values from a <code>viewport meta</code> tag even if its syntax is invalid.
-							</p>
-
+							<p id="confreq-fxl-rs-xhtml-icb_invalid_meta" data-tests="#lay-fxl-xhtml-icb_invalid_meta">
+								Reading systems SHOULD attempt to extract <code>width</code> and <code>height</code>
+								values from a <code>viewport meta</code> tag even if its syntax is invalid. </p>
 							<p id="confreq-fxl-rs-xhtml-icb_repeated-in-meta"
-							   data-tests="#lay-fxl-xhtml-icb_repeated-in-meta">
-								Reading systems MUST use the first declaration of a <code>width</code> and <code>height</code> property in a <code>viewport meta</code> tag (i.e., ignore repeated declarations).
-							</p>
-							
-							<p>
-								If the <code>viewport meta</code> does not contain a width or a height value, or if these
-								values are invalid, reading systems MAY supply the values. For example, a reading system may:
-							</p>
-
+								data-tests="#lay-fxl-xhtml-icb_repeated-in-meta"> Reading systems MUST use the first
+								declaration of a <code>width</code> and <code>height</code> property in a <code>viewport
+									meta</code> tag (i.e., ignore repeated declarations). </p>
+							<p> If the <code>viewport meta</code> does not contain a width or a height value, or if
+								these values are invalid, reading systems MAY supply the values. For example, a reading
+								system may: </p>
 							<ul>
-								<li>consider these as having the values <code>device-width</code> and <code>device-height</code>, respectively; or</li>
-								<li>look for the previous content document in the [=spine=], if applicable, and use the ICB value defined there; or</li>
+								<li>consider these as having the values <code>device-width</code> and
+										<code>device-height</code>, respectively; or</li>
+								<li>look for the previous content document in the [=spine=], if applicable, and use the
+									ICB value defined there; or</li>
 								<li>consider the content document as erroneous XHTML content altogether.</li>
 							</ul>
-
 							<p id="confreq-fxl-rs-xhtml-multiple-icb-def"
 								data-tests="#lay-fxl-xhtml-icb_multi_declarations">If an XHTML content document contains
 								more than one <code>viewport meta</code> tags, reading systems MUST use the first in
 								document order to obtain the height and width dimensions. Subsequent declarations MUST
 								be ignored.</p>
-
 							<p id="confreq-fxl-rs-xhtml-icb-ratio">When the ICB aspect ratio does not match the aspect
 								ratio of the reading system [=content display area=], reading systems MAY position the
 								ICB inside the area to accommodate the user interface; in other words, added
 								letter-boxing space MAY appear on either side (or both) of the content.</p>
-	
 						</dd>
 
 						<dt>SVG</dt>
@@ -2482,14 +2474,14 @@
 					publications through the process of "sideloading") SHOULD treat such content as insecure (e.g.,
 					prompt users to allow scripting and network access).</p>
 
-				<p >When processing XML documents, a reading system SHOULD NOT resolve 
-					<a data-cite="xml#NT-ExternalID">external identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[xml]].
-					Reading systems SHOULD also consider security risks related to <a data-cite="xml#sec-internal-ent">internal</a> or 
-					<a data-cite="xml#sec-external-ent">external</a> XML entities like, for example, DoS attacks 
-					also known as <a href="https://en.wikipedia.org/wiki/Billion_laughs_attack">"Billion laughs attacks"</a>
-					or <a href="https://en.wikipedia.org/wiki/XML_external_entity_attack">"XML external entity attacks"</a>.
-				</p>
-	
+				<p>When processing XML documents, a reading system SHOULD NOT resolve <a data-cite="xml#NT-ExternalID"
+						>external identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[xml]]. Reading systems
+					SHOULD also consider security risks related to <a data-cite="xml#sec-internal-ent">internal</a> or
+						<a data-cite="xml#sec-external-ent">external</a> XML entities like, for example, DoS attacks
+					also known as <a href="https://en.wikipedia.org/wiki/Billion_laughs_attack">"Billion laughs
+						attacks"</a> or <a href="https://en.wikipedia.org/wiki/XML_external_entity_attack">"XML external
+						entity attacks"</a>. </p>
+
 				<div class="note">
 					<p>Additional security recommendations for external links, network access and scripting are
 						available in <a href="#sec-epub-rs-external-links"></a>, <a href="#sec-epub-rs-network-access"
@@ -2712,13 +2704,12 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				<ul>
 					<li>13-Oct-2022: Added sections to explain expectations for error handling and reporting. See <a
 							href="https://github.com/w3c/epub-specs/issues/2454">issue 2454</a>.</li>
-					<li>11-Oct-2023: Additional text sketching the RS behavior in the case of erroneous ICB setting.
-						See <a href="https://github.com/w3c/epub-specs/issues/2442">issue 2442</a>.
-					<li>06-10-2022: Moved the restriction on XML external identifiers from the XML conformance clause to 
-						the security and privacy section, adding an additional note on security risks on 
-						internal or external entities. See <a href="https://github.com/w3c/epub-specs/issues/2433">issue 2433</a>
-						and <a href="https://github.com/w3c/epub-specs/issues/2447">issue 2477</a>.
-					</li>
+					<li>11-Oct-2023: Additional text sketching the RS behavior in the case of erroneous ICB setting. See
+							<a href="https://github.com/w3c/epub-specs/issues/2442">issue 2442</a>.</li>
+					<li>06-10-2022: Moved the restriction on XML external identifiers from the XML conformance clause to
+						the security and privacy section, adding an additional note on security risks on internal or
+						external entities. See <a href="https://github.com/w3c/epub-specs/issues/2433">issue 2433</a>
+						and <a href="https://github.com/w3c/epub-specs/issues/2447">issue 2477</a>. </li>
 					<li>23-Sep-2023: Added a note on a possible future feature, whereby the value of
 							<code>rendition:flow</code> would control the publication of webtoon-like publications. See
 							<a href="https://github.com/w3c/epub-specs/issues/2412">issue 2412</a>.</li>


### PR DESCRIPTION
This PR changes all the general links/references to "origin" to reference the HTML spec.

The only reference to the URL definition I've kept is the one about uniqueness in the container root url.

Fixes #2472


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2473.html" title="Last updated on Oct 31, 2022, 4:59 PM UTC (dde1181)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2473/e3801a0...dde1181.html" title="Last updated on Oct 31, 2022, 4:59 PM UTC (dde1181)">Diff</a>