### PR TITLE
Add section about compatibility with Accessibility 1.0

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -216,15 +216,15 @@
 				</section>
 			</section>
 
-			<section id="sec-compat">
+			<section id="sec-compat" class="informative">
 				<h3>Compatibility with EPUB Accessibility 1.0</h3>
 
 				<p>EPUB publications that meet the requirements of this specification are backwards-compatible with EPUB
 					Accessibility 1.0 [[epub-a11y-10]].</p>
 
 				<p>Although EPUB Accessibility 1.0 did not recognize a <a href="#sec-conf-reporting-pub">conformance
-						identifier</a> for WCAG 2.1 [[wcag-21]], as WCAG 2.1 builds on and is backwards-compatible with
-					WCAG 2.0 [[wcag-20]], EPUB publications that meet the higher WCAG requirements are also compatible
+						identifier</a> for WCAG 2.1 [[wcag21]], as WCAG 2.1 builds on and is backwards-compatible with
+					WCAG 2.0 [[wcag20]], EPUB publications that meet the higher WCAG requirements are also compatible
 					with EPUB Accessibility 1.0.</p>
 			</section>
 
@@ -1883,6 +1883,9 @@
 						Recommendation</a></h3>
 
 				<ul>
+					<li>23-Jan-2023: Added section to the introduction clarifying compatibility with the EPUB
+						Accessibiltiy 1.0 specification. See <a href="https://github.com/w3c/epub-specs/issues/2526"
+							>issue 2526</a>.</li>
 					<li>12-Aug-2022: Changed <code>accessibilitySummary</code> from a required to a recommended property
 						and updated its definition to focus less on repeating information available in the other
 						metadata. See <a href="https://github.com/w3c/epub-specs/issues/2399">issue 2399</a>.</li>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -216,8 +216,20 @@
 				</section>
 			</section>
 
+			<section id="sec-compat">
+				<h3>Compatibility with EPUB Accessibility 1.0</h3>
+
+				<p>EPUB publications that meet the requirements of this specification are backwards-compatible with EPUB
+					Accessibility 1.0 [[epub-a11y-10]].</p>
+
+				<p>Although EPUB Accessibility 1.0 did not recognize a <a href="#sec-conf-reporting-pub">conformance
+						identifier</a> for WCAG 2.1 [[wcag-21]], as WCAG 2.1 builds on and is backwards-compatible with
+					WCAG 2.0 [[wcag-20]], EPUB publications that meet the higher WCAG requirements are also compatible
+					with EPUB Accessibility 1.0.</p>
+			</section>
+
 			<section id="sec-application" class="informative">
-				<h3>Application to older versions</h3>
+				<h3>Application to older versions of EPUB</h3>
 
 				<p>This specification is applicable to any <a href="https://www.w3.org/TR/epub/#dfn-epub-publication"
 						>EPUB publication</a>, even if the content conforms to an older version of EPUB that does not


### PR DESCRIPTION
This pull request becomes valid assuming we agree to publish the erratum noted in issue #2526.

If we can vote on moving ahead with that erratum on this week's call, this pull request doesn't add any new normative requirements.

If it's too late to change the specification and vote on moving to PR in the same call, we can defer integrating this and leave it for the maintenance group. Getting the erratum agreed on is more important and it doesn't affect the transition of the specifications.