### PR TITLE
Remove the acquire and xmp properties

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3302,9 +3302,9 @@
       …
       &lt;link
           rel="record"
-          href="http://example.org/meta/12389347?format=xmp"
+          href="http://example.org/meta/12389347?format=onix"
           media-type="application/xml"
-          properties="xmp"/>
+          properties="onix"/>
       …
    &lt;/metadata>
    …
@@ -4572,10 +4572,10 @@
 						</li>
 					</ul>
 
-					<p>In all other cases (e.g., when linking to standalone [[?onix]] or [[?xmp]] records), the
-						resources referenced are not [=publication resources=] (i.e., are not subject to <a
-							href="#sec-core-media-types">core media type requirements</a>) and [=EPUB creators=] MUST
-						NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
+					<p>In all other cases (e.g., when linking to standalone [[?onix]] records), the resources referenced
+						are not [=publication resources=] (i.e., are not subject to <a href="#sec-core-media-types">core
+							media type requirements</a>) and [=EPUB creators=] MUST NOT list them in the <a
+							href="#sec-manifest-elem">manifest</a>.</p>
 
 					<aside class="example" title="Reference to a record embedded in an XHTML content document">
 						<p>In this example, the metadata record is embedded in a <code>script</code> element. Note that
@@ -4650,15 +4650,15 @@ XHTML:
 							<code>properties</code> attribute.</p>
 
 					<aside class="example" title="Identifying a record type via a property">
-						<p>In this example, the <code>properties</code> attribute identifies the link is to a XMP
+						<p>In this example, the <code>properties</code> attribute identifies the link is to a ONIX
 							record.</p>
 
 						<pre>&lt;metadata …>
    …
    &lt;link rel="record"
-       href="http://example.org/meta/12389347?format=xmp"
+       href="http://example.org/meta/12389347?format=onix"
        media-type="application/xml"
-       properties="xmp"/>
+       properties="onix"/>
    …
 &lt;/metadata></pre>
 					</aside>
@@ -11777,6 +11777,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>08-Dec-2022: Removed the <code>acquire</code> and <code>xmp</code> properties after finding no
+						evidence these are used by publishers or reading systems. See <a
+							href="https://github.com/w3c/epub-specs/issues/2489">issue 2489</a>.</li>
 					<li>29-Nov-2022: Clarified that data URLs are not unique publication resources, and not allowed in
 						the package document, but are subject to fallback requirements. See <a
 							href="https://github.com/w3c/epub-specs/issues/2485">issue 2485</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4650,7 +4650,7 @@ XHTML:
 							<code>properties</code> attribute.</p>
 
 					<aside class="example" title="Identifying a record type via a property">
-						<p>In this example, the <code>properties</code> attribute identifies the link is to a ONIX
+						<p>In this example, the <code>properties</code> attribute identifies the link is to an ONIX
 							record.</p>
 
 						<pre>&lt;metadata …>

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -15,45 +15,6 @@
 					><code>rel</code> attribute</a> to establish the relationship of the resource referenced in
 			the <a href="#attrdef-href"><code>href</code> attribute</a>.</p>
 		
-		<section id="sec-acquire">
-			<h5>acquire</h5>
-			
-			<table class="tabledef" id="acquire">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>acquire</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>The <code>acquire</code> keyword is used with <a
-								href="https://idpf.org/epub/previews/">EPUB Previews</a> to identify where the
-							full version of the [=EPUB publication=] can be acquired.</td>
-					</tr>
-					<tr>
-						<th>Cardinality:</th>
-						<td>
-							<code>Zero or more</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Extends:</th>
-						<td>Only applies to the EPUB publication or collection. MUST NOT be used when the <a
-								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
-					</tr>
-					<tr>
-						<th>Example:</th>
-						<td>
-							<code>&lt;link rel="acquire" href="http://example.org/book/9781448103706"
-								media-type="text/html"/&gt;</code>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-		</section>
-		
 		<section id="sec-alternate">
 			<h5>alternate</h5>
 			
@@ -250,10 +211,7 @@
 		<section id="sec-xmp-record">
 			<h5>xmp-record (deprecated)</h5>
 			
-			<p id="xmp-record">Use of the <code>xmp-record</code> keyword is <a href="#deprecated">deprecated</a>. It
-				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
-					href="#attrdef-properties">properties attribute</a> value <a href="#xmp"
-						><code>xmp</code></a>.</p>
+			<p id="xmp-record">Use of the <code>xmp-record</code> keyword is <a href="#deprecated">deprecated</a>.</p>
 			
 			<p>Refer to the <a 
 				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"><code>xmp-record</code>
@@ -290,33 +248,6 @@
 						<td>
 							<code>&lt;link rel="record" href="pub/meta/nor-wood-onix.xml"
 								media-type="application/xml" properties="onix"/&gt;</code>
-						</td>
-					</tr>
-				</tbody>
-			</table>
-		</section>
-		
-		<section id="sec-xmp">
-			<h5>xmp</h5>
-			
-			<table class="tabledef" id="xmp">
-				<tbody>
-					<tr>
-						<th>Name:</th>
-						<td>
-							<code>xmp</code>
-						</td>
-					</tr>
-					<tr>
-						<th>Description:</th>
-						<td>The <code>xmp</code> property indicates the referenced resource is an XMP record
-							[[!xmp]].</td>
-					</tr>
-					<tr>
-						<th>Example:</th>
-						<td>
-							<code>&lt;link rel="record" href="pub/meta/nor-wood-xmp.xml"
-								media-type="application/xml" properties="xmp"/&gt;</code>
 						</td>
 					</tr>
 				</tbody>


### PR DESCRIPTION
Assuming everyone is fine with dropping these rather than keeping them around as under-implemented.

Fixes #2489


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2500.html" title="Last updated on Dec 8, 2022, 1:00 PM UTC (7767f0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2500/0d6432d...7767f0d.html" title="Last updated on Dec 8, 2022, 1:00 PM UTC (7767f0d)">Diff</a>