### PR TITLE
Updated file paths and names to reference infra scalar value strings

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1692,7 +1692,7 @@
 					<h4>File paths and file names</h4>
 
 					<p id="ocf-fn-cs">In the context of the [=OCF abstract container=], [=file paths=] and [=file
-						names=] are case sensitive.</p>
+						names=] are [=scalar value strings=] [[infra]] (i.e., their values are case sensitive).</p>
 
 					<p>In addition, the following restrictions are designed to allow file paths and file names to be
 						used without modification on most operating systems:</p>
@@ -11772,7 +11772,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-
+					<li>17-Nov-2022: Updated file paths and names to identify that they are scalar value strings in the
+						OCF abstract container, not just case sensitive. See <a
+							href="https://github.com/w3c/epub-specs/issues/2461">issue 2461</a>.</li>
 					<li>11-Nov-2022: Added caution about reading systems not retaining HTML element-based rendering
 						instructions in navigation document elements. See <a
 							href="https://github.com/w3c/epub-specs/issues/2477">issue 2477</a>.</li>


### PR DESCRIPTION
This PR fixes the outstanding part of #2461. It adds a reference to scalar value strings and adds that this makes path and names case sensitive in a parenthetical.

Does this work for you @rdeltour ?

Fixes #2461


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2480.html" title="Last updated on Nov 17, 2022, 3:32 PM UTC (975c573)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2480/95999e5...975c573.html" title="Last updated on Nov 17, 2022, 3:32 PM UTC (975c573)">Diff</a>