### PR TITLE
Updating CR testing reports

### DIFF
--- a/epub33/reports/a11y-properties-use.html
+++ b/epub33/reports/a11y-properties-use.html
@@ -51,7 +51,8 @@
     <script class="remove">
         var respecConfig = {
             specStatus: "base",
-            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/a11y-properties-use.html",
+            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/a11-properties-use.html",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub33/reports/a11-properties-use.html",
             noRecTrack: true,
             editors: [{
                 name: "Matt Garrish",
@@ -62,8 +63,7 @@
             github: {
                 repoURL: "https://github.com/w3c/epub-specs",
                 branch: "main"
-            },
-            shortName: "exit-criteria"
+            }
         };
     </script>
 </head>
@@ -71,7 +71,7 @@
 <body>
     <section id="abstract">
         <p>
-            This document provides information on the usage of the accessibility metadata defined by the <a href="https://w3c.github.io/epub-specs/epub33/a11y/">EPUB Accessibility 1.1</a> specification.
+            This document provides information on the usage of the accessibility metadata defined by the [[epub-a11y-11]] specification.
             It corresponds to the specification's <a href="exit_criteria.html#exit-criteria-a11y-2">category 2 exit criteria</a>.
     </section>
     <section id="sotd">

--- a/epub33/reports/a11y-properties-use.html
+++ b/epub33/reports/a11y-properties-use.html
@@ -51,7 +51,7 @@
     <script class="remove">
         var respecConfig = {
             specStatus: "base",
-            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/a11-properties-use.html",
+            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/a11y-properties-use.html",
             edDraftURI: "https://w3c.github.io/epub-specs/epub33/reports/a11-properties-use.html",
             noRecTrack: true,
             editors: [{

--- a/epub33/reports/a11y-properties-use.html
+++ b/epub33/reports/a11y-properties-use.html
@@ -52,7 +52,7 @@
         var respecConfig = {
             specStatus: "base",
             latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/a11y-properties-use.html",
-            edDraftURI: "https://w3c.github.io/epub-specs/epub33/reports/a11-properties-use.html",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub33/reports/a11y-properties-use.html",
             noRecTrack: true,
             editors: [{
                 name: "Matt Garrish",

--- a/epub33/reports/a11y-properties-use.md
+++ b/epub33/reports/a11y-properties-use.md
@@ -1,7 +1,7 @@
 ## Candidate Recommendation Exit Criteria
 
 The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
-the [EPUB Accessibility 1.1](https://w3c.github.io/epub-specs/epub33/a11y/) specification for
+the [EPUB Accessibility 1.1](https://www.w3.org/TR/epub-a11y-11/) specification for
 consideration as a W3C Proposed Recommendation after documenting implementation of each feature.
 
 For this specification to advance to Proposed Recommendation, it has to be
@@ -20,11 +20,11 @@ metadata for their EPUB publications (as appropriate for each title).
 ### Schema.org discovery metadata
 
 The following table provides a list of publishers who have stated that they are currently using
-the [schema.org discovery metadata properties](https://w3c.github.io/epub-specs/epub33/a11y/#sec-disc-package)
+the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-11/#sec-disc-package)
 in production or who are in the process of rolling out their implementations.
 
 Discovery properties are expressed in the
-[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property).
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-a11y-11/#attrdef-meta-property).
 
 <table>
     <thead>
@@ -35,7 +35,7 @@ Discovery properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilityFeature">schema:accessibilityFeature</a></td>
+            <td><a href="https://www.w3.org/TR/epub-a11y-11/#confreq-schema-accessibilityFeature">schema:accessibilityFeature</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -79,7 +79,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilityHazard">schema:accessibilityHazard</a></td>
+            <td><a href="https://www.w3.org/TR/epub-a11y-11/#confreq-schema-accessibilityHazard">schema:accessibilityHazard</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -123,7 +123,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessibilitySummary">schema:accessibilitySummary</a></td>
+            <td><a href="hhttps://www.w3.org/TR/epub-a11y-11/#confreq-schema-accessibilitySummary">schema:accessibilitySummary</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -166,7 +166,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessMode">schema:accessMode</a></td>
+            <td><a href="https://www.w3.org/TR/epub-a11y-11/#confreq-schema-accessMode">schema:accessMode</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -210,7 +210,7 @@ Discovery properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#confreq-schema-accessModeSufficient">schema:accessModeSufficient</a></td>
+            <td><a href="https://www.w3.org/TR/epub-a11y-11/#confreq-schema-accessModeSufficient">schema:accessModeSufficient</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -276,7 +276,7 @@ and in the
     </thead>
     <tbody>
         <tr>
-        	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#dcterms-conformsTo">dcterms:conformsTo</a></td>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-11/#dcterms-conformsTo">dcterms:conformsTo</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -320,7 +320,7 @@ and in the
             </td>
         </tr>
         <tr>
-        	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifiedBy">a11y:certifiedBy</a></td>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-11/#a11y-certifiedBy">a11y:certifiedBy</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -363,7 +363,7 @@ and in the
             </td>
         </tr>
         <tr>
-        	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifierCredential">a11y:certifierCredential</a></td>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-11/#a11y-certifierCredential">a11y:certifierCredential</a></td>
             <td>
             	<ul>
             		<li>Acorn Press</li>
@@ -406,7 +406,7 @@ and in the
             </td>
         </tr>
         <tr>
-        	<td><a href="https://w3c.github.io/epub-specs/epub33/a11y/#a11y-certifierReport">a11y:certifierReport</a></td>
+        	<td><a href="https://www.w3.org/TR/epub-a11y-11/#a11y-certifierReport">a11y:certifierReport</a></td>
             <td>
             	<ul>
                     <li>Fondazione LIA</li>
@@ -430,7 +430,7 @@ The tool additionally allows authors to generate discovery and certifier metadat
 ## Vendor Implementations
 
 The following is a list of vendors who have stated that they are currently including
-the [schema.org discovery metadata properties](https://w3c.github.io/epub-specs/epub33/a11y/#sec-disc-package) for the publishers they serve. For publishers who have received third-party certification, they also include the [conformance reporting metadata properties](https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting) on their behalf.
+the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-11/#sec-disc-package) for the publishers they serve. For publishers who have received third-party certification, they also include the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting) on their behalf.
 
 - Amnet
 - Apex
@@ -443,8 +443,8 @@ the [schema.org discovery metadata properties](https://w3c.github.io/epub-specs/
 
 ## Bookstore Implementations
 
-The following is a list of Bookstore's who display the [schema.org discovery metadata properties](https://w3c.github.io/epub-specs/epub33/a11y/#sec-disc-package)
-and the [conformance reporting metadata properties](https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting) when present, or who are in the process of rolling out their implementations for every EPUB in their collection.
+The following is a list of Bookstore's who display the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-11/#sec-disc-package)
+and the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting) when present, or who are in the process of rolling out their implementations for every EPUB in their collection.
 
 - [RedShelf](https://redshelf.com)
 - [VitalSource](https://www.vitalsource.com)
@@ -452,6 +452,6 @@ and the [conformance reporting metadata properties](https://w3c.github.io/epub-s
 
 ## Catalog Feed
 
-The following is a list of Vendors who provide the [schema.org discovery metadata properties](https://w3c.github.io/epub-specs/epub33/a11y/#sec-disc-package) and the [conformance reporting metadata properties](https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting) in their catalog feed to partners when present, or who are in the process of rolling out their implementations for every EPUB in their collection.
+The following is a list of Vendors who provide the [schema.org discovery metadata properties](https://www.w3.org/TR/epub-a11y-11/#sec-disc-package) and the [conformance reporting metadata properties](https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting) in their catalog feed to partners when present, or who are in the process of rolling out their implementations for every EPUB in their collection.
 
 - [VitalSource](https://www.vitalsource.com)

--- a/epub33/reports/a11y-usage.html
+++ b/epub33/reports/a11y-usage.html
@@ -3,11 +3,56 @@
 <head>
     <meta charset="utf-8" />
     <title>EPUB Accessibility 1.1 Usage Report</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <style>
+        .todo {
+          background-color: yellow;
+          color: #900;
+        }
+        .todo::before {
+          content: "(still to be done)";
+        }
+          /* Table zebra style... */
+  
+          table {
+              font-size:inherit;
+              font:90%;
+              margin:1em;
+          }
+  
+          table td {
+              padding-left: 0.3em;
+          }
+  
+          table th {
+              font-weight: bold;
+              text-align: center;
+              background-color: rgb(0,0,128) !important;
+              font-size: 110%;
+              background: hsl(180, 30%, 50%);
+              color: #fff;
+          }
+  
+          table th a:link {
+            color: #fff;
+          }
+  
+          table th a:visited {
+            color: #aaa;
+          }
+  
+          table tr:nth-child(even) {
+              background-color: hsl(180, 30%, 93%) !important;
+          }
+  
+          table th{border-bottom:1px solid #bbb;padding:.2em 1em;}
+          table td{border-bottom:1px solid #ddd;padding:.2em 1em;}
+      </style>
+      <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <script class="remove">
         var respecConfig = {
             specStatus: "base",
             latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/a11y-usage.html",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub33/reports/a11y-usage.html",
             noRecTrack: true,
             editors: [{
                 name: "Matt Garrish",
@@ -18,8 +63,7 @@
             github: {
                 repoURL: "https://github.com/w3c/epub-specs",
                 branch: "main"
-            },
-            shortName: "exit-criteria"
+            }
         };
     </script>
 </head>

--- a/epub33/reports/a11y-usage.md
+++ b/epub33/reports/a11y-usage.md
@@ -1,9 +1,13 @@
 ## Candidate Recommendation Exit Criteria
 
 The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
-the [EPUB Accessibility 1.1](https://w3c.github.io/epub-specs/epub33/a11y/) specification for
+the [EPUB Accessibility 1.1](https://www.w3.org/TR/epub-a11y-11/) specification for
 consideration as a W3C Proposed Recommendation after documenting that publishers can
 meet the requirements at WCAG 2.0 Level AA.
+
+For this specification to advance to Proposed Recommendation, it has to be
+proven that at least 5 publishers will produce at least 1 EPUB publication each that 
+conform to [EPUB Accessibility 1.1 - WCAG 2.0 Level AA](https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting-pub).
 
 Publishers are not expected to be producing content that claims conformance
 to the specification prior to it becoming a recommendation, only that they have

--- a/epub33/reports/a11y-usage.md
+++ b/epub33/reports/a11y-usage.md
@@ -16,4 +16,50 @@ new revision does not introduce stricter content requirements.
 
 ## Publisher Implementations
 
+- Acorn Press
+- Annick Press
+- Au Press
+- BTL Book
+- Book*hug Press
+- Brick Books
+- Brush Education Inc.
+- Coach House Books
+- Cormorant Books
+- DCB
+- Dog Training Press
+- Dundurn Press
+- ECW Press
+- Éditions Alto
+- Éditions Bourton d'or Acadie
+- Éditions MultiMondes
+- Flanker Press
 - Fondazione LIA
+- Formac Lorimer
+- Goose Lane Editions
+- Guilford Press
+- House of Anansi Press/Groundwood Books
+- Heritage Group Distribution
+- Hurtubise
+- Invisible Publishing
+- Jones and Bartlett Learning
+- Kogan Page
+- Les Éditions Perce-Neige
+- Linda Leith Publishing
+- Macmillan Learning
+- md
+- Nimbus Publishing
+- Pearson
+- Planète rebelle
+- Playwrights Canada
+- Radiant Press
+- Saint Jean
+- Second Story Press
+- Simon &amp; Schuster
+- Taylor &amp; Francis
+- Tidewater Press
+- UBC Press
+- University of Michigan Press
+- University of Ottawa Press
+- Wiley
+- Wilfred Laurier University Press
+- XYZ

--- a/epub33/reports/epub-properties-use.html
+++ b/epub33/reports/epub-properties-use.html
@@ -51,7 +51,8 @@
     <script class="remove">
         var respecConfig = {
             specStatus: "base",
-            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/index.html",
+            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/epub-properties-use.html",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub33/reports/epub-properties-use.html",
             noRecTrack: true,
             editors: [{
                 name: "Matt Garrish",
@@ -62,8 +63,7 @@
             github: {
                 repoURL: "https://github.com/w3c/epub-specs",
                 branch: "main"
-            },
-            shortName: "exit-criteria"
+            }
         };
     </script>
 </head>
@@ -71,7 +71,7 @@
 <body>
     <section id="abstract">
         <p>
-            This document provides information on the usage of the various metadata defined by the <a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a> specification.
+            This document provides information on the usage of the various metadata defined by the [[epub-33]] specification.
             It corresponds to the specification's <a href="exit_criteria.html#exit-criteria-core-3">category 3 exit criteria</a>.
 
     </section>

--- a/epub33/reports/epub-properties-use.md
+++ b/epub33/reports/epub-properties-use.md
@@ -1,7 +1,7 @@
 ## Candidate Recommendation Exit Criteria
 
 The EPUB Working Group intends to exit the Candidate Recommendation stage and submit
-the [EPUB 3.3](https://w3c.github.io/epub-specs/epub33/core/) specification for consideration
+the [EPUB 3.3](https://www.w3.org/TR/epub-33/) specification for consideration
 as a W3C Proposed Recommendation after documenting implementation of each feature.
 
 For this specification to advance to Proposed Recommendation, it has to be
@@ -20,11 +20,11 @@ rendering, etc. (for reading system developers).
 ### Meta Properties Vocabulary
 
 The following table lists organizations that have stated that they are currently using
-the [meta properties](https://w3c.github.io/epub-specs/epub33/core/#app-meta-property-vocab)
+the [meta properties](https://www.w3.org/TR/epub-33/#app-meta-property-vocab)
 in production.
 
 Meta properties are expressed in the
-[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property).
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-33/#attrdef-meta-property).
 
 <table>
     <thead>
@@ -35,7 +35,7 @@ Meta properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-alternate-script">alternate-script</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-alternate-script">alternate-script</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -48,7 +48,7 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-authority">authority</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-authority">authority</a></td>
             <td>
             	<ul>
                     <li>American Academy of Pediatrics</li>
@@ -57,7 +57,7 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-belongs-to-collection">belongs-to-collection</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-belongs-to-collection">belongs-to-collection</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -68,7 +68,7 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-collection-type">collection-type</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-collection-type">collection-type</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -77,7 +77,7 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-display-seq">display-seq</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-display-seq">display-seq</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -98,7 +98,7 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-file-as">file-as</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-file-as">file-as</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -121,7 +121,7 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-group-position">group-position</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-group-position">group-position</a></td>
             <td>
             	<ul>
                     <li>BookFusion Inc</li>
@@ -130,7 +130,7 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-identifier-type">identifier-type</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-identifier-type">identifier-type</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -157,14 +157,14 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-meta-auth"><s>meta-auth</s></a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-meta-auth"><s>meta-auth</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-role">role</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-role">role</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -199,7 +199,7 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-source-of">source-of</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-source-of">source-of</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -218,7 +218,7 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-term">term</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-term">term</a></td>
             <td>
             	<ul>
                     <li>American Academy of Pediatrics</li>
@@ -231,7 +231,7 @@ Meta properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-title-type">title-type</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-title-type">title-type</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -264,11 +264,11 @@ Meta properties are expressed in the
 #### Link Relationships
 
 The following table lists organizations that have stated that they are currently using
-the [link relationships](https://w3c.github.io/epub-specs/epub33/core/#sec-link-rel)
+the [link relationships](https://www.w3.org/TR/epub-33/#sec-link-rel)
 in production.
 
 Link relationships are expressed in the
-[`link` element's `rel` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-link-rel).
+[`link` element's `rel` attribute](https://www.w3.org/TR/epub-33/#attrdef-link-rel).
 
 <table>
     <thead>
@@ -279,7 +279,7 @@ Link relationships are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-alternate">alternate</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-alternate">alternate</a></td>
             <td>
             	<ul>
                     <li>KnowledgeWorks Global Ltd.</li>
@@ -288,28 +288,28 @@ Link relationships are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-marc21xml-record"><s>marc21xml-record</s></a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-marc21xml-record"><s>marc21xml-record</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-mods-record"><s>mods-record</s></a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-mods-record"><s>mods-record</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-onix-record"><s>onix-record</s></a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-onix-record"><s>onix-record</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-record">record</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-record">record</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -320,7 +320,7 @@ Link relationships are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-voicing">voicing</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-voicing">voicing</a></td>
             <td>
             	<ul>
                     <li>KnowledgeWorks Global Ltd.</li>
@@ -329,14 +329,14 @@ Link relationships are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xml-signature"><s>xml-signature</s></a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-xml-signature"><s>xml-signature</s></a></td>
             <td>
             	<p>This property deprecated and is no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xmp-record"><s>xmp-record</s></a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-xmp-record"><s>xmp-record</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
@@ -348,11 +348,11 @@ Link relationships are expressed in the
 #### Link Properties
 
 The following table lists organizations that have stated that they are currently using
-the [link properties](https://w3c.github.io/epub-specs/epub33/core/#sec-link-properties)
+the [link properties](https://www.w3.org/TR/epub-33/#sec-link-properties)
 in production.
 
 Link properties are expressed in the
-[`link` element's `properties` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-properties).
+[`link` element's `properties` attribute](https://www.w3.org/TR/epub-33/#attrdef-properties).
 
 <table>
     <thead>
@@ -363,7 +363,7 @@ Link properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-onix">onix</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-onix">onix</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -381,13 +381,13 @@ Link properties are expressed in the
 #### General Properties
 
 The following table lists organizations that have stated that they are currently using
-the [general package rendering properties](https://w3c.github.io/epub-specs/epub33/core/#sec-rendering-general)
+the [general package rendering properties](https://www.w3.org/TR/epub-33/#sec-rendering-general)
 in production.
 
 General package rendering properties are expressed both globally in the
-[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property)
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-33/#attrdef-meta-property)
 and as overrides in the
-[`itemref` element's `properties` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-properties).
+[`itemref` element's `properties` attribute](https://www.w3.org/TR/epub-33/#attrdef-properties).
 
 <table>
     <thead>
@@ -398,7 +398,7 @@ and as overrides in the
     </thead>
     <tbody>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-flow">rendition:flow</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-flow">rendition:flow</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -412,7 +412,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#flow-auto">rendition:flow-auto</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#flow-auto">rendition:flow-auto</a></td>
             <td>
             	<ul>
                     <li>EDRLab (Thorium Reader)</li>
@@ -422,7 +422,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#flow-paginated">rendition:flow-paginated</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#flow-paginated">rendition:flow-paginated</a></td>
             <td>
             	<ul>
                     <li>EDRLab (Thorium Reader)</li>
@@ -433,7 +433,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#flow-scrolled-continuous">rendition:flow-scrolled-continuous</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#flow-scrolled-continuous">rendition:flow-scrolled-continuous</a></td>
             <td>
             	<ul>
                     <li>KADOKAWA</li>
@@ -443,7 +443,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#flow-scrolled-doc">rendition:flow-scrolled-doc</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#flow-scrolled-doc">rendition:flow-scrolled-doc</a></td>
             <td>
             	<ul>
                     <li>EDRLab (Thorium Reader)</li>
@@ -453,7 +453,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-align-x-center">rendition:align-x-center</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-align-x-center">rendition:align-x-center</a></td>
             <td>
             	<ul>
                     <li>KnowledgeWorks Global Ltd.</li>
@@ -467,13 +467,13 @@ and as overrides in the
 #### Fixed-Layout Properties
 
 The following table lists organizations that have stated that they are currently using
-the [fixed-layout rendering properties](https://w3c.github.io/epub-specs/epub33/core/#sec-rendering-fxl)
+the [fixed-layout rendering properties](https://www.w3.org/TR/epub-33/#sec-rendering-fxl)
 in production.
 
 Fixed-layout properties are expressed both globally in the
-[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property)
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-33/#attrdef-meta-property)
 and as overrides in the
-[`itemref` element's `properties` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-properties).
+[`itemref` element's `properties` attribute](https://www.w3.org/TR/epub-33/#attrdef-properties).
 
 <table>
     <thead>
@@ -484,7 +484,7 @@ and as overrides in the
     </thead>
     <tbody>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#layout">rendition:layout</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#layout">rendition:layout</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -510,7 +510,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#layout-pre-paginated">rendition:layout-pre-paginated</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#layout-pre-paginated">rendition:layout-pre-paginated</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -530,7 +530,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#layout-reflowable">rendition:layout-reflowable</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#layout-reflowable">rendition:layout-reflowable</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -545,7 +545,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#orientation">rendition:orientation</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#orientation">rendition:orientation</a></td>
             <td>
             	<ul>
                     <li>Amnet</li>
@@ -567,7 +567,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#orientation-auto">rendition:orientation-auto</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#orientation-auto">rendition:orientation-auto</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -585,7 +585,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#orientation-landscape">rendition:orientation-landscape</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#orientation-landscape">rendition:orientation-landscape</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -600,7 +600,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#orientation-portrait">rendition:orientation-portrait</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#orientation-portrait">rendition:orientation-portrait</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -616,7 +616,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread">rendition:spread</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#spread">rendition:spread</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -644,7 +644,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-auto">rendition:spread-auto</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#spread-auto">rendition:spread-auto</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -663,7 +663,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-both">rendition:spread-both</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#spread-both">rendition:spread-both</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -678,7 +678,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-landscape">rendition:spread-landscape</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#spread-landscape">rendition:spread-landscape</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -695,7 +695,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-none">rendition:spread-none</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#spread-none">rendition:spread-none</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -711,14 +711,14 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#spread-portrait"><s>rendition:spread-portrait</s></a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#spread-portrait"><s>rendition:spread-portrait</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#page-spread-center">rendition:page-spread-center</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#page-spread-center">rendition:page-spread-center</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -735,7 +735,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#page-spread-left">rendition:page-spread-left</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#page-spread-left">rendition:page-spread-left</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -751,7 +751,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#page-spread-right">rendition:page-spread-right</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#page-spread-right">rendition:page-spread-right</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -767,7 +767,7 @@ and as overrides in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#viewport"><s>rendition:viewport</s></a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#viewport"><s>rendition:viewport</s></a></td>
             <td>
             	<p>This property is deprecated and no longer recommended for use in EPUB publications.
             		It is only listed for completeness of reporting.</p>
@@ -779,11 +779,11 @@ and as overrides in the
 ### Manifest Properties Vocabulary
 
 The following table lists organizations that have stated that they are currently using
-the [manifest properties](https://w3c.github.io/epub-specs/epub33/core/#app-item-properties-vocab)
+the [manifest properties](https://www.w3.org/TR/epub-33/#app-item-properties-vocab)
 in production.
 
 Manifest properties are expressed in the
-[`item` element's `properties` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-properties).
+[`item` element's `properties` attribute](https://www.w3.org/TR/epub-33/#attrdef-properties).
 
 <table>
     <thead>
@@ -794,7 +794,7 @@ Manifest properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-cover-image">cover-image</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-cover-image">cover-image</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -836,7 +836,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-mathml">mathml</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-mathml">mathml</a></td>
             <td>
             	<ul>
                     <li>Amnet</li>
@@ -850,7 +850,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-nav">nav</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-nav">nav</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -890,7 +890,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-remote-resources">remote-resources</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-remote-resources">remote-resources</a></td>
             <td>
             	<ul>
                     <li>Carson Dellosa Education</li>
@@ -902,7 +902,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-scripted">scripted</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-scripted">scripted</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -921,7 +921,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-svg">svg</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-svg">svg</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -942,7 +942,7 @@ Manifest properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-switch"><s>switch</s></a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-switch"><s>switch</s></a></td>
             <td>
             	<p>This property indicates that the deprecated switch element is present.
                     It is only listed for completeness of reporting.</p>
@@ -954,11 +954,11 @@ Manifest properties are expressed in the
 ### Spine properties vocabulary
 
 The following table lists organizations that have stated that they are currently using
-the [spine properties](https://w3c.github.io/epub-specs/epub33/core/#app-itemref-properties-vocab)
+the [spine properties](https://www.w3.org/TR/epub-33/#app-itemref-properties-vocab)
 in production.
 
 Spine properties are expressed in the
-[`itemref` element's `properties` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-properties).
+[`itemref` element's `properties` attribute](https://www.w3.org/TR/epub-33/#attrdef-properties).
 
 <table>
     <thead>
@@ -969,7 +969,7 @@ Spine properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-page-spread-left">page-spread-left</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-page-spread-left">page-spread-left</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -991,7 +991,7 @@ Spine properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-page-spread-right">page-spread-right</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-page-spread-right">page-spread-right</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -1018,11 +1018,11 @@ Spine properties are expressed in the
 ### Media Overlays Vocabulary
 
 The following table lists organizations that have stated that they are currently using
-the [Media Overlays properties](https://w3c.github.io/epub-specs/epub33/core/#app-overlays-vocab)
+the [Media Overlays properties](https://www.w3.org/TR/epub-33/#app-overlays-vocab)
 in production.
 
 Media Overlays properties are expressed in the
-[`meta` element's `property` attribute](https://w3c.github.io/epub-specs/epub33/core/#attrdef-meta-property).
+[`meta` element's `property` attribute](https://www.w3.org/TR/epub-33/#attrdef-meta-property).
 
 <table>
     <thead>
@@ -1033,7 +1033,7 @@ Media Overlays properties are expressed in the
     </thead>
     <tbody>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-active-class">active-class</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-active-class">active-class</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -1051,7 +1051,7 @@ Media Overlays properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-duration">duration</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-duration">duration</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -1067,7 +1067,7 @@ Media Overlays properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-narrator">narrator</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-narrator">narrator</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -1079,7 +1079,7 @@ Media Overlays properties are expressed in the
             </td>
         </tr>
         <tr>
-            <td><a href="https://w3c.github.io/epub-specs/epub33/core/#sec-playback-active-class">playback-active-class</a></td>
+            <td><a href="https://www.w3.org/TR/epub-33/#sec-playback-active-class">playback-active-class</a></td>
             <td>
             	<ul>
                     <li>Advantage | ForbesBooks</li>
@@ -1098,4 +1098,3 @@ Media Overlays properties are expressed in the
 Where machine-testable assertions are made about the use of this metadata, conformance is checked by EPUBCheck.
 In particular, it is able to determine if authors have not set manifest properties correctly.
 
-(TBD what authoring tools support the metadata.)

--- a/epub33/reports/exit_criteria.html
+++ b/epub33/reports/exit_criteria.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>EPUB 3.3 Testing Strategies and Exit Criteria</title>
+    <title>EPUB 3.3 Testing Strategies and CR Exit Criteria</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <style>
       .todo {
@@ -41,7 +41,7 @@
 <body>
     <section id="abstract">
         <p>
-            This document outlines the testing strategies and specifies the <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation (CR)</a> exit criteria for the EPUB 3.3 specifications. The three Recommendation-track specifications that are subject to testing and CR review are:
+            This document outlines the testing strategies, reporting, and specifies the <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation (CR)</a> exit criteria for the EPUB 3.3 specifications. The three Recommendation-track specifications that are subject to testing and PR review are:
         </p>
         <ol>
             <li>EPUB Reading Systems 3.3 [[epub-rs-33]]</li>
@@ -63,16 +63,14 @@
             <li>provide some additional features <em>“on top”</em> of that renderer.</li>
         </ul>
 
+        <p>See also the the EPUB 3 Overview [[epub-overview-33]] for more details on the structure of EPUB 3.3 publications.</p>
         <p>
-          What this also means is that the validity and conformance of an EPUB 3.3 publication, as well as a reading system implementation, <em>includes</em> the requirement of valid and conformant publication resources, and the conformant rendering thereof.
+          As a consequence of this particular structure, the validity and conformance of an EPUB 3.3 publication, as well as of a reading system implementation, <em>includes</em> the requirement of valid and conformant publication resources, and the conformant rendering thereof.
+          Comprehensive testing would therefore require to include the union of all HTML, SVG, or CSS tests both on the content side as well as the implementation side <em>as well as</em> testing the unique, EPUB 3.3 specific features. The standard checking tools that are widely used by the publishing community, like <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> or <a href="https://daisy.github.io/ace/">ACE</a>, indeed include externally developed HTML, CSS, or accessibility checkers, which would check the validity or conformance of the publication resources. Also, today’s reading systems do not develop an HTML renderer themselves; they, rather, rely on external tools (typically a “WebView” implementation) that can be assumed to conform to the relevant W3C specifications.
         </p>
 
         <p>
-          Comprehensive testing would require to include the union of all HTML, SVG, or CSS tests both on the content side as well as the implementation side <em>as well as</em> testing the unique, EPUB 3.3 specific features. The industry standard checking tools, like <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a> or <a href="https://daisy.github.io/ace/">ACE, by Daisy</a> indeed include standard, and externally developed, HTML, CSS, or accessibility checkers, which would check the validity or conformance of the publication resources. Similarly, today’s reading systems do not develop an HTML renderer themselves; they, rather, rely on external tools (typically a webview implementation) that can be assumed to conform to the relevant W3C specifications.
-        </p>
-
-        <p>
-          However, taking into account these additional test would be quite unnecessary for the purpose of testing the EPUB 3.3 specification (which is the main purpose of a <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation</a>). As a consequence, the <em><strong>testing strategy of EPUB 3.3 concentrates on the unique EPUB 3.3 features only</strong></em>, and considers the publication resources, as well as the reading systems, to conform to the relevant Open Web Platform  specifications.
+          This means that these additional tests would be quite unnecessary for the purpose of testing the EPUB 3.3 specification (which is the main purpose of a <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation</a>). As a consequence, the <em><strong>testing strategy of EPUB 3.3 concentrates on the unique EPUB 3.3 features only</strong></em>, and considers the publication resources, as well as the reading systems, to conform to the relevant Open Web Platform  specifications.
         </p>
     </section>
 
@@ -87,23 +85,26 @@
           <li>EPUB Accessibility 1.1 [[epub-a11y-11]]</li>
       </ol>
 
-        <p>The strategy for each of these are a bit different and are detailed below.</p>
+        <p>Due to the specificities of these documents the strategy, exit criteria, and reporting are different. These are detailed below.</p>
 
         <section>
             <h2 id="epub-3.3-reading-systems">EPUB 3.3 Reading Systems</h2>
 
             <p>
-              Interested implementers for the <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a> are provided with a <a href="https://w3c.github.io/epub-tests/">test suite</a> that follows the examples of the web platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for all <em style="font-variant: small-caps;">must</em> statements, as well as for many <em style="font-variant: small-caps;">should</em> and for some <em style="font-variant: small-caps;">may</em> statements, that appear in the <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a> specification.
+              Implementers of the <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a> specification are provided with a <a href="https://w3c.github.io/epub-tests/">test suite</a> that follows the examples of the Web Platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for <em>all</em> <em style="font-variant: small-caps;">must</em> statements, as well as for many <em style="font-variant: small-caps;">should</em> and for some <em style="font-variant: small-caps;">may</em> statements, that appear in the <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a> specification.
             </p>
 
             <p>
-              The <a href="https://w3c.github.io/epub-tests/">test suite documentation</a> describes the individual tests, linking them to the relevant section(s) of the specifications. The <a href="https://w3c.github.io/epub-specs/epub33/rs/"><em>editors’ draft</em></a> (as opposed to the official, published version) also has a pull-down menu attached to each <em style="font-variant: small-caps;">must</em> statement providing the references to the relevant tests.
+              The <a href="https://w3c.github.io/epub-tests/">test suite documentation</a> describes the individual tests, linking them to the relevant section(s) of the specifications. The <a href="https://w3c.github.io/epub-specs/epub33/rs/"><em>editors’ draft</em></a> (as opposed to the official, published version) of the specification has a pull-down menu attached to each <em style="font-variant: small-caps;">must</em> statement providing the references to the relevant tests.
             </p>
             <section>
                 <h3 id="exit-criteria-rs">Exit criteria</h3>
 
                 <p>
-                  The <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading System</a> document must have at least two passing, independent implementations for <a href="https://w3c.github.io/epub-tests/">each test</a> linked to a <em style="font-variant: small-caps;">must</em> statement in the specification. The results of testing are available in a separate <a href="https://w3c.github.io/epub-tests/results">implementation report</a>.
+                  The <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading System</a> document must have at least two passing, independent implementations for <a href="https://w3c.github.io/epub-tests/">each test</a> linked to a <em style="font-variant: small-caps;">must</em> statement in the specification.
+                </p>
+                <p>                  
+                  The results of testing are available in a separate <a href="https://w3c.github.io/epub-tests/results">implementation report</a>.
                 </p>
             </section>
         </section>
@@ -111,7 +112,7 @@
         <section>
             <h2 id="epub-3.3-core">EPUB 3.3 (Core)</h2>
             <p>
-              The normative features of the <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a> document can be divided, roughly, into the following categories:
+              The normative features of the <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a> specification can be divided, roughly, into the following categories:
             </p>
 
             <ol>
@@ -132,7 +133,7 @@
                 </li>
                 <li>
                     <p>
-                      Vocabulary items which serve as metadata for the publication, and added to the <a href="https://www.w3.org/TR/epub-33/#sec-package-doc">EPUB 3.3 package document</a>. Although only few of those vocabulary items are <em>required</em> in a conformant EPUB specification, their formats, value constraints, etc., are normatively specified in the standard and these <em>must</em> be followed for a publication to be valid if they are used.
+                      Vocabulary items which serve as metadata for the publication, and added to the <a href="https://www.w3.org/TR/epub-33/#sec-package-doc">EPUB 3.3 package document</a>. Although only few of those vocabulary items are <em>required</em> for a conformant EPUB specification, their formats, value constraints, etc., are normatively specified in the standard and these <em>must</em> be followed for a publication to be valid if they are used.
                     </p>
                 </li>
             </ol>
@@ -142,18 +143,32 @@
                 <ol>
                     <li id="exit-criteria-core-1">
                         <p>
-                          Features in category 1 share the testing methodology, as well as the <a href="https://w3c.github.io/epub-tests/">tests</a> and <a href="https://w3c.github.io/epub-tests/results">implementation</a>, with the <a href="#exit-criteria-rs">criteria</a> of <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a>.
+                          Features in category 1 share the testing methodology, exit criteria, as well as the <a href="https://w3c.github.io/epub-tests/">tests</a> and <a href="https://w3c.github.io/epub-tests/results">implementation results</a>, with the <a href="#exit-criteria-rs">criteria</a> of <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a>. This includes the mechanism whereby the tests are referenced from the <a href="https://w3c.github.io/epub-specs/epub33/core/"><em>editors’ draft</em></a> via pull-down menus.
                         </p>
                     </li>
-                    <li id="exit-criteria-core-2">
+                    <li id="exit-criteria-core-2-3">
                         <p>
-                          Testing the features in categories 2 and 3 concentrates on whether these restrictions are <em>feasible</em> in practice, i.e., whether they are enforceable when checking validity. The main tool to check this is <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>, which is being upgraded for EPUB 3.3, and whose earlier versions for EPUB 3.2 have been extensively used throughout the industry for several years now; EPUBCheck <em>must</em> be able to validate a valid EPUB 3.3 Publication as well as report an error or warning for invalid publications. The relevant tests themselves are either part of the <a href="https://github.com/w3c/epub-tests">test suite</a> or will be provided in another, similar test suite documentation, with a
-                          corresponding implementation report.                          
+                          Testing the features in categories 2 and 3 concentrates on whether these restrictions are <em>feasible</em> in practice, i.e., whether they are enforceable when checking validity. 
                         </p>
-                    </li>
-                    <li id="exit-criteria-core-3">
+                        <p>  
+                          The latest version of <a href="https://www.w3.org/publishing/epubcheck/">EPUBCheck</a>, namely <a href="https://github.com/w3c/epubcheck/releases/tag/v5.0.0">EPUBCheck 5</a>, validates EPUB 3.3. Earlier versions of EPUBCheck are extensively used throughout the industry for several years now, and act as “gatekeepers” in the publication workflow for the major EPUB platforms; it is to be expected that all these platforms will upgrade their workflow for EPUB 3.3.
+                        </p>
+
                         <p>
-                          Testing the features in category 4 concentrates on vocabulary term <em>usage</em>, i.e., whether real-world publishers use those terms. Each term must have at least two independent publishers using those terms in production. The results of testing are available in a separate <a href="https://w3c.github.io/epub-specs/epub33/reports/epub-properties-use">implementation report</a>.
+                          EPUBCheck has its own <a href="https://github.com/w3c/epubcheck/tree/w3c/epub-33-cr-report/src/test/resources">test suite</a>; the exit criteria for testing categories 2 and 3 features is therefore formulated by requiring that each relevant <em style="font-variant: small-caps;">must</em> statement in <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a> is covered by at least one EPUBCheck test.
+                        </p>
+
+                        <p>
+                          The results of testing is shown in a <a href="https://w3c.github.io/epub-structural-tests/">separate document</a>, providing a short description, and reference, for each relevant EPUBCheck test. The test descriptions are grouped using the structure of <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a>, and these groups are referenced, via pull-down menus, from the section headers of the <a href="https://w3c.github.io/epub-specs/epub33/core/"><em>editors’ draft</em></a> of the specification.
+                        </p>
+                            
+                    </li>
+                    <li id="exit-criteria-core-4">
+                        <p>
+                          Testing the features in category 4 concentrates on vocabulary term <em>usage</em>, i.e., whether real-world publishers use those terms. Each term must have at least two independent publishers using those terms in production.
+                        </p>
+                        <p>
+                          The results of testing are available in the separate <a href="epub-properties-use.html">EPUB 3.3 Metadata Usage Report</a>.
                         </p>
                     </li>
                 </ol>
@@ -181,16 +196,23 @@
                 <ol>
                     <li id="exit-criteria-a11y-1">
                         <p>
-                          Testing the features in category 1 tests whether these restrictions are <em>feasible</em> and <em>used</em> in practice. This is achieved by the requirement that at least 5 publishers will produce at least 1 EPUB each that conform to <a href="https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting-pub">EPUB Accessibility 1.1 - WCAG 2.0 Level AA</a>.
+                          Testing the features in category 1 tests whether these restrictions are <em>feasible</em> and <em>used</em> in practice. This is achieved by the requirement that at least 5 publishers will produce at least 1 EPUB publication each that conform to <a href="https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting-pub">EPUB Accessibility 1.1 - WCAG 2.0 Level AA</a>.
                         </p> 
                           
                         <p>
-                          Note that these conformance levels rely on each publication resource to conform to WCAG 2.0 AA, when applicable; there are only a few EPUB specific features like page numbering. An EPUB Accessibility 1.1 Usage Report <span class="todo">to be done!!</span> shows that conformance table.
+                          Note that these conformance levels rely on each publication resource to conform to WCAG 2.0 AA, when applicable; there are only a few EPUB specific features like page numbering. At least two independent publishers should be fulfilling that conformance level.
+                        </p>
+                          
+                        <p>
+                          The separate <a href="a11y-usage">EPUB Accessibility 1.1 Usage Report</a> shows the conformance table.
                         </p>
                     </li>
                     <li id="exit-criteria-a11y-2">
                         <p>
-                          Testing the features in category 2 concentrates on vocabulary term <em>usage</em>, i.e., that real-world publishers use those terms. Each term must have at least two independent publishers using those terms in production. A separate <a href="https://w3c.github.io/epub-specs/epub33/reports/a11y-properties-use">EPUB Accessibility 1.1 Metadata Usage Report</a> shows that implementation table.
+                          Testing the features in category 2 concentrates on vocabulary term <em>usage</em>, i.e., that real-world publishers use those terms. Each term must have at least two independent publishers using those terms in production.
+                        </p>
+                        <p>
+                          The separate <a href="a11y-properties-use">EPUB Accessibility 1.1 Metadata Usage Report</a> shows the implementation table.
                         </p>
                     </li>
                 </ol>

--- a/epub33/reports/exit_criteria.html
+++ b/epub33/reports/exit_criteria.html
@@ -15,6 +15,7 @@
         var respecConfig = {
             specStatus: "base",
             latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/exit_criteria.html",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub33/reports/exit_criteria.html",
             noRecTrack: true,
             editors: [{
                 name: "Ivan Herman",
@@ -43,9 +44,9 @@
             This document outlines the testing strategies and specifies the <a href="https://www.w3.org/2021/Process-20211102/#RecsCR">W3C Candidate Recommendation (CR)</a> exit criteria for the EPUB 3.3 specifications. The three Recommendation-track specifications that are subject to testing and CR review are:
         </p>
         <ol>
-            <li><a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB Reading Systems 3.3</a></li>
-            <li><a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a></li>
-            <li><a href="https://w3c.github.io/epub-specs/epub33/a11y/">EPUB Accessibility 1.1</a></li>
+            <li>EPUB Reading Systems 3.3 [[epub-rs-33]]</li>
+            <li>EPUB 3.3 [[epub-33]]</li>
+            <li>EPUB Accessibility 1.1 [[epub-a11y-11]]</li>
         </ol>
     </section>
     <section id="sotd">
@@ -81,10 +82,10 @@
         <p>EPUB 3.3 consists of three recommendation-track documents:</p>
 
         <ol type="1">
-            <li><a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a></li>
-            <li><a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a></li>
-            <li><a href="https://w3c.github.io/epub-specs/epub33/a11y/">EPUB Accessibility 1.1</a></li>
-        </ol>
+          <li>EPUB Reading Systems 3.3 [[epub-rs-33]]</li>
+          <li>EPUB 3.3 [[epub-33]]</li>
+          <li>EPUB Accessibility 1.1 [[epub-a11y-11]]</li>
+      </ol>
 
         <p>The strategy for each of these are a bit different and are detailed below.</p>
 
@@ -92,7 +93,7 @@
             <h2 id="epub-3.3-reading-systems">EPUB 3.3 Reading Systems</h2>
 
             <p>
-              Interested implementers for the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> are provided with a <a href="https://w3c.github.io/epub-tests/">test suite</a> that follows the examples of the web platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for all <em style="font-variant: small-caps;">must</em> statements, as well as for many <em style="font-variant: small-caps;">should</em> and for some <em style="font-variant: small-caps;">may</em> statements, that appear in the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> specification.
+              Interested implementers for the <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a> are provided with a <a href="https://w3c.github.io/epub-tests/">test suite</a> that follows the examples of the web platform test model, but adapted to the specificities of EPUB. The test suite provides separate tests for all <em style="font-variant: small-caps;">must</em> statements, as well as for many <em style="font-variant: small-caps;">should</em> and for some <em style="font-variant: small-caps;">may</em> statements, that appear in the <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a> specification.
             </p>
 
             <p>
@@ -102,7 +103,7 @@
                 <h3 id="exit-criteria-rs">Exit criteria</h3>
 
                 <p>
-                  The <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading System</a> document must have at least two passing, independent implementations for <a href="https://w3c.github.io/epub-tests/">each test</a> linked to a <em style="font-variant: small-caps;">must</em> statement in the specification. The results of testing are available in a separate <a href="https://w3c.github.io/epub-tests/results">implementation report</a>.
+                  The <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading System</a> document must have at least two passing, independent implementations for <a href="https://w3c.github.io/epub-tests/">each test</a> linked to a <em style="font-variant: small-caps;">must</em> statement in the specification. The results of testing are available in a separate <a href="https://w3c.github.io/epub-tests/results">implementation report</a>.
                 </p>
             </section>
         </section>
@@ -110,28 +111,28 @@
         <section>
             <h2 id="epub-3.3-core">EPUB 3.3 (Core)</h2>
             <p>
-              The normative features of the <a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a> document can be divided, roughly, into the following categories:
+              The normative features of the <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a> document can be divided, roughly, into the following categories:
             </p>
 
             <ol>
                 <li>
                     <p>
-                      Features that have a direct effect on the reading system behavior, and whose behavioral details are mostly specified by <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a>. Examples are the list of <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-core-media-types">supported media types</a>, semantics of some <a href="https://w3c.github.io/epub-specs/epub33/core/#attrdef-dir">internationalization features</a>, or the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-container-iri">specificities of URLs</a> in the case of packaged contents. These features have their counterpart in the <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a> document and they share the relevant tests. In other words, some of the aforementioned tests, and their implementations, are also relevant for the core <a href="https://w3c.github.io/epub-specs/epub33/core/">EPUB 3.3</a> document.
+                      Features that have a direct effect on the reading system behavior, and whose behavioral details are mostly specified by <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a>. Examples are the list of <a href="https://www.w3.org/TR/epub-33/#sec-core-media-types">supported media types</a>, semantics of some <a href="https://www.w3.org/TR/epub-33/#attrdef-dir">internationalization features</a>, or the <a href="https://www.w3.org/TR/epub-33/#sec-container-iri">specificities of URLs</a> in the case of packaged contents. These features have their counterpart in the <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a> document and they share the relevant tests. In other words, some of the aforementioned tests, and their implementations, are also relevant for the core <a href="https://www.w3.org/TR/epub-33/">EPUB 3.3</a> document.
                     </p>
                 </li>
                 <li>
                     <p>
-                      Structural constraints on a the EPUB-specific files of the publication; examples include the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-ocf">structure of the container format (OCF)</a> or of the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-package-doc">package document</a>.
+                      Structural constraints on a the EPUB-specific files of the publication; examples include the <a href="https://www.w3.org/TR/epub-33/#sec-ocf">structure of the container format (OCF)</a> or of the <a href="https://www.w3.org/TR/epub-33/#sec-package-doc">package document</a>.
                     </p>
                 </li>
                 <li>
                     <p>
-                      Extra restrictions concerning content documents such as the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xhtml-deviations">restrictions on XHTML</a>, the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-nav">format of an XHTML navigation document</a>, or the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-xml-constraints">requirements on XML conformance</a>.
+                      Extra restrictions concerning content documents such as the <a href="https://www.w3.org/TR/epub-33/#sec-xhtml-deviations">restrictions on XHTML</a>, the <a href="https://www.w3.org/TR/epub-33/#sec-nav">format of an XHTML navigation document</a>, or the <a href="https://www.w3.org/TR/epub-33/#sec-xml-constraints">requirements on XML conformance</a>.
                     </p>
                 </li>
                 <li>
                     <p>
-                      Vocabulary items which serve as metadata for the publication, and added to the <a href="https://w3c.github.io/epub-specs/epub33/core/#sec-package-doc">EPUB 3.3 package document</a>. Although only few of those vocabulary items are <em>required</em> in a conformant EPUB specification, their formats, value constraints, etc., are normatively specified in the standard and these <em>must</em> be followed for a publication to be valid if they are used.
+                      Vocabulary items which serve as metadata for the publication, and added to the <a href="https://www.w3.org/TR/epub-33/#sec-package-doc">EPUB 3.3 package document</a>. Although only few of those vocabulary items are <em>required</em> in a conformant EPUB specification, their formats, value constraints, etc., are normatively specified in the standard and these <em>must</em> be followed for a publication to be valid if they are used.
                     </p>
                 </li>
             </ol>
@@ -141,7 +142,7 @@
                 <ol>
                     <li id="exit-criteria-core-1">
                         <p>
-                          Features in category 1 share the testing methodology, as well as the <a href="https://w3c.github.io/epub-tests/">tests</a> and <a href="https://w3c.github.io/epub-tests/results">implementation</a>, with the <a href="#exit-criteria-rs">criteria</a> of <a href="https://w3c.github.io/epub-specs/epub33/rs/">EPUB 3.3 Reading Systems</a>.
+                          Features in category 1 share the testing methodology, as well as the <a href="https://w3c.github.io/epub-tests/">tests</a> and <a href="https://w3c.github.io/epub-tests/results">implementation</a>, with the <a href="#exit-criteria-rs">criteria</a> of <a href="https://www.w3.org/TR/epub-rs-33/">EPUB 3.3 Reading Systems</a>.
                         </p>
                     </li>
                     <li id="exit-criteria-core-2">
@@ -161,17 +162,17 @@
         <section>
             <h2 id="epub-accessibility-1.1">EPUB Accessibility 1.1</h2>
             <p>
-              The goals of the <a href="https://w3c.github.io/epub-specs/epub33/a11y/">EPUB Accessibility 1.1</a> document is to define accessibility conformance of EPUB publications beyond the accessibility requirements defined by WCAG for publication resources. The normative features of this specification can be divided, roughly, into the following categories:
+              The goals of the <a href="https://www.w3.org/TR/epub-a11y-11/">EPUB Accessibility 1.1</a> document is to define accessibility conformance of EPUB publications beyond the accessibility requirements defined by WCAG for publication resources. The normative features of this specification can be divided, roughly, into the following categories:
             </p>
             <ol>
                 <li>
                     <p>
-                      Additional structural constraints on a publication; examples include the <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-page-list">requirement on page lists</a> or <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-mo-order">reading order</a>. Through those constraints the document defines accessibility <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting-pub">conformance requirements</a> on top of the conformance levels defined by <a href="https://www.w3.org/TR/WCAG21/">WCAG</a>.
+                      Additional structural constraints on a publication; examples include the <a href="https://www.w3.org/TR/epub-a11y-11/#sec-page-list">requirement on page lists</a> or <a href="https://www.w3.org/TR/epub-a11y-11/#sec-mo-order">reading order</a>. Through those constraints the document defines accessibility <a href="https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting-pub">conformance requirements</a> on top of the conformance levels defined by <a href="https://www.w3.org/TR/WCAG21/">WCAG</a>.
                     </p>
                 </li>
                 <li>
                     <p>
-                      Vocabulary items which serve as metadata for reporting; for example, <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting-pub">conformance levels</a>, or disclosing the <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-disc-package">accessibility features</a> related to this publication.
+                      Vocabulary items which serve as metadata for reporting; for example, <a href="https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting-pub">conformance levels</a>, or disclosing the <a href="https://www.w3.org/TR/epub-a11y-11/#sec-disc-package">accessibility features</a> related to this publication.
                     </p>
                 </li>
             </ol>
@@ -180,7 +181,7 @@
                 <ol>
                     <li id="exit-criteria-a11y-1">
                         <p>
-                          Testing the features in category 1 tests whether these restrictions are <em>feasible</em> and <em>used</em> in practice. This is achieved by the requirement that at least 5 publishers will produce at least 1 EPUB each that conform to <a href="https://w3c.github.io/epub-specs/epub33/a11y/#sec-conf-reporting-pub">EPUB Accessibility 1.1 - WCAG 2.0 Level AA</a>.
+                          Testing the features in category 1 tests whether these restrictions are <em>feasible</em> and <em>used</em> in practice. This is achieved by the requirement that at least 5 publishers will produce at least 1 EPUB each that conform to <a href="https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting-pub">EPUB Accessibility 1.1 - WCAG 2.0 Level AA</a>.
                         </p> 
                           
                         <p>

--- a/epub33/reports/index.html
+++ b/epub33/reports/index.html
@@ -73,7 +73,7 @@
                 <a href="exit_criteria.html#exit-criteria-core-4">Category 4</a>: each metadata item defined and required in the [=package document=] defined by [[epub-33]] has sufficient usage by the target communities, i.e., at least two organizations regularly include the metadata in the package document (for publishers) or use them in bookshelves, content rendering, etc. (for reading system developers).
               </p>
               <p>
-                See the <a href="epub-properties-use">EPUB 3.3 Metadata Usage Report</a> document.
+                See the <a href="epub-properties-use.html">EPUB 3.3 Metadata Usage Report</a> document.
               </p>
             </li>
           </ul>

--- a/epub33/reports/index.html
+++ b/epub33/reports/index.html
@@ -103,7 +103,7 @@
               conforms to <a href="https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting-pub">EPUB Accessibility 1.1 - WCAG 2.0 Level AA</a>.  
             </p>
             <p>
-              See the <a href="a11y-usage">EPUB Accessibility 1.1 Usage Report</a> document.
+              See the <a href="a11y-usage.html">EPUB Accessibility 1.1 Usage Report</a> document.
             </p>
           </li>
           <li>

--- a/epub33/reports/index.html
+++ b/epub33/reports/index.html
@@ -112,7 +112,7 @@
               target communities, i.e., at least two organizations regularly include them in the [=package document=] metadata for their EPUB publications (as appropriate for each title).
             </p>
             <p>
-              See the <a href="a11y-properties-use">EPUB Accessibility 1.1 Metadata Usage Report</a> document.
+              See the <a href="a11y-properties-use.html">EPUB Accessibility 1.1 Metadata Usage Report</a> document.
             </p>
           </li>
         </ul>

--- a/epub33/reports/index.html
+++ b/epub33/reports/index.html
@@ -17,7 +17,8 @@
     <script class="remove">
         var respecConfig = {
             specStatus: "base",
-            "latestVersion": "https://w3c.github.io/epub-specs/epub33/reports/index.html",
+            latestVersion: "https://w3c.github.io/epub-specs/epub33/reports/",
+            edDraftURI: "https://w3c.github.io/epub-specs/epub33/reports/index.html",
             noRecTrack: true,
             editors: [{
                 name: "Ivan Herman",
@@ -30,8 +31,7 @@
             github: {
                 repoURL: "https://github.com/w3c/epub-specs",
                 branch: "main"
-            },
-            shortName: "exit-criteria"
+            }
         };
     </script>
 </head>

--- a/epub33/reports/index.html
+++ b/epub33/reports/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>EPUB 3.3 CR Implementation report</title>
+    <title>EPUB 3.3 Implementation reports</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
     <style>
       .todo {
@@ -31,7 +31,12 @@
             github: {
                 repoURL: "https://github.com/w3c/epub-specs",
                 branch: "main"
-            }
+            },
+            xref: {
+              profile: "web-platform",
+              specs: ["epub-rs-33","epub-33"]
+            },
+
         };
     </script>
 </head>
@@ -48,44 +53,67 @@
       <h1 id="reports-per-criteria">Reports per documents and criteria</h1>
 
       <dl>
-        <dt><a href="exit_criteria.html#exit-criteria-core">EPUB 3.3 (Core)</a></dt>
+        <dt><a href="exit_criteria.html#exit-criteria-core">EPUB 3.3 (Core)</a> [[epub-33]]</dt>
         <dd>
           <ul>
             <li>
-              <a href="exit_criteria.html#exit-criteria-core-1">Category 1</a>: 
-              see the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.3 Test Results</a>
+              <p>
+                <a href="exit_criteria.html#exit-criteria-core-1">Category 1</a>: each <em>required</em> feature define by [[epub-33]], that has a direct effect on the reading system behavior, and whose behavioral details are mostly specified by [[epub-rs-33]], must have at least two, mutually independent implementations.
+              </p>
+              <p>See the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.3 Test Results</a> document.</p>
             </li>
             <li>
-              <a href="exit_criteria.html#exit-criteria-core-2">Category 2</a>: 
-              see the <a href="https://w3c.github.io/epub-structural-tests/">EPUB 3.3 Structural Test Results</a>
+              <p>
+                <a href="exit_criteria.html#exit-criteria-core-2-3">Categories 2 and 3</a>: each <em>required</em> constraint on EPUB-specific files, as well as restrictions on [=publication resources=], must be enforceable when checking validity through <a href="https://github.com/w3c/epubcheck/releases/tag/v5.0.0">EPUBCheck 5</a>.
+              </p> 
+              <p>See the <a href="https://w3c.github.io/epub-structural-tests/">EPUB 3.3 Structural Test Results</a> document.</p>
             </li>
             <li>
-              <a href="exit_criteria.html#exit-criteria-core-3">Category 3</a>: 
-              see the <a href="epub-properties-use">EPUB 3.3 Metadata Usage Report</a>
+              <p>
+                <a href="exit_criteria.html#exit-criteria-core-4">Category 4</a>: each metadata item defined and required in the [=package document=] defined by [[epub-33]] has sufficient usage by the target communities, i.e., at least two organizations regularly include the metadata in the package document (for publishers) or use them in bookshelves, content rendering, etc. (for reading system developers).
+              </p>
+              <p>
+                See the <a href="epub-properties-use">EPUB 3.3 Metadata Usage Report</a> document.
+              </p>
             </li>
           </ul>
         </dd>
       </dl>
 
-      <dt><a href="exit_criteria.html#exit-criteria-rs">EPUB 3.3 Reading Systems</a></dt>
+      <dt><a href="exit_criteria.html#exit-criteria-rs">EPUB 3.3 Reading Systems</a> [[epub-rs-33]]</dt>
       <dd>
         <ul>
           <li> 
-            See the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.3 Test Results</a>
+            <p>
+              Each <em>required</em> feature, whose behavior is specified by [[epub-rs-33]], must have at least two, mutually independent implementations.
+            </p>
+            <p>
+              See the <a href="https://w3c.github.io/epub-tests/results">EPUB 3.3 Test Results</a> document.
+            </p>
           </li>
         </ul>
       </dd>
 
-      <dt><a href="exit_criteria.html#exit-criteria-a11y">EPUB Accessibility 1.1</a></dt>
+      <dt><a href="exit_criteria.html#exit-criteria-a11y">EPUB Accessibility 1.1</a> [[epub-a11y-11]]</dt>
       <dd>
         <ul>
           <li>
-            <a href="exit_criteria.html#exit-criteria-a11y-1">Category 1</a>: 
-            <span class="todo"></span>
+            <p>
+              <a href="exit_criteria.html#exit-criteria-a11y-1">Category 1</a>: at least 5 publishers produce at least 1 EPUB publication each that
+              conforms to <a href="https://www.w3.org/TR/epub-a11y-11/#sec-conf-reporting-pub">EPUB Accessibility 1.1 - WCAG 2.0 Level AA</a>.  
+            </p>
+            <p>
+              See the <a href="a11y-usage">EPUB Accessibility 1.1 Usage Report</a> document.
+            </p>
           </li>
           <li>
-            <a href="exit_criteria.html#exit-criteria-a11y-2">Category 2</a>: 
-            see the <a href="a11y-properties-use">EPUB Accessibility 1.1 Metadata Usage Report</a>
+            <p>
+              <a href="exit_criteria.html#exit-criteria-a11y-2">Category 2</a>: each metadata item defined and required in [[epub-a11y-11]] has sufficient usage by the
+              target communities, i.e., at least two organizations regularly include them in the [=package document=] metadata for their EPUB publications (as appropriate for each title).
+            </p>
+            <p>
+              See the <a href="a11y-properties-use">EPUB Accessibility 1.1 Metadata Usage Report</a> document.
+            </p>
           </li>
         </ul>
       </dd>


### PR DESCRIPTION
I have gone through all the report documents on the spec repository to refresh them and to make them usable for the official PR review request. All the changes are stylistic.

The usual preview mechanism does not work, so here is the list of documents to look at:

- [Index file](https://raw.githack.com/w3c/epub-specs/updating-testing-reports/epub33/reports/index.html)
- [EPUB 3.3 Testing Strategies and CR Exit Criteria](https://raw.githack.com/w3c/epub-specs/updating-testing-reports/epub33/reports/exit_criteria.html)
- [EPUB Accessibility 1.1 Metadata Usage Report](https://raw.githack.com/w3c/epub-specs/updating-testing-reports/epub33/reports/a11y-properties-use.html)
- [EPUB Accessibility 1.1 Usage Report](https://raw.githack.com/w3c/epub-specs/updating-testing-reports/epub33/reports/a11y-usage.html)
- [EPUB 3.3. Metadata Usage Report](https://raw.githack.com/w3c/epub-specs/updating-testing-reports/epub33/reports/epub-properties-use.html)

For reviewing: the first two documents are HTML files in respec; while the last three documents are also respec files, but the only thing they do is to include a markdown file. Proposed changes may have to be made on those.