### PR TITLE
Remove the precedence and processing requirements for linked records

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -4694,18 +4694,10 @@ XHTML:
 					</aside>
 
 					<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB creators MAY provide one or more <a
-							href="#record">linked metadata records</a> to enhance the information available to reading
-						systems, but reading systems may ignore these records.</p>
+							href="#record">linked metadata records</a>.</p>
 
-					<p id="sec-linked-records-priority"
-						data-tests="#pkg-linked-records_link-priority,#pkg-linked-records_link-order">When a reading
-						system <a data-cite="epub-rs-33#sec-linked-records">processes linked records</a> [[epub-rs-33]],
-						the document order of <code>link</code> elements is used to determine which has the highest
-						priority in the case of conflicts (i.e., first in document order has the highest priority).</p>
-
-					<aside class="example" title="Specifying metadata precedence">
-						<p>In this example, the first remote record has the highest precedence, the local record has the
-							next highest, and the metadata in the <code>metadata</code> element the lowest.</p>
+					<aside class="example" title="Specifying linked records">
+						<p>In this example, linked ONIX and JSON-LD records are included in the EPUB container.</p>
 
 						<pre>&lt;metadata …>
    &lt;link rel="record"
@@ -4716,10 +4708,6 @@ XHTML:
    &lt;link rel="record"
        href="meta/meta.jsonld"
        media-type="application/ld+json" />
-    
-    &lt;dc:title>The Sound and The Fury&lt;/dc:title>
-    &lt;dc:identifier>urn:isbn:9780101010101&lt;/dc:identifier>
-    &lt;dc:language>en-us&lt;/dc:language>
     …
 &lt;/metadata></pre>
 					</aside>
@@ -11789,6 +11777,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>05-Jan-2023: Removed the precedence rules for linked records as reading systems do not support
+						their processing. See <a href="https://github.com/w3c/epub-specs/pull/2512">pull request
+							2512</a>.</li>
 					<li>16-Dec-2022: Clarified that the special files for processing the OCF container are not listed in
 						the manifest, so the restriction that the manifest only list publication resources is not
 						needed. See <a href="https://github.com/w3c/epub-specs/pull/2506">pull request 2506</a>.</li>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -862,21 +862,6 @@
 							purely advisory. The language information expressed in the resource determines its language
 							for processing and rendering purposes, as defined in the <a
 								href="#confreq-rs-pkg-lang-no-content">internationalization requirements</a>.</p>
-						<p id="sec-linked-records" data-tests="#pkg-linked-records">In the case of a <a
-								data-cite="epub-33#record">linked metadata record</a> [[epub-33]], reading systems MUST
-							NOT skip processing the metadata expressed in the package document (i.e., use only the
-							information expressed in the record). Reading systems MAY compile metadata from multiple
-							linked records.</p>
-						<p id="confreq-rs-pkg-link-order"
-							data-tests="#pkg-linked-records_link-priority,#pkg-linked-records_link-order">When resolving
-							discrepancies and conflicts between metadata expressed in the package document and in linked
-							metadata records, reading systems MUST use the document order of <span data-cite="epub-33"
-								>[^link^]</span> elements [[epub-33]] in the package document to establish precedence
-							(i.e., metadata in the first linked record has the highest precedence and metadata in the
-							package document the lowest, regardless of whether the <code>link</code> elements occur
-							before, within, or after the package metadata elements).</p>
-						<p id="confreq-rs-pkg-link-rendering">Reading systems MUST ignore any instructions contained in
-							linked resources related to the layout and rendering of the EPUB publication.</p>
 					</dd>
 				</dl>
 			</section>
@@ -2712,6 +2697,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>05-Jan-2023: Removed the processing requirements for linked records. See <a
+							href="https://github.com/w3c/epub-specs/pull/2512">pull request 2512</a>.</li>
 					<li>11-Nov-2022: Added requirement to replace unsupported non-text elements with their text
 						alternatives when generating non-HTML navigation widgets. See <a
 							href="https://github.com/w3c/epub-specs/issues/2477">issue 2477</a>.</li>


### PR DESCRIPTION
As discussed on the 2023-01-05 telecon, this PR removes the precedence rules and processing requirements for linked records.

These rules were added in EPUB 3.1 when there was an expectation that there might be linked browser-friendly json records in the container that reading systems could harvest additional information from. The test results have proven that without that format materializing, support for bibliographic records has not taken off, leaving the precedence and processing rules an unnecessary complexity. This change moves the specification back to its original purpose of allowing linked records for use, for example, with library systems.

* [Preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/remove-linked-rec-proc/epub33/rs/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/remove-linked-rec-proc/epub33/rs/index.html)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2512.html" title="Last updated on Jan 9, 2023, 5:16 PM UTC (d427778)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2512/a0cb14e...d427778.html" title="Last updated on Jan 9, 2023, 5:16 PM UTC (d427778)">Diff</a>