### PR TITLE
Clarify data URLs are not publication resources

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -540,9 +540,10 @@
 							render the EPUB publication as the [=EPUB creator=] intends. Examples of publication
 							resources include the [=package document=], [=EPUB content documents=], CSS Style Sheets,
 							audio, video, images, embedded fonts, and scripts.</p>
-						<p>EPUB creators list publication resources in the package document [=EPUB manifest | manifest=]
-							and typically bundle them all in the [=EPUB container=] (the exception being they may locate
-							resources listed in <a href="#sec-resource-locations"></a> outside the EPUB container).</p>
+						<p>EPUB creators must list publication resources in the package document [=EPUB manifest |
+							manifest=] and typically bundle them all in the [=EPUB container=] (the exception being they
+							may locate resources listed in <a href="#sec-resource-locations"></a> outside the EPUB
+							container).</p>
 						<div class="note">
 							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
 									<code>href</code> attribute of an [[html]] [^a^] element) are not publication
@@ -1463,9 +1464,9 @@
 					directly into a URL string. The advantage of this scheme is that it allows [=EPUB creators=] to
 					embed a resource within another, avoiding the need for an external file.</p>
 
-				<p>A consequence of embedding is that data URLs are not considered their own unique publication
-					resources (i.e., they are part of their containing publication resource). As a result, EPUB creators
-					MUST NOT declare data URLs in the manifest [^item^] element's <a href="#attrdef-item-href"
+				<p>A consequence of embedding is that data URLs are not considered their own unique [=publication
+					resources=] (i.e., they are part of their containing publication resource). As a result, EPUB
+					creators MUST NOT declare data URLs in the manifest [^item^] element's <a href="#attrdef-item-href"
 							><code>href</code></a> attribute.</p>
 
 				<p>EPUB creators MAY use data URLs anywhere else in [=EPUB publications=] provided their use does not
@@ -1488,14 +1489,14 @@
 
 				<p>Although data URLs are considered part of their containing resource, because they have their own
 					media types they are still subject to the <a href="#sec-foreign-resources">foreign resource
-						restrictions</a>. EPUB creators MUST therefore encode data URLs as core media type resources or
-					use them where they can provide a fallback.</p>
-
-				<p>These restrictions on the use of data URLs are to prevent security issues and also to ensure that
-					[=reading systems=] can determine where to take a user next (i.e., because data URLs cannot be
-					referenced from the [=EPUB spine | spine=]).</p>
+						restrictions</a>. EPUB creators MUST therefore encode data URLs as [=core media type resources=]
+					or provide a fallback using the intrinsic fallback mechanisms of the host format.</p>
 
 				<div class="note">
+					<p>These restrictions on the use of data URLs are to prevent security issues and also to ensure that
+						[=reading systems=] can determine where to take a user next (i.e., because data URLs cannot be
+						referenced from the [=EPUB spine | spine=]).</p>
+
 					<p>The list of prohibited uses for data URLs is subject to change as the respective standards that
 						allow their use evolve.</p>
 				</div>
@@ -4613,9 +4614,16 @@ XHTML:
 						resources outside the EPUB container.</p>
 
 					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
-							attribute</a> is OPTIONAL when a linked resource is located outside the EPUB container, as
-						more than one media type could be served from the same URL [[url]]. EPUB creators MUST specify
-						the attribute for all linked resources within the EPUB container.</p>
+							attribute</a> is OPTIONAL when:</p>
+
+					<ul>
+						<li>a linked resource is located outside the EPUB container (more than one media type could be
+							served from the same URL [[?url]]); or</li>
+						<li>the resource is encoded as a <a href="#sec-data-urls">data URL</a> in the <code>href</code>
+							attribute (the data URL provides the media type).</li>
+					</ul>
+
+					<p>EPUB creators MUST specify the attribute for all linked resources within the EPUB container.</p>
 
 					<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of the
 						linked resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language
@@ -11769,8 +11777,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>29-Nov-2022: Clarified that data URLs are not unique publication resources (i.e., never listed in
-						the manifest) but are subject to fallback requirements. See <a
+					<li>29-Nov-2022: Clarified that data URLs are not unique publication resources (i.e., never listed
+						in the manifest) but are subject to fallback requirements. See <a
 							href="https://github.com/w3c/epub-specs/issues/2485">issue 2485</a>.</li>
 					<li>17-Nov-2022: Updated file paths and names to identify that they are scalar value strings in the
 						OCF abstract container, not just case sensitive. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4619,10 +4619,9 @@ XHTML:
 						resources outside the EPUB container.</p>
 
 					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
-							attribute</a> is OPTIONAL when a linked resource is located outside the EPUB container (more
-						than one media type could be served from the same URL [[?url]]).</p>
-
-					<p>EPUB creators MUST specify the attribute for all linked resources within the EPUB container.</p>
+							attribute</a> is OPTIONAL when a linked resource is located outside the EPUB container, as
+						more than one media type could be served from the same URL [[?url]]. EPUB creators MUST specify
+						the attribute for all linked resources within the EPUB container.</p>
 
 					<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of the
 						linked resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -540,22 +540,15 @@
 							render the EPUB publication as the [=EPUB creator=] intends. Examples of publication
 							resources include the [=package document=], [=EPUB content documents=], CSS Style Sheets,
 							audio, video, images, embedded fonts, and scripts.</p>
-						<p>EPUB creators typically list publication resources in the package document [=EPUB manifest |
-							manifest=] and bundle them in the [=EPUB container=], with the following exceptions:</p>
-						<ul>
-							<li>
-								<p>they do not have to list resources encoded as <a href="#sec-data-urls">data URLs</a>
-									in the manifest; and</p>
-							</li>
-							<li>
-								<p>they may locate resources listed in <a href="#sec-resource-locations"></a> outside
-									the EPUB container.</p>
-							</li>
-						</ul>
+						<p>EPUB creators list publication resources in the package document [=EPUB manifest | manifest=]
+							and typically bundle them all in the [=EPUB container=] (the exception being they may locate
+							resources listed in <a href="#sec-resource-locations"></a> outside the EPUB container).</p>
 						<div class="note">
 							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
 									<code>href</code> attribute of an [[html]] [^a^] element) are not publication
 								resources.</p>
+							<p><a href="#sec-data-urls">Data urls</a> are also not publication resources &#8212; they
+								are considered part of the resource they are embedded in.</p>
 						</div>
 					</dd>
 
@@ -1470,15 +1463,22 @@
 					directly into a URL string. The advantage of this scheme is that it allows [=EPUB creators=] to
 					embed a resource within another, avoiding the need for an external file.</p>
 
+				<p>A consequence of embedding is that data URLs are not considered their own unique publication
+					resources (i.e., they are part of their containing publication resource). As a result, EPUB creators
+					cannot declare data URLs in the [=manifest=] &#8212; the manifest [^item^] element's <a
+						href="#attrdef-item-href"><code>href</code></a> attribute does not allow the <code>data:</code>
+					scheme.</p>
+
+				<p>Although data URLs are considered part of their containing resource, because they have their own
+					media types they are still subject to the <a href="#sec-foreign-resources">foreign resource
+						restrictions</a>. EPUB creators MUST therefore encode data URLs as core media type resources or
+					use them where they can provide a fallback.</p>
+
 				<p>EPUB creators MAY use data URLs in [=EPUB publications=] provided their use does not result in a
 					[=top-level content document=] or [=top-level browsing context=] [[html]]. This restriction applies
 					to data URLs used in the following scenarios:</p>
 
 				<ul>
-					<li>
-						<p>in [EPUB manifest | manifest=] [^item^] elements referenced from the [=EPUB spine |
-							spine=];</p>
-					</li>
 					<li>
 						<p>in the <code>href</code> attribute on [[html]] or [[svg]] <code>a</code> elements (except
 							when inside an [^iframe^] element [[html]]);</p>
@@ -1492,21 +1492,21 @@
 					</li>
 				</ul>
 
+				<p>These restrictions on their use are to prevent security issues and also to ensure that [=reading
+					systems=] can determine where to take a user next (i.e., because data URLs cannot be referenced from
+					the [=spine=]).</p>
+
 				<div class="note">
 					<p>The list of prohibited uses for data URLs is subject to change as the respective standards that
 						allow their use evolve.</p>
 				</div>
 
-				<p>This restriction on their use is to prevent security issues and also to ensure that [=reading
-					systems=] can determine where to take a user next (i.e., because these resources are not be listed
-					in the spine).</p>
-
-				<p>Resources represented as data URLs are not publication resources so are exempt from the requirement
-					for EPUB creators to list them in the manifest.</p>
-
-				<p>EPUB creators MUST encode Data URLs as core media type resources or use them where they can provide a
-					fallback (i.e., data URLs are subject to the <a href="#sec-foreign-resources">foreign resource
-						restrictions</a>).</p>
+				<div class="note">
+					<p>The restrictions in this section do not apply to the use of data URLs in manifest [^link^]
+						elements (i.e., for [=linked resources=]). The <code>link</code> element's <code>href</code>
+						attribute does not restrict schemes, for example, and linked resources are not subject to
+						fallback requirements.</p>
+				</div>
 			</section>
 
 			<section id="sec-file-urls">
@@ -4828,7 +4828,7 @@ XHTML:
 								</li>
 								<li>
 									<p>
-										<a href="#attrdef-href">
+										<a href="#attrdef-item-href">
 											<code>href</code>
 										</a>
 										<code>[required]</code>
@@ -4874,12 +4874,12 @@ XHTML:
 						</dd>
 					</dl>
 
-					<p>Each <code>item</code> element identifies a publication resource by the URL [[url]] in its
-							<code>href</code> attribute. The value MUST be an <a data-lt="absolute-url string"
-							>absolute-</a> or <a data-lt="path-relative-scheme-less-url string"
-							>path-relative-scheme-less-URL</a> string [[url]]. [=EPUB creators=] MUST ensure each URL is
-						unique within the <code>manifest</code> scope after <a href="#sec-parse-package-urls"
-							>parsing</a>.</p>
+					<p id="attrdef-item-href">Each <code>item</code> element identifies a publication resource by the
+						URL [[url]] in its <a href="#attrdef-href"><code>href</code> attribute</a>. The value MUST be an
+							<a data-lt="absolute-url string">absolute-</a> or <a
+							data-lt="path-relative-scheme-less-url string">path-relative-scheme-less-URL</a>
+						string [[url]]. [=EPUB creators=] MUST ensure each URL is unique within the
+							<code>manifest</code> scope after <a href="#sec-parse-package-urls">parsing</a>.</p>
 
 					<p id="attrdef-item-media-type">The publication resource identified by an <code>item</code> element
 						MUST conform to the applicable specification(s) as inferred from the MIME media type [[rfc2046]]
@@ -11772,6 +11772,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>29-Nov-2022: Clarified that data URLs are not unique publication resources (i.e, never listed in
+						manifest) but are subject to fallback requirements. See <a
+							href="https://github.com/w3c/epub-specs/issues/2485">issue 2485</a>.</li>
 					<li>17-Nov-2022: Updated file paths and names to identify that they are scalar value strings in the
 						OCF abstract container, not just case sensitive. See <a
 							href="https://github.com/w3c/epub-specs/issues/2461">issue 2461</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4620,7 +4620,7 @@ XHTML:
 
 					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
 							attribute</a> is OPTIONAL when a linked resource is located outside the EPUB container, as
-						more than one media type could be served from the same URL [[?url]]. EPUB creators MUST specify
+						more than one media type could be served from the same URL [[url]]. EPUB creators MUST specify
 						the attribute for all linked resources within the EPUB container.</p>
 
 					<p id="attrdef-hreflang">The OPTIONAL <code>hreflang</code> attribute identifies the language of the

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1493,7 +1493,7 @@
 
 				<p>These restrictions on the use of data URLs are to prevent security issues and also to ensure that
 					[=reading systems=] can determine where to take a user next (i.e., because data URLs cannot be
-					referenced from the [=spine=]).</p>
+					referenced from the [=EPUB spine|spine=]).</p>
 
 				<div class="note">
 					<p>The list of prohibited uses for data URLs is subject to change as the respective standards that

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1465,18 +1465,12 @@
 
 				<p>A consequence of embedding is that data URLs are not considered their own unique publication
 					resources (i.e., they are part of their containing publication resource). As a result, EPUB creators
-					cannot declare data URLs in the [=manifest=] &#8212; the manifest [^item^] element's <a
-						href="#attrdef-item-href"><code>href</code></a> attribute does not allow the <code>data:</code>
-					scheme.</p>
+					MUST NOT declare data URLs in the manifest [^item^] element's <a href="#attrdef-item-href"
+							><code>href</code></a> attribute.</p>
 
-				<p>Although data URLs are considered part of their containing resource, because they have their own
-					media types they are still subject to the <a href="#sec-foreign-resources">foreign resource
-						restrictions</a>. EPUB creators MUST therefore encode data URLs as core media type resources or
-					use them where they can provide a fallback.</p>
-
-				<p>EPUB creators MAY use data URLs in [=EPUB publications=] provided their use does not result in a
-					[=top-level content document=] or [=top-level browsing context=] [[html]]. This restriction applies
-					to data URLs used in the following scenarios:</p>
+				<p>EPUB creators MAY use data URLs anywhere else in [=EPUB publications=] provided their use does not
+					result in a [=top-level content document=] or [=top-level browsing context=] [[html]]. This
+					restriction applies to data URLs used in the following scenarios:</p>
 
 				<ul>
 					<li>
@@ -1492,9 +1486,14 @@
 					</li>
 				</ul>
 
-				<p>These restrictions on their use are to prevent security issues and also to ensure that [=reading
-					systems=] can determine where to take a user next (i.e., because data URLs cannot be referenced from
-					the [=spine=]).</p>
+				<p>Although data URLs are considered part of their containing resource, because they have their own
+					media types they are still subject to the <a href="#sec-foreign-resources">foreign resource
+						restrictions</a>. EPUB creators MUST therefore encode data URLs as core media type resources or
+					use them where they can provide a fallback.</p>
+
+				<p>These restrictions on the use of data URLs are to prevent security issues and also to ensure that
+					[=reading systems=] can determine where to take a user next (i.e., because data URLs cannot be
+					referenced from the [=spine=]).</p>
 
 				<div class="note">
 					<p>The list of prohibited uses for data URLs is subject to change as the respective standards that
@@ -1503,9 +1502,7 @@
 
 				<div class="note">
 					<p>The restrictions in this section do not apply to the use of data URLs in manifest [^link^]
-						elements (i.e., for [=linked resources=]). The <code>link</code> element's <code>href</code>
-						attribute does not restrict schemes, for example, and linked resources are not subject to
-						fallback requirements.</p>
+						elements (i.e., for [=linked resources=]).</p>
 				</div>
 			</section>
 
@@ -11773,7 +11770,7 @@ EPUB/images/cover.png</pre>
 
 				<ul>
 					<li>29-Nov-2022: Clarified that data URLs are not unique publication resources (i.e, never listed in
-						manifest) but are subject to fallback requirements. See <a
+						the manifest) but are subject to fallback requirements. See <a
 							href="https://github.com/w3c/epub-specs/issues/2485">issue 2485</a>.</li>
 					<li>17-Nov-2022: Updated file paths and names to identify that they are scalar value strings in the
 						OCF abstract container, not just case sensitive. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1474,33 +1474,26 @@
 					directly into a URL string. The advantage of this scheme is that it allows [=EPUB creators=] to
 					embed a resource within another, avoiding the need for an external file.</p>
 
-				<p>A consequence of embedding is that data URLs are not considered their own unique [=publication
-					resources=] (i.e., they are part of their containing publication resource). As a result, EPUB
-					creators MUST NOT declare data URLs in the manifest [^item^] element's <a href="#attrdef-item-href"
-							><code>href</code></a> attribute.</p>
-
-				<p>EPUB creators MAY use data URLs anywhere else in [=EPUB publications=] provided their use does not
-					result in a [=top-level content document=] or [=top-level browsing context=] [[html]]. This
-					restriction applies to data URLs used in the following scenarios:</p>
+				<p>EPUB creators MUST NOT use data URLs in the following scenarios where they can result in a
+					[=top-level content document=] or [=top-level browsing context=] [[html]]:</p>
 
 				<ul>
 					<li>
-						<p>in the <code>href</code> attribute on [[html]] or [[svg]] <code>a</code> elements (except
-							when inside an [^iframe^] element [[html]]);</p>
+						<p>in <code>href</code> attributes in the package document &#8212; this applies both to manifest
+							[^item^] elements and metadata [^link^] elements;</p>
 					</li>
 					<li>
-						<p>in the <code>href</code> attribute on [[html]] <code>area</code> elements (except when inside
-							an <code>iframe</code> element);</p>
+						<p>in the <code>href</code> attribute on [[html]] or [[svg]] <code>a</code> elements, except
+							when inside an [^iframe^] element [[html]];</p>
+					</li>
+					<li>
+						<p>in the <code>href</code> attribute on [[html]] <code>area</code> elements, except when inside
+							an <code>iframe</code> element;</p>
 					</li>
 					<li>
 						<p>in calls to [[ecmascript]] <code>window.open</code> or <code>document.open</code>.</p>
 					</li>
 				</ul>
-
-				<p>Although data URLs are considered part of their containing resource, because they have their own
-					media types they are still subject to the <a href="#sec-foreign-resources">foreign resource
-						restrictions</a>. EPUB creators MUST therefore encode data URLs as [=core media type resources=]
-					or provide a fallback using the intrinsic fallback mechanisms of the host format.</p>
 
 				<div class="note">
 					<p>These restrictions on the use of data URLs are to prevent security issues and also to ensure that
@@ -1511,10 +1504,12 @@
 						allow their use evolve.</p>
 				</div>
 
-				<div class="note">
-					<p>The restrictions in this section do not apply to the use of data URLs in manifest [^link^]
-						elements (i.e., for [=linked resources=]).</p>
-				</div>
+				<p>A consequence of embedding is that the data in a data URL is not considered its own unique
+					[=publication resource=] for manifest reporting purposes (i.e., only its containing publication
+					resource gets listed). As this data has its own media type, however, it is still subject to <a
+						href="#sec-foreign-resources">foreign resource restrictions</a>. EPUB creators MUST therefore
+					encode data URLs as [=core media type resources=] or provide a fallback using the intrinsic fallback
+					mechanisms of the host format.</p>
 			</section>
 
 			<section id="sec-file-urls">
@@ -4624,14 +4619,8 @@ XHTML:
 						resources outside the EPUB container.</p>
 
 					<p id="attrdef-link-media-type">The <a href="#attrdef-media-type"><code>media-type</code>
-							attribute</a> is OPTIONAL when:</p>
-
-					<ul>
-						<li>a linked resource is located outside the EPUB container (more than one media type could be
-							served from the same URL [[?url]]); or</li>
-						<li>the resource is encoded as a <a href="#sec-data-urls">data URL</a> in the <code>href</code>
-							attribute (the data URL provides the media type).</li>
-					</ul>
+							attribute</a> is OPTIONAL when a linked resource is located outside the EPUB container (more
+						than one media type could be served from the same URL [[?url]]).</p>
 
 					<p>EPUB creators MUST specify the attribute for all linked resources within the EPUB container.</p>
 
@@ -11788,8 +11777,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>29-Nov-2022: Clarified that data URLs are not unique publication resources (i.e., never listed
-						in the manifest) but are subject to fallback requirements. See <a
+					<li>29-Nov-2022: Clarified that data URLs are not unique publication resources, and not allowed in
+						the package document, but are subject to fallback requirements. See <a
 							href="https://github.com/w3c/epub-specs/issues/2485">issue 2485</a>.</li>
 					<li>29-Nov-2022: Clarified the <code>epub:type</code> attribute is not allowed on the
 							<code>head</code> element and metadata content in XHTML content documents. See <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11769,7 +11769,7 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>29-Nov-2022: Clarified that data URLs are not unique publication resources (i.e, never listed in
+					<li>29-Nov-2022: Clarified that data URLs are not unique publication resources (i.e., never listed in
 						the manifest) but are subject to fallback requirements. See <a
 							href="https://github.com/w3c/epub-specs/issues/2485">issue 2485</a>.</li>
 					<li>17-Nov-2022: Updated file paths and names to identify that they are scalar value strings in the

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1493,7 +1493,7 @@
 
 				<p>These restrictions on the use of data URLs are to prevent security issues and also to ensure that
 					[=reading systems=] can determine where to take a user next (i.e., because data URLs cannot be
-					referenced from the [=EPUB spine|spine=]).</p>
+					referenced from the [=EPUB spine | spine=]).</p>
 
 				<div class="note">
 					<p>The list of prohibited uses for data URLs is subject to change as the respective standards that


### PR DESCRIPTION
This one got me pretty twisted up trying to solve.

There's a second case I thought of where you could technically use a data URL in the manifest: fallback resources. You could encode a CMT image as a data URL for an img element fallback, for example. But do we really want to support this or having a nav doc not in the spine as a data URL? I'm guessing not.

Assuming that's the case, what I've done is try to make clearer that data URLs are not unique from their container resource. They must not be listed in the manifest, but because they have media types separate from their container they are still subject to fallback restrictions.

I've also assumed that we don't care what people do with linked resources, so data URLs are allowed in `link` elements in the metadata.

Anyway, take a good look at this PR as it's a bit of a convoluted problem.

Fixes #2485


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2494.html" title="Last updated on Dec 3, 2022, 2:34 PM UTC (ab0261a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2494/58879d0...ab0261a.html" title="Last updated on Dec 3, 2022, 2:34 PM UTC (ab0261a)">Diff</a>