### PR TITLE
Add property for exempt resources

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1247,11 +1247,11 @@
 					resources (i.e., the requirement for a fallback for the foreign content document covers any
 					rendering issues within it). As the resource is not referenced from an EPUB content document, it
 					automatically becomes exempt from fallbacks.</p>
-				
+
 				<div class="note">
 					<p>Resources that fall under this latter exemption should be identified in the manifest using the
-						<code>exempt</code> property on their [^item^] entry to avoid their being flagged by EPUB conformance
-						checkers. Refer to <a href="#sec-exempt"></a> for more information.</p>
+							<code>exempt</code> property on their [^item^] entry to avoid their being flagged by EPUB
+						conformance checkers. Refer to <a href="#sec-exempt"></a> for more information.</p>
 				</div>
 			</section>
 
@@ -4937,6 +4937,9 @@ XHTML:
 							<li><a href="#sec-svg">svg</a></li>
 							<li><a href="#sec-switch">switch</a></li>
 						</ul>
+
+						<p>EPUB creators SHOULD set the <a>exempt</a> property whenever a resource referenced by an
+								<code>item</code> element matches its definition.</p>
 
 						<aside class="example" id="example-item-properties-scripted-mathml"
 							title="Identifying a scripted content document with embedded MathML">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4938,8 +4938,8 @@ XHTML:
 							<li><a href="#sec-switch">switch</a></li>
 						</ul>
 
-						<p>EPUB creators SHOULD set the <a>exempt</a> property whenever a resource referenced by an
-								<code>item</code> element matches its definition.</p>
+						<p>EPUB creators SHOULD set the <a href="#sec-exempt">exempt</a> property whenever a resource
+							referenced by an <code>item</code> element matches its definition.</p>
 
 						<aside class="example" id="example-item-properties-scripted-mathml"
 							title="Identifying a scripted content document with embedded MathML">

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1249,9 +1249,9 @@
 					automatically becomes exempt from fallbacks.</p>
 				
 				<div class="note">
-					<p>Resources that fall under this latter exemption have to be identified in the manifest using the
-						<code>exempt</code> property on their [^item^] entry. Refer to <a href="#sec-exempt"></a>
-						for more information.</p>
+					<p>Resources that fall under this latter exemption should be identified in the manifest using the
+						<code>exempt</code> property on their [^item^] entry to avoid their being flagged by EPUB conformance
+						checkers. Refer to <a href="#sec-exempt"></a> for more information.</p>
 				</div>
 			</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1247,6 +1247,12 @@
 					resources (i.e., the requirement for a fallback for the foreign content document covers any
 					rendering issues within it). As the resource is not referenced from an EPUB content document, it
 					automatically becomes exempt from fallbacks.</p>
+				
+				<div class="note">
+					<p>Resources that fall under this latter exemption have to be identified in the manifest using the
+						<code>exempt</code> property on their [^item^] entry. Refer to <a href="#sec-exempt"></a>
+						for more information.</p>
+				</div>
 			</section>
 
 			<section id="sec-resource-fallbacks">

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -38,7 +38,7 @@
 	</section>
 	
 	<section id="sec-exempt">
-		<h4>data</h4>
+		<h4>exempt</h4>
 		
 		<table class="tabledef" id="exempt">
 			<tbody>

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -54,9 +54,9 @@
 						<p>The <code>exempt</code> property indicates that the [=publication resource=]
 							is an [=exempt resource=] (e.g., is used as script input or is included in the
 							[=EPUB container=] for non-rendering purposes).</p>
-						<p>If [=EPUB creators=] do not set this property, acknowledging the resources are include by
-							design, reading systems and [=EPUB validators=] may flag the resources as unused if they
-							cannot find references to them.</p>
+						<p>If [=EPUB creators=] do not set this property, acknowledging the resources are
+							include by design, reading systems and [=EPUB conformance checkers=] may flag the
+							resources as unused if they cannot find references to them.</p>
 					</td>
 				</tr>
 				<tr>

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -55,7 +55,7 @@
 							is an [=exempt resource=] (e.g., is used as script input or is included in the
 							[=EPUB container=] for non-rendering purposes).</p>
 						<p>If [=EPUB creators=] do not set this property, acknowledging the resources are
-							include by design, reading systems and [=EPUB conformance checkers=] may flag the
+							included by design, reading systems and [=EPUB conformance checkers=] may flag the
 							resources as unused if they cannot find references to them.</p>
 					</td>
 				</tr>

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -37,6 +37,43 @@
 		</table>
 	</section>
 	
+	<section id="sec-exempt">
+		<h4>data</h4>
+		
+		<table class="tabledef" id="exempt">
+			<tbody>
+				<tr>
+					<th>Name:</th>
+					<td>
+						<code>exempt</code>
+					</td>
+				</tr>
+				<tr>
+					<th>Description:</th>
+					<td>
+						<p>The <code>exempt</code> property indicates that the [=publication resource=]
+							is an [=exempt resource=] (e.g., is used as script input or is included in the
+							[=EPUB container=] for non-rendering purposes).</p>
+						<p>If [=EPUB creators=] do not set this property, acknowledging the resources are include by
+							design, reading systems and [=EPUB validators=] may flag the resources as unused if they
+							cannot find references to them.</p>
+					</td>
+				</tr>
+				<tr>
+					<th>Applies to:</th>
+					<td>All publication resources that meet the <a href="#confreq-foreign-no-fallback">exempt
+						resources condition</a> that allows unreferenced resources.</td>
+				</tr>
+				<tr>
+					<th>Cardinality:</th>
+					<td>
+						<code>Zero or more</code>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
+	
 	<section id="sec-mathml">
 		<h4>mathml</h4>
 		


### PR DESCRIPTION
With 3.3, we now allow resources in the container, and listed in the manifest, that may or may not be used in rendering the publication. These are defined at the end of the [exempt resources ](https://www.w3.org/TR/epub-33/#sec-exempt-resources) section - to allow data sets, etc. to travel with an EPUB.

A problem raised in https://github.com/w3c/epubcheck/issues/1452, however, is that epubcheck has for a long time reported unused resources in the container because it's been an issue with vendors rejecting publications with these.

There's no way of determining whether a resource is unused or was intentionally meant to travel in the container when a reading system or validator cannot find a reference to it in content documents, so if we don't do anything then exempt resources will result in warnings that they appear unused.

This PR represents one option to solve this problem, which is to add a new manifest item `properties` value for tagging exempt resources. This would clarify that the author intended them to be included. Since no one has yet been able to use this feature, adding this requirement is not problematic from an existing content perspective.

I'm opening this now, but I don't know we'll be able to resolve this until people are back in the new year. It's open for discussion by anyone who desperately needs an epub fix over the next couple of weeks! 😉


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2507.html" title="Last updated on Dec 17, 2022, 1:25 AM UTC (fa2b580)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2507/27599ee...fa2b580.html" title="Last updated on Dec 17, 2022, 1:25 AM UTC (fa2b580)">Diff</a>