### PR TITLE
Remove statement about terms being capitalized

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -268,8 +268,7 @@
 			<section id="sec-terminology">
 				<h3>Terminology</h3>
 
-				<p>This specification defines the following terms specific to EPUB 3. They appear capitalized wherever
-					used.</p>
+				<p>This specification defines the following terms specific to EPUB 3.</p>
 
 				<div class="note">
 					<p>Only the first instance of a term in a section links to its definition.</p>


### PR DESCRIPTION
Missed when terminology was lowercased.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2502.html" title="Last updated on Dec 10, 2022, 4:35 PM UTC (240f9c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2502/e596285...240f9c8.html" title="Last updated on Dec 10, 2022, 4:35 PM UTC (240f9c8)">Diff</a>