### PR TITLE
Remove reference to getOverrideStyle

### DIFF
--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1205,10 +1205,8 @@
 					</li>
 					<li>
 						<p id="confreq-css-overrides">SHOULD NOT override the EPUB creator's style sheets, but SHOULD do
-							so in a way that preserves the Cascade when necessary: through a user agent style sheet, the
-								<a data-cite="DOM-Level-2-Style/css.html#CSS-OverrideAndComputed"
-									><code>getOverrideStyle</code></a> method [[dom-level-2-style]], or [[html]]
-							[^html-global/style^] attributes.</p>
+							so in a way that preserves the Cascade when necessary: through a user agent style sheet, or
+							[[html]] [^html-global/style^] attributes.</p>
 					</li>
 					<li>
 						<p id="confreq-css-user-styles">It MAY override parts of the EPUB creator's style sheet because
@@ -1840,23 +1838,24 @@
 			<section id="sec-behaviors-loading">
 				<h4>Loading the media overlay</h4>
 
-				<p id="confreq-rs-loading-mol" data-tests="#mol-support_xhtml,#mol-support_xhtml-fxl">When a reading system loads a [=package
-					document=], it MUST refer to the [=EPUB manifest | manifest=] [^item^] elements' [[epub-33]]
-						<code>media-overlay</code> attributes to discover the corresponding media overlays for [=EPUB
-					content documents=].</p>
+				<p id="confreq-rs-loading-mol" data-tests="#mol-support_xhtml,#mol-support_xhtml-fxl">When a reading
+					system loads a [=package document=], it MUST refer to the [=EPUB manifest | manifest=] [^item^]
+					elements' [[epub-33]] <code>media-overlay</code> attributes to discover the corresponding media
+					overlays for [=EPUB content documents=].</p>
 
 				<p id="confreq-rs-xhtml-svg">
-					<span id="mol-xhtml-support" data-tests="#mol-support_xhtml,#mol-support_xhtml-fxl">Reading systems MUST support playback
-						for [=XHTML content documents=], and</span>
+					<span id="mol-xhtml-support" data-tests="#mol-support_xhtml,#mol-support_xhtml-fxl">Reading systems
+						MUST support playback for [=XHTML content documents=], and</span>
 					<span id="mol-svg-support">MAY support [=SVG content documents=].</span>
 				</p>
 
 				<p>
-					<span id="mol-support-xhtml-load" data-tests="#mol-support_xhtml-load,#mol-support_xhtml-load-fxl"> Playback MUST start at the
-						media overlay element which corresponds to the desired EPUB content document starting point.
-						Note that the start of an EPUB content document could correspond to an element at the start or
-						in the middle of a media overlay. </span>
-					<span id="mol-support-xhtml-load-next" data-tests="#mol-support_xhtml-load-next,#mol-support_xhtml-load-next-fxl"> When the media
+					<span id="mol-support-xhtml-load" data-tests="#mol-support_xhtml-load,#mol-support_xhtml-load-fxl">
+						Playback MUST start at the media overlay element which corresponds to the desired EPUB content
+						document starting point. Note that the start of an EPUB content document could correspond to an
+						element at the start or in the middle of a media overlay. </span>
+					<span id="mol-support-xhtml-load-next"
+						data-tests="#mol-support_xhtml-load-next,#mol-support_xhtml-load-next-fxl"> When the media
 						overlay document finishes playing, the reading system SHOULD load the next EPUB content document
 						(as specified in the package document [=EPUB spine | spine=]) and also load its corresponding
 						media overlay document, provided that one is given. </span>
@@ -1922,13 +1921,14 @@
 							Identifiers</a> [[svg]], reading systems MAY support other fragment identifier schemes.</p>
 
 					<p id="mol-rendering-with-styling"
-						data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_svg-fxl">During
-						media overlays playback, reading systems with a viewport SHOULD add the class names given by the
-						metadata properties <a data-cite="epub-33#active-class"><code>active-class</code></a> and <a
-							data-cite="epub-33#playback-active-class"><code>playback-active-class</code></a> [[epub-33]]
-						to the appropriate elements, when specified, in the [=EPUB content document=]. Conversely, the
-						class names SHOULD be removed when the playback state changes, as described in <a
-							data-cite="epub-33#sec-docs-assoc-style">Associating style information</a> [[epub-33]].</p>
+						data-tests="#mol-css,#mol-timing-synchronization_fxl,#mol-timing-synchronization_svg,#mol-timing-synchronization_svg-fxl"
+						>During media overlays playback, reading systems with a viewport SHOULD add the class names
+						given by the metadata properties <a data-cite="epub-33#active-class"
+							><code>active-class</code></a> and <a data-cite="epub-33#playback-active-class"
+								><code>playback-active-class</code></a> [[epub-33]] to the appropriate elements, when
+						specified, in the [=EPUB content document=]. Conversely, the class names SHOULD be removed when
+						the playback state changes, as described in <a data-cite="epub-33#sec-docs-assoc-style"
+							>Associating style information</a> [[epub-33]].</p>
 
 					<p>The <code>active-class</code> and <code>playback-active-class</code> metadata properties are
 						OPTIONAL, and if omitted, reading system behavior is implementation-specific.</p>
@@ -2697,6 +2697,9 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 						Recommendation</a></h3>
 
 				<ul>
+					<li>01-Feb-2023: Removed reference to <code>getOverrideStyle</code> in DOM Level 2 as it was dropped
+						from the DOM Living Standard. See <a href="https://github.com/w3c/epub-specs/pull/2531">pull
+							request 2531</a>.</li>
 					<li>11-Jan-2023: Added note advising reading system developers to support package metadata
 						directionality even though marked as under-implemented for authoring. See <a
 							href="https://github.com/w3c/epub-specs/pull/2515">pull request 2515</a>.</li>


### PR DESCRIPTION
A comment was made in the CR transition request to remove the reference to `getOverrideStyle` and DOM Level 2 Style, but didn't get turned into an issue. See https://github.com/w3c/transitions/issues/427#issuecomment-1119973256

This pull request deletes the reference in question as it was only used as an example of how to preserve the CSS cascade. It doesn't appear it ever got widely adopted and isn't in the DOM Living Standard spec.

* Reading Systems [Preview](https://cdn.statically.io/gh/w3c/epub-specs/editorial/remove-old-ref/epub33/rs/index.html)
* Reading Systems [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/rs/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/editorial/remove-old-ref/epub33/rs/index.html)
