### PR TITLE
Clarify fxl dimensions must be in first viewport meta tag

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7623,8 +7623,8 @@ No Entry</pre>
 								</ul>
 								<p>The <code>device-width</code> and <code>device-height</code> values refer to the 100%
 									of the width and height, respectively, of the reading system's [=viewport=].</p>
-								<p>The height and width of the fixed-layout document MUST be defined in the first
-										<code>viewport meta</code> tag in document order in the [[html]] <a
+								<p>The <code>height</code> and <code>width</code> definitions MUST be specified in the
+									first <code>viewport meta</code> tag in document order in the [[html]] <a
 										data-cite="html#the-head-element"><code>head</code></a> element. Reading systems
 									will ignore subsequent <code>viewport meta</code> tags.</p>
 								<p>EPUB creators MUST NOT specify more than one <code>height</code> or

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7623,9 +7623,12 @@ No Entry</pre>
 								</ul>
 								<p>The <code>device-width</code> and <code>device-height</code> values refer to the 100%
 									of the width and height, respectively, of the reading system's [=viewport=].</p>
-								<p>EPUB creators MUST NOT specify duplicate <code>height</code> or <code>width</code>
-									definitions either within a single <code>viewport meta</code> tag or by specifying
-									multiple <code>viewport meta</code> tags.</p>
+								<p>The height and width of the fixed-layout document MUST be defined in the first
+										<code>viewport meta</code> tag in document order in the [[html]] <a
+										data-cite="html#the-head-element"><code>head</code></a> element. Reading systems
+									will ignore subsequent <code>viewport meta</code> tags.</p>
+								<p>EPUB creators MUST NOT specify more than one <code>height</code> or
+										<code>width</code> definition within a <code>viewport meta</code> tag.</p>
 								<aside class="example"
 									title="Specifying the initial containing block in a viewport meta tag">
 									<pre>&lt;html …>
@@ -11776,6 +11779,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>12-Dec-2022: Clarified that fixed layout height and width declarations must be in the first
+							<code>viewport meta</code> tag. See <a href="https://github.com/w3c/epub-specs/pull/2503"
+							>pull request 2503</a>.</li>
 					<li>08-Dec-2022: Removed the <code>acquire</code> and <code>xmp</code> properties after finding no
 						evidence these are used by publishers or reading systems. See <a
 							href="https://github.com/w3c/epub-specs/issues/2489">issue 2489</a>.</li>


### PR DESCRIPTION
As noted in https://github.com/w3c/epubcheck/issues/1401, it's not clear in the authoring spec that the height and width have to be declared in the first `viewport meta` tag. The reading system spec requires reading systems to ignore subsequent definitions, so this pull request adds an authoring requirement to match.

Making this explicit means we no longer have to talk about subsequent definitions in the authoring spec, since they can't be declared there.

I also switched "MUST NOT specify duplicate..." with "MUST NOT declare more than one..." for avoiding repeated definitions within a single tag. Not specifying "duplicate" dimensions sounds like it's okay if you have two declarations within a single tag so long as they have different values.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2503.html" title="Last updated on Dec 13, 2022, 1:44 AM UTC (e201e8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2503/72f9947...e201e8f.html" title="Last updated on Dec 13, 2022, 1:44 AM UTC (e201e8f)">Diff</a>