### PR TITLE
Generated the structural test references

### DIFF
--- a/epub33/common/css/common.css
+++ b/epub33/common/css/common.css
@@ -321,3 +321,9 @@ details.explanation > summary, details.desc > summary {
     font-weight: normal !important;
     font-style: italic;
 }
+
+/* Give a slightly different aspect to epubcheck test references */
+a.epubcheck {
+    background-color: antiquewhite ;
+}
+

--- a/epub33/common/js/data-test-display.js
+++ b/epub33/common/js/data-test-display.js
@@ -1,8 +1,40 @@
 function data_test_display() {
+    // 1. step: modify the test references to display only the test name, rather than the full URL
     const test_references = document.querySelectorAll('details.respec-tests-details a');
     for( const a of test_references ) {
         const href = a.href;
+        // This is a bit of a hack, and fragile at that...
         const test_reference = href.split('#')[1];
+        // if the string contains a '.feature' then this is an epubcheck test reference
+        if (test_reference.match(".feature")) {
+            // give a separate class name to these references if we want to give them a distinctive look
+            a.className = 'epubcheck';
+        } 
         a.textContent = test_reference;
-    }    
+    }
+    
+    // 2. step: find the sections that have tests associated to them (those are usually epubcheck tests). 
+    // The child details element must be moved ahead (respec puts these at the very end of the section element)
+    // right after the header of the section
+    const epubcheck_references = document.querySelectorAll('section[data-epubcheck="true"]');
+    for (const section of epubcheck_references) {
+        // There may be several 'details' elements in the section; we have to locate the one that
+        // has been "attached" to the section element proper. That is the one that has to be moved.
+        const all_details = section.querySelectorAll('details.respec-tests-details');
+        let details = null;
+        for (const d of all_details){
+            if (section.isEqualNode(d.parentNode)) {
+                details = d;
+                break;
+            }
+        }
+        if(details !== null) {
+            // The header is wrapped into a 'div' element with class 'header-wrapper'. The test reports should come
+            // right after this, so we have to find it:
+            const div_hx = section.querySelector('div.header-wrapper');
+            
+            // Move the details element ahead, right after the section header
+            section.insertBefore(details, div_hx.nextSibling);
+        }
+    }
 }

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1,7 +1,5 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-	<head>
-		<meta charset="utf-8" />
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US"><head>
+		<meta charset="utf-8">
 		<title>EPUB 3.3</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="./biblio.js" class="remove"></script>
@@ -124,8 +122,7 @@
 
 				<p>An EPUB publication is, in its most basic sense, a bundle of resources with instructions on how to
 					render those resources to present the content in a logical order. The types of resources that are
-					allowed in EPUB publication, as well as restrictions on their use, are defined in <a
-						href="#sec-publication-resources"></a>.</p>
+					allowed in EPUB publication, as well as restrictions on their use, are defined in <a href="#sec-publication-resources"></a>.</p>
 
 				<p>A ZIP-based archive with the file extension <code>.epub</code> bundles the EPUB publication's
 					resources for distribution. As conformant ZIP archives, EPUB publications can be unzipped by many
@@ -145,8 +142,8 @@
 					through the content. Refer to <a href="#sec-package-doc"></a> for the requirements for the package
 					document.</p>
 
-				<p>The actual content of an EPUB publication &#8212; what users are presented with when they begin
-					reading &#8212; is built on the Open Web Platform and comes in two flavors: XHTML and SVG. Called
+				<p>The actual content of an EPUB publication — what users are presented with when they begin
+					reading — is built on the Open Web Platform and comes in two flavors: XHTML and SVG. Called
 					[=EPUB content documents=], these documents typically reference many additional resources required
 					for their proper rendering, such as images, audio and video clips, scripts, and style sheets.</p>
 
@@ -157,13 +154,11 @@
 					document provides critical navigation capabilities, such as the table of contents, that allow users
 					to navigate the content quickly and easily. The navigation document is a specialized type of [=XHTML
 					content document=] which also allows EPUB creators to use it in the content (i.e., avoiding one
-					table of contents for machine processing and another for user consumption). Refer to <a
-						href="#sec-nav"></a> for more information about this document.</p>
+					table of contents for machine processing and another for user consumption). Refer to <a href="#sec-nav"></a> for more information about this document.</p>
 
 				<p>EPUB publications by default are intended to reflow to fit the available screen space. It is also
 					possible to create publications that have pixel-precise fixed layouts using images and/or CSS
-					positioning. The metadata to control layouts are defined in <a href="#sec-rendering-control"
-					></a>.</p>
+					positioning. The metadata to control layouts are defined in <a href="#sec-rendering-control"></a>.</p>
 
 				<p>[=Media overlay documents=] complement EPUB content documents. They provide declarative markup for
 					synchronizing the text in EPUB content documents with prerecorded audio. The result is the ability
@@ -199,7 +194,7 @@
 				<section id="sec-overview-relations-html">
 					<h4>Relationship to HTML</h4>
 
-					<p>The [[html]] standard is continuously evolving &#8212; there are no longer versioned releases of
+					<p>The [[html]] standard is continuously evolving — there are no longer versioned releases of
 						it. That standard, in turn, references various technologies that continue to evolve, such as
 						MathML, SVG, CSS, and JavaScript.</p>
 
@@ -240,8 +235,7 @@
 
 					<p>EPUB 3 only supports <a href="https://www.w3.org/TR/MathML3/chapter3.html">Presentation
 							Markup</a> [[mathml3]]. <a href="https://www.w3.org/TR/MathML3/chapter4.html">Content
-							Markup</a> is only allowed in <a
-							href="https://www.w3.org/TR/MathML3/chapter5.html#mixing.elements.annotation.xml">structured
+							Markup</a> is only allowed in <a href="https://www.w3.org/TR/MathML3/chapter5.html#mixing.elements.annotation.xml">structured
 							markup annotations</a>.</p>
 				</section>
 
@@ -298,17 +292,15 @@
 						<dfn class="export">container root URL</dfn>
 					</dt>
 					<dd>
-						<p>The [=URL=] [[url]] of the [=root directory=] representing the [=OCF abstract container=]. It
-							is implementation specific, but EPUB creators must assume it has properties defined in <a
-								href="#sec-container-iri"></a>.</p>
+						<p>The [=URL=]&nbsp;[[url]] of the [=root directory=] representing the [=OCF abstract container=]. It
+							is implementation specific, but EPUB creators must assume it has properties defined in <a href="#sec-container-iri"></a>.</p>
 					</dd>
 
 					<dt>
 						<dfn class="export">content URL</dfn>
 					</dt>
 					<dd>
-						<p> The [=URL=] of a file or directory in the [=OCF abstract container=], defined in <a
-								href="#sec-container-iri"></a>. </p>
+						<p> The [=URL=] of a file or directory in the [=OCF abstract container=], defined in <a href="#sec-container-iri"></a>. </p>
 					</dd>
 
 					<dt>
@@ -338,8 +330,7 @@
 						<dfn class="export">OCF ZIP container</dfn>
 					</dt>
 					<dd>
-						<p>The ZIP-based packaging and distribution format for [=EPUB publications=] defined in <a
-								href="#sec-container-zip"></a>.</p>
+						<p>The ZIP-based packaging and distribution format for [=EPUB publications=] defined in <a href="#sec-container-zip"></a>.</p>
 						<p>EPUB container and OCF ZIP container are synonymous.</p>
 					</dd>
 
@@ -352,8 +343,7 @@
 							document=] definitions.</p>
 						<p>EPUB content documents contain all or part of the content of an [=EPUB publication=] (i.e.,
 							the textual, visual and/or audio content).</p>
-						<p>[=EPUB creators=] can include EPUB content documents in the spine without the provision of <a
-								href="#sec-foreign-resources">fallbacks</a>.</p>
+						<p>[=EPUB creators=] can include EPUB content documents in the spine without the provision of <a href="#sec-foreign-resources">fallbacks</a>.</p>
 					</dd>
 
 					<dt>
@@ -370,8 +360,7 @@
 								part of a publication pipeline). As a result, not every party or process may be
 								responsible for ensuring every requirement is met, but there is always an EPUB creator
 								responsible for the conformance of the final EPUB publication. </p>
-							<p>Previous versions of this specification referred to the EPUB creator as the <span
-									id="dfn-author">Author</span>.</p>
+							<p>Previous versions of this specification referred to the EPUB creator as the <span id="dfn-author">Author</span>.</p>
 						</div>
 					</dd>
 
@@ -395,14 +384,12 @@
 						<dfn class="export">EPUB publication</dfn>
 					</dt>
 					<dd>
-						<p>A logical document entity consisting of a set of interrelated <a
-								data-lt="publication resource">resources</a> packaged in an [=EPUB container=].</p>
+						<p>A logical document entity consisting of a set of interrelated <a data-lt="publication resource">resources</a> packaged in an [=EPUB container=].</p>
 						<p>An EPUB publication typically represents a single intellectual or artistic work, but this
 							specification does not restrict the nature of the content.</p>
 					</dd>
 
-					<dt><dfn class="export"
-							data-lt="EPUB reading system|EPUB reading systems|reading system|reading systems">EPUB
+					<dt><dfn class="export" data-lt="EPUB reading system|EPUB reading systems|reading system|reading systems">EPUB
 							reading system</dfn> (or reading system)</dt>
 					<dd>
 						<p>A system that processes [=EPUB publications=] for presentation to a user in a manner
@@ -423,8 +410,7 @@
 					</dt>
 					<dd>
 						<p>Exempt resources are a special class of [=publication resources=] that reading systems are
-							not required to support the rendering of, but [=EPUB creators=] do not have to provide <a
-								href="#sec-foreign-resources">fallbacks</a> for.</p>
+							not required to support the rendering of, but [=EPUB creators=] do not have to provide <a href="#sec-foreign-resources">fallbacks</a> for.</p>
 						<p>Refer to <a href="#sec-exempt-resources"></a> for more information.</p>
 					</dd>
 
@@ -499,8 +485,7 @@
 					</dt>
 					<dd>
 						<p>An XML document that associates the [=XHTML content document=] with pre-recorded audio
-							narration to provide a synchronized playback experience, as defined in <a
-								href="#sec-media-overlays"></a>.</p>
+							narration to provide a synchronized playback experience, as defined in <a href="#sec-media-overlays"></a>.</p>
 					</dd>
 
 					<dt>
@@ -547,7 +532,7 @@
 							<p>Resources on the web identified in outbound hyperlinks (e.g., referenced from the
 									<code>href</code> attribute of an [[html]] [^a^] element) are not publication
 								resources.</p>
-							<p><a href="#sec-data-urls">Data urls</a> are also not publication resources &#8212; they
+							<p><a href="#sec-data-urls">Data urls</a> are also not publication resources — they
 								are considered part of the resource they are embedded in.</p>
 						</div>
 					</dd>
@@ -585,8 +570,7 @@
 						<dfn class="export">SVG content document</dfn>
 					</dt>
 					<dd>
-						<p>An [=EPUB content document=] that conforms to the constraints expressed in <a href="#sec-svg"
-							></a>.</p>
+						<p>An [=EPUB content document=] that conforms to the constraints expressed in <a href="#sec-svg"></a>.</p>
 					</dd>
 
 					<dt>
@@ -610,8 +594,7 @@
 					</dt>
 					<dd>
 						<p>The primary identifier for an [=EPUB publication=]. The unique identifier is the [=value=] of
-							the [^dc:identifier^] element specified by the <a href="#attrdef-package-unique-identifier"
-									><code>unique-identifier</code> attribute</a> in the [=package document=].</p>
+							the [^dc:identifier^] element specified by the <a href="#attrdef-package-unique-identifier"><code>unique-identifier</code> attribute</a> in the [=package document=].</p>
 						<p>Significant revision, abridgement, etc. of the content requires a new unique identifier.</p>
 					</dd>
 
@@ -627,8 +610,7 @@
 						<dfn class="export">XHTML content document</dfn>
 					</dt>
 					<dd>
-						<p>An [=EPUB content document=] that conforms to the profile of [[html]] defined in <a
-								href="#sec-xhtml"></a>.</p>
+						<p>An [=EPUB content document=] that conforms to the profile of [[html]] defined in <a href="#sec-xhtml"></a>.</p>
 						<p>XHTML content documents use the <a data-cite="html#the-xhtml-syntax">XML syntax</a> defined
 							in [[html]].</p>
 					</dd>
@@ -653,7 +635,7 @@
 					always having an explicit declaration (<code>xmlns:epub="http://www.idpf.org/2007/ops"</code>).</p>
 			</section>
 		</section>
-		<section id="sec-epub-conf">
+		<section id="sec-epub-conf" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#02-epub-publication-conformance_epub-publication-conformance.feature_L15,https://w3c.github.io/epub-structural-tests/#02-epub-publication-conformance_epub-publication-conformance.feature_L20,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L259">
 			<h2>EPUB publication conformance</h2>
 
 			<p>An [=EPUB publication=]:</p>
@@ -663,13 +645,11 @@
 					<p id="confreq-package">MUST define at least one rendering of its content as follows:</p>
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-package-doc">MUST contain a [=package document=] that conforms to <a
-									href="#sec-package-doc"></a> and meet all [=publication resource=] requirements for
+							<p id="confreq-package-doc">MUST contain a [=package document=] that conforms to <a href="#sec-package-doc"></a> and meet all [=publication resource=] requirements for
 								the package document.</p>
 						</li>
 						<li>
-							<p id="confreq-nav">MUST contain an [=EPUB navigation document=] that conforms to <a
-									href="#sec-nav"></a>.</p>
+							<p id="confreq-nav">MUST contain an [=EPUB navigation document=] that conforms to <a href="#sec-nav"></a>.</p>
 						</li>
 					</ul>
 				</li>
@@ -678,13 +658,11 @@
 						[[epub-a11y-11]].</p>
 				</li>
 				<li>
-					<p id="confreq-ocf">MUST be packaged in an [=EPUB container=] as defined in <a href="#sec-ocf"
-						></a>.</p>
+					<p id="confreq-ocf">MUST be packaged in an [=EPUB container=] as defined in <a href="#sec-ocf"></a>.</p>
 				</li>
 			</ul>
 
-			<p id="confreq-res-location">In addition, all publication resources MUST adhere to the requirements in <a
-					href="#sec-publication-resources"></a>.</p>
+			<p id="confreq-res-location">In addition, all publication resources MUST adhere to the requirements in <a href="#sec-publication-resources"></a>.</p>
 
 			<p>The rest of this specification covers specific conformance details.</p>
 
@@ -698,8 +676,7 @@
 				<p><a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> is the de facto EPUB conformance
 					checker used by the publishing industry and has been updated with each new version of EPUB. It is
 					integrated into a number of authoring tools and also available in alternative interfaces and other
-					languages (for more information, refer to its <a
-						href="https://www.w3.org/publishing/epubcheck/docs/apps-and-tools/">Apps and Tools
+					languages (for more information, refer to its <a href="https://www.w3.org/publishing/epubcheck/docs/apps-and-tools/">Apps and Tools
 					page</a>).</p>
 
 				<p>When verifying their EPUB publications, EPUB creators should ensure they do not violate the
@@ -740,11 +717,11 @@
 				<p>The three planes are:</p>
 
 				<ul>
-					<li>The [=manifest plane=] &#8212; The manifest plane holds all the resources of the EPUB
+					<li>The [=manifest plane=] — The manifest plane holds all the resources of the EPUB
 						publication (namely, publication resources and [=linked resources=]).</li>
-					<li>The [=spine plane=] &#8212; The spine plane holds only the resources used in rendering the spine
+					<li>The [=spine plane=] — The spine plane holds only the resources used in rendering the spine
 						(namely, EPUB content documents and [=foreign content documents=]).</li>
-					<li>The [=content plane=] &#8212; The content plane holds only the resources used in the rendering
+					<li>The [=content plane=] — The content plane holds only the resources used in the rendering
 						of EPUB and foreign content documents (namely, [=core media type resources=], [=foreign
 						resources=] and [=exempt resources=]).</li>
 				</ul>
@@ -810,8 +787,7 @@
 					<h4>The spine plane</h4>
 
 					<p>The <dfn class="export" data-lt-no-plural="">spine plane</dfn> defines resources used in the
-						default reading order established by the [=EPUB spine | spine=], which includes both <a
-							href="#attrdef-itemref-linear">linear and non-linear content</a>. The spine instructs
+						default reading order established by the [=EPUB spine | spine=], which includes both <a href="#attrdef-itemref-linear">linear and non-linear content</a>. The spine instructs
 						[=reading systems=] on how to load these resources as the user progresses through the [=EPUB
 						publication=]. Although many resources may be bundled in an [=EPUB container=], they are not all
 						allowed by default in the spine.</p>
@@ -828,8 +804,7 @@
 
 					<p>A mechanism called <a href="#sec-manifest-fallbacks">manifest fallbacks</a> allows EPUB creators
 						to provide fallbacks for foreign content documents. In this model, the [=EPUB manifest |
-						manifest=] entry for the foreign content document must include a <a
-							href="#attrdef-item-fallback"><code>fallback</code> attribute</a> that points to the next
+						manifest=] entry for the foreign content document must include a <a href="#attrdef-item-fallback"><code>fallback</code> attribute</a> that points to the next
 						possible resource for reading systems to try when they do not support its format. Although not
 						common, a fallback resource can specify another fallback, thereby making chains many resources
 						deep. The one requirement is that there must be at least one EPUB content document in a
@@ -881,13 +856,12 @@
 
 					<p>The preferred method is to use the fallback capabilities of the host format. Many HTML elements,
 						for example, have intrinsic fallback capabilities. One example is the [^picture^]
-						element [[html]], which allows [=EPUB creators=] to specify multiple alternative image
+						element&nbsp;[[html]], which allows [=EPUB creators=] to specify multiple alternative image
 						formats.</p>
 
 					<p>If an intrinsic fallback method is not available, it is also possible to use manifest fallbacks,
 						but this method, as <a href="#caution-fallbacks">cautioned against</a> in the previous section,
-						is discouraged. For more information about foreign resources, refer to <a
-							href="#sec-foreign-resources"></a>.</p>
+						is discouraged. For more information about foreign resources, refer to <a href="#sec-foreign-resources"></a>.</p>
 
 					<p>Falling between core media type resources and foreign resources are exempt resources. These are
 						most closely associated with foreign resources, as there is no guarantee that reading systems
@@ -895,8 +869,7 @@
 
 					<p>Exempt resources tend to address specific cases for which there are no core media types defined,
 						but for which providing a fallback would prove cumbersome or unnecessary. These include
-						embedding video, adding accessibility tracks, and linking to resources from the [[html]] <a
-							data-cite="html#the-link-element"><code>link</code></a> element.</p>
+						embedding video, adding accessibility tracks, and linking to resources from the [[html]] <a data-cite="html#the-link-element"><code>link</code></a> element.</p>
 
 					<p>Refer to <a href="#sec-exempt-resources"></a> for more information about these exceptions.</p>
 
@@ -1117,19 +1090,18 @@
 					<p>Inclusion as a core media type resource does not mean that all reading systems will support the
 						rendering of a resource. Reading system support also depends on the capabilities of the
 						application (e.g., a reading system with a [=viewport=] must support image core media type
-						resources, but a reading system without a viewport does not). Refer to <a
-							data-cite="epub-rs-33#sec-epub-rs-conf-cmt">Core media types</a> [[epub-rs-33]] for more
+						resources, but a reading system without a viewport does not). Refer to <a data-cite="epub-rs-33#sec-epub-rs-conf-cmt">Core media types</a> [[epub-rs-33]] for more
 						information about which reading systems rendering capabilities require support for which core
 						media type resources.</p>
 
 					<p>The Working Group typically only includes formats as core media type resources when they have
-						broad support in web browser cores &#8212; the rendering engines that EPUB 3 reading systems
+						broad support in web browser cores — the rendering engines that EPUB 3 reading systems
 						build upon. They are an agreement between reading system developers and EPUB creators to ensure
 						the predictability of rendering of EPUB publications.</p>
 				</div>
 			</section>
 
-			<section id="sec-foreign-resources">
+			<section id="sec-foreign-resources" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L95,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L100,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L106,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L112,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L117,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L123,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L129,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L134,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L140,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L184,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L189">
 				<h3>Foreign resources</h3>
 
 				<p>A [=foreign resource=], unlike a <a href="#sec-core-media-types">core media type resource</a> is one
@@ -1159,7 +1131,7 @@
 				</div>
 			</section>
 
-			<section id="sec-exempt-resources">
+			<section id="sec-exempt-resources" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L151,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L159,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L164,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L177,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L196,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L165">
 				<h3>Exempt resources</h3>
 
 				<p>An [=exempt resource=] shares properties with both [=foreign resources=] and [=core media type
@@ -1189,21 +1161,20 @@
 
 					<dt id="exempt-links">Linked resources</dt>
 					<dd id="confreq-resources-cd-fallback-link">
-						<p>Any resource referenced from the [[html]] <a data-cite="html#the-link-element"
-									><code>link</code></a> element that is not already a core media type resource (e.g.,
+						<p>Any resource referenced from the [[html]] <a data-cite="html#the-link-element"><code>link</code></a> element that is not already a core media type resource (e.g.,
 							CSS style sheets) is an exempt resource.</p>
 					</dd>
 
 					<dt id="exempt-track">Tracks</dt>
 					<dd id="confreq-resources-cd-fallback-track">
 						<p>All audio and video tracks (e.g., [[?webvtt]] captions, subtitles and descriptions)
-							referenced from the [[html]] [^track^] element are exempt resources.</p>
+							referenced from the [[html]]&nbsp;[^track^] element are exempt resources.</p>
 					</dd>
 
 					<dt id="exempt-video">Video</dt>
 					<dd id="confreq-resources-cd-fallback-video">
-						<p>All video codecs referenced from the [[html]] [^video^] — including any child [^source^]
-							elements — are exempt resources.</p>
+						<p>All video codecs referenced from the [[html]] [^video^] —&nbsp;including any child [^source^]
+							elements&nbsp;— are exempt resources.</p>
 						<div class="note">
 							<p>Although reading systems are encouraged to support at least one of the H.264 [[?h264]]
 								and VP8 [[?rfc6386]] video codecs, support for video codecs is not a conformance
@@ -1228,11 +1199,8 @@
 							document=]); <strong><em>and</em></strong></p>
 					</li>
 					<li>
-						<p>it is not embedded directly in EPUB content documents (e.g., via [[?html]] [=embedded
-							content=] and [[?svg]] <a href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"
-									><code>image</code></a> and <a
-								href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
-									><code>foreignObject</code></a> elements).</p>
+						<p>it is not embedded directly in EPUB content documents (e.g., via [[?html]]&nbsp;[=embedded
+							content=] and [[?svg]]&nbsp;<a href="https://www.w3.org/TR/SVG/embedded.html#ImageElement"><code>image</code></a> and <a href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"><code>foreignObject</code></a> elements).</p>
 					</li>
 				</ul>
 
@@ -1252,11 +1220,10 @@
 			<section id="sec-resource-fallbacks">
 				<h4>Resource fallbacks</h4>
 
-				<section id="sec-manifest-fallbacks">
+				<section id="sec-manifest-fallbacks" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L205,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L211,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L217,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L224,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L229,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L234,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L239,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L245">
 					<h5>Manifest fallbacks</h5>
 
-					<p>Manifest fallbacks are a feature of the [=package document=] that create a <dfn class="export"
-							>manifest fallback chain</dfn> for a [=publication resource=], allowing [=reading systems=]
+					<p>Manifest fallbacks are a feature of the [=package document=] that create a <dfn class="export">manifest fallback chain</dfn> for a [=publication resource=], allowing [=reading systems=]
 						to select an alternative format they can render.</p>
 
 					<p>Fallback chains are created using the <a href="#attrdef-item-fallback"><code>fallback</code>
@@ -1275,8 +1242,7 @@
 							<p>EPUB creators MUST specify a fallback chain for a [=foreign content document=] to ensure
 								that reading systems can always render the [=EPUB spine | spine=] item. In this case,
 								the chain MUST contain at least one [=EPUB content document=].</p>
-							<p>EPUB creators MAY provide fallbacks for EPUB content documents (e.g., to provide a <a
-									href="#confreq-cd-scripted-flbk">fallback for scripted content</a>).</p>
+							<p>EPUB creators MAY provide fallbacks for EPUB content documents (e.g., to provide a <a href="#confreq-cd-scripted-flbk">fallback for scripted content</a>).</p>
 							<p>When a fallback chain includes more than one EPUB content document, EPUB creators can use
 								the <a href="#attrdef-properties"><code>properties</code> attribute</a> to differentiate
 								the purpose of each.</p>
@@ -1303,8 +1269,7 @@
 						self-references or circular references to <code>item</code> elements in the chain.</p>
 
 					<div class="note">
-						<p>As it is not possible to use manifest fallbacks for resources represented in <a
-								href="#sec-data-urls">data URLs</a>, EPUB creators can only represent foreign resources
+						<p>As it is not possible to use manifest fallbacks for resources represented in <a href="#sec-data-urls">data URLs</a>, EPUB creators can only represent foreign resources
 							as data URLs where an intrinsic fallback mechanism is available.</p>
 					</div>
 				</section>
@@ -1315,14 +1280,13 @@
 					<p>The following sections provide additional clarifications about the intrinsic fallback
 						requirements of specific elements.</p>
 
-					<section id="sec-fallbacks-audio">
+					<section id="sec-fallbacks-audio" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L256,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L262,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L272">
 						<h5>HTML <code>audio</code> and <code>video</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-media">[=EPUB creators=] MUST NOT use embedded
-							[[html]] [=flow content=] within a <a data-cite="html#the-media-element">media element</a>
-							(i.e, <a data-cite="html#the-audio-element"><code>audio</code></a> or <a
-								data-cite="html#the-vido-element"><code>video</code></a>) as an intrinsic fallback for
-							audio [=foreign resources=]. Only child [^source^] elements [[html]] provide intrinsic
+							[[html]]&nbsp;[=flow content=] within a <a data-cite="html#the-media-element">media element</a>
+							(i.e, <a data-cite="html#the-audio-element"><code>audio</code></a> or <a data-cite="html#the-vido-element"><code>video</code></a>) as an intrinsic fallback for
+							audio [=foreign resources=]. Only child [^source^] elements&nbsp;[[html]] provide intrinsic
 							fallback capabilities.</p>
 
 						<p>Only older [=reading systems=] that do not recognize the <code>audio</code> or the
@@ -1337,7 +1301,7 @@
 						</div>
 					</section>
 
-					<section id="sec-fallbacks-img">
+					<section id="sec-fallbacks-img" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L280,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L285,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L290,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L296,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L302,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L308,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L313">
 						<h5>HTML <code>img</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-img">Due to the variety of sources that [=EPUB creators=]
@@ -1358,8 +1322,7 @@
 							</li>
 
 							<li>Otherwise, it MAY reference foreign resources in its <code>[^img/src^]</code> and
-									<code>[^img/srcset^]</code> attributes provided EPUB creators define a <a
-									href="#sec-manifest-fallbacks">manifest fallback</a>.</li>
+									<code>[^img/srcset^]</code> attributes provided EPUB creators define a <a href="#sec-manifest-fallbacks">manifest fallback</a>.</li>
 						</ul>
 					</section>
 
@@ -1372,18 +1335,16 @@
 							provide manifest fallbacks because data blocks cannot be defined as standalone files in the
 							EPUB container but are always embedded as inline <code>script</code> elements.</p>
 
-						<p>But, as the <code>script</code> element does not represent user content &#8212; <a
-								data-cite="html#data-block">data blocks</a> are not rendered unless manipulated by
+						<p>But, as the <code>script</code> element does not represent user content — <a data-cite="html#data-block">data blocks</a> are not rendered unless manipulated by
 							script, and content rendered by scripts already has <a href="#confreq-cd-scripted-flbk">core
-								media type requirements</a> &#8212; requiring fallbacks for the raw data does not serve
+								media type requirements</a> — requiring fallbacks for the raw data does not serve
 							a useful purpose.</p>
 
 						<p>Consequently, to ensure that [=EPUB creators=] can include data blocks for scripting
 							purposes, they are exempt from fallback requirements.</p>
 
 						<div class="note">
-							<p>This exemption aligns data blocks with the <a href="#confreq-foreign-no-fallback"
-									>exemption for data files</a>.</p>
+							<p>This exemption aligns data blocks with the <a href="#confreq-foreign-no-fallback">exemption for data files</a>.</p>
 						</div>
 
 						<div class="note">
@@ -1394,7 +1355,7 @@
 				</section>
 			</section>
 
-			<section id="sec-resource-locations">
+			<section id="sec-resource-locations" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L267,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L341,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L346,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L351,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L357,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L362,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L367,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L373,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L379,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L385,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L391,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L397,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L403,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L408,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L413,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L418,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L423,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L429,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L435,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L441,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L449,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L457,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L463,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L469,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L475,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L481,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L487">
 				<h4>Resource locations</h4>
 
 				<p>[=EPUB creators=] MAY host the following types of [=publication resources=] outside the [=EPUB
@@ -1436,38 +1397,36 @@
 				</div>
 
 				<aside class="example" title="Referencing a container resource">
-					<p>In this example, the audio file referenced from the [[html]] <a
-							data-cite="html#the-audio-element"><code>audio</code></a> element is located inside the EPUB
+					<p>In this example, the audio file referenced from the [[html]] <a data-cite="html#the-audio-element"><code>audio</code></a> element is located inside the EPUB
 						container.</p>
-					<pre>&lt;html …>
+					<pre>&lt;html …&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       …
       &lt;audio
           src="audio/ch01.mp4"
-          controls="controls"/>
+          controls="controls"/&gt;
       …
-   &lt;/body>
-&lt;/html></pre>
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
 				</aside>
 
 				<aside class="example" title="Referencing a remote resource">
-					<p>In this example, the audio file referenced from the [[html]] <a
-							data-cite="html#the-audio-element"><code>audio</code></a> element is hosted on the web.</p>
-					<pre>&lt;html …>
+					<p>In this example, the audio file referenced from the [[html]] <a data-cite="html#the-audio-element"><code>audio</code></a> element is hosted on the web.</p>
+					<pre>&lt;html …&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       …
          &lt;audio
              src="http://www.example.com/book/audio/ch01.mp4"
-             controls="controls"/>
+             controls="controls"/&gt;
       …
-   &lt;/body>
-&lt;/html></pre>
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
 				</aside>
 			</section>
 
-			<section id="sec-data-urls">
+			<section id="sec-data-urls" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L495,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L501,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L507,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L513,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L519,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L525,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L531,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L536,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L541,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L546">
 				<h3>Data URLs</h3>
 
 				<p>The <a data-cite="rfc2397#"><code>data:</code> URL scheme</a> [[rfc2397]] is used to encode resources
@@ -1479,12 +1438,12 @@
 
 				<ul>
 					<li>
-						<p>in <code>href</code> attributes in the package document &#8212; this applies both to manifest
+						<p>in <code>href</code> attributes in the package document — this applies both to manifest
 							[^item^] elements and metadata [^link^] elements;</p>
 					</li>
 					<li>
 						<p>in the <code>href</code> attribute on [[html]] or [[svg]] <code>a</code> elements, except
-							when inside an [^iframe^] element [[html]];</p>
+							when inside an [^iframe^] element&nbsp;[[html]];</p>
 					</li>
 					<li>
 						<p>in the <code>href</code> attribute on [[html]] <code>area</code> elements, except when inside
@@ -1506,13 +1465,12 @@
 
 				<p>A consequence of embedding is that the data in a data URL is not considered its own unique
 					[=publication resource=] for manifest reporting purposes (i.e., only its containing publication
-					resource gets listed). As this data has its own media type, however, it is still subject to <a
-						href="#sec-foreign-resources">foreign resource restrictions</a>. EPUB creators MUST therefore
+					resource gets listed). As this data has its own media type, however, it is still subject to <a href="#sec-foreign-resources">foreign resource restrictions</a>. EPUB creators MUST therefore
 					encode data URLs as [=core media type resources=] or provide a fallback using the intrinsic fallback
 					mechanisms of the host format.</p>
 			</section>
 
-			<section id="sec-file-urls">
+			<section id="sec-file-urls" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L554,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L560,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L566,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L572">
 				<h3>File URLs</h3>
 
 				<p>The <a data-cite="rfc8089#"><code>file:</code> URL scheme</a> is defined in [[rfc8089]] as
@@ -1525,21 +1483,19 @@
 					NOT use file URLs in EPUB publications.</p>
 			</section>
 
-			<section id="sec-xml-constraints">
+			<section id="sec-xml-constraints" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L581,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L586,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L591,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L596,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L602,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L608,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L615,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L621,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L627,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L634,https://w3c.github.io/epub-structural-tests/#03-resources_resources.feature_L640">
 				<h3>XML conformance</h3>
 
 				<p>Any [=publication resource=] that is an XML-based media type [[rfc2046]]:</p>
 
 				<ul class="conformance-list">
 					<li>
-						<p id="confreq-xml-wellformed">MUST be a conformant XML 1.0 Document as defined in <a
-								data-cite="xml-names#Conformance">Conformance of Documents</a> [[xml-names]].</p>
+						<p id="confreq-xml-wellformed">MUST be a conformant XML 1.0 Document as defined in <a data-cite="xml-names#Conformance">Conformance of Documents</a> [[xml-names]].</p>
 					</li>
 					<li>
 						<p id="confreq-xml-identifiers">MAY only specify a <a data-cite="xml#dt-doctype">document type
 								declaration</a> that references an <a data-cite="xml#NT-ExternalID">external
-								identifier</a> appropriate for its media type &#8212; as defined in <a
-								href="#app-identifiers-allowed"></a> &#8212; or that omits external identifiers
+								identifier</a> appropriate for its media type — as defined in <a href="#app-identifiers-allowed"></a> — or that omits external identifiers
 							[[xml]].</p>
 					</li>
 					<li>
@@ -1550,7 +1506,7 @@
 						<p id="confreq-xml-xinc">MUST NOT make use of XInclude [[xinclude]].</p>
 					</li>
 					<li>
-						<p id="confreq-xml-enc">MUST be encoded in UTF-8 or UTF-16 [[unicode]], with UTF-8 as the
+						<p id="confreq-xml-enc">MUST be encoded in UTF-8 or UTF-16&nbsp;[[unicode]], with UTF-8 as the
 							RECOMMENDED encoding.</p>
 					</li>
 				</ul>
@@ -1662,15 +1618,14 @@
 						in the <code>META-INF</code> directory.</p>
 				</section>
 
-				<section id="sec-container-file-and-dir-structure">
+				<section id="sec-container-file-and-dir-structure" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L17">
 					<h4>File and directory structure</h4>
 
 					<p>The virtual file system for the [=OCF abstract container=] MUST have a single common [=root
 						directory=] for all the contents of the container.</p>
 
 					<p>The OCF abstract container MUST include a directory for configuration files named
-							<code>META-INF</code> that is a direct child of the container's root directory. Refer to <a
-							href="#sec-container-metainf"></a> for the requirements for the contents of this
+							<code>META-INF</code> that is a direct child of the container's root directory. Refer to <a href="#sec-container-metainf"></a> for the requirements for the contents of this
 						directory.</p>
 
 					<p>The file name <code>mimetype</code> in the root directory is reserved for use by [=OCF ZIP
@@ -1689,12 +1644,11 @@
 							[=package document=] is stored. EPUB creators should therefore place all resources at or
 							below the directory containing the package document to avoid interoperability issues.</p>
 
-						<p>This problem is more commonly encountered when <a data-cite="epub-multi-rend-11#container"
-								>creating multiple renditions</a> [[epub-multi-rend-11]] of the publication.</p>
+						<p>This problem is more commonly encountered when <a data-cite="epub-multi-rend-11#container">creating multiple renditions</a> [[epub-multi-rend-11]] of the publication.</p>
 					</div>
 				</section>
 
-				<section id="sec-container-filenames">
+				<section id="sec-container-filenames" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L26,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L31,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L37,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L43,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L49,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L54,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L59,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L65,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L71,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L76,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L82,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L89,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L96,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L102">
 					<h4>File paths and file names</h4>
 
 					<p id="ocf-fn-cs">In the context of the [=OCF abstract container=], [=file paths=] and [=file
@@ -1734,7 +1688,7 @@
 									<p>LESS-THAN SIGN: <code>&lt;</code> (<code>U+003C</code>)</p>
 								</li>
 								<li>
-									<p>GREATER-THAN SIGN: <code>></code> (<code>U+003E</code>)</p>
+									<p>GREATER-THAN SIGN: <code>&gt;</code> (<code>U+003E</code>)</p>
 								</li>
 								<li>
 									<p>QUESTION MARK: <code>?</code> (<code>U+003F</code>)</p>
@@ -1785,8 +1739,7 @@
 								</li>
 							</ul>
 							<div class="note">
-								<p>The Unicode Character Database [[uax44]] also includes a <a
-										href="https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt">list of
+								<p>The Unicode Character Database [[uax44]] also includes a <a href="https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt">list of
 										deprecated characters</a>. EPUB creators are advised to avoid these characters,
 									as well, as it is expected that [=EPUB conformance checkers=] will flag their
 									use.</p>
@@ -1798,9 +1751,8 @@
 						</li>
 						<li>
 							<p id="ocf-fn-cn">All file names within the same directory MUST be unique following Unicode
-								canonical normalization [[uax15]] and then full case folding [[unicode]]. (Refer to <a
-									data-cite="charmod-norm#CanonicalFoldNormalizationStep">Unicode Canonical Case Fold
-									Normalization Step</a> [[?charmod-norm]] for more information.)</p>
+								canonical normalization [[uax15]] and then full case folding [[unicode]]. (Refer to <a data-cite="charmod-norm#CanonicalFoldNormalizationStep">Unicode Canonical Case Fold
+									Normalization Step</a>&nbsp;[[?charmod-norm]] for more information.)</p>
 						</li>
 					</ul>
 					<div class="note">
@@ -1808,8 +1760,7 @@
 							control), they should be aware that automatic truncation of file names to keep them within
 							the 255 bytes limit can lead to corruption. This is due to the difference between bytes and
 							characters in multibyte encodings such as UTF-8; it is, therefore, important to avoid
-							mid-character truncation. See the section on <a
-								data-cite="international-specs/#char_truncation">"Truncating or limiting the length of
+							mid-character truncation. See the section on <a data-cite="international-specs/#char_truncation">"Truncating or limiting the length of
 								strings"</a> in [[international-specs]] for more information.</p>
 					</div>
 
@@ -1826,8 +1777,7 @@
 				<section id="sec-file-names-to-path-names">
 					<h4>Deriving file paths</h4>
 
-					<p>To <strong>derive the file path</strong>, given a file or directory <var>file</var> in the <a
-							href="#sec-container-abstract">OCF abstract container</a>, apply the following steps
+					<p>To <strong>derive the file path</strong>, given a file or directory <var>file</var> in the <a href="#sec-container-abstract">OCF abstract container</a>, apply the following steps
 						(expressed using the terminology of [[infra]]):</p>
 
 					<ol class="algorithm">
@@ -1839,32 +1789,24 @@
 							</ol>
 						</li>
 						<li>Return the <a data-cite="infra#string-concatenate">concatenation</a> of <var>path</var>
-							using the <code>U+002F (/)</code> character.</li>
+							using the <code>U+002F&nbsp;(/)</code> character.</li>
 					</ol>
 				</section>
 
-				<section id="sec-container-iri">
+				<section id="sec-container-iri" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L112,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L119,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L125,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L133,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L139,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L145,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L153,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L159,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L478,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L491,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L69,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L81,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L255,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L621,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L626,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L632,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L639">
 					<h4>URLs in the OCF abstract container</h4>
 
-					<p id="sec-container-iri-root"
-						data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">The [=container root
-						URL=] is the [=URL=] [[url]] of the [=root directory=]. It is implementation-specific, but
+					<p id="sec-container-iri-root" data-tests="#ocf-url_manifest,#ocf-url_relative,#ocf-url_link-relative">The [=container root
+						URL=] is the [=URL=]&nbsp;[[url]] of the [=root directory=]. It is implementation-specific, but
 						[=EPUB creators=] MUST assume it has the following properties:</p>
 
 					<ul id="sec-root-url-properties">
-						<li id="sec-container-iri-root-parse"
-							data-tests="#ocf-url_link-path-absolute,#ocf-url_parse-path-absolute">The result of <a
-								data-lt="url parser">parsing</a> "<code>/</code>" with the [=container root URL=] as <a
-								data-cite="url#concept-base-url"><var>base</var></a> is the [=container root URL=].</li>
-						<li id="sec-container-iri-step-parse"
-							data-tests="#ocf-url_link-leaking-relative,#ocf-url_parse-leaking-relative">The result of <a
-								data-lt="url parser">parsing</a> "<code>..</code>" with the [=container root URL=] as <a
-								data-cite="url#concept-base-url"><var>base</var></a> is the [=container root URL=].</li>
+						<li id="sec-container-iri-root-parse" data-tests="#ocf-url_link-path-absolute,#ocf-url_parse-path-absolute">The result of <a data-lt="url parser">parsing</a> "<code>/</code>" with the [=container root URL=] as <a data-cite="url#concept-base-url"><var>base</var></a> is the [=container root URL=].</li>
+						<li id="sec-container-iri-step-parse" data-tests="#ocf-url_link-leaking-relative,#ocf-url_parse-leaking-relative">The result of <a data-lt="url parser">parsing</a> "<code>..</code>" with the [=container root URL=] as <a data-cite="url#concept-base-url"><var>base</var></a> is the [=container root URL=].</li>
 					</ul>
 
 					<p>The [=content URL=] of a file or directory in the [=OCF abstract container=] is the result of
-						[=url parser | parsing=] the file's [=file path=] with the container root URL as <a
-							data-cite="url#concept-base-url"><var>base</var></a>.</p>
+						[=url parser | parsing=] the file's [=file path=] with the container root URL as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 					<div class="note" id="note-cru-explanation">
 						<p>The container root URL is the URL assigned by the [=reading system=] to the root of the
@@ -1888,16 +1830,13 @@
 					</div>
 
 					<div class="note">
-						<p>Parsing may replace some characters in the file path by their <a
-								data-cite="url#percent-encode">percent encoded</a> alternative. For example,
-								<code>A/B/C/file&#160;name.xhtml</code> becomes <code>A/B/C/file%20name.xhtml</code>.
+						<p>Parsing may replace some characters in the file path by their <a data-cite="url#percent-encode">percent encoded</a> alternative. For example,
+								<code>A/B/C/file&nbsp;name.xhtml</code> becomes <code>A/B/C/file%20name.xhtml</code>.
 						</p>
 					</div>
 
-					<p>A string <var>url</var> is a <dfn class="export"
-							id="dfn-valid-relative-container-url-with-fragment-string"
-							>valid-relative-ocf-URL-with-fragment string</dfn> if it is a
-						[=path-relative-scheme-less-url string=], optionally followed by <code>U+0023 (#)</code> and a
+					<p>A string <var>url</var> is a <dfn class="export" id="dfn-valid-relative-container-url-with-fragment-string">valid-relative-ocf-URL-with-fragment string</dfn> if it is a
+						[=path-relative-scheme-less-url string=], optionally followed by <code>U+0023&nbsp;(#)</code> and a
 						[=url-fragment string=], and if the following steps return <var>true</var>:</p>
 
 					<ol class="algorithm" id="algo-out-of-container">
@@ -1910,8 +1849,7 @@
 									algorithm=] is used with an artificial root URL; the detection of the "leak" is done
 									by comparing the result of the parsing with the presence of the first test path
 									segment (<code>A</code>). (Note that the artificial container root URL wilfully
-									violates, for the purpose of this algorithm, the <a href="#sec-root-url-properties"
-										>required properties</a> by using that first test path segment.)</p>
+									violates, for the purpose of this algorithm, the <a href="#sec-root-url-properties">required properties</a> by using that first test path segment.)</p>
 							</details>
 						</li>
 
@@ -1928,8 +1866,7 @@
 									container root URL (see <a href="#sec-parsing-urls-metainf"></a>). In the case of a
 									URL in an [=XHTML content document=], the base URL used for parsing is defined by
 									the <a data-cite="html#resolving-urls">HTML standard</a>. Typically, it will be the
-									content URL of the content document (unless the <a href="#sec-xhtml-deviations-base"
-										>discouraged</a>
+									content URL of the content document (unless the <a href="#sec-xhtml-deviations-base">discouraged</a>
 									<code>base</code> element is used).</p>
 							</details>
 						</li>
@@ -1953,8 +1890,7 @@
 
 						<li>Set <var>base</var> to be the <a data-cite="url#concept-base-url">base URL</a> that must be
 							used to parse <var>url</var> as defined by the context (document or environment) where
-								<var>url</var> is used, and according to the content URL of the package document (see <a
-								href="#sec-parse-package-urls"></a>).</li>
+								<var>url</var> is used, and according to the content URL of the package document (see <a href="#sec-parse-package-urls"></a>).</li>
 
 						<li>Set <var>testURLRecord</var> to be the result of applying the [=URL parser=] to
 								<var>url</var>, with <var>base</var>. </li>
@@ -1992,8 +1928,7 @@
 					<p id="urls-in-ocf-constraints">In the OCF abstract container, any URL string MUST be an
 						[=absolute-url-with-fragment string=] or a [=valid-relative-ocf-URL-with-fragment string=].</p>
 
-					<p>In addition, all [=relative-URL-with-fragment strings=] [[url]] MUST, after <a
-							data-lt="url parser">parsing</a>, be equal to the content URL of an existing file in the OCF
+					<p>In addition, all [=relative-URL-with-fragment strings=]&nbsp;[[url]] MUST, after <a data-lt="url parser">parsing</a>, be equal to the content URL of an existing file in the OCF
 						abstract container.</p>
 
 					<div class="note">
@@ -2008,8 +1943,7 @@
 						</ul>
 
 						<p>Note that in any case, even the disallowed URL strings described above will not "leak"
-							outside the container after parsing (as explained in the <a href="#note-cru-explanation"
-								>first note</a> of this section). They are nevertheless disallowed for better
+							outside the container after parsing (as explained in the <a href="#note-cru-explanation">first note</a> of this section). They are nevertheless disallowed for better
 							interoperability with non-conforming or legacy reading systems and toolchains.</p>
 					</div>
 
@@ -2017,27 +1951,26 @@
 						<p>In this example, the file <code>image1.jpg</code> is in the same directory as the XHTML
 							content document.</p>
 
-						<pre>&lt;html …>
+						<pre>&lt;html …&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       &lt;img
           src="image1.jpg"
-          alt="…" />
+          alt="…" /&gt;
    …
-   &lt;/body>
-&lt;/html></pre>
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
 					</aside>
 
-					<aside class="example" title='An "out-of-container" URL'>
+					<aside class="example" title="An &quot;out-of-container&quot; URL">
 						<p>Given the following container structure:</p>
 
-						<pre>
-							/
+						<pre>							/
 							├── mimetype
 							├── META-INF
-							│   └── container.xml
+							│&nbsp;&nbsp; └── container.xml
 							└── EPUB
-							    └── content.xhtml
+							 &nbsp;&nbsp; └── content.xhtml
 						</pre>
 
 						<p> A URL `../../../../EPUB/secret.xhtml` appearing in `content.xhtml` would be parsed by a
@@ -2057,29 +1990,27 @@
 						<p>All [=OCF abstract containers=] MUST include a directory called <code>META-INF</code> in
 							their [=root directory=].</p>
 
-						<p>This directory is reserved for configuration files, specifically those defined in <a
-								href="#sec-container-metainf-files"></a>.</p>
+						<p>This directory is reserved for configuration files, specifically those defined in <a href="#sec-container-metainf-files"></a>.</p>
 					</section>
 
 					<section id="sec-parsing-urls-metainf">
 						<h5>Parsing URLs in the <code>META-INF</code> directory</h5>
 
 						<p id="sec-container-metainf-url-parsing" data-tests="#ocf-url_relative">To parse a URL string
-								<var>url</var> used in files located in the <code>META-INF</code> directory the <a
-								data-lt="url parser">URL parser</a> MUST be applied to <var>url</var>, with the
+								<var>url</var> used in files located in the <code>META-INF</code> directory the <a data-lt="url parser">URL parser</a> MUST be applied to <var>url</var>, with the
 							[=container root URL=] as <a data-cite="url#concept-base-url"><var>base</var></a>.</p>
 
 						<aside class="example" title="Resolving paths in the container file">
 							<p>If container file (<code>META-INF/container.xml</code>) has the following content:</p>
 
-							<pre>&lt;?xml version="1.0"?>
-&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-   &lt;rootfiles>
+							<pre>&lt;?xml version="1.0"?&gt;
+&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
+   &lt;rootfiles&gt;
       &lt;rootfile
           full-path="EPUB/Great_Expectations.opf"
-          media-type="application/oebps-package+xml" />	
-   &lt;/rootfiles>
-&lt;/container></pre>
+          media-type="application/oebps-package+xml" /&gt;	
+   &lt;/rootfiles&gt;
+&lt;/container&gt;</pre>
 
 							<p>then the path <code>EPUB/Great_Expectations.opf</code> is relative to the [=root
 								directory=] for the [=OCF abstract container=] and not relative to the
@@ -2090,7 +2021,7 @@
 					<section id="sec-container-metainf-files">
 						<h5>Reserved files</h5>
 
-						<section id="sec-container-metainf-container.xml">
+						<section id="sec-container-metainf-container.xml" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L176,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L183,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L189">
 							<h6>Container file (<code>container.xml</code>)</h6>
 
 							<p>The REQUIRED <code>container.xml</code> file in the <code>META-INF</code> directory
@@ -2117,8 +2048,7 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>container</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>container</code></dfn>
 										</p>
 									</dd>
 
@@ -2161,8 +2091,7 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>rootfiles</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>rootfiles</code></dfn>
 										</p>
 									</dd>
 
@@ -2185,7 +2114,7 @@
 								</dl>
 							</section>
 
-							<section id="sec-container.xml-rootfile-elem">
+							<section id="sec-container.xml-rootfile-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L198">
 								<h6>The <code>rootfile</code> element</h6>
 
 								<p>Each <code>rootfile</code> element identifies the location of one [=package
@@ -2195,8 +2124,7 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>rootfile</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>rootfile</code></dfn>
 										</p>
 									</dd>
 
@@ -2259,8 +2187,7 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>links</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>links</code></dfn>
 										</p>
 									</dd>
 
@@ -2350,14 +2277,14 @@
 								<h6>Examples</h6>
 
 								<aside class="example" title="A basic container file">
-									<pre>&lt;?xml version="1.0"?>
-&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-   &lt;rootfiles>
+									<pre>&lt;?xml version="1.0"?&gt;
+&lt;container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
+   &lt;rootfiles&gt;
       &lt;rootfile
           full-path="EPUB/My_Crazy_Life.opf"
-          media-type="application/oebps-package+xml" />
-   &lt;/rootfiles>
-&lt;/container></pre>
+          media-type="application/oebps-package+xml" /&gt;
+   &lt;/rootfiles&gt;
+&lt;/container&gt;</pre>
 								</aside>
 							</section>
 						</section>
@@ -2371,15 +2298,14 @@
 									<code>encryption.xml</code> file to provide information about the encryption
 								used.</p>
 
-							<section id="sec-encryption.xml-encryption">
+							<section id="sec-encryption.xml-encryption" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L209,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L225">
 								<h6>The <code>encryption</code> element</h6>
 
 								<dl class="elemdef" id="elemdef-encryption">
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>encryption</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>encryption</code></dfn>
 										</p>
 									</dd>
 
@@ -2413,10 +2339,8 @@
 										<code>EncryptedKey</code> and <code>EncryptedData</code> as defined by
 									[[xmlenc-core1]].</p>
 
-								<p>An <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-											><code>EncryptedKey</code></dfn> element describes each encryption key used
-									in the container, while an <dfn class="export" data-lt-no-plural=""
-										data-dfn-type="element"><code>EncryptedData</code></dfn> element describes each
+								<p>An <dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>EncryptedKey</code></dfn> element describes each encryption key used
+									in the container, while an <dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>EncryptedData</code></dfn> element describes each
 									encrypted file. Each <code>EncryptedData</code> element refers to an
 										<code>EncryptedKey</code> element, as described in XML Encryption.</p>
 
@@ -2446,8 +2370,7 @@
 								<p id="encryption-obfuscation">Note that some situations require obfuscating the storage
 									of embedded fonts referenced by an [=EPUB publication=] to make them more difficult
 									to extract for unrestricted use. Although obfuscation is not encryption, reading
-									systems use the <code>encryption.xml</code> file in conjunction with the <a
-										href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify fonts to
+									systems use the <code>encryption.xml</code> file in conjunction with the <a href="#sec-font-obfuscation">font obfuscation algorithm</a> to identify fonts to
 									deobfuscate.</p>
 
 								<p id="encryption-restrictions">EPUB creators MUST NOT encrypt the following files:</p>
@@ -2478,13 +2401,12 @@
 								</ul>
 
 								<p>EPUB creators MAY subsequently encrypt signed resources using the Decryption
-									Transform for XML Signature [[xmlenc-decrypt]]. This feature enables a [=reading
+									Transform for XML Signature&nbsp;[[xmlenc-decrypt]]. This feature enables a [=reading
 									system=] to distinguish data encrypted before signing from data encrypted after
 									signing.</p>
 
 								<aside class="example" title="An encrypted image">
-									<p>In this example, adapted from <a data-cite="xmlenc-core1#sec-eg-Symmetric-Key"
-											>Section 2.2.1 </a> of [[xmlenc-core1]], the resource
+									<p>In this example, adapted from <a data-cite="xmlenc-core1#sec-eg-Symmetric-Key">Section 2.2.1 </a> of [[xmlenc-core1]], the resource
 											<code>image.jpeg</code> is encrypted using a symmetric key algorithm (AES)
 										and the symmetric key is further encrypted using an asymmetric key algorithm
 										(RSA) with a key of "John Smith".</p>
@@ -2492,39 +2414,39 @@
 									<pre>&lt;encryption
     xmlns ="urn:oasis:names:tc:opendocument:xmlns:container"
     xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
-    xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-   &lt;enc:EncryptedKey Id="EK">
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"&gt;
+   &lt;enc:EncryptedKey Id="EK"&gt;
       &lt;enc:EncryptionMethod
-          Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
-      &lt;ds:KeyInfo>
-         &lt;ds:KeyName>
+          Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+      &lt;ds:KeyInfo&gt;
+         &lt;ds:KeyName&gt;
             John Smith
-         &lt;/ds:KeyName>
-      &lt;/ds:KeyInfo>
-      &lt;enc:CipherData>
-         &lt;enc:CipherValue>
+         &lt;/ds:KeyName&gt;
+      &lt;/ds:KeyInfo&gt;
+      &lt;enc:CipherData&gt;
+         &lt;enc:CipherValue&gt;
             xyzabc
-         &lt;/enc:CipherValue>
-      &lt;/enc:CipherData>
-   &lt;/enc:EncryptedKey>
-   &lt;enc:EncryptedData Id="ED1">
+         &lt;/enc:CipherValue&gt;
+      &lt;/enc:CipherData&gt;
+   &lt;/enc:EncryptedKey&gt;
+   &lt;enc:EncryptedData Id="ED1"&gt;
       &lt;enc:EncryptionMethod
-          Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/>
-      &lt;ds:KeyInfo>
+          Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/&gt;
+      &lt;ds:KeyInfo&gt;
          &lt;ds:RetrievalMethod
              URI="#EK"
-             Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/>
-      &lt;/ds:KeyInfo>
-      &lt;enc:CipherData>
+             Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/&gt;
+      &lt;/ds:KeyInfo&gt;
+      &lt;enc:CipherData&gt;
          &lt;enc:CipherReference
-             URI="image.jpeg"/>
-      &lt;/enc:CipherData>
-   &lt;/enc:EncryptedData>
-&lt;/encryption></pre>
+             URI="image.jpeg"/&gt;
+      &lt;/enc:CipherData&gt;
+   &lt;/enc:EncryptedData&gt;
+&lt;/encryption&gt;</pre>
 								</aside>
 							</section>
 
-							<section id="sec-enc-compression">
+							<section id="sec-enc-compression" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L234">
 								<h6>Order of compression and encryption</h6>
 
 								<p>When stored in an [=OCF ZIP container=], [=EPUB creators=] SHOULD compress streams of
@@ -2553,8 +2475,7 @@
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>Compression</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>Compression</code></dfn>
 										</p>
 									</dd>
 
@@ -2599,25 +2520,25 @@
 										original size was 3500000 bytes.</p>
 
 									<pre>&lt;encryption
-    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
    &lt;enc:EncryptedData 
-       xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
+       xmlns:enc="http://www.w3.org/2001/04/xmlenc#"&gt;
       …
-      &lt;enc:CipherData>
+      &lt;enc:CipherData&gt;
          &lt;enc:CipherReference
-             URI="OEPBS/video.mp4"/>
-      &lt;/enc:CipherData>
-      &lt;enc:EncryptionProperties>
+             URI="OEPBS/video.mp4"/&gt;
+      &lt;/enc:CipherData&gt;
+      &lt;enc:EncryptionProperties&gt;
          &lt;enc:EncryptionProperty
-             xmlns:ns="http://www.idpf.org/2016/encryption#compression">
+             xmlns:ns="http://www.idpf.org/2016/encryption#compression"&gt;
             &lt;ns:Compression
                 Method="8"
-                OriginalLength="3500000"/>
-         &lt;/enc:EncryptionProperty>
-      &lt;/enc:EncryptionProperties>
+                OriginalLength="3500000"/&gt;
+         &lt;/enc:EncryptionProperty&gt;
+      &lt;/enc:EncryptionProperties&gt;
       …
-   &lt;/enc:EncryptedData>
-&lt;/encryption></pre>
+   &lt;/enc:EncryptedData&gt;
+&lt;/encryption&gt;</pre>
 								</aside>
 							</section>
 						</section>
@@ -2643,8 +2564,7 @@
 								only for container-level metadata.</p>
 
 							<p>If [=EPUB creators=] include a <code>metadata.xml</code> file, they SHOULD use only
-								namespace-qualified elements [[xml-names]] in it. The file SHOULD contain the <a
-									data-cite="xml#dt-root">root element</a> [[xml]] <code>metadata</code> in the
+								namespace-qualified elements [[xml-names]] in it. The file SHOULD contain the <a data-cite="xml#dt-root">root element</a> [[xml]] <code>metadata</code> in the
 								namespace <code>http://www.idpf.org/2013/metadata</code>, but this specification allows
 								other root elements for backwards compatibility.</p>
 
@@ -2677,15 +2597,14 @@
 							<p>The OPTIONAL <code>signatures.xml</code> file in the <code>META-INF</code> directory
 								holds digital signatures for the container and its contents.</p>
 
-							<section id="sec-signatures.xml-signatures">
+							<section id="sec-signatures.xml-signatures" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L246">
 								<h6>The <code>signatures</code> element</h6>
 
 								<dl class="elemdef" id="elemdef-signatures">
 									<dt>Element Name:</dt>
 									<dd>
 										<p>
-											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-													><code>signatures</code></dfn>
+											<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>signatures</code></dfn>
 										</p>
 									</dd>
 
@@ -2751,8 +2670,7 @@
 										<code>signatures.xml</code> file.</p>
 
 								<p>If the EPUB creator wants any addition or removal of a signature to invalidate their
-									signature, they can use the Enveloped Signature transform defined in <a
-										data-cite="xmldsig-core#sec-EnvelopedSignature">Section 6.6.4</a> of
+									signature, they can use the Enveloped Signature transform defined in <a data-cite="xmldsig-core#sec-EnvelopedSignature">Section 6.6.4</a> of
 									[[xmldsig-core1]] to sign the entire pre-existing signature file excluding the
 										<code>Signature</code> being created. This transform would sign all previous
 									signatures, and it would become invalid if a subsequent signature were added to the
@@ -2772,67 +2690,66 @@
 									a signature, such as by use the <code>SignatureProperties</code> element.</p>
 
 								<aside class="example" title="Signing resources">
-									<p>In this example, based on the examples found in <a
-											data-cite="xmldsig-core1#sec-Overview">Section 2</a> of [[xmldsig-core1]],
+									<p>In this example, based on the examples found in <a data-cite="xmldsig-core1#sec-Overview">Section 2</a> of [[xmldsig-core1]],
 										one signature applies to two resources (<code>EPUB/book.xhtml</code> and
 											<code>EPUB/images/cover.jpeg</code>).</p>
 
 									<pre>&lt;signatures
-    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
    &lt;Signature
        Id="sig"
-       xmlns="http://www.w3.org/2000/09/xmldsig#">
-      &lt;SignedInfo>
+       xmlns="http://www.w3.org/2000/09/xmldsig#"&gt;
+      &lt;SignedInfo&gt;
          &lt;CanonicalizationMethod 
-             Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+             Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
             &lt;SignatureMethod
-                Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/>
+                Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/&gt;
             &lt;Reference
-                URI="#Manifest1">
+                URI="#Manifest1"&gt;
                &lt;DigestMethod
-                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-               &lt;DigestValue>j6lwx3rvEPO0vKtMup4NbeVu8nk=&lt;/DigestValue>
-            &lt;/Reference>
-      &lt;/SignedInfo>
-      &lt;SignatureValue>
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
+               &lt;DigestValue&gt;j6lwx3rvEPO0vKtMup4NbeVu8nk=&lt;/DigestValue&gt;
+            &lt;/Reference&gt;
+      &lt;/SignedInfo&gt;
+      &lt;SignatureValue&gt;
          …
-      &lt;/SignatureValue>
-      &lt;KeyInfo>
-         &lt;KeyValue>
-            &lt;DSAKeyValue>
-               &lt;P>…&lt;/P>
-               &lt;Q>…&lt;/Q>
-               &lt;G>…&lt;/G>
-               &lt;Y>…&lt;/Y> 
-            &lt;/DSAKeyValue>
-         &lt;/KeyValue>
-      &lt;/KeyInfo>
-      &lt;Object>
+      &lt;/SignatureValue&gt;
+      &lt;KeyInfo&gt;
+         &lt;KeyValue&gt;
+            &lt;DSAKeyValue&gt;
+               &lt;P&gt;…&lt;/P&gt;
+               &lt;Q&gt;…&lt;/Q&gt;
+               &lt;G&gt;…&lt;/G&gt;
+               &lt;Y&gt;…&lt;/Y&gt; 
+            &lt;/DSAKeyValue&gt;
+         &lt;/KeyValue&gt;
+      &lt;/KeyInfo&gt;
+      &lt;Object&gt;
          &lt;Manifest
-             Id="Manifest1">
+             Id="Manifest1"&gt;
             &lt;Reference
-                URI="EPUB/book.xhtml">                    
-               &lt;Transforms>                                                
+                URI="EPUB/book.xhtml"&gt;                    
+               &lt;Transforms&gt;                                                
                   &lt;Transform
-                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>                        
-               &lt;/Transforms>
+                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;                        
+               &lt;/Transforms&gt;
                &lt;DigestMethod
-                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-               &lt;DigestValue>…&lt;/DigestValue>
-            &lt;/Reference>
-            &lt;Reference URI="EPUB/images/cover.jpeg">
-               &lt;Transforms>                                                
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
+               &lt;DigestValue&gt;…&lt;/DigestValue&gt;
+            &lt;/Reference&gt;
+            &lt;Reference URI="EPUB/images/cover.jpeg"&gt;
+               &lt;Transforms&gt;                                                
                   &lt;Transform
-                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>                        
-               &lt;/Transforms>
+                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;                        
+               &lt;/Transforms&gt;
                &lt;DigestMethod
-                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-               &lt;DigestValue>…&lt;/DigestValue>
-            &lt;/Reference>
-         &lt;/Manifest>
-      &lt;/Object>
-   &lt;/Signature> 
-&lt;/signatures></pre>
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
+               &lt;DigestValue&gt;…&lt;/DigestValue&gt;
+            &lt;/Reference&gt;
+         &lt;/Manifest&gt;
+      &lt;/Object&gt;
+   &lt;/Signature&gt; 
+&lt;/signatures&gt;</pre>
 								</aside>
 							</section>
 						</section>
@@ -2864,7 +2781,7 @@
 					</ul>
 				</section>
 
-				<section id="sec-zip-container-zipreqs">
+				<section id="sec-zip-container-zipreqs" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L259,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L264,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L272,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L279,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L286,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L292,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L297,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L303,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L308">
 					<h4>ZIP file requirements</h4>
 
 					<p>An [=OCF ZIP container=] uses the ZIP format as specified by [[zip]], but with the following
@@ -2872,8 +2789,7 @@
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-zip-abstr">The contents of the OCF ZIP container MUST be a conforming <a
-									href="#sec-container-abstract">OCF abstract container</a>.</p>
+							<p id="confreq-zip-abstr">The contents of the OCF ZIP container MUST be a conforming <a href="#sec-container-abstract">OCF abstract container</a>.</p>
 						</li>
 						<li>
 							<p id="confreq-zip-mult">OCF ZIP containers MUST NOT use the features in the ZIP application
@@ -2891,8 +2807,7 @@
 						</li>
 						<li>
 							<p id="confreq-zip-enc">OCF ZIP containers MUST NOT use the encryption features defined by
-								the ZIP format; instead, encryption MUST be done using the features described in <a
-									href="#sec-container-metainf-encryption.xml"></a>.</p>
+								the ZIP format; instead, encryption MUST be done using the features described in <a href="#sec-container-metainf-encryption.xml"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-zip-utf8">OCF ZIP containers MUST encode file system names using UTF-8
@@ -2917,7 +2832,7 @@
 					</ul>
 				</section>
 
-				<section id="sec-zip-container-mime">
+				<section id="sec-zip-container-mime" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L317,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L323,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L329,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L335,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L341,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L347">
 					<h4>OCF ZIP container media type identification</h4>
 
 					<p>[=EPUB creators=] MUST include the <code>mimetype</code> file as the first file in the [=OCF ZIP
@@ -3098,12 +3013,10 @@
 					</ol>
 				</section>
 
-				<section id="obfus-specifying">
+				<section id="obfus-specifying" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L358,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L363,https://w3c.github.io/epub-structural-tests/#04-ocf_ocf.feature_L369">
 					<h4>Specifying obfuscated fonts</h4>
 
-					<p>Although not technically encrypted data, all obfuscated fonts MUST have an entry in the <code
-							class="filename">encryption.xml</code> file accompanying the [=EPUB publication=] (see <a
-							href="#sec-container-metainf-encryption.xml"></a>).</p>
+					<p>Although not technically encrypted data, all obfuscated fonts MUST have an entry in the <code class="filename">encryption.xml</code> file accompanying the [=EPUB publication=] (see <a href="#sec-container-metainf-encryption.xml"></a>).</p>
 
 					<p>[=EPUB creators=] MUST specify an <code>EncryptedData</code> element for each obfuscated font.
 						Each <code>EncryptedData</code> element MUST contain a child <code>EncryptionMethod</code>
@@ -3113,22 +3026,21 @@
 
 					<p>EPUB creators MUST list the path to the obfuscated font in the <code>CipherReference</code> child
 						of the <code>CipherData</code> element. As the obfuscation algorithm is restricted to fonts, the
-							<code>URI</code> attribute of the <code>CipherReference</code> element MUST reference a <a
-							href="#cmt-grp-font">Font core media type resource</a>.</p>
+							<code>URI</code> attribute of the <code>CipherReference</code> element MUST reference a <a href="#cmt-grp-font">Font core media type resource</a>.</p>
 
 					<aside class="example" title="An entry for an obfuscated font">
 						<pre>&lt;encryption 
     xmlns="urn:oasis:names:tc:opendocument:xmlns:container" 
-    xmlns:enc="http://www.w3.org/2001/04/xmlenc#">
-   &lt;enc:EncryptedData> 
+    xmlns:enc="http://www.w3.org/2001/04/xmlenc#"&gt;
+   &lt;enc:EncryptedData&gt; 
       &lt;enc:EncryptionMethod
-          Algorithm="http://www.idpf.org/2008/embedding"/> 
-      &lt;enc:CipherData> 
+          Algorithm="http://www.idpf.org/2008/embedding"/&gt; 
+      &lt;enc:CipherData&gt; 
          &lt;enc:CipherReference
-             URI="EPUB/Fonts/BKANT.TTF"/>  
-      &lt;/enc:CipherData> 
-   &lt;/enc:EncryptedData>  
-&lt;/encryption></pre>
+             URI="EPUB/Fonts/BKANT.TTF"/&gt;  
+      &lt;/enc:CipherData&gt; 
+   &lt;/enc:EncryptedData&gt;  
+&lt;/encryption&gt;</pre>
 					</aside>
 
 					<p>To prevent trivial copying of the embedded font to other EPUB publications, EPUB creators MUST
@@ -3180,8 +3092,7 @@
 
 				<div class="note">
 					<p>An EPUB publication can reference more than one package document, allowing for alternative
-						representations of the content. For more information, refer to <a
-							href="#sec-container-metainf-container.xml"></a></p>
+						representations of the content. For more information, refer to <a href="#sec-container-metainf-container.xml"></a></p>
 				</div>
 
 				<div class="note">
@@ -3195,7 +3106,7 @@
 
 				<p id="pkg-parse-package-url" data-tests="#ocf-url_link-relative,#ocf-url_relative"> To parse a URL
 					string <var>url</var> used in the [=package document=], the <a data-lt="url parser">URL
-					parser</a> [[url]] MUST be applied to <var>url</var>, with the [=content URL=] of the package
+					parser</a>&nbsp;[[url]] MUST be applied to <var>url</var>, with the [=content URL=] of the package
 					document as <var>base</var>.</p>
 			</section>
 
@@ -3205,7 +3116,7 @@
 				<p>This section provides definitions for shared attributes (i.e., attributes allowed on two or more
 					elements).</p>
 
-				<section id="attrdef-dir">
+				<section id="attrdef-dir" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L24">
 					<h4>The <code>dir</code> attribute (under-implemented)</h4>
 
 					<div class="note">
@@ -3216,17 +3127,15 @@
 							improves.</p>
 					</div>
 
-					<p
-						data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl"
-						>Specifies the <a data-cite="bidi#BD5">base direction</a> [[bidi]] of the textual content and
+					<p data-tests="#pkg-dir_creator-rtl,#pkg-dir_rtl-root-ltr,#pkg-dir_rtl-root-unset,#pkg-dir_unset-root-rtl,#pkg-dir_unset-root-unset,#pkg-dir-auto_root-rtl">Specifies the <a data-cite="bidi#BD5">base direction</a> [[bidi]] of the textual content and
 						attribute values of the carrying element and its descendants.</p>
 
 					<p>Allowed values are:</p>
 
 					<ul>
-						<li><code>ltr</code> &#8212; left-to-right base direction;</li>
-						<li><code>rtl</code> &#8212; right-to-left base direction; and</li>
-						<li><code>auto</code> &#8212; base direction is determined using the Unicode Bidi Algorithm
+						<li><code>ltr</code> — left-to-right base direction;</li>
+						<li><code>rtl</code> — right-to-left base direction; and</li>
+						<li><code>auto</code> — base direction is determined using the Unicode Bidi Algorithm
 							[[bidi]].</li>
 					</ul>
 
@@ -3240,63 +3149,52 @@
 					</div>
 
 					<aside class="example" title="Setting the global base direction for package document text">
-						<pre>&lt;package … dir="ltr">
+						<pre>&lt;package … dir="ltr"&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:coverage</code></a>, [^dc:creator^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:rights</code></a>, [^dc:subject^], [^dc:title^], [^meta^] and [^package^].</p>
+					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, [^dc:creator^], <a href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, [^dc:subject^], [^dc:title^], [^meta^] and [^package^].</p>
 				</section>
 
 
-				<section id="attrdef-href">
+				<section id="attrdef-href" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L32,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L484">
 					<h4>The <code>href</code> attribute</h4>
 
-					<p>A [=valid URL string=] [[url]] that references a resource.</p>
+					<p>A [=valid URL string=]&nbsp;[[url]] that references a resource.</p>
 
 					<p>The URL string MUST NOT reference resources via elements in the package document (e.g., via a
 						manifest [^item^] or spine [^itemref^] declaration).</p>
 
 					<aside class="example" title="Linking a metadata record">
-						<pre>&lt;package …>
-   &lt;metadata …>
+						<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;link
           rel="record"
           href="meta/9780000000001.xml" 
-          media-type="application/marc"/>
+          media-type="application/marc"/&gt;
       …
-   &lt;/metadata>
+   &lt;/metadata&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 					</aside>
 
 					<p>Allowed on: [^item^] and [^link^].</p>
 				</section>
 
-				<section id="attrdef-id">
+				<section id="attrdef-id" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L45,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L51">
 					<h4>The <code>id</code> attribute</h4>
 
 					<p>The <a data-cite="xml#id">ID</a> [[xml]] of the element, which MUST be unique within the document
 						scope.</p>
 
 					<aside class="example" title="Adding an identifier attribute">
-						<pre>&lt;dc:title id="pub-title">The Lord of the Rings&lt;/dc:title></pre>
+						<pre>&lt;dc:title id="pub-title"&gt;The Lord of the Rings&lt;/dc:title&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:coverage</code></a>, [^dc:creator^], [^dc:date^], <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, [^dc:identifier^],
-						[^dc:language^], <a href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, [^dc:subject^], [^dc:title^],
+					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, [^dc:creator^], [^dc:date^], <a href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"><code>dc:format</code></a>, [^dc:identifier^],
+						[^dc:language^], <a href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, <a href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>, [^dc:subject^], [^dc:title^],
 						[^dc:type^], [^item^], [^itemref^], [^link^], [^manifest^], [^meta^], [^package^] and
 						[^spine^].</p>
 				</section>
@@ -3307,18 +3205,18 @@
 					<p>A media type [[rfc2046]] that specifies the type and format of the referenced resource.</p>
 
 					<aside class="example" title="Adding the media type for a linked record">
-						<pre>&lt;package …>
-   &lt;metadata …>
+						<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;link
           rel="record"
           href="http://example.org/meta/12389347?format=onix"
           media-type="application/xml"
-          properties="onix"/>
+          properties="onix"/&gt;
       …
-   &lt;/metadata>
+   &lt;/metadata&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 					</aside>
 
 					<p>Allowed on: [^item^] and [^link^].</p>
@@ -3333,49 +3231,49 @@
 						for the attribute.</p>
 
 					<aside class="example" title="Identifying the EPUB navigation document in the manifest">
-						<pre>&lt;package …>
+						<pre>&lt;package …&gt;
    …
-   &lt;manifest>
+   &lt;manifest&gt;
       …
       &lt;item
           id="nav" 
           href="nav.xhtml"
           properties="nav"
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       …
-   &lt;/manifest>
+   &lt;/manifest&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 					</aside>
 
 					<p>Allowed on: [^item^], [^itemref^] and [^link^].</p>
 				</section>
 
-				<section id="attrdef-refines">
+				<section id="attrdef-refines" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L60,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L73,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L80">
 					<h4>The <code>refines</code> attribute</h4>
 
 					<p>Establishes an association between the current expression and the element or resource identified
 						by its value. [=EPUB creators=] MUST use as the value a [=path-relative-scheme-less-URL
-						string=], optionally followed by <code>U+0023 (#)</code> and a [=URL-fragment string=] that
+						string=], optionally followed by <code>U+0023&nbsp;(#)</code> and a [=URL-fragment string=] that
 						references the resource or element they are describing.</p>
 
 					<aside class="example" title="Specifying that a creator is the illustrator">
-						<pre>&lt;package …>
-   &lt;metadata …>
+						<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
-      &lt;dc:creator id="creator02">
+      &lt;dc:creator id="creator02"&gt;
          E.H. Shepard
-      &lt;/dc:creator>
+      &lt;/dc:creator&gt;
       &lt;meta
           refines="#creator02"
           property="role"
-          scheme="marc:relators">
+          scheme="marc:relators"&gt;
          ill
-      &lt;/meta>
+      &lt;/meta&gt;
       …
-   &lt;/metadata>
+   &lt;/metadata&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 					</aside>
 
 					<p>The <code>refines</code> attribute is OPTIONAL depending on the type of metadata expressed. When
@@ -3388,32 +3286,32 @@
 					<p>Refinement chains MUST NOT contain circular references or self-references.</p>
 
 					<aside class="example" title="Setting the duration of a media overlay document">
-						<pre>&lt;package …>
-   &lt;metadata …>
+						<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
           property="media:duration" 
-          refines="#c01_overlay">
+          refines="#c01_overlay"&gt;
          0:32:29
-      &lt;/meta>
+      &lt;/meta&gt;
       …
-   &lt;/metadata>
-   &lt;manifest>
+   &lt;/metadata&gt;
+   &lt;manifest&gt;
       …
       &lt;item
           id="c01_overlay"
           href="overlays/chapter01.smil"
-          media-type="application/smil+xml"/>
+          media-type="application/smil+xml"/&gt;
       …
-   &lt;/manifest>
+   &lt;/manifest&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 					</aside>
 
 					<p>Allowed on: [^link^] and [^meta^].</p>
 				</section>
 
-				<section id="attrdef-xml-lang">
+				<section id="attrdef-xml-lang" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L89,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L94,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L100,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L106">
 					<h4>The <code>xml:lang</code> attribute</h4>
 
 					<p>Specifies the language of the textual content and attribute values of the carrying element and
@@ -3422,21 +3320,16 @@
 							<a data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[bcp47]].</p>
 
 					<aside class="example" title="Setting the global language for package document text">
-						<pre>&lt;package … xml:lang="ja">
+						<pre>&lt;package … xml:lang="ja"&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 					</aside>
 
-					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:coverage</code></a>, [^dc:creator^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:rights</code></a>, [^dc:subject^], [^dc:title^], [^meta^] and [^package^].</p>
+					<p>Allowed on: [^collection^], [^dc:contributor^], <a href="#sec-opf-dcmes-optional-def"><code>dc:coverage</code></a>, [^dc:creator^], <a href="#sec-opf-dcmes-optional-def"><code>dc:description</code></a>, <a href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>, <a href="#sec-opf-dcmes-optional-def"><code>dc:relation</code></a>, <a href="#sec-opf-dcmes-optional-def"><code>dc:rights</code></a>, [^dc:subject^], [^dc:title^], [^meta^] and [^package^].</p>
 				</section>
 			</section>
 
-			<section id="sec-package-elem">
+			<section id="sec-package-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L114,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L121,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L128,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L136">
 				<h3>The <code>package</code> element</h3>
 
 				<p>The <code>package</code> element encapsulates all the information expressed in the [=package
@@ -3583,8 +3476,7 @@
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>metadata</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>metadata</code></dfn>
 							</p>
 						</dd>
 
@@ -3668,31 +3560,30 @@
 						[^dcterms:modified^] property. All other metadata is OPTIONAL.</p>
 
 					<aside class="example" title="The minimal set of metadata required in the package document">
-						<pre>&lt;package … unique-identifier="pub-id">
+						<pre>&lt;package … unique-identifier="pub-id"&gt;
     …
-    &lt;metadata …>
+    &lt;metadata …&gt;
        &lt;dc:identifier
-           id="pub-id">
+           id="pub-id"&gt;
           urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
-       &lt;/dc:identifier>
-       &lt;dc:title>
+       &lt;/dc:identifier&gt;
+       &lt;dc:title&gt;
           Norwegian Wood
-       &lt;/dc:title>
-       &lt;dc:language>
+       &lt;/dc:title&gt;
+       &lt;dc:language&gt;
           en
-       &lt;/dc:language>
+       &lt;/dc:language&gt;
        &lt;meta
-           property="dcterms:modified">
+           property="dcterms:modified"&gt;
           2011-01-01T12:00:00Z
-       &lt;/meta>
-    &lt;/metadata>
+       &lt;/meta&gt;
+    &lt;/metadata&gt;
     …
-&lt;/package>
+&lt;/package&gt;
 </pre>
 					</aside>
 
-					<p>The [^meta^] element provides a generic mechanism for including <a href="#sec-vocab-assoc"
-							>metadata properties from any vocabulary</a>. Although EPUB creators MAY use this mechanism
+					<p>The [^meta^] element provides a generic mechanism for including <a href="#sec-vocab-assoc">metadata properties from any vocabulary</a>. Although EPUB creators MAY use this mechanism
 						for any metadata purposes, they will typically use it to include rendering metadata defined in
 						EPUB specifications.</p>
 
@@ -3701,21 +3592,20 @@
 					</div>
 				</section>
 
-				<section id="sec-metadata-values">
+				<section id="sec-metadata-values" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L153,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L162,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L169,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L176,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L183">
 					<h4>Metadata values</h4>
 
 					<p>The Dublin Core elements [[dcterms]] and [^meta^] element have mandatory [=child text content=]
 						[[dom]]. In the descriptions for these elements, this specification refers to this content as
 						the element's <dfn>value</dfn>.</p>
 
-					<p>These elements MUST have non-empty values after <a
-							data-lt="strip leading and trailing ascii whitespace">leading and trailing ASCII
-							whitespace</a> [[infra]] is stripped (i.e., they must consist of at least one non-whitespace
+					<p>These elements MUST have non-empty values after <a data-lt="strip leading and trailing ascii whitespace">leading and trailing ASCII
+							whitespace</a>&nbsp;[[infra]] is stripped (i.e., they must consist of at least one non-whitespace
 						character).</p>
 
 					<p>Whitespace within these element values is not significant. Sequences of one or more whitespace
 						characters are <a data-lt="strip and collapse ascii whitespace">collapsed to a single
-						space</a> [[infra]] during processing .</p>
+						space</a>&nbsp;[[infra]] during processing .</p>
 				</section>
 
 				<section id="sec-opf-dcmes-required">
@@ -3724,17 +3614,13 @@
 					<section id="sec-opf-dcidentifier">
 						<h5>The <code>dc:identifier</code> element</h5>
 
-						<p>The <code>dc:identifier</code> element [[dcterms]] contains an identifier such as a <abbr
-								title="Universally Unique Identifier">UUID</abbr>, <abbr
-								title="Digital Object Identfier">DOI</abbr> or <abbr
-								title="International Standard Book Number">ISBN</abbr>.</p>
+						<p>The <code>dc:identifier</code> element [[dcterms]] contains an identifier such as a <abbr title="Universally Unique Identifier">UUID</abbr>, <abbr title="Digital Object Identfier">DOI</abbr> or <abbr title="International Standard Book Number">ISBN</abbr>.</p>
 
 						<dl id="elemdef-opf-dcidentifier" class="elemdef">
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-											><code>dc:identifier</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>dc:identifier</code></dfn>
 								</p>
 							</dd>
 
@@ -3771,21 +3657,20 @@
 						</dl>
 
 						<p>The [=EPUB creator=] MUST provide an identifier that is unique to one and only one [=EPUB
-							publication=] &#8212; its [=unique identifier=] &#8212; in an <code>dc:identifier</code>
+							publication=] — its [=unique identifier=] — in an <code>dc:identifier</code>
 							element. This <code>dc:identifier</code> element MUST specify an <code>id</code> attribute
-							whose value is referenced from the [^package^] element's <a
-								href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
+							whose value is referenced from the [^package^] element's <a href="#attrdef-package-unique-identifier"><code>unique-identifier</code>
 							attribute</a>.</p>
 
 						<aside class="example" title="Specifying the element with the unique identifier">
-							<pre>&lt;package … unique-identifier="pub-id">
-    &lt;metadata …>
-       &lt;dc:identifier id="pub-id">
+							<pre>&lt;package … unique-identifier="pub-id"&gt;
+    &lt;metadata …&gt;
+       &lt;dc:identifier id="pub-id"&gt;
            urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
-       &lt;/dc:identifier>
+       &lt;/dc:identifier&gt;
        …
-    &lt;/metadata>
-&lt;/package></pre>
+    &lt;/metadata&gt;
+&lt;/package&gt;</pre>
 						</aside>
 
 						<p>Although not static, EPUB creators should make changes to the unique identifier for an EPUB
@@ -3802,28 +3687,27 @@
 							to an established system or an issuing authority granted it.</p>
 
 						<aside class="example" title="Specifying the type of the identifier">
-							<p>In this example, the <code>identifier-type</code> property is used with the <a
-									href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> scheme to indicate the
+							<p>In this example, the <code>identifier-type</code> property is used with the <a href="https://ns.editeur.org/onix/en/5">ONIX codelist 5</a> scheme to indicate the
 								product identifier type is a <a href="https://www.doi.org">DOI</a> (i.e., the value
 									<code>06</code> in codelist 5 is for DOIs).</p>
 
-							<pre>&lt;metadata …>
+							<pre>&lt;metadata …&gt;
    &lt;dc:identifier
-       id="pub-id">
+       id="pub-id"&gt;
       urn:doi:10.1016/j.iheduc.2008.03.001
-   &lt;/dc:identifier>
+   &lt;/dc:identifier&gt;
    &lt;meta
        refines="#pub-id"
        property="identifier-type"
-       scheme="onix:codelist5">
+       scheme="onix:codelist5"&gt;
       06
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 						</aside>
 					</section>
 
-					<section id="sec-opf-dctitle">
+					<section id="sec-opf-dctitle" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L203">
 						<h5>The <code>dc:title</code> element</h5>
 
 						<p>The <code>dc:title</code> element [[dcterms]] represents an instance of a name for the [=EPUB
@@ -3833,8 +3717,7 @@
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-											><code>dc:title</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>dc:title</code></dfn>
 								</p>
 							</dd>
 
@@ -3890,12 +3773,12 @@
 							of the EPUB publication (i.e., the primary one reading systems present to users).</p>
 
 						<aside class="example" title="A basic title element">
-							<pre>&lt;metadata …>
-   &lt;dc:title>
+							<pre>&lt;metadata …&gt;
+   &lt;dc:title&gt;
       Norwegian Wood
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    …
-&lt;/metadata>
+&lt;/metadata&gt;
 </pre>
 						</aside>
 
@@ -3910,38 +3793,36 @@
 
 							<p>For example, the following example shows a basic multipart title:</p>
 
-							<pre>&lt;metadata …>
-   &lt;dc:title>
+							<pre>&lt;metadata …&gt;
+   &lt;dc:title&gt;
       THE LORD OF THE RINGS
-   &lt;/dc:title>
-   &lt;dc:title>
+   &lt;/dc:title&gt;
+   &lt;dc:title&gt;
       Part One: The Fellowship of the Ring
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    …
-&lt;/metadata>
+&lt;/metadata&gt;
 </pre>
 
 							<p>The same title could instead be expressed using a single <code>dc:title</code> element as
 								follows:</p>
 
-							<pre>&lt;metadata …>
-   &lt;dc:title>
+							<pre>&lt;metadata …&gt;
+   &lt;dc:title&gt;
        THE LORD OF THE RINGS, Part One:
        The Fellowship of the Ring
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    …
-&lt;/metadata>
+&lt;/metadata&gt;
 </pre>
 
-							<p>Previous versions of this specification recommended using the <a href="#sec-title-type"
-										><code>title-type</code></a> and <a href="#sec-display-seq"
-										><code>display-seq</code></a> properties to identify and format the segments of
+							<p>Previous versions of this specification recommended using the <a href="#sec-title-type"><code>title-type</code></a> and <a href="#sec-display-seq"><code>display-seq</code></a> properties to identify and format the segments of
 								multipart titles (see the <a href="#cookbook-ex">Great Cookbooks example</a>). It is
 								still possible to add these semantics, but they are also not well supported.</p>
 						</div>
 					</section>
 
-					<section id="sec-opf-dclanguage">
+					<section id="sec-opf-dclanguage" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L213">
 						<h5>The <code>dc:language</code> element</h5>
 
 						<p>The <code>dc:language</code> element [[dcterms]] specifies the language of the content of the
@@ -3951,8 +3832,7 @@
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-											><code>dc:language</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>dc:language</code></dfn>
 								</p>
 							</dd>
 
@@ -3984,17 +3864,16 @@
 							</dd>
 						</dl>
 
-						<p>The [=value=] of each <code>dc:language</code> element MUST be a <a
-								data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[bcp47]].</p>
+						<p>The [=value=] of each <code>dc:language</code> element MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language tag</a> [[bcp47]].</p>
 
 						<aside class="example" title="Specifying U.S. English as the language of the EPUB publication">
-							<pre>&lt;metadata …>
+							<pre>&lt;metadata …&gt;
    …
-   &lt;dc:language>
+   &lt;dc:language&gt;
       en-US
-   &lt;/dc:language>
+   &lt;/dc:language&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 						</aside>
 
 						<p>Although [=EPUB creators=] MAY specify additional <code>dc:language</code> elements for
@@ -4079,8 +3958,7 @@
 					<section id="sec-opf-dccontributor">
 						<h5>The <code>dc:contributor</code> element</h5>
 
-						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>dc:contributor</code></dfn> element [[dcterms]] is used to represent the name
+						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>dc:contributor</code></dfn> element [[dcterms]] is used to represent the name
 							of a person, organization, etc. that played a secondary role in the creation of the
 							content.</p>
 
@@ -4091,10 +3969,8 @@
 					<section id="sec-opf-dccreator">
 						<h5>The <code>dc:creator</code> element</h5>
 
-						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-								><code>dc:creator</code></dfn> element [[dcterms]] represents the name of a person,
-							organization, etc. responsible for the creation of the content. [=EPUB creators=] MAY <a
-								href="#subexpression">associate</a> a <a href="#role"><code>role</code> property</a>
+						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>dc:creator</code></dfn> element [[dcterms]] represents the name of a person,
+							organization, etc. responsible for the creation of the content. [=EPUB creators=] MAY <a href="#subexpression">associate</a> a <a href="#role"><code>role</code> property</a>
 							with the element to indicate the function the creator played.</p>
 
 						<aside class="example" title="Specifying that a creator is an author">
@@ -4102,21 +3978,21 @@
 									relators</a> scheme is used to indicate the role (i.e., the value <code>aut</code>
 								indicates an author in MARC).</p>
 
-							<pre>&lt;metadata …>
+							<pre>&lt;metadata …&gt;
    …
    &lt;dc:creator
-       id="creator">
+       id="creator"&gt;
       Haruki Murakami
-   &lt;/dc:creator>
+   &lt;/dc:creator&gt;
    &lt;meta
        refines="#creator"
        property="role"
        scheme="marc:relators"
-       id="role">
+       id="role"&gt;
       aut
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 						</aside>
 
 						<p>The <code>dc:creator</code> element should contain the name of the creator as EPUB creators
@@ -4128,25 +4004,25 @@
 							creator's name in another language or script.</p>
 
 						<aside class="example" title="Expressing sorting and rendering information for a creator">
-							<pre>&lt;metadata …>
+							<pre>&lt;metadata …&gt;
    …
    &lt;dc:creator
-       id="creator">
+       id="creator"&gt;
       Haruki Murakami
-   &lt;/dc:creator>
+   &lt;/dc:creator&gt;
    &lt;meta
        refines="#creator"
        property="alternate-script"
-       xml:lang="ja">
+       xml:lang="ja"&gt;
       村上 春樹
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#creator"
-       property="file-as">
+       property="file-as"&gt;
       Murakami, Haruki
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 						</aside>
 
 						<p>If an [=EPUB publication=] has more than one creator, EPUB creators should specify each in a
@@ -4159,31 +4035,29 @@
 						<aside class="example" title="Expressing the primary creator">
 							<p>In this example, Lewis Carroll is the primary creator because he is listed first.</p>
 
-							<pre>&lt;metadata …>
+							<pre>&lt;metadata …&gt;
    …
    &lt;dc:creator
-       id="creator01">
+       id="creator01"&gt;
       Lewis Carroll
-   &lt;/dc:creator>
+   &lt;/dc:creator&gt;
    &lt;dc:creator
-       id="creator02">
+       id="creator02"&gt;
       John Tenniel
-   &lt;/dc:creator>
+   &lt;/dc:creator&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 						</aside>
 
 						<p>EPUB creators should represent secondary contributors using the [^dc:contributor^]
 							element.</p>
 					</section>
 
-					<section id="sec-opf-dcdate">
+					<section id="sec-opf-dcdate" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L231">
 						<h5>The <code>dc:date</code> element</h5>
 
-						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-								><code>dc:date</code></dfn> element [[dcterms]] defines the publication date of the
-							[=EPUB publication=]. The publication date is not the same as the <a
-								href="#last-modified-date">last modified date</a> (the last time the [=EPUB creator=]
+						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>dc:date</code></dfn> element [[dcterms]] defines the publication date of the
+							[=EPUB publication=]. The publication date is not the same as the <a href="#last-modified-date">last modified date</a> (the last time the [=EPUB creator=]
 							changed the EPUB publication).</p>
 
 						<p>It is RECOMMENDED that the date string conform to [[iso8601]], particularly the subset
@@ -4191,13 +4065,13 @@
 							machine readable.</p>
 
 						<aside class="example" title="Expressing the publication date">
-							<pre>&lt;metadata …>
+							<pre>&lt;metadata …&gt;
    …
-   &lt;dc:date>
+   &lt;dc:date&gt;
       2000-01-01T00:00:00Z
-   &lt;/dc:date>
+   &lt;/dc:date&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 						</aside>
 
 						<p>EPUB creators should express additional dates using the specialized date properties available
@@ -4209,8 +4083,7 @@
 					<section id="sec-opf-dcsubject">
 						<h5>The <code>dc:subject</code> element</h5>
 
-						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-								><code>dc:subject</code></dfn> element [[dcterms]] identifies the subject of the [=EPUB
+						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>dc:subject</code></dfn> element [[dcterms]] identifies the subject of the [=EPUB
 							publication=]. [=EPUB creators=] should set the [=value=] of the element to the
 							human-readable heading or label, but may use a code value if the subject taxonomy does not
 							provide a separate descriptive label.</p>
@@ -4222,39 +4095,39 @@
 							subject code using the <a href="#term"><code>term</code> property</a>.</p>
 
 						<aside class="example" title="Specifying a BISAC code and heading">
-							<pre>&lt;metadata …>
-   &lt;dc:subject id="subject01">
+							<pre>&lt;metadata …&gt;
+   &lt;dc:subject id="subject01"&gt;
       FICTION / Occult &amp;amp; Supernatural
-   &lt;/dc:subject>
+   &lt;/dc:subject&gt;
    &lt;meta
        refines="#subject01"
-       property="authority">
+       property="authority"&gt;
       BISAC
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#subject01"
-       property="term">
+       property="term"&gt;
       FIC024000
-   &lt;/meta>
+   &lt;/meta&gt;
 &lt;/metadata</pre>
 						</aside>
 
 						<aside class="example" title="Specifying a URL for the scheme">
-							<pre>&lt;metadata …>
-   &lt;dc:subject id="sbj01">
+							<pre>&lt;metadata …&gt;
+   &lt;dc:subject id="sbj01"&gt;
       Number Theory
-   &lt;/dc:subject>
+   &lt;/dc:subject&gt;
    &lt;meta
        refines="#sbj01"
-       property="authority">
+       property="authority"&gt;
       http://www.ams.org/msc/msc2010.html
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
       refines="#sbj01"
-      property="term">
+      property="term"&gt;
      11
-  &lt;/meta>
-&lt;/metadata></pre>
+  &lt;/meta&gt;
+&lt;/metadata&gt;</pre>
 						</aside>
 
 						<p>The <code>term</code> property MUST NOT be <a href="#subexpression">associated with a
@@ -4267,8 +4140,7 @@
 					<section id="sec-opf-dctype">
 						<h5>The <code>dc:type</code> element</h5>
 
-						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-								><code>dc:type</code></dfn> element [[dcterms]] is used to indicate that the [=EPUB
+						<p>The <dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>dc:type</code></dfn> element [[dcterms]] is used to indicate that the [=EPUB
 							publication=] is of a specialized type (e.g., annotations or a dictionary packaged in EPUB
 							format).</p>
 
@@ -4276,15 +4148,14 @@
 
 						<div class="note">
 							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB 3
-								Working Group maintained a <a href="http://idpf.org/epub/vocab/package/types/"
-									>non-normative registry of specialized EPUB publication types</a> for use with this
+								Working Group maintained a <a href="http://idpf.org/epub/vocab/package/types/">non-normative registry of specialized EPUB publication types</a> for use with this
 								element. This Working Group no longer maintains the registry and does not anticipate
 								developing new specialized publication types.</p>
 						</div>
 					</section>
 				</section>
 
-				<section id="sec-meta-elem">
+				<section id="sec-meta-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L272,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L279,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L287,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L297,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L304">
 					<h4>The <code>meta</code> element</h4>
 
 					<p>The <code>meta</code> element provides a generic means of including package metadata.</p>
@@ -4389,62 +4260,56 @@
 					<p class="note">All the [[dcterms]] elements represent primary expressions, and permit refinement by
 						meta element subexpressions.</p>
 
-					<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a
-							href="#sec-default-vocab">default vocabulary</a> for use with the <code>property</code>
+					<p>The <a href="#app-meta-property-vocab">Meta Properties Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for use with the <code>property</code>
 						attribute.</p>
 
-					<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-						></a>.</p>
+					<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"></a>.</p>
 
 					<aside class="example" title="Using properties with reserved prefixes">
 						<p>For the full list of reserved prefixes, refer to <a href="#sec-reserved-prefixes"></a>.</p>
 
-						<pre>&lt;metadata …>
+						<pre>&lt;metadata …&gt;
    …
    &lt;meta
-       property="dcterms:modified">
+       property="dcterms:modified"&gt;
       2016-02-29T12:34:56Z
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
-       property="rendition:layout">
+       property="rendition:layout"&gt;
       pre-paginated
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
-       property="media:active-class">
+       property="media:active-class"&gt;
       my-active-item
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 					</aside>
 
 					<p id="attrdef-scheme">The <code>scheme</code> attribute identifies the system or scheme the EPUB
-						creator obtained the element's [=value=] from. The value of the attribute MUST be a <a
-							href="#sec-property-datatype"><var>property</var> data type value</a> that resolves to the
-						resource that defines the scheme. The <code>scheme</code> attribute does not have a <a
-							href="#sec-default-vocab">default vocabulary</a> (i.e., all values require a <a
-							href="#property.ebnf.prefix">prefix</a>).</p>
+						creator obtained the element's [=value=] from. The value of the attribute MUST be a <a href="#sec-property-datatype"><var>property</var> data type value</a> that resolves to the
+						resource that defines the scheme. The <code>scheme</code> attribute does not have a <a href="#sec-default-vocab">default vocabulary</a> (i.e., all values require a <a href="#property.ebnf.prefix">prefix</a>).</p>
 
 					<aside class="example" title="Using values from a scheme">
 						<p>In this example, the <code>scheme</code> attribute indicates that the [=value=] of the tag is
 							from [[onix]] code list 5 (i.e., the value <code>15</code> indicates a 13 digit ISBN).</p>
-						<pre>&lt;metadata &#8230;>
-   &#8230;
+						<pre>&lt;metadata …&gt;
+   …
    &lt;meta
        refines="#isbn-id"
        property="identifier-type"
-       scheme="onix:codelist5">
+       scheme="onix:codelist5"&gt;
       15
-   &lt;/meta>
-   &#8230;
-&lt;/metadata></pre>
+   &lt;/meta&gt;
+   …
+&lt;/metadata&gt;</pre>
 					</aside>
 				</section>
 
-				<section id="sec-metadata-last-modified">
+				<section id="sec-metadata-last-modified" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L313,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L320">
 					<h4>Last modified date</h4>
 
-					<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one <dfn
-							class="export" data-lt-no-plural=""><code>dcterms:modified</code></dfn> property [[dcterms]]
+					<p id="last-modified-date">The <code>metadata</code> section MUST contain exactly one <dfn class="export" data-lt-no-plural=""><code>dcterms:modified</code></dfn> property [[dcterms]]
 						containing the last modification date. The [=value=] of this property MUST be an [[xmlschema-2]]
 						dateTime conformant date of the form: <code>CCYY-MM-DDThh:mm:ssZ</code></p>
 
@@ -4452,14 +4317,14 @@
 						MUST terminate it with the "<code>Z</code>" (Zulu) time zone indicator.</p>
 
 					<aside class="example" title="Expressing a last modification date">
-						<pre>&lt;metadata …>
+						<pre>&lt;metadata …&gt;
    …
    &lt;meta
-       property="dcterms:modified">
+       property="dcterms:modified"&gt;
       2016-01-01T00:00:01Z
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 					</aside>
 
 					<p>EPUB creators should update the last modified date whenever they make changes to the [=EPUB
@@ -4471,13 +4336,11 @@
 
 					<div class="note">
 						<p>The requirements for the last modification date are to ensure compatibility with earlier
-							versions of EPUB 3 that defined a <a
-								href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid"
-								>release identifier</a> [[epubpackages-32]] for EPUB publications.</p>
+							versions of EPUB 3 that defined a <a href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-metadata-elem-identifiers-pid">release identifier</a> [[epubpackages-32]] for EPUB publications.</p>
 					</div>
 				</section>
 
-				<section id="sec-link-elem">
+				<section id="sec-link-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L335,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L341,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L346,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L351,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L358,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L364,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L369,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L374,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L380,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L386,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L391">
 					<h4>The <code>link</code> element</h4>
 
 					<p>The <code>link</code> element associates resources with an [=EPUB publication=], such as metadata
@@ -4577,15 +4440,14 @@
 						</li>
 						<li>
 							<p>included or embedded in an [=EPUB content document=] (e.g., a metadata record serialized
-								as RDFa [[?rdfa-core]] or as JSON-LD [[?json-ld11]] embedded in an [[html]] [^script^]
+								as RDFa [[?rdfa-core]] or as JSON-LD [[?json-ld11]] embedded in an [[html]]&nbsp;[^script^]
 								element).</p>
 						</li>
 					</ul>
 
 					<p>In all other cases (e.g., when linking to standalone [[?onix]] records), the resources referenced
 						are not [=publication resources=] (i.e., are not subject to <a href="#sec-core-media-types">core
-							media type requirements</a>) and [=EPUB creators=] MUST NOT list them in the <a
-							href="#sec-manifest-elem">manifest</a>.</p>
+							media type requirements</a>) and [=EPUB creators=] MUST NOT list them in the <a href="#sec-manifest-elem">manifest</a>.</p>
 
 					<aside class="example" title="Reference to a record embedded in an XHTML content document">
 						<p>In this example, the metadata record is embedded in a <code>script</code> element. Note that
@@ -4595,34 +4457,34 @@
 
 						<pre>Package document:
 
-&lt;package …>
-   &lt;metadata …>
+&lt;package …&gt;
+   &lt;metadata …&gt;
       … 
       &lt;link rel="record"
           href="front.xhtml#meta-json"
           media-type="application/xhtml+xml"
-          hreflang="en"/>
+          hreflang="en"/&gt;
       …
-   &lt;/metadata>
+   &lt;/metadata&gt;
    …
-&lt;/package>
+&lt;/package&gt;
 
 XHTML:
 
-&lt;html …>
-   &lt;head>
+&lt;html …&gt;
+   &lt;head&gt;
       …
-      &lt;script id="meta-json" type="application/ld+json">
+      &lt;script id="meta-json" type="application/ld+json"&gt;
           "@context" : "http://schema.org",
           "name" : "…",
          …
-      &lt;/script>
+      &lt;/script&gt;
       …
-   &lt;/head>
-   &lt;body>
+   &lt;/head&gt;
+   &lt;body&gt;
       …
-   &lt;/body>
-&lt;/html></pre>
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
 					</aside>
 
 					<p id="linked-res-location">EPUB creators MAY locate linked resources within the [=EPUB container=]
@@ -4638,19 +4500,18 @@ XHTML:
 						linked resource. The value MUST be a <a data-cite="bcp47#section-2.2.9">well-formed language
 							tag</a> [[bcp47]].</p>
 
-					<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated list of <a
-							href="#sec-property-datatype">property</a> values that establish the relationship the linked
+					<p id="attrdef-link-rel">The REQUIRED <code>rel</code> attribute takes a space-separated list of <a href="#sec-property-datatype">property</a> values that establish the relationship the linked
 						resource has with the EPUB publication.</p>
 
 					<aside class="example" title="Linking to a MARC XML record">
-						<pre>&lt;metadata …>
+						<pre>&lt;metadata …&gt;
    …
    &lt;link
        rel="record"
        href="meta/9780000000001.xml" 
-       media-type="application/marc"/>
+       media-type="application/marc"/&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 					</aside>
 
 					<p>The value of the <code>media-type</code> attribute is not always sufficient to identify the type
@@ -4663,61 +4524,57 @@ XHTML:
 						<p>In this example, the <code>properties</code> attribute identifies the link is to an ONIX
 							record.</p>
 
-						<pre>&lt;metadata …>
+						<pre>&lt;metadata …&gt;
    …
    &lt;link rel="record"
        href="http://example.org/meta/12389347?format=onix"
        media-type="application/xml"
-       properties="onix"/>
+       properties="onix"/&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 					</aside>
 
-					<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a href="#sec-default-vocab"
-							>default vocabulary</a> for the <code>rel</code> and <code>properties</code> attributes.</p>
+					<p>The <a href="#app-link-vocab">Metadata Link Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the <code>rel</code> and <code>properties</code> attributes.</p>
 
-					<p>EPUB creators MAY add relationships and properties from other vocabularies as defined in <a
-							href="#sec-vocab-assoc"></a>.</p>
+					<p>EPUB creators MAY add relationships and properties from other vocabularies as defined in <a href="#sec-vocab-assoc"></a>.</p>
 
 					<aside class="example" title="Declaring a new link relationship">
 						<p>In this example, the <code>link</code> element is used to associate an author's home page
-							using the FOAF vocabulary. Note that as <code>foaf</code> is not a <a
-								href="#sec-metadata-reserved-prefixes">predefined prefix</a>, it must be declared in the
+							using the FOAF vocabulary. Note that as <code>foaf</code> is not a <a href="#sec-metadata-reserved-prefixes">predefined prefix</a>, it must be declared in the
 								<a href="#attrdef-package-prefix">prefix attribute</a>.</p>
 
 						<pre>&lt;package
     …
-    prefix="foaf: http://xmlns.com/foaf/spec/">
-   &lt;metadata …>
+    prefix="foaf: http://xmlns.com/foaf/spec/"&gt;
+   &lt;metadata …&gt;
       … 
       &lt;link
           refines="#creator01"
           rel="foaf:homepage"
-          href="http://example.org/book-info/12389347" />
+          href="http://example.org/book-info/12389347" /&gt;
       …
-   &lt;/metadata> 
+   &lt;/metadata&gt; 
    …
-&lt;/package>
+&lt;/package&gt;
 </pre>
 					</aside>
 
-					<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB creators MAY provide one or more <a
-							href="#record">linked metadata records</a>.</p>
+					<p id="sec-linked-records" data-tests="#pkg-linked-records">EPUB creators MAY provide one or more <a href="#record">linked metadata records</a>.</p>
 
 					<aside class="example" title="Specifying linked records">
 						<p>In this example, linked ONIX and JSON-LD records are included in the EPUB container.</p>
 
-						<pre>&lt;metadata …>
+						<pre>&lt;metadata …&gt;
    &lt;link rel="record"
        href="http://example.org/onix/12389347"
        media-type="application/xml"
-       properties="onix" />
+       properties="onix" /&gt;
     
    &lt;link rel="record"
        href="meta/meta.jsonld"
-       media-type="application/ld+json" />
+       media-type="application/ld+json" /&gt;
     …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 					</aside>
 
 					<div class="note">
@@ -4733,14 +4590,14 @@ XHTML:
 						<p>In this example, the description of the EPUB publication is contained in an HTML
 							document.</p>
 
-						<pre>&lt;metadata …>
+						<pre>&lt;metadata …&gt;
    …
    &lt;link
        rel="dcterms:description"
        href="description.html"
-       media-type="text/html"/>
+       media-type="text/html"/&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 					</aside>
 				</section>
 			</section>
@@ -4748,7 +4605,7 @@ XHTML:
 			<section id="sec-pkg-manifest">
 				<h3>Manifest section</h3>
 
-				<section id="sec-manifest-elem">
+				<section id="sec-manifest-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L401,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L407,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L413,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L419,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L425,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L431,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L75,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L81,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L281,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L339,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L428">
 					<h4>The <code>manifest</code> element</h4>
 
 					<p>The <code>manifest</code> element provides an exhaustive list of [=publication resources=] used
@@ -4758,8 +4615,7 @@ XHTML:
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>manifest</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>manifest</code></dfn>
 							</p>
 						</dd>
 
@@ -4789,14 +4645,12 @@ XHTML:
 							<code>manifest</code> MUST list all publication resources regardless of whether they are
 						[=container resources=] or [=remote resources=].</p>
 
-					<p>As the package document is already identified by the <a
-							href="#sec-container-metainf-container.xml"><code>container.xml</code> file</a>, the
+					<p>As the package document is already identified by the <a href="#sec-container-metainf-container.xml"><code>container.xml</code> file</a>, the
 							<code>manifest</code> MUST NOT specify an <code>item</code> element for it (i.e., a
 						self-reference serves no purpose).</p>
 
 					<div class="note">
-						<p>The manifest is only for listing publication resources. [=Linked resources=] and <a
-								href="#sec-container-file-and-dir-structure">the special files for processing the OCF
+						<p>The manifest is only for listing publication resources. [=Linked resources=] and <a href="#sec-container-file-and-dir-structure">the special files for processing the OCF
 								Container</a> (i.e., files in the <code>META-INF</code> directory, and the
 								<code>mimetype</code> file) are restricted from inclusion.</p>
 
@@ -4806,7 +4660,7 @@ XHTML:
 					</div>
 				</section>
 
-				<section id="sec-item-elem">
+				<section id="sec-item-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L447,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L460,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L466,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L472,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L478,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L484,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L491,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L497,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L503">
 					<h4>The <code>item</code> element</h4>
 
 					<p>The <code>item</code> element represents a [=publication resource=].</p>
@@ -4885,20 +4739,17 @@ XHTML:
 
 					<p id="attrdef-item-href">Each <code>item</code> element identifies a publication resource by the
 						URL [[url]] in its <a href="#attrdef-href"><code>href</code> attribute</a>. The value MUST be an
-							<a data-lt="absolute-url string">absolute-</a> or <a
-							data-lt="path-relative-scheme-less-url string">path-relative-scheme-less-URL</a>
-						string [[url]]. [=EPUB creators=] MUST ensure each URL is unique within the
+							<a data-lt="absolute-url string">absolute-</a> or <a data-lt="path-relative-scheme-less-url string">path-relative-scheme-less-URL</a>
+						string&nbsp;[[url]]. [=EPUB creators=] MUST ensure each URL is unique within the
 							<code>manifest</code> scope after <a href="#sec-parse-package-urls">parsing</a>.</p>
 
 					<p id="attrdef-item-media-type">The publication resource identified by an <code>item</code> element
 						MUST conform to the applicable specification(s) as inferred from the MIME media type [[rfc2046]]
 						provided in the <a href="#attrdef-media-type"><code>media-type</code> attribute</a>. For [=core
-						media type resources=], EPUB creators MUST use the media type designated in <a
-							href="#sec-core-media-types"></a>.</p>
+						media type resources=], EPUB creators MUST use the media type designated in <a href="#sec-core-media-types"></a>.</p>
 
 					<p id="attrdef-item-fallback">The <code>fallback</code> attribute specifies the fallback for the
-						referenced publication resource. The <code>fallback</code> attribute's <a data-cite="xml#idref"
-							>IDREF</a> [[xml]] value MUST resolve to another <code>item</code> in the
+						referenced publication resource. The <code>fallback</code> attribute's <a data-cite="xml#idref">IDREF</a> [[xml]] value MUST resolve to another <code>item</code> in the
 							<code>manifest</code>.</p>
 
 					<p>The fallback for one <code>item</code> MAY specify a fallback to another <code>item</code>, and
@@ -4914,7 +4765,7 @@ XHTML:
 							[^spine^] element provides the presentation sequence of content documents.</p>
 					</div>
 
-					<section id="sec-item-resource-properties">
+					<section id="sec-item-resource-properties" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L518,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L526,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L533,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L539,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L547,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L554,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L560,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L566,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L572,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L578,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L584,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L590,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L596,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L602,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L608,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L616,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L622,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L628,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L634,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L641,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L647,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L653,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L662,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L673,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L680,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L687">
 						<h6>Resource properties</h6>
 
 						<p>The <a href="#attrdef-properties"><code>properties</code> attribute</a> provides information
@@ -4938,8 +4789,7 @@ XHTML:
 							<li><a href="#sec-switch">switch</a></li>
 						</ul>
 
-						<aside class="example" id="example-item-properties-scripted-mathml"
-							title="Identifying a scripted content document with embedded MathML">
+						<aside class="example" id="example-item-properties-scripted-mathml" title="Identifying a scripted content document with embedded MathML">
 							<pre class="synopsis">&lt;item
     properties="scripted mathml"
     id="c2"
@@ -4957,8 +4807,7 @@ XHTML:
 						<p>EPUB creators MUST declare exactly one <code>item</code> as the EPUB navigation document
 							using the <a href="#sec-nav-prop"><code>nav</code> property</a>.</p>
 
-						<aside class="example" id="example-item-properties-nav"
-							title="Identifying the EPUB navigation document">
+						<aside class="example" id="example-item-properties-nav" title="Identifying the EPUB navigation document">
 							<pre class="synopsis">&lt;item
     properties="nav"
     id="c1"
@@ -4966,12 +4815,10 @@ XHTML:
     media-type="application/xhtml+xml" /&gt;</pre>
 						</aside>
 
-						<p>If an EPUB publication contains a cover image, it is recommended to set the <a
-								href="#sec-cover-image"><code>cover-image</code> property</a>, but setting this property
+						<p>If an EPUB publication contains a cover image, it is recommended to set the <a href="#sec-cover-image"><code>cover-image</code> property</a>, but setting this property
 							is OPTIONAL.</p>
 
-						<aside class="example" id="example-item-properties-cover-image"
-							title="Identifying the cover image">
+						<aside class="example" id="example-item-properties-cover-image" title="Identifying the cover image">
 							<pre class="synopsis">&lt;item
     properties="cover-image"
     id="ci"
@@ -4979,110 +4826,106 @@ XHTML:
     media-type="image/svg+xml" /&gt;</pre>
 						</aside>
 
-						<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-							></a>.</p>
+						<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"></a>.</p>
 					</section>
 
 					<section id="sec-item-elem-examples">
 						<h6>Examples</h6>
 
-						<aside class="example" id="example-manifest-cmt"
-							title="A manifest with only core media type resources">
-							<pre>&lt;package …>
+						<aside class="example" id="example-manifest-cmt" title="A manifest with only core media type resources">
+							<pre>&lt;package …&gt;
    …
-   &lt;manifest>
+   &lt;manifest&gt;
       &lt;item
           id="nav" 
           href="nav.xhtml" 
           properties="nav"
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       &lt;item
           id="intro" 
           href="intro.xhtml" 
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       &lt;item
           id="c1" 
           href="chap1.xhtml" 
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       &lt;item
           id="c1-answerkey" 
           href="chap1-answerkey.xhtml" 
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       &lt;item
           id="c2" 
           href="chap2.xhtml" 
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       &lt;item
           id="c2-answerkey" 
           href="chap2-answerkey.xhtml" 
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       &lt;item
           id="c3" 
           href="chap3.xhtml" 
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       &lt;item
           id="c3-answerkey" 
           href="chap3-answerkey.xhtml" 
-          media-type="application/xhtml+xml"/>    
+          media-type="application/xhtml+xml"/&gt;    
       &lt;item
           id="notes" 
           href="notes.xhtml" 
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       &lt;item
           id="cover" 
           href="./images/cover.svg" 
           properties="cover-image"
-          media-type="image/svg+xml"/>
+          media-type="image/svg+xml"/&gt;
       &lt;item
           id="f1" 
           href="./images/fig1.jpg" 
-          media-type="image/jpeg"/>
+          media-type="image/jpeg"/&gt;
       &lt;item
           id="f2" 
           href="./images/fig2.jpg" 
-          media-type="image/jpeg"/>
+          media-type="image/jpeg"/&gt;
       &lt;item
           id="css" 
           href="./style/book.css" 
-          media-type="text/css"/>   
-   &lt;/manifest>
+          media-type="text/css"/&gt;   
+   &lt;/manifest&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 						</aside>
 
-						<aside class="example" id="example-manifest-flbk"
-							title="Foreign content document in spine with fallback">
+						<aside class="example" id="example-manifest-flbk" title="Foreign content document in spine with fallback">
 							<p>The following example shows the [=manifest fallback chain=] allowing a [=foreign content
 								document=] (JPEG) to be listed in the spine with fallback to an SVG content
 								document.</p>
 
-							<pre>&lt;package …>
+							<pre>&lt;package …&gt;
    …
-   &lt;manifest>
+   &lt;manifest&gt;
       …
       &lt;item
           id="page-001"
           href="images/page-001.jpg"
           media-type="image/jpeg"
-          fallback="page-001-svg"/>
+          fallback="page-001-svg"/&gt;
 
       &lt;item
           id="page-001-svg"
           href="images/page-001.svg"
-          media-type="image/svg+xml"/>
+          media-type="image/svg+xml"/&gt;
       … 
       …
-   &lt;/manifest>
-   &lt;spine>
+   &lt;/manifest&gt;
+   &lt;spine&gt;
       …
-      &lt;itemref idref="page-001"/>
+      &lt;itemref idref="page-001"/&gt;
       …
-   &lt;/spine>
-&lt;/package></pre>
+   &lt;/spine&gt;
+&lt;/package&gt;</pre>
 						</aside>
 
-						<aside class="example"
-							title="Embedded core media type resource with Link to View as top-level content document">
+						<aside class="example" title="Embedded core media type resource with Link to View as top-level content document">
 							<p>The following example shows a JPEG embedded in an [=EPUB content document=] (via the
 									<code>img</code> tag) with a hyperlink that allows it to open as a separate page
 								(e.g., for easier zooming). Although embedding the image using the <code>img</code> tag
@@ -5092,47 +4935,47 @@ XHTML:
 								include a fallback to an EPUB content document.</p>
 
 							<pre>XHTML:
-&lt;html …>
+&lt;html …&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       …
       &lt;img
           src="images/infographic.jpg"
-          alt="…"/>
+          alt="…"/&gt;
       &lt;a
-          href="images/infographic.jpg">
+          href="images/infographic.jpg"&gt;
          Expand Image
-      &lt;/a>
+      &lt;/a&gt;
       …
-   &lt;/body>
-&lt;/html>
+   &lt;/body&gt;
+&lt;/html&gt;
 
 Package document:
-&lt;package …>
+&lt;package …&gt;
    …
-   &lt;manifest>
+   &lt;manifest&gt;
       …
       &lt;item
           id="img01"
           href="images/infographic.jpg"
           media-type="image/jpeg"
-          fallback="infographic-svg"/>
+          fallback="infographic-svg"/&gt;
 
       &lt;item
           id="infographic-svg"
           href="images/infographic.svg"
-          media-type="image/svg+xml"/>
+          media-type="image/svg+xml"/&gt;
       …
-   &lt;/manifest>
-   &lt;spine>
+   &lt;/manifest&gt;
+   &lt;spine&gt;
       …
       &lt;itemref
           idref="img01"
           properties="layout-pre-paginated"
-          linear="no"/>
+          linear="no"/&gt;
       …
-   &lt;/spine>
-&lt;/package></pre>
+   &lt;/spine&gt;
+&lt;/package&gt;</pre>
 						</aside>
 
 						<aside class="example" title="Link to View foreign resource as top-level content document">
@@ -5144,49 +4987,49 @@ Package document:
 								how to extract the file from the [=EPUB container=] are also provided.</p>
 
 							<pre>XHTML:
-&lt;html …>
+&lt;html …&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       …
-      &lt;p>
-         &lt;a href="../data/raw.csv">
+      &lt;p&gt;
+         &lt;a href="../data/raw.csv"&gt;
             [Open the raw CSV data for this project.]
-         &lt;/a>
-      &lt;/p>
-      &lt;p class="small">To extract the data file
+         &lt;/a&gt;
+      &lt;/p&gt;
+      &lt;p class="small"&gt;To extract the data file
          from this publication, unzip the EPUB file.
          The data is located in the
-      	&lt;code>/EPUB/data/raw.csv&lt;/code> file.
-      &lt;/p>
+      	&lt;code&gt;/EPUB/data/raw.csv&lt;/code&gt; file.
+      &lt;/p&gt;
       …
-   &lt;/body>
-&lt;/html>
+   &lt;/body&gt;
+&lt;/html&gt;
 
 Package document:
-&lt;package …>
+&lt;package …&gt;
    …
-   &lt;manifest>
+   &lt;manifest&gt;
       …
       &lt;item
           id="data01"
           href="data/raw.csv"
           media-type="text/csv"
-          fallback="data-html"/>
+          fallback="data-html"/&gt;
 
       &lt;item
           id="data-html"
           href="xhtml/data-table.html"
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       …
-   &lt;/manifest>
-   &lt;spine>
+   &lt;/manifest&gt;
+   &lt;spine&gt;
       …
       &lt;itemref
           idref="data01"
-          linear="no"/>
+          linear="no"/&gt;
       …
-   &lt;/spine>
-&lt;/package></pre>
+   &lt;/spine&gt;
+&lt;/package&gt;</pre>
 						</aside>
 
 						<aside class="example" title="Remote resources that are publication resources">
@@ -5197,36 +5040,36 @@ Package document:
 								a [=remote resource=].</p>
 
 							<pre>XHTML:
-&lt;html …>
+&lt;html …&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       …
       &lt;audio
           src="http://www.example.com/book/audio/ch01.mp4"
-          controls="controls"/>
+          controls="controls"/&gt;
       …
-   &lt;/body>
-&lt;/html>
+   &lt;/body&gt;
+&lt;/html&gt;
 
 Package document:
-&lt;package …>
+&lt;package …&gt;
    …
-   &lt;manifest>
+   &lt;manifest&gt;
       …
       &lt;item
           id="audio01"
           href="http://www.example.com/book/audio/ch01.mp4"
-          media-type="audio/mp4"/>
+          media-type="audio/mp4"/&gt;
    
       &lt;item
           id="c01"
           href="XHTML/chapter001.xhtml"
           media-type="application/xhtml+xml"
-          properties="remote-resources"/>
+          properties="remote-resources"/&gt;
       …
-   &lt;/manifest>
+   &lt;/manifest&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 						</aside>
 
 						<aside class="example" title="External Resources that are not publication resources">
@@ -5236,17 +5079,17 @@ Package document:
 								file in the manifest because it is not a [=publication resource=].</p>
 
 							<pre>XHTML:
-&lt;html …>
+&lt;html …&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       …
       &lt;a
-          href="http://www.example.com/book/audio/ch01.mp4">
+          href="http://www.example.com/book/audio/ch01.mp4"&gt;
          Listen to audio
-      &lt;/a>
+      &lt;/a&gt;
       …
-   &lt;/body>
-&lt;/html>
+   &lt;/body&gt;
+&lt;/html&gt;
 
 Manifest:
 No Entry</pre>
@@ -5262,9 +5105,7 @@ No Entry</pre>
 
 					<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
 
-					<p>Refer to the <a
-							href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"
-								><code>bindings</code> element definition</a> in [[epubpublications-301]] for more
+					<p>Refer to the <a href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#sec-bindings-elem"><code>bindings</code> element definition</a> in [[epubpublications-301]] for more
 						information.</p>
 				</section>
 			</section>
@@ -5272,7 +5113,7 @@ No Entry</pre>
 			<section id="sec-pkg-spine">
 				<h3>Spine section</h3>
 
-				<section id="sec-spine-elem">
+				<section id="sec-spine-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L709,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L716,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L723,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L729,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L15">
 					<h4>The <code>spine</code> element</h4>
 
 					<p>The <code>spine</code> element defines an ordered list of <a href="#sec-itemref-elem">manifest
@@ -5282,8 +5123,7 @@ No Entry</pre>
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>spine</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>spine</code></dfn>
 							</p>
 						</dd>
 
@@ -5372,7 +5212,7 @@ No Entry</pre>
 						the manifest item that represents the <a href="#sec-opf2-ncx">NCX</a>.</p>
 				</section>
 
-				<section id="sec-itemref-elem">
+				<section id="sec-itemref-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L738,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L743,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L750,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L757,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L763,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L768,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L773,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L780">
 					<h4>The <code>itemref</code> element</h4>
 
 					<p>The <code>itemref</code> element identifies an [=EPUB content document=] or [=foreign content
@@ -5382,8 +5222,7 @@ No Entry</pre>
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>itemref</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>itemref</code></dfn>
 							</p>
 						</dd>
 
@@ -5436,9 +5275,8 @@ No Entry</pre>
 						</dd>
 					</dl>
 
-					<p id="attrdef-itemref-idref">Each <code>itemref</code> element MUST reference the <a
-							data-cite="xml#id">ID</a> [[xml]] of an [^item^] in the [=EPUB manifest | manifest=] via the
-							<a data-cite="xml#idref">IDREF</a> [[xml]] in its <code>idref</code> attribute.
+					<p id="attrdef-itemref-idref">Each <code>itemref</code> element MUST reference the <a data-cite="xml#id">ID</a> [[xml]] of an [^item^] in the [=EPUB manifest | manifest=] via the
+							<a data-cite="xml#idref">IDREF</a>&nbsp;[[xml]] in its <code>idref</code> attribute.
 							<code>item</code> element IDs MUST NOT be referenced more than once. </p>
 
 					<p id="confreq-spine-itemtypes">Each referenced manifest <code>item</code> MUST be either a) an
@@ -5472,48 +5310,46 @@ No Entry</pre>
 					</div>
 
 					<p id="linear-itemrefs">A linear <code>itemref</code> element is one whose <code>linear</code>
-						attribute value is explicitly set to "<code>yes</code>" or that omits the attribute — reading
+						attribute value is explicitly set to "<code>yes</code>" or that omits the attribute&nbsp;—&nbsp;reading
 						systems will assume the value "<code>yes</code>" for <code>itemref</code> elements without the
 						attribute. The spine MUST contain at least one linear <code>itemref</code> element.</p>
 
 					<p id="confreq-spine-nonlinear" data-tests="#pkg-spine-nonlinear">EPUB creators MUST provide a means
-						of accessing all non-linear content (e.g., hyperlinks in the content or from the <a
-							href="#sec-nav">EPUB navigation document</a>).</p>
+						of accessing all non-linear content (e.g., hyperlinks in the content or from the <a href="#sec-nav">EPUB navigation document</a>).</p>
 
 					<p id="attrdef-itemref-properties">The <a href="#app-itemref-properties-vocab">Spine Properties
 							Vocabulary</a> is the <a href="#sec-default-vocab">default vocabulary</a> for the
 							<code>properties</code> attribute.</p>
 
-					<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"
-						></a>.</p>
+					<p>EPUB creators MAY add terms from other vocabularies as defined in <a href="#sec-vocab-assoc"></a>.</p>
 
 					<aside class="example" title="A basic spine">
 						<p>In this example, the spine entries correspond to <a href="#example-manifest-cmt">the manifest
 								example above</a>.</p>
 
 						<pre>&lt;spine
-    page-progression-direction="ltr">
+    page-progression-direction="ltr"&gt;
    &lt;itemref
-       idref="intro"/>
+       idref="intro"/&gt;
    &lt;itemref
-       idref="c1"/>
+       idref="c1"/&gt;
    &lt;itemref
        idref="c1-answerkey"
-       linear="no"/>
+       linear="no"/&gt;
    &lt;itemref
-       idref="c2"/>
+       idref="c2"/&gt;
    &lt;itemref
        idref="c2-answerkey"
-       linear="no"/>
+       linear="no"/&gt;
    &lt;itemref
-       idref="c3"/>
+       idref="c3"/&gt;
    &lt;itemref
        idref="c3-answerkey"
-       linear="no"/>
+       linear="no"/&gt;
    &lt;itemref
        idref="notes"
-       linear="no"/>
-&lt;/spine>
+       linear="no"/&gt;
+&lt;/spine&gt;
 </pre>
 					</aside>
 				</section>
@@ -5522,7 +5358,7 @@ No Entry</pre>
 			<section id="sec-pkg-collections">
 				<h3>Collections</h3>
 
-				<section id="sec-collection-elem">
+				<section id="sec-collection-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L791,https://w3c.github.io/epub-structural-tests/#05-package-document_package-document.feature_L796">
 					<h4>The <code>collection</code> element</h4>
 
 					<p>The <code>collection</code> element defines a related group of resources.</p>
@@ -5531,8 +5367,7 @@ No Entry</pre>
 						<dt>Element Name:</dt>
 						<dd>
 							<p>
-								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-									><code>collection</code></dfn>
+								<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>collection</code></dfn>
 							</p>
 						</dd>
 
@@ -5610,23 +5445,20 @@ No Entry</pre>
 					</div>
 
 					<aside class="example" title="A multi-document index">
-						<pre>&lt;collection role="index">
-   &lt;link href="subjectIndex01.xhtml"/>
-   &lt;link href="subjectIndex02.xhtml"/>
-   &lt;link href="subjectIndex03.xhtml"/>
-&lt;/collection></pre>
+						<pre>&lt;collection role="index"&gt;
+   &lt;link href="subjectIndex01.xhtml"/&gt;
+   &lt;link href="subjectIndex02.xhtml"/&gt;
+   &lt;link href="subjectIndex03.xhtml"/&gt;
+&lt;/collection&gt;</pre>
 					</aside>
 				</section>
 
 				<section id="sec-defining-collection-types">
 					<h4>Defining collection types (deprecated)</h4>
 
-					<p>The creation of new <code>collection</code> element roles is now <a href="#deprecated"
-							>deprecated</a>.</p>
+					<p>The creation of new <code>collection</code> element roles is now <a href="#deprecated">deprecated</a>.</p>
 
-					<p>Refer to the <a
-							href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"
-								><code>collection</code> element definition</a> in [[epubpackages-32]] for more
+					<p>Refer to the <a href="https://www.w3.org/publishing/epub32/epub-packages.html#sec-collection-elem"><code>collection</code> element definition</a> in [[epubpackages-32]] for more
 						information about the creation of specialized collections, including the requirements and
 						restrictions on their use.</p>
 				</section>
@@ -5674,16 +5506,14 @@ No Entry</pre>
 							element</a> [[opf-201]] provides a means of including generic metadata for EPUB 2 [=reading
 						systems=].</p>
 
-					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"
-								><code>meta</code> element definition</a> in [[opf-201]] for more information.</p>
+					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.2"><code>meta</code> element definition</a> in&nbsp;[[opf-201]] for more information.</p>
 
 					<div class="note">
 						<p>The EPUB 3 [^meta^] element, which uses different attributes and requires text content,
 							provides metadata capabilities for EPUB 3 reading systems.</p>
 
 						<p>The [[opf-201]] <code>meta</code> element also allows [=EPUB creators=] to identify a cover
-							image for EPUB 2 reading systems. In EPUB 3, the cover image must be identified using the <a
-								href="#sec-cover-image"><code>cover-image</code> property</a> on the manifest [^item^]
+							image for EPUB 2 reading systems. In EPUB 3, the cover image must be identified using the <a href="#sec-cover-image"><code>cover-image</code> property</a> on the manifest [^item^]
 							for the image.</p>
 					</div>
 				</section>
@@ -5692,11 +5522,10 @@ No Entry</pre>
 					<h4>The <code>guide</code> element</h4>
 
 					<p>The <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code>
-							element</a> [[opf-201]] provides machine-processable navigation to key structures in EPUB 2
+							element</a>&nbsp;[[opf-201]] provides machine-processable navigation to key structures in EPUB 2
 						[=reading systems=].</p>
 
-					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"
-								><code>guide</code> element definition</a> in [[opf-201]] for more information.</p>
+					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.6"><code>guide</code> element definition</a> in&nbsp;[[opf-201]] for more information.</p>
 
 					<div class="note">
 						<p>The <a href="#sec-nav-landmarks">landmarks nav</a> in the [=EPUB navigation document=]
@@ -5711,7 +5540,7 @@ No Entry</pre>
 						provides a table of contents for EPUB 2 [=reading systems=].</p>
 
 					<p>Refer to the <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4.1">NCX
-							definition</a> in [[opf-201]] for more information.</p>
+							definition</a> in&nbsp;[[opf-201]] for more information.</p>
 
 					<div class="note">
 						<p>The <a href="#sec-nav">EPUB navigation document</a> replaces the NCX for EPUB 3 reading
@@ -5734,20 +5563,18 @@ No Entry</pre>
 						referred to in this specification as an XHTML content document.</p>
 				</section>
 
-				<section id="sec-xhtml-req">
+				<section id="sec-xhtml-req" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L21,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L26,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L32,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L529,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L534">
 					<h4>XHTML requirements</h4>
 
 					<p>An [=XHTML content document=]:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-cd-html-docprops-syntax">MUST be an [[html]] document that conforms to the <a
-									data-cite="html#the-xhtml-syntax">XML</a> syntax.</p>
+							<p id="confreq-cd-html-docprops-syntax">MUST be an [[html]] document that conforms to the <a data-cite="html#the-xhtml-syntax">XML</a> syntax.</p>
 						</li>
 						<li>
 							<p id="confreq-cd-html-docprops-html">MUST conform to the conformance criteria for all
-								document constructs defined by [[html]] unless explicitly overridden in <a
-									href="#sec-xhtml-deviations"></a>.</p>
+								document constructs defined by [[html]] unless explicitly overridden in <a href="#sec-xhtml-deviations"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-cd-html-docprops-schema">MAY include extensions to the [[html]] grammar as
@@ -5761,8 +5588,7 @@ No Entry</pre>
 
 					<div class="note">
 						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
-							[[epub-a11y-11]] applies to XHTML content documents. See <a href="#confreq-a11y"
-								>Accessibility</a>.</p>
+							[[epub-a11y-11]] applies to XHTML content documents. See <a href="#confreq-a11y">Accessibility</a>.</p>
 					</div>
 				</section>
 
@@ -5773,22 +5599,20 @@ No Entry</pre>
 						document model.</p>
 
 					<div class="note">
-						<p>Although [[html]] allows user agents to support <a data-cite="html#extensibility-2"
-								>vendor-neutral extensions</a>, unless such extensions are listed in this section, they
+						<p>Although [[html]] allows user agents to support <a data-cite="html#extensibility-2">vendor-neutral extensions</a>, unless such extensions are listed in this section, they
 							are not supported features of EPUB 3.</p>
 					</div>
 
-					<section id="sec-xhtml-structural-semantics">
+					<section id="sec-xhtml-structural-semantics" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L656,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L661">
 						<h5>Structural semantics</h5>
 
 						<p>[=EPUB creators=] MAY use the [^/epub:type^] attribute in [=XHTML content documents=] to
 							express <a href="#sec-structural-semantics-intro">structural semantics</a>.</p>
 
-						<p>The attribute MUST NOT be used on the <a data-cite="html#the-head-element"
-								><code>head</code></a> element or [=metadata content=] [[html]].</p>
+						<p>The attribute MUST NOT be used on the <a data-cite="html#the-head-element"><code>head</code></a> element or [=metadata content=] [[html]].</p>
 					</section>
 
-					<section id="sec-xhtml-rdfa">
+					<section id="sec-xhtml-rdfa" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L703">
 						<h5>RDFa</h5>
 
 						<p>The [[html-rdfa]] specification defines a set of attributes that [=EPUB creators=] MAY use in
@@ -5801,8 +5625,7 @@ No Entry</pre>
 						<div class="note">
 							<p>The listing of RDFa does not express a preference on the part of the Working Group, only
 								that these attributes represent an extension of the HTML grammar. EPUB creators can also
-								specify <a data-cite="html#microdata">microdata attributes</a> [[html]] and <a
-									data-cite="json-ld11#">linked data</a> [[json-ld11]] in XHTML content documents as
+								specify <a data-cite="html#microdata">microdata attributes</a> [[html]] and <a data-cite="json-ld11#">linked data</a> [[json-ld11]] in XHTML content documents as
 								both are natively supported.</p>
 						</div>
 					</section>
@@ -5816,9 +5639,7 @@ No Entry</pre>
 
 						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
 
-						<p>Refer to the <a
-								href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"
-									><code>switch</code> element definition</a> in [[epubcontentdocs-301]] for more
+						<p>Refer to the <a href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-switch"><code>switch</code> element definition</a> in&nbsp;[[epubcontentdocs-301]] for more
 							information.</p>
 					</section>
 
@@ -5831,17 +5652,14 @@ No Entry</pre>
 
 						<p>Use of the element is <a href="#deprecated">deprecated</a>.</p>
 
-						<p>Refer to the <a
-								href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"
-									><code>epub:trigger</code> element definition</a> in [[epubcontentdocs-301]] for
+						<p>Refer to the <a href="https://idpf.org/epub/301/spec/epub-contentdocs-20140626.html#sec-xhtml-epub-trigger"><code>epub:trigger</code> element definition</a> in&nbsp;[[epubcontentdocs-301]] for
 							more information.</p>
 					</section>
 
-					<section id="sec-xhtml-custom-attributes">
+					<section id="sec-xhtml-custom-attributes" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L790,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L795">
 						<h5>Custom attributes</h5>
 
-						<p>[=XHTML content documents=] MAY contain custom attributes, which are <a
-								data-cite="xml-names#NT-Prefix">prefixed</a> [[xml-names]] attributes whose namespace
+						<p>[=XHTML content documents=] MAY contain custom attributes, which are <a data-cite="xml-names#NT-Prefix">prefixed</a> [[xml-names]] attributes whose namespace
 							URL does not include either of the following strings in its [=domain=] [[url]]:</p>
 
 						<ul>
@@ -5861,7 +5679,7 @@ No Entry</pre>
 					</section>
 				</section>
 
-				<section id="sec-xhtml-deviations">
+				<section id="sec-xhtml-deviations" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L823,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L834,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L847,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L852,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L873,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L888">
 					<h4>HTML deviations and constraints</h4>
 
 					<p>This section defines deviations from, and constraints on, the underlying [[html]] document model
@@ -5877,15 +5695,13 @@ No Entry</pre>
 						<dl class="conformance-list">
 							<dt id="math-pres">Presentation MathML</dt>
 							<dd>
-								<p id="confreq-mathml-pres">The <code>math</code> element MUST contain only <a
-										data-cite="mathml3/chapter3.html#">Presentation MathML</a>, except within the
+								<p id="confreq-mathml-pres">The <code>math</code> element MUST contain only <a data-cite="mathml3/chapter3.html#">Presentation MathML</a>, except within the
 										<code>annotation-xml</code> element.</p>
 							</dd>
 
 							<dt id="math-cont">Content MathML</dt>
 							<dd>
-								<p id="confreq-mathml-annot-cont">[=EPUB creators=] MAY include <a
-										data-cite="mathml3/chapter4.html#">Content MathML</a> within MathML markup in
+								<p id="confreq-mathml-annot-cont">[=EPUB creators=] MAY include <a data-cite="mathml3/chapter4.html#">Content MathML</a> within MathML markup in
 									XHTML content documents, and, when present, MUST include it within an
 										<code>annotation-xml</code> child element of a <code>semantics</code>
 									element.</p>
@@ -5907,11 +5723,10 @@ No Entry</pre>
 						</div>
 					</section>
 
-					<section id="sec-xhtml-svg">
+					<section id="sec-xhtml-svg" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L910,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 						<h5>Embedded SVG</h5>
 
-						<p>[=XHTML content documents=] support the embedding of <a
-								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
+						<p>[=XHTML content documents=] support the embedding of <a href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
 								fragments</a> [[svg]] <em>by reference</em> (embedding via reference, for example, from
 							an <code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
 							direct inclusion of the <code>svg</code> element in the XHTML content document).</p>
@@ -5991,75 +5806,61 @@ No Entry</pre>
 						specification as an [=SVG content document=].</p>
 
 					<div class="note">
-						<p>This section defines conformance requirements for SVG content documents. Refer to <a
-								href="#sec-xhtml-svg"></a> for the conformance requirements for SVG embedded in XHTML
+						<p>This section defines conformance requirements for SVG content documents. Refer to <a href="#sec-xhtml-svg"></a> for the conformance requirements for SVG embedded in XHTML
 							content documents.</p>
 					</div>
 				</section>
 
-				<section id="sec-svg-req">
+				<section id="sec-svg-req" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L33,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L41,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L47,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 					<h4>SVG requirements</h4>
 
 					<p>An [=SVG content document=]:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-cd-svg-docprops-schema">MUST be a <a
-									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles"
-									>conforming SVG stand-alone file</a> [[svg]] and conform to all content conformance
+							<p id="confreq-cd-svg-docprops-schema">MUST be a <a href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles">conforming SVG stand-alone file</a> [[svg]] and conform to all content conformance
 								constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
 						</li>
 						<li>
 							<p id="confreq-svg-structural-semantics">MAY include the [^/epub:type^] attribute for
 								expressing <a href="#app-structural-semantics">structural semantics</a>. When specified,
-								the attribute MUST only be included on <a
-									href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
-									<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
-									href="https://www.w3.org/TR/SVG11/text.html">text</a> elements [[svg]].</p>
+								the attribute MUST only be included on <a href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
+									<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a href="https://www.w3.org/TR/SVG11/text.html">text</a> elements [[svg]].</p>
 						</li>
 						<li>
-							<p id="confreq-svg-vocab-assoc">MAY include all applicable <a href="#sec-vocab-assoc"
-									>vocabulary association mechanisms</a>.</p>
+							<p id="confreq-svg-vocab-assoc">MAY include all applicable <a href="#sec-vocab-assoc">vocabulary association mechanisms</a>.</p>
 						</li>
 					</ul>
 					<div class="note">
 						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
-							[[epub-a11y-11]] applies to SVG content documents. See <a href="#confreq-a11y"
-								>Accessibility</a>.</p>
+							[[epub-a11y-11]] applies to SVG content documents. See <a href="#confreq-a11y">Accessibility</a>.</p>
 					</div>
 				</section>
 
-				<section id="sec-svg-restrictions">
+				<section id="sec-svg-restrictions" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L129,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L139,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L146,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L153,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L160,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L169,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L174,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L183">
 					<h4>Restrictions on SVG</h4>
 
-					<p>This specification restricts the content model of [=SVG content documents=] and <a
-							href="#sec-xhtml-svg">SVG embedded in XHTML content documents</a> as follows:</p>
+					<p>This specification restricts the content model of [=SVG content documents=] and <a href="#sec-xhtml-svg">SVG embedded in XHTML content documents</a> as follows:</p>
 
 					<ul class="conformance-list">
 						<li>
-							<p id="confreq-svg-foreignObject">The [[svg]] <a
-									href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"
-										><code>foreignObject</code></a> element:</p>
+							<p id="confreq-svg-foreignObject">The [[svg]] <a href="https://www.w3.org/TR/SVG/embedded.html#ForeignObjectElement"><code>foreignObject</code></a> element:</p>
 							<ul class="conformance-list">
 								<li>
 									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[html]] [=flow
-										content=] or exactly one [[html]] <a data-cite="html#the-body-element"
-												><code>body</code></a> element.</p>
+										content=] or exactly one [[html]] <a data-cite="html#the-body-element"><code>body</code></a> element.</p>
 									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
-											<code>body</code> element is not permitted per the <a data-cite="html#svg-0"
-											>restrictions on SVG</a> defined in [[html]].</p>
+											<code>body</code> element is not permitted per the <a data-cite="html#svg-0">restrictions on SVG</a> defined in [[html]].</p>
 								</li>
 								<li>
 									<p id="confreq-svg-foreignObject-xhtml-frag">MUST contain a valid document fragment
-										that conforms to the XHTML content document model defined in <a
-											href="#sec-xhtml-req"></a>.</p>
+										that conforms to the XHTML content document model defined in <a href="#sec-xhtml-req"></a>.</p>
 								</li>
 							</ul>
 						</li>
 						<li>
 							<p id="confreq-svg-title" data-cite="svg">If the [[svg]] [^title^] element contains
-								marked-up text, the markup MUST contain only elements declared in the <a
-									data-cite="infra#html-namespace">HTML namespace</a> [[infra]].</p>
+								marked-up text, the markup MUST contain only elements declared in the <a data-cite="infra#html-namespace">HTML namespace</a> [[infra]].</p>
 						</li>
 					</ul>
 					<div class="note">
@@ -6110,7 +5911,7 @@ No Entry</pre>
 						</div>
 					</section>
 
-					<section id="sec-css-req">
+					<section id="sec-css-req" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L17,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L24,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L31,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L40,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L45,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L51,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-css.feature_L57">
 						<h4>CSS requirements</h4>
 
 						<p>A CSS style sheet:</p>
@@ -6121,23 +5922,20 @@ No Entry</pre>
 									exceptions:</p>
 								<ul class="conformance-list">
 									<li>
-										<p id="confreq-css-props-exc-direction">It MUST NOT include the <a
-												data-cite="css-writing-modes-3#direction"><code>direction</code>
+										<p id="confreq-css-props-exc-direction">It MUST NOT include the <a data-cite="css-writing-modes-3#direction"><code>direction</code>
 												property</a> [[css-writing-modes-3]].</p>
 									</li>
 									<li>
-										<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT include the <a
-												data-cite="css-writing-modes-3#unicode-bidi"><code>unicode-bidi</code>
+										<p id="confreq-css-props-exc-unicode-bidi">It MUST NOT include the <a data-cite="css-writing-modes-3#unicode-bidi"><code>unicode-bidi</code>
 												property</a> [[css-writing-modes-3]].</p>
 									</li>
 								</ul>
 							</li>
 							<li>
-								<p id="confreq-css-prefixed">MAY include the prefixed properties defined in <a
-										href="#sec-css-prefixed"></a>.</p>
+								<p id="confreq-css-prefixed">MAY include the prefixed properties defined in <a href="#sec-css-prefixed"></a>.</p>
 							</li>
 							<li>
-								<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16 [[unicode]], with UTF-8
+								<p id="confreq-css-encoding">MUST be encoded in UTF-8 or UTF-16&nbsp;[[unicode]], with UTF-8
 									as the RECOMMENDED encoding.</p>
 							</li>
 						</ul>
@@ -6149,15 +5947,11 @@ No Entry</pre>
 
 							<ul>
 								<li>
-									<p>the [^html-global/dir^] attribute [[html]] and <a
-											href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"
-												><code>direction</code></a> attribute [[svg]] for inline base
+									<p>the [^html-global/dir^] attribute [[html]] and <a href="https://www.w3.org/TR/SVG/text.html#DirectionProperty"><code>direction</code></a> attribute [[svg]] for inline base
 										directionality.</p>
 								</li>
 								<li>
-									<p>the [^bdo^] element with the [^html-global/dir^] attribute [[html]] and the <a
-											href="https://www.w3.org/TR/SVG/styling.html#PresentationAttributes"
-											>presentation attribute alternative</a> for <code>unicode-bidi</code>
+									<p>the [^bdo^] element with the [^html-global/dir^] attribute&nbsp;[[html]] and the <a href="https://www.w3.org/TR/SVG/styling.html#PresentationAttributes">presentation attribute alternative</a> for <code>unicode-bidi</code>
 										[[svg]] for bidirectionality.</p>
 								</li>
 							</ul>
@@ -6171,8 +5965,7 @@ No Entry</pre>
 							world languages were not yet mature. To ensure backwards compatibility for content authored
 							using these prefixes, they have been retained in this specification. Unless otherwise noted,
 							prefixed properties and values behave exactly as their unprefixed equivalents as described
-							in the appropriate CSS specification. The prefixed properties are documented in <a
-								href="#css-prefixes"></a>. </p>
+							in the appropriate CSS specification. The prefixed properties are documented in <a href="#css-prefixes"></a>. </p>
 
 						<div class="caution">
 							<p>[=EPUB creators=] should use unprefixed properties and [=reading systems=] should support
@@ -6205,7 +5998,7 @@ No Entry</pre>
 							scripted content document.</p>
 
 						<p>When an [[html]] <code>script</code> element contains a <a data-cite="html#data-block">data
-								block</a> [[html]], it does not represent scripted content.</p>
+								block</a>&nbsp;[[html]], it does not represent scripted content.</p>
 
 						<div class="note">
 							<p>[[svg]] does not define data blocks as of publication, but the same exclusion would apply
@@ -6218,8 +6011,7 @@ No Entry</pre>
 							between EPUB publications.</p>
 
 						<p>Which <a href="#sec-scripted-context">context</a> a script is used in also determines the
-							rights and restrictions that a reading system places on it (refer to <a
-								data-cite="epub-rs-33#sec-scripted-content">Scripting</a> [[?epub-rs-33]] for more
+							rights and restrictions that a reading system places on it (refer to <a data-cite="epub-rs-33#sec-scripted-content">Scripting</a> [[?epub-rs-33]] for more
 							information).</p>
 
 						<div class="note">
@@ -6235,9 +6027,9 @@ No Entry</pre>
 						<p>EPUB 3 defines two contexts for script execution:</p>
 
 						<ul>
-							<li><a href="#sec-scripted-container-constrained">container constrained</a> &#8212; when the
+							<li><a href="#sec-scripted-container-constrained">container constrained</a> — when the
 								execution of a script occurs within an [[html]] [^iframe^] element; and</li>
-							<li><a href="#sec-scripted-spine">spine level</a> &#8212; when the execution of a script
+							<li><a href="#sec-scripted-spine">spine level</a> — when the execution of a script
 								occurs directly within a [=top-level content document=].</li>
 						</ul>
 
@@ -6274,9 +6066,7 @@ No Entry</pre>
 										[^iframe^] element.</p>
 								</li>
 								<li>
-									<p>An instance of the [[svg]] <a
-											href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"
-												><code>script</code></a> element contained in an [=SVG content
+									<p>An instance of the [[svg]] <a href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a> element contained in an [=SVG content
 										document=] that is embedded in a XHTML content document using the [[html]]
 										[^iframe^] element.</p>
 								</li>
@@ -6305,13 +6095,11 @@ No Entry</pre>
 						<section id="sec-scripted-spine">
 							<h5>Spine-level scripts</h5>
 
-							<p>A <em>spine-level script</em> is an instance of the [[html]] [^script^] or [[svg]] <a
-									href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
+							<p>A <em>spine-level script</em> is an instance of the [[html]] [^script^] or [[svg]] <a href="https://www.w3.org/TR/SVG/interact.html#ScriptElement"><code>script</code></a>
 								element contained in a [=top-level content document=].</p>
 
 							<p>[=EPUB creators=] should note that support for spine-level scripting in [=reading
-								systems=] is only recommended in <a
-									data-cite="epub-rs-33#confreq-rs-scripted-fxl-support">fixed-layout documents</a>
+								systems=] is only recommended in <a data-cite="epub-rs-33#confreq-rs-scripted-fxl-support">fixed-layout documents</a>
 								and <a data-cite="epub-rs-33#confreq-rs-scripted-scrolled">reflowable documents set to
 									scroll</a> [[epub-rs-33]]. Furthermore, reading system support in all other contexts
 								is optional.</p>
@@ -6319,8 +6107,7 @@ No Entry</pre>
 							<p id="confreq-cd-scripted-spine">[=Top-level content documents=] that include spine-level
 								scripting SHOULD remain consumable by the user without any information loss or other
 								significant deterioration when scripting is disabled or not available (e.g., by
-								employing progressive enhancement techniques or <a href="#sec-scripted-fallbacks"
-									>fallbacks</a>). Failing to account for non-scripted environments in top-level
+								employing progressive enhancement techniques or <a href="#sec-scripted-fallbacks">fallbacks</a>). Failing to account for non-scripted environments in top-level
 								content documents can result in [=EPUB publications=] being unreadable.</p>
 						</section>
 					</section>
@@ -6369,11 +6156,9 @@ No Entry</pre>
 					publication=]. It allows [=EPUB creators=] to include a human- and machine-readable global
 					navigation layer, thereby ensuring increased usability and accessibility for the user.</p>
 
-				<p>The EPUB navigation document is a special type of [=XHTML content document=] that defines the <a
-						href="#sec-nav-toc">table of contents</a> for [=reading systems=]. It may also include other
+				<p>The EPUB navigation document is a special type of [=XHTML content document=] that defines the <a href="#sec-nav-toc">table of contents</a> for [=reading systems=]. It may also include other
 					specialized navigation elements, such as a <a href="#sec-nav-pagelist">page list</a> and a list of
-					key <a href="#sec-nav-landmarks">landmarks</a>. These navigation elements have <a
-						href="#sec-nav-def-model">additional restrictions</a> on their content to facilitate their
+					key <a href="#sec-nav-landmarks">landmarks</a>. These navigation elements have <a href="#sec-nav-def-model">additional restrictions</a> on their content to facilitate their
 					processing.</p>
 
 				<p>The EPUB navigation document is not exclusively for machine processing, however. There are no
@@ -6381,8 +6166,7 @@ No Entry</pre>
 					navigation elements (i.e., EPUB creators can mark the rest of the document up like any other XHTML
 					content document). As a result, it can also be part of the linear reading order, avoiding the need
 					for duplicate tables of contents. EPUB creators can hide navigation elements that are only for
-					machine processing (e.g., the page list) with the <a href="#sec-nav-doc-use-spine"
-							><code>hidden</code> attribute</a>.</p>
+					machine processing (e.g., the page list) with the <a href="#sec-nav-doc-use-spine"><code>hidden</code> attribute</a>.</p>
 
 				<p>Note that reading systems may strip scripting, styling, and HTML formatting as they generate
 					navigational interfaces from information found in the EPUB navigation document, and this may make
@@ -6392,7 +6176,7 @@ No Entry</pre>
 					ensure the content will retain its integrity when rendered in a non-browser context.</p>
 			</section>
 
-			<section id="sec-nav-content-req">
+			<section id="sec-nav-content-req" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L14,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L20,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L27">
 				<h3>Navigation document requirements</h3>
 
 				<p>A valid EPUB navigation document:</p>
@@ -6403,8 +6187,7 @@ No Entry</pre>
 							content documents=] defined in <a href="#sec-xhtml-req"></a>;</p>
 					</li>
 					<li>
-						<p id="confreq-navdoc-navs">MUST conform to the <code>nav</code> element constraints defined <a
-								href="#sec-nav-def-model"></a>;</p>
+						<p id="confreq-navdoc-navs">MUST conform to the <code>nav</code> element constraints defined <a href="#sec-nav-def-model"></a>;</p>
 					</li>
 					<li>
 						<p id="confreq-navdoc-toc">MUST include exactly one <code>toc nav</code> element as defined in
@@ -6413,7 +6196,7 @@ No Entry</pre>
 				</ul>
 			</section>
 
-			<section id="sec-nav-def-model">
+			<section id="sec-nav-def-model" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L35,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L43,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L51,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L59,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L67,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L75,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L83,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L98,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L106,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L112,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L118">
 				<h3>The <code>nav</code> element: restrictions</h3>
 
 				<p>When a <code>nav</code> element carries the [^/epub:type^] attribute in an [=EPUB navigation
@@ -6517,8 +6300,7 @@ No Entry</pre>
 							of the <code>a</code> element:</p>
 						<ul class="conformance-list">
 							<li>
-								<p id="confreq-nav-a-href-default">MUST, in the case of the <a href="#sec-nav-toc"
-											><code>toc nav</code></a>, <a href="#sec-nav-landmarks"><code>landmarks
+								<p id="confreq-nav-a-href-default">MUST, in the case of the <a href="#sec-nav-toc"><code>toc nav</code></a>, <a href="#sec-nav-landmarks"><code>landmarks
 											nav</code></a> and <a href="#sec-nav-pagelist"><code>page-list
 										nav</code></a>, resolve to a [=top-level content document=] or fragment
 									therein.</p>
@@ -6546,35 +6328,35 @@ No Entry</pre>
 					</li>
 				</ul>
 				<aside class="example" title="Basic patterns of a navigation element">
-					<pre>&lt;nav epub:type="…">
-   &lt;h1>…&lt;/h1>
-   &lt;ol>
-      &lt;li>
-         &lt;a href="chap1.xhtml">
+					<pre>&lt;nav epub:type="…"&gt;
+   &lt;h1&gt;…&lt;/h1&gt;
+   &lt;ol&gt;
+      &lt;li&gt;
+         &lt;a href="chap1.xhtml"&gt;
             A basic leaf node
-         &lt;/a>
-      &lt;/li>
-      &lt;li>
-         &lt;a href="chap2.xhtml">
+         &lt;/a&gt;
+      &lt;/li&gt;
+      &lt;li&gt;
+         &lt;a href="chap2.xhtml"&gt;
             A linked heading
-         &lt;/a>
-         &lt;ol>
+         &lt;/a&gt;
+         &lt;ol&gt;
             …
-         &lt;/ol>
-      &lt;/li>
-      &lt;li>
-         &lt;span>An unlinked heading&lt;/span>
-         &lt;ol>
+         &lt;/ol&gt;
+      &lt;/li&gt;
+      &lt;li&gt;
+         &lt;span&gt;An unlinked heading&lt;/span&gt;
+         &lt;ol&gt;
             …
-         &lt;/ol>
-      &lt;/li>
-      &lt;li>
-         &lt;a href="appendix.xhtml">
-            &lt;img src="app1.jpg" alt="An image-based heading"/>
-         &lt;/a>
-      &lt;/li>
-   &lt;/ol>
-&lt;/nav></pre>
+         &lt;/ol&gt;
+      &lt;/li&gt;
+      &lt;li&gt;
+         &lt;a href="appendix.xhtml"&gt;
+            &lt;img src="app1.jpg" alt="An image-based heading"/&gt;
+         &lt;/a&gt;
+      &lt;/li&gt;
+   &lt;/ol&gt;
+&lt;/nav&gt;</pre>
 				</aside>
 
 				<div class="caution">
@@ -6590,8 +6372,7 @@ No Entry</pre>
 					include the EPUB navigation document in the [=EPUB spine | spine=].</p>
 
 				<p id="confreq-nav-ol-style">In the context of this specification, the default display style of list
-					items within <code>nav</code> elements is equivalent to the <a
-						href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:</code>
+					items within <code>nav</code> elements is equivalent to the <a href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style"><code>list-style:</code>
 						<code>none</code> property</a> [[csssnapshot]]. EPUB creators MAY specify alternative list
 					styling using CSS for rendering of the document in the spine.</p>
 			</section>
@@ -6641,8 +6422,7 @@ No Entry</pre>
 
 					<p>An EPUB navigation document may contain at most one navigation aid for each of these types.</p>
 
-					<p>The EPUB navigation document may include additional navigation types. See <a
-							href="#sec-nav-def-types-other"></a> for more information.</p>
+					<p>The EPUB navigation document may include additional navigation types. See <a href="#sec-nav-def-types-other"></a> for more information.</p>
 				</section>
 
 				<section id="sec-nav-toc">
@@ -6667,7 +6447,7 @@ No Entry</pre>
 					</ul>
 				</section>
 
-				<section id="sec-nav-pagelist">
+				<section id="sec-nav-pagelist" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L162,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L168">
 					<h4>The <code>page-list nav</code> element </h4>
 
 					<p>The <code>page-list</code> element provides navigation to static page boundaries in the content.
@@ -6681,11 +6461,10 @@ No Entry</pre>
 						(i.e., no nested sublists).</p>
 
 					<p>[=EPUB creators=] MAY identify the destinations of the <code>page-list</code> references in their
-						respective [=EPUB content documents=] using the <a data-cite="epub-ssv-11/#pagebreak"
-								><code>pagebreak</code> term</a> [[epub-ssv-11]].</p>
+						respective [=EPUB content documents=] using the <a data-cite="epub-ssv-11/#pagebreak"><code>pagebreak</code> term</a> [[epub-ssv-11]].</p>
 				</section>
 
-				<section id="sec-nav-landmarks">
+				<section id="sec-nav-landmarks" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L199,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L205,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L213,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L221,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L227">
 					<h4>The <code>landmarks nav</code> element</h4>
 
 					<p>The <code>landmarks nav</code> element identifies fundamental structural components in the
@@ -6704,31 +6483,31 @@ No Entry</pre>
 
 					<aside class="example" title="A basic landmarks nav">
 						<p>In this example, the <code>epub:type</code> attribute value are drawn from structural
-							semantics drawn from [[epub-ssv-11]].</p>
+							semantics drawn from&nbsp;[[epub-ssv-11]].</p>
 
-						<pre>&lt;nav epub:type="landmarks">
-   &lt;h2>Guide&lt;/h2>
-   &lt;ol>
-       &lt;li>
+						<pre>&lt;nav epub:type="landmarks"&gt;
+   &lt;h2&gt;Guide&lt;/h2&gt;
+   &lt;ol&gt;
+       &lt;li&gt;
           &lt;a epub:type="toc"
-             href="#toc">
+             href="#toc"&gt;
             Table of Contents
-          &lt;/a>
-       &lt;/li>
-       &lt;li>
+          &lt;/a&gt;
+       &lt;/li&gt;
+       &lt;li&gt;
           &lt;a epub:type="loi"
-             href="content.html#loi">
+             href="content.html#loi"&gt;
             List of Illustrations
-          &lt;/a>
-       &lt;/li>
-       &lt;li>
+          &lt;/a&gt;
+       &lt;/li&gt;
+       &lt;li&gt;
           &lt;a epub:type="bodymatter"
-             href="content.html#bodymatter">
+             href="content.html#bodymatter"&gt;
             Start of Content
-          &lt;/a>
-       &lt;/li>
-   &lt;/ol>
-&lt;/nav></pre>
+          &lt;/a&gt;
+       &lt;/li&gt;
+   &lt;/ol&gt;
+&lt;/nav&gt;</pre>
 					</aside>
 
 					<p>The <code>landmarks nav</code> MUST NOT include multiple entries with the same
@@ -6741,10 +6520,10 @@ No Entry</pre>
 					<p>The following landmarks are recommended to include when available:</p>
 
 					<ul>
-						<li><a data-cite="epub-ssv-11#bodymatter"><code>bodymatter</code></a> [[?epub-ssv-11]] &#8212;
+						<li><a data-cite="epub-ssv-11#bodymatter"><code>bodymatter</code></a> [[?epub-ssv-11]] —
 							Reading systems often use this landmark to automatically jump users past the front matter
 							when they begin reading.</li>
-						<li><a data-cite="epub-ssv-11#toc-1"><code>toc</code></a> [[?epub-ssv-11]] &#8212; If the table
+						<li><a data-cite="epub-ssv-11#toc-1"><code>toc</code></a>&nbsp;[[?epub-ssv-11]] — If the table
 							of contents is available in the spine, reading systems may use this landmark to take users
 							to the document containing it.</li>
 					</ul>
@@ -6757,7 +6536,7 @@ No Entry</pre>
 						systems may expose the links directly to users.</p>
 				</section>
 
-				<section id="sec-nav-def-types-other">
+				<section id="sec-nav-def-types-other" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L245,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L251,https://w3c.github.io/epub-structural-tests/#07-navigation-document_navigation-document.feature_L259">
 					<h4>Other <code>nav</code> elements</h4>
 
 					<p>[=EPUB navigation documents=] MAY contain one or more <code>nav</code> elements in addition to
@@ -6776,27 +6555,27 @@ No Entry</pre>
 
 						<pre>&lt;nav
     epub:type="lot"
-    aria-labelledby="lot">
-   &lt;h2 id="lot">List of tables&lt;/h2>
-   &lt;ol>
-      &lt;li>
-         &lt;span>Tables in Chapter 1&lt;/span>
-         &lt;ol>
-            &lt;li>
-               &lt;a href="chap1.xhtml#table-1.1">
+    aria-labelledby="lot"&gt;
+   &lt;h2 id="lot"&gt;List of tables&lt;/h2&gt;
+   &lt;ol&gt;
+      &lt;li&gt;
+         &lt;span&gt;Tables in Chapter 1&lt;/span&gt;
+         &lt;ol&gt;
+            &lt;li&gt;
+               &lt;a href="chap1.xhtml#table-1.1"&gt;
                   Table 1.1
-               &lt;/a>
-            &lt;/li>
-            &lt;li>
-               &lt;a href="chap1.xhtml#table-1.2">
+               &lt;/a&gt;
+            &lt;/li&gt;
+            &lt;li&gt;
+               &lt;a href="chap1.xhtml#table-1.2"&gt;
                   Table 1.2
-               &lt;/a>
-            &lt;/li>
-         &lt;/ol>
-      &lt;/li>
+               &lt;/a&gt;
+            &lt;/li&gt;
+         &lt;/ol&gt;
+      &lt;/li&gt;
       …
-   &lt;/ol>
-&lt;/nav></pre>
+   &lt;/ol&gt;
+&lt;/nav&gt;</pre>
 					</aside>
 				</section>
 			</section>
@@ -6806,8 +6585,7 @@ No Entry</pre>
 
 				<p>Although it is possible to reuse the [=EPUB navigation document=] in the [=EPUB spine | spine=], it
 					is often the case that not all of the navigation structures, or branches within them, are needed.
-					[=EPUB creators=] will often want to hide the <a href="#sec-nav-pagelist">page list</a> and <a
-						href="#sec-nav-landmarks">landmarks</a> navigation elements or trim the branches of the table of
+					[=EPUB creators=] will often want to hide the <a href="#sec-nav-pagelist">page list</a> and <a href="#sec-nav-landmarks">landmarks</a> navigation elements or trim the branches of the table of
 					contents for books that have many levels of subsections.</p>
 
 				<p>While the <a href="https://www.w3.org/TR/CSS2/visuren.html#propdef-display"><code>display</code>
@@ -6833,17 +6611,17 @@ No Entry</pre>
 
 					<pre>&lt;nav
     epub:type="page-list"
-    hidden="hidden">
-   &lt;h2>Pagebreaks of the print version, third edition&lt;/h2>
-   &lt;ol>
-      &lt;li>
-         &lt;a href="frontmatter.xhtml#pi">
+    hidden="hidden"&gt;
+   &lt;h2&gt;Pagebreaks of the print version, third edition&lt;/h2&gt;
+   &lt;ol&gt;
+      &lt;li&gt;
+         &lt;a href="frontmatter.xhtml#pi"&gt;
             I
-         &lt;/a>
-      &lt;/li>
+         &lt;/a&gt;
+      &lt;/li&gt;
       …
-   &lt;/ol>
-&lt;/nav>
+   &lt;/ol&gt;
+&lt;/nav&gt;
 </pre>
 				</aside>
 
@@ -6854,33 +6632,33 @@ No Entry</pre>
 
 					<pre>&lt;nav
     epub:type="toc"
-    id="toc">
-   &lt;h1>Table of contents&lt;/h1>
-   &lt;ol>
-      &lt;li>
-         &lt;a href="chap1.xhtml">
+    id="toc"&gt;
+   &lt;h1&gt;Table of contents&lt;/h1&gt;
+   &lt;ol&gt;
+      &lt;li&gt;
+         &lt;a href="chap1.xhtml"&gt;
             Chapter 1
-         &lt;/a>
-         &lt;ol>
-            &lt;li>
-               &lt;a href="chap1.xhtml#sec-1.1">
+         &lt;/a&gt;
+         &lt;ol&gt;
+            &lt;li&gt;
+               &lt;a href="chap1.xhtml#sec-1.1"&gt;
                   Chapter 1.1
-               &lt;/a>
-               &lt;ol hidden="">
-                  &lt;li>
-                     &lt;a href="chap1.xhtml#sec-1.1.1">
+               &lt;/a&gt;
+               &lt;ol hidden=""&gt;
+                  &lt;li&gt;
+                     &lt;a href="chap1.xhtml#sec-1.1.1"&gt;
                         Section 1.1.1
-                     &lt;/a>
-                  &lt;/li>
+                     &lt;/a&gt;
+                  &lt;/li&gt;
                   …
-               &lt;/ol>
-            &lt;/li>
+               &lt;/ol&gt;
+            &lt;/li&gt;
             …
-         &lt;/ol>
-      &lt;/li>
+         &lt;/ol&gt;
+      &lt;/li&gt;
       …
-   &lt;/ol>
-&lt;/nav></pre>
+   &lt;/ol&gt;
+&lt;/nav&gt;</pre>
 				</aside>
 			</section>
 		</section>
@@ -6907,8 +6685,7 @@ No Entry</pre>
 					<h4>Introduction</h4>
 
 					<p>[=EPUB publications=], unlike print books or PDF files, are designed to change. The content
-						flows, or reflows, to fit the screen and to fit the needs of the user. As noted in <a
-							data-cite="epub-overview-33#sec-rendering">Rendering and CSS</a> "content presentation
+						flows, or reflows, to fit the screen and to fit the needs of the user. As noted in <a data-cite="epub-overview-33#sec-rendering">Rendering and CSS</a> "content presentation
 						adapts to the user, rather than the user having to adapt to a particular presentation of
 						content." [[epub-overview-33]]</p>
 
@@ -6918,8 +6695,7 @@ No Entry</pre>
 						over presentation when a reflowable EPUB is not suitable for the content.</p>
 
 					<p>EPUB creators define fixed layouts using a <a href="#sec-fxl-package">set of package document
-							properties</a> to control the rendering in [=reading systems=]. In addition, they set <a
-							href="#sec-fxl-package">the dimensions of each fixed-layout document</a> in its respective
+							properties</a> to control the rendering in [=reading systems=]. In addition, they set <a href="#sec-fxl-package">the dimensions of each fixed-layout document</a> in its respective
 						[=EPUB content document=].</p>
 
 					<div class="note" id="note-mechanisms">
@@ -6933,7 +6709,7 @@ No Entry</pre>
 				<section id="sec-fxl-package">
 					<h4>Fixed-layout package settings</h4>
 
-					<section id="layout">
+					<section id="layout" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L22,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L27,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L36,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L43,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L50">
 						<h5>Layout</h5>
 
 						<p>The <code>rendition:layout</code> property specifies whether the content is reflowable or
@@ -6976,8 +6752,7 @@ No Entry</pre>
 
 						<p>EPUB creators MUST NOT declare the <code>rendition:layout</code> property more than once.</p>
 
-						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
-									><code>refines</code> attribute</a>. Refer to <a href="#layout-overrides"></a> for
+						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code> attribute</a>. Refer to <a href="#layout-overrides"></a> for
 							setting the property for individual [=EPUB content documents=].</p>
 
 						<aside class="example" id="fxl-ex1" title="Fixed Layout Document with media queries">
@@ -6990,54 +6765,53 @@ No Entry</pre>
 
 							<p>Package document:</p>
 
-							<pre>&lt;package …>
-   &lt;metadata …>
+							<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
-          property="rendition:layout">
+          property="rendition:layout"&gt;
          pre-paginated
-      &lt;/meta>
+      &lt;/meta&gt;
       …
-   &lt;/metadata>
+   &lt;/metadata&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 
 							<p>XHTML</p>
 
-							<pre>&lt;html …>
-   &lt;head>
+							<pre>&lt;html …&gt;
+   &lt;head&gt;
       &lt;meta
           name="viewport"
           content="width=1200,
-          height=900"/>
+          height=900"/&gt;
       
       &lt;link
           rel="stylesheet"
           href="eink-style.css"
-          media="(max-monochrome: 3)"/>
+          media="(max-monochrome: 3)"/&gt;
          
       &lt;link
           rel="stylesheet"
           href="skinnytablet-style.css"
           media="((color) and (max-height:600px) and (orientation:landscape),
-                  (color) and (max-width:600px) and (orientation:portrait))"/>
+                  (color) and (max-width:600px) and (orientation:portrait))"/&gt;
       
       &lt;link
           rel="stylesheet"
           href="fattablet-style.css"
           media="((color) and (min-height:601px) and (orientation:landscape),
-                  (color) and (min-width:601px) and (orientation:portrait))"/>	
-   &lt;/head>
+                  (color) and (min-width:601px) and (orientation:portrait))"/&gt;	
+   &lt;/head&gt;
    …
-&lt;/html></pre>
+&lt;/html&gt;</pre>
 						</aside>
 
-						<section id="layout-overrides">
+						<section id="layout-overrides" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L59,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L64">
 							<h6>Layout overrides</h6>
 
 							<p id="property-layout-local">[=EPUB creators=] MAY specify the following properties locally
-								on [=EPUB spine | spine=] [^itemref^] elements to override the <a
-									href="#property-layout-global">global value</a> for the given spine item:</p>
+								on [=EPUB spine | spine=] [^itemref^] elements to override the <a href="#property-layout-global">global value</a> for the given spine item:</p>
 
 							<dl>
 								<dt id="layout-pre-paginated">rendition:layout-pre-paginated</dt>
@@ -7051,14 +6825,13 @@ No Entry</pre>
 						</section>
 					</section>
 
-					<section id="orientation">
+					<section id="orientation" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L74,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L79,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L86,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L93">
 						<h5>Orientation</h5>
 
 						<p>The <code>rendition:orientation</code> property specifies which orientation the [=EPUB
 							creator=] intends the content to be rendered in. </p>
 
-						<p id="property-orientation-global">When the <a href="#orientation"
-									><code>rendition:orientation</code> property</a> is specified on a [^meta^] element,
+						<p id="property-orientation-global">When the <a href="#orientation"><code>rendition:orientation</code> property</a> is specified on a [^meta^] element,
 							it indicates that the intended orientation applies globally (i.e., for all [=EPUB spine |
 							spine=] items).</p>
 
@@ -7085,36 +6858,34 @@ No Entry</pre>
 						<p id="fxl-orientation-duplication">EPUB creators
 							MUST NOT declare the <code>rendition:orientation</code> property more than once.</p>
 
-						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
-									><code>refines</code> attribute</a>. Refer to <a href="#orientation-overrides"></a>
+						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code> attribute</a>. Refer to <a href="#orientation-overrides"></a>
 							for setting the property for individual [=EPUB content documents=].</p>
 
 						<aside class="example" id="fxl-ex2" title="Specifying global landscape orientation">
 							<p>In this example, items in the spine are to be rendered in landscape mode.</p>
 
-							<pre>&lt;package …>
-   &lt;metadata …>
+							<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
-          property="rendition:layout">
+          property="rendition:layout"&gt;
          pre-paginated
-      &lt;/meta>
+      &lt;/meta&gt;
 
       &lt;meta
-          property="rendition:orientation">
+          property="rendition:orientation"&gt;
          landscape
-      &lt;/meta>
-   &lt;/metadata>
+      &lt;/meta&gt;
+   &lt;/metadata&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 						</aside>
 
-						<section id="orientation-overrides">
+						<section id="orientation-overrides" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L102,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L107">
 							<h6>Orientation overrides</h6>
 
 							<p id="property-orientation-local">[=EPUB creators=] MAY specify the following properties
-								locally on [=EPUB spine | spine=] [^itemref^] elements to override the <a
-									href="#property-orientation-global">global value</a> for the given spine item:</p>
+								locally on [=EPUB spine | spine=] [^itemref^] elements to override the <a href="#property-orientation-global">global value</a> for the given spine item:</p>
 
 							<dl>
 								<dt id="orientation-auto">rendition:orientation-auto</dt>
@@ -7134,7 +6905,7 @@ No Entry</pre>
 						</section>
 					</section>
 
-					<section id="spread">
+					<section id="spread" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L117,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L122,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L129,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L136,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L143,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L178">
 						<h5>Synthetic spreads</h5>
 
 						<p>The <code>rendition:spread</code> property specifies the intended [=reading system=]
@@ -7162,8 +6933,7 @@ No Entry</pre>
 
 							<dt>portrait (deprecated)</dt>
 							<dd>
-								<p>The use of spreads only in portrait orientation is <a href="#deprecated"
-										>deprecated</a>.</p>
+								<p>The use of spreads only in portrait orientation is <a href="#deprecated">deprecated</a>.</p>
 								<p>EPUB creators should use the value "<code>both</code>" instead, as spreads that are
 									readable in portrait orientation are also readable in landscape.</p>
 							</dd>
@@ -7182,15 +6952,12 @@ No Entry</pre>
 
 						<p>EPUB creators MUST NOT declare the <code>rendition:spread</code> property more than once.</p>
 
-						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"
-									><code>refines</code> attribute</a>. Refer to <a href="#spread-overrides"></a> for
+						<p>They also MUST NOT declare the property using the <a href="#attrdef-refines"><code>refines</code> attribute</a>. Refer to <a href="#spread-overrides"></a> for
 							setting the property for individual [=EPUB content documents=].</p>
 
 						<div class="note">
 							<p>When synthetic spreads are used in the context of [=XHTML content document | XHTML=] and
-								[=SVG content documents=], the dimensions given via the <a href="#sec-fxl-icb-html"
-										><code>viewport meta</code> element</a> and <a href="#sec-fxl-icb-svg"
-										><code>viewBox</code> attribute</a> represents the size of one page in the
+								[=SVG content documents=], the dimensions given via the <a href="#sec-fxl-icb-html"><code>viewport meta</code> element</a> and <a href="#sec-fxl-icb-svg"><code>viewBox</code> attribute</a> represents the size of one page in the
 								spread, respectively.</p>
 						</div>
 
@@ -7200,34 +6967,29 @@ No Entry</pre>
 								local page-progression-direction within content documents.</p>
 						</div>
 
-						<aside class="example" id="spread-none-example"
-							title="A fixed-layout EPUB publication without synthetic spread">
-							<pre>&lt;package …>
-   &lt;metadata …>
+						<aside class="example" id="spread-none-example" title="A fixed-layout EPUB publication without synthetic spread">
+							<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
-          property="rendition:layout">
+          property="rendition:layout"&gt;
          pre-paginated
-      &lt;/meta>
+      &lt;/meta&gt;
       
       &lt;meta
-          property="rendition:spread">
+          property="rendition:spread"&gt;
          none
-      &lt;/meta>
-   &lt;/metadata>
+      &lt;/meta&gt;
+   &lt;/metadata&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 
 							<figure id="spread-none-figure">
 								<figcaption> Rendering of three fixed-layout documents without synthetic spread.
-										<br /><span class="attribution">(Comics courtesy of <a
-											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+										<br><span class="attribution">(Comics courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
 										2.5</a>.)</span>
 								</figcaption>
-								<img src="images/example_spread_none.svg" width="600" aria-details="spread-none-diagram"
-									alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time everywhere"
-								 />
+								<img src="images/example_spread_none.svg" width="600" aria-details="spread-none-diagram" alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time everywhere">
 							</figure>
 
 							<details id="spread-none-diagram" class="desc">
@@ -7241,36 +7003,30 @@ No Entry</pre>
 						</aside>
 
 
-						<aside class="example" id="spread-landscape-example"
-							title="Specifying the usage of syntetic spreads in landscape orientation only">
-							<pre>&lt;package …>
-   &lt;metadata …>
+						<aside class="example" id="spread-landscape-example" title="Specifying the usage of syntetic spreads in landscape orientation only">
+							<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
-          property="rendition:layout">
+          property="rendition:layout"&gt;
          pre-paginated
-      &lt;/meta>
+      &lt;/meta&gt;
       
       &lt;meta
-          property="rendition:spread">
+          property="rendition:spread"&gt;
          landscape
-      &lt;/meta>
-   &lt;/metadata>
+      &lt;/meta&gt;
+   &lt;/metadata&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 
 
 							<figure id="spread-landscape-figure">
 								<figcaption> Rendering of three fixed-layout documents, with synthetic spread in
-									landscape orientation only. <br /><span class="attribution">(Comics courtesy of <a
-											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+									landscape orientation only. <br><span class="attribution">(Comics courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
 										2.5</a>.)</span>
 								</figcaption>
-								<img src="images/example_spread_landscape.svg" width="600"
-									aria-details="spread-landscape-diagram"
-									alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time in portrait and using synthetic spread in landscape."
-								 />
+								<img src="images/example_spread_landscape.svg" width="600" aria-details="spread-landscape-diagram" alt="Progression of FXL pages both in portrait and in landscape modes, showing one page at a time in portrait and using synthetic spread in landscape.">
 							</figure>
 
 							<details id="spread-landscape-diagram" class="desc">
@@ -7287,35 +7043,31 @@ No Entry</pre>
 						</aside>
 
 
-						<aside class="example" id="spread-both-example"
-							title="Specifying to use synthetic spreads both in portrait and in landscape orientations">
+						<aside class="example" id="spread-both-example" title="Specifying to use synthetic spreads both in portrait and in landscape orientations">
 							<p>See also <a href="#spread-both-figure"></a>.</p>
-							<pre>&lt;package …>
-   &lt;metadata …>
+							<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
-          property="rendition:layout">
+          property="rendition:layout"&gt;
          pre-paginated
-      &lt;/meta>
+      &lt;/meta&gt;
       
       &lt;meta
-          property="rendition:spread">
+          property="rendition:spread"&gt;
          both
-      &lt;/meta>
-   &lt;/metadata>
+      &lt;/meta&gt;
+   &lt;/metadata&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 
 							<figure id="spread-both-figure">
 								<figcaption> Rendering of three fixed-layout documents, with synthetic spread in both
-									portrait and landscape orientations. <br /><span class="attribution">(Comics
-										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+									portrait and landscape orientations. <br><span class="attribution">(Comics
+										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
 										2.5</a>.)</span>
 								</figcaption>
-								<img src="images/example_spread_both.svg" width="600" aria-details="spread-both-diagram"
-									alt="Progression of FXL pages both in portrait and in landscape modes, using synthetic spread in both cases."
-								 />
+								<img src="images/example_spread_both.svg" width="600" aria-details="spread-both-diagram" alt="Progression of FXL pages both in portrait and in landscape modes, using synthetic spread in both cases.">
 							</figure>
 
 							<details id="spread-both-diagram" class="desc">
@@ -7330,46 +7082,40 @@ No Entry</pre>
 						</aside>
 
 
-						<aside class="example" id="spread-both-with-intro-example"
-							title="Overriding the global spread behavior">
+						<aside class="example" id="spread-both-with-intro-example" title="Overriding the global spread behavior">
 							<p>In this example, the EPUB creator overrides the global reflowable setting in the spine
 								for the introductory page. The intention is for reading systems to render it as a
 								reflowable document.</p>
 
-							<pre>&lt;package …>
-   &lt;metadata …>
+							<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
-          property="rendition:layout">
+          property="rendition:layout"&gt;
          pre-paginated
-      &lt;/meta>
+      &lt;/meta&gt;
       &lt;meta
-          property="rendition:spread">
+          property="rendition:spread"&gt;
          both
-      &lt;/meta>
-   &lt;/metadata>
+      &lt;/meta&gt;
+   &lt;/metadata&gt;
    
-   &lt;spine>
+   &lt;spine&gt;
       &lt;itemref
           idref="introduction"
-          properties="rendition:layout-reflowable"/>
+          properties="rendition:layout-reflowable"/&gt;
       …
-   &lt;/spine>
+   &lt;/spine&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 
 							<figure id="spread-both-with-intro-figure">
 								<figcaption>Rendering of an introduction document in reflowable layout, followed by
 									three fixed-layout documents with synthetic spread in portrait orientation.
-										<br /><span class="attribution">(Comics courtesy of <a
-											href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+										<br><span class="attribution">(Comics courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
 										2.5</a>.)</span>
 								</figcaption>
-								<img src="images/example_spread_both_with_reflowable_intro.svg" width="600"
-									aria-details="spread-both-with-intro-diagram"
-									alt="Progression of FXL pages both in portrait using synthetic spread in both cases, preceded by an introduction with reflowable contnt."
-								 />
+								<img src="images/example_spread_both_with_reflowable_intro.svg" width="600" aria-details="spread-both-with-intro-diagram" alt="Progression of FXL pages both in portrait using synthetic spread in both cases, preceded by an introduction with reflowable contnt.">
 							</figure>
 
 							<details id="spread-both-with-intro-diagram" class="desc">
@@ -7385,12 +7131,11 @@ No Entry</pre>
 							</details>
 						</aside>
 
-						<section id="spread-overrides">
+						<section id="spread-overrides" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L151,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L156">
 							<h6>Synthetic spread overrides</h6>
 
 							<p id="property-spread-local">[=EPUB creators=] MAY specify the following properties locally
-								on [=EPUB spine | spine=] [^itemref^] elements to override the <a
-									href="#property-spread-global">global value</a> for the given spine item:</p>
+								on [=EPUB spine | spine=] [^itemref^] elements to override the <a href="#property-spread-global">global value</a> for the given spine item:</p>
 
 							<dl>
 								<dt id="spread-auto">rendition:spread-auto</dt>
@@ -7411,25 +7156,21 @@ No Entry</pre>
 
 								<dt id="spread-portrait">rendition:spread-portrait</dt>
 								<dd>
-									<p>The <code>rendition:spread-portrait</code> property is <a href="#deprecated"
-											>deprecated</a>.</p>
-									<p></p>Refer to the <a
-										href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"
-											><code>spread-portrait</code> property definition</a>
-									in [[epubpublications-301]] for more information.</dd>
+									<p>The <code>rendition:spread-portrait</code> property is <a href="#deprecated">deprecated</a>.</p>
+									<p></p>Refer to the <a href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#spread-portrait"><code>spread-portrait</code> property definition</a>
+									in&nbsp;[[epubpublications-301]] for more information.</dd>
 							</dl>
 
 							<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
 						</section>
 					</section>
 
-					<section id="page-spread">
+					<section id="page-spread" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L166,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L171">
 						<h5>Spread placement</h5>
 
 						<p>When a [=reading system=] renders a [=synthetic spread=], the default behavior is to populate
 							the spread by rendering the next [=EPUB content document=] in the next available unpopulated
-							[=viewport=], where the next available viewport is determined by the given <a
-								href="#attrdef-spine-page-progression-direction">page progression direction</a> or by
+							[=viewport=], where the next available viewport is determined by the given <a href="#attrdef-spine-page-progression-direction">page progression direction</a> or by
 							local declarations within [=EPUB content documents=]. An [=EPUB creator=] MAY override this
 							automatic population behavior and force reading systems to place a document in a particular
 							viewport by specifying one of the following properties on its spine <code>itemref</code>
@@ -7438,22 +7179,19 @@ No Entry</pre>
 						<dl>
 							<dt id="page-spread-center">
 								<code>rendition:page-spread-center</code></dt>
-							<dd>The <code>rendition:page-spread-center</code> property is an alias of the <a
-									href="#spread-none"><code>spread-none</code> property</a> for centering a spine
+							<dd>The <code>rendition:page-spread-center</code> property is an alias of the <a href="#spread-none"><code>spread-none</code> property</a> for centering a spine
 								item.</dd>
 
 							<dt id="fxl-page-spread-left">
 								<code>rendition:page-spread-left</code>
 							</dt>
-							<dd>The <code>rendition:page-spread-left</code> property is an alias of the <code><a
-										href="#page-spread-left">page-spread-left</a></code> property for placing a
+							<dd>The <code>rendition:page-spread-left</code> property is an alias of the <code><a href="#page-spread-left">page-spread-left</a></code> property for placing a
 								spine item in the left-hand slot of a two-page spread.</dd>
 
 							<dt id="fxl-page-spread-right">
 								<code>rendition:page-spread-right</code>
 							</dt>
-							<dd>The <code>rendition:page-spread-right</code> property is an alias of the <code><a
-										href="#page-spread-right">page-spread-right</a></code> property for placing a
+							<dd>The <code>rendition:page-spread-right</code> property is an alias of the <code><a href="#page-spread-right">page-spread-right</a></code> property for placing a
 								spine item in the right-hand slot of a two-page spread.</dd>
 						</dl>
 
@@ -7488,42 +7226,37 @@ No Entry</pre>
 								or <code>spread-none</code> to disable spread behavior in reading systems.</p>
 						</div>
 
-						<aside class="example" id="spread-page-spread-right-example"
-							title="Starting the first document on the right">
-							<pre>&lt;package …>
-   &lt;metadata …>
+						<aside class="example" id="spread-page-spread-right-example" title="Starting the first document on the right">
+							<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
-          property="rendition:layout">
+          property="rendition:layout"&gt;
           reflowable
-      &lt;/meta>
+      &lt;/meta&gt;
 	  
       &lt;meta
-          property="rendition:spread">
+          property="rendition:spread"&gt;
           landscape
-      &lt;/meta>
+      &lt;/meta&gt;
       …
-   &lt;/metadata>
-   &lt;spine page-progression-direction="ltr">
+   &lt;/metadata&gt;
+   &lt;spine page-progression-direction="ltr"&gt;
       …
       &lt;itemref
           idref="first-panel"
-          properties="rendition:page-spread-right"/>
+          properties="rendition:page-spread-right"/&gt;
       …
-   &lt;/spine>
-&lt;/package></pre>
+   &lt;/spine&gt;
+&lt;/package&gt;</pre>
 
 							<figure id="spread-page-spread-right-figure">
 								<figcaption>Rendering of three fixed-layout documents, with synthetic spread in
-									landscape orientation starting on the right. <br /><span class="attribution">(Comics
-										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a
-											href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
+									landscape orientation starting on the right. <br><span class="attribution">(Comics
+										courtesy of <a href="https://xkcd.com/927/">xkcd</a>, licensed under <a href="https://creativecommons.org/licenses/by-nc/2.5/">cc by-nc
 										2.5</a>.)</span>
 								</figcaption>
-								<img src="images/example_spread_page_spread_right.svg" width="600"
-									aria-details="spread-page-spread-right-diagram"
-									alt="Progression of FXL pages in landscape modes, showing synthetic spread in both cases but with the first page appearing on the right side of the first page."
-								 />
+								<img src="images/example_spread_page_spread_right.svg" width="600" aria-details="spread-page-spread-right-diagram" alt="Progression of FXL pages in landscape modes, showing synthetic spread in both cases but with the first page appearing on the right side of the first page.">
 							</figure>
 
 							<details id="spread-page-spread-right-diagram" class="desc">
@@ -7544,47 +7277,47 @@ No Entry</pre>
 								since the global value of <code>rendition:spread</code> initializes to <code>auto</code>
 								by default.</p>
 
-							<pre>&lt;package …>
+							<pre>&lt;package …&gt;
    …
-   &lt;spine page-progression-direction="ltr">
+   &lt;spine page-progression-direction="ltr"&gt;
       …
       &lt;itemref
           idref="center-plate-left"
-          properties="rendition:spread-both rendition:page-spread-left"/>
+          properties="rendition:spread-both rendition:page-spread-left"/&gt;
       &lt;itemref
           idref="center-plate-right"
-          properties="rendition:spread-both rendition:page-spread-right"/>
+          properties="rendition:spread-both rendition:page-spread-right"/&gt;
       …
-   &lt;/spine>
-&lt;/package></pre>
+   &lt;/spine&gt;
+&lt;/package&gt;</pre>
 						</aside>
 
 						<aside class="example" id="fxl-ex6" title="Creating a centered layout">
-							<pre>&lt;package …>
-   &lt;metadata …>
+							<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
-          property="rendition:layout">
+          property="rendition:layout"&gt;
          pre-paginated
-      &lt;/meta>
+      &lt;/meta&gt;
       &lt;meta
-          property="rendition:spread">
+          property="rendition:spread"&gt;
          auto
-      &lt;/meta>
-   &lt;/metadata>
-   &lt;spine>
+      &lt;/meta&gt;
+   &lt;/metadata&gt;
+   &lt;spine&gt;
       …
       &lt;itemref
           idref="center-plate"
-          properties="rendition:page-spread-center"/>
+          properties="rendition:page-spread-center"/&gt;
       …
-   &lt;/spine>
+   &lt;/spine&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 						</aside>
 					</section>
 
-					<section id="viewport">
+					<section id="viewport" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L187">
 						<h5>Viewport dimensions (deprecated)</h5>
 
 						<p>The <code>rendition:viewport</code> property allows [=EPUB creators=] to express the CSS
@@ -7594,35 +7327,29 @@ No Entry</pre>
 
 						<p>Use of the property is <a href="#deprecated">deprecated</a>.</p>
 
-						<p>Refer to the <a
-								href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"
-									><code>rendition:viewport</code> property definition</a> in [[epubpublications-301]]
+						<p>Refer to the <a href="https://idpf.org/epub/301/spec/epub-publications-20140626.html#fxl-property-viewport"><code>rendition:viewport</code> property definition</a> in&nbsp;[[epubpublications-301]]
 							for more information.</p>
 					</section>
 
-					<section id="sec-fxl-content-dimensions">
+					<section id="sec-fxl-content-dimensions" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L457,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L212,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L217,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L222,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L227,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L233,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L239,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L245,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L251,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L257,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L263,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L269,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L275,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L283,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L297,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L303,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L309">
 						<h4>Content document dimensions</h4>
 
 						<p>This section defines rules for the expression and interpretation of dimensional properties of
 							[=fixed-layout documents=].</p>
 
-						<p id="confreg-fxl-icb">Fixed-layout documents specify their <a
-								href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
+						<p id="confreg-fxl-icb">Fixed-layout documents specify their <a href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
 								containing block</a> [[css2]] in the manner applicable to their format:</p>
 
 						<dl class="conformance-list" id="sec-fxl-html-svg-dimensions">
-							<dt id="sec-fxl-icb-html" data-tests="#lay-fxl-xhtml-icb,#lay-fxl-xhtml-icb_multi"
-								>Expressing in XHTML</dt>
+							<dt id="sec-fxl-icb-html" data-tests="#lay-fxl-xhtml-icb,#lay-fxl-xhtml-icb_multi">Expressing in XHTML</dt>
 							<dd>
-								<p>For XHTML [=fixed-layout documents=], the <a
-										href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
+								<p>For XHTML [=fixed-layout documents=], the <a href="https://www.w3.org/TR/CSS2/visudet.html#containing-block-details">initial
 										containing block</a> [[css2]] is obtained from the REQUIRED <code>height</code>
 									and <code>width</code> definitions in a <a href="#app-viewport-meta"><code>viewport
 											meta</code> tag</a>, where:</p>
 								<ul>
 									<li>the <code>height</code>
-										<a href="#viewport.ebnf.property">property</a> MUST have as its <a
-											href="#viewport.ebnf.value">value</a> a positive number or the keyword
+										<a href="#viewport.ebnf.property">property</a> MUST have as its <a href="#viewport.ebnf.value">value</a> a positive number or the keyword
 											<code>device-height</code>; and</li>
 									<li>the <code>width</code> property MUST have as its value a positive number or the
 										keyword <code>device-width</code>.</li>
@@ -7630,43 +7357,37 @@ No Entry</pre>
 								<p>The <code>device-width</code> and <code>device-height</code> values refer to the 100%
 									of the width and height, respectively, of the reading system's [=viewport=].</p>
 								<p>The <code>height</code> and <code>width</code> definitions MUST be specified in the
-									first <code>viewport meta</code> tag in document order in the [[html]] <a
-										data-cite="html#the-head-element"><code>head</code></a> element. Reading systems
+									first <code>viewport meta</code> tag in document order in the [[html]] <a data-cite="html#the-head-element"><code>head</code></a> element. Reading systems
 									will ignore subsequent <code>viewport meta</code> tags.</p>
 								<p>EPUB creators MUST NOT specify more than one <code>height</code> or
 										<code>width</code> definition within a <code>viewport meta</code> tag.</p>
-								<aside class="example"
-									title="Specifying the initial containing block in a viewport meta tag">
-									<pre>&lt;html …>
-   &lt;head>
+								<aside class="example" title="Specifying the initial containing block in a viewport meta tag">
+									<pre>&lt;html …&gt;
+   &lt;head&gt;
       …
       &lt;meta
           name="viewport"
-          content="width=1200, height=600"/>
+          content="width=1200, height=600"/&gt;
       …
-   &lt;/head>
+   &lt;/head&gt;
    …
-&lt;/html></pre>
+&lt;/html&gt;</pre>
 								</aside>
 							</dd>
 
 							<dt id="sec-fxl-icb-svg" data-tests="#fxl-svg-icb_multi">Expressing in SVG</dt>
 							<dd>
-								<p>For SVG [=fixed-layout documents=], the initial containing block [[css2]] dimensions
-									MUST be expressed using the <a
-										href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"
-											><code>viewBox</code> attribute</a> [[svg]].</p>
-								<aside class="example"
-									title="Specifying the initial containing block in the viewBox attribute">
+								<p>For SVG [=fixed-layout documents=], the initial containing block&nbsp;[[css2]] dimensions
+									MUST be expressed using the <a href="https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute"><code>viewBox</code> attribute</a> [[svg]].</p>
+								<aside class="example" title="Specifying the initial containing block in the viewBox attribute">
 									<p>In this example, the <code>viewBox</code> attribute sets the ICB to an aspect
 										ratio of 844 pixels wide by 1200 pixels high.</p>
 
-									<pre>
-&lt;svg xmlns="http://www.w3.org/2000/svg"
+									<pre>&lt;svg xmlns="http://www.w3.org/2000/svg"
      version="1.1" 
-     viewBox="0 0 844 1200">
+     viewBox="0 0 844 1200"&gt;
    …
-&lt;/svg></pre>
+&lt;/svg&gt;</pre>
 								</aside>
 							</dd>
 						</dl>
@@ -7681,13 +7402,12 @@ No Entry</pre>
 			<section id="sec-reflowable-layouts">
 				<h3>Reflowable layouts</h3>
 
-				<p>Although control over the rendering of [=EPUB content documents=] to create <a
-						href="#sec-fixed-layouts">fixed layouts</a> is an obvious need not handled by other
+				<p>Although control over the rendering of [=EPUB content documents=] to create <a href="#sec-fixed-layouts">fixed layouts</a> is an obvious need not handled by other
 					technologies, there are also considerations for reflowable content that are unique to [=EPUB
 					publications=] (e.g., how to handle the flow of content in the [=viewport=]). This section defines
 					properties that allow [=EPUB creators=] to control presentation aspects of reflowable content.</p>
 
-				<section id="flow">
+				<section id="flow" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L320,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L325,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L332,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L339">
 					<h4>The <code>rendition:flow</code> property</h4>
 
 					<p>The <code>rendition:flow</code> property specifies the [=EPUB creator=] preference for how
@@ -7734,10 +7454,7 @@ No Entry</pre>
 					</dl>
 
 					<p id="html-body-page-break-before">Note that when two reflowable EPUB content documents occur
-						sequentially in the spine, the default rendering for their [[!html]] <a
-							data-cite="html#the-body-element"><code>body</code></a> elements is consistent with the <a
-							href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"
-								><code>page-break-before</code> property</a> [[!csssnapshot]] having been set to
+						sequentially in the spine, the default rendering for their [[!html]] <a data-cite="html#the-body-element"><code>body</code></a> elements is consistent with the <a href="https://www.w3.org/TR/CSS2/page.html#propdef-page-break-before"><code>page-break-before</code> property</a> [[!csssnapshot]] having been set to
 							<code>always</code>. In addition to using the <code>rendition:flow</code> property, EPUB
 						creators MAY override this behavior through an appropriate style sheet declaration, if the
 						reading system supports such overrides.</p>
@@ -7751,9 +7468,7 @@ No Entry</pre>
 					<figure id="fig-flow-paginated-single">
 						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
 								<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
-						<img src="images/example_rendering_paginated_single_spine.svg" width="600"
-							aria-details="flow-paginated-single-diagram"
-							alt="The continuous progression of paginated content produced for a single document." />
+						<img src="images/example_rendering_paginated_single_spine.svg" width="600" aria-details="flow-paginated-single-diagram" alt="The continuous progression of paginated content produced for a single document.">
 					</figure>
 
 					<details id="flow-paginated-single-diagram" class="desc">
@@ -7767,10 +7482,8 @@ No Entry</pre>
 					<figure id="fig-flow-paginated-multiple">
 						<figcaption>Rendering of an EPUB publication with multiple spine items, and with the
 								<code>rendition:flow</code> set to <code>paginated</code>.</figcaption>
-						<img src="images/example_rendering_paginated_multiple_spine.svg" width="600"
-							aria-details="flow-paginated-multiple-diagram"
-							alt="The continuous progression of paginated content produced for each document with transitions to
-					new pages between documents." />
+						<img src="images/example_rendering_paginated_multiple_spine.svg" width="600" aria-details="flow-paginated-multiple-diagram" alt="The continuous progression of paginated content produced for each document with transitions to
+					new pages between documents.">
 					</figure>
 
 					<details id="flow-paginated-multiple-diagram" class="desc">
@@ -7785,10 +7498,8 @@ No Entry</pre>
 					<figure id="fig-flow-scrolled-continuous">
 						<figcaption>Rendering of an EPUB publication with a single spine item, and with the
 								<code>rendition:flow</code> set to <code>scrolled-continuous</code>.</figcaption>
-						<img src="images/example_rendering_scrolled_continuous.svg" width="220"
-							aria-details="flow-scrolled-continuous-diagram"
-							alt="The progression of a continuous scroll of content extends vertically off the user's screen,
-					with new documents added to the bottom as encountered." />
+						<img src="images/example_rendering_scrolled_continuous.svg" width="220" aria-details="flow-scrolled-continuous-diagram" alt="The progression of a continuous scroll of content extends vertically off the user's screen,
+					with new documents added to the bottom as encountered.">
 					</figure>
 
 					<details id="flow-scrolled-continuous-diagram" class="desc">
@@ -7801,10 +7512,8 @@ No Entry</pre>
 					<figure id="fig-flow-scrolled-doc">
 						<figcaption>Rendering of an EPUB publication with multiple spine items, and with the
 								<code>rendition:flow</code> set to <code>scrolled-doc</code>.</figcaption>
-						<img src="images/example_rendering_scrolled_doc.svg" width="600"
-							aria-details="flow-scrolled-doc-diagram"
-							alt="The progression of scrollable documents depicting how only the content within each document
-					is scrollable." />
+						<img src="images/example_rendering_scrolled_doc.svg" width="600" aria-details="flow-scrolled-doc-diagram" alt="The progression of scrollable documents depicting how only the content within each document
+					is scrollable.">
 					</figure>
 
 					<details id="flow-scrolled-doc-diagram" class="desc">
@@ -7816,12 +7525,11 @@ No Entry</pre>
 							schematic view of a tablet.</p>
 					</details>
 
-					<section id="flow-overrides">
+					<section id="flow-overrides" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L348,https://w3c.github.io/epub-structural-tests/#08-layout_layout.feature_L353">
 						<h5>Spine overrides</h5>
 
 						<p id="layout-property-flow-local">[=EPUB creators=] MAY specify the following properties
-							locally on [=EPUB spine | spine=] [^itemref^] elements to override the <a
-								href="#property-flow-global">global value</a> for the given spine item:</p>
+							locally on [=EPUB spine | spine=] [^itemref^] elements to override the <a href="#property-flow-global">global value</a> for the given spine item:</p>
 
 						<dl>
 							<dt id="flow-auto">rendition:flow-auto</dt>
@@ -7843,11 +7551,10 @@ No Entry</pre>
 
 						<p>EPUB creators MUST NOT use more than one of these overrides on any given spine item.</p>
 
-						<aside class="example" id="property-flow-ex1"
-							title="Overriding a global paginated flow declaration">
+						<aside class="example" id="property-flow-ex1" title="Overriding a global paginated flow declaration">
 							<p>In this example, the EPUB creator's intent is to have a paginated [=EPUB publication=]
 								with a scrollable table of contents.</p>
-							<pre>&lt;package …>
+							<pre>&lt;package …&gt;
 &lt;metadata …&gt;
 	…
 	&lt;meta
@@ -7866,7 +7573,7 @@ No Entry</pre>
 	&lt;itemref
 		idref="c01"/&gt;
 &lt;/spine&gt;
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 						</aside>
 					</section>
 				</section>
@@ -7927,7 +7634,7 @@ No Entry</pre>
 			<section id="sec-overlay-docs">
 				<h3>Media overlay documents</h3>
 
-				<section id="sec-overlay-req">
+				<section id="sec-overlay-req" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L21,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L26,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L31,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L37">
 					<h4>Media overlay document requirements</h4>
 
 					<p>A [=media overlay document=]:</p>
@@ -7962,8 +7669,7 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>smil</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>smil</code></dfn>
 								</p>
 							</dd>
 
@@ -8024,7 +7730,7 @@ No Entry</pre>
 						</dl>
 					</section>
 
-					<section id="sec-smil-head-elem">
+					<section id="sec-smil-head-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L47">
 						<h5>The <code>head</code> element</h5>
 
 						<p>The <code>head</code> element is the container for metadata in the [=media overlay
@@ -8034,8 +7740,7 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>head</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>head</code></dfn>
 								</p>
 							</dd>
 
@@ -8107,8 +7812,7 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>body</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>body</code></dfn>
 								</p>
 							</dd>
 
@@ -8128,9 +7832,7 @@ No Entry</pre>
 									<dd>
 										<p>An expression of the structural semantics of the corresponding element in the
 											[=EPUB content document=].</p>
-										<p>The value is a white space separated list of <a href="#sec-property-datatype"
-												>property</a> types. Refer to <a href="#sec-docs-structural-semantic"
-											></a> for more information.</p>
+										<p>The value is a white space separated list of <a href="#sec-property-datatype">property</a> types. Refer to <a href="#sec-docs-structural-semantic"></a> for more information.</p>
 									</dd>
 
 									<dt>
@@ -8150,7 +7852,7 @@ No Entry</pre>
 										<p>Refers to the associated EPUB content document and, optionally, identifies a
 											specific part of it.</p>
 										<p>The value MUST be a [=path-relative-scheme-less-URL string=], optionally
-											followed by <code>U+0023 (#)</code> and a [=URL-fragment string=].</p>
+											followed by <code>U+0023&nbsp;(#)</code> and a [=URL-fragment string=].</p>
 									</dd>
 								</dl>
 							</dd>
@@ -8173,7 +7875,7 @@ No Entry</pre>
 						</dl>
 					</section>
 
-					<section id="sec-smil-seq-elem">
+					<section id="sec-smil-seq-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L64">
 						<h5>The <code>seq</code> element</h5>
 
 						<p>The <code>seq</code> element is a sequential time container for media objects and/or child
@@ -8183,8 +7885,7 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>seq</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>seq</code></dfn>
 								</p>
 							</dd>
 
@@ -8204,9 +7905,7 @@ No Entry</pre>
 									<dd>
 										<p>An expression of the structural semantics of the corresponding element in the
 											[=EPUB content document=].</p>
-										<p>The value is a white space separated list of <a href="#sec-property-datatype"
-												>property</a> types. Refer to <a href="#sec-docs-structural-semantic"
-											></a> for more information.</p>
+										<p>The value is a white space separated list of <a href="#sec-property-datatype">property</a> types. Refer to <a href="#sec-docs-structural-semantic"></a> for more information.</p>
 									</dd>
 
 									<dt>
@@ -8226,7 +7925,7 @@ No Entry</pre>
 										<p>Refers to the associated [=EPUB content document=] and, optionally,
 											identifies a specific part of it.</p>
 										<p>The value MUST be a [=path-relative-scheme-less-URL string=], optionally
-											followed by <code>U+0023 (#)</code> and a [=URL-fragment string=].</p>
+											followed by <code>U+0023&nbsp;(#)</code> and a [=URL-fragment string=].</p>
 										<p>Refer to <a href="#sec-media-overlays-structure"></a> for more
 											information.</p>
 									</dd>
@@ -8251,7 +7950,7 @@ No Entry</pre>
 						</dl>
 					</section>
 
-					<section id="sec-smil-par-elem">
+					<section id="sec-smil-par-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L75,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L82">
 						<h5>The <code>par</code> element</h5>
 
 						<p>The <code>par</code> element is a parallel time container for media objects.</p>
@@ -8260,8 +7959,7 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>par</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>par</code></dfn>
 								</p>
 							</dd>
 
@@ -8281,9 +7979,7 @@ No Entry</pre>
 									<dd>
 										<p>An expression of the structural semantics of the corresponding element in the
 											[=EPUB content document=].</p>
-										<p>The value is a white space separated list of <a href="#sec-property-datatype"
-												>property</a> types. Refer to <a href="#sec-docs-structural-semantic"
-											></a> for more information.</p>
+										<p>The value is a white space separated list of <a href="#sec-property-datatype">property</a> types. Refer to <a href="#sec-docs-structural-semantic"></a> for more information.</p>
 									</dd>
 
 									<dt>
@@ -8320,15 +8016,13 @@ No Entry</pre>
 						<p>The <code>text</code> element references an element in an [=EPUB content document=]. A
 								<code>text</code> element typically refers to a textual element but can also refer to
 							other [=EPUB content document=] media elements. In the absence of a sibling [^audio^]
-							element, textual content referred to by this element may be rendered via <a href="#sec-tts"
-								>text-to-speech</a>.</p>
+							element, textual content referred to by this element may be rendered via <a href="#sec-tts">text-to-speech</a>.</p>
 
 						<dl class="elemdef" id="elemdef-smil-text">
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>text</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>text</code></dfn>
 								</p>
 							</dd>
 
@@ -8348,7 +8042,7 @@ No Entry</pre>
 										<p>Refers to the associated EPUB content document and, optionally, identifies a
 											specific part of it.</p>
 										<p>The value MUST be a [=path-relative-scheme-less-URL string=], optionally
-											followed by <code>U+0023 (#)</code> and a [=URL-fragment string=].</p>
+											followed by <code>U+0023&nbsp;(#)</code> and a [=URL-fragment string=].</p>
 									</dd>
 
 									<dt>
@@ -8371,19 +8065,16 @@ No Entry</pre>
 						<p class="note">This specification places no restriction on the <code>src</code> attribute of a
 								<code>text</code> element. [=EPUB creators=] should, however, refer to a content that
 							can be styled with CSS to make the <a href="#sec-docs-assoc-style">association with style
-								information</a> effective (i.e., [=palpable content=] for XHTML or <a
-								href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a
-								href="https://www.w3.org/TR/SVG11/shapes.html">basic shapes</a>, or <a
-								href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG). </p>
+								information</a> effective (i.e., [=palpable content=] for XHTML or <a href="https://www.w3.org/TR/SVG11/paths.html">paths</a>, <a href="https://www.w3.org/TR/SVG11/shapes.html">basic shapes</a>, or <a href="https://www.w3.org/TR/SVG11/text.html">text</a> elements in SVG). </p>
 
 						<p class="note">[[epub-rs-33]] no longer provides guidance for reading systems on the playback
 							of timed media (i.e., the automatic starting of the referenced media). Although the
 								<code>src</code> attribute of a <code>text</code> element may refer to embedded timed
-							media (e.g., via an [[html]] [^video^] element), referencing such media may have
+							media (e.g., via an [[html]]&nbsp;[^video^] element), referencing such media may have
 							unpredictable results.</p>
 					</section>
 
-					<section id="sec-smil-audio-elem">
+					<section id="sec-smil-audio-elem" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L95,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L101,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L106,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L111,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L116,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L122,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L128,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L134">
 						<h5>The <code>audio</code> element</h5>
 
 						<p>The <code>audio</code> element represents a clip of audio media.</p>
@@ -8392,8 +8083,7 @@ No Entry</pre>
 							<dt>Element Name:</dt>
 							<dd>
 								<p>
-									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"
-										><code>audio</code></dfn>
+									<dfn class="export" data-lt-no-plural="" data-dfn-type="element"><code>audio</code></dfn>
 								</p>
 							</dd>
 
@@ -8419,10 +8109,8 @@ No Entry</pre>
 										<code>[required]</code>
 									</dt>
 									<dd>
-										<p>The [=relative-url string | relative-=] or <a data-lt="absolute-url string"
-												>absolute-URL string</a> [[url]] reference to an audio file. The audio
-											file MUST be one of the audio formats listed in the <a
-												href="#sec-core-media-types">core media type resources</a> table.</p>
+										<p>The [=relative-url string | relative-=] or <a data-lt="absolute-url string">absolute-URL string</a> [[url]] reference to an audio file. The audio
+											file MUST be one of the audio formats listed in the <a href="#sec-core-media-types">core media type resources</a> table.</p>
 									</dd>
 
 									<dt id="attrdef-smil-clipBegin">
@@ -8492,19 +8180,18 @@ No Entry</pre>
 					<p>The <code>text</code> element <code>src</code> attribute references the associated phrase,
 						sentence, or other segment of the EPUB content document by its URL [[url]] reference. The
 							<code>audio</code> element <code>src</code> attribute similarly references the location of
-						the corresponding audio clip and adds the OPTIONAL <a href="#attrdef-smil-clipBegin"
-								><code>clipBegin</code></a> and <a href="#attrdef-smil-clipEnd"><code>clipEnd</code></a>
+						the corresponding audio clip and adds the OPTIONAL <a href="#attrdef-smil-clipBegin"><code>clipBegin</code></a> and <a href="#attrdef-smil-clipEnd"><code>clipEnd</code></a>
 						attributes to indicate a specific offset within the clip.</p>
 
 					<aside class="example" title="Media overlays markup for a single phrase or sentence">
-						<pre>&lt;par>                        
+						<pre>&lt;par&gt;                        
    &lt;text
-       src="chapter1.xhtml#sentence1"/>
+       src="chapter1.xhtml#sentence1"/&gt;
    &lt;audio
        src="chapter1_audio.mp3"
        clipBegin="23s"
-       clipEnd="30s"/>
-&lt;/par></pre>
+       clipEnd="30s"/&gt;
+&lt;/par&gt;</pre>
 					</aside>
 
 					<p>EPUB creators place <code>par</code> elements together sequentially to form a series of phrases
@@ -8518,39 +8205,38 @@ No Entry</pre>
 
 						<pre>&lt;smil
     xmlns="http://www.w3.org/ns/SMIL" 
-    version="3.0">
-   &lt;body>
-      &lt;par id="par1">
+    version="3.0"&gt;
+   &lt;body&gt;
+      &lt;par id="par1"&gt;
          &lt;text
-             src="chapter1.xhtml#sentence1"/>
+             src="chapter1.xhtml#sentence1"/&gt;
          &lt;audio
              src="chapter1_audio.mp3"
              clipBegin="0s"
-             clipEnd="10s"/>
-      &lt;/par>
-      &lt;par id="par2">
+             clipEnd="10s"/&gt;
+      &lt;/par&gt;
+      &lt;par id="par2"&gt;
          &lt;text
-             src="chapter1.xhtml#sentence2"/>
+             src="chapter1.xhtml#sentence2"/&gt;
          &lt;audio
              src="chapter1_audio.mp3"
              clipBegin="10s"
-             clipEnd="20s"/>
-      &lt;/par>
-      &lt;par id="par3">
+             clipEnd="20s"/&gt;
+      &lt;/par&gt;
+      &lt;par id="par3"&gt;
          &lt;text
-             src="chapter1.xhtml#sentence3"/>
+             src="chapter1.xhtml#sentence3"/&gt;
          &lt;audio
              src="chapter1_audio.mp3"
              clipBegin="20s"
-             clipEnd="30s"/>
-      &lt;/par>
-   &lt;/body>
-&lt;/smil></pre>
+             clipEnd="30s"/&gt;
+      &lt;/par&gt;
+   &lt;/body&gt;
+&lt;/smil&gt;</pre>
 					</aside>
 
 					<p>EPUB creators can also add <code>par</code> elements to <code>seq</code> elements to define more
-						complex structures such as parts and chapters (see <a href="#sec-media-overlays-structure"
-						></a>).</p>
+						complex structures such as parts and chapters (see <a href="#sec-media-overlays-structure"></a>).</p>
 				</section>
 
 				<section id="sec-docs-relations">
@@ -8575,14 +8261,13 @@ No Entry</pre>
 							markup. Each element identifies both the content to display (in the [^text^] element) and
 							audio to synchronize (in the [^audio^] element) during playback.</p>
 
-						<p>The <code>seq</code> element represents sequences &#8212; sets of <code>seq</code> and/or
+						<p>The <code>seq</code> element represents sequences — sets of <code>seq</code> and/or
 								<code>par</code> elements that together represent a logical component of the content.
 							[=EPUB creators=] can use it to represent nested containers such as sections, asides,
 							headers, tables, lists, and footnotes. It allows EPUB creators to retain the structure
 							inherent in these containers in the media overlay document.</p>
 
-						<p>The <code>seq</code> element MUST contain an <a href="#attrdef-body-textref"
-									><code>epub:textref</code> attribute</a>. As <code>seq</code> elements do not
+						<p>The <code>seq</code> element MUST contain an <a href="#attrdef-body-textref"><code>epub:textref</code> attribute</a>. As <code>seq</code> elements do not
 							provide synchronization instructions, this attribute allows a [=reading system=] to match
 							the fragment to a location in the text.</p>
 
@@ -8604,141 +8289,141 @@ No Entry</pre>
 							<pre>&lt;smil
     xmlns="http://www.w3.org/ns/SMIL"
     xmlns:epub="http://www.idpf.org/2007/ops"
-    version="3.0">
-   &lt;body>
+    version="3.0"&gt;
+   &lt;body&gt;
 
-      &lt;!-- a chapter -->
+      &lt;!-- a chapter --&gt;
       
       &lt;seq
           id="id1"
           epub:textref="chapter1.xhtml#sectionstart"
-          epub:type="chapter">
+          epub:type="chapter"&gt;
 
-         &lt;!-- the section title -->
+         &lt;!-- the section title --&gt;
          
-         &lt;par id="id2">
+         &lt;par id="id2"&gt;
             &lt;text
-                src="chapter1.xhtml#section1_title"/>
+                src="chapter1.xhtml#section1_title"/&gt;
             &lt;audio
                 src="chapter1_audio.mp3"
                 clipBegin="0:23:23.84"
-                clipEnd="0:23:34.221"/>
-         &lt;/par>
+                clipEnd="0:23:34.221"/&gt;
+         &lt;/par&gt;
 
-         &lt;!-- some sentences in the chapter -->
+         &lt;!-- some sentences in the chapter --&gt;
          
-         &lt;par id="id3">
+         &lt;par id="id3"&gt;
             &lt;text
-                src="chapter1.xhtml#text1"/>
+                src="chapter1.xhtml#text1"/&gt;
             &lt;audio
                 src="chapter1_audio.mp3"
                 clipBegin="0:23:34.221"
-                clipEnd="0:23:59.003"/>
-         &lt;/par>
-         &lt;par id="id4">
+                clipEnd="0:23:59.003"/&gt;
+         &lt;/par&gt;
+         &lt;par id="id4"&gt;
             &lt;text
-                src="chapter1.xhtml#text2"/>
+                src="chapter1.xhtml#text2"/&gt;
             &lt;audio
                 src="chapter1_audio.mp3"
                 clipBegin="0:23:59.003"
-                clipEnd="0:24:15.000"/>
-         &lt;/par>
+                clipEnd="0:24:15.000"/&gt;
+         &lt;/par&gt;
 
-         &lt;!-- a figure -->
+         &lt;!-- a figure --&gt;
          
          &lt;seq
              id="id7"
-             epub:textref="chapter1.xhtml#figure">
-            &lt;par id="id8">
+             epub:textref="chapter1.xhtml#figure"&gt;
+            &lt;par id="id8"&gt;
                &lt;text
-                   src="chapter1.xhtml#photo"/>
+                   src="chapter1.xhtml#photo"/&gt;
                &lt;audio
                    src="chapter1_audio.mp3"
                    clipBegin="0:24:18.123"
-                   clipEnd="0:24:28.764"/>
-            &lt;/par>
-            &lt;par id="id9">
+                   clipEnd="0:24:28.764"/&gt;
+            &lt;/par&gt;
+            &lt;par id="id9"&gt;
                &lt;text
-                   src="chapter1.xhtml#caption"/>
+                   src="chapter1.xhtml#caption"/&gt;
                &lt;audio
                    src="chapter1_audio.mp3"
                    clipBegin="0:24:28.764"
-                   clipEnd="0:24:50.010"/>
-            &lt;/par>
-         &lt;/seq>
+                   clipEnd="0:24:50.010"/&gt;
+            &lt;/par&gt;
+         &lt;/seq&gt;
 
-         &lt;!-- more sentences in the chapter (outside the figure) -->
+         &lt;!-- more sentences in the chapter (outside the figure) --&gt;
          
-         &lt;par id="id12">
+         &lt;par id="id12"&gt;
             &lt;text
-                src="chapter1.xhtml#text3"/>
+                src="chapter1.xhtml#text3"/&gt;
             &lt;audio
                 src="chapter1_audio.mp3"
                 clipBegin="0:25:45.515"
-                clipEnd="0:26:30.203"/>
-         &lt;/par>
-         &lt;par id="id13">
+                clipEnd="0:26:30.203"/&gt;
+         &lt;/par&gt;
+         &lt;par id="id13"&gt;
             &lt;text
-                src="chapter1.xhtml#text4"/>
+                src="chapter1.xhtml#text4"/&gt;
             &lt;audio
                 src="chapter1_audio.mp3"
                 clipBegin="0:26:30.203"
-                clipEnd="0:27:15.000"/>
-         &lt;/par>
-      &lt;/seq>
-   &lt;/body>
-&lt;/smil></pre>
+                clipEnd="0:27:15.000"/&gt;
+         &lt;/par&gt;
+      &lt;/seq&gt;
+   &lt;/body&gt;
+&lt;/smil&gt;</pre>
 
 							<p>XHTML content document:</p>
 
-							<pre>&lt;html …>
-   &lt;head>
-      &lt;title>
+							<pre>&lt;html …&gt;
+   &lt;head&gt;
+      &lt;title&gt;
          Media Overlays Example of
          EPUB content document
-      &lt;/title>
-   &lt;/head>
-   &lt;body id="sec1">
+      &lt;/title&gt;
+   &lt;/head&gt;
+   &lt;body id="sec1"&gt;
       &lt;section
           id="sectionstart"
-          epub:type="chapter">
+          epub:type="chapter"&gt;
          
-         &lt;h1 id="section1_title">
+         &lt;h1 id="section1_title"&gt;
             The Section Title
-         &lt;/h1>
+         &lt;/h1&gt;
          
-         &lt;p id="text1">
+         &lt;p id="text1"&gt;
             The first phrase of the main text body.
-         &lt;/p>
+         &lt;/p&gt;
          
-         &lt;p id="text2">
+         &lt;p id="text2"&gt;
             The second phrase of the main text body.
-         &lt;/p>
+         &lt;/p&gt;
          
-         &lt;figure id="figure">
+         &lt;figure id="figure"&gt;
             &lt;img id="photo"
                 src="photo.png" 
-                alt="a photograph for which there is a caption" />
+                alt="a photograph for which there is a caption" /&gt;
             
-            &lt;figcaption id="caption">
+            &lt;figcaption id="caption"&gt;
                The photo caption
-            &lt;/figcaption>
-         &lt;/figure>
+            &lt;/figcaption&gt;
+         &lt;/figure&gt;
          
-         &lt;p id="text3">
+         &lt;p id="text3"&gt;
             The third phrase of the main text body.
-         &lt;/p>
+         &lt;/p&gt;
          
-         &lt;p id="text4">
+         &lt;p id="text4"&gt;
             The fourth phrase of the main text body.
-         &lt;/p>
-      &lt;/section>
-   &lt;/body>
-&lt;/html></pre>
+         &lt;/p&gt;
+      &lt;/section&gt;
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
 						</aside>
 					</section>
 
-					<section id="sec-media-overlays-fragids">
+					<section id="sec-media-overlays-fragids" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L153,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L158,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L164,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L170,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L175">
 						<h5>Referencing document fragments</h5>
 
 						<p>Both the <code>epub:textref</code> attribute and the [^text^] element's <code>src</code>
@@ -8746,8 +8431,7 @@ No Entry</pre>
 							element via its ID) of the associated [=EPUB content document=].</p>
 
 						<p>For [=XHTML content document | XHTML=] and [=SVG content documents=], the URL-fragment string
-							SHOULD be a reference to a specific element via its ID, or an <a
-								href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
+							SHOULD be a reference to a specific element via its ID, or an <a href="https://www.w3.org/TR/SVG/linking.html#SVGFragmentIdentifiers">SVG Fragment
 								Identifier</a> [[svg]], respectively.</p>
 
 						<p>EPUB creators MAY use other fragment identifier schemes, but [=reading systems=] may not
@@ -8773,9 +8457,9 @@ No Entry</pre>
 					<section id="sec-tts">
 						<h5>Text-to-speech rendering</h5>
 
-						<p>This specification allows the use of text-to-speech (TTS) &#8212; the rendering of the
+						<p>This specification allows the use of text-to-speech (TTS) — the rendering of the
 							textual content of an [=EPUB publication=] as artificial human speech using a synthesized
-							voice &#8212; in addition to pre-recorded audio clips.</p>
+							voice — in addition to pre-recorded audio clips.</p>
 
 						<p>When a media overlay [^par^] element omits its [^audio^] element, its [^text^] element may be
 							rendered in reading systems via TTS. If the text fragment is not appropriate for TTS
@@ -8797,9 +8481,7 @@ No Entry</pre>
 						[^body^] elements.</p>
 
 					<p>The <code>epub:type</code> attribute facilitates [=reading system=] behavior appropriate for the
-						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape"
-							>skippability and escapability</a> and <a data-cite="epub-rs-33#note-table-reading-mode"
-							>table reading mode</a> [[?epub-rs-33]].</p>
+						semantic type(s) indicated. Examples of these behaviors are <a href="#sec-behaviors-skip-escape">skippability and escapability</a> and <a data-cite="epub-rs-33#note-table-reading-mode">table reading mode</a> [[?epub-rs-33]].</p>
 
 					<p>[=Media overlay documents=] MAY use the applicable <a href="#sec-vocab-assoc">vocabulary
 							association mechanisms</a> for the <code>epub:type</code> attribute to define additional
@@ -8809,51 +8491,49 @@ No Entry</pre>
 						<pre>&lt;smil
     xmlns="http://www.w3.org/ns/SMIL" 
     xmlns:epub="http://www.idpf.org/2007/ops"
-    version="3.0">
-   &lt;body>
+    version="3.0"&gt;
+   &lt;body&gt;
       &lt;seq
           id="id1"
           epub:textref="chapter1.xhtml#figure"
-          epub:type="figure">
-         &lt;par id="id2">
+          epub:type="figure"&gt;
+         &lt;par id="id2"&gt;
             &lt;text
-                src="chapter1.xhtml#figuretitle"/>
+                src="chapter1.xhtml#figuretitle"/&gt;
             &lt;audio
                 src="chapter1_audio.mp3"
                 clipBegin="0:24:15.000"
-                clipEnd="0:24:18.123"/>
-         &lt;/par>
-         &lt;par id="id3">
+                clipEnd="0:24:18.123"/&gt;
+         &lt;/par&gt;
+         &lt;par id="id3"&gt;
             &lt;text
-                src="chapter1.xhtml#figurecaption"/>
+                src="chapter1.xhtml#figurecaption"/&gt;
             &lt;audio
                 src="chapter1_audio.mp3"
                 clipBegin="0:24:18.123"
-                clipEnd="0:24:38.530"/>
-         &lt;/par>
-         &lt;par id="id4">
+                clipEnd="0:24:38.530"/&gt;
+         &lt;/par&gt;
+         &lt;par id="id4"&gt;
             &lt;text
-                src="chapter1.xhtml#figuretext1"/>
+                src="chapter1.xhtml#figuretext1"/&gt;
             &lt;audio
                 src="chapter1_audio.mp3"
                 clipBegin="0:24:38.530"
-                clipEnd="0:25:00.515"/>
-         &lt;/par>
-      &lt;/seq>
-   &lt;/body>
-&lt;/smil></pre>
+                clipEnd="0:25:00.515"/&gt;
+         &lt;/par&gt;
+      &lt;/seq&gt;
+   &lt;/body&gt;
+&lt;/smil&gt;</pre>
 					</aside>
 				</section>
 
-				<section id="sec-docs-assoc-style">
+				<section id="sec-docs-assoc-style" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L206,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L213,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L220,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L227,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L234,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L241,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L255,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L261,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L267,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L273,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L280,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L287,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L294">
 					<h4>Associating style information</h4>
 
 					<p>[=EPUB creators=] MAY express visual rendering information for the currently playing [=EPUB
 						content document=] element in a CSS Style Sheet using author-defined classes.</p>
 
-					<p>When used, EPUB creators MUST declare the class names in the [=package document=] using the <a
-							href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
-								><code>playback-active-class</code></a> properties.</p>
+					<p>When used, EPUB creators MUST declare the class names in the [=package document=] using the <a href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"><code>playback-active-class</code></a> properties.</p>
 
 					<p>EPUB creators MUST define exactly one CSS class name in each property they define. Each property
 						MUST define a <a href="https://www.w3.org/TR/CSS2/syndata.html#characters">valid CSS class
@@ -8873,25 +8553,23 @@ No Entry</pre>
 					<aside class="example" title="Associating style information with the
 						currently playing EPUB content document">
 
-						<p>The author-defined CSS class names are declared using the metadata properties <a
-								href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"
-									><code>playback-active-class</code></a> in the package document:</p>
+						<p>The author-defined CSS class names are declared using the metadata properties <a href="#active-class"><code>active-class</code></a> and <a href="#playback-active-class"><code>playback-active-class</code></a> in the package document:</p>
 
-						<pre>&lt;package …>
-   &lt;metadata …>
+						<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
-          property="media:active-class">
+          property="media:active-class"&gt;
          my-active-item
-      &lt;/meta>
+      &lt;/meta&gt;
       &lt;meta
-          property="media:playback-active-class">
+          property="media:playback-active-class"&gt;
          my-document-playing
-      &lt;/meta>
+      &lt;/meta&gt;
       …
-   &lt;/metadata>
+   &lt;/metadata&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 
 						<p>The CSS Style Sheet containing the author-defined class names:</p>
 
@@ -8909,22 +8587,22 @@ html.my-document-playing * {
 
 						<p>The relevant EPUB content document excerpt:</p>
 
-						<pre>&lt;html>
+						<pre>&lt;html&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       …
-      &lt;span id="txt1">
+      &lt;span id="txt1"&gt;
          This is the first phrase.
-      &lt;/span>
-      &lt;span id="txt2">
+      &lt;/span&gt;
+      &lt;span id="txt2"&gt;
          This is the second phrase.
-      &lt;/span>
-      &lt;span id="txt3">
+      &lt;/span&gt;
+      &lt;span id="txt3"&gt;
          This is the third phrase.
-      &lt;/span>
+      &lt;/span&gt;
       …
-   &lt;/body>
-&lt;/html></pre>
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
 
 						<p>In this example, the reading system would apply the author-defined
 								<code>my-active-item</code> class to each text element in the EPUB content document as
@@ -8946,13 +8624,12 @@ html.my-document-playing * {
 				<section id="sec-docs-package">
 					<h4>Media overlays packaging</h4>
 
-					<section id="sec-package-including">
+					<section id="sec-package-including" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L307,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L313,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L319,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L325,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L332">
 						<h5>Including media overlays</h5>
 
 						<p>If an [=EPUB content document=] is wholly or partially referenced by a [=media overlay
 							document=], then its [=EPUB manifest | manifest=] [^item^] element MUST specify a
-								<code>media-overlay</code> attribute. The attribute MUST reference the <a
-								data-cite="xml#id">ID</a> [[xml]] of the manifest <code>item</code> for the
+								<code>media-overlay</code> attribute. The attribute MUST reference the <a data-cite="xml#id">ID</a> [[xml]] of the manifest <code>item</code> for the
 							corresponding media overlay document.</p>
 
 						<p>[=EPUB creators=] MUST only specify the <code>media-overlay</code> attribute on manifest
@@ -8963,39 +8640,37 @@ html.my-document-playing * {
 
 						<aside class="example" title="Entries for an EPUB content document and its associated
 							media overlay document in the package document manifest">
-							<pre>&lt;package …>
+							<pre>&lt;package …&gt;
    …
-   &lt;manifest>
+   &lt;manifest&gt;
       &lt;item
           id="ch1" 
           href="chapter1.xhtml" 
           media-type="application/xhtml+xml" 
-          media-overlay="ch1_audio"/>
+          media-overlay="ch1_audio"/&gt;
    
       &lt;item
           id="ch1_audio" 
           href="chapter1_audio.smil" 
-          media-type="application/smil+xml"/>
+          media-type="application/smil+xml"/&gt;
       …
-   &lt;/manifest>
-&lt;/package></pre>
+   &lt;/manifest&gt;
+&lt;/package&gt;</pre>
 						</aside>
 					</section>
 
-					<section id="sec-mo-package-metadata">
+					<section id="sec-mo-package-metadata" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L342,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L349,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L356,https://w3c.github.io/epub-structural-tests/#09-media-overlays_media-overlays.feature_L362">
 						<h5>Overlays package metadata</h5>
 
 						<p id="total-duration">[=EPUB creators=] MUST specify the duration of the entire [=EPUB
-							publication=] in the [=package document=] using a [^meta^] element with the <a
-								href="#duration"><code>duration</code> property</a>.</p>
+							publication=] in the [=package document=] using a [^meta^] element with the <a href="#duration"><code>duration</code> property</a>.</p>
 
 						<p>In addition, EPUB creators MUST provide the duration of each [=media overlay document=]. EPUB
 							creators MUST use the <a href="#attrdef-refines"><code>refines</code> attribute</a> to
 							associate each duration declaration to the corresponding [=EPUB manifest | manifest=]
 							[^item^].</p>
 
-						<p>The sum of the durations for each media overlay document SHOULD equal the <a
-								href="#total-duration">total duration</a> plus or minus one second.</p>
+						<p>The sum of the durations for each media overlay document SHOULD equal the <a href="#total-duration">total duration</a> plus or minus one second.</p>
 
 						<div class="note">
 							<p>Although the sum of indivudal durations may not exactly match the total due to rounding
@@ -9013,49 +8688,49 @@ html.my-document-playing * {
 						</div>
 
 						<aside class="example" title="Media overlays metadata in the package document">
-							<pre>&lt;package …>
-   &lt;metadata …>
+							<pre>&lt;package …&gt;
+   &lt;metadata …&gt;
       …
       &lt;meta
           property="media:duration"
-          refines="#ch1_audio">
+          refines="#ch1_audio"&gt;
          0:32:29
-      &lt;/meta>
+      &lt;/meta&gt;
       
       &lt;meta
           property="media:duration"
-          refines="#ch2_audio">
+          refines="#ch2_audio"&gt;
          0:34:02
-      &lt;/meta>
+      &lt;/meta&gt;
       
       &lt;meta
           property="media:duration"
-          refines="#ch3_audio">
+          refines="#ch3_audio"&gt;
          0:29:49
-      &lt;/meta>
+      &lt;/meta&gt;
       
       &lt;meta
-          property="media:duration">
+          property="media:duration"&gt;
          1:36:20
-      &lt;/meta>
+      &lt;/meta&gt;
       
       &lt;meta
-          property="media:narrator">
+          property="media:narrator"&gt;
          Joe Speaker
-      &lt;/meta>
+      &lt;/meta&gt;
       
       &lt;meta
-          property="media:active-class">
+          property="media:active-class"&gt;
          my-active-item
-      &lt;/meta>
+      &lt;/meta&gt;
       
       &lt;meta
-          property="media:playback-active-class">
+          property="media:playback-active-class"&gt;
          my-document-playing
-      &lt;/meta>
+      &lt;/meta&gt;
       …
-   &lt;/metadata>
-&lt;/package></pre>
+   &lt;/metadata&gt;
+&lt;/package&gt;</pre>
 						</aside>
 					</section>
 				</section>
@@ -9088,7 +8763,7 @@ html.my-document-playing * {
 					</ul>
 
 					<p>This list is non-exhaustive, however. It represents terms from the Structural Semantics
-						Vocabulary [[?epub-ssv-11]] for which reading systems are most likely to offer the option of
+						Vocabulary&nbsp;[[?epub-ssv-11]] for which reading systems are most likely to offer the option of
 						skippability.</p>
 
 					<aside class="example" title="Media overlay document with a page break">
@@ -9100,62 +8775,62 @@ html.my-document-playing * {
 						<pre>&lt;smil
     xmlns="http://www.w3.org/ns/SMIL" 
     xmlns:epub="http://www.idpf.org/2007/ops"
-    version="3.0">
-   &lt;body>
-      &lt;!-- a paragraph -->
-      &lt;par id="id1">
+    version="3.0"&gt;
+   &lt;body&gt;
+      &lt;!-- a paragraph --&gt;
+      &lt;par id="id1"&gt;
          &lt;text
-             src="chapter1.xhtml#para1"/>
+             src="chapter1.xhtml#para1"/&gt;
          &lt;audio
              src="chapter1_audio.mp3"
              clipBegin="0:23:22.000"
-             clipEnd="0:24:15.000"/>
-      &lt;/par>
+             clipEnd="0:24:15.000"/&gt;
+      &lt;/par&gt;
 
-      &lt;!-- a page number -->
+      &lt;!-- a page number --&gt;
       &lt;par
           id="id2"
-          epub:type="pagebreak">
+          epub:type="pagebreak"&gt;
          &lt;text
-             src="chapter1.xhtml#pgbreak1"/>
+             src="chapter1.xhtml#pgbreak1"/&gt;
          &lt;audio
              src="chapter1_audio.mp3"
              clipBegin="0:24:15.000"
-             clipEnd="0:24:18.123"/>
-      &lt;/par>
+             clipEnd="0:24:18.123"/&gt;
+      &lt;/par&gt;
 
-      &lt;!-- another paragraph -->
-      &lt;par id="id3">
+      &lt;!-- another paragraph --&gt;
+      &lt;par id="id3"&gt;
          &lt;text
-             src="chapter1.xhtml#para2"/>
+             src="chapter1.xhtml#para2"/&gt;
          &lt;audio
              src="chapter1_audio.mp3"
              clipBegin="0:24:18.123"
-             clipEnd="0:25:28.530"/>
-      &lt;/par>
-   &lt;/body>
-&lt;/smil>
+             clipEnd="0:25:28.530"/&gt;
+      &lt;/par&gt;
+   &lt;/body&gt;
+&lt;/smil&gt;
 </pre>
 
 						<p>EPUB content document:</p>
 
-						<pre>&lt;html … >
+						<pre>&lt;html … &gt;
    …
-   &lt;body>
-      &lt;p id="para1">
+   &lt;body&gt;
+      &lt;p id="para1"&gt;
          This is the paragraph before the page break …
-      &lt;/p>
+      &lt;/p&gt;
       
       &lt;span
           id="pgbreak1"
           role="doc-pagebreak"
-          aria-label="14"/>
+          aria-label="14"/&gt;
       
-      &lt;p id="para2">
+      &lt;p id="para2"&gt;
          This is the paragraph after the page break …
-      &lt;/p>
-   &lt;/body>
-&lt;/html></pre>
+      &lt;/p&gt;
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
 					</aside>
 				</section>
 
@@ -9186,7 +8861,7 @@ html.my-document-playing * {
 					</ul>
 
 					<p>This list is non-exhaustive list, however. It represents terms from the Structural Semantics
-						Vocabulary [[?epub-ssv-11]] for which [=reading systems=] are most likely to offer the option of
+						Vocabulary&nbsp;[[?epub-ssv-11]] for which [=reading systems=] are most likely to offer the option of
 						escapability.</p>
 
 					<div class="note">
@@ -9206,114 +8881,114 @@ html.my-document-playing * {
 						<pre>&lt;smil
     xmlns="http://www.w3.org/ns/SMIL" 
     xmlns:epub="http://www.idpf.org/2007/ops"
-    version="3.0">
-   &lt;body>
-      &lt;!-- a paragraph, part of the regular document text -->
-      &lt;par id="id1">
+    version="3.0"&gt;
+   &lt;body&gt;
+      &lt;!-- a paragraph, part of the regular document text --&gt;
+      &lt;par id="id1"&gt;
          &lt;text
-             src="c01.xhtml#para1"/>
+             src="c01.xhtml#para1"/&gt;
          &lt;audio
              src="chapter1_audio.mp3"
              clipBegin="0:23:22.000"
-             clipEnd="0:24:15.000"/>
-      &lt;/par>
+             clipEnd="0:24:15.000"/&gt;
+      &lt;/par&gt;
 
-      &lt;!-- a table with two nested rows -->
+      &lt;!-- a table with two nested rows --&gt;
       &lt;seq
           id="id2"
           epub:textref="c01.xhtml#t1"
-          epub:type="table">
+          epub:type="table"&gt;
          
          &lt;seq
              id="id3"
              epub:textref="c01.xhtml#tr1"
-             epub:type="table-row">
+             epub:type="table-row"&gt;
             
             &lt;par
                 id="id4"
-                epub:type="table-cell">
+                epub:type="table-cell"&gt;
                &lt;text
-                   src="c01.xhtml#td1"/>
+                   src="c01.xhtml#td1"/&gt;
                &lt;audio
                    src="chapter1_audio.mp3"
                    clipBegin="0:24:15.000"
-                   clipEnd="0:24:18.123"/>
-            &lt;/par>
+                   clipEnd="0:24:18.123"/&gt;
+            &lt;/par&gt;
             
             &lt;par
                 id="id5"
-                epub:type="table-cell">
+                epub:type="table-cell"&gt;
                &lt;text
-                   src="c01.xhtml#td2"/>
+                   src="c01.xhtml#td2"/&gt;
                &lt;audio
                    src="chapter1_audio.mp3"
                    clipBegin="0:24:18.123"
-                   clipEnd="0:25:28.530"/>
-            &lt;/par>
+                   clipEnd="0:25:28.530"/&gt;
+            &lt;/par&gt;
             
             &lt;par
                 id="id6"
-                epub:type="table-cell">
+                epub:type="table-cell"&gt;
                &lt;text
-                   src="c01.xhtml#td3"/>
+                   src="c01.xhtml#td3"/&gt;
                &lt;audio
                    src="chapter1_audio.mp3"
                    clipBegin="0:25:28.530"
-                   clipEnd="0:25:45.515"/>
-            &lt;/par>
-         &lt;/seq>
+                   clipEnd="0:25:45.515"/&gt;
+            &lt;/par&gt;
+         &lt;/seq&gt;
          
          &lt;seq
              id="id7"
              epub:textref="c01.xhtml#tr2"
-             epub:type="table-row">
+             epub:type="table-row"&gt;
             
             &lt;par
                 id="id8"
-                epub:type="table-cell">
+                epub:type="table-cell"&gt;
                &lt;text
-                   src="c01.xhtml#td4"/>
+                   src="c01.xhtml#td4"/&gt;
                &lt;audio
                    src="chapter1_audio.mp3"
                    clipBegin="0:25:45.515"
-                   clipEnd="0:26:45.700"/>
-            &lt;/par>
+                   clipEnd="0:26:45.700"/&gt;
+            &lt;/par&gt;
             
             &lt;par
                 id="id9"
-                epub:type="table-cell">
+                epub:type="table-cell"&gt;
                &lt;text
-                   src="chapter1.xhtml#td5"/>
+                   src="chapter1.xhtml#td5"/&gt;
                &lt;audio
                    src="chapter1_audio.mp3"
                    clipBegin="0:26:45.700"
-                   clipEnd="0:28:02.033"/>
-            &lt;/par>
+                   clipEnd="0:28:02.033"/&gt;
+            &lt;/par&gt;
             
             &lt;par
                 id="id10"
-                epub:type="table-cell">
+                epub:type="table-cell"&gt;
                &lt;text
-                   src="chapter1.xhtml#td6"/>
+                   src="chapter1.xhtml#td6"/&gt;
                &lt;audio
                    src="chapter1_audio.mp3"
                    clipBegin="0:28:02.033"
-                   clipEnd="0:28:52.207"/>
-            &lt;/par>
-         &lt;/seq>
-      &lt;/seq>
+                   clipEnd="0:28:52.207"/&gt;
+            &lt;/par&gt;
+         &lt;/seq&gt;
+      &lt;/seq&gt;
 
-      &lt;!-- another paragraph -->
-      &lt;par id="id11">
+      &lt;!-- another paragraph --&gt;
+      &lt;par id="id11"&gt;
          &lt;text
-             src="c01.xhtml#para2"/>
+             src="c01.xhtml#para2"/&gt;
          &lt;audio
              src="chapter1_audio.mp3"
              clipBegin="0:28:52.207"
-             clipEnd="0:30:01.000"/>
-      &lt;/par>
-   &lt;/body>
-&lt;/smil></pre>
+             clipEnd="0:30:01.000"/&gt;
+      &lt;/par&gt;
+   &lt;/body&gt;
+&lt;/smil&gt;</pre>
 					</aside>
 				</section>
 			</section>
@@ -9340,9 +9015,7 @@ html.my-document-playing * {
 					</li>
 				</ul>
 				<div class="note">
-					<p>Specific implementation details are beyond the scope of this specification. The <a
-							href="https://daisy.org/info-help/document-archive/archived-publications/media-overlays-playback-requirements/"
-							>DAISY Media Overlays Playback Requirements</a> document describes best practices for [=EPUB
+					<p>Specific implementation details are beyond the scope of this specification. The <a href="https://daisy.org/info-help/document-archive/archived-publications/media-overlays-playback-requirements/">DAISY Media Overlays Playback Requirements</a> document describes best practices for [=EPUB
 						creators=] and provides recommendations for reading system developers.</p>
 				</div>
 			</section>
@@ -9357,13 +9030,12 @@ html.my-document-playing * {
 				W3C's <a href="https://www.w3.org/TR/WCAG2/">Web Content Accessibility Guidelines (WCAG)</a> [[wcag2]].
 				These guidelines also form the basis for defining accessibility in [=EPUB publications=].</p>
 
-			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, <a
-					data-cite="epub-a11y-11#">EPUB Accessibility</a> [[epub-a11y-11]], defines how to apply the standard
+			<p>As the current WCAG guidelines (version 2) are heavily focused on web pages, a separate specification, <a data-cite="epub-a11y-11#">EPUB Accessibility</a> [[epub-a11y-11]], defines how to apply the standard
 				to EPUB publications. It also adds EPUB-specific requirements and recommendations for metadata,
 				pagination, and media overlays.</p>
 
 			<p>This specification recommends that EPUB publications <a href="#confreq-a11y">conform to the accessibility
-					requirements</a> defined in [[epub-a11y-11]]. A benefit of following this recommendation is that it
+					requirements</a> defined in&nbsp;[[epub-a11y-11]]. A benefit of following this recommendation is that it
 				helps to ensure that EPUB publications meet the accessibility requirements legislated in jurisdictions
 				around the world.</p>
 
@@ -9373,7 +9045,7 @@ html.my-document-playing * {
 
 			<div class="note">
 				<p>This specification does not integrate the accessibility requirements to allow them to adapt and
-					evolve independent of the EPUB specification &#8212; accessibility practices often need more
+					evolve independent of the EPUB specification — accessibility practices often need more
 					frequent updating. The accessibility specification is also intended for use with past, present, and
 					future versions of EPUB. The approach of a separate specification ensures that the evolution of EPUB
 					does not lock accessibility in time (i.e., it allows producers of older versions of EPUB to
@@ -9387,8 +9059,8 @@ html.my-document-playing * {
 				<h3>Overview</h3>
 
 				<p>The particularity of an [=EPUB publication=] is its structure. The EPUB format provides a means of
-					representing, packaging, and encoding structured and semantically enhanced web content — including
-					HTML, CSS, SVG, JavaScript, and other resources — for distribution in a single-file container.</p>
+					representing, packaging, and encoding structured and semantically enhanced web content&nbsp;—&nbsp;including
+					HTML, CSS, SVG, JavaScript, and other resources&nbsp;—&nbsp;for distribution in a single-file container.</p>
 
 				<p>This means that EPUB 3's security and privacy issues are primarily linked to the features of those
 					formats, and closely mirror the threats presented by web content.</p>
@@ -9399,8 +9071,7 @@ html.my-document-playing * {
 					with the aim of helping EPUB creators recognize and mitigate these risks.</p>
 
 				<div class="note">
-					<p>For the risks associated with [=reading systems=], refer to the <a
-							data-cite="epub-rs-33#sec-security-privacy">security and privacy section</a> of
+					<p>For the risks associated with [=reading systems=], refer to the <a data-cite="epub-rs-33#sec-security-privacy">security and privacy section</a> of
 						[[epub-rs-33]].</p>
 				</div>
 			</section>
@@ -9431,11 +9102,7 @@ html.my-document-playing * {
 						<p>The <a href="#sec-container-iri">origin</a> of an EPUB is both unknown to the EPUB creator
 							and specific to each reading system implementation. Consequently, if the EPUB creator hosts
 							[=remote resources=] on a web server they control, the server effectively cannot use
-							security features that require specifying allowable origins, such as headers for <a
-								href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a
-								href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"
-									><code>Content-Security-Policy</code></a>, or <a
-								href="https://www.rfc-editor.org/rfc/rfc7034"><code>X-Frame-Options</code></a>.</p>
+							security features that require specifying allowable origins, such as headers for <a href="https://fetch.spec.whatwg.org/#cors-protocol">CORS</a>, <a href="https://www.w3.org/TR/CSP2/#content-security-policy-header-field"><code>Content-Security-Policy</code></a>, or <a href="https://www.rfc-editor.org/rfc/rfc7034"><code>X-Frame-Options</code></a>.</p>
 					</dd>
 
 					<dt>Linking to external resources</dt>
@@ -9447,8 +9114,8 @@ html.my-document-playing * {
 						<p>Even if the intentions of the EPUB creator are not malicious, adding tracking information to
 							external links is problematic for user privacy as it can allow a user's activity to be
 							tracked without their consent.</p>
-						<p>Broken-link hijacking &#8212; when a domain expires and is bought by another party to exploit
-							the links to it &#8212; can also lead to users being taken to resources the EPUB creator did
+						<p>Broken-link hijacking — when a domain expires and is bought by another party to exploit
+							the links to it — can also lead to users being taken to resources the EPUB creator did
 							not intend.</p>
 					</dd>
 
@@ -9518,8 +9185,7 @@ html.my-document-playing * {
 
 					<ul>
 						<li>
-							<p><a href="#sec-xhtml-content-switch">Content switching</a> and <a
-									href="#sec-xhtml-epub-trigger">multimedia control elements</a> only allow hiding of
+							<p><a href="#sec-xhtml-content-switch">Content switching</a> and <a href="#sec-xhtml-epub-trigger">multimedia control elements</a> only allow hiding of
 								content and script-less control of playback in HTML. Moreover, these features,
 								introduced in the first release of EPUB 3.0, are <a href="#deprecated">deprecated</a>
 								and no longer recommended for use.</p>
@@ -9530,8 +9196,7 @@ html.my-document-playing * {
 						</li>
 					</ul>
 
-					<p>The one potential exception is the <a data-cite="epub-rs-33#app-epubReadingSystem"
-								><code>epubReadingSystem</code> object</a> [[epub-rs-33]] that allows [=EPUB creators=]
+					<p>The one potential exception is the <a data-cite="epub-rs-33#app-epubReadingSystem"><code>epubReadingSystem</code> object</a> [[epub-rs-33]] that allows [=EPUB creators=]
 						to query information about the current [=reading system=]. EPUB creators need to be mindful that
 						they only use the information exposed by this object to improve the rendering of their content
 						(i.e., avoid using the information to profile the user and their environment).</p>
@@ -9543,8 +9208,7 @@ html.my-document-playing * {
 
 				<p>Although [=EPUB creators=] cannot prevent every method of exploiting users, they are ultimately
 					responsible for the secure construction of their content. That means that they need to take
-					precautions to limit the exposure of their [=EPUB publications=] to the types of <a
-						href="#epub-threat-model">malicious exploits</a> described in the previous section.</p>
+					precautions to limit the exposure of their [=EPUB publications=] to the types of <a href="#epub-threat-model">malicious exploits</a> described in the previous section.</p>
 
 				<p>Some practical steps include:</p>
 
@@ -9555,9 +9219,7 @@ html.my-document-playing * {
 					<li>Avoiding links to untrustworthy web sites (e.g., that browsers do not recognize as safe).</li>
 					<li>Using secure connections to external sites and resources (i.e., using the HTTPS protocol).</li>
 					<li>Not using scripts to send or receive data over the network without the consent of the user.</li>
-					<li>Obtaining user consent for the use of Web APIs with privacy implications, such as <a
-							href="https://www.w3.org/TR/geolocation/">Geolocation</a> [[geolocation]] and <a
-							href="https://www.w3.org/TR/push-api/">Push Notifications</a> [[push-api]].</li>
+					<li>Obtaining user consent for the use of Web APIs with privacy implications, such as <a href="https://www.w3.org/TR/geolocation/">Geolocation</a> [[geolocation]] and <a href="https://www.w3.org/TR/push-api/">Push Notifications</a> [[push-api]].</li>
 					<li>Avoiding embedding content not provided by reputable organizations or individuals.</li>
 					<li>Avoiding deprecated features of EPUB due to the potential for undiscovered bugs in
 						implementations.</li>
@@ -9577,11 +9239,9 @@ html.my-document-playing * {
 					content on a publisher's web site, or remotely hosting resources on their servers, can lead to
 					profiling users, especially if unique tracking identifiers are added to the URLs.</p>
 
-				<p>When collecting and storing user information within an EPUB publication (e.g., through the use of <a
-						data-cite="html#dom-document-cookie">cookies</a> and <a data-cite="html#webstorage">web
+				<p>When collecting and storing user information within an EPUB publication (e.g., through the use of <a data-cite="html#dom-document-cookie">cookies</a> and <a data-cite="html#webstorage">web
 						storage</a> [[?html]]), EPUB creators need to consider to potential for data theft by other EPUB
-					publications on a [=reading system=]. Although [[epub-rs-33]] introduces a <a
-						data-cite="epub-rs-33#sec-container-iri">unique origin requirement</a> for EPUB publications,
+					publications on a [=reading system=]. Although [[epub-rs-33]] introduces a <a data-cite="epub-rs-33#sec-container-iri">unique origin requirement</a> for EPUB publications,
 					which limits the potential for attacks, there is still a risk that reading systems will allow EPUB
 					publications access to shared persistent storage (e.g., older reading systems that have not been
 					updated and non-conforming newer reading systems). Consequently, EPUB creators SHOULD NOT store
@@ -9613,8 +9273,7 @@ html.my-document-playing * {
 				<h3>Under-implemented features</h3>
 
 				<p>A <strong>under-implemented</strong> feature is a feature introduced prior to EPUB 3.3 for which the
-					Working Group has not been able to establish enough <a
-						href="https://www.w3.org/Consortium/Process/#adequate-implementation">implementation
+					Working Group has not been able to establish enough <a href="https://www.w3.org/Consortium/Process/#adequate-implementation">implementation
 						experience</a>.</p>
 
 				<p>These features are considered important to retain despite this limitation because they are known to
@@ -9660,16 +9319,14 @@ html.my-document-playing * {
 				</div>
 			</section>
 		</section>
-		<section id="app-identifiers-allowed" class="appendix">
+		<section id="app-identifiers-allowed" class="appendix" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#B-external-identifiers_external-identifiers.feature_L13,https://w3c.github.io/epub-structural-tests/#B-external-identifiers_external-identifiers.feature_L23">
 			<h2>Allowed external identifiers</h2>
 
 			<p>The following table lists the <a aria-label="public identifiers" data-cite="xml#dt-pubid">public </a> and
-					<a data-cite="xml#dt-sysid">system identifiers</a> [[xml]] allowed in <a data-cite="xml#dt-doctype"
-					>document type declarations</a>. [[xml]]</p>
+					<a data-cite="xml#dt-sysid">system identifiers</a> [[xml]] allowed in <a data-cite="xml#dt-doctype">document type declarations</a>. [[xml]]</p>
 
 			<p>[=EPUB creators=] MAY use these external identifiers only in [=publication resources=] with the listed
-				media types [[rfc2046]] specified in their [=EPUB manifest | manifest=] declarations. (Refer to <a
-					href="#sec-xml-constraints"></a> for more information.)</p>
+				media types [[rfc2046]] specified in their [=EPUB manifest | manifest=] declarations. (Refer to <a href="#sec-xml-constraints"></a> for more information.)</p>
 
 			<table class="zebra">
 				<thead>
@@ -9738,7 +9395,7 @@ html.my-document-playing * {
 					complementing the underlying vocabulary.</p>
 
 				<p>The applied semantics refine the meaning of their containing elements without changing their nature
-					for assistive technologies, as happens when using the similar [^/role^] attribute [[html]]. The
+					for assistive technologies, as happens when using the similar [^/role^] attribute&nbsp;[[html]]. The
 					attribute does not enhance the accessibility of the content, in other words; it only provides hints
 					about the purpose.</p>
 
@@ -9759,8 +9416,7 @@ html.my-document-playing * {
 					<dt>Attribute Name:</dt>
 					<dd>
 						<p>
-							<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr"
-								><code>epub:type</code></dfn>
+							<dfn class="export" data-lt-no-plural="" data-dfn-type="element-attr"><code>epub:type</code></dfn>
 						</p>
 					</dd>
 
@@ -9773,8 +9429,7 @@ html.my-document-playing * {
 
 					<dt>Usage:</dt>
 					<dd>
-						<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">XHTML</a>, <a
-								href="#confreq-svg-structural-semantics">SVG</a>, and <a href="#sec-overlays-def">media
+						<p>Refer to the requirements for <a href="#sec-xhtml-structural-semantics">XHTML</a>, <a href="#confreq-svg-structural-semantics">SVG</a>, and <a href="#sec-overlays-def">media
 								overlays</a>.</p>
 					</dd>
 
@@ -9788,10 +9443,9 @@ html.my-document-playing * {
 
 				<div class="caution">
 					<p>Although the <code>epub:type</code> attribute is similar in nature to the [^/role^]
-						attribute [[html]], the attributes serve different purposes. The values of the
+						attribute&nbsp;[[html]], the attributes serve different purposes. The values of the
 							<code>epub:type</code> attribute do not enhance access through assistive technologies like
-						screen readers as they do not map to the accessibility <abbr
-							title="Application Programming Interfaces">APIs</abbr> used by these technologies. This
+						screen readers as they do not map to the accessibility <abbr title="Application Programming Interfaces">APIs</abbr> used by these technologies. This
 						means that adding <code>epub:type</code> values to semantically neutral elements like [[html]]
 						[^div^] and [^span^] does not make them any more accessible to assistive technologies. Only ARIA
 						roles influence how assistive technologies understand such elements.</p>
@@ -9802,7 +9456,7 @@ html.my-document-playing * {
 						where interaction with assistive technologies is not essential.</p>
 
 					<p>Refer to <a href="https://www.w3.org/TR/dpub-aria/">Digital Publishing WAI-ARIA
-						Module</a> [[?dpub-aria]] for more information about accessible publishing roles.</p>
+						Module</a>&nbsp;[[?dpub-aria]] for more information about accessible publishing roles.</p>
 				</div>
 
 				<p>The <code>epub:type</code> attribute inflects semantics on the element on which it appears. Its value
@@ -9810,7 +9464,7 @@ html.my-document-playing * {
 					document instance.</p>
 
 				<p>The <a href="#sec-default-vocab">default vocabulary</a> for the <code>epub:type</code> attribute is
-					the EPUB 3 Structural Semantics Vocabulary [[?epub-ssv-11]]. EPUB creators MAY include unprefixed
+					the EPUB&nbsp;3 Structural Semantics Vocabulary&nbsp;[[?epub-ssv-11]]. EPUB creators MAY include unprefixed
 					terms that are not part of this vocabulary, but the preferred method for adding custom semantics is
 					to use <a href="#sec-prefix-attr">prefixes</a> for them. Refer to <a href="#sec-vocab-assoc"></a>
 					for more information.</p>
@@ -9818,52 +9472,52 @@ html.my-document-playing * {
 				<aside class="example" id="ex.epubtype.note" title="Identifying a preamble">
 					<pre>&lt;html
     …
-    xmlns:epub="http://www.idpf.org/2007/ops">
+    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       …
-      &lt;section epub:type="preamble">
+      &lt;section epub:type="preamble"&gt;
          …    
-      &lt;/section>
+      &lt;/section&gt;
       …
-   &lt;/body>
-&lt;/html></pre>
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
 				</aside>
 
 				<aside class="example" id="ex.epubtype.gloss" title="Identifying a glossary">
 					<pre>&lt;html
     …
-    xmlns:epub="http://www.idpf.org/2007/ops">
+    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       …
-      &lt;dl epub:type="glossary">
+      &lt;dl epub:type="glossary"&gt;
          …    
-      &lt;/dl>        
+      &lt;/dl&gt;        
       …
-   &lt;/body>
-&lt;/html></pre>
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
 				</aside>
 
 				<aside class="example" id="ex.epubtype.pg" title="Adding page break semantics">
 					<pre>&lt;html
     …
-    xmlns:epub="http://www.idpf.org/2007/ops">
+    xmlns:epub="http://www.idpf.org/2007/ops"&gt;
    …
-   &lt;body>
+   &lt;body&gt;
       …
-      &lt;p>
+      &lt;p&gt;
          … 
          &lt;span
             epub:type="pagebreak"
             id="p234"
             role="doc-pagebreak"
-            aria-label="234"/>
+            aria-label="234"/&gt;
          …
-      &lt;/p>    
+      &lt;/p&gt;    
       …
-   &lt;/body>
-&lt;/html></pre>
+   &lt;/body&gt;
+&lt;/html&gt;</pre>
 				</aside>
 			</section>
 		</section>
@@ -9886,7 +9540,7 @@ html.my-document-playing * {
 						for example, while the <code>property</code> and <code>rel</code> attributes use the data type
 						to define properties and relationships in the [=package document=].</p>
 
-					<p>A <var>property</var> value is like a CURIE [[rdfa-core]] &#8212; it represents a URL [[url]] in
+					<p>A <var>property</var> value is like a CURIE [[rdfa-core]] — it represents a URL [[url]] in
 						compact form. The expression consists of a prefix and a reference, where the prefix — whether
 						literal or implied — is a shorthand mapping of a URL that typically resolves to a term
 						vocabulary. When a [=reading system=] converts the prefix to its URL representation and combines
@@ -9899,9 +9553,7 @@ html.my-document-playing * {
 						use to map to a URL is predefined.</p>
 
 					<p>The power of the <var>property</var> data type lies in its easy extensibility. To incorporate new
-						terms and properties, [=EPUB creators=] only need to declare a <a href="#sec-prefix-attr"
-							>prefix</a>. In another authoring convenience, this specification also <a
-							href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
+						terms and properties, [=EPUB creators=] only need to declare a <a href="#sec-prefix-attr">prefix</a>. In another authoring convenience, this specification also <a href="#sec-metadata-reserved-prefixes">reserves prefixes</a> for many commonly used
 						publishing vocabularies (i.e., their declaration is optional).</p>
 
 					<p>The following sections provide additional details on the <var>property</var> data type and
@@ -9916,18 +9568,17 @@ html.my-document-playing * {
 
 					<table class="productionset">
 						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
+							14977</a>)<br> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
 							U+007F).</caption>
-						<tr>
+						<tbody><tr>
 							<td id="property.ebnf.property">
 								<a href="#property.ebnf.property">property</a>
 							</td>
 							<td>
 								<code>=</code>
 							</td>
-							<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a
-									href="#property.ebnf.reference">reference</a>; </td>
-							<td> </td>
+							<td>[ <a href="#property.ebnf.prefix">prefix</a> , ":" ] , <a href="#property.ebnf.reference">reference</a>; </td>
+							<td>&nbsp;</td>
 						</tr>
 						<tr>
 							<td id="property.ebnf.prefix">
@@ -9937,7 +9588,7 @@ html.my-document-playing * {
 								<code>=</code>
 							</td>
 							<td>? xsd:NCName ? ;</td>
-							<td> </td>
+							<td>&nbsp;</td>
 						</tr>
 						<tr>
 							<td id="property.ebnf.reference">
@@ -9947,9 +9598,9 @@ html.my-document-playing * {
 								<code>=</code>
 							</td>
 							<td>? [=path-relative-scheme-less-URL string=] [[url]] ? ;</td>
-							<td>/* as defined in [[url]] */<br /></td>
+							<td>/*&nbsp;as defined in [[url]]&nbsp;*/<br></td>
 						</tr>
-					</table>
+					</tbody></table>
 
 					<p>This specification derives the <var>property</var> data type from the CURIE data type defined in
 						[[rdfa-core]]. A <var>property</var> represents a subset of CURIEs.</p>
@@ -9972,7 +9623,7 @@ html.my-document-playing * {
 						<p>In this example, the <var>property</var> value is composed of the prefix <code>dcterms</code>
 							and the reference <code>modified</code>.</p>
 
-						<pre>&lt;meta property="dcterms:modified">2011-01-01T12:00:00Z&lt;/meta></pre>
+						<pre>&lt;meta property="dcterms:modified"&gt;2011-01-01T12:00:00Z&lt;/meta&gt;</pre>
 
 						<p>After <a data-cite="epub-rs-33#sec-property-values">processing</a> [[epub-rs-33]], this
 							property would expand to the following URL:</p>
@@ -9991,7 +9642,7 @@ html.my-document-playing * {
 						<p>In this example, the <a href="#mathml"><code>mathml</code> property</a> is specified on a
 							manifest [^item^] element:</p>
 
-						<pre>&lt;item … properties="mathml"/></pre>
+						<pre>&lt;item … properties="mathml"/&gt;</pre>
 
 						<p>This property expands to:</p>
 
@@ -10004,45 +9655,39 @@ html.my-document-playing * {
 				<section id="sec-default-vocab">
 					<h5>Default vocabularies</h5>
 
-					<p>A default vocabulary is one that [=EPUB creators=] do not have to declare a <a
-							href="#sec-prefix-attr">prefix</a> for in order to use its terms and properties where a <a
-							href="#sec-property-datatype"><var>property</var> value</a> is expected. EPUB creators MUST
+					<p>A default vocabulary is one that [=EPUB creators=] do not have to declare a <a href="#sec-prefix-attr">prefix</a> for in order to use its terms and properties where a <a href="#sec-property-datatype"><var>property</var> value</a> is expected. EPUB creators MUST
 						NOT add a prefix to terms and properties from a default vocabulary.</p>
 
 					<p>EPUB creators MUST NOT assign a prefix to the URLs associated with these vocabularies using the
 							<a href="#sec-prefix-attr"><code>prefix</code></a> attribute.</p>
 
 					<div class="note">
-						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"
-									><var>property</var> data type</a> for more information about its default
+						<p>Refer to the definition of each attribute that takes a <a href="#sec-property-datatype"><var>property</var> data type</a> for more information about its default
 							vocabulary.</p>
 					</div>
 				</section>
 
-				<section id="sec-prefix-attr">
+				<section id="sec-prefix-attr" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L671,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L694,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L17,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L22,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L28,https://w3c.github.io/epub-structural-tests/#D-vocabularies_vocabulary-association.feature_L34">
 					<h4>The <code>prefix</code> attribute</h4>
 
-					<p>The <code>prefix</code> attribute defines prefix mappings for use in <a
-							href="#sec-property-datatype"><var>property</var> values</a>.</p>
+					<p>The <code>prefix</code> attribute defines prefix mappings for use in <a href="#sec-property-datatype"><var>property</var> values</a>.</p>
 
 					<p>The value of the <code>prefix</code> attribute is a white space-separated list of one or more
 						prefix-to-URL mappings of the form:</p>
 
 					<table class="productionset">
 						<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-							14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
+							14977</a>)<br> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000 to
 							U+007F).</caption>
-						<tr>
+						<tbody><tr>
 							<td id="prefix.ebnf.def">
 								<a href="#prefix.ebnf.def">prefixes</a>
 							</td>
 							<td>
 								<code>=</code>
 							</td>
-							<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace"
-									>whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a
-									href="#prefix.ebnf.mapping">mapping</a> } ; </td>
-							<td> </td>
+							<td><a href="#prefix.ebnf.mapping">mapping</a> , { <a href="#prefix.ebnf.whitespace">whitespace</a>, { <a href="#prefix.ebnf.space">whitespace</a> } , <a href="#prefix.ebnf.mapping">mapping</a> } ; </td>
+							<td>&nbsp;</td>
 						</tr>
 						<tr>
 							<td id="prefix.ebnf.mapping">
@@ -10053,7 +9698,7 @@ html.my-document-playing * {
 							</td>
 							<td><a href="#prefix.ebnf.prefix">prefix</a> , ":" , <a href="#prefix.ebnf.space">space</a>
 								, { <a href="#prefix.ebnf.space">space</a> } , ? xsd:anyURI ? ; </td>
-							<td> </td>
+							<td>&nbsp;</td>
 						</tr>
 						<tr>
 							<td id="prefix.ebnf.prefix">
@@ -10063,7 +9708,7 @@ html.my-document-playing * {
 								<code>=</code>
 							</td>
 							<td>? xsd:NCName ? ;</td>
-							<td> </td>
+							<td>&nbsp;</td>
 						</tr>
 						<tr>
 							<td id="prefix.ebnf.space">
@@ -10073,7 +9718,7 @@ html.my-document-playing * {
 								<code>=</code>
 							</td>
 							<td>#x20 ;</td>
-							<td> </td>
+							<td>&nbsp;</td>
 						</tr>
 						<tr>
 							<td id="prefix.ebnf.whitespace">
@@ -10083,9 +9728,9 @@ html.my-document-playing * {
 								<code>=</code>
 							</td>
 							<td>(#x20 | #x9 | #xD | #xA) ;</td>
-							<td> </td>
+							<td>&nbsp;</td>
 						</tr>
-					</table>
+					</tbody></table>
 
 					<p>With the exception of <a href="#sec-reserved-prefixes">reserved prefixes</a>, [=EPUB creators=]
 						MUST declare all prefixes used in a document. [=EPUB creators=] MUST only specify the
@@ -10101,9 +9746,9 @@ html.my-document-playing * {
 						<pre>&lt;package
     … 
     prefix="foaf: http://xmlns.com/foaf/spec/
-            dbp: http://dbpedia.org/ontology/">
+            dbp: http://dbpedia.org/ontology/"&gt;
    …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 					</aside>
 
 					<p>EPUB creators MUST declare the attribute in the namespace
@@ -10116,9 +9761,9 @@ html.my-document-playing * {
 
 						<pre>&lt;html …
       xmlns:epub="http://www.idpf.org/2007/ops"
-      epub:prefix="z3998: https://www.daisy.org/z3998/2012/vocab/structure/">
+      epub:prefix="z3998: https://www.daisy.org/z3998/2012/vocab/structure/"&gt;
    …
-&lt;/html></pre>
+&lt;/html&gt;</pre>
 					</aside>
 
 					<div class="note">
@@ -10132,8 +9777,8 @@ html.my-document-playing * {
 
 						<pre>&lt;html … prefix="…"
         xmlns:epub="http://www.idpf.org/2007/ops"
-        epub:prefix="…">   …
-&lt;/html></pre>
+        epub:prefix="…"&gt;   …
+&lt;/html&gt;</pre>
 					</div>
 
 					<p>Note that for <a href="#sec-xhtml-svg">embedded SVG</a>, prefixes MUST be declared on the
@@ -10162,13 +9807,10 @@ html.my-document-playing * {
 							avoid such issues.</p>
 					</div>
 
-					<p>[=EPUB creators=] MAY use reserved prefixes in attributes that expect a <a
-							href="#sec-property-datatype"><var>property</var> value</a> without declaring them in a <a
-							href="#sec-prefix-attr"><code>prefix</code> attribute</a>.</p>
+					<p>[=EPUB creators=] MAY use reserved prefixes in attributes that expect a <a href="#sec-property-datatype"><var>property</var> value</a> without declaring them in a <a href="#sec-prefix-attr"><code>prefix</code> attribute</a>.</p>
 
 
-					<p>EPUB creators SHOULD NOT override reserved prefixes in the <a href="#sec-prefix-attr"
-								><code>prefix</code> attribute</a>.</p>
+					<p>EPUB creators SHOULD NOT override reserved prefixes in the <a href="#sec-prefix-attr"><code>prefix</code> attribute</a>.</p>
 
 					<p>The reserved prefixes an EPUB creators can use depends on the context:</p>
 
@@ -10223,8 +9865,7 @@ html.my-document-playing * {
 
 						<dt id="sec-content-reserved-prefixes">Structural Semantics</dt>
 						<dd>
-							<p>EPUB creators MAY use the following reserved prefixes in the <a
-									href="#app-structural-semantics"><code>epub:type</code> attribute</a> without having
+							<p>EPUB creators MAY use the following reserved prefixes in the <a href="#app-structural-semantics"><code>epub:type</code> attribute</a> without having
 								to declare them.</p>
 							<table id="tbl-reserved-prefixes" class="prefix">
 								<thead>
@@ -10264,8 +9905,7 @@ html.my-document-playing * {
 					<dd>
 						<p>Specifies which publication resource type(s) [=EPUB creators=] MAY specify the property
 							on.</p>
-						<p>This field appears for properties used in the <a href="#attrdef-properties"
-									><code>properties</code> attribute</a>.</p>
+						<p>This field appears for properties used in the <a href="#attrdef-properties"><code>properties</code> attribute</a>.</p>
 					</dd>
 
 					<dt>Cardinality</dt>
@@ -10330,8 +9970,7 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-writing-modes-text-orientation" data-tests="#css-epub-text-orientation">
 					<h6>The <code>-epub-text-orientation</code> property</h6>
 
-					<p>This property is a prefixed version of the <a
-							data-cite="css-writing-modes-3#propdef-text-orientation"><code>text-orientation</code>
+					<p>This property is a prefixed version of the <a data-cite="css-writing-modes-3#propdef-text-orientation"><code>text-orientation</code>
 							property</a> [[css-writing-modes-3]].</p>
 
 					<table class="tabledef">
@@ -10379,8 +10018,7 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-writing-modes-writing-mode" data-tests="#css-epub-writing-mode">
 					<h6>The <code>-epub-writing-mode</code> property</h6>
 
-					<p>This property is a prefixed version of the <a
-							data-cite="css-writing-modes-3#propdef-writing-mode"><code>writing-mode</code> property</a>
+					<p>This property is a prefixed version of the <a data-cite="css-writing-modes-3#propdef-writing-mode"><code>writing-mode</code> property</a>
 						[[css-writing-modes-3]], with the same syntax and behavior.</p>
 
 					<table class="tabledef">
@@ -10401,8 +10039,7 @@ html.my-document-playing * {
 					<h6>The <code>-epub-text-combine-horizontal</code> and <code>-epub-text-combine</code>
 						properties</h6>
 
-					<p>These properties are prefixed versions of the <a
-							data-cite="css-writing-modes-3#text-combine-upright"><code>text-combine-upright</code>
+					<p>These properties are prefixed versions of the <a data-cite="css-writing-modes-3#text-combine-upright"><code>text-combine-upright</code>
 							property</a> [[css-writing-modes-3]], although <code>-epub-text-combine</code> is
 						deprecated.</p>
 
@@ -10427,7 +10064,7 @@ html.my-document-playing * {
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
-								<td> none | horizontal | horizontal &lt;number> </td>
+								<td> none | horizontal | horizontal &lt;number&gt; </td>
 							</tr>
 						</tbody>
 					</table>
@@ -10461,7 +10098,7 @@ html.my-document-playing * {
 								<td><code>text-combine-upright: all</code></td>
 							</tr>
 							<tr>
-								<td><code>-epub-text-combine: horizontal &lt;number></code></td>
+								<td><code>-epub-text-combine: horizontal &lt;number&gt;</code></td>
 								<td><em>no equivalent</em></td>
 							</tr>
 						</tbody>
@@ -10478,8 +10115,7 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-hyphens" data-tests="#css-epub-hyphens">
 					<h6>The <code>-epub-hyphens</code> property</h6>
 
-					<p>This property is a prefixed version of the <a data-cite="css-text-3#hyphens-property"
-								><code>hyphens</code> property</a> [[css-text-3]].</p>
+					<p>This property is a prefixed version of the <a data-cite="css-text-3#hyphens-property"><code>hyphens</code> property</a> [[css-text-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10502,8 +10138,7 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-line-break" data-tests="#css-epub-line-break">
 					<h6>The <code>-epub-line-break</code> property</h6>
 
-					<p>This property is a prefixed version of the <a data-cite="css-text-3#line-break-property"
-								><code>line-break</code> property</a> [[css-text-3]].</p>
+					<p>This property is a prefixed version of the <a data-cite="css-text-3#line-break-property"><code>line-break</code> property</a> [[css-text-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10522,8 +10157,7 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-text-align-last" data-tests="#css-epub-text-align-last">
 					<h6>The <code>-epub-text-align-last</code> property</h6>
 
-					<p>This property is a prefixed version of the <a data-cite="css-text-3#text-align-last-property"
-								><code>text-align-last</code> property</a> [[css-text-3]].</p>
+					<p>This property is a prefixed version of the <a data-cite="css-text-3#text-align-last-property"><code>text-align-last</code> property</a> [[css-text-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10542,8 +10176,7 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-word-break" data-tests="#css-epub-word-break">
 					<h6>The <code>-epub-word-break</code> property</h6>
 
-					<p>This property is a prefixed version of the <a data-cite="css-text-3#word-break-property"
-								><code>word-break</code> property</a> [[css-text-3]].</p>
+					<p>This property is a prefixed version of the <a data-cite="css-text-3#word-break-property"><code>word-break</code> property</a> [[css-text-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10562,8 +10195,7 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-text-transform" data-tests="#css-epub-text-transform">
 					<h6>The <code>text-transform</code> property</h6>
 
-					<p>This property is a prefixed value for the <a data-cite="css-text-3#text-transform-property"
-								><code>text-transform</code> property</a> [[css-text-3]].</p>
+					<p>This property is a prefixed value for the <a data-cite="css-text-3#text-transform-property"><code>text-transform</code> property</a> [[css-text-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10592,8 +10224,7 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-text-emphasis-color" data-tests="#css-epub-text-emphasis">
 					<h6>The <code>-epub-text-emphasis-color</code> Property</h6>
 
-					<p>This property is a prefixed version of the <a
-							data-cite="css-text-decor-3#text-emphasis-color-property"><code>text-emphasis-color</code>
+					<p>This property is a prefixed version of the <a data-cite="css-text-decor-3#text-emphasis-color-property"><code>text-emphasis-color</code>
 							property</a> [[css-text-decor-3]].</p>
 
 					<table class="tabledef">
@@ -10604,7 +10235,7 @@ html.my-document-playing * {
 							</tr>
 							<tr class="value">
 								<th>Value:</th>
-								<td> &lt;color> </td>
+								<td> &lt;color&gt; </td>
 							</tr>
 						</tbody>
 					</table>
@@ -10613,9 +10244,7 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-text-emphasis-position" data-tests="#css-epub-text-emphasis">
 					<h6>The <code>-epub-text-emphasis-position</code> property</h6>
 
-					<p>This property is a prefixed version of the <a
-							data-cite="css-text-decor-3#text-emphasis-position-property"
-								><code>text-emphasis-position</code> property</a> [[css-text-decor-3]].</p>
+					<p>This property is a prefixed version of the <a data-cite="css-text-decor-3#text-emphasis-position-property"><code>text-emphasis-position</code> property</a> [[css-text-decor-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10634,8 +10263,7 @@ html.my-document-playing * {
 				<section id="sec-css-prefixed-text-epub-text-emphasis-style" data-tests="#css-epub-text-emphasis">
 					<h6>The <code>-epub-text-emphasis-style</code> property</h6>
 
-					<p>This property is a prefixed version of the <a
-							data-cite="css-text-decor-3#text-emphasis-style-property"><code>text-emphasis-style</code>
+					<p>This property is a prefixed version of the <a data-cite="css-text-decor-3#text-emphasis-style-property"><code>text-emphasis-style</code>
 							property</a> [[css-text-decor-3]].</p>
 
 					<table class="tabledef">
@@ -10647,19 +10275,16 @@ html.my-document-playing * {
 							<tr class="value">
 								<th>Value:</th>
 								<td> none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ]
-									] | &lt;string> </td>
+									] | &lt;string&gt; </td>
 							</tr>
 						</tbody>
 					</table>
 				</section>
 
-				<section id="sec-css-prefixed-text-epub-text-underline-position"
-					data-tests="#css-epub-text-underline-position">
+				<section id="sec-css-prefixed-text-epub-text-underline-position" data-tests="#css-epub-text-underline-position">
 					<h6>The <code>-epub-text-underline-position</code> property</h6>
 
-					<p>This property is a prefixed version of the <a
-							data-cite="css-text-decor-3#text-underline-position-property"
-								><code>text-underline-position</code> property</a> [[css-text-decor-3]].</p>
+					<p>This property is a prefixed version of the <a data-cite="css-text-decor-3#text-underline-position-property"><code>text-underline-position</code> property</a> [[css-text-decor-3]].</p>
 
 					<table class="tabledef">
 						<tbody>
@@ -10686,10 +10311,8 @@ html.my-document-playing * {
 			<section id="app-viewport-meta-intro" class="informative">
 				<h3>Introduction</h3>
 
-				<p>As the <a
-						href="https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW6"
-						>Safari HTML definition</a> of the <code>viewport meta</code> tag, that was used in earlier
-					versions of EPUB 3, is not an officially recognized standard, this specification defines a basic
+				<p>As the <a href="https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW6">Safari HTML definition</a> of the <code>viewport meta</code> tag, that was used in earlier
+					versions of EPUB&nbsp;3, is not an officially recognized standard, this specification defines a basic
 					syntax in order to allow [=EPUB creators=] to express <a href="#sec-fxl-icb-html">width and height
 						dimensions</a> for use rendering [=fixed-layout documents=].</p>
 
@@ -10710,33 +10333,29 @@ html.my-document-playing * {
 
 				<dl>
 					<dt id="viewport-name-attr">name</dt>
-					<dd>The value of the [^meta/name^] attribute [[html]] after <a data-cite="xml#AVNormalize"
-							>whitespace normalization</a> [[xml]] MUST be <code>viewport</code>.</dd>
+					<dd>The value of the [^meta/name^] attribute [[html]] after <a data-cite="xml#AVNormalize">whitespace normalization</a>&nbsp;[[xml]] MUST be <code>viewport</code>.</dd>
 
 					<dt id="viewport-content-attr">content</dt>
 					<dd>
-						<p>The value of the [^meta/content^] attribute [[html]] after <a data-cite="xml#AVNormalize"
-								>whitespace normalization</a> [[xml]] MUST be of the following form:</p>
+						<p>The value of the [^meta/content^] attribute [[html]] after <a data-cite="xml#AVNormalize">whitespace normalization</a>&nbsp;[[xml]] MUST be of the following form:</p>
 						<table class="productionset">
 							<caption>(EBNF productions <a href="https://www.iso.org/standard/26153.html">ISO/IEC
-									14977</a>)<br /> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000
+									14977</a>)<br> All terminal symbols are in the Unicode Block 'Basic Latin' (U+0000
 								to U+007F).</caption>
 
-							<tr>
+							<tbody><tr>
 								<td id="viewport.ebnf.def">
 									<a href="#viewport.ebnf.def">viewport</a>
 								</td>
 								<td>=</td>
-								<td><a href="#viewport.ebnf.property">property</a>, { <a href="#viewport.ebnf.sep"
-										>sep</a>, <a href="#viewport.ebnf.property">property</a> } ;</td>
+								<td><a href="#viewport.ebnf.property">property</a>, { <a href="#viewport.ebnf.sep">sep</a>, <a href="#viewport.ebnf.property">property</a> } ;</td>
 							</tr>
 							<tr>
 								<td id="viewport.ebnf.property">
 									<a href="#viewport.ebnf.property">property</a>
 								</td>
 								<td>=</td>
-								<td><a href="#viewport.ebnf.name">name</a>, [ <a href="#viewport.ebnf.assign"
-									>assign</a>, <a href="#viewport.ebnf.value">value</a> ] ;</td>
+								<td><a href="#viewport.ebnf.name">name</a>, [ <a href="#viewport.ebnf.assign">assign</a>, <a href="#viewport.ebnf.value">value</a> ] ;</td>
 							</tr>
 							<tr>
 								<td id="viewport.ebnf.name">
@@ -10758,8 +10377,7 @@ html.my-document-playing * {
 								</td>
 								<td>=</td>
 								<td>
-									<a href="#viewport.ebnf.sep-char">sep-char</a>, { <a href="#viewport.ebnf.sep-char"
-										>sep-char</a> } ;</td>
+									<a href="#viewport.ebnf.sep-char">sep-char</a>, { <a href="#viewport.ebnf.sep-char">sep-char</a> } ;</td>
 							</tr>
 							<tr>
 								<td id="viewport.ebnf.sep-char">
@@ -10773,8 +10391,7 @@ html.my-document-playing * {
 									<a href="#viewport.ebnf.assign">assign</a>
 								</td>
 								<td>=</td>
-								<td>[ <a href="#viewport.ebnf.space">space</a> ], "=", [ <a href="#viewport.ebnf.space"
-										>space</a> ] ;</td>
+								<td>[ <a href="#viewport.ebnf.space">space</a> ], "=", [ <a href="#viewport.ebnf.space">space</a> ] ;</td>
 							</tr>
 							<tr>
 								<td id="viewport.ebnf.space">
@@ -10783,23 +10400,19 @@ html.my-document-playing * {
 								<td>=</td>
 								<td>#x20 ;</td>
 							</tr>
-						</table>
+						</tbody></table>
 					</dd>
 				</dl>
 
-				<p>The only restriction on property <a href="#viewport.ebnf.name">names</a> and <a
-						href="#viewport.ebnf.value">values</a> is that they MUST NOT contain <a
-						href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign"
-						>assignment character</a>.</p>
+				<p>The only restriction on property <a href="#viewport.ebnf.name">names</a> and <a href="#viewport.ebnf.value">values</a> is that they MUST NOT contain <a href="#viewport.ebnf.sep-char">separator characters</a> or the <a href="#viewport.ebnf.assign">assignment character</a>.</p>
 
 				<p>The authoring requirements in this section apply <em>after</em>
-					<a data-cite="xml#AVNormalize">whitespace normalization</a> [[xml]] (i.e., after a reading system
+					<a data-cite="xml#AVNormalize">whitespace normalization</a>&nbsp;[[xml]] (i.e., after a reading system
 					strips leading and trailing whitespace and compacts all instances of multiple whitespace within the
 					attribute to single spaces). EPUB creators MAY include any valid [=ascii whitespace=] [[infra]] in
 					the authored tag so long as the result is valid to this definition.</p>
 
-				<p>There are no restrictions on any other attributes allowed on the <a data-cite="html#the-meta-element"
-							><code>meta</code></a> element by the [[html]] grammar.</p>
+				<p>There are no restrictions on any other attributes allowed on the <a data-cite="html#the-meta-element"><code>meta</code></a> element by the [[html]] grammar.</p>
 
 				<div class="note">
 					<p>For more information about specifying the required <code>height</code> and <code>width</code>
@@ -10818,9 +10431,7 @@ html.my-document-playing * {
 			<section id="app-package-schema">
 				<h3>Package document schema</h3>
 
-				<p>A schema for [=package documents=] is available at <a
-						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl"
-						>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.</p>
+				<p>A schema for [=package documents=] is available at <a href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl">https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/package-30.nvdl</a>.</p>
 
 				<p>Validation using this schema requires a processor that supports [[nvdl]], [[relaxng-schema]],
 					[[isoschematron]] and [[xmlschema-2]].</p>
@@ -10843,8 +10454,7 @@ html.my-document-playing * {
 					<h4>Schema for <code>container.xml</code></h4>
 
 					<p>A schema for <a href="#sec-container-metainf-container.xml"><code>container.xml</code> files</a>
-						is available at <a
-							href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl">
+						is available at <a href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl">
 							<code>https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/ocf-container-30.nvdl</code></a>.</p>
 
 					<p>Validation using this schema requires a processor that supports [[relaxng-schema]] and
@@ -10869,9 +10479,7 @@ html.my-document-playing * {
 			<section id="app-schema-overlays">
 				<h3>Media overlays schema</h3>
 
-				<p>A schema for [=media overlay documents=] is available at <a
-						href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl"
-						>https://github.com/w3c/epubcheck/tree/main/src/master/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl</a>.</p>
+				<p>A schema for [=media overlay documents=] is available at <a href="https://github.com/w3c/epubcheck/tree/master/src/main/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl">https://github.com/w3c/epubcheck/tree/main/src/master/resources/com/adobe/epubcheck/schema/30/media-overlay-30.nvdl</a>.</p>
 
 				<p>Validation using this schema requires a processor that supports [[nvdl]], [[relaxng-schema]],
 					[[isoschematron]] and [[xmlschema-2]].</p>
@@ -10890,96 +10498,95 @@ html.my-document-playing * {
 
 				<p>Consider the following extracts of a [=package document=] and an [=XHTML content document=]:</p>
 
-				<pre>&lt;package …>
-    &lt;metadata …>
+				<pre>&lt;package …&gt;
+    &lt;metadata …&gt;
         …
         &lt;link rel="record" 
             href="meta/data.xml" 
-            media-type="application/marc"/>
+            media-type="application/marc"/&gt;
         &lt;link rel="record" 
             href="https://www.example.org/meta/data2.xml" 
-            media-type="application/marc"/>
+            media-type="application/marc"/&gt;
         …
-    &lt;/metadata>
-    &lt;manifest>
+    &lt;/metadata&gt;
+    &lt;manifest&gt;
         …
         &lt;item id="page"
             href="page.xhtml"
-            media-type="application/xhtml+xml"/>
+            media-type="application/xhtml+xml"/&gt;
         &lt;item id="nav"
             href="nav.xhtml"
             media-type="application/xhtml+xml"
-            properties="nav"/>
+            properties="nav"/&gt;
         &lt;item id="style"        
             href="style.css"
-            media-type="text/css"/>
+            media-type="text/css"/&gt;
         &lt;item id="font_otf"
             href="fonts/font-file.otf"
-            media-type="font/otf"/>
+            media-type="font/otf"/&gt;
         &lt;item id="font_otf_remote"
             href="https://www.example.org/fonts/font-file2.otf"
-            media-type="font/otf"/>
+            media-type="font/otf"/&gt;
         &lt;item id="font_cff"
             href="fonts/font-file.cff"
-            media-type="font/sfnt"/>
+            media-type="font/sfnt"/&gt;
         &lt;item id="pls"
             href="speech/cmn.pls"
-            media-type="application/pls+xml"/>
+            media-type="application/pls+xml"/&gt;
         &lt;item id="image_1"
             href="media/image_1.png"
-            media-type="image/png"/>
+            media-type="image/png"/&gt;
         &lt;item id="image_2"
             href="media/image_2.png"
             media-type="image/png"
-            fallback="image_desc"/>
+            fallback="image_desc"/&gt;
         &lt;item id="image_desc"
             href="image_desc.xhtml"
-            media-type="application/xhtml+xml"/>
+            media-type="application/xhtml+xml"/&gt;
         &lt;item id="image_3_heic"
             href="media/image_3.heic"
-            media-type="image/heic"/>
+            media-type="image/heic"/&gt;
         &lt;item id="image_3_png"
             href="media/image_3.png"
-            media-type="image/png"/>
+            media-type="image/png"/&gt;
         &lt;item id="widget"
             href="widget.xhtml"
-            media-type="application/xhtml+xml"/>
+            media-type="application/xhtml+xml"/&gt;
         …
-    &lt;/manifest>
-    &lt;spine>
+    &lt;/manifest&gt;
+    &lt;spine&gt;
         …
-        &lt;itemref idref="page_001"/>
-        &lt;itemref idref="image_2"/>
+        &lt;itemref idref="page_001"/&gt;
+        &lt;itemref idref="image_2"/&gt;
         …
-    &lt;/spine>
-&lt;/package>
+    &lt;/spine&gt;
+&lt;/package&gt;
 	
-&lt;html …>
-    &lt;head …>
+&lt;html …&gt;
+    &lt;head …&gt;
         …
-        &lt;link rel="stylesheet" type="text/css" href="style.css"/>
-        &lt;link rel="pronunciation" type="application/pls+xml" href="speech/cmn.pls"/>
+        &lt;link rel="stylesheet" type="text/css" href="style.css"/&gt;
+        &lt;link rel="pronunciation" type="application/pls+xml" href="speech/cmn.pls"/&gt;
         …
-    &lt;/head>
-    &lt;body>
-        &lt;img src="media/image1_png"/>
+    &lt;/head&gt;
+    &lt;body&gt;
+        &lt;img src="media/image1_png"/&gt;
         …
-        &lt;a href="media/image_2.png">…&lt;/a>
+        &lt;a href="media/image_2.png"&gt;…&lt;/a&gt;
         …
-        &lt;picture>
-            &lt;source srcset="media/image_3.heic" type="image/heic"/>
-            &lt;img src="media/image_3.png"/>
-        &lt;/picture>
+        &lt;picture&gt;
+            &lt;source srcset="media/image_3.heic" type="image/heic"/&gt;
+            &lt;img src="media/image_3.png"/&gt;
+        &lt;/picture&gt;
         …        
-        &lt;iframe src="widget.xhtml">&lt;/iframe>
+        &lt;iframe src="widget.xhtml"&gt;&lt;/iframe&gt;
         …
-        &lt;a href="https://www.example.org/some_content">…&lt;/a>
-    &lt;/body>
-&lt;/html>					
+        &lt;a href="https://www.example.org/some_content"&gt;…&lt;/a&gt;
+    &lt;/body&gt;
+&lt;/html&gt;					
 				</pre>
 
-				<p>The various resources in the [=EPUB publication=] can be categorized as follows. (Refer to <a
-						href="#sec-publication-resources"></a> for more information about these categories.)</p>
+				<p>The various resources in the [=EPUB publication=] can be categorized as follows. (Refer to <a href="#sec-publication-resources"></a> for more information about these categories.)</p>
 
 				<dl>
 					<dt><code>meta/data.xml</code></dt>
@@ -11039,8 +10646,7 @@ html.my-document-playing * {
 					<dt><code>font/font-file.cff</code></dt>
 					<dd>
 						<p>The resource is a font file in Compact Font Format. It is not listed in the spine but is
-							referenced from a CSS file. Its media type is not listed as a <a
-								href="#sec-core-media-types">core media type</a>. It is a publication resource on the
+							referenced from a CSS file. Its media type is not listed as a <a href="#sec-core-media-types">core media type</a>. It is a publication resource on the
 							manifest plane, a container resource, is not present on the spine plane, and is an [=exempt
 							resource=] on the content plane. No fallback is necessary.</p>
 					</dd>
@@ -11067,8 +10673,7 @@ html.my-document-playing * {
 							is referenced from a hyperlink, it <em>must</em> be listed in the spine. It is a publication
 							resource on the manifest plane, a container resource, a [=foreign content document=] on the
 							spine plane, and a core media type resource on the content plane. As a foreign content
-							document, a fallback is required, which is provided via a <a href="#sec-manifest-fallbacks"
-								>manifest fallback</a>.</p>
+							document, a fallback is required, which is provided via a <a href="#sec-manifest-fallbacks">manifest fallback</a>.</p>
 					</dd>
 
 					<dt><code>image_desc.xhtml</code></dt>
@@ -11083,8 +10688,7 @@ html.my-document-playing * {
 					<dt><code>image/image_3.heic</code></dt>
 					<dd>
 						<p>The resource is a High Efficiency (HEIC) image file. It is not listed in the spine but is
-							referenced from an [[html]] [^source^] element. Its media type is not listed as a <a
-								href="#sec-core-media-types">core media type</a>. It is a publication resource on the
+							referenced from an [[html]] [^source^] element. Its media type is not listed as a <a href="#sec-core-media-types">core media type</a>. It is a publication resource on the
 							manifest plane, a container resource, is not present on the spine plane, and is a foreign
 							resource on the content plane. As a foreign resource, a fallback is required, which is
 							provided via the sibling [[html]] [^img^] element in an [[html]] [^picture^] element.</p>
@@ -11116,8 +10720,7 @@ html.my-document-playing * {
 					</dd>
 				</dl>
 
-				<p>Additional examples on the usage of different types of resources can be found in <a
-						href="#sec-item-elem-examples"></a>.</p>
+				<p>Additional examples on the usage of different types of resources can be found in <a href="#sec-item-elem-examples"></a>.</p>
 			</section>
 
 			<section id="scripted-contexts-example">
@@ -11125,57 +10728,57 @@ html.my-document-playing * {
 
 				<p>Consider the following example [=package document=]:</p>
 
-				<pre>&lt;package …>
+				<pre>&lt;package …&gt;
     …
-    &lt;manifest>
+    &lt;manifest&gt;
         …
         &lt;item id="chap01" 
             href="scripted01.xhtml" 
             media-type="application/xhtml+xml"
-            properties="scripted"/>
+            properties="scripted"/&gt;
         &lt;item id="inset01" 
             href="scripted02.xhtml" 
             media-type="application/xhtml+xml"
-            properties="scripted"/>
+            properties="scripted"/&gt;
         &lt;item id="slideshowjs" 
             href="slideshow.js" 
-            media-type="text/javascript"/>
-    &lt;/manifest>
+            media-type="text/javascript"/&gt;
+    &lt;/manifest&gt;
     
-    &lt;spine …>
-        &lt;itemref idref="chap01"/>
+    &lt;spine …&gt;
+        &lt;itemref idref="chap01"/&gt;
         …
-    &lt;/spine>
+    &lt;/spine&gt;
     …
-&lt;/package></pre>
+&lt;/package&gt;</pre>
 
 				<p>and the following file <code>scripted01.xhtml</code>:</p>
 
-				<pre>&lt;html …>
-    &lt;head>
+				<pre>&lt;html …&gt;
+    &lt;head&gt;
         …
-        &lt;script type="text/javascript">
+        &lt;script type="text/javascript"&gt;
             alert("Reading system name: " + navigator.epubReadingSystem.name);
-        &lt;/script>
-    &lt;/head>
-    &lt;body>
+        &lt;/script&gt;
+    &lt;/head&gt;
+    &lt;body&gt;
         …
-        &lt;iframe src="scripted02.xhtml" … />
+        &lt;iframe src="scripted02.xhtml" … /&gt;
         …
-    &lt;/body>
-&lt;/html></pre>
+    &lt;/body&gt;
+&lt;/html&gt;</pre>
 
 				<p>and the following file <code>scripted02.xhtml</code>:</p>
 
-				<pre>&lt;html …>
-    &lt;head>
+				<pre>&lt;html …&gt;
+    &lt;head&gt;
         …
-        &lt;script type="text/javascript" href="slideshow.js">&lt;/script>
-    &lt;/head>
-    &lt;body>
+        &lt;script type="text/javascript" href="slideshow.js"&gt;&lt;/script&gt;
+    &lt;/head&gt;
+    &lt;body&gt;
         …
-    &lt;/body>
-&lt;/html></pre>
+    &lt;/body&gt;
+&lt;/html&gt;</pre>
 
 				<p>From these examples, it is true that:</p>
 
@@ -11186,8 +10789,7 @@ html.my-document-playing * {
 							because the document is referenced from the spine; and</p>
 					</li>
 					<li>
-						<p>the code in the <code>script</code> element in <code>scripted02.xhtml</code> is a <a
-								href="#sec-scripted-container-constrained">container-constrained script</a> because the
+						<p>the code in the <code>script</code> element in <code>scripted02.xhtml</code> is a <a href="#sec-scripted-container-constrained">container-constrained script</a> because the
 							XHTML document it occurs in is included in <code>scripted01.xhtml</code> via the
 								<code>iframe</code> element.</p>
 					</li>
@@ -11217,255 +10819,255 @@ EPUB/images/cover.png</pre>
 
 				<p>The contents of the <code>META-INF/container.xml</code> file</p>
 
-				<pre>&lt;?xml version="1.0"?>
+				<pre>&lt;?xml version="1.0"?&gt;
 &lt;container
     version="1.0"
-    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
-   &lt;rootfiles>
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
+   &lt;rootfiles&gt;
       &lt;rootfile
           full-path="EPUB/As_You_Like_It.opf"
-          media-type="application/oebps-package+xml"/>
-   &lt;/rootfiles>
-&lt;/container></pre>
+          media-type="application/oebps-package+xml"/&gt;
+   &lt;/rootfiles&gt;
+&lt;/container&gt;</pre>
 
 				<p>The contents of the <code>META-INF/signatures.xml</code> file</p>
 
 				<pre>&lt;signatures
-    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
    &lt;Signature
        Id="AsYouLikeItSignature"
-       xmlns="http://www.w3.org/2000/09/xmldsig#">
+       xmlns="http://www.w3.org/2000/09/xmldsig#"&gt;
         
       &lt;!--
            SignedInfo is the information that is actually signed.
            In this case, the SHA-1 algorithm is used to sign the 
            canonical form of the XML documents enumerated in the
            Object element below.
-      -->
+      --&gt;
       
-      &lt;SignedInfo>
+      &lt;SignedInfo&gt;
          &lt;CanonicalizationMethod
-             Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+             Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
          &lt;SignatureMethod
-             Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/>
+             Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/&gt;
          &lt;Reference
-             URI="#AsYouLikeIt">
+             URI="#AsYouLikeIt"&gt;
             &lt;DigestMethod
-                Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-            &lt;DigestValue>
+                Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
+            &lt;DigestValue&gt;
                …
-            &lt;/DigestValue>
-         &lt;/Reference>
-      &lt;/SignedInfo>
+            &lt;/DigestValue&gt;
+         &lt;/Reference&gt;
+      &lt;/SignedInfo&gt;
       
       &lt;!--
            The signed value of the digest above, using the DSA 
            algorithm
-      -->
-      &lt;SignatureValue>
+      --&gt;
+      &lt;SignatureValue&gt;
          …
-      &lt;/SignatureValue>
+      &lt;/SignatureValue&gt;
       
       &lt;!--
            The key used to validate the signature
-      -->
-      &lt;KeyInfo>
-         &lt;KeyValue>
-            &lt;DSAKeyValue>
-               &lt;P>…&lt;/P>
-               &lt;Q>…&lt;/Q>
-               &lt;G>…&lt;/G>
-               &lt;Y>…&lt;/Y>
-            &lt;/DSAKeyValue>
-         &lt;/KeyValue>
-      &lt;/KeyInfo>
+      --&gt;
+      &lt;KeyInfo&gt;
+         &lt;KeyValue&gt;
+            &lt;DSAKeyValue&gt;
+               &lt;P&gt;…&lt;/P&gt;
+               &lt;Q&gt;…&lt;/Q&gt;
+               &lt;G&gt;…&lt;/G&gt;
+               &lt;Y&gt;…&lt;/Y&gt;
+            &lt;/DSAKeyValue&gt;
+         &lt;/KeyValue&gt;
+      &lt;/KeyInfo&gt;
       
       &lt;!--
            The list of resources to sign (note that the canonical
            form of XML documents is signed, while the binary form
            of all other resources is used)
-      -->
-      &lt;Object>
+      --&gt;
+      &lt;Object&gt;
          &lt;Manifest
-             Id="AsYouLikeIt">
+             Id="AsYouLikeIt"&gt;
             &lt;Reference
-                URI="EPUB/As_You_Like_It.opf">
-               &lt;Transforms>
+                URI="EPUB/As_You_Like_It.opf"&gt;
+               &lt;Transforms&gt;
                   &lt;Transform
-                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
-               &lt;/Transforms>
+                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
+               &lt;/Transforms&gt;
                &lt;DigestMethod
-                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-               &lt;DigestValue>
-               &lt;/DigestValue>
-            &lt;/Reference>
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
+               &lt;DigestValue&gt;
+               &lt;/DigestValue&gt;
+            &lt;/Reference&gt;
             
-            &lt;Reference URI="EPUB/book.html">
-               &lt;Transforms>
+            &lt;Reference URI="EPUB/book.html"&gt;
+               &lt;Transforms&gt;
                   &lt;Transform
-                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
-               &lt;/Transforms>
+                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
+               &lt;/Transforms&gt;
                &lt;DigestMethod
-                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-               &lt;DigestValue>
-               &lt;/DigestValue>
-            &lt;/Reference>
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
+               &lt;DigestValue&gt;
+               &lt;/DigestValue&gt;
+            &lt;/Reference&gt;
             
             &lt;Reference
-                URI="EPUB/images/cover.png">
+                URI="EPUB/images/cover.png"&gt;
                &lt;DigestMethod
-                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
-               &lt;DigestValue>
-               &lt;/DigestValue>
-            &lt;/Reference>
-         &lt;/Manifest>
-      &lt;/Object>
-   &lt;/Signature>
-&lt;/signatures></pre>
+                   Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
+               &lt;DigestValue&gt;
+               &lt;/DigestValue&gt;
+            &lt;/Reference&gt;
+         &lt;/Manifest&gt;
+      &lt;/Object&gt;
+   &lt;/Signature&gt;
+&lt;/signatures&gt;</pre>
 
 				<p>The contents of the <code>META-INF/encryption.xml</code> file</p>
 
-				<pre>&lt;?xml version="1.0"?>
+				<pre>&lt;?xml version="1.0"?&gt;
 &lt;encryption
     xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
     xmlns:enc="http://www.w3.org/2001/04/xmlenc#"
-    xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"&gt;
 
    &lt;!--
         The RSA-encrypted AES-128 symmetric key used to encrypt
         data enumerated in EncryptedData blocks below
-   -->
+   --&gt;
    &lt;enc:EncryptedKey
-       Id="EK">
+       Id="EK"&gt;
       &lt;enc:EncryptionMethod
-          Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/>
-      &lt;ds:KeyInfo>
-         &lt;ds:KeyName>
+          Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+      &lt;ds:KeyInfo&gt;
+         &lt;ds:KeyName&gt;
             John Smith
-         &lt;/ds:KeyName>
-      &lt;/ds:KeyInfo>
-      &lt;enc:CipherData>
-         &lt;enc:CipherValue>
+         &lt;/ds:KeyName&gt;
+      &lt;/ds:KeyInfo&gt;
+      &lt;enc:CipherData&gt;
+         &lt;enc:CipherValue&gt;
             xyzabc…
-         &lt;/enc:CipherValue>
-      &lt;/enc:CipherData>
-   &lt;/enc:EncryptedKey>
+         &lt;/enc:CipherValue&gt;
+      &lt;/enc:CipherData&gt;
+   &lt;/enc:EncryptedKey&gt;
 
    &lt;!--
         Each EncryptedData block identifies a single resource
         that has been encrypted using the AES-128 algorithm.
         The data remains stored, in its encrypted form, in the
         original file within the container.
-   -->
-   &lt;enc:EncryptedData Id="ED1">
+   --&gt;
+   &lt;enc:EncryptedData Id="ED1"&gt;
       &lt;enc:EncryptionMethod
-          Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/>
-      &lt;ds:KeyInfo>
+          Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/&gt;
+      &lt;ds:KeyInfo&gt;
          &lt;ds:RetrievalMethod
              URI="#EK"
-             Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/>
-      &lt;/ds:KeyInfo>
-      &lt;enc:CipherData>
+             Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/&gt;
+      &lt;/ds:KeyInfo&gt;
+      &lt;enc:CipherData&gt;
          &lt;enc:CipherReference
-             URI="EPUB/book.html"/>
-      &lt;/enc:CipherData>
-   &lt;/enc:EncryptedData>
+             URI="EPUB/book.html"/&gt;
+      &lt;/enc:CipherData&gt;
+   &lt;/enc:EncryptedData&gt;
 
-   &lt;enc:EncryptedData Id="ED2">
+   &lt;enc:EncryptedData Id="ED2"&gt;
       &lt;enc:EncryptionMethod
-          Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/>
-      &lt;ds:KeyInfo>
+          Algorithm="http://www.w3.org/2001/04/xmlenc#kw-aes128"/&gt;
+      &lt;ds:KeyInfo&gt;
          &lt;ds:RetrievalMethod
-             URI="#EK" Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/>
-      &lt;/ds:KeyInfo>
-      &lt;enc:CipherData>
+             URI="#EK" Type="http://www.w3.org/2001/04/xmlenc#EncryptedKey"/&gt;
+      &lt;/ds:KeyInfo&gt;
+      &lt;enc:CipherData&gt;
          &lt;enc:CipherReference
-             URI="EPUB/images/cover.png"/>
-      &lt;/enc:CipherData>
-   &lt;/enc:EncryptedData>
-&lt;/encryption></pre>
+             URI="EPUB/images/cover.png"/&gt;
+      &lt;/enc:CipherData&gt;
+   &lt;/enc:EncryptedData&gt;
+&lt;/encryption&gt;</pre>
 
 				<p>The contents of the <code>EPUB/As_You_Like_It.opf</code> file</p>
 
-				<pre>&lt;?xml version="1.0"?>
+				<pre>&lt;?xml version="1.0"?&gt;
 &lt;package
     version="3.0"
     xml:lang="en"
     xmlns="http://www.idpf.org/2007/opf"
-    unique-identifier="pub-id">
+    unique-identifier="pub-id"&gt;
     
    &lt;metadata
-       xmlns:dc="http://purl.org/dc/elements/1.1/">
+       xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
       
       &lt;dc:identifier
-          id="pub-id">
+          id="pub-id"&gt;
          urn:uuid:B9B412F2-CAAD-4A44-B91F-A375068478A0
-      &lt;/dc:identifier>
+      &lt;/dc:identifier&gt;
       
-      &lt;dc:language>
+      &lt;dc:language&gt;
          en
-      &lt;/dc:language>
+      &lt;/dc:language&gt;
       
-      &lt;dc:title>
+      &lt;dc:title&gt;
          As You Like It
-      &lt;/dc:title>
+      &lt;/dc:title&gt;
        
       &lt;dc:creator
-          id="creator">
+          id="creator"&gt;
          William Shakespeare
-      &lt;/dc:creator>
+      &lt;/dc:creator&gt;
       
       &lt;meta
-          property="dcterms:modified">
+          property="dcterms:modified"&gt;
          2000-03-24T00:00:00Z
-      &lt;/meta>
+      &lt;/meta&gt;
       
-      &lt;dc:publisher>
+      &lt;dc:publisher&gt;
          Project Gutenberg
-      &lt;/dc:publisher>
+      &lt;/dc:publisher&gt;
       
-      &lt;dc:date>
+      &lt;dc:date&gt;
          2000-03-24
-      &lt;/dc:date>
+      &lt;/dc:date&gt;
       
       &lt;meta
-          property="dcterms:dateCopyrighted">
+          property="dcterms:dateCopyrighted"&gt;
          9999-01-01
-      &lt;/meta>
+      &lt;/meta&gt;
       
       &lt;dc:identifier
-          id="isbn13">
+          id="isbn13"&gt;
          urn:isbn:9780741014559
-      &lt;/dc:identifier>
+      &lt;/dc:identifier&gt;
       
       &lt;dc:identifier
-          id="isbn10">
+          id="isbn10"&gt;
          0-7410-1455-6
-      &lt;/dc:identifier>
+      &lt;/dc:identifier&gt;
       
       &lt;link
           rel="xml-signature"
-          href="../META-INF/signatures.xml#AsYouLikeItSignature"/>
-   &lt;/metadata>
+          href="../META-INF/signatures.xml#AsYouLikeItSignature"/&gt;
+   &lt;/metadata&gt;
     
-   &lt;manifest>
+   &lt;manifest&gt;
       &lt;item id="r4915" 
           href="book.html" 
-          media-type="application/xhtml+xml"/>
+          media-type="application/xhtml+xml"/&gt;
       &lt;item id="r7184" 
           href="images/cover.png" 
-          media-type="image/png"/>
+          media-type="image/png"/&gt;
       &lt;item id="nav" 
           href="nav.html" 
           media-type="application/xhtml+xml" 
-          properties="nav"/>
-   &lt;/manifest>
+          properties="nav"/&gt;
+   &lt;/manifest&gt;
    
-   &lt;spine>
+   &lt;spine&gt;
       &lt;itemref
-          idref="r4915"/>
-   &lt;/spine>
-&lt;/package></pre>
+          idref="r4915"/&gt;
+   &lt;/spine&gt;
+&lt;/package&gt;</pre>
 			</section>
 
 			<section id="clock-examples">
@@ -11517,8 +11119,7 @@ EPUB/images/cover.png</pre>
 				<h3>The <code>application/oebps-package+xml</code> media type</h3>
 
 				<p>This appendix registers the media type <code>application/oebps-package+xml</code> for the EPUB
-					package document. This registration supersedes RFC4839 (see <a
-						href="https://www.rfc-editor.org/rfc/rfc4839">https://www.rfc-editor.org/rfc/rfc4839</a>).</p>
+					package document. This registration supersedes RFC4839 (see <a href="https://www.rfc-editor.org/rfc/rfc4839">https://www.rfc-editor.org/rfc/rfc4839</a>).</p>
 
 				<p>The package document is an XML file that describes an EPUB publication. It identifies the resources
 					in the EPUB publication and provides metadata information. The package document and its related
@@ -11578,12 +11179,9 @@ EPUB/images/cover.png</pre>
 					<dt>Published specification:</dt>
 					<dd>
 						<p>This media type registration is for the EPUB package document, as described by the EPUB 3
-							specification located at <a href="https://www.w3.org/TR/epub-33/"
-								>https://www.w3.org/TR/epub-33/</a>.</p>
+							specification located at <a href="https://www.w3.org/TR/epub-33/">https://www.w3.org/TR/epub-33/</a>.</p>
 						<p>The EPUB 3 specification supersedes the Open Packaging Format 2.0.1 specification, which is
-							located at <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm"
-								>https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm</a> and which also uses the <code
-								class="media-type">application/oepbs-package+xml</code> media type.</p>
+							located at <a href="https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm">https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm</a> and which also uses the <code class="media-type">application/oepbs-package+xml</code> media type.</p>
 					</dd>
 
 					<dt>Applications which use this media type:</dt>
@@ -11616,8 +11214,7 @@ EPUB/images/cover.png</pre>
 								<p> EPUB Canonical Fragment Identifiers are custom fragment identifiers defined for [=
 									EPUB Publications =]. They may be used to refer to an arbitrary content within any
 									[=publication resource=] defined for the publication. These identifiers are defined
-									at <a href="https://idpf.org/epub/linking/cfi/"
-										>https://idpf.org/epub/linking/cfi/</a>. </p>
+									at <a href="https://idpf.org/epub/linking/cfi/">https://idpf.org/epub/linking/cfi/</a>. </p>
 							</dd>
 						</dl>
 					</dd>
@@ -11646,10 +11243,8 @@ EPUB/images/cover.png</pre>
 					Format (OCF).</p>
 
 				<p>An OCF ZIP container, or EPUB container, file is a container technology based on the zip archive
-					format (see <a href="https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT"
-						>https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT</a>). It is used to encapsulate the
-					EPUB publication. OCF and its related standards are maintained and defined by the <a
-						href="https://www.w3.org">World Wide Web Consortium</a> (W3C).</p>
+					format (see <a href="https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT">https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT</a>). It is used to encapsulate the
+					EPUB publication. OCF and its related standards are maintained and defined by the <a href="https://www.w3.org">World Wide Web Consortium</a> (W3C).</p>
 
 				<dl class="variablelist">
 					<dt>MIME media type name:</dt>
@@ -11678,8 +11273,7 @@ EPUB/images/cover.png</pre>
 
 					<dt>Encoding considerations:</dt>
 					<dd>
-						<p>OCF ZIP container files are binary files encoded in the <a class="media-type"
-								href="https://www.iana.org/assignments/media-types/application/zip">
+						<p>OCF ZIP container files are binary files encoded in the <a class="media-type" href="https://www.iana.org/assignments/media-types/application/zip">
 								<code>application/zip</code></a> media type.</p>
 					</dd>
 
@@ -11705,13 +11299,9 @@ EPUB/images/cover.png</pre>
 					<dt>Published specification:</dt>
 					<dd>
 						<p>This media type registration is for the EPUB Open Container Format (OCF), as described by the
-							EPUB 3 specification located at <a href="https://www.w3.org/TR/epub-33/"
-									><code>https://www.w3.org/TR/epub-33/</code></a>.</p>
-						<p>The EPUB 3 specification supersedes both <a
-								href="https://datatracker.ietf.org/doc/html/rfc4839">RFC 4839</a> and the Open Container
-							Format 2.0.1 specification, which is located at <a
-								href="https://idpf.org/epub/20/spec/OCF_2.0.1_draft.doc"
-									><code>https://idpf.org/epub/20/spec/OCF_2.0.1_draft.doc</code></a>, and which also
+							EPUB 3 specification located at <a href="https://www.w3.org/TR/epub-33/"><code>https://www.w3.org/TR/epub-33/</code></a>.</p>
+						<p>The EPUB 3 specification supersedes both <a href="https://datatracker.ietf.org/doc/html/rfc4839">RFC 4839</a> and the Open Container
+							Format 2.0.1 specification, which is located at <a href="https://idpf.org/epub/20/spec/OCF_2.0.1_draft.doc"><code>https://idpf.org/epub/20/spec/OCF_2.0.1_draft.doc</code></a>, and which also
 							uses the <code>application/epub+zip</code> media type.</p>
 					</dd>
 
@@ -11745,8 +11335,7 @@ EPUB/images/cover.png</pre>
 								<p> EPUB Canonical Fragment Identifiers are custom fragment identifiers defined for [=
 									EPUB Publications =]. They may be used to refer to an arbitrary content within any
 									[=publication resource=] defined for the publication. These identifiers are defined
-									at <a href="https://idpf.org/epub/linking/cfi/"
-										>https://idpf.org/epub/linking/cfi/</a>. </p>
+									at <a href="https://idpf.org/epub/linking/cfi/">https://idpf.org/epub/linking/cfi/</a>. </p>
 							</dd>
 						</dl>
 					</dd>
@@ -11772,13 +11361,10 @@ EPUB/images/cover.png</pre>
 		<section id="change-log" class="appendix informative">
 			<h2>Change log</h2>
 
-			<p>Note that this change log only identifies substantive changes since <a
-					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> &#8212; those that affect the
+			<p>Note that this change log only identifies substantive changes since <a href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> — those that affect the
 				conformance of [=EPUB publications=] or are similarly noteworthy.</p>
 
-			<p>For a list of all issues addressed during the revision, refer to the <a
-					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+-label%3ASpec-RS+"
-					>Working Group's issue tracker</a>.</p>
+			<p>For a list of all issues addressed during the revision, refer to the <a href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+-label%3ASpec-RS+">Working Group's issue tracker</a>.</p>
 
 			<section id="change-latest">
 				<h3>Substantive changes since <a href="https://www.w3.org/TR/2022/CR-epub-33-20220512/">Candidate
@@ -11788,8 +11374,7 @@ EPUB/images/cover.png</pre>
 					<li>11-Jan-2023: Marked the <code>dir</code> attribute under-implemented due to lack of support in
 						reading systems. See <a href="https://github.com/w3c/epub-specs/pull/2515">pull request
 						2515</a>.</li>
-					<li>09-Jan-2023: Fixed incorrect OPUS media type. See <a
-							href="https://github.com/w3c/epub-specs/issues/2516">issue 2516</a>.</li>
+					<li>09-Jan-2023: Fixed incorrect OPUS media type. See <a href="https://github.com/w3c/epub-specs/issues/2516">issue 2516</a>.</li>
 					<li>05-Jan-2023: Removed the precedence rules for linked records as reading systems do not support
 						their processing. See <a href="https://github.com/w3c/epub-specs/pull/2512">pull request
 							2512</a>.</li>
@@ -11797,50 +11382,38 @@ EPUB/images/cover.png</pre>
 						the manifest, so the restriction that the manifest only list publication resources is not
 						needed. See <a href="https://github.com/w3c/epub-specs/pull/2506">pull request 2506</a>.</li>
 					<li>12-Dec-2022: Clarified that fixed layout height and width declarations must be in the first
-							<code>viewport meta</code> tag. See <a href="https://github.com/w3c/epub-specs/pull/2503"
-							>pull request 2503</a>.</li>
+							<code>viewport meta</code> tag. See <a href="https://github.com/w3c/epub-specs/pull/2503">pull request 2503</a>.</li>
 					<li>08-Dec-2022: Removed the <code>acquire</code> and <code>xmp</code> properties after finding no
-						evidence these are used by publishers or reading systems. See <a
-							href="https://github.com/w3c/epub-specs/issues/2489">issue 2489</a>.</li>
+						evidence these are used by publishers or reading systems. See <a href="https://github.com/w3c/epub-specs/issues/2489">issue 2489</a>.</li>
 					<li>29-Nov-2022: Clarified that data URLs are not unique publication resources, and not allowed in
-						the package document, but are subject to fallback requirements. See <a
-							href="https://github.com/w3c/epub-specs/issues/2485">issue 2485</a>.</li>
+						the package document, but are subject to fallback requirements. See <a href="https://github.com/w3c/epub-specs/issues/2485">issue 2485</a>.</li>
 					<li>29-Nov-2022: Clarified the <code>epub:type</code> attribute is not allowed on the
-							<code>head</code> element and metadata content in XHTML content documents. See <a
-							href="https://github.com/w3c/epub-specs/issues/2486">issue 2486</a>.</li>
+							<code>head</code> element and metadata content in XHTML content documents. See <a href="https://github.com/w3c/epub-specs/issues/2486">issue 2486</a>.</li>
 					<li>17-Nov-2022: Updated file paths and names to identify that they are scalar value strings in the
-						OCF abstract container, not just case sensitive. See <a
-							href="https://github.com/w3c/epub-specs/issues/2461">issue 2461</a>.</li>
+						OCF abstract container, not just case sensitive. See <a href="https://github.com/w3c/epub-specs/issues/2461">issue 2461</a>.</li>
 					<li>11-Nov-2022: Added caution about reading systems not retaining HTML element-based rendering
-						instructions in navigation document elements. See <a
-							href="https://github.com/w3c/epub-specs/issues/2477">issue 2477</a>.</li>
+						instructions in navigation document elements. See <a href="https://github.com/w3c/epub-specs/issues/2477">issue 2477</a>.</li>
 					<li>02-Nov-2022: Removed the restriction on deprecated characters in the Tags and Variation
 						Selectors Supplement and replaced with a general note to avoid the use of characters already
-						deprecated by the Unicode standard, as the list changes over time. See <a
-							href="https://github.com/w3c/epub-specs/issues/2469">issue 2469</a>.</li>
+						deprecated by the Unicode standard, as the list changes over time. See <a href="https://github.com/w3c/epub-specs/issues/2469">issue 2469</a>.</li>
 					<li>20-Oct-2022: Removed requirement to encode file names in abstract container in UTF-8 as it is
-						not possible in the abstract and is already covered by a ZIP container requirement. See <a
-							href="https://github.com/w3c/epub-specs/issues/2461">issue 2461</a>.</li>
-					<li>17-Oct-2022: Added recommendation against using spaces in file paths and names. See <a
-							href="https://github.com/w3c/epub-specs/issues/2458">issue 2458</a>.</li>
+						not possible in the abstract and is already covered by a ZIP container requirement. See <a href="https://github.com/w3c/epub-specs/issues/2461">issue 2461</a>.</li>
+					<li>17-Oct-2022: Added recommendation against using spaces in file paths and names. See <a href="https://github.com/w3c/epub-specs/issues/2458">issue 2458</a>.</li>
 					<li>15-Oct-2022: Allow properties without values in <code>viewport meta</code> tag definition. See
 							<a href="https://github.com/w3c/epub-specs/pull/2457">pull request 2457</a>.</li>
 					<li>11-Oct-2022: Added additional requirement that <code>viewport meta</code> height and width not
 						be declared multiple times. See <a href="https://github.com/w3c/epub-specs/issues/2442">issue
 							2442</a>.</li>
-					<li>21-Sept-2022: Made the requirement to declare property prefixes explicit. See <a
-							href="https://github.com/w3c/epub-specs/issues/2438">issue 2438</a>.</li>
+					<li>21-Sept-2022: Made the requirement to declare property prefixes explicit. See <a href="https://github.com/w3c/epub-specs/issues/2438">issue 2438</a>.</li>
 					<li>19-Sept-2022: Removed minor contradictions in the <code>epub:type</code> attribute usage
 						definitions. See <a href="https://github.com/w3c/epub-specs/issues/2434">issue 2434</a>.</li>
-					<li>14-Sept-2022: Combined the legacy feature section into the package document definition. See <a
-							href="https://github.com/w3c/epub-specs/issues/2423">issue 2423</a>.</li>
+					<li>14-Sept-2022: Combined the legacy feature section into the package document definition. See <a href="https://github.com/w3c/epub-specs/issues/2423">issue 2423</a>.</li>
 					<li>14-Sept-2022: Clarified that the <code>href</code> attribute in the package document must not be
 						used to reference other package document elements (i.e., to indirectly reference a resource via
 						its manifest or spine entry). See <a href="https://github.com/w3c/epub-specs/issues/2420">issue
 							2420</a>.</li>
 					<li>14-Sept-2022: Re-establish that empty reference and property values are not valid to ensure that
-						metadata properties do not consist only of prefixes. See <a
-							href="https://github.com/w3c/epub-specs/issues/2417">issue 2417</a>.</li>
+						metadata properties do not consist only of prefixes. See <a href="https://github.com/w3c/epub-specs/issues/2417">issue 2417</a>.</li>
 					<li>14-Sept-2022: Added a new section for expressing all the primary navigation document content
 						requirements. See <a href="https://github.com/w3c/epub-specs/issues/2421">issue 2421</a>.</li>
 					<li>7-Sept-2022: Added clarifying requirement that the manifest only list publication resources. See
@@ -11848,32 +11421,22 @@ EPUB/images/cover.png</pre>
 					<li>28-Aug-2022: Added a note to Media Overlays <code>text</code> element definition regarding using
 						embedded timed media. See <a href="https://github.com/w3c/epub-specs/issues/2397">issue
 						2397</a>.</li>
-					<li>02-Aug-2022: Updated the media type registrations, following the <a
-							href="https://lists.w3.org/Archives/Public/public-epub-wg/2022Aug/0000.html">official IANA
-							review comments</a> on updating the previous registrations. See <a
-							href="https://github.com/w3c/epub-specs/issues/1398">issue 1398</a>. </li>
+					<li>02-Aug-2022: Updated the media type registrations, following the <a href="https://lists.w3.org/Archives/Public/public-epub-wg/2022Aug/0000.html">official IANA
+							review comments</a> on updating the previous registrations. See <a href="https://github.com/w3c/epub-specs/issues/1398">issue 1398</a>. </li>
 					<li>28-July-2022: The restrictions on the elements where <code>epub:type</code> may be used has been
 						made explicit. See <a href="https://github.com/w3c/epub-specs/issues/2377">issue 2377</a>.</li>
 					<li>18-July-2022: The viewport <code>meta</code> element for specifying the initial containing
-						boundary in fixed-layout documents is now formally defined. See <a
-							href="https://github.com/w3c/epub-specs/issues/2292">issue 2292</a>. </li>
+						boundary in fixed-layout documents is now formally defined. See <a href="https://github.com/w3c/epub-specs/issues/2292">issue 2292</a>. </li>
 					<li>14-July-2022: Clarified that the markup in the SVG <code>title</code> element is restricted to
 						HTML elements. See <a href="https://github.com/w3c/epub-specs/issues/2355">issue 2355</a>.</li>
-					<li>10-June-2022: Clarified that data blocks are exempt from fallback requirements. See <a
-							href="https://github.com/w3c/epub-specs/issues/2331">issue 2331</a>.</li>
-					<li>07-June-2022: The usage of File URLs has been disallowed. See <a
-							href="https://github.com/w3c/epub-specs/issues/2324">issue 2324</a>.</li>
-					<li>07-June-2022: Media type registration sections are now normative. See <a
-							href="https://github.com/w3c/epub-specs/issues/2313">issue 2313</a>.</li>
-					<li>07-June-2022: Updated privacy and security recommendations to use normative language. See <a
-							href="https://github.com/w3c/epub-specs/pull/2297">pull request 2297</a>.</li>
-					<li>27-May-2022: Added recommendation to only reference remote resources via https. See <a
-							href="https://github.com/w3c/epub-specs/issues/2263">issue 2263</a>.</li>
+					<li>10-June-2022: Clarified that data blocks are exempt from fallback requirements. See <a href="https://github.com/w3c/epub-specs/issues/2331">issue 2331</a>.</li>
+					<li>07-June-2022: The usage of File URLs has been disallowed. See <a href="https://github.com/w3c/epub-specs/issues/2324">issue 2324</a>.</li>
+					<li>07-June-2022: Media type registration sections are now normative. See <a href="https://github.com/w3c/epub-specs/issues/2313">issue 2313</a>.</li>
+					<li>07-June-2022: Updated privacy and security recommendations to use normative language. See <a href="https://github.com/w3c/epub-specs/pull/2297">pull request 2297</a>.</li>
+					<li>27-May-2022: Added recommendation to only reference remote resources via https. See <a href="https://github.com/w3c/epub-specs/issues/2263">issue 2263</a>.</li>
 					<li>20-May-2022: Add recommendation not to store sensitive user data in persistent storage, and to
-						encrypt it if there is no other choice. See <a
-							href="https://github.com/w3c/epub-specs/issues/2264">issue 2264</a>.</li>
-					<li>17-May-2022: Added an index of terms. See <a
-							href="https://github.com/w3c/epub-specs/issues/2260">issue 2260</a>.</li>
+						encrypt it if there is no other choice. See <a href="https://github.com/w3c/epub-specs/issues/2264">issue 2264</a>.</li>
+					<li>17-May-2022: Added an index of terms. See <a href="https://github.com/w3c/epub-specs/issues/2260">issue 2260</a>.</li>
 				</ul>
 			</section>
 
@@ -11882,41 +11445,33 @@ EPUB/images/cover.png</pre>
 
 				<ul>
 					<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and
-						updated the list of semantics to use for escaping to match the guidance. See <a
-							href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>
+						updated the list of semantics to use for escaping to match the guidance. See <a href="https://github.com/w3c/epub-specs/issues/2221">issue 2221</a>.</li>
 					<li>6-Apr-2022: Removed the restrictions on the value of the <code>authority</code> property and
-						added a note referencing the old IDPF registry. See <a
-							href="https://github.com/w3c/epub-specs/issues/2120">issue 2200</a>.</li>
+						added a note referencing the old IDPF registry. See <a href="https://github.com/w3c/epub-specs/issues/2120">issue 2200</a>.</li>
 					<li>31-Mar-2022: Removed the restriction on deprecated MathML features and added a general caution
 						that any technology may make changes that can cause an EPUB publication to become invalid. See
 							<a href="https://github.com/w3c/epub-specs/issues/2118">issue 2118</a>.</li>
 					<li>31-Mar-2022: Reformulated custom attributes as a content authoring feature and added a new
-						section on custom rendering properties. See <a
-							href="https://github.com/w3c/epub-specs/issues/2134">issue 2134</a>.</li>
+						section on custom rendering properties. See <a href="https://github.com/w3c/epub-specs/issues/2134">issue 2134</a>.</li>
 					<li>25-Mar-2022: Fixed conflicting statements about the requirement for semantics in media overlay
-						documents and clarified requirements for skippability and escapability. See <a
-							href="https://github.com/w3c/epub-specs/issues/2066">issue 2066</a>.</li>
+						documents and clarified requirements for skippability and escapability. See <a href="https://github.com/w3c/epub-specs/issues/2066">issue 2066</a>.</li>
 					<li>22-Mar-2022: Removed the recommendation that reading systems recognize the built-in
 						`collection-type` values and replaced with a note about enabling improved handling of related
 						content. See <a href="https://github.com/w3c/epub-specs/issues/2071">issue 2071</a>.</li>
 					<li>21-Mar-2022: Add a tolerance of one second for the sum of the individual media overlay docuemnts
 						matching the total duration. See <a href="https://github.com/w3c/epub-specs/issues/2093">issue
 							2093</a>.</li>
-					<li>17-Mar-2022: Deprecate the creation of new collection types. See <a
-							href="https://github.com/w3c/epub-specs/pull/2060">issue 2060</a>.</li>
+					<li>17-Mar-2022: Deprecate the creation of new collection types. See <a href="https://github.com/w3c/epub-specs/pull/2060">issue 2060</a>.</li>
 					<li>17-Mar-2022: Removed dated requirements on the use of <code>epub:type</code> that suggest
 						equivalence with ARIA roles. See <a href="https://github.com/w3c/epub-specs/pull/2070">issue
 							2070</a>.</li>
 					<li>16-Mar-2022: Add new section on conformance checking and definition for EPUB conformance
 						checker. See <a href="https://github.com/w3c/epub-specs/pull/2025">pull request 2025</a>.</li>
 					<li>14-Mar-2022: Renamed the term "valid-relative-container-URL-with-fragment" to
-						"valid-relative-ocf-URL-with-fragment string". See <a
-							href="https://github.com/w3c/epub-specs/issues/2076">issue 2076</a>.</li>
+						"valid-relative-ocf-URL-with-fragment string". See <a href="https://github.com/w3c/epub-specs/issues/2076">issue 2076</a>.</li>
 					<li>09-Mar-2022: Restore requirement that valid-relative-container-URL-with-fragment strings resolve
-						to resources in the OCF abstract container. See <a
-							href="https://github.com/w3c/epub-specs/issues/2024">issue 2024</a>.</li>
-					<li>09-Mar-2022: Added NCX doctype to allowed external identifiers. See <a
-							href="https://github.com/w3c/epub-specs/issues/2045">issue 2045</a>.</li>
+						to resources in the OCF abstract container. See <a href="https://github.com/w3c/epub-specs/issues/2024">issue 2024</a>.</li>
+					<li>09-Mar-2022: Added NCX doctype to allowed external identifiers. See <a href="https://github.com/w3c/epub-specs/issues/2045">issue 2045</a>.</li>
 					<li>08-Mar-2022: Require use of the fixed layout property values defined in this specification. See
 							<a href="https://github.com/w3c/epub-specs/issues/2039">issue 2039</a>.</li>
 					<li>08-Mar-2022: Clarified that the refines attribute must not be used with global fixed layout
@@ -11925,28 +11480,20 @@ EPUB/images/cover.png</pre>
 					<li>07-Mar-2022: Consolidated the usage requirements for manifest properties into a new Resource
 						Properties section. See <a href="https://github.com/w3c/epub-specs/issues/2030">issue
 						2030</a>.</li>
-					<li>05-Mar-2022: Forbid circular references and self-references in refinement chains. See <a
-							href="https://github.com/w3c/epub-specs/issues/2031">issue 2031</a>.</li>
+					<li>05-Mar-2022: Forbid circular references and self-references in refinement chains. See <a href="https://github.com/w3c/epub-specs/issues/2031">issue 2031</a>.</li>
 					<li>19-Feb-2022: Clarified the [^audio^] element's definition by making it optional and adapted the
 						specification's text elsewhere to address the situation when the element is indeed not present.
 						See <a href="https://github.com/w3c/epub-specs/issues/1986">issue 1986</a>.</li>
 					<li>04-Feb-2022: Expanded the section on security and privacy to include new sections on the threat
 						model for EPUB publications and additional recommendations for ensuring security and privacy.
-						See <a href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a
-							href="https://github.com/w3c/epub-specs/issues/1872">issue 1872</a>, <a
-							href="https://github.com/w3c/epub-specs/issues/1875">issue 1875</a> and <a
-							href="https://github.com/w3c/epub-specs/issues/1876">issue 1876</a>.</li>
+						See <a href="https://github.com/w3c/epub-specs/issues/1871">issue 1871</a>, <a href="https://github.com/w3c/epub-specs/issues/1872">issue 1872</a>, <a href="https://github.com/w3c/epub-specs/issues/1875">issue 1875</a> and <a href="https://github.com/w3c/epub-specs/issues/1876">issue 1876</a>.</li>
 					<li>21-Jan-2022: term "risky", used for the class of unsupported features, has been renamed to
-						"under-implemented". See the <a
-							href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-01-20-epub#resolution1"
-							>WG resolution</a>.</li>
+						"under-implemented". See the <a href="https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2022-01-20-epub#resolution1">WG resolution</a>.</li>
 					<li>08-Dec-2021: The <code>page-spread-center</code> property is now an alias for
 							<code>spread-none</code>. See <a href="https://github.com/w3c/epub-specs/issues/1929">issue
 							1929</a>.</li>
-					<li>03-Dec-2021: Added a new risky class for unsupported features. See <a
-							href="https://github.com/w3c/epub-specs/issues/1944">issue 1944</a>.</li>
-					<li>03-Dec-2021: Remove the element-based restrictions on remote resources. See <a
-							href="https://github.com/w3c/epub-specs/issues/1913">issue 1913</a>.</li>
+					<li>03-Dec-2021: Added a new risky class for unsupported features. See <a href="https://github.com/w3c/epub-specs/issues/1944">issue 1944</a>.</li>
+					<li>03-Dec-2021: Remove the element-based restrictions on remote resources. See <a href="https://github.com/w3c/epub-specs/issues/1913">issue 1913</a>.</li>
 					<li>01-Dec-2021: Deprecated the use of <code>page-spread-center</code>. It is now an alias for
 							<code>spread-none</code>. See <a href="https://github.com/w3c/epub-specs/issues/1929">issue
 							1929</a>.</li>
@@ -11958,44 +11505,32 @@ EPUB/images/cover.png</pre>
 					<li>12-Nov-2021: Change the recommendation to use SHA-1 to encrypt the obfuscation key to a
 						requirement. See <a href="https://github.com/w3c/epub-specs/issues/1873">issue 1873</a>.</li>
 					<li>12-Nov-2021: Restrict the obfuscation algorithm to fonts and add caution to use better
-						protection methods whenever possible. See <a
-							href="https://github.com/w3c/epub-specs/issues/1873">issue 1873</a>.</li>
+						protection methods whenever possible. See <a href="https://github.com/w3c/epub-specs/issues/1873">issue 1873</a>.</li>
 					<li>12-Nov-2021: Removed the statement about rights.xml being reserved for future standardization of
 						DRM information. See <a href="https://github.com/w3c/epub-specs/issues/181">issue 1874</a>.</li>
-					<li>10-Nov-2021: Proper definition of the content URL and handling of relative URLs. See <a
-							href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and <a
-							href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
+					<li>10-Nov-2021: Proper definition of the content URL and handling of relative URLs. See <a href="https://github.com/w3c/epub-specs/issues/1374">issue 1374</a> and <a href="https://github.com/w3c/epub-specs/issues/1888">issue 1888</a></li>
 					<li>29-Oct-2021: Recommended that EPUB creators not use path-absolute-URL strings for referencing
-						resources due to the lack of a consistent root. See <a
-							href="https://github.com/w3c/epub-specs/issues/1681">issue 1681</a>.</li>
-					<li>18-Oct-2021: Clarified the contexts from which remote resources may be referenced. See <a
-							href="https://github.com/w3c/epub-specs/issues/1857">issue 1857</a>.</li>
+						resources due to the lack of a consistent root. See <a href="https://github.com/w3c/epub-specs/issues/1681">issue 1681</a>.</li>
+					<li>18-Oct-2021: Clarified the contexts from which remote resources may be referenced. See <a href="https://github.com/w3c/epub-specs/issues/1857">issue 1857</a>.</li>
 					<li>12-Oct-2021: The Structure Semantics Vocabulary has been moved into a separate Working Group
 						Note. See <a href="https://github.com/w3c/epub-specs/issues/1763">issue 1763</a>.</li>
 					<li>27-Aug-2021: Add clarifications for including landmarks, such as limiting the number,
 						recommending known semantics, and ensuring the labels are human readable. Also added
-						recommendation to not include nested lists to match the page list. See <a
-							href="https://github.com/w3c/epub-specs/issues/1761">issue 1761</a>.</li>
-					<li>22-July-2021: Clarified TTS handling of images in media overlays. See <a
-							href="https://github.com/w3c/epub-specs/issues/1745">issue 1745</a>.</li>
+						recommendation to not include nested lists to match the page list. See <a href="https://github.com/w3c/epub-specs/issues/1761">issue 1761</a>.</li>
+					<li>22-July-2021: Clarified TTS handling of images in media overlays. See <a href="https://github.com/w3c/epub-specs/issues/1745">issue 1745</a>.</li>
 					<li>09-July-2021: Restored the custom attributes section due to known usage but without reference to
 						the attribute registry. See <a href="https://github.com/w3c/epub-specs/issues/1602">issue
 							1602</a>.</li>
 					<li>09-July-2021: Added the "Relationship to URL" section to explain the use of URL standard
-						terminology in this document relative to resource formats that do not reference it. See <a
-							href="https://github.com/w3c/epub-specs/issues/1726">issue 1726</a>.</li>
+						terminology in this document relative to resource formats that do not reference it. See <a href="https://github.com/w3c/epub-specs/issues/1726">issue 1726</a>.</li>
 					<li>05-July-2021: Removed the section on private use area characters from the XHTML restrictions.
-						The issues are more complex than what is covered and not in scope of EPUB to define. See <a
-							href="https://github.com/w3c/epub-specs/issues/1732">issue 1732</a>.</li>
+						The issues are more complex than what is covered and not in scope of EPUB to define. See <a href="https://github.com/w3c/epub-specs/issues/1732">issue 1732</a>.</li>
 					<li>28-June-2021: Added a note discouraging EPUB creators from referencing resources outside the
-						directory containing the package document to avoid interoperability issues. See <a
-							href="https://github.com/w3c/epub-specs/issues/1687">issue 1687</a></li>
+						directory containing the package document to avoid interoperability issues. See <a href="https://github.com/w3c/epub-specs/issues/1687">issue 1687</a></li>
 					<li>23-June-2021: Added the <code>base</code> element to the list of discouraged XHTML constructs.
 						See <a href="https://github.com/w3c/epub-specs/issues/1699">issue 1699</a>.</li>
-					<li>18-June-2021: Moved requirements for authoring SSML, PLS lexicons and CSS 3 Speech to the <a
-							href="https://www.w3.org/TR/epub-tts-10/">EPUB 3 Text-to-Speech Enhancements</a> note. The
-						ability to use these technologies in EPUB 3 publications remains unchanged. See <a
-							href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
+					<li>18-June-2021: Moved requirements for authoring SSML, PLS lexicons and CSS 3 Speech to the <a href="https://www.w3.org/TR/epub-tts-10/">EPUB 3 Text-to-Speech Enhancements</a> note. The
+						ability to use these technologies in EPUB 3 publications remains unchanged. See <a href="https://github.com/w3c/epub-specs/issues/1690">issue 1690</a>.</li>
 					<li>16-June-2021: Absolute URLs with <code>file</code> scheme should not be used on manifest items.
 						See <a href="https://github.com/w3c/epub-specs/issues/1688">issue 1688</a>.</li>
 					<li>31-May-2021: Require Unicode normalization and full case folding (in this order) for file name
@@ -12004,80 +11539,59 @@ EPUB/images/cover.png</pre>
 						1648</a>.</li>
 					<li>31-May-2021: Confirmed that SVG content documents do not have to be valid to the SVG
 						specification, only meet the well-formedness and ID requirements currently referenced and the
-						restrictions imposed by this specification. See <a
-							href="https://github.com/w3c/epub-specs/issues/1323">issue 1323</a>.</li>
-					<li>12-May-2021: Clarified that manifest items must not contain fragment identifiers. See <a
-							href="https://github.com/w3c/epub-specs/issues/1303">issue 1303</a>.</li>
+						restrictions imposed by this specification. See <a href="https://github.com/w3c/epub-specs/issues/1323">issue 1323</a>.</li>
+					<li>12-May-2021: Clarified that manifest items must not contain fragment identifiers. See <a href="https://github.com/w3c/epub-specs/issues/1303">issue 1303</a>.</li>
 					<li>12-May-2021: Changed all references to URIs/IRIs to URLs and references to RFCs 3986 and 3987 to
 						the URL standard. See <a href="https://github.com/w3c/epub-specs/issues/808">issue 808</a>.</li>
 					<li>08-May-2021: Added clarifying text that <code>link</code> element can be used to link individual
-						metadata properties in an alternative format. See <a
-							href="https://github.com/w3c/epub-specs/issues/1666">issue 1666</a>.</li>
+						metadata properties in an alternative format. See <a href="https://github.com/w3c/epub-specs/issues/1666">issue 1666</a>.</li>
 					<li>06-May-2021: Noted that the working group will no longer maintain the publication type and
 						collection role registries and removed dependence on the latter for validating collection types
 						(use of NMToken values remains restricted to extension specifications). The registry of
-						authority codes is now integrated into the property definition. See <a
-							href="https://github.com/w3c/epub-specs/pull/1664">pull request 1664</a>.</li>
-					<li>06-May-2021: Added <code>application/ecmascript</code> as a core media type for scripts. See <a
-							href="https://github.com/w3c/epub-specs/issues/1353">issue 1353</a>.</li>
+						authority codes is now integrated into the property definition. See <a href="https://github.com/w3c/epub-specs/pull/1664">pull request 1664</a>.</li>
+					<li>06-May-2021: Added <code>application/ecmascript</code> as a core media type for scripts. See <a href="https://github.com/w3c/epub-specs/issues/1353">issue 1353</a>.</li>
 					<li>06-May-2021: Added new section on fragment identifiers to media overlays and now recommend HTML
 						target element references and SVG fragment identifiers instead of requiring conformance to the
-						incompatible XPointer Shorthand syntax. See <a
-							href="https://github.com/w3c/epub-specs/issues/1586">issue 1586</a>.</li>
+						incompatible XPointer Shorthand syntax. See <a href="https://github.com/w3c/epub-specs/issues/1586">issue 1586</a>.</li>
 					<li>28-Apr-2021: Drop requirement for resources referenced from HTML <code>link</code> elements to
-						have core media type fallbacks. See <a href="https://github.com/w3c/epub-specs/issues/1312"
-							>issue 1312</a>.</li>
+						have core media type fallbacks. See <a href="https://github.com/w3c/epub-specs/issues/1312">issue 1312</a>.</li>
 					<li>22-Apr-2021: The usage of UTF-16 for CSS and XML has been changed, UTF-8 is the recommended
 						encoding. See <a href="https://github.com/w3c/epub-specs/issues/1628">issue 1628</a>.</li>
 					<li>19-Apr-2021: The use of custom attributes in EPUB content documents is no longer supported. See
 							<a href="https://github.com/w3c/epub-specs/issues/1602">issue 1602</a>.</li>
-					<li>13-Apr-2021: Require path names in OCF to also be UTF-8 encoded. See <a
-							href="https://github.com/w3c/epub-specs/issues/1630">issue 1630</a>.</li>
-					<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in <a
-							href="#sec-css-req"></a>. See <a href="https://github.com/w3c/epub-specs/issues/1613">issue
+					<li>13-Apr-2021: Require path names in OCF to also be UTF-8 encoded. See <a href="https://github.com/w3c/epub-specs/issues/1630">issue 1630</a>.</li>
+					<li>12-Apr-2021: Added a reference to the SVG <code>direction</code> attribute in <a href="#sec-css-req"></a>. See <a href="https://github.com/w3c/epub-specs/issues/1613">issue
 							1614</a>.</li>
 					<li>09-Apr-2021: Added a new section dedicated to accessibility in EPUB publications.</li>
-					<li>04-May-2021: Removed requirements around SVG <code>requiredExtensions</code> attribute. See <a
-							href="https://github.com/w3c/epub-specs/issues/1087">issue 1087</a>.</li>
+					<li>04-May-2021: Removed requirements around SVG <code>requiredExtensions</code> attribute. See <a href="https://github.com/w3c/epub-specs/issues/1087">issue 1087</a>.</li>
 					<li>26-Mar-2021: Removed requirement for page list ordering to reflect the order of page breaks in
 						the content. See <a href="https://github.com/w3c/epub-specs/issues/1500">issue 1500</a>.</li>
 					<li>26-Mar-2021: Allowed <code>dc:creator</code> and <code>dc:contributor</code> elements to have
-						multiple roles and allowed roles for <code>publisher</code>. See <a
-							href="https://github.com/w3c/epub-specs/issues/1129">issue 1129</a> and <a
-							href="https://github.com/w3c/epub-specs/issues/1583">issue 1583</a></li>
-					<li>23-Mar-2021: Clarified the requirements for the use of data URLs in EPUB publications. See <a
-							href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a>.</li>
+						multiple roles and allowed roles for <code>publisher</code>. See <a href="https://github.com/w3c/epub-specs/issues/1129">issue 1129</a> and <a href="https://github.com/w3c/epub-specs/issues/1583">issue 1583</a></li>
+					<li>23-Mar-2021: Clarified the requirements for the use of data URLs in EPUB publications. See <a href="https://github.com/w3c/epub-specs/issues/1564">issue 1564</a>.</li>
 					<li>17-Mar-2021: Include non characters at the end of the supplementary planes in list of characters
 						not allowed in file names. See <a href="https://github.com/w3c/epub-specs/issues/1538">issue
 							1538</a>.</li>
 					<li>15-Mar-2021: Removed the normative dependencies on XML schemas and added element and attribute
 						definitions for the <code>container.xml</code>, <code>encryption.xml</code> and
-							<code>signatures.xml</code> files. All schemas are considered non-normative. See <a
-							href="https://github.com/w3c/epub-specs/issues/1566">issue 1566</a>.</li>
+							<code>signatures.xml</code> files. All schemas are considered non-normative. See <a href="https://github.com/w3c/epub-specs/issues/1566">issue 1566</a>.</li>
 					<li>10-Mar-2021: Require that resources referenced from an EPUB publication not be located in the
-							<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205"
-							>issue 1205</a>.</li>
+							<code>META-INF</code> directory. See <a href="https://github.com/w3c/epub-specs/issues/1205">issue 1205</a>.</li>
 					<li>08-Mar-2021: The fix for <a href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>
 						on 20-Jan-2021 incorrectly mentioned EPUB content documents having durations. Corrected to media
 						overlay documents.</li>
 					<li>08-Mar-2021: Added recommendation that <code>refines</code> attribute use fragment identifiers
-						to reference publication resources. See <a href="https://github.com/w3c/epub-specs/issues/1361"
-							>issue 1361</a>.</li>
+						to reference publication resources. See <a href="https://github.com/w3c/epub-specs/issues/1361">issue 1361</a>.</li>
 					<li>08-Mar-2021: Change requirement that media overlay document <code>par</code> and
-							<code>seq</code> ordering match the default reading order to guidance. See <a
-							href="https://github.com/w3c/epub-specs/issues/1458">issue 1458</a></li>
+							<code>seq</code> ordering match the default reading order to guidance. See <a href="https://github.com/w3c/epub-specs/issues/1458">issue 1458</a></li>
 					<li>05-Mar-2021: Clarified that whitespace within metadata element values is collapsed per the
-						[[infra]] specification definition. See <a href="https://github.com/w3c/epub-specs/issues/1528"
-							>issue 1528</a>.</li>
+						[[infra]] specification definition. See <a href="https://github.com/w3c/epub-specs/issues/1528">issue 1528</a>.</li>
 					<li>26-Feb-2021: Created a new section for describing general metadata value requirements,
-						specifically whitespace handling. See <a href="https://github.com/w3c/epub-specs/issues/1528"
-							>issue 1528</a>.</li>
+						specifically whitespace handling. See <a href="https://github.com/w3c/epub-specs/issues/1528">issue 1528</a>.</li>
 					<li>17-Feb-2020: File extension recommendations have been removed (affects the package document,
-						XHTML content documents, media overlay documents). See <a
-							href="https://github.com/w3c/epub-specs/issues/1294">issue 1294</a>.</li>
+						XHTML content documents, media overlay documents). See <a href="https://github.com/w3c/epub-specs/issues/1294">issue 1294</a>.</li>
 					<li>15-Feb-2021: Clarified that <code>nav</code> elements without an <code>epub:type</code>
-						attribute are not subject to the EPUB navigation document's content model restrictions. See <a
-							href="https://github.com/w3c/epub-specs/issues/976">issue 976</a>.</li>
+						attribute are not subject to the EPUB navigation document's content model restrictions. See <a href="https://github.com/w3c/epub-specs/issues/976">issue 976</a>.</li>
 					<li>10-Feb-2021: A first draft of the <a href="#sec-security-privacy">security and privacy
 							section</a> has been added.</li>
 					<li>04-Feb-2021: Clarify that the value of <code>dc:language</code> elements must be well-formed
@@ -12086,14 +11600,12 @@ EPUB/images/cover.png</pre>
 						precedence of the attribute. See <a href="https://github.com/w3c/epub-specs/issues/1491">issue
 							1491</a> and <a href="https://github.com/w3c/epub-specs/issues/1494">issue 1494</a>.</li>
 					<li>02-Feb-2021: Added the <code>hreflang</code> attribute to <code>link</code> elements to identify
-						the language of linked resources. See <a href="https://github.com/w3c/epub-specs/issues/1488"
-							>issue 1488</a>.</li>
+						the language of linked resources. See <a href="https://github.com/w3c/epub-specs/issues/1488">issue 1488</a>.</li>
 					<li>20-Jan-2021: Clarified that user-defined media overlay style classes must be declared in the
 						package document metadata. See <a href="https://github.com/w3c/epub-specs/issues/1319">issue
 							1319</a>.</li>
 					<li>20-Jan-2021: Add recommendation that the sum of the media overlay durations for each EPUB
-						content document match the total duration specified for the EPUB publication. See <a
-							href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>.</li>
+						content document match the total duration specified for the EPUB publication. See <a href="https://github.com/w3c/epub-specs/issues/1322">issue 1322</a>.</li>
 					<li>20-Jan-2021: Clarified that the <code>epub:type</code> attribute does not improve the
 						accessibility of publications. Added pointers to the <code>role</code> attribute and the
 						DPUB-ARIA vocabulary for accessibility.</li>
@@ -12101,14 +11613,12 @@ EPUB/images/cover.png</pre>
 						changed to a recommendation that top-level content documents remain consumable when scripting is
 						not available. See <a href="https://github.com/w3c/epub-specs/issues/1444">issue 1444</a>.</li>
 					<li>24-Dec-2020: The specification no longer refers to a release identifier, but the requirement to
-						include a last modification date remains for backwards compatibility. See <a
-							href="https://github.com/w3c/epub-specs/issues/1440">issue 1440</a>.</li>
+						include a last modification date remains for backwards compatibility. See <a href="https://github.com/w3c/epub-specs/issues/1440">issue 1440</a>.</li>
 					<li>16-Dec-2020: Terminology and requirements related to "renditions" of an EPUB publication have
 						been simplified to improve the readability of the specifications (i.e., to align with the
 						generally understood concept that an EPUB publication has only a single rendering described by a
 						single package document). These changes do not affect the ability to include multiple
-						renditions, which are now more fully covered in [[epub-multi-rend-11]]. See <a
-							href="https://github.com/w3c/epub-specs/issues/1436">issue 1436</a>.</li>
+						renditions, which are now more fully covered in [[epub-multi-rend-11]]. See <a href="https://github.com/w3c/epub-specs/issues/1436">issue 1436</a>.</li>
 					<li>14-Nov-2020: The term "semantic inflection" is no longer used to describe the process of adding
 						structural semantics to elements. The term is not widely understood outside of EPUB and is
 						unnecessarily complex. The specification now simply refers to "expressing" or "adding"
@@ -12116,18 +11626,13 @@ EPUB/images/cover.png</pre>
 					<li>09-Nov-2020: The requirement that the ordering of the <code>toc nav</code> match the ordering of
 						EPUB content documents in the spine, and the elements within each file, has been reduced to a
 						recommendation. See <a href="https://github.com/w3c/epub-specs/issues/1283">issue 1283</a>.</li>
-					<li>06-Nov-2020: Clarified that HTML <code>script</code> elements that contain <a
-							href="#sec-scripted-context">data blocks are not instances of scripting</a>. See <a
-							href="https://github.com/w3c/epub-specs/issues/1352">issue 1352</a>.</li>
-					<li>06-Nov-2020: Added WebP to the <a href="#cmt-grp-image">image core media types</a>. See <a
-							href="https://github.com/w3c/epub-specs/issues/1344">issue 1344</a>.</li>
+					<li>06-Nov-2020: Clarified that HTML <code>script</code> elements that contain <a href="#sec-scripted-context">data blocks are not instances of scripting</a>. See <a href="https://github.com/w3c/epub-specs/issues/1352">issue 1352</a>.</li>
+					<li>06-Nov-2020: Added WebP to the <a href="#cmt-grp-image">image core media types</a>. See <a href="https://github.com/w3c/epub-specs/issues/1344">issue 1344</a>.</li>
 					<li>06-Nov-2020: A <a href="#app-identifiers-allowed">restricted set of external identifiers</a> are
 						now allowed in publication resources. <a href="#sec-xml-constraints">References to external
-							entities</a> from the internal DTD subset remain restricted, however. See <a
-							href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
+							entities</a> from the internal DTD subset remain restricted, however. See <a href="https://github.com/w3c/epub-specs/issues/1338">issue 1338</a>.</li>
 					<li>12-Oct-2020: Added OPUS to the <a href="#cmt-grp-audio">audio core media types</a> with a
-						warning that it is still subject to review depending on support in Mac/iOS. See <a
-							href="https://github.com/w3c/epub-specs/issues/645">issue 645</a>.</li>
+						warning that it is still subject to review depending on support in Mac/iOS. See <a href="https://github.com/w3c/epub-specs/issues/645">issue 645</a>.</li>
 					<li>30-Sept-2020: The structure of the EPUB core specifications has been simplified to ease
 						understanding and access to information. This specification now consolidates the authoring
 						requirements from the EPUB 3.2 specification together with the Packages, Content Documents, OCF
@@ -12136,7 +11641,7 @@ EPUB/images/cover.png</pre>
 				</ul>
 			</section>
 		</section>
-		<div data-include="../common/acknowledgements-dedication.html" data-oninclude="fixIncludes"
-			data-include-replace="true"></div>
-	</body>
-</html>
+		<div data-include="../common/acknowledgements-dedication.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+	
+
+</body></html>

--- a/epub33/core/vocab/item-properties.html
+++ b/epub33/core/vocab/item-properties.html
@@ -1,4 +1,4 @@
-<section id="app-item-properties-vocab" class="vocab">
+<html><head></head><body><section id="app-item-properties-vocab" class="vocab">
 	<h3>Manifest properties vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the manifest [^item^]
@@ -218,8 +218,7 @@
 					<th>Description:</th>
 					<td>
 						<p>The <code>switch</code> property indicates that the described [=publication resource=]
-							contains one or more instances of the <a href="#sec-xhtml-content-switch"
-									>deprecated <code>epub:switch</code> element</a>.</p>
+							contains one or more instances of the <a href="#sec-xhtml-content-switch">deprecated <code>epub:switch</code> element</a>.</p>
 					</td>
 				</tr>
 				<tr>
@@ -236,3 +235,4 @@
 		</table>
 	</section>
 </section>
+</body></html>

--- a/epub33/core/vocab/itemref-properties.html
+++ b/epub33/core/vocab/itemref-properties.html
@@ -1,5 +1,4 @@
-
-<section id="app-itemref-properties-vocab" class="vocab">
+<html><head></head><body><section id="app-itemref-properties-vocab" class="vocab">
 	<h3>Spine properties vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the spine [^itemref^] element's
@@ -80,3 +79,4 @@
 		</aside>
 	</section>
 </section>
+</body></html>

--- a/epub33/core/vocab/link.html
+++ b/epub33/core/vocab/link.html
@@ -1,5 +1,4 @@
-
-<section id="app-link-vocab" class="vocab">
+<html><head></head><body><section id="app-link-vocab" class="vocab">
 	<h3>Metadata link vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the metadata [^link^]
@@ -11,11 +10,10 @@
 	<section id="sec-link-rel">
 		<h4>Link relationships</h4>
 		
-		<p>The following values can be used in the <code>link</code> element <a href="#attrdef-link-rel"
-					><code>rel</code> attribute</a> to establish the relationship of the resource referenced in
+		<p>The following values can be used in the <code>link</code> element <a href="#attrdef-link-rel"><code>rel</code> attribute</a> to establish the relationship of the resource referenced in
 			the <a href="#attrdef-href"><code>href</code> attribute</a>.</p>
 		
-		<section id="sec-alternate">
+		<section id="sec-alternate" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L29,https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L34">
 			<h5>alternate</h5>
 			
 			<table class="tabledef" id="alternate">
@@ -29,8 +27,7 @@
 					<tr>
 						<th>Description:</th>
 						<td>
-							<p>The <code>alternate</code> keyword is a subset of the <a
-								data-cite="html#link-type-alternate">HTML
+							<p>The <code>alternate</code> keyword is a subset of the <a data-cite="html#link-type-alternate">HTML
 										<code>alternate</code> keyword</a> for links. It differs as follows:</p>
 							<ul>
 								<li>It MUST NOT be paired with other keywords.</li>
@@ -52,8 +49,7 @@
 					</tr>
 					<tr>
 						<th>Extends:</th>
-						<td>Only applies to the EPUB publication or collection. MUST NOT be used when the <a
-								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+						<td>Only applies to the EPUB publication or collection. MUST NOT be used when the <a href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
 					</tr>
 					<tr>
 						<th>Example:</th>
@@ -70,42 +66,35 @@
 			<h5>marc21xml-record (deprecated)</h5>
 			
 			<p id="marc2xml-record">Use of the <code>marc21xml-record</code> keyword is <a href="#deprecated">deprecated</a>.
-				It is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
-					href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
+				It is replaced by the <a href="#record"><code>record</code></a> keyword with the <a href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
 				"<code>application/marcxml+xml</code>".</p>
 			
-			<p>Refer to the <a 
-				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"><code>marc21xml-record</code>
-				property definition</a> in [[!epubpublications-30]] for more information.</p>
+			<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#marc21xml-record"><code>marc21xml-record</code>
+				property definition</a> in&nbsp;[[!epubpublications-30]] for more information.</p>
 		</section>
 		
 		<section id="sec-mods-record">
 			<h5>mods-record (deprecated)</h5>
 			
 			<p id="mods-record">Use of the <code>mods-record</code> keyword is <a href="#deprecated">deprecated</a>. It
-				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
-					href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
+				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a href="#attrdef-link-media-type"><code>media-type</code> attribute</a> value
 				"<code>application/mods+xml</code>".</p>
 			
-			<p>Refer to the <a 
-				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"><code>mods-record</code>
-				property definition</a> in [[!epubpublications-30]] for more information.</p>
+			<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#mods-record"><code>mods-record</code>
+				property definition</a> in&nbsp;[[!epubpublications-30]] for more information.</p>
 		</section>
 		
 		<section id="sec-onix-record">
 			<h5>onix-record (deprecated)</h5>
 			
 			<p id="onix-record">Use of the <code>onix-record</code> keyword is <a href="#deprecated">deprecated</a>. It
-				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a
-					href="#attrdef-properties">properties attribute</a> value <a href="#onix"
-						><code>onix</code></a>.</p>
+				is replaced by the <a href="#record"><code>record</code></a> keyword with the <a href="#attrdef-properties">properties attribute</a> value <a href="#onix"><code>onix</code></a>.</p>
 			
-			<p>Refer to the <a 
-				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"><code>onix-record</code>
-				property definition</a> in [[!epubpublications-30]] for more information.</p>
+			<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#onix-record"><code>onix-record</code>
+				property definition</a> in&nbsp;[[!epubpublications-30]] for more information.</p>
 		</section>
 		
-		<section id="sec-record">
+		<section id="sec-record" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L69,https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L75">
 			<h5>record</h5>
 			
 			<table class="tabledef" id="record">
@@ -120,14 +109,11 @@
 						<th>Description:</th>
 						<td>
 							<p>Indicates that the referenced resource is a metadata record.</p>
-							<p>The media type of the record MUST be identified in the <a
-									href="#attrdef-link-media-type"><code>media-type</code> attribute</a> when
+							<p>The media type of the record MUST be identified in the <a href="#attrdef-link-media-type"><code>media-type</code> attribute</a> when
 								this keyword is specified.</p>
-							<p>For a list of commonly linked metadata record types, refer to the <a
-									href="https://idpf.org/epub/guides/linked-records/">EPUB Linked Metadata
+							<p>For a list of commonly linked metadata record types, refer to the <a href="https://idpf.org/epub/guides/linked-records/">EPUB Linked Metadata
 									Guide</a></p>
-							<p>If the type of record cannot be identified from the media type, an <a
-									href="#sec-link-properties">identifier property</a> can be assigned in the
+							<p>If the type of record cannot be identified from the media type, an <a href="#sec-link-properties">identifier property</a> can be assigned in the
 									<a href="#attrdef-properties"><code>properties</code> attribute</a>.</p>
 						</td>
 					</tr>
@@ -139,8 +125,7 @@
 					</tr>
 					<tr>
 						<th>Extends:</th>
-						<td>Only applies to the [=EPUB publication=] or collection. MUST NOT be used when the <a
-								href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
+						<td>Only applies to the [=EPUB publication=] or collection. MUST NOT be used when the <a href="#attrdef-refines"><code>refines</code> attribute</a> is present.</td>
 					</tr>
 					<tr>
 						<th>Example:</th>
@@ -153,7 +138,7 @@
 			</table>
 		</section>
 		
-		<section id="sec-voicing">
+		<section id="sec-voicing" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L85,https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L90,https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L97,https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L103">
 			<h5>voicing</h5>
 			
 			<table class="tabledef" id="voicing">
@@ -170,8 +155,7 @@
 							<p>Indicates that the referenced audio file provides an aural representation of the
 								expression or resource (typically, the title or creator) specified by the
 								refines attribute.</p>
-							<p>The media type of the audio file MUST be identified in the <a
-									href="#attrdef-link-media-type"><code>media-type</code> attribute</a> when
+							<p>The media type of the audio file MUST be identified in the <a href="#attrdef-link-media-type"><code>media-type</code> attribute</a> when
 								this keyword is specified.</p>
 						</td>
 					</tr>
@@ -203,9 +187,8 @@
 			<p id="xml-signature">Use of the <code>xml-signature</code> keyword is <a href="#deprecated">deprecated</a>.
 				It is not replaced by another linking method.</p>
 			
-			<p>Refer to the <a 
-				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"><code>xml-signature</code>
-				property definition</a> in [[!epubpublications-30]] for more information.</p>
+			<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xml-signature"><code>xml-signature</code>
+				property definition</a> in&nbsp;[[!epubpublications-30]] for more information.</p>
 		</section>
 		
 		<section id="sec-xmp-record">
@@ -213,13 +196,12 @@
 			
 			<p id="xmp-record">Use of the <code>xmp-record</code> keyword is <a href="#deprecated">deprecated</a>.</p>
 			
-			<p>Refer to the <a 
-				href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"><code>xmp-record</code>
-				property definition</a> in [[!epubpublications-30]] for more information.</p>
+			<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#xmp-record"><code>xmp-record</code>
+				property definition</a> in&nbsp;[[!epubpublications-30]] for more information.</p>
 		</section>
 	</section>
 	
-	<section id="sec-link-properties">
+	<section id="sec-link-properties" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_metadata-link.feature_L123">
 		<h4>Link properties</h4>
 		
 		<p>The following values can be used in the [^link^] element's
@@ -255,3 +237,4 @@
 		</section>
 	</section>
 </section>
+</body></html>

--- a/epub33/core/vocab/meta-property.html
+++ b/epub33/core/vocab/meta-property.html
@@ -1,4 +1,4 @@
-<section id="app-meta-property-vocab" class="vocab">
+<html><head></head><body><section id="app-meta-property-vocab" class="vocab">
 	<h3>Meta properties vocabulary</h3>
 	
 	<p>The properties in this vocabulary are usable in the [^meta^]
@@ -6,8 +6,7 @@
 	
 	<p>Unless indicated otherwise in its "Extends" field, the properties defined in this section are used to
 		define <a href="#subexpression">subexpressions</a>: in other words, a [^meta^] element
-		carrying a property defined in this section MUST have a <code><a
-				href="#attrdef-refines">refines</a></code> attribute referencing a resource or expression being
+		carrying a property defined in this section MUST have a <code><a href="#attrdef-refines">refines</a></code> attribute referencing a resource or expression being
 		augmented.</p>
 	
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
@@ -28,8 +27,8 @@
 					<td>
 						<p>The <code>alternate-script</code> property provides an alternate expression of the
 							associated property value in a different language and/or script. 
-							The language tags of the alternate-script property and its associated property — as expressed 
-							by their respective in-scope xml:lang attributes — MUST NOT be the same.</p>
+							The language tags of the alternate-script property and its associated property&nbsp;— as expressed 
+							by their respective in-scope xml:lang attributes&nbsp;— MUST NOT be the same.</p>
 						<p>This property is typically attached to <code>creator</code> and <code>title</code>
 							properties for internationalization purposes.</p>
 					</td>
@@ -54,22 +53,22 @@
 		</table>
 		
 		<aside class="example" title="Author name expressed in English and Japanese">
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
-   &lt;dc:creator id="creator">
+   &lt;dc:creator id="creator"&gt;
       Haruki Murakami
-   &lt;/dc:creator>
+   &lt;/dc:creator&gt;
    &lt;meta
        refines="#creator"
        property="alternate-script"
-       xml:lang="ja">
+       xml:lang="ja"&gt;
       村上春樹
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
-	<section id="sec-authority">
+	<section id="sec-authority" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L16,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L21,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L28,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L35">
 		<h5>authority</h5>
 		<table class="tabledef" id="authority">
 			<tbody>
@@ -92,8 +91,7 @@
 						<code>xsd:string</code>
 						<div class="note">
 							<p>The former <abbr title="International Digital Publishing Forum">IDPF</abbr> EPUB
-								3 Working Group maintained a <a
-									href="https://idpf.github.io/epub-registries/authorities/">registry of
+								3 Working Group maintained a <a href="https://idpf.github.io/epub-registries/authorities/">registry of
 									subject authorities</a> for use with this property. This Working Group no
 								longer maintains the registry.</p>
 						</div>
@@ -114,7 +112,7 @@
 			</tbody>
 		</table>
 		<aside class="example" title="Expressing A BISAC subject heading">
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
    &lt;dc:subject
       id="subject01"&gt;
@@ -122,14 +120,14 @@
    &lt;/dc:subject&gt;
    &lt;meta
        refines="#subject01"
-       property="authority">
+       property="authority"&gt;
       BISAC
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
-	<section id="sec-belongs-to-collection">
+	<section id="sec-belongs-to-collection" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L45,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L50">
 		<h5>belongs-to-collection</h5>
 		<table class="tabledef" id="belongs-to-collection">
 			<tbody>
@@ -145,16 +143,14 @@
 						<p>The <code>belongs-to-collection</code> property identifies the name of a collection
 							to which the [=EPUB publication=] belongs. An EPUB publication MAY belong to one or more
 							collections.</p>
-						<p>It is also possible to chain these properties using the <a href="#attrdef-refines"
-									><code>refines</code> attribute</a> to indicate that one collection is
+						<p>It is also possible to chain these properties using the <a href="#attrdef-refines"><code>refines</code> attribute</a> to indicate that one collection is
 							itself a member of another collection.</p>
 						<p>To allow [=reading systems=] to organize collections and avoid naming collisions (e.g.,
 							unrelated collections might share a similar name, or different editions of a
 							collection could be released), [=EPUB creators=] SHOULD provide an identifier that uniquely
 							identifies the instance of the collection. The <code>dcterms:identifier</code>
 							property must carry this identifier.</p>
-						<p>The collection MAY more precisely define its nature by attaching a <a
-								href="#collection-type"><code>collection-type</code></a> property.</p>
+						<p>The collection MAY more precisely define its nature by attaching a <a href="#collection-type"><code>collection-type</code></a> property.</p>
 						<p>The position of the EPUB publication within the collection MAY be provided by
 							attaching a <a href="#group-position"><code>group-position</code> property</a>.</p>
 					</td>
@@ -192,10 +188,10 @@
       set
    &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
-	<section id="sec-collection-type">
+	<section id="sec-collection-type" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L60,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L67,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L74">
 		<h5>collection-type</h5>
 		<table class="tabledef" id="collection-type">
 			<tbody>
@@ -262,7 +258,7 @@
 		</table>
 		<aside class="example" title="Identifying a publication belongs to a series">
 			<p>In this example, the publication belongs to the series The New French Cuisine Masters.</p>
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
    &lt;meta
        property="belongs-to-collection"
@@ -275,10 +271,10 @@
       series
    &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
-	<section id="sec-display-seq">
+	<section id="sec-display-seq" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L84,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L89">
 		<h5>display-seq</h5>
 		<table class="tabledef" id="display-seq">
 			<tbody>
@@ -317,7 +313,7 @@
 			</tbody>
 		</table>
 	</section>
-	<section id="sec-file-as">
+	<section id="sec-file-as" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L99,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L104">
 		<h5>file-as</h5>
 		<table class="tabledef" id="file-as">
 			<tbody>
@@ -352,22 +348,22 @@
 		</table>
 		
 		<aside class="example" title="Expressing an author name for sorting">
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
    &lt;dc:creator
-       id="creator01">
+       id="creator01"&gt;
       Lewis Carroll
-   &lt;/dc:creator>
+   &lt;/dc:creator&gt;
    &lt;meta
        refines="#creator01"
-       property="file-as">
+       property="file-as"&gt;
       Carroll, Lewis
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
-	<section id="sec-group-position">
+	<section id="sec-group-position" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L114,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L119">
 		<h5>group-position</h5>
 		<table class="tabledef" id="group-position">
 			<tbody>
@@ -384,8 +380,7 @@
 							[=EPUB publication=] is ordered relative to other works belonging to the same group
 							(whether all EPUB publications or not).</p>
 						<p>[=EPUB creators=] can attach the <code>group-position</code> property to any metadata
-							property that establishes the group but it is typically associated with the <a
-								href="#belongs-to-collection"><code>belongs-to-collection</code>
+							property that establishes the group but it is typically associated with the <a href="#belongs-to-collection"><code>belongs-to-collection</code>
 							property</a>.</p>
 						<p>An EPUB publication can belong to more than one group.</p>
 					</td>
@@ -409,7 +404,7 @@
 		</table>
 		<aside class="example" title="Identifying a publication's position in a set">
 			<p>In this example, the publication is the second in the Lord of the Rings set of books.</p>
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
    &lt;meta property="belongs-to-collection" id="c01"&gt;
       The Lord of the Rings
@@ -425,7 +420,7 @@
       2
    &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 		<aside class="example" title="Expressing a decimal-separated value for position">
 			<p>In this example, the decimal-separated value in the <code>group-position</code> attribute
@@ -434,24 +429,24 @@
    …
    &lt;meta
        property="belongs-to-collection"
-       id="cygnus-x-1">
+       id="cygnus-x-1"&gt;
       Physical Review D
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#cygnus-x-1"
-       property="collection-type">
+       property="collection-type"&gt;
       series
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#cygnus-x-1"
-       property="group-position">
+       property="group-position"&gt;
       98.4
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
-	<section id="sec-identifier-type">
+	<section id="sec-identifier-type" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L129,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L136">
 		<h5>identifier-type</h5>
 		<table class="tabledef" id="identifier-type">
 			<tbody>
@@ -486,8 +481,7 @@
 				<tr>
 					<th>Extends:</th>
 					<td>
-						[^dc:identifier^], <a href="#sec-opf-dcmes-optional-def"
-								><code>dc:source</code></a>
+						[^dc:identifier^], <a href="#sec-opf-dcmes-optional-def"><code>dc:source</code></a>
 					</td>
 				</tr>
 			</tbody>
@@ -495,20 +489,20 @@
 		<aside class="example" title="Indicating an identifier is an ISBN">
 			<p>In this example, the ONIX code list 5 scheme defines the meaning of the numeric value
 					<code>15</code>.</p>
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
    &lt;dc:identifier
-       id="isbn-id">
+       id="isbn-id"&gt;
       urn:isbn:9780101010101
-   &lt;/dc:identifier>
+   &lt;/dc:identifier&gt;
    &lt;meta
       refines="#isbn-id"
       property="identifier-type"
-      scheme="onix:codelist5">
+      scheme="onix:codelist5"&gt;
      15
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
 	<section id="sec-meta-auth">
@@ -516,11 +510,10 @@
 		
 		<p id="meta-auth">Use of this property is <a href="#deprecated">deprecated</a>.</p>
 		
-		<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"
-					><code>meta-auth</code> property definition</a> in [[!epubpublications-30]] for more
+		<p>Refer to the <a href="https://idpf.org/epub/30/spec/epub30-publications-20111011.html#meta-auth"><code>meta-auth</code> property definition</a> in&nbsp;[[!epubpublications-30]] for more
 			information.</p>
 	</section>
-	<section id="sec-role">
+	<section id="sec-role" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L155,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L160">
 		<h5>role</h5>
 		<table class="tabledef" id="role">
 			<tbody>
@@ -560,8 +553,7 @@
 				<tr>
 					<th>Extends:</th>
 					<td>
-						[^dc:contributor^], [^dc:creator^], <a
-							href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>
+						[^dc:contributor^], [^dc:creator^], <a href="#sec-opf-dcmes-optional-def"><code>dc:publisher</code></a>
 					</td>
 				</tr>
 			</tbody>
@@ -569,57 +561,57 @@
 		<aside class="example" title="Differentiating creator roles">
 			<p>In this example, MARC Relators vocabulary values differentiate the author from the illustrator of
 				a work.</p>
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
    &lt;dc:creator
-      id="creator01">
+      id="creator01"&gt;
      Lewis Carroll
-   &lt;/dc:creator>
+   &lt;/dc:creator&gt;
    &lt;meta
        refines="#creator01"
        property="role"
-       scheme="marc:relators">
+       scheme="marc:relators"&gt;
       aut
-   &lt;/meta>
+   &lt;/meta&gt;
 
    &lt;dc:creator
-       id="creator02">
+       id="creator02"&gt;
       John Tenniel
-   &lt;/dc:creator>
+   &lt;/dc:creator&gt;
    &lt;meta
        refines="#creator02"
        property="role"
-       scheme="marc:relators">
+       scheme="marc:relators"&gt;
       ill
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 		<aside class="example" title="Identifying a creator who has multiple roles">
 			<p>In this example, the creator is both the author and illustrator of the work.</p>
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
    &lt;dc:creator
-       id="creator01">
+       id="creator01"&gt;
       Maurice Sendak
-   &lt;/dc:creator>
+   &lt;/dc:creator&gt;
    &lt;meta
        refines="#creator01"
        property="role"
-       scheme="marc:relators">
+       scheme="marc:relators"&gt;
       aut
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#creator01"
        property="role"
-       scheme="marc:relators">
+       scheme="marc:relators"&gt;
       ill
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
-	<section id="sec-source-of">
+	<section id="sec-source-of" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L170,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L175,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L182,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L189,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L196">
 		<h5>source-of</h5>
 		<table class="tabledef" id="source-of">
 			<tbody>
@@ -635,8 +627,7 @@
 						<p>The <code>source-of</code> property indicates a unique aspect of an adapted source
 							resource that has been retained in the [=EPUB publication=]. </p>
 						<p>This specification defines the <code>pagination</code> value to indicate that the
-							referenced <code>dc:source</code> element is the source of the <a
-								data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code> properties</a> defined in the
+							referenced <code>dc:source</code> element is the source of the <a data-cite="epub-ssv-11#pagebreak"><code>pagebreak</code> properties</a> defined in the
 							content.</p>
 					</td>
 				</tr>
@@ -667,39 +658,39 @@
 			navigation.</p>
 		
 		<aside class="example" title="Identifying the print pagination source of a publication">
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
    &lt;dc:identifier
-       id="isbn-id">
+       id="isbn-id"&gt;
       urn:isbn:9780101010101
-   &lt;/dc:identifier>
+   &lt;/dc:identifier&gt;
    &lt;meta
        refines="#isbn-id"
        property="identifier-type"
-       scheme="onix:codelist5">
+       scheme="onix:codelist5"&gt;
       15
-   &lt;/meta>
+   &lt;/meta&gt;
 
    &lt;dc:source
-       id="src-id">
+       id="src-id"&gt;
       urn:isbn:9780375704024
-   &lt;/dc:source>
+   &lt;/dc:source&gt;
    &lt;meta
        refines="#src-id"
        property="identifier-type"
-       scheme="onix:codelist5">
+       scheme="onix:codelist5"&gt;
       15
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#src-id"
-       property="source-of">
+       property="source-of"&gt;
       pagination
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
-	<section id="sec-term">
+	<section id="sec-term" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L206,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L211,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L218,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L225">
 		<h5>term</h5>
 		<table class="tabledef" id="term">
 			<tbody>
@@ -737,7 +728,7 @@
 		</table>
 		<aside class="example" title="Expressing a BISAC code for a subject heading">
 			<p>The following example shows a BISAC code for a subject heading.</p>
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
    &lt;dc:subject
        id="subject01"&gt;
@@ -745,19 +736,19 @@
    &lt;/dc:subject&gt;
    &lt;meta
        refines="#subject01"
-       property="authority">
+       property="authority"&gt;
       BISAC
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#subject01"
-       property="term">
+       property="term"&gt;
       FIC024000
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
-	<section id="sec-title-type">
+	<section id="sec-title-type" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L235,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L240,https://w3c.github.io/epub-structural-tests/#D-vocabularies_meta-properties.feature_L247">
 		<h5>title-type</h5>
 		<table class="tabledef" id="title-type">
 			<tbody>
@@ -802,188 +793,189 @@
 			</tbody>
 		</table>
 		<aside class="example" title="Expressing different title types">
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
-   &lt;dc:title id="t1">
+   &lt;dc:title id="t1"&gt;
       A Dictionary of Modern English Usage
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    &lt;meta
        refines="#t1"
-       property="title-type">
+       property="title-type"&gt;
       main
-   &lt;/meta>
+   &lt;/meta&gt;
 
-   &lt;dc:title id="t2">
+   &lt;dc:title id="t2"&gt;
       First Edition
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    &lt;meta
        refines="#t2"
-       property="title-type">
+       property="title-type"&gt;
       edition
-   &lt;/meta>
+   &lt;/meta&gt;
 
-   &lt;dc:title id="t3">
+   &lt;dc:title id="t3"&gt;
       Fowler's
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    &lt;meta
        refines="#t3"
-       property="title-type">
+       property="title-type"&gt;
       short
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 		
 		<aside class="example" title="Expressing complex titles">
 			<p id="cookbook-ex">This example shows how to classify the title "The Great Cookbooks of the World:
 				Mon premier guide de cuisson, un Mémoire. The New French Cuisine Masters, Volume Two. Special
 				Anniversary Edition".</p>
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
    …
    &lt;dc:title
        id="t1"
-       xml:lang="fr">
+       xml:lang="fr"&gt;
       Mon premier guide de cuisson, un Mémoire
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    &lt;meta
        refines="#t1"
-       property="title-type">
+       property="title-type"&gt;
       main
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#t1"
-       property="display-seq">
+       property="display-seq"&gt;
       2
-   &lt;/meta>
+   &lt;/meta&gt;
 
-   &lt;dc:title id="t2">
+   &lt;dc:title id="t2"&gt;
       The Great Cookbooks of the World
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    &lt;meta
        refines="#t2"
-       property="title-type">
+       property="title-type"&gt;
       collection
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#t2"
-       property="display-seq">
+       property="display-seq"&gt;
       1
-   &lt;/meta>
+   &lt;/meta&gt;
 
-   &lt;dc:title id="t3">
+   &lt;dc:title id="t3"&gt;
       The New French Cuisine Masters
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    &lt;meta
        refines="#t3"
-       property="title-type">
+       property="title-type"&gt;
       collection
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#t3"
-       property="display-seq">
+       property="display-seq"&gt;
       3
-   &lt;/meta>
+   &lt;/meta&gt;
 
-   &lt;dc:title id="t4">
+   &lt;dc:title id="t4"&gt;
       Special Anniversary Edition
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    &lt;meta
        refines="#t4"
-       property="title-type">
+       property="title-type"&gt;
       edition
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#t4"
-       property="display-seq">
+       property="display-seq"&gt;
       4
-   &lt;/meta>
+   &lt;/meta&gt;
 
-   &lt;dc:title id="t5">
+   &lt;dc:title id="t5"&gt;
       The Great Cookbooks of the World: 
       Mon premier guide de cuisson, un Mémoire. 
       The New French Cuisine Masters, Volume Two. 
       Special Anniversary Edition
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    &lt;meta
        refines="#t5"
-       property="title-type">
+       property="title-type"&gt;
       expanded
-   &lt;/meta>
+   &lt;/meta&gt;
    …
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
 	<section id="sec-property-examples">
 		<h5>Examples</h5>
 		<aside class="example" title="A typical set of refines metadata in an EPUB publication">
-			<pre>&lt;metadata …>
+			<pre>&lt;metadata …&gt;
 
-   &lt;dc:identifier id="pub-id">
+   &lt;dc:identifier id="pub-id"&gt;
       urn:uuid:A1B0D67E-2E81-4DF5-9E67-A64CBE366809
-   &lt;/dc:identifier>
+   &lt;/dc:identifier&gt;
 
-   &lt;dc:identifier id="isbn-id">
+   &lt;dc:identifier id="isbn-id"&gt;
       urn:isbn:9780101010101
-   &lt;/dc:identifier>
+   &lt;/dc:identifier&gt;
    &lt;meta
        refines="#isbn-id"
        property="identifier-type"
-       scheme="onix:codelist5">
+       scheme="onix:codelist5"&gt;
       15
-   &lt;/meta>
+   &lt;/meta&gt;
 
-   &lt;dc:source id="src-id">
+   &lt;dc:source id="src-id"&gt;
       urn:isbn:9780375704024
-   &lt;/dc:source>
+   &lt;/dc:source&gt;
    &lt;meta
        refines="#src-id"
        property="identifier-type"
-       scheme="onix:codelist5">
+       scheme="onix:codelist5"&gt;
       15
-   &lt;/meta>
+   &lt;/meta&gt;
 
-   &lt;dc:title id="title">
+   &lt;dc:title id="title"&gt;
       Norwegian Wood
-   &lt;/dc:title>
+   &lt;/dc:title&gt;
    &lt;meta
        refines="#title"
-       property="title-type">
+       property="title-type"&gt;
       main
-   &lt;/meta>
+   &lt;/meta&gt;
 
-   &lt;dc:language>
+   &lt;dc:language&gt;
       en
-   &lt;/dc:language>
+   &lt;/dc:language&gt;
 
    &lt;dc:creator
-       id="creator">
+       id="creator"&gt;
       Haruki Murakami
-   &lt;/dc:creator>
+   &lt;/dc:creator&gt;
    &lt;meta
        refines="#creator"
        property="role"
        scheme="marc:relators"
-       id="role">
+       id="role"&gt;
       aut
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#creator"
        property="alternate-script"
-       xml:lang="ja">
+       xml:lang="ja"&gt;
       村上 春樹
-   &lt;/meta>
+   &lt;/meta&gt;
    &lt;meta
        refines="#creator"
-       property="file-as">
+       property="file-as"&gt;
       Murakami, Haruki
-   &lt;/meta>
+   &lt;/meta&gt;
 
    &lt;meta
-       property="dcterms:modified">
+       property="dcterms:modified"&gt;
       2011-01-01T12:00:00Z
-   &lt;/meta>
+   &lt;/meta&gt;
 
-&lt;/metadata></pre>
+&lt;/metadata&gt;</pre>
 		</aside>
 	</section>
 </section>
+</body></html>

--- a/epub33/core/vocab/overlays.html
+++ b/epub33/core/vocab/overlays.html
@@ -1,4 +1,4 @@
-<section id="app-overlays-vocab" class="vocab">
+<html><head></head><body><section id="app-overlays-vocab" class="vocab">
 	<h3>Media overlays vocabulary</h3>
 	<p>The properties in this vocabulary are usable in the [^meta^] element's
 			<code>property</code> attribute.</p>
@@ -6,7 +6,7 @@
 			<code>http://www.idpf.org/epub/vocab/overlays/#</code>.</p>
 	<p>The prefix "<code>media:</code>" is <a href="#sec-metadata-reserved-prefixes">reserved for use</a> with
 		properties in this vocabulary and does not have to be declared in the [=package document=].</p>
-	<section id="sec-active-class">
+	<section id="sec-active-class" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_media-overlays.feature_L16">
 		<h4>active-class</h4>
 		<table class="tabledef" id="active-class">
 			<tbody>
@@ -43,7 +43,7 @@
 			</tbody>
 		</table>
 	</section>
-	<section id="sec-duration">
+	<section id="sec-duration" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_media-overlays.feature_L25,https://w3c.github.io/epub-structural-tests/#D-vocabularies_media-overlays.feature_L30,https://w3c.github.io/epub-structural-tests/#D-vocabularies_media-overlays.feature_L35">
 		<h4>duration</h4>
 		<table class="tabledef" id="duration">
 			<tbody>
@@ -114,7 +114,7 @@
 			</tbody>
 		</table>
 	</section>
-	<section id="sec-playback-active-class">
+	<section id="sec-playback-active-class" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_media-overlays.feature_L47">
 		<h4>playback-active-class</h4>
 		<table class="tabledef" id="playback-active-class">
 			<tbody>
@@ -152,3 +152,4 @@
 		</table>
 	</section>
 </section>
+</body></html>

--- a/epub33/core/vocab/rendering.html
+++ b/epub33/core/vocab/rendering.html
@@ -1,4 +1,4 @@
-<section id="app-rendering-vocab">
+<html><head></head><body><section id="app-rendering-vocab">
 	<h3>Package rendering vocabulary</h3>
 	
 	<p>The prefix URL for <a href="#sec-default-vocab">referencing these properties</a> is
@@ -17,7 +17,7 @@
 			The following table provides a map to the properties, overrides, and where they are defined.</p>
 	</div>
 		
-	<table class="tabledef" class="zebra">
+	<table class="tabledef">
 		<thead>
 			<tr>
 				<th>Property</th>
@@ -61,7 +61,7 @@
 				<td><a href="#spread"></a></td>
 			</tr>
 			<tr>
-				<td>&#8212;</td>
+				<td>—</td>
 				<td>
 					<ul>
 						<li><code>rendition:page-spread-center</code></li>
@@ -73,7 +73,7 @@
 			</tr>
 			<tr>
 				<td><code>rendition:viewport</code> (Deprecated)</td>
-				<td>&#8212;</td>
+				<td>—</td>
 				<td><a href="#viewport"></a></td>
 			</tr>
 			<tr>
@@ -89,7 +89,7 @@
 				<td><a href="#flow"></a></td>
 			</tr>
 			<tr>
-				<td>&#8212;</td>
+				<td>—</td>
 				<td>
 					<ul>
 						<li><code>rendition:align-x-center</code></li>
@@ -100,7 +100,7 @@
 		</tbody>
 	</table>
 	
-	<section id="sec-rendering-custom-properties">
+	<section id="sec-rendering-custom-properties" data-epubcheck="true" data-tests="https://w3c.github.io/epub-structural-tests/#D-vocabularies_package-rendering-vocab.feature_L19">
 		<h4>Custom rendering properties</h4>
 		
 		<p>[=Reading system=] developers may introduce functionality not defined in this specification to address 
@@ -117,3 +117,4 @@
 		</div>
 	</section>
 </section>
+</body></html>


### PR DESCRIPTION
The preview and diff files generated automatically are useless: the former does not include the vocabularies and the latter is way too large. A [githack preview](https://raw.githack.com/w3c/epub-specs/add-structural-test-references/epub33/core/index.html#sec-container-file-and-dir-structure) is preferable: this URL points to a typical occurence of a epubcheck test reference.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2520.html" title="Last updated on Jan 13, 2023, 7:41 AM UTC (6674868)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2520/03cf42f...6674868.html" title="Last updated on Jan 13, 2023, 7:41 AM UTC (6674868)">Diff</a>