### PR TITLE
Update workflows to use checkout@v3

### DIFF
--- a/.github/workflows/epub-a11y-eaa-mapping.yml
+++ b/.github/workflows/epub-a11y-eaa-mapping.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish EPUB Accessibility - EU Accessibility Act Mapping 
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: epub33/epub-a11y-eaa-mapping/

--- a/.github/workflows/epub-a11y-tech.yml
+++ b/.github/workflows/epub-a11y-tech.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish EPUB Accessibility Techniques 1.1 
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: epub33/a11y-tech/

--- a/.github/workflows/epub-a11y.yml
+++ b/.github/workflows/epub-a11y.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish EPUB Accessibility 1.1 
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: epub33/a11y/

--- a/.github/workflows/epub-core.yml
+++ b/.github/workflows/epub-core.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish EPUB 33 
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: epub33/core/

--- a/.github/workflows/epub-multi-rend.yml
+++ b/.github/workflows/epub-multi-rend.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish EPUB Multiple-Rendition Publications 1.1 
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: epub33/multi-rend/

--- a/.github/workflows/epub-overview.yml
+++ b/.github/workflows/epub-overview.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish EPUB 3 Overview 
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: epub33/overview/

--- a/.github/workflows/epub-rs.yml
+++ b/.github/workflows/epub-rs.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish Reading Systems 3.3 
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: epub33/rs/

--- a/.github/workflows/epub-ssv.yml
+++ b/.github/workflows/epub-ssv.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish Structural Semantics Vocabulary 
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: epub33/ssv/

--- a/.github/workflows/epub-tts.yml
+++ b/.github/workflows/epub-tts.yml
@@ -15,7 +15,7 @@ jobs:
     name: Publish EPUB 3 Text-to-Speech Enhancements 1.0 
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2
         with:
           SOURCE: epub33/tts/


### PR DESCRIPTION
The accessibility spec failed to run this morning (for no particular reason as it resolved itself on the next run). When I opened the action, though, it had this new warning after the failure message:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2

If you follow the provided URL to [the page on what to update](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-versioned-actions), we need to switch all the workflows to "actions/checkout@v3", so that's what this PR does.