### PR TITLE
Mention that roles are not allowed on html body

### DIFF
--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -104,8 +104,7 @@
 			
 			.subproplabel {
 				font-style: italic;
-			}
-		</style>
+			}</style>
 	</head>
 	<body>
 		<section id="abstract">
@@ -147,11 +146,11 @@
 					listed, but must ensure that the semantics they express represent a subset of the carrying element's
 					semantics and do not attach an existing element's meaning to a semantically neutral element.</p>
 
-				<p>The <i>DPUB-ARIA role</i> fields indicate the [[dpub-aria-1.0]] roles that can alternatively be used
-					with the [[html]] <code>role</code> attribute to improve accessibility. These roles may have more
-					restrictive usage contexts, however, so may not be valid wherever the [^/epub:type^] attribute
-					[[epub-33]] is used. Refer to [[html-aria]] for more information about where the roles are
-					allowed.</p>
+				<p data-cite="html">The <i>DPUB-ARIA role</i> fields indicate the [[dpub-aria-1.0]] roles that can
+					alternatively be used with the [[html]] <code>role</code> attribute to improve accessibility. These
+					roles may have more restrictive usage contexts, however, so may not be valid wherever the
+					[^/epub:type^] attribute [[epub-33]] is used (e.g., roles are not allowed on the [[?html]] [^body^]
+					element). Refer to [[html-aria]] for more information about where the roles are allowed.</p>
 
 				<p>When processing HTML documents, reading systems may ignore such non-compliant properties, unless
 					their usage context is explicitly overridden or extended by the host specification.</p>


### PR DESCRIPTION
This PR adds an extra bit of clarity about one of the big differences between SSV term usage and role usage.

I don't think we decided to republish the document about transitioning from using epub types to aria roles after converting it to respec format: https://w3c.github.io/epub-specs/epub33/epub-aria-authoring/

We could add a reference to that document, too, if we publish it. (There's also an old branch of editorial cleanup on it that could finally be merged.)