### PR TITLE
Clarify data block exemption from fallbacks

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1368,20 +1368,30 @@
 									href="#sec-manifest-fallbacks">manifest fallback</a>.</li>
 						</ul>
 					</section>
+
 					<section>
 						<h5>HTML <code>script</code> element</h5>
 
-						<p>Although the [[html]] [^script^] element lacks intrinsic fallback capabilities, it is not
-							required that [=EPUB creators=] provide fallbacks for <a data-cite="html#data-block">data
-								blocks</a> [[html]]. As the <code>script</code> element does not represent user content,
-							data blocks are not rendered unless manipulated by script.</p>
+						<p>Although data blocks have a separate MIME media type [[rfc2046]] from their containing
+							[=XHTML content document=], it is not possible to provide intrinsic fallbacks as there are
+							no mechanisms for the [[html]] [^script^] element. It is also not possible to provide
+							manifest fallbacks because data blocks are always embedded in a <code>script</code>
+							element.</p>
+
+						<p>But, as the <code>script</code> element does not represent user content &#8212; <a
+								data-cite="html#data-block">data blocks</a> are not rendered unless manipulated by
+							script, and content rendered by scripts already has <a href="#confreq-cd-scripted-flbk">core
+								media type requirements</a> &#8212; requiring fallbacks for the raw data does not serve
+							a useful purpose.</p>
+
+						<p>Consequently, to ensure that [=EPUB creators=] can include data blocks for scripting
+							purposes, they are exempt from fallback requirements.</p>
 
 						<div class="note">
-							<p>The exemption from fallbacks aligns data blocks with the exemption made to <a
-									href="#confreq-foreign-no-fallback">allow data files</a> to travel in the [=EPUB
-								container=]. As data blocks are not separate resources from their host [=EPUB content
-								document=], they do not fall under the same exemption.</p>
+							<p>This exemption aligns data blocks with the <a href="#confreq-foreign-no-fallback"
+									>exemption for data files</a>.</p>
 						</div>
+
 						<div class="note">
 							<p>[[svg]] does not define data blocks as of publication, but the same exclusion would apply
 								if a future update adds the concept.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1373,8 +1373,7 @@
 						<h5>HTML <code>script</code> element</h5>
 
 						<p>Although data blocks have a separate MIME media type [[rfc2046]] from their containing
-							[=XHTML content document=], it is not possible to provide intrinsic fallbacks as there are
-							no mechanisms for the [[html]] [^script^] element. It is also not possible to provide
+							[=XHTML content document=], it is not possible to provide intrinsic fallbacks as no such mechanisms are specified for the [[html]] [^script^] element. It is also not possible to provide
 							manifest fallbacks because data blocks are always embedded in a <code>script</code>
 							element.</p>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1373,9 +1373,10 @@
 						<h5>HTML <code>script</code> element</h5>
 
 						<p>Although data blocks have a separate MIME media type [[rfc2046]] from their containing
-							[=XHTML content document=], it is not possible to provide intrinsic fallbacks as no such mechanisms are specified for the [[html]] [^script^] element. It is also not possible to provide
-							manifest fallbacks because data blocks are always embedded in a <code>script</code>
-							element.</p>
+							[=XHTML content document=], it is not possible to provide intrinsic fallbacks as no such
+							mechanisms are specified for the [[html]] [^script^] element. It is also not possible to
+							provide manifest fallbacks because data blocks cannot be defined as standalone files in the
+							EPUB container but are always embedded as inline <code>script</code> elements.</p>
 
 						<p>But, as the <code>script</code> element does not represent user content &#8212; <a
 								data-cite="html#data-block">data blocks</a> are not rendered unless manipulated by


### PR DESCRIPTION
Implements the text in https://github.com/w3c/epub-specs/issues/2487

(Not adding a change log entry for this since it's just clarifying the text, not adding anything new.)

Fixes #2487


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2495.html" title="Last updated on Dec 2, 2022, 9:18 PM UTC (bf1a20d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2495/27fbf42...bf1a20d.html" title="Last updated on Dec 2, 2022, 9:18 PM UTC (bf1a20d)">Diff</a>