### PR TITLE
Fix broken links

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -6049,7 +6049,7 @@ No Entry</pre>
 						<li>
 							<p id="confreq-svg-title" data-cite="svg">If the [[svg]] [^title^] element contains
 								marked-up text, the markup MUST contain only elements declared in the <a
-									data-cite="dom#html-namespace">HTML namespace</a> [[dom]].</p>
+									data-cite="infra#html-namespace">HTML namespace</a> [[infra]].</p>
 						</li>
 					</ul>
 					<div class="note">
@@ -9961,7 +9961,7 @@ html.my-document-playing * {
 
 						<pre>&lt;meta property="dcterms:modified">2011-01-01T12:00:00Z&lt;/meta></pre>
 
-						<p>After <a data-cite="epub-rs-33#sec-property-datatype">processing</a> [[epub-rs-33]], this
+						<p>After <a data-cite="epub-rs-33#sec-property-values">processing</a> [[epub-rs-33]], this
 							property would expand to the following URL:</p>
 
 						<pre class="nohighlight">http://purl.org/dc/terms/modified</pre>


### PR DESCRIPTION
Fixes #2481


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2482.html" title="Last updated on Nov 21, 2022, 7:12 PM UTC (a95815e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2482/8f5c6c0...a95815e.html" title="Last updated on Nov 21, 2022, 7:12 PM UTC (a95815e)">Diff</a>