### PR TITLE
Clarify that ocf processing files are not listed in the manifest

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4799,7 +4799,8 @@ XHTML:
 					<div class="note">
 						<p>The manifest is only for listing publication resources. [=Linked resources=] and <a
 								href="#sec-container-file-and-dir-structure">the special files for processing the OCF
-								Container</a> are restricted from inclusion.</p>
+								Container</a> (i.e., files in the <code>META-INF</code> directory, and the
+								<code>mimetype</code> file) are restricted from inclusion.</p>
 
 						<p>Failure to provide a complete manifest of publication resources may lead to rendering issues.
 							[=Reading systems=] might not unzip such resources or could prevent access to them for

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1676,6 +1676,9 @@
 					<p>The file name <code>mimetype</code> in the root directory is reserved for use by [=OCF ZIP
 						containers=], as explained in <a href="#sec-container-zip"></a>.</p>
 
+					<p>Files in the <code>META-INF</code> directory and the <code>mimetype</code> file are not
+						[=publication resources=] so MUST NOT be listed in the [=EPUB manifest|manifest=].</p>
+
 					<p>[=EPUB creators=] MAY locate all other files within the OCF abstract container in any location
 						descendant from the root directory, provided they are not within the <code>META-INF</code>
 						directory. EPUB creators MUST NOT reference files in the <code>META-INF</code> directory from an
@@ -4788,15 +4791,19 @@ XHTML:
 
 					<p id="confreq-rendition-manifest">[=EPUB creators=] MUST list all publication resources in the
 							<code>manifest</code>, regardless of whether they are [=container resources=] or [=remote
-						resources=]. Moreover, the <code>manifest</code> MUST only list publication resources.</p>
+						resources=].</p>
 
 					<p>Note that the <code>manifest</code> is not self-referencing: EPUB creators MUST NOT specify an
 							<code>item</code> element that refers to the [=package document=] itself.</p>
 
 					<div class="note">
-						<p>Failure to provide a complete manifest of resources may lead to rendering issues. [=Reading
-							systems=] might not unzip such resources or could prevent access to them for security
-							reasons.</p>
+						<p>The manifest is only for listing publication resources. [=Linked resources=] and <a
+								href="#sec-container-file-and-dir-structure">the special files for processing the OCF
+								Container</a> are restricted from inclusion.</p>
+
+						<p>Failure to provide a complete manifest of publication resources may lead to rendering issues.
+							[=Reading systems=] might not unzip such resources or could prevent access to them for
+							security reasons.</p>
 					</div>
 				</section>
 
@@ -11779,6 +11786,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>16-Dec-2022: Clarified that the special files for processing the OCF container are not listed in
+						the manifest, so the restriction that the manifest only list publication resources is not
+						needed. See <a href="https://github.com/w3c/epub-specs/pull/2506">pull request 2506</a>.</li>
 					<li>12-Dec-2022: Clarified that fixed layout height and width declarations must be in the first
 							<code>viewport meta</code> tag. See <a href="https://github.com/w3c/epub-specs/pull/2503"
 							>pull request 2503</a>.</li>


### PR DESCRIPTION
As raised in https://github.com/w3c/epubcheck/issues/1452, I don't know that we can ever perfectly clarify what publication resources are, but PR makes clear that the mimetype file and meta-inf files are not, so they are not listed in the manifest.

That should make the statement about the manifest only listing publication resources redundant, as the other cases are now explained (linked resources and the above files).

There will still be impossibilities for epubcheck to determine, like whether a publication resource without any reference to it is intentionally travelling in the container or was forgotten to be removed, but as noted in the epubcheck issue we can add usage messages to flag those.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2506.html" title="Last updated on Dec 16, 2022, 5:47 PM UTC (37cb0cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2506/564fd05...37cb0cd.html" title="Last updated on Dec 16, 2022, 5:47 PM UTC (37cb0cd)">Diff</a>