### PR TITLE
Fix broken links and redirects

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -78,7 +78,7 @@
 						"Charles LaPierre",
 						"Avneesh Singh"],
 						"title": "EPUB Accessibility 1.0",
-						"href": "http://idpf.org/epub/a11y/accessibility-20170105.html",
+						"href": "https://idpf.org/epub/a11y/accessibility-20170105.html",
 						"date": "05 January 2017",
 						"publisher": "IDPF"
 					},
@@ -92,7 +92,7 @@
 					},
 					"opf-201": {
 						"title": "Open Packaging Format 2.0.1",
-						"href": "http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
+						"href": "https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
 						"date": "04 September 2010",
 						"publisher": "IDPF"
 					},
@@ -1858,7 +1858,7 @@
 		<section id="change-log" class="appendix informative">
 			<h2>Change log</h2>
 
-			<p>Note that this change log only identifies substantive changes since <a href="http://idpf.org/epub/a11y/"
+			<p>Note that this change log only identifies substantive changes since <a href="https://idpf.org/epub/a11y/"
 					>EPUB Accessibility 1.0</a> &#8212; those that affect the conformance of <a
 					href="https://www.w3.org/TR/epub/#dfn-epub-publication">EPUB publications</a> or are similarly
 				noteworthy.</p>
@@ -1885,7 +1885,7 @@
 			</section>
 
 			<section id="changes-older">
-				<h3>Substantive changes since <a href="https://www.idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
+				<h3>Substantive changes since <a href="https://idpf.org/epub/a11y/">EPUB Accessibility 1.0</a></h3>
 
 				<ul>
 					<li>12-Apr-2022: Restored recommendation to include links to all reproduced pages in the page list

--- a/epub33/core/biblio.js
+++ b/epub33/core/biblio.js
@@ -20,7 +20,7 @@ var biblio = {
 		"Elika J. Etimad",
 		"Matt Garrish"],
 		"title": "EPUB Content Documents 3.0.1",
-		"href": "http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
+		"href": "https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
 		"date": "26 June 2014",
 		"publisher": "IDPF"
 	},
@@ -55,7 +55,7 @@ var biblio = {
 		"William McCoy",
 		"Matt Garrish"],
 		"title": "EPUB Publications 3.0",
-		"href": "http://idpf.org/epub/30/spec/epub30-publications-20111011.html",
+		"href": "https://idpf.org/epub/30/spec/epub30-publications-20111011.html",
 		"date": "11 October 2011",
 		"publisher": "IDPF"
 	},
@@ -65,7 +65,7 @@ var biblio = {
 		"William McCoy",
 		"Matt Garrish"],
 		"title": "EPUB Publications 3.0.1",
-		"href": "http://idpf.org/epub/301/spec/epub-publications-20140626.html",
+		"href": "https://idpf.org/epub/301/spec/epub-publications-20140626.html",
 		"date": "26 June 2014",
 		"publisher": "IDPF"
 	},
@@ -100,7 +100,7 @@ var biblio = {
 	},
 	"opf-201": {
 		"title": "Open Packaging Format 2.0.1",
-		"href": "http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
+		"href": "https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm",
 		"date": "04 September 2010",
 		"publisher": "IDPF"
 	},

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1378,7 +1378,7 @@
 
 						<div class="note">
 							<p>The exemption from fallbacks aligns data blocks with the exemption made to <a
-									href="confreq-foreign-no-fallback">allow data files</a> to travel in the [=EPUB
+									href="#confreq-foreign-no-fallback">allow data files</a> to travel in the [=EPUB
 								container=]. As data blocks are not separate resources from their host [=EPUB content
 								document=], they do not fall under the same exemption.</p>
 						</div>
@@ -5254,7 +5254,7 @@ No Entry</pre>
 					<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
 
 					<p>Refer to the <a
-							href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
+							href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
 								><code>bindings</code> element definition</a> in [[epubpublications-301]] for more
 						information.</p>
 				</section>
@@ -5595,8 +5595,8 @@ No Entry</pre>
 
 					<div class="note">
 						<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3 Working
-							Group maintained both a <a href="http://idpf.org/epub/registries/roles/">registry of role
-								extensions</a> and a list of <a href="http://idpf.org/epub/extensions/roles/">custom
+							Group maintained both a <a href="https://idpf.org/epub/registries/roles/">registry of role
+								extensions</a> and a list of <a href="https://idpf.org/epub/extensions/roles/">custom
 								extension roles</a>. This Working Group no longer maintains these registries.</p>
 					</div>
 
@@ -5661,11 +5661,11 @@ No Entry</pre>
 				<section id="sec-opf2-meta">
 					<h4>The <code>meta</code> element</h4>
 
-					<p>The <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"><code>meta</code>
+					<p>The <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"><code>meta</code>
 							element</a> [[opf-201]] provides a means of including generic metadata for EPUB 2 [=reading
 						systems=].</p>
 
-					<p>Refer to the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
+					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
 								><code>meta</code> element definition</a> in [[opf-201]] for more information.</p>
 
 					<div class="note">
@@ -5682,11 +5682,11 @@ No Entry</pre>
 				<section id="sec-opf2-guide">
 					<h4>The <code>guide</code> element</h4>
 
-					<p>The <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code>
+					<p>The <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code>
 							element</a> [[opf-201]] provides machine-processable navigation to key structures in EPUB 2
 						[=reading systems=].</p>
 
-					<p>Refer to the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
+					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
 								><code>guide</code> element definition</a> in [[opf-201]] for more information.</p>
 
 					<div class="note">
@@ -5698,10 +5698,10 @@ No Entry</pre>
 				<section id="sec-opf2-ncx">
 					<h4>NCX</h4>
 
-					<p>The <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a> [[opf-201]]
+					<p>The <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX</a> [[opf-201]]
 						provides a table of contents for EPUB 2 [=reading systems=].</p>
 
-					<p>Refer to the <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
+					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
 							definition</a> in [[opf-201]] for more information.</p>
 
 					<div class="note">
@@ -5807,7 +5807,7 @@ No Entry</pre>
 						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
 
 						<p>Refer to the <a
-								href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
+								href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
 									><code>switch</code> element definition</a> in [[epubcontentdocs-301]] for more
 							information.</p>
 					</section>
@@ -5822,7 +5822,7 @@ No Entry</pre>
 						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
 
 						<p>Refer to the <a
-								href="http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
+								href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
 									><code>epub:trigger</code> element definition</a> in [[epubcontentdocs-301]] for
 							more information.</p>
 					</section>
@@ -7404,7 +7404,7 @@ No Entry</pre>
 									<p>The <code>rendition:spread-portrait</code> property is <a href="#deprecated"
 											>deprecated</a>.</p>
 									<p></p>Refer to the <a
-										href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
+										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
 											><code>spread-portrait</code> property definition</a>
 									in [[epubpublications-301]] for more information.</dd>
 							</dl>
@@ -7585,7 +7585,7 @@ No Entry</pre>
 						<p>Use of the property is <a href="#deprecated">deprecated</a>.</p>
 
 						<p>Refer to the <a
-								href="http://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
+								href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
 									><code>rendition:viewport</code> property definition</a> in [[epubpublications-301]]
 							for more information.</p>
 					</section>
@@ -11568,8 +11568,8 @@ EPUB/images/cover.png</pre>
 							specification located at <a href="https://www.w3.org/TR/epub-33/"
 								>https://www.w3.org/TR/epub-33/</a>.</p>
 						<p>The EPUB 3 specification supersedes the Open Packaging Format 2.0.1 specification, which is
-							located at <a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm"
-								>http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm</a> and which also uses the <code
+							located at <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm"
+								>https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm</a> and which also uses the <code
 								class="media-type">application/oepbs-package+xml</code> media type.</p>
 					</dd>
 
@@ -11697,8 +11697,8 @@ EPUB/images/cover.png</pre>
 						<p>The EPUB 3 specification supersedes both <a
 								href="https://datatracker.ietf.org/doc/html/rfc4839">RFC 4839</a> and the Open Container
 							Format 2.0.1 specification, which is located at <a
-								href="http://idpf.org/epub/20/spec/OCF_2.0.1_draft.doc"
-									><code>http://idpf.org/epub/20/spec/OCF_2.0.1_draft.doc</code></a>, and which also
+								href="https://idpf.org/epub/20/spec/OCF_2.0.1_draft.doc"
+									><code>https://idpf.org/epub/20/spec/OCF_2.0.1_draft.doc</code></a>, and which also
 							uses the <code>application/epub+zip</code> media type.</p>
 					</dd>
 

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -29,7 +29,7 @@
 					<tr>
 						<th>Description:</th>
 						<td>The <code>acquire</code> keyword is used with <a
-								href="http://idpf.org/epub/previews/">EPUB Previews</a> to identify where the
+								href="https://idpf.org/epub/previews/">EPUB Previews</a> to identify where the
 							full version of the [=EPUB publication=] can be acquired.</td>
 					</tr>
 					<tr>
@@ -114,7 +114,7 @@
 				"<code>application/marcxml+xml</code>".</p>
 			
 			<p>Refer to the <a 
-				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"><code>marc21xml-record</code>
+				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"><code>marc21xml-record</code>
 				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 		
@@ -127,7 +127,7 @@
 				"<code>application/mods+xml</code>".</p>
 			
 			<p>Refer to the <a 
-				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"><code>mods-record</code>
+				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"><code>mods-record</code>
 				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 		
@@ -140,7 +140,7 @@
 						><code>onix</code></a>.</p>
 			
 			<p>Refer to the <a 
-				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"><code>onix-record</code>
+				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"><code>onix-record</code>
 				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 		
@@ -163,7 +163,7 @@
 									href="#attrdef-link-media-type"><code>media-type</code> attribute</a> when
 								this keyword is specified.</p>
 							<p>For a list of commonly linked metadata record types, refer to the <a
-									href="http://idpf.org/epub/guides/linked-records/">EPUB Linked Metadata
+									href="https://idpf.org/epub/guides/linked-records/">EPUB Linked Metadata
 									Guide</a></p>
 							<p>If the type of record cannot be identified from the media type, an <a
 									href="#sec-link-properties">identifier property</a> can be assigned in the
@@ -243,7 +243,7 @@
 				It is not replaced by another linking method.</p>
 			
 			<p>Refer to the <a 
-				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"><code>xml-signature</code>
+				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"><code>xml-signature</code>
 				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 		
@@ -256,7 +256,7 @@
 						><code>xmp</code></a>.</p>
 			
 			<p>Refer to the <a 
-				href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"><code>xmp-record</code>
+				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"><code>xmp-record</code>
 				property definition</a> in [[!epubpublications-30]] for more information.</p>
 		</section>
 	</section>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -516,7 +516,7 @@
 		
 		<p id="meta-auth">Use of this property is <a href="#deprecated">deprecated</a>.</p>
 		
-		<p>Refer to the <a href="http://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"
+		<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"
 					><code>meta-auth</code> property definition</a> in [[!epubpublications-30]] for more
 			information.</p>
 	</section>
@@ -636,8 +636,8 @@
 							resource that has been retained in the [=EPUB publication=]. </p>
 						<p>This specification defines the <code>pagination</code> value to indicate that the
 							referenced <code>dc:source</code> element is the source of the <a
-								href="http://idpf.org/epub/vocab/structure/#pagebreak"
-									><code>pagebreak</code> properties</a> defined in the content.</p>
+								data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code> properties</a> defined in the
+							content.</p>
 					</td>
 				</tr>
 				<tr>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -58,7 +58,7 @@
 						"Elika J. Etimad",
 						"Matt Garrish"],
 						"title": "EPUB Content Documents 3.0.1",
-						"href": "http://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
+						"href": "https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html",
 						"date": "26 June 2014",
 						"publisher": "IDPF"
 					},
@@ -1000,7 +1000,7 @@
 			<section id="sec-pkg-doc-legacy">
 				<h3>Legacy features</h3>
 
-				<p id="confreq-rs-legacy">Reading systems MUST NOT support <a data-cite="epub-33#legacy">legacy
+				<p id="confreq-rs-legacy">Reading systems MUST NOT support <a data-cite="epub-33#sec-pkg-legacy">legacy
 						features</a> in content that conforms to <a data-cite="epub-33#attrdef-package-version">this
 						version of EPUB</a> [[epub-33]].</p>
 			</section>
@@ -1420,10 +1420,10 @@
 							data-cite="epub-33#sec-nav-toc"><code>toc nav</code> element</a> [[epub-33]].</p>
 				</li>
 				<li>
-					<p id="confreq-nav-alt-text" data-tests="#nav-non-text_img,#nav-non-text_img_title">MUST, when generating non-HTML based navigation widgets, replace
-						unsupported non-text elements in headings and labels with their <a
-							data-cite="epub-33#confreq-nav-a-cnt">alternative text</a> [[epub-33]]. If both
-							<code>alt</code> and <code>title</code> attributes are present on an element, preference
+					<p id="confreq-nav-alt-text" data-tests="#nav-non-text_img,#nav-non-text_img_title">MUST, when
+						generating non-HTML based navigation widgets, replace unsupported non-text elements in headings
+						and labels with their <a data-cite="epub-33#confreq-nav-a-cnt">alternative text</a> [[epub-33]].
+						If both <code>alt</code> and <code>title</code> attributes are present on an element, preference
 						SHOULD be given to the <code>alt</code> attribute. If neither attribute is present, reading
 						systems MAY provide their own text or ignore the element.</p>
 				</li>


### PR DESCRIPTION
Mostly switches http://idpf... links to https:// to avoid warnings from the link checker.

Also fixes a link using http://www.idpf.org/epub that now gets mangled by the redirect to https://idpf.orgepub/

Otherwise, there was one internal link missing a hash mark, a reference to the old legacy features section that needed fixing, and a reference to the old idpf.org SSV.

(That's all I found rechecking the three main specs.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2484.html" title="Last updated on Nov 24, 2022, 12:31 PM UTC (ef5849b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2484/999ee60...ef5849b.html" title="Last updated on Nov 24, 2022, 12:31 PM UTC (ef5849b)">Diff</a>