### PR TITLE
Minor clarification to summary technique

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -557,9 +557,9 @@
 
 				<p>The accessibility summary should not simply repeat the conformance information provided in the
 						<code>dcterms:conformsTo</code> property, for example, or the features listed in the
-						<code>schema:accessibilityFeature</code> properties. When other accessibility metadata is present in the
-					package document, systems that process EPUB publications can already present it to users. Repeating
-					it in the summary only makes them hear the information again.</p>
+						<code>schema:accessibilityFeature</code> properties. When other accessibility metadata is
+					present in the package document, systems that process EPUB publications can already present it to
+					users. Repeating it in the summary only makes them hear the information again.</p>
 
 				<aside class="example" title="Accessibility summary that complements the conformance statement">
 					<pre>&lt;meta

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -557,9 +557,9 @@
 
 				<p>The accessibility summary should not simply repeat the conformance information provided in the
 						<code>dcterms:conformsTo</code> property, for example, or the features listed in the
-						<code>schema:accessibilityFeature</code> properties. As this metadata is required by the EPUB
-					Accessibility specification, systems that process EPUB publications can already present it to users.
-					Repeating it in the summary only makes them hear the information again.</p>
+						<code>schema:accessibilityFeature</code> properties. When other accessibility metadata is present in the
+					package document, systems that process EPUB publications can already present it to users. Repeating
+					it in the summary only makes them hear the information again.</p>
 
 				<aside class="example" title="Accessibility summary that complements the conformance statement">
 					<pre>&lt;meta


### PR DESCRIPTION
Changes the following sentence from:

> As this metadata is required by the EPUB Accessibility specification,

to:

> When other accessibility metadata is present in the package document,

as it's been noted that the meaning of "this metadata" may not be clear.