### PR TITLE
Fix OPUS media type

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1012,7 +1012,7 @@
 						</tr>
 						<tr>
 							<td id="cmt-ogg-opus" data-tests="#pub-cmt-opus">
-								<code>audio/opus</code>
+								<code>audio/ogg; codecs=opus</code>
 							</td>
 							<td> [[rfc7845]] </td>
 							<td>OPUS audio using OGG container</td>
@@ -11789,6 +11789,8 @@ EPUB/images/cover.png</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>09-Jan-2023: Fixed incorrect OPUS media type. See <a
+							href="https://github.com/w3c/epub-specs/issues/2516">issue 2516</a>.</li>
 					<li>16-Dec-2022: Clarified that the special files for processing the OCF container are not listed in
 						the manifest, so the restriction that the manifest only list publication resources is not
 						needed. See <a href="https://github.com/w3c/epub-specs/pull/2506">pull request 2506</a>.</li>


### PR DESCRIPTION
Switches "audio/opus" in the CMT table to "audio/ogg; codecs=opus" as described in #2516 

Fixes #2516


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2517.html" title="Last updated on Jan 9, 2023, 1:20 PM UTC (7c36f6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2517/27252e9...7c36f6d.html" title="Last updated on Jan 9, 2023, 1:20 PM UTC (7c36f6d)">Diff</a>