### PR TITLE
Intrinsic fallbacks for audio/video

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1323,21 +1323,25 @@
 						requirements of specific elements.</p>
 
 					<section id="sec-fallbacks-audio">
-						<h5>HTML <code>audio</code> fallbacks</h5>
+						<h5>HTML <code>audio</code> and <code>video</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-media">[=EPUB creators=] MUST NOT use embedded
-							[[html]] [=flow content=] within the <a data-cite="html#the-audio-element"
-									><code>audio</code></a> element as an intrinsic fallback for [=foreign resources=].
+							[[html]] [=flow content=] within the <a data-cite="html#the-media-element"
+									>media element</a> (i.e, <a data-cite="html#the-audio-element"
+									><code>audio</code></a> or <a data-cite="html#the-vido-element"
+									><code>video</code></a>) as an intrinsic
+									fallback for [=foreign resources=].
 							Only child [^source^] elements [[html]] provide intrinsic fallback capabilities.</p>
 
-						<p>Only older [=reading systems=] that do not recognize the <code>audio</code> element (e.g.,
-							EPUB 2 reading systems) will render the embedded content. When reading systems support the
-								<code>audio</code> element but not the available audio formats, they do not render the
+						<p>Only older [=reading systems=] that do not recognize the <code>audio</code> or 
+							the <code>video</code> elements (e.g., EPUB 2 reading systems) will render the embedded content. 
+							When reading systems support these elements but not the available media formats, they do not render the
 							embedded content for the user.</p>
 
 						<div class="note">
 							<p>As video resources are [=exempt resources=], this requirement does not apply to the
-									<code>video</code> element. EPUB creators may also include flow content in the
+									<code>video</code> element when used to render a video content. 
+									EPUB creators may also include flow content in the
 									<code>video</code> element for reading systems that do not support the element,
 								however.</p>
 						</div>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1330,7 +1330,7 @@
 									>media element</a> (i.e, <a data-cite="html#the-audio-element"
 									><code>audio</code></a> or <a data-cite="html#the-vido-element"
 									><code>video</code></a>) as an intrinsic
-									fallback for [=foreign resources=].
+									fallback for audio [=foreign resources=].
 							Only child [^source^] elements [[html]] provide intrinsic fallback capabilities.</p>
 
 						<p>Only older [=reading systems=] that do not recognize the <code>audio</code> or 
@@ -1339,11 +1339,10 @@
 							embedded content for the user.</p>
 
 						<div class="note">
-							<p>As video resources are [=exempt resources=], this requirement does not apply to the
-									<code>video</code> element when used to render a video content. 
-									EPUB creators may also include flow content in the
-									<code>video</code> element for reading systems that do not support the element,
-								however.</p>
+							<p>The requirement for fallbacks only applies to audio foreign resources 
+								referenced from <code>audio</code> and <code>video</code> elements. 
+								Fallbacks are not required for video resources; they are [=exempt resources=].
+							</p>
 						</div>
 					</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1326,7 +1326,7 @@
 						<h5>HTML <code>audio</code> and <code>video</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-media">[=EPUB creators=] MUST NOT use embedded
-							[[html]] [=flow content=] within the <a data-cite="html#the-media-element"
+							[[html]] [=flow content=] within a <a data-cite="html#the-media-element"
 									>media element</a> (i.e, <a data-cite="html#the-audio-element"
 									><code>audio</code></a> or <a data-cite="html#the-vido-element"
 									><code>video</code></a>) as an intrinsic


### PR DESCRIPTION
This is to Fix #2490.

I do have a problem, however: I am not sure I understand the note. What does "this requirement" means? Does it mean that the authors may add intrinsic fallback for a video element, at least in case a video resource is played? This seems to contradict with the HTML spec, which says (in the [video element](https://html.spec.whatwg.org/multipage/media.html#the-video-element):

> Content may be provided inside the video element. User agents should not show this content to the user; it is intended for older web browsers which do not support video, so that legacy video plugins can be tried, or to show text to the users of these older browsers informing them of how to access the video contents.

(This is the same text as for the audio element.) Ie, the restrictions seem to be identical to audio and video; I wonder if, with this change, the note should not simply be removed altogether, as not providing any further information...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2496.html" title="Last updated on Dec 1, 2022, 5:15 AM UTC (bd90dde)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2496/27fbf42...bd90dde.html" title="Last updated on Dec 1, 2022, 5:15 AM UTC (bd90dde)">Diff</a>