### PR TITLE
Mark the rtl dir value under-implemented

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3217,7 +3217,8 @@
 
 					<ul>
 						<li><code>ltr</code> &#8212; left-to-right base direction;</li>
-						<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
+						<li><code>rtl</code> &#8212; right-to-left base direction (<a href="#under-implemented"
+								>under-implemented</a>); and</li>
 						<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi Algorithm
 							[[bidi]].</li>
 					</ul>
@@ -11789,6 +11790,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>06-Jan-2023: Marked the <code>rtl</code> value of the <code>dir</code> attribute
+						under-implemented due to lack of support in reading systems. See <a
+							href="https://github.com/w3c/epub-specs/pull/2515">pull request 2515</a>.</li>
 					<li>16-Dec-2022: Clarified that the special files for processing the OCF container are not listed in
 						the manifest, so the restriction that the manifest only list publication resources is not
 						needed. See <a href="https://github.com/w3c/epub-specs/pull/2506">pull request 2506</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3206,7 +3206,15 @@
 					elements).</p>
 
 				<section id="attrdef-dir">
-					<h4>The <code>dir</code> attribute</h4>
+					<h4>The <code>dir</code> attribute (under-implemented)</h4>
+
+					<div class="note">
+						<p>The <code>dir</code> attribute is marked <a href="#under-implemented">under-implemented</a>
+							as [=reading systems=] often only support a single default directionality for text display.
+							[=EPUB creators=] are still strongly encouraged to set the proper directionality of text
+							values in the [=package document=] to ensure proper rendering once this situation
+							improves.</p>
+					</div>
 
 					<p
 						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
@@ -3217,14 +3225,13 @@
 
 					<ul>
 						<li><code>ltr</code> &#8212; left-to-right base direction;</li>
-						<li><code>rtl</code> &#8212; right-to-left base direction (<a href="#under-implemented"
-								>under-implemented</a>); and</li>
+						<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
 						<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi Algorithm
 							[[bidi]].</li>
 					</ul>
 
-					<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">[=Reading systems=] will assume the
-						value <code>auto</code> when [=EPUB creators=] omit the attribute or use an invalid value.</p>
+					<p data-tests="#pkg-dir-auto_root-rtl,#pkg-dir-auto_root-unset">Reading systems will assume the
+						value <code>auto</code> when EPUB creators omit the attribute or use an invalid value.</p>
 
 					<div class="note">
 						<p>The base direction specified in the <code>dir</code> attribute does not affect the ordering
@@ -11790,9 +11797,9 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
-					<li>06-Jan-2023: Marked the <code>rtl</code> value of the <code>dir</code> attribute
-						under-implemented due to lack of support in reading systems. See <a
-							href="https://github.com/w3c/epub-specs/pull/2515">pull request 2515</a>.</li>
+					<li>11-Jan-2023: Marked the <code>dir</code> attribute under-implemented due to lack of support in
+						reading systems. See <a href="https://github.com/w3c/epub-specs/pull/2515">pull request
+						2515</a>.</li>
 					<li>16-Dec-2022: Clarified that the special files for processing the OCF container are not listed in
 						the manifest, so the restriction that the manifest only list publication resources is not
 						needed. See <a href="https://github.com/w3c/epub-specs/pull/2506">pull request 2506</a>.</li>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11788,9 +11788,6 @@ EPUB/images/cover.png</pre>
 					<li>11-Jan-2023: Marked the <code>dir</code> attribute under-implemented due to lack of support in
 						reading systems. See <a href="https://github.com/w3c/epub-specs/pull/2515">pull request
 						2515</a>.</li>
-					<li>09-Jan-2023: Marked the <code>rtl</code> value of the <code>dir</code> attribute
-						under-implemented due to lack of support in reading systems. See <a
-							href="https://github.com/w3c/epub-specs/pull/2515">pull request 2515</a>.</li>
 					<li>09-Jan-2023: Fixed incorrect OPUS media type. See <a
 							href="https://github.com/w3c/epub-specs/issues/2516">issue 2516</a>.</li>
 					<li>05-Jan-2023: Removed the precedence rules for linked records as reading systems do not support

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -777,6 +777,16 @@
 					the base direction is <code>auto</code>, in which case reading systems MUST determine the text's
 					direction by applying the Unicode Bidi Algorithm, beginning with <a data-cite="bidi#P2">Rule P2</a>
 					of [[bidi]].</p>
+
+				<div class="note">
+					<p>Although <a data-cite="epub-33#attrdef-dir">setting the directionality of package document
+							metadata</a> is marked as <a data-cite="epub-33#under-implemented">under-implemented</a> in
+						[[epub-33]], reading system with an international audience, or that claim support for
+						international content, are strongly advised to implement this feature when exposing that
+						metadata to users. Ignoring the directionality of text can cause readability issues.</p>
+					<p>The under-implemented label will be removed from [[epub-33]] when the necessary baseline of
+						support in reading systems has been achieved.</p>
+				</div>
 			</section>
 
 			<section id="sec-pkg-doc-pub-identifiers">
@@ -2502,18 +2512,8 @@
 		<section id="app-unsupported" class="appendix">
 			<h2>Unsupported features</h2>
 
-			<p>For features marked as unsupported, [=reading systems=]:</p>
-
-			<ul class="conformance-list">
-				<li>
-					<p id="confreq-rs-under-implemented">SHOULD support <a data-cite="epub-33#under-implemented"
-							>under-implemented features</a> [[epub-33]] as described.</p>
-				</li>
-				<li>
-					<p id="confreq-rs-deprecated">MAY support <a data-cite="epub-33#deprecated">deprecated features</a>
-						[[epub-33]].</p>
-				</li>
-			</ul>
+			<p id="confreq-rs-deprecated">[=reading systems=] MAY support <a data-cite="epub-33#deprecated">deprecated
+					features</a> [[epub-33]].</p>
 
 			<div class="note">
 				<p>Developers should consider the unlikelihood of encountering content with deprecated features before
@@ -2712,6 +2712,11 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>11-Jan-2023: Added note advising reading system developers to support package metadata
+						directionality even though marked as under-implemented for authoring. See <a
+							href="https://github.com/w3c/epub-specs/pull/2515">pull request 2515</a>.</li>
+					<li>11-Jan-2023: Removed support description for under-implemented features. See <a
+							href="https://github.com/w3c/epub-specs/pull/2515">pull request 2515</a>.</li>
 					<li>11-Nov-2022: Added requirement to replace unsupported non-text elements with their text
 						alternatives when generating non-HTML navigation widgets. See <a
 							href="https://github.com/w3c/epub-specs/issues/2477">issue 2477</a>.</li>


### PR DESCRIPTION
As discussed on the 2023-01-05 telecon, there are support gaps for the `dir` attribute in the package document. Looking at the tests, these failures appear to all be centred around support for the `rtl` value.

Consequently, rather than mark the whole attribute under-implemented, this PR only adds the label to the `rtl` value. This is in keeping with how the `portrait` value for `rendition:spread` is deprecated.

If I've misread the test results and we need to consider a whole-attribute labelling, please feel free to say so, though.

And as this looks like it could be the only under-implemented feature we'll have, and we want reading systems to support it moving forward, it doesn't make sense to me to label it in the Reading Systems specification. It seems to undermine the goal of getting support improved. Can we limit ourselves only to warning authors? And, similarly, can we remove the text in the RS appendix about not having to support under-implemented features?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2515.html" title="Last updated on Jan 11, 2023, 1:25 PM UTC (0ff1bd6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2515/6293601...0ff1bd6.html" title="Last updated on Jan 11, 2023, 1:25 PM UTC (0ff1bd6)">Diff</a>