### PR TITLE
Remove editorializing from the AAA note

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -397,8 +397,8 @@
 					native elements and controls whenever possible and enhancing custom interactive content with
 					[[wai-aria]] roles, states, and properties. Plus, whenever possible, the EPUB community adds
 					publishing accessibility needs to these standards &#8212; for example, through the creation of the
-					[[dpub-aria-1.0]] role module. It is not necessary for anyone familiar with web accessibility to learn a
-					new accessibility framework to make EPUB publications accessible.</p>
+					[[dpub-aria-1.0]] role module. It is not necessary for anyone familiar with web accessibility to
+					learn a new accessibility framework to make EPUB publications accessible.</p>
 
 				<p>The primary source for producing accessible web content is the W3C's Web Content Accessibility
 					Guidelines (WCAG) [[wcag2]], which establish benchmarks for accessible content. WCAG defines four
@@ -470,8 +470,7 @@
 								of Level A, but it is strongly recommended that it meet the requirements of Level
 								AA.</p>
 							<div class="note">
-								<p>Although, as <a data-cite="wcag21#h-note-29">noted in WCAG</a>, conforming at level
-									AAA is typically not possible, and not required by this specification, <a
+								<p>Although conforming at level AAA is not required by this specification, <a
 										href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> are
 									encouraged to follow the practices detailed in AAA success criteria when producing
 									accessible EPUB publications.</p>


### PR DESCRIPTION
This PR writes out the text about the ability to meet AAA as described in https://github.com/w3c/publ-a11y/issues/141#issuecomment-1353345225.

Encouraging people to follow AAA SC is more important than wading into whether conforming at AAA is possible.