### PR TITLE
Switch "Conformance Properties" to "Certifier Properties"

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1707,7 +1707,7 @@
 							document</a>.</p>
 				</section>
 				<section id="app-vocab-properties">
-					<h3>Conformance properties</h3>
+					<h3>Certifier properties</h3>
 
 					<section id="certifiedBy">
 						<h4>certifiedBy</h4>


### PR DESCRIPTION
The appendix that defines the accessibility vocabulary calls the one section of properties "Conformance Properties", but we only define properties about the certifier in it.

@clapierre has pointed out that it's probably more accurate to call this section "Certifier Properties".

This change only affects the sub-section title. There are no other references to the title.