### PR TITLE
Editorial: correct double-dot URL path segment reference

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1937,7 +1937,7 @@
 						<ul>
 							<li>relative URL strings starting with a <code>/</code> (<code>U+002F</code>) (for example,
 									<code>/EPUB/content.xhtml</code>) are disallowed; </li>
-							<li>relative URL strings containing more [=double-dot path segments=] than needed to reach
+							<li>relative URL strings containing more [=double-dot URL path segments=] than needed to reach
 								the target file (for example, <code>EPUB/../../../../config.xml</code>) are disallowed; </li>
 							<li>any other absolute or relative URL string is allowed.</li>
 						</ul>
@@ -2008,7 +2008,7 @@
    &lt;rootfiles&gt;
       &lt;rootfile
           full-path="EPUB/Great_Expectations.opf"
-          media-type="application/oebps-package+xml" /&gt;	
+          media-type="application/oebps-package+xml" /&gt;
    &lt;/rootfiles&gt;
 &lt;/container&gt;</pre>
 
@@ -2521,7 +2521,7 @@
 
 									<pre>&lt;encryption
     xmlns="urn:oasis:names:tc:opendocument:xmlns:container"&gt;
-   &lt;enc:EncryptedData 
+   &lt;enc:EncryptedData
        xmlns:enc="http://www.w3.org/2001/04/xmlenc#"&gt;
       …
       &lt;enc:CipherData&gt;
@@ -2700,7 +2700,7 @@
        Id="sig"
        xmlns="http://www.w3.org/2000/09/xmldsig#"&gt;
       &lt;SignedInfo&gt;
-         &lt;CanonicalizationMethod 
+         &lt;CanonicalizationMethod
              Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
             &lt;SignatureMethod
                 Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/&gt;
@@ -2720,7 +2720,7 @@
                &lt;P&gt;…&lt;/P&gt;
                &lt;Q&gt;…&lt;/Q&gt;
                &lt;G&gt;…&lt;/G&gt;
-               &lt;Y&gt;…&lt;/Y&gt; 
+               &lt;Y&gt;…&lt;/Y&gt;
             &lt;/DSAKeyValue&gt;
          &lt;/KeyValue&gt;
       &lt;/KeyInfo&gt;
@@ -2728,19 +2728,19 @@
          &lt;Manifest
              Id="Manifest1"&gt;
             &lt;Reference
-                URI="EPUB/book.xhtml"&gt;                    
-               &lt;Transforms&gt;                                                
+                URI="EPUB/book.xhtml"&gt;
+               &lt;Transforms&gt;
                   &lt;Transform
-                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;                        
+                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
                &lt;/Transforms&gt;
                &lt;DigestMethod
                    Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
                &lt;DigestValue&gt;…&lt;/DigestValue&gt;
             &lt;/Reference&gt;
             &lt;Reference URI="EPUB/images/cover.jpeg"&gt;
-               &lt;Transforms&gt;                                                
+               &lt;Transforms&gt;
                   &lt;Transform
-                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;                        
+                      Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
                &lt;/Transforms&gt;
                &lt;DigestMethod
                    Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/&gt;
@@ -2748,7 +2748,7 @@
             &lt;/Reference&gt;
          &lt;/Manifest&gt;
       &lt;/Object&gt;
-   &lt;/Signature&gt; 
+   &lt;/Signature&gt;
 &lt;/signatures&gt;</pre>
 								</aside>
 							</section>
@@ -3029,17 +3029,17 @@
 							<code>URI</code> attribute of the <code>CipherReference</code> element MUST reference a <a href="#cmt-grp-font">Font core media type resource</a>.</p>
 
 					<aside class="example" title="An entry for an obfuscated font">
-						<pre>&lt;encryption 
-    xmlns="urn:oasis:names:tc:opendocument:xmlns:container" 
+						<pre>&lt;encryption
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container"
     xmlns:enc="http://www.w3.org/2001/04/xmlenc#"&gt;
-   &lt;enc:EncryptedData&gt; 
+   &lt;enc:EncryptedData&gt;
       &lt;enc:EncryptionMethod
-          Algorithm="http://www.idpf.org/2008/embedding"/&gt; 
-      &lt;enc:CipherData&gt; 
+          Algorithm="http://www.idpf.org/2008/embedding"/&gt;
+      &lt;enc:CipherData&gt;
          &lt;enc:CipherReference
-             URI="EPUB/Fonts/BKANT.TTF"/&gt;  
-      &lt;/enc:CipherData&gt; 
-   &lt;/enc:EncryptedData&gt;  
+             URI="EPUB/Fonts/BKANT.TTF"/&gt;
+      &lt;/enc:CipherData&gt;
+   &lt;/enc:EncryptedData&gt;
 &lt;/encryption&gt;</pre>
 					</aside>
 
@@ -3172,7 +3172,7 @@
       …
       &lt;link
           rel="record"
-          href="meta/9780000000001.xml" 
+          href="meta/9780000000001.xml"
           media-type="application/marc"/&gt;
       …
    &lt;/metadata&gt;
@@ -3236,7 +3236,7 @@
    &lt;manifest&gt;
       …
       &lt;item
-          id="nav" 
+          id="nav"
           href="nav.xhtml"
           properties="nav"
           media-type="application/xhtml+xml"/&gt;
@@ -3290,7 +3290,7 @@
    &lt;metadata …&gt;
       …
       &lt;meta
-          property="media:duration" 
+          property="media:duration"
           refines="#c01_overlay"&gt;
          0:32:29
       &lt;/meta&gt;
@@ -4459,7 +4459,7 @@
 
 &lt;package …&gt;
    &lt;metadata …&gt;
-      … 
+      …
       &lt;link rel="record"
           href="front.xhtml#meta-json"
           media-type="application/xhtml+xml"
@@ -4508,7 +4508,7 @@ XHTML:
    …
    &lt;link
        rel="record"
-       href="meta/9780000000001.xml" 
+       href="meta/9780000000001.xml"
        media-type="application/marc"/&gt;
    …
 &lt;/metadata&gt;</pre>
@@ -4547,13 +4547,13 @@ XHTML:
     …
     prefix="foaf: http://xmlns.com/foaf/spec/"&gt;
    &lt;metadata …&gt;
-      … 
+      …
       &lt;link
           refines="#creator01"
           rel="foaf:homepage"
           href="http://example.org/book-info/12389347" /&gt;
       …
-   &lt;/metadata&gt; 
+   &lt;/metadata&gt;
    …
 &lt;/package&gt;
 </pre>
@@ -4569,7 +4569,7 @@ XHTML:
        href="http://example.org/onix/12389347"
        media-type="application/xml"
        properties="onix" /&gt;
-    
+
    &lt;link rel="record"
        href="meta/meta.jsonld"
        media-type="application/ld+json" /&gt;
@@ -4837,59 +4837,59 @@ XHTML:
    …
    &lt;manifest&gt;
       &lt;item
-          id="nav" 
-          href="nav.xhtml" 
+          id="nav"
+          href="nav.xhtml"
           properties="nav"
           media-type="application/xhtml+xml"/&gt;
       &lt;item
-          id="intro" 
-          href="intro.xhtml" 
+          id="intro"
+          href="intro.xhtml"
           media-type="application/xhtml+xml"/&gt;
       &lt;item
-          id="c1" 
-          href="chap1.xhtml" 
+          id="c1"
+          href="chap1.xhtml"
           media-type="application/xhtml+xml"/&gt;
       &lt;item
-          id="c1-answerkey" 
-          href="chap1-answerkey.xhtml" 
+          id="c1-answerkey"
+          href="chap1-answerkey.xhtml"
           media-type="application/xhtml+xml"/&gt;
       &lt;item
-          id="c2" 
-          href="chap2.xhtml" 
+          id="c2"
+          href="chap2.xhtml"
           media-type="application/xhtml+xml"/&gt;
       &lt;item
-          id="c2-answerkey" 
-          href="chap2-answerkey.xhtml" 
+          id="c2-answerkey"
+          href="chap2-answerkey.xhtml"
           media-type="application/xhtml+xml"/&gt;
       &lt;item
-          id="c3" 
-          href="chap3.xhtml" 
+          id="c3"
+          href="chap3.xhtml"
           media-type="application/xhtml+xml"/&gt;
       &lt;item
-          id="c3-answerkey" 
-          href="chap3-answerkey.xhtml" 
-          media-type="application/xhtml+xml"/&gt;    
-      &lt;item
-          id="notes" 
-          href="notes.xhtml" 
+          id="c3-answerkey"
+          href="chap3-answerkey.xhtml"
           media-type="application/xhtml+xml"/&gt;
       &lt;item
-          id="cover" 
-          href="./images/cover.svg" 
+          id="notes"
+          href="notes.xhtml"
+          media-type="application/xhtml+xml"/&gt;
+      &lt;item
+          id="cover"
+          href="./images/cover.svg"
           properties="cover-image"
           media-type="image/svg+xml"/&gt;
       &lt;item
-          id="f1" 
-          href="./images/fig1.jpg" 
+          id="f1"
+          href="./images/fig1.jpg"
           media-type="image/jpeg"/&gt;
       &lt;item
-          id="f2" 
-          href="./images/fig2.jpg" 
+          id="f2"
+          href="./images/fig2.jpg"
           media-type="image/jpeg"/&gt;
       &lt;item
-          id="css" 
-          href="./style/book.css" 
-          media-type="text/css"/&gt;   
+          id="css"
+          href="./style/book.css"
+          media-type="text/css"/&gt;
    &lt;/manifest&gt;
    …
 &lt;/package&gt;</pre>
@@ -4914,7 +4914,7 @@ XHTML:
           id="page-001-svg"
           href="images/page-001.svg"
           media-type="image/svg+xml"/&gt;
-      … 
+      …
       …
    &lt;/manifest&gt;
    &lt;spine&gt;
@@ -5060,7 +5060,7 @@ Package document:
           id="audio01"
           href="http://www.example.com/book/audio/ch01.mp4"
           media-type="audio/mp4"/&gt;
-   
+
       &lt;item
           id="c01"
           href="XHTML/chapter001.xhtml"
@@ -6785,23 +6785,23 @@ No Entry</pre>
           name="viewport"
           content="width=1200,
           height=900"/&gt;
-      
+
       &lt;link
           rel="stylesheet"
           href="eink-style.css"
           media="(max-monochrome: 3)"/&gt;
-         
+
       &lt;link
           rel="stylesheet"
           href="skinnytablet-style.css"
           media="((color) and (max-height:600px) and (orientation:landscape),
                   (color) and (max-width:600px) and (orientation:portrait))"/&gt;
-      
+
       &lt;link
           rel="stylesheet"
           href="fattablet-style.css"
           media="((color) and (min-height:601px) and (orientation:landscape),
-                  (color) and (min-width:601px) and (orientation:portrait))"/&gt;	
+                  (color) and (min-width:601px) and (orientation:portrait))"/&gt;
    &lt;/head&gt;
    …
 &lt;/html&gt;</pre>
@@ -6975,7 +6975,7 @@ No Entry</pre>
           property="rendition:layout"&gt;
          pre-paginated
       &lt;/meta&gt;
-      
+
       &lt;meta
           property="rendition:spread"&gt;
          none
@@ -7011,7 +7011,7 @@ No Entry</pre>
           property="rendition:layout"&gt;
          pre-paginated
       &lt;/meta&gt;
-      
+
       &lt;meta
           property="rendition:spread"&gt;
          landscape
@@ -7052,7 +7052,7 @@ No Entry</pre>
           property="rendition:layout"&gt;
          pre-paginated
       &lt;/meta&gt;
-      
+
       &lt;meta
           property="rendition:spread"&gt;
          both
@@ -7099,7 +7099,7 @@ No Entry</pre>
          both
       &lt;/meta&gt;
    &lt;/metadata&gt;
-   
+
    &lt;spine&gt;
       &lt;itemref
           idref="introduction"
@@ -7234,7 +7234,7 @@ No Entry</pre>
           property="rendition:layout"&gt;
           reflowable
       &lt;/meta&gt;
-	  
+
       &lt;meta
           property="rendition:spread"&gt;
           landscape
@@ -7384,7 +7384,7 @@ No Entry</pre>
 										ratio of 844 pixels wide by 1200 pixels high.</p>
 
 									<pre>&lt;svg xmlns="http://www.w3.org/2000/svg"
-     version="1.1" 
+     version="1.1"
      viewBox="0 0 844 1200"&gt;
    …
 &lt;/svg&gt;</pre>
@@ -8184,7 +8184,7 @@ No Entry</pre>
 						attributes to indicate a specific offset within the clip.</p>
 
 					<aside class="example" title="Media overlays markup for a single phrase or sentence">
-						<pre>&lt;par&gt;                        
+						<pre>&lt;par&gt;
    &lt;text
        src="chapter1.xhtml#sentence1"/&gt;
    &lt;audio
@@ -8204,7 +8204,7 @@ No Entry</pre>
 							document.</p>
 
 						<pre>&lt;smil
-    xmlns="http://www.w3.org/ns/SMIL" 
+    xmlns="http://www.w3.org/ns/SMIL"
     version="3.0"&gt;
    &lt;body&gt;
       &lt;par id="par1"&gt;
@@ -8293,14 +8293,14 @@ No Entry</pre>
    &lt;body&gt;
 
       &lt;!-- a chapter --&gt;
-      
+
       &lt;seq
           id="id1"
           epub:textref="chapter1.xhtml#sectionstart"
           epub:type="chapter"&gt;
 
          &lt;!-- the section title --&gt;
-         
+
          &lt;par id="id2"&gt;
             &lt;text
                 src="chapter1.xhtml#section1_title"/&gt;
@@ -8311,7 +8311,7 @@ No Entry</pre>
          &lt;/par&gt;
 
          &lt;!-- some sentences in the chapter --&gt;
-         
+
          &lt;par id="id3"&gt;
             &lt;text
                 src="chapter1.xhtml#text1"/&gt;
@@ -8330,7 +8330,7 @@ No Entry</pre>
          &lt;/par&gt;
 
          &lt;!-- a figure --&gt;
-         
+
          &lt;seq
              id="id7"
              epub:textref="chapter1.xhtml#figure"&gt;
@@ -8353,7 +8353,7 @@ No Entry</pre>
          &lt;/seq&gt;
 
          &lt;!-- more sentences in the chapter (outside the figure) --&gt;
-         
+
          &lt;par id="id12"&gt;
             &lt;text
                 src="chapter1.xhtml#text3"/&gt;
@@ -8387,33 +8387,33 @@ No Entry</pre>
       &lt;section
           id="sectionstart"
           epub:type="chapter"&gt;
-         
+
          &lt;h1 id="section1_title"&gt;
             The Section Title
          &lt;/h1&gt;
-         
+
          &lt;p id="text1"&gt;
             The first phrase of the main text body.
          &lt;/p&gt;
-         
+
          &lt;p id="text2"&gt;
             The second phrase of the main text body.
          &lt;/p&gt;
-         
+
          &lt;figure id="figure"&gt;
             &lt;img id="photo"
-                src="photo.png" 
+                src="photo.png"
                 alt="a photograph for which there is a caption" /&gt;
-            
+
             &lt;figcaption id="caption"&gt;
                The photo caption
             &lt;/figcaption&gt;
          &lt;/figure&gt;
-         
+
          &lt;p id="text3"&gt;
             The third phrase of the main text body.
          &lt;/p&gt;
-         
+
          &lt;p id="text4"&gt;
             The fourth phrase of the main text body.
          &lt;/p&gt;
@@ -8489,7 +8489,7 @@ No Entry</pre>
 
 					<aside class="example" title="Semantic markup for a media overlay document containing a figure">
 						<pre>&lt;smil
-    xmlns="http://www.w3.org/ns/SMIL" 
+    xmlns="http://www.w3.org/ns/SMIL"
     xmlns:epub="http://www.idpf.org/2007/ops"
     version="3.0"&gt;
    &lt;body&gt;
@@ -8644,14 +8644,14 @@ html.my-document-playing * {
    …
    &lt;manifest&gt;
       &lt;item
-          id="ch1" 
-          href="chapter1.xhtml" 
-          media-type="application/xhtml+xml" 
+          id="ch1"
+          href="chapter1.xhtml"
+          media-type="application/xhtml+xml"
           media-overlay="ch1_audio"/&gt;
-   
+
       &lt;item
-          id="ch1_audio" 
-          href="chapter1_audio.smil" 
+          id="ch1_audio"
+          href="chapter1_audio.smil"
           media-type="application/smil+xml"/&gt;
       …
    &lt;/manifest&gt;
@@ -8696,34 +8696,34 @@ html.my-document-playing * {
           refines="#ch1_audio"&gt;
          0:32:29
       &lt;/meta&gt;
-      
+
       &lt;meta
           property="media:duration"
           refines="#ch2_audio"&gt;
          0:34:02
       &lt;/meta&gt;
-      
+
       &lt;meta
           property="media:duration"
           refines="#ch3_audio"&gt;
          0:29:49
       &lt;/meta&gt;
-      
+
       &lt;meta
           property="media:duration"&gt;
          1:36:20
       &lt;/meta&gt;
-      
+
       &lt;meta
           property="media:narrator"&gt;
          Joe Speaker
       &lt;/meta&gt;
-      
+
       &lt;meta
           property="media:active-class"&gt;
          my-active-item
       &lt;/meta&gt;
-      
+
       &lt;meta
           property="media:playback-active-class"&gt;
          my-document-playing
@@ -8773,7 +8773,7 @@ html.my-document-playing * {
 						<p>Media overlay document:</p>
 
 						<pre>&lt;smil
-    xmlns="http://www.w3.org/ns/SMIL" 
+    xmlns="http://www.w3.org/ns/SMIL"
     xmlns:epub="http://www.idpf.org/2007/ops"
     version="3.0"&gt;
    &lt;body&gt;
@@ -8820,12 +8820,12 @@ html.my-document-playing * {
       &lt;p id="para1"&gt;
          This is the paragraph before the page break …
       &lt;/p&gt;
-      
+
       &lt;span
           id="pgbreak1"
           role="doc-pagebreak"
           aria-label="14"/&gt;
-      
+
       &lt;p id="para2"&gt;
          This is the paragraph after the page break …
       &lt;/p&gt;
@@ -8879,7 +8879,7 @@ html.my-document-playing * {
 							next paragraph.</p>
 
 						<pre>&lt;smil
-    xmlns="http://www.w3.org/ns/SMIL" 
+    xmlns="http://www.w3.org/ns/SMIL"
     xmlns:epub="http://www.idpf.org/2007/ops"
     version="3.0"&gt;
    &lt;body&gt;
@@ -8898,12 +8898,12 @@ html.my-document-playing * {
           id="id2"
           epub:textref="c01.xhtml#t1"
           epub:type="table"&gt;
-         
+
          &lt;seq
              id="id3"
              epub:textref="c01.xhtml#tr1"
              epub:type="table-row"&gt;
-            
+
             &lt;par
                 id="id4"
                 epub:type="table-cell"&gt;
@@ -8914,7 +8914,7 @@ html.my-document-playing * {
                    clipBegin="0:24:15.000"
                    clipEnd="0:24:18.123"/&gt;
             &lt;/par&gt;
-            
+
             &lt;par
                 id="id5"
                 epub:type="table-cell"&gt;
@@ -8925,7 +8925,7 @@ html.my-document-playing * {
                    clipBegin="0:24:18.123"
                    clipEnd="0:25:28.530"/&gt;
             &lt;/par&gt;
-            
+
             &lt;par
                 id="id6"
                 epub:type="table-cell"&gt;
@@ -8937,12 +8937,12 @@ html.my-document-playing * {
                    clipEnd="0:25:45.515"/&gt;
             &lt;/par&gt;
          &lt;/seq&gt;
-         
+
          &lt;seq
              id="id7"
              epub:textref="c01.xhtml#tr2"
              epub:type="table-row"&gt;
-            
+
             &lt;par
                 id="id8"
                 epub:type="table-cell"&gt;
@@ -8953,7 +8953,7 @@ html.my-document-playing * {
                    clipBegin="0:25:45.515"
                    clipEnd="0:26:45.700"/&gt;
             &lt;/par&gt;
-            
+
             &lt;par
                 id="id9"
                 epub:type="table-cell"&gt;
@@ -8964,7 +8964,7 @@ html.my-document-playing * {
                    clipBegin="0:26:45.700"
                    clipEnd="0:28:02.033"/&gt;
             &lt;/par&gt;
-            
+
             &lt;par
                 id="id10"
                 epub:type="table-cell"&gt;
@@ -9477,7 +9477,7 @@ html.my-document-playing * {
    &lt;body&gt;
       …
       &lt;section epub:type="preamble"&gt;
-         …    
+         …
       &lt;/section&gt;
       …
    &lt;/body&gt;
@@ -9492,8 +9492,8 @@ html.my-document-playing * {
    &lt;body&gt;
       …
       &lt;dl epub:type="glossary"&gt;
-         …    
-      &lt;/dl&gt;        
+         …
+      &lt;/dl&gt;
       …
    &lt;/body&gt;
 &lt;/html&gt;</pre>
@@ -9507,14 +9507,14 @@ html.my-document-playing * {
    &lt;body&gt;
       …
       &lt;p&gt;
-         … 
+         …
          &lt;span
             epub:type="pagebreak"
             id="p234"
             role="doc-pagebreak"
             aria-label="234"/&gt;
          …
-      &lt;/p&gt;    
+      &lt;/p&gt;
       …
    &lt;/body&gt;
 &lt;/html&gt;</pre>
@@ -9744,7 +9744,7 @@ html.my-document-playing * {
 								(<code>foaf</code>) and DBPedia (<code>dbp</code>) vocabularies.</p>
 
 						<pre>&lt;package
-    … 
+    …
     prefix="foaf: http://xmlns.com/foaf/spec/
             dbp: http://dbpedia.org/ontology/"&gt;
    …
@@ -10501,11 +10501,11 @@ html.my-document-playing * {
 				<pre>&lt;package …&gt;
     &lt;metadata …&gt;
         …
-        &lt;link rel="record" 
-            href="meta/data.xml" 
+        &lt;link rel="record"
+            href="meta/data.xml"
             media-type="application/marc"/&gt;
-        &lt;link rel="record" 
-            href="https://www.example.org/meta/data2.xml" 
+        &lt;link rel="record"
+            href="https://www.example.org/meta/data2.xml"
             media-type="application/marc"/&gt;
         …
     &lt;/metadata&gt;
@@ -10518,7 +10518,7 @@ html.my-document-playing * {
             href="nav.xhtml"
             media-type="application/xhtml+xml"
             properties="nav"/&gt;
-        &lt;item id="style"        
+        &lt;item id="style"
             href="style.css"
             media-type="text/css"/&gt;
         &lt;item id="font_otf"
@@ -10561,7 +10561,7 @@ html.my-document-playing * {
         …
     &lt;/spine&gt;
 &lt;/package&gt;
-	
+
 &lt;html …&gt;
     &lt;head …&gt;
         …
@@ -10578,12 +10578,12 @@ html.my-document-playing * {
             &lt;source srcset="media/image_3.heic" type="image/heic"/&gt;
             &lt;img src="media/image_3.png"/&gt;
         &lt;/picture&gt;
-        …        
+        …
         &lt;iframe src="widget.xhtml"&gt;&lt;/iframe&gt;
         …
         &lt;a href="https://www.example.org/some_content"&gt;…&lt;/a&gt;
     &lt;/body&gt;
-&lt;/html&gt;					
+&lt;/html&gt;
 				</pre>
 
 				<p>The various resources in the [=EPUB publication=] can be categorized as follows. (Refer to <a href="#sec-publication-resources"></a> for more information about these categories.)</p>
@@ -10732,19 +10732,19 @@ html.my-document-playing * {
     …
     &lt;manifest&gt;
         …
-        &lt;item id="chap01" 
-            href="scripted01.xhtml" 
+        &lt;item id="chap01"
+            href="scripted01.xhtml"
             media-type="application/xhtml+xml"
             properties="scripted"/&gt;
-        &lt;item id="inset01" 
-            href="scripted02.xhtml" 
+        &lt;item id="inset01"
+            href="scripted02.xhtml"
             media-type="application/xhtml+xml"
             properties="scripted"/&gt;
-        &lt;item id="slideshowjs" 
-            href="slideshow.js" 
+        &lt;item id="slideshowjs"
+            href="slideshow.js"
             media-type="text/javascript"/&gt;
     &lt;/manifest&gt;
-    
+
     &lt;spine …&gt;
         &lt;itemref idref="chap01"/&gt;
         …
@@ -10837,14 +10837,14 @@ EPUB/images/cover.png</pre>
    &lt;Signature
        Id="AsYouLikeItSignature"
        xmlns="http://www.w3.org/2000/09/xmldsig#"&gt;
-        
+
       &lt;!--
            SignedInfo is the information that is actually signed.
-           In this case, the SHA-1 algorithm is used to sign the 
+           In this case, the SHA-1 algorithm is used to sign the
            canonical form of the XML documents enumerated in the
            Object element below.
       --&gt;
-      
+
       &lt;SignedInfo&gt;
          &lt;CanonicalizationMethod
              Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/&gt;
@@ -10859,15 +10859,15 @@ EPUB/images/cover.png</pre>
             &lt;/DigestValue&gt;
          &lt;/Reference&gt;
       &lt;/SignedInfo&gt;
-      
+
       &lt;!--
-           The signed value of the digest above, using the DSA 
+           The signed value of the digest above, using the DSA
            algorithm
       --&gt;
       &lt;SignatureValue&gt;
          …
       &lt;/SignatureValue&gt;
-      
+
       &lt;!--
            The key used to validate the signature
       --&gt;
@@ -10881,7 +10881,7 @@ EPUB/images/cover.png</pre>
             &lt;/DSAKeyValue&gt;
          &lt;/KeyValue&gt;
       &lt;/KeyInfo&gt;
-      
+
       &lt;!--
            The list of resources to sign (note that the canonical
            form of XML documents is signed, while the binary form
@@ -10901,7 +10901,7 @@ EPUB/images/cover.png</pre>
                &lt;DigestValue&gt;
                &lt;/DigestValue&gt;
             &lt;/Reference&gt;
-            
+
             &lt;Reference URI="EPUB/book.html"&gt;
                &lt;Transforms&gt;
                   &lt;Transform
@@ -10912,7 +10912,7 @@ EPUB/images/cover.png</pre>
                &lt;DigestValue&gt;
                &lt;/DigestValue&gt;
             &lt;/Reference&gt;
-            
+
             &lt;Reference
                 URI="EPUB/images/cover.png"&gt;
                &lt;DigestMethod
@@ -10995,74 +10995,74 @@ EPUB/images/cover.png</pre>
     xml:lang="en"
     xmlns="http://www.idpf.org/2007/opf"
     unique-identifier="pub-id"&gt;
-    
+
    &lt;metadata
        xmlns:dc="http://purl.org/dc/elements/1.1/"&gt;
-      
+
       &lt;dc:identifier
           id="pub-id"&gt;
          urn:uuid:B9B412F2-CAAD-4A44-B91F-A375068478A0
       &lt;/dc:identifier&gt;
-      
+
       &lt;dc:language&gt;
          en
       &lt;/dc:language&gt;
-      
+
       &lt;dc:title&gt;
          As You Like It
       &lt;/dc:title&gt;
-       
+
       &lt;dc:creator
           id="creator"&gt;
          William Shakespeare
       &lt;/dc:creator&gt;
-      
+
       &lt;meta
           property="dcterms:modified"&gt;
          2000-03-24T00:00:00Z
       &lt;/meta&gt;
-      
+
       &lt;dc:publisher&gt;
          Project Gutenberg
       &lt;/dc:publisher&gt;
-      
+
       &lt;dc:date&gt;
          2000-03-24
       &lt;/dc:date&gt;
-      
+
       &lt;meta
           property="dcterms:dateCopyrighted"&gt;
          9999-01-01
       &lt;/meta&gt;
-      
+
       &lt;dc:identifier
           id="isbn13"&gt;
          urn:isbn:9780741014559
       &lt;/dc:identifier&gt;
-      
+
       &lt;dc:identifier
           id="isbn10"&gt;
          0-7410-1455-6
       &lt;/dc:identifier&gt;
-      
+
       &lt;link
           rel="xml-signature"
           href="../META-INF/signatures.xml#AsYouLikeItSignature"/&gt;
    &lt;/metadata&gt;
-    
+
    &lt;manifest&gt;
-      &lt;item id="r4915" 
-          href="book.html" 
+      &lt;item id="r4915"
+          href="book.html"
           media-type="application/xhtml+xml"/&gt;
-      &lt;item id="r7184" 
-          href="images/cover.png" 
+      &lt;item id="r7184"
+          href="images/cover.png"
           media-type="image/png"/&gt;
-      &lt;item id="nav" 
-          href="nav.html" 
-          media-type="application/xhtml+xml" 
+      &lt;item id="nav"
+          href="nav.html"
+          media-type="application/xhtml+xml"
           properties="nav"/&gt;
    &lt;/manifest&gt;
-   
+
    &lt;spine&gt;
       &lt;itemref
           idref="r4915"/&gt;
@@ -11642,6 +11642,6 @@ EPUB/images/cover.png</pre>
 			</section>
 		</section>
 		<div data-include="../common/acknowledgements-dedication.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-	
+
 
 </body></html>


### PR DESCRIPTION
This was changed slightly in https://github.com/whatwg/url/pull/736 to give it a more unique name.

This change also strips trailing whitespace.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/annevk/epub-specs/pull/2522.html" title="Last updated on Jan 19, 2023, 8:30 AM UTC (f165f03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2522/ccbc72f...annevk:f165f03.html" title="Last updated on Jan 19, 2023, 8:30 AM UTC (f165f03)">Diff</a>