### PR TITLE
Reduce the requirement to support prefixed css properties

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1201,8 +1201,8 @@
 					<li>
 						<p id="confreq-css-rs-prefixed"
 							data-tests="#css-epub-hyphens, #css-epub-line-break, #css-epub-text-align-last, #css-epub-text-combine-horizontal, #css-epub-text-emphasis, #css-epub-text-orientation, #css-epub-text-transform, #css-epub-text-underline-position, #css-epub-word-break, #css-epub-writing-mode"
-							>MUST support all prefixed properties defined in <a data-cite="epub-33#sec-css-prefixed">CSS
-								Style Sheets — Prefixed properties</a> [[epub-33]].</p>
+							>SHOULD support all prefixed properties defined in <a data-cite="epub-33#sec-css-prefixed"
+								>CSS Style Sheets — Prefixed properties</a> [[epub-33]].</p>
 					</li>
 					<li>
 						<p id="confreq-css-creator-styles">SHOULD apply [=EPUB creator=] style sheets as written to
@@ -2712,6 +2712,8 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>06-Jan-2023: Reduced the requirement to support prefixed CSS properties to a recommendation. See
+							<a href="https://github.com/w3c/epub-specs/pull/2514">pull request 2514</a>.</li>
 					<li>11-Nov-2022: Added requirement to replace unsupported non-text elements with their text
 						alternatives when generating non-HTML navigation widgets. See <a
 							href="https://github.com/w3c/epub-specs/issues/2477">issue 2477</a>.</li>


### PR DESCRIPTION
I'm not sure if this exactly matches what we resolved on the 2023-01-05 telecon, but throwing it out for consideration.

We mentioned how the need for these prefixed properties has passed, and authors should be using the regular css versions now, so does it make sense to drop the requirement for reading systems to support them to a recommendation? Developers of new reading systems will still have to consider that there is content out there that uses the prefixed properties, but why compel everyone to support properties if we know they're becoming obsolete?

In that vein, this pull request drops the support requirement to a recommendation, but I'm open to alternative approaches if that's going to far.

* [Preview](https://cdn.statically.io/gh/w3c/epub-specs/fix/prefixed-css/epub33/rs/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/fix/prefixed-css/epub33/rs/index.html)
