### PR TITLE
Add note about not using unicode deprecated characters

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1772,16 +1772,19 @@
 									<p>Specials (<code>U+FFF0 … U+FFFF</code>)</p>
 								</li>
 								<li>
-									<p>The Deprecated Characters in the Tags and Variation Selectors Supplement
-											(<code>U+E0001</code> and <code>U+E007F</code>)</p>
-								</li>
-								<li>
 									<p>Supplementary Private Use Area-A (<code>U+F0000 … U+FFFFF</code>)</p>
 								</li>
 								<li>
 									<p>Supplementary Private Use Area-B (<code>U+100000 … U+10FFFF</code>)</p>
 								</li>
 							</ul>
+							<div class="note">
+								<p>The Unicode Character Database [[uax44]] also includes a <a
+										href="https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt">list of
+										deprecated characters</a>. EPUB creators are advised to avoid these characters,
+									as well, as it is expected that [=EPUB conformance checkers=] will flag their
+									use.</p>
+							</div>
 						</li>
 						<li>
 							<p id="ocf-fn-space">For compatibility with older [=reading systems=], file names SHOULD NOT
@@ -11755,6 +11758,10 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>02-Nov-2022: Removed the restriction on deprecated characters in the Tags and Variation
+						Selectors Supplement and replaced with a general note to avoid the use of characters already
+						deprecated by the Unicode standard, as the list changes over time. See <a
+							href="https://github.com/w3c/epub-specs/issues/2469">issue 2469</a>.</li>
 					<li>20-Oct-2022: Removed requirement to encode file names in abstract container in UTF-8 as it is
 						not possible in the abstract and is already covered by a ZIP container requirement. See <a
 							href="https://github.com/w3c/epub-specs/issues/2461">issue 2461</a>.</li>


### PR DESCRIPTION
Removes the bullet prohibiting the two characters in the Tags and Variation Selectors Supplement and replaces with a general note not to use deprecated characters.

I've also noted that epub conformance checkers may flag these to justify any future warnings about their use.

Fixes #2469


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2476.html" title="Last updated on Nov 2, 2022, 12:15 PM UTC (a211eb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2476/eb6bf35...a211eb1.html" title="Last updated on Nov 2, 2022, 12:15 PM UTC (a211eb1)">Diff</a>