### PR TITLE
Change requirement to use alternative text in nav doc labels to a recommendation

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1422,7 +1422,7 @@
 							data-cite="epub-33#sec-nav-toc"><code>toc nav</code> element</a> [[epub-33]].</p>
 				</li>
 				<li>
-					<p id="confreq-nav-alt-text" data-tests="#nav-non-text_img,#nav-non-text_img_title">MUST, when
+					<p id="confreq-nav-alt-text" data-tests="#nav-non-text_img,#nav-non-text_img_title">SHOULD, when
 						generating non-HTML based navigation widgets, replace unsupported non-text elements in headings
 						and labels with their <a data-cite="epub-33#confreq-nav-a-cnt">alternative text</a> [[epub-33]].
 						If both <code>alt</code> and <code>title</code> attributes are present on an element, preference
@@ -2712,6 +2712,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>06-Jan-2023: Reduced the requirement to use alternative text for non-text elements in the
+						navigation document to a recommendation due to the lack of support for both. See <a
+							href="https://github.com/w3c/epub-specs/pull/2513">pull request 2513</a>.</li>
 					<li>11-Nov-2022: Added requirement to replace unsupported non-text elements with their text
 						alternatives when generating non-HTML navigation widgets. See <a
 							href="https://github.com/w3c/epub-specs/issues/2477">issue 2477</a>.</li>


### PR DESCRIPTION
As discussed on the 2023-01-05 telecon, this pull request changes the requirement to a recommendation due to the lack of support both for images and fallback alternative text in navigation document labels and headings.

I forgot that we added a caution box to the authoring specification about the lack of support, so we don't need to do anything more to warn authors about the usability issues non-text content can cause.

From an accessibility perspective, there are other problems with non-text content that the specification doesn't solve, so avoiding the content is probably the best solution (i.e., the alt text is not required to be presented if the non-text content is supported, which disadvantages non-sighted readers). Not presenting alt text when non-text content isn't supported disadvantages everyone equally.

* [Preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/toc-img/epub33/rs/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/toc-img/epub33/rs/index.html)
