### PR TITLE
Clarify where epub:type is not allowed

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5775,7 +5775,8 @@ No Entry</pre>
 						<p>[=EPUB creators=] MAY use the [^/epub:type^] attribute in [=XHTML content documents=] to
 							express <a href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
-						<p>The attribute MUST only be used on [=palpable content=] [[html]].</p>
+						<p>The attribute MUST NOT be used on the <a data-cite="html#the-head-element"
+								><code>head</code></a> element or [=metadata content=] [[html]].</p>
 					</section>
 
 					<section id="sec-xhtml-rdfa">
@@ -10691,9 +10692,9 @@ html.my-document-playing * {
 			<section id="app-viewport-meta-syntax">
 				<h3>Syntax</h3>
 
-				<p>For [=fixed-layout documents=], a <code>viewport</code> [^meta^] tag [[html]] MUST have
-						<code>name</code> and <code>content</code> attributes that conform to the following
-					definition:</p>
+				<p>For [=fixed-layout documents=], a <code>viewport</code>
+					<a data-cite="html#the-meta-element"><code>meta</code></a> tag [[html]] MUST have <code>name</code>
+					and <code>content</code> attributes that conform to the following definition:</p>
 
 				<dl>
 					<dt id="viewport-name-attr">name</dt>
@@ -10785,8 +10786,8 @@ html.my-document-playing * {
 					attribute to single spaces). EPUB creators MAY include any valid [=ascii whitespace=] [[infra]] in
 					the authored tag so long as the result is valid to this definition.</p>
 
-				<p>There are no restrictions on any other attributes allowed on the [^meta^] element by the [[html]]
-					grammar.</p>
+				<p>There are no restrictions on any other attributes allowed on the <a data-cite="html#the-meta-element"
+							><code>meta</code></a> element by the [[html]] grammar.</p>
 
 				<div class="note">
 					<p>For more information about specifying the required <code>height</code> and <code>width</code>
@@ -11772,6 +11773,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>29-Nov-2022: Clarify the <code>epub:type</code> attribute is not allowed on the
+							<code>head</code> element and metadata content in XHTML content documents. See <a
+							href="https://github.com/w3c/epub-specs/issues/2486">issue 2486</a>.</li>
 					<li>17-Nov-2022: Updated file paths and names to identify that they are scalar value strings in the
 						OCF abstract container, not just case sensitive. See <a
 							href="https://github.com/w3c/epub-specs/issues/2461">issue 2461</a>.</li>


### PR DESCRIPTION
Restricts is from head element and metadata content to better match the RS restriction.

Fixes #2486


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2493.html" title="Last updated on Nov 29, 2022, 5:49 PM UTC (03519f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2493/27fbf42...03519f5.html" title="Last updated on Nov 29, 2022, 5:49 PM UTC (03519f5)">Diff</a>