### PR TITLE
Removing unnecessary test reference

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7082,7 +7082,7 @@ No Entry</pre>
 							</dd>
 						</dl>
 
-						<p id="fxl-orientation-duplication" data-tests="#lay-fxl-orientation-duplication">EPUB creators
+						<p id="fxl-orientation-duplication">EPUB creators
 							MUST NOT declare the <code>rendition:orientation</code> property more than once.</p>
 
 						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"


### PR DESCRIPTION
This is the counterpart of https://github.com/w3c/epub-tests/pull/280


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2519.html" title="Last updated on Jan 12, 2023, 4:33 PM UTC (237e9b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2519/99d2e65...237e9b6.html" title="Last updated on Jan 12, 2023, 4:33 PM UTC (237e9b6)">Diff</a>