### PR TITLE
Preparation to final round

### DIFF
--- a/.github/workflows/epub-a11y.this_should_be_yml
+++ b/.github/workflows/epub-a11y.this_should_be_yml
@@ -24,4 +24,4 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2021-02-12-epub#resolution2
           W3C_BUILD_OVERRIDE: |
              shortName: epub-a11y-11
-             specStatus: CRD
+             specStatus: REC

--- a/.github/workflows/epub-core.this_should_be_yml
+++ b/.github/workflows/epub-core.this_should_be_yml
@@ -24,4 +24,4 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-11-20-epub#resolution2
           W3C_BUILD_OVERRIDE: |
              shortName: epub-33
-             specStatus: CRD
+             specStatus: REC

--- a/.github/workflows/epub-rs.this_should_be_yml
+++ b/.github/workflows/epub-rs.this_should_be_yml
@@ -24,4 +24,4 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/publishing/groups/epub-wg/Meetings/Minutes/2020-11-20-epub#resolution2
           W3C_BUILD_OVERRIDE: |
              shortName: epub-rs-33
-             specStatus: CRD
+             specStatus: REC

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
 				group: "epub",
@@ -49,6 +50,7 @@
 					branch: "main"
 				},
 				profile: "web-platform",
+				postProcess: [modifyCopyright],
 				localBiblio: {
 					"a11y-discov-vocab": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -6,6 +6,7 @@
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/data-test-display.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
 				subtitle: "Conformance and Discoverability Requirements for EPUB publications",
@@ -103,7 +104,7 @@
 					}
 				},
 				preProcess:[inlineCustomCSS],
-				postProcess: [data_test_display],
+				postProcess: [data_test_display,modifyCopyright],
 			};</script>
 		<style>
 			.conf-pattern {

--- a/epub33/common/js/copyright.js
+++ b/epub33/common/js/copyright.js
@@ -1,0 +1,22 @@
+function modifyCopyright() {
+    // This is where the copyright statement resides...
+    const p = document.querySelector("p.copyright");
+
+    // get the years out of the text, because that can change...
+    const index = p.textContent.search(/[0-9]{4}-[0-9]{4}/)
+    const years = p.textContent.slice(index,index+9);
+
+    // Replacement text
+    p.innerHTML = `
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © ${years}
+    <a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+	and
+    <a href="https://www.w3.org/">World Wide Web Consortium</a>.
+    <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+    <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+    `
+}
+
+// 1999-2022

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -8,6 +8,7 @@
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/add-caution-hd.js" class="remove"></script>
 		<script src="../common/js/data-test-display.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
             var respecConfig = {
@@ -50,7 +51,7 @@
                 },
                 localBiblio: biblio,
                 preProcess:[inlineCustomCSS],
-                postProcess:[addCautionHeaders, data_test_display],
+                postProcess:[addCautionHeaders,data_test_display,modifyCopyright],
                 testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
                 lint: {
                      "wpt-tests-exist": true,

--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -5,6 +5,7 @@
 		<title>EPUB Accessibility - EU Accessibility Act Mapping</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
 				group: "epub",
@@ -36,6 +37,7 @@
 				includePermalinks: true,
 				permalinkEdge: true,
 				permalinkHide: false,
+				postProcess: [modifyCopyright],
 				github: {
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"

--- a/epub33/epub-aria-authoring/index.html
+++ b/epub33/epub-aria-authoring/index.html
@@ -5,6 +5,7 @@
 		<title>EPUB Type to ARIA Role Authoring Guide 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
                 group: "epub",
@@ -27,7 +28,7 @@
                     repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
-                preProcess:[inlineCustomCSS],
+                preProcess:[inlineCustomCSS,modifyCopyright],
 				localBiblio: {
 					"dpub-aria": {
 						"title": "Digital Publishing WAI-ARIA Module",

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -5,6 +5,7 @@
 		<title>EPUB Canonical Fragment Identifiers 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
       	// <![CDATA[
           var respecConfig = {
@@ -77,7 +78,8 @@
 				branch: "main"
 			  },
 			  pluralize: true,
-			  preProcess:[inlineCustomCSS]
+			  preProcess:[inlineCustomCSS],
+			  postProcess: [modifyCopyright]
           };
          // ]]>
       </script>

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -5,6 +5,7 @@
 		<title>EPUB Fixed Layout Accessibility</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
             var respecConfig = {
@@ -39,7 +40,8 @@
 						"publisher": "W3C"
 					}
                 },
-                preProcess:[inlineCustomCSS]
+                preProcess:[inlineCustomCSS],
+				postProcess: [modifyCopyright]
             };//]]>
       </script>
         

--- a/epub33/locators/index.html
+++ b/epub33/locators/index.html
@@ -5,6 +5,7 @@
 		<title>EPUB Locators</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
             var respecConfig = {
@@ -32,7 +33,8 @@
                     branch: "main"
                 },
                 pluralize: true,
-                preProcess:[inlineCustomCSS]
+                preProcess:[inlineCustomCSS],
+                postProcess: [modifyCopyright]
             };//]]>
       </script>
 	</head>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -5,6 +5,7 @@
 		<title>EPUB 3 Multiple-Rendition Publications 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
             var respecConfig = {
@@ -67,7 +68,8 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-                preProcess:[inlineCustomCSS]
+                preProcess:[inlineCustomCSS],
+				postProcess: [modifyCopyright]
             };//]]>
       </script>
 	</head>

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -8,6 +8,7 @@
 		<script src="../common/js/add-caution-hd.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/remove-empty-index.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
 				group: "epub",
@@ -47,7 +48,7 @@
 				},
 				localBiblio: biblio,
 				preProcess:[inlineCustomCSS],
-				postProcess: [removeEmptyIndex]
+				postProcess: [removeEmptyIndex,modifyCopyright]
 			};</script>
 	</head>
 	<body>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -6,6 +6,7 @@
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/data-test-display.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
@@ -105,7 +106,7 @@
 					},
 				},
 				preProcess:[inlineCustomCSS],
-				postProcess: [data_test_display],
+				postProcess: [data_test_display,modifyCopyright],
 				testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
 				lint: {
 					"wpt-tests-exist": true,

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -5,6 +5,7 @@
 		<title>EPUB 3 Structural Semantics Vocabulary 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
@@ -90,7 +91,8 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-				preProcess:[inlineCustomCSS]
+				preProcess:[inlineCustomCSS],
+				postProcess: [modifyCopyright]
 			};//]]>
 		</script>
 		<style>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -5,6 +5,7 @@
 		<title>EPUB 3 Text-to-Speech Enhancements 1.0</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
+		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
@@ -51,7 +52,8 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-				preProcess:[inlineCustomCSS]
+				preProcess:[inlineCustomCSS],
+				postProcess: [modifyCopyright]
 			};//]]>
 		</script>
 	</head>


### PR DESCRIPTION
This PR does two things:

- The three github action scripts that control echidna for rec-track documents have been "switched off" (by renaming the suffix from yml). This is important at this stage when the upcoming publications (PR and REC) must go through the old-skool route
- Have added a small script as well as modified the header of _all_ documents (Rec track and Note track alike) to change the default copyright statement to include IDPF alongside W3C.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2532.html" title="Last updated on Feb 22, 2023, 3:14 PM UTC (06358d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2532/79e2ce5...06358d8.html" title="Last updated on Feb 22, 2023, 3:14 PM UTC (06358d8)">Diff</a>