### PR TITLE
Clarify why manifest does not reference the package document

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4790,12 +4790,13 @@ XHTML:
 					</dl>
 
 					<p id="confreq-rendition-manifest">With the exception of the [=package document=], the
-							<code>manifest</code> MUST list all publication resources, regardless of whether they are
+							<code>manifest</code> MUST list all publication resources regardless of whether they are
 						[=container resources=] or [=remote resources=].</p>
 
-					<p>As the package document is identifed by the <a href="#sec-container-metainf-container.xml"
-								><code>container.xml</code> file</a>, the <code>manifest</code> MUST NOT specify an
-							<code>item</code> element for it (i.e., a self-reference serves no purpose).</p>
+					<p>As the package document is already identified by the <a
+							href="#sec-container-metainf-container.xml"><code>container.xml</code> file</a>, the
+							<code>manifest</code> MUST NOT specify an <code>item</code> element for it (i.e., a
+						self-reference serves no purpose).</p>
 
 					<div class="note">
 						<p>The manifest is only for listing publication resources. [=Linked resources=] and <a

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4789,12 +4789,13 @@ XHTML:
 						</dd>
 					</dl>
 
-					<p id="confreq-rendition-manifest">[=EPUB creators=] MUST list all publication resources in the
-							<code>manifest</code>, regardless of whether they are [=container resources=] or [=remote
-						resources=].</p>
+					<p id="confreq-rendition-manifest">With the exception of the [=package document=], the
+							<code>manifest</code> MUST list all publication resources, regardless of whether they are
+						[=container resources=] or [=remote resources=].</p>
 
-					<p>Note that the <code>manifest</code> is not self-referencing: EPUB creators MUST NOT specify an
-							<code>item</code> element that refers to the [=package document=] itself.</p>
+					<p>As the package document is identifed by the <a href="#sec-container-metainf-container.xml"
+								><code>container.xml</code> file</a>, the <code>manifest</code> MUST NOT specify an
+							<code>item</code> element for it (i.e., a self-reference serves no purpose).</p>
 
 					<div class="note">
 						<p>The manifest is only for listing publication resources. [=Linked resources=] and <a


### PR DESCRIPTION
The text that the manifest is not self-referencing as justification for not including the package document in the manifest is a bit confusing. For one, it's the package document that is not self-referencing; the manifest is not actually referencing itself. But it also doesn't say why a self-reference is pointless - the container.xml file already provides the entry for finding the package document.

This PR makes some minor editorial changes to better explain the restriction.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2509.html" title="Last updated on Jan 3, 2023, 3:30 PM UTC (f8f31ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2509/b33a702...f8f31ef.html" title="Last updated on Jan 3, 2023, 3:30 PM UTC (f8f31ef)">Diff</a>