### PR TITLE
Updates to nav processing

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6483,7 +6483,7 @@ No Entry</pre>
 						<p id="confreq-nav-a">Each list item of the ordered list represents a heading, structure, or
 							other item of interest. A child <code>a</code> element describes the target that the link
 							points to, while a <code>span</code> element serves as a heading for breaking down lists
-							into distinct groups (for example, an [=EPUB creator=] could segment a large list of
+							into distinct groups (for example, an EPUB creator could segment a large list of
 							illustrations into several lists, one for each chapter).</p>
 					</li>
 					<li>
@@ -6555,9 +6555,23 @@ No Entry</pre>
             …
          &lt;/ol>
       &lt;/li>
+      &lt;li>
+         &lt;a href="appendix.xhtml">
+            &lt;img src="app1.jpg" alt="An image-based heading"/>
+         &lt;/a>
+      &lt;/li>
    &lt;/ol>
 &lt;/nav></pre>
 				</aside>
+
+				<div class="caution">
+					<p>Although the headings and links in <code>nav</code> elements allow any [[html]] [=phrasing
+						content=], app-based reading systems often only support simple text labels. Because these apps
+						create their own navigation widgets that are not based on HTML rendering, they often cannot
+						retain embedded images and multimedia, MathML, inline styling and other element- and
+						attribute-based rendering instructions. EPUB creators should avoid using these types of elements
+						where their absence may lead to usability issues.</p>
+				</div>
 
 				<p id="confreq-cd-nav-docprops-spine">As a conforming [=XHTML content document=], EPUB creators MAY
 					include the EPUB navigation document in the [=EPUB spine | spine=].</p>
@@ -11755,6 +11769,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>11-Nov-2022: Added caution about reading systems not retaining HTML element-based rendering
+						instructions in navigation document elements. See <a
+							href="https://github.com/w3c/epub-specs/issues/2477">issue 2477</a>.</li>
 					<li>20-Oct-2022: Removed requirement to encode file names in abstract container in UTF-8 as it is
 						not possible in the abstract and is already covered by a ZIP container requirement. See <a
 							href="https://github.com/w3c/epub-specs/issues/2461">issue 2461</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1420,6 +1420,14 @@
 							data-cite="epub-33#sec-nav-toc"><code>toc nav</code> element</a> [[epub-33]].</p>
 				</li>
 				<li>
+					<p id="confreq-nav-alt-text">MUST, when generating non-HTML based navigation widgets, replace
+						unsupported non-text elements in headings and labels with their <a
+							data-cite="epub-33#confreq-nav-a-cnt">alternative text</a> [[epub-33]]. If both
+							<code>alt</code> and <code>title</code> attributes are present on an element, preference
+						SHOULD be given to the <code>alt</code> attribute. If neither attribute is present, reading
+						systems MAY provide their own text or ignore the element.</p>
+				</li>
+				<li>
 					<p id="confreq-nav-pagelist-access">SHOULD provide a method to navigate to the listed page breaks
 						when a <a data-cite="epub-33#sec-nav-pagelist"><code>page-list nav</code> element</a>
 						[[epub-33]] is present.</p>
@@ -2702,6 +2710,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>11-Nov-2022: Added requirement to replace unsupported non-text elements with their text
+						alternatives when generating non-HTML navigation widgets. See <a
+							href="https://github.com/w3c/epub-specs/issues/2477">issue 2477</a>.</li>
 					<li>13-Oct-2022: Added sections to explain expectations for error handling and reporting. See <a
 							href="https://github.com/w3c/epub-specs/issues/2454">issue 2454</a>.</li>
 					<li>11-Oct-2023: Additional text sketching the RS behavior in the case of erroneous ICB setting. See

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1420,7 +1420,7 @@
 							data-cite="epub-33#sec-nav-toc"><code>toc nav</code> element</a> [[epub-33]].</p>
 				</li>
 				<li>
-					<p id="confreq-nav-alt-text">MUST, when generating non-HTML based navigation widgets, replace
+					<p id="confreq-nav-alt-text" data-tests="#nav-non-text_img,#nav-non-text_img_title">MUST, when generating non-HTML based navigation widgets, replace
 						unsupported non-text elements in headings and labels with their <a
 							data-cite="epub-33#confreq-nav-a-cnt">alternative text</a> [[epub-33]]. If both
 							<code>alt</code> and <code>title</code> attributes are present on an element, preference


### PR DESCRIPTION
This pull request fixes #2477 as follows:

- adds a requirement that reading systems use the alternative text for non-text elements that are not supported in a non-html rendering of a nav component. Also adds precedence rule for alt over title and lets RS do what it wants when neither are specified.
- adds a caution to the authoring spec that reading systems that build their own navigation widgets may not be able to retain element- and attribute-based rendering instructions, so authors need to be aware of possible usability issues
- adds an image with alt text to the nav patterns example

I don't expect that requiring the use of the alt text will be controversial, as when it's not used you generally get a really bad user experience. Open to suggestions on the authoring caution, though. I don't want to tell people not to use html formatting, as it could be fine in a browser-based reading system, or when used in spine, so I tried to tie it into being a usability issue.

Reading Systems:
* [Preview](https://raw.githack.com/w3c/epub-specs/fix/issue-2477/epub33/rs/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/w3c/epub-specs/fix/issue-2477/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2479.html" title="Last updated on Nov 16, 2022, 12:47 PM UTC (da8e5cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2479/5894e8d...da8e5cc.html" title="Last updated on Nov 16, 2022, 12:47 PM UTC (da8e5cc)">Diff</a>