### PR TITLE
Add dedication to Ben Schroeter

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1958,7 +1958,7 @@
 				</ul>
 			</section>
 		</section>
-		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
+		<div data-include="../common/acknowledgements-a11y-dedication.html" data-oninclude="fixIncludes" data-include-replace="true"
 		></div>
 	</body>
 </html>

--- a/epub33/common/ack-script/ack_a11y_dedication_pattern.html
+++ b/epub33/common/ack-script/ack_a11y_dedication_pattern.html
@@ -1,0 +1,16 @@
+<section id="ack" class="appendix informative">
+    <h2>Acknowledgements</h2>
+
+	<p>The journey to make publications accessible for all can sometimes feels like a long and winding road. It
+		takes a special kind of person with strong dedication to the goal and an abundance of perseverance to
+		keep going even when it seems like there are still miles to go and many hills to climb. Ben Schroeter
+		was one such person, working tirelessly to help EPUB reach its potential as a universally accessible
+		format. We miss him greatly and dedicate this document to his memory.</p>
+
+    <p>The following members of the EPUB 3 Working Group contributed to the development of this specification:</p>
+
+    <ul class="ack">
+        %%GROUP_MEMBERS_LISTING%%
+    </ul>
+    
+</section>

--- a/epub33/common/acknowledgements-a11y-dedication.html
+++ b/epub33/common/acknowledgements-a11y-dedication.html
@@ -1,84 +1,90 @@
 <section id="ack" class="appendix informative">
-	<h2>Acknowledgements</h2>
+    <h2>Acknowledgements</h2>
+
 	<p>The journey to make publications accessible for all can sometimes feels like a long and winding road. It
 		takes a special kind of person with strong dedication to the goal and an abundance of perseverance to
 		keep going even when it seems like there are still miles to go and many hills to climb. Ben Schroeter
 		was one such person, working tirelessly to help EPUB reach its potential as a universally accessible
 		format. We miss him greatly and dedicate this document to his memory.</p>
-	<p>The following members of the EPUB 3 Working Group contributed to the development of this document:</p>
-	<ul class="ack">
-		<li>Will AWAD (Newgen Knowledgeworks)</li>
-		<li>Sofia Bautista (Legible Media Inc.)</li>
-		<li>Laura Brady (Legible Media Inc.)</li>
-		<li>Leah Brochu (National Network for Equitable Library Service)</li>
-		<li>Matthew C. Chan (House of Anansi Press)</li>
-		<li>Yu-Wei Chang (Taiwan Digital Publishing Forum)</li>
-		<li>Fred Chasen (Scribd)</li>
-		<li>Juan Corona (Legible Media Inc.)</li>
-		<li>Dave Cramer (W3C Invited Expert, chair)</li>
-		<li>Romain Deltour (DAISY Consortium)</li>
-		<li>Marisa DeMeglio (DAISY Consortium)</li>
-		<li>Brady Duga (Google LLC)</li>
-		<li>Reinaldo Ferraz (NIC.br - Brazilian Network Information Center)</li>
-		<li>John Foliot (W3C Invited Expert)</li>
-		<li>Teenya Franklin (Pearson plc)</li>
-		<li>Hadrien Gardeur (EDRLab)</li>
-		<li>Matt Garrish (DAISY Consortium)</li>
-		<li>Jen Goulden (Crawford Technologies)</li>
-		<li>Ivan Herman (W3C, staff contact)</li>
-		<li>Tetsu Hoshino (Kodansha, Publishers, Ltd.)</li>
-		<li>Norikazu Ishizu (Kadokawa Corporation)</li>
-		<li>Norihito IYENAGA (Kodansha, Publishers, Ltd.)</li>
-		<li>Rick Johnson (VitalSource Technologies)</li>
-		<li>Ken Jones (Circular Software)</li>
-		<li>Antonio Kamiya (Dentsu Group Inc.)</li>
-		<li>Deborah Kaplan (W3C Invited Expert)</li>
-		<li>Bill Kasdorf (Book Industry Study Group)</li>
-		<li>George Kerscher (DAISY Consortium)</li>
-		<li>Kazuhito Kidachi (Mitsue-Links Co., Ltd.)</li>
-		<li>Masakazu Kitahara (Voyager Japan, Inc.)</li>
-		<li>Toshiaki Koike (Voyager Japan, Inc.)</li>
-		<li>Ryo Kuroda (ACCESS CO., LTD.)</li>
-		<li>Charles LaPierre (Benetech)</li>
-		<li>Dan Lazin (Google LLC)</li>
-		<li>Laurent Le Meur (EDRLab)</li>
-		<li>Victoria Lee (Apple, Inc.)</li>
-		<li>Farrah Little (National Network for Equitable Library Service)</li>
-		<li>Victor Lopes (Apple, Inc.)</li>
-		<li>Karan Malhotra (Newgen Knowledgeworks)</li>
-		<li>Makoto Murata (DAISY Consortium)</li>
-		<li>Cristina Mussinelli (Fondazione LIA)</li>
-		<li>Yoichiro Nagao (Kodansha, Publishers, Ltd.)</li>
-		<li>Theresa O'Connor (Apple, Inc.)</li>
-		<li>Yoshinori Ohmura (SHUEISHA Inc.)</li>
-		<li>Rachel Osolen (National Network for Equitable Library Service)</li>
-		<li>Gregorio Pellegrino (Fondazione LIA)</li>
-		<li>Vijaya Gowri Perumal (Newgen Knowledgeworks)</li>
-		<li>Wendy Reid (Rakuten Group, Inc., chair)</li>
-		<li>John Roque (Apple, Inc.)</li>
-		<li>Leonard Rosenthol (Adobe)</li>
-		<li>Shinobu Sato (Kadokawa Corporation)</li>
-		<li>Ben Schroeter (Pearson plc)</li>
-		<li>Daihei Shiohama (MEDIA DO Co., Ltd.)</li>
-		<li>Tzviya Siegman (Wiley)</li>
-		<li>Avneesh Singh (DAISY Consortium)</li>
-		<li>MOTOI SUZUKI (SHUEISHA Inc.)</li>
-		<li>Yutaka Suzuki (Kadokawa Corporation)</li>
-		<li>Kyrce Swenson (Pearson plc)</li>
-		<li>Shinya Takami (Kadokawa Corporation, chair)</li>
-		<li>Mateus Teixeira (W. W. Norton & Company)</li>
-		<li>Yukio Tomikura (Kodansha, Publishers, Ltd.)</li>
-		<li>Aimee Ubbink (Crawford Technologies)</li>
-		<li>Daniel Weck (DAISY Consortium)</li>
-		<li>Zheng Xu (Gardenia Corp)</li>
-		<li>Fuqiao Xue (W3C)</li>
-		<li>Evan Yamanishi (W. W. Norton & Company)</li>
-		<li>Osamu Yoshiba (Kodansha, Publishers, Ltd.)</li>
-		<li>Junichi Yoshii (Kodansha, Publishers, Ltd.)</li>
-		<li>Naomi Yoshizawa (W3C)</li>
-		<li>Laurence Zaysser (EDRLab)</li>
-	</ul>
-	<p>In addition, the Working Group would like to extend a special thanks to the former editors of the EPUB 3
-		specifications and overview: Garth Conboy, Marisa DeMeglio, Elika J. Etemad, Markus Gylling, William
-		McCoy, MURATA Makoto, James Pritchett, Tzviya Siegman, and Daniel Weck.</p>
+
+    <p>The following members of the EPUB 3 Working Group contributed to the development of this specification:</p>
+
+    <ul class="ack">
+                <li>Shadi Abou-Zahra (Amazon)</li>
+        <li>Will AWAD (Newgen Knowledgeworks)</li>
+        <li>Noel Ray Barron (Apple Inc.)</li>
+        <li>Sofia Bautista (Legible Media Inc.)</li>
+        <li>Leah Brochu (National Network for Equitable Library Service)</li>
+        <li>Matthew C. Chan (House of Anansi Press)</li>
+        <li>Yu-Wei Chang (Taiwan Digital Publishing Forum)</li>
+        <li>Juan Corona (Legible Media Inc.)</li>
+        <li>Dave Cramer (W3C Invited Expert, chair)</li>
+        <li>Romain Deltour (DAISY Consortium)</li>
+        <li>Marisa DeMeglio (DAISY Consortium)</li>
+        <li>Brady Duga (Google LLC)</li>
+        <li>Reinaldo Ferraz (NIC.br - Brazilian Network Information Center)</li>
+        <li>Symon Flaming (Rakuten Group, Inc.)</li>
+        <li>John Foliot (W3C Invited Expert)</li>
+        <li>Teenya Franklin (Pearson plc)</li>
+        <li>Hadrien Gardeur (EDRLab)</li>
+        <li>Matt Garrish (DAISY Consortium)</li>
+        <li>Jen Goulden (Crawford Technologies)</li>
+        <li>David Hall (Apple Inc.)</li>
+        <li>Ivan Herman (W3C, staff contact)</li>
+        <li>Tetsu Hoshino (Kodansha, Publishers, Ltd.)</li>
+        <li>jasen huang (ByteDance)</li>
+        <li>Norikazu Ishizu (Kadokawa Corporation)</li>
+        <li>Norihito IYENAGA (Kodansha, Publishers, Ltd.)</li>
+        <li>Rick Johnson (VitalSource Technologies)</li>
+        <li>Ken Jones (Circular Software)</li>
+        <li>Antonio Kamiya (Dentsu Group Inc.)</li>
+        <li>Deborah Kaplan (W3C Invited Expert)</li>
+        <li>Bill Kasdorf (Book Industry Study Group)</li>
+        <li>Hiroshi Kawada (MEDIA DO Co., Ltd.)</li>
+        <li>George Kerscher (DAISY Consortium)</li>
+        <li>Kazuhito Kidachi (Mitsue-Links Co., Ltd.)</li>
+        <li>Masakazu Kitahara (Voyager Japan, Inc.)</li>
+        <li>Toshiaki Koike (Voyager Japan, Inc.)</li>
+        <li>Ryo Kuroda (ACCESS CO., LTD.)</li>
+        <li>Charles LaPierre (Benetech)</li>
+        <li>Dan Lazin (Google LLC)</li>
+        <li>Philippe Le Hegaret (W3C)</li>
+        <li>Laurent Le Meur (EDRLab)</li>
+        <li>YuYu Lin (Taiwan Digital Publishing Forum)</li>
+        <li>Farrah Little (National Network for Equitable Library Service)</li>
+        <li>Victor Lopes (Apple Inc.)</li>
+        <li>Karan  Malhotra (Newgen Knowledgeworks)</li>
+        <li>Makoto Murata (DAISY Consortium)</li>
+        <li>Cristina Mussinelli (Fondazione LIA)</li>
+        <li>Yoichiro Nagao (Kodansha, Publishers, Ltd.)</li>
+        <li>Theresa O'Connor (Apple Inc.)</li>
+        <li>Yoshinori Ohmura (SHUEISHA Inc.)</li>
+        <li>Rachel Osolen (National Network for Equitable Library Service)</li>
+        <li>Gregorio Pellegrino (Fondazione LIA)</li>
+        <li>Vijaya Gowri Perumal (Newgen Knowledgeworks)</li>
+        <li>Wendy Reid (Rakuten Group, Inc., chair)</li>
+        <li>John Roque (Apple Inc.)</li>
+        <li>Leonard Rosenthol (Adobe)</li>
+        <li>Shinobu Sato (Kadokawa Corporation)</li>
+        <li>Ben Schroeter (Pearson plc)</li>
+        <li>Daihei Shiohama (MEDIA DO Co., Ltd.)</li>
+        <li>Tzviya Siegman (Wiley)</li>
+        <li>Avneesh Singh (DAISY Consortium)</li>
+        <li>MOTOI SUZUKI (SHUEISHA Inc.)</li>
+        <li>Yutaka Suzuki (Kadokawa Corporation)</li>
+        <li>Kyrce Swenson (Pearson plc)</li>
+        <li>Shinya Takami (Kadokawa Corporation, chair)</li>
+        <li>Mateus Teixeira (W. W. Norton & Company)</li>
+        <li>Yukio Tomikura (Kodansha, Publishers, Ltd.)</li>
+        <li>Aimee Ubbink (Crawford Technologies)</li>
+        <li>xinyuan wang (ByteDance)</li>
+        <li>Daniel Weck (DAISY Consortium)</li>
+        <li>Fuqiao Xue (W3C)</li>
+        <li>Evan Yamanishi (W. W. Norton & Company)</li>
+        <li>Osamu Yoshiba (Kodansha, Publishers, Ltd.)</li>
+        <li>Junichi Yoshii (Kodansha, Publishers, Ltd.)</li>
+        <li>Naomi Yoshizawa (W3C)</li>
+        <li>Laurence Zaysser (EDRLab)</li>
+    </ul>
+    
 </section>

--- a/epub33/common/acknowledgements-a11y-dedication.html
+++ b/epub33/common/acknowledgements-a11y-dedication.html
@@ -1,0 +1,84 @@
+<section id="ack" class="appendix informative">
+	<h2>Acknowledgements</h2>
+	<p>The journey to make publications accessible for all can sometimes feels like a long and winding road. It
+		takes a special kind of person with strong dedication to the goal and an abundance of perseverance to
+		keep going even when it seems like there are still miles to go and many hills to climb. Ben Schroeter
+		was one such person, working tirelessly to help EPUB reach its potential as a universally accessible
+		format. We miss him greatly and dedicate this document to his memory.</p>
+	<p>The following members of the EPUB 3 Working Group contributed to the development of this document:</p>
+	<ul class="ack">
+		<li>Will AWAD (Newgen Knowledgeworks)</li>
+		<li>Sofia Bautista (Legible Media Inc.)</li>
+		<li>Laura Brady (Legible Media Inc.)</li>
+		<li>Leah Brochu (National Network for Equitable Library Service)</li>
+		<li>Matthew C. Chan (House of Anansi Press)</li>
+		<li>Yu-Wei Chang (Taiwan Digital Publishing Forum)</li>
+		<li>Fred Chasen (Scribd)</li>
+		<li>Juan Corona (Legible Media Inc.)</li>
+		<li>Dave Cramer (W3C Invited Expert, chair)</li>
+		<li>Romain Deltour (DAISY Consortium)</li>
+		<li>Marisa DeMeglio (DAISY Consortium)</li>
+		<li>Brady Duga (Google LLC)</li>
+		<li>Reinaldo Ferraz (NIC.br - Brazilian Network Information Center)</li>
+		<li>John Foliot (W3C Invited Expert)</li>
+		<li>Teenya Franklin (Pearson plc)</li>
+		<li>Hadrien Gardeur (EDRLab)</li>
+		<li>Matt Garrish (DAISY Consortium)</li>
+		<li>Jen Goulden (Crawford Technologies)</li>
+		<li>Ivan Herman (W3C, staff contact)</li>
+		<li>Tetsu Hoshino (Kodansha, Publishers, Ltd.)</li>
+		<li>Norikazu Ishizu (Kadokawa Corporation)</li>
+		<li>Norihito IYENAGA (Kodansha, Publishers, Ltd.)</li>
+		<li>Rick Johnson (VitalSource Technologies)</li>
+		<li>Ken Jones (Circular Software)</li>
+		<li>Antonio Kamiya (Dentsu Group Inc.)</li>
+		<li>Deborah Kaplan (W3C Invited Expert)</li>
+		<li>Bill Kasdorf (Book Industry Study Group)</li>
+		<li>George Kerscher (DAISY Consortium)</li>
+		<li>Kazuhito Kidachi (Mitsue-Links Co., Ltd.)</li>
+		<li>Masakazu Kitahara (Voyager Japan, Inc.)</li>
+		<li>Toshiaki Koike (Voyager Japan, Inc.)</li>
+		<li>Ryo Kuroda (ACCESS CO., LTD.)</li>
+		<li>Charles LaPierre (Benetech)</li>
+		<li>Dan Lazin (Google LLC)</li>
+		<li>Laurent Le Meur (EDRLab)</li>
+		<li>Victoria Lee (Apple, Inc.)</li>
+		<li>Farrah Little (National Network for Equitable Library Service)</li>
+		<li>Victor Lopes (Apple, Inc.)</li>
+		<li>Karan Malhotra (Newgen Knowledgeworks)</li>
+		<li>Makoto Murata (DAISY Consortium)</li>
+		<li>Cristina Mussinelli (Fondazione LIA)</li>
+		<li>Yoichiro Nagao (Kodansha, Publishers, Ltd.)</li>
+		<li>Theresa O'Connor (Apple, Inc.)</li>
+		<li>Yoshinori Ohmura (SHUEISHA Inc.)</li>
+		<li>Rachel Osolen (National Network for Equitable Library Service)</li>
+		<li>Gregorio Pellegrino (Fondazione LIA)</li>
+		<li>Vijaya Gowri Perumal (Newgen Knowledgeworks)</li>
+		<li>Wendy Reid (Rakuten Group, Inc., chair)</li>
+		<li>John Roque (Apple, Inc.)</li>
+		<li>Leonard Rosenthol (Adobe)</li>
+		<li>Shinobu Sato (Kadokawa Corporation)</li>
+		<li>Ben Schroeter (Pearson plc)</li>
+		<li>Daihei Shiohama (MEDIA DO Co., Ltd.)</li>
+		<li>Tzviya Siegman (Wiley)</li>
+		<li>Avneesh Singh (DAISY Consortium)</li>
+		<li>MOTOI SUZUKI (SHUEISHA Inc.)</li>
+		<li>Yutaka Suzuki (Kadokawa Corporation)</li>
+		<li>Kyrce Swenson (Pearson plc)</li>
+		<li>Shinya Takami (Kadokawa Corporation, chair)</li>
+		<li>Mateus Teixeira (W. W. Norton & Company)</li>
+		<li>Yukio Tomikura (Kodansha, Publishers, Ltd.)</li>
+		<li>Aimee Ubbink (Crawford Technologies)</li>
+		<li>Daniel Weck (DAISY Consortium)</li>
+		<li>Zheng Xu (Gardenia Corp)</li>
+		<li>Fuqiao Xue (W3C)</li>
+		<li>Evan Yamanishi (W. W. Norton & Company)</li>
+		<li>Osamu Yoshiba (Kodansha, Publishers, Ltd.)</li>
+		<li>Junichi Yoshii (Kodansha, Publishers, Ltd.)</li>
+		<li>Naomi Yoshizawa (W3C)</li>
+		<li>Laurence Zaysser (EDRLab)</li>
+	</ul>
+	<p>In addition, the Working Group would like to extend a special thanks to the former editors of the EPUB 3
+		specifications and overview: Garth Conboy, Marisa DeMeglio, Elika J. Etemad, Markus Gylling, William
+		McCoy, MURATA Makoto, James Pritchett, Tzviya Siegman, and Daniel Weck.</p>
+</section>

--- a/epub33/common/acknowledgements-dedication.html
+++ b/epub33/common/acknowledgements-dedication.html
@@ -1,83 +1,89 @@
 <section id="ack" class="appendix informative">
-	<h2>Acknowledgements</h2>
-	<p>Specifications, like art, are human creations. No human has done more for EPUB than Garth Conboy, who has
+    <h2>Acknowledgements</h2>
+
+    <p>Specifications, like art, are human creations. No human has done more for EPUB than Garth Conboy, who has
 		been there every step of the way, from the very first OEB 1.0 in 1999 to today's EPUB 3.3. None of this
-		would have happened without Garth's vision, knowledge, and preternatural good nature. We dedicate
-		EPUB 3.3 to his memory. We are forever in your debt, Garth.</p>
-	<p>The following members of the EPUB 3 Working Group contributed to the development of this document:</p>
-	<ul class="ack">
-		<li>Will AWAD (Newgen Knowledgeworks)</li>
-		<li>Sofia Bautista (Legible Media Inc.)</li>
-		<li>Laura Brady (Legible Media Inc.)</li>
-		<li>Leah Brochu (National Network for Equitable Library Service)</li>
-		<li>Matthew C. Chan (House of Anansi Press)</li>
-		<li>Yu-Wei Chang (Taiwan Digital Publishing Forum)</li>
-		<li>Fred Chasen (Scribd)</li>
-		<li>Juan Corona (Legible Media Inc.)</li>
-		<li>Dave Cramer (W3C Invited Expert, chair)</li>
-		<li>Romain Deltour (DAISY Consortium)</li>
-		<li>Marisa DeMeglio (DAISY Consortium)</li>
-		<li>Brady Duga (Google LLC)</li>
-		<li>Reinaldo Ferraz (NIC.br - Brazilian Network Information Center)</li>
-		<li>John Foliot (W3C Invited Expert)</li>
-		<li>Teenya Franklin (Pearson plc)</li>
-		<li>Hadrien Gardeur (EDRLab)</li>
-		<li>Matt Garrish (DAISY Consortium)</li>
-		<li>Jen Goulden (Crawford Technologies)</li>
-		<li>Ivan Herman (W3C, staff contact)</li>
-		<li>Tetsu Hoshino (Kodansha, Publishers, Ltd.)</li>
-		<li>Norikazu Ishizu (Kadokawa Corporation)</li>
-		<li>Norihito IYENAGA (Kodansha, Publishers, Ltd.)</li>
-		<li>Rick Johnson (VitalSource Technologies)</li>
-		<li>Ken Jones (Circular Software)</li>
-		<li>Antonio Kamiya (Dentsu Group Inc.)</li>
-		<li>Deborah Kaplan (W3C Invited Expert)</li>
-		<li>Bill Kasdorf (Book Industry Study Group)</li>
-		<li>George Kerscher (DAISY Consortium)</li>
-		<li>Kazuhito Kidachi (Mitsue-Links Co., Ltd.)</li>
-		<li>Masakazu Kitahara (Voyager Japan, Inc.)</li>
-		<li>Toshiaki Koike (Voyager Japan, Inc.)</li>
-		<li>Ryo Kuroda (ACCESS CO., LTD.)</li>
-		<li>Charles LaPierre (Benetech)</li>
-		<li>Dan Lazin (Google LLC)</li>
-		<li>Laurent Le Meur (EDRLab)</li>
-		<li>Victoria Lee (Apple, Inc.)</li>
-		<li>Farrah Little (National Network for Equitable Library Service)</li>
-		<li>Victor Lopes (Apple, Inc.)</li>
-		<li>Karan Malhotra (Newgen Knowledgeworks)</li>
-		<li>Makoto Murata (DAISY Consortium)</li>
-		<li>Cristina Mussinelli (Fondazione LIA)</li>
-		<li>Yoichiro Nagao (Kodansha, Publishers, Ltd.)</li>
-		<li>Theresa O'Connor (Apple, Inc.)</li>
-		<li>Yoshinori Ohmura (SHUEISHA Inc.)</li>
-		<li>Rachel Osolen (National Network for Equitable Library Service)</li>
-		<li>Gregorio Pellegrino (Fondazione LIA)</li>
-		<li>Vijaya Gowri Perumal (Newgen Knowledgeworks)</li>
-		<li>Wendy Reid (Rakuten Group, Inc., chair)</li>
-		<li>John Roque (Apple, Inc.)</li>
-		<li>Leonard Rosenthol (Adobe)</li>
-		<li>Shinobu Sato (Kadokawa Corporation)</li>
-		<li>Ben Schroeter (Pearson plc)</li>
-		<li>Daihei Shiohama (MEDIA DO Co., Ltd.)</li>
-		<li>Tzviya Siegman (Wiley)</li>
-		<li>Avneesh Singh (DAISY Consortium)</li>
-		<li>MOTOI SUZUKI (SHUEISHA Inc.)</li>
-		<li>Yutaka Suzuki (Kadokawa Corporation)</li>
-		<li>Kyrce Swenson (Pearson plc)</li>
-		<li>Shinya Takami (Kadokawa Corporation, chair)</li>
-		<li>Mateus Teixeira (W. W. Norton & Company)</li>
-		<li>Yukio Tomikura (Kodansha, Publishers, Ltd.)</li>
-		<li>Aimee Ubbink (Crawford Technologies)</li>
-		<li>Daniel Weck (DAISY Consortium)</li>
-		<li>Zheng Xu (Gardenia Corp)</li>
-		<li>Fuqiao Xue (W3C)</li>
-		<li>Evan Yamanishi (W. W. Norton & Company)</li>
-		<li>Osamu Yoshiba (Kodansha, Publishers, Ltd.)</li>
-		<li>Junichi Yoshii (Kodansha, Publishers, Ltd.)</li>
-		<li>Naomi Yoshizawa (W3C)</li>
-		<li>Laurence Zaysser (EDRLab)</li>
-	</ul>
-	<p>In addition, the Working Group would like to extend a special thanks to the former editors of the EPUB 3
-		specifications and overview: Garth Conboy, Marisa DeMeglio, Elika J. Etemad, Markus Gylling, William McCoy,
-		MURATA Makoto, James Pritchett, Tzviya Siegman, and Daniel Weck.</p>
+		would have happened without Garth's vision, knowledge, and preternatural good nature. We dedicate EPUB 3.3 to his memory. 
+        We are forever in your debt, Garth.</p>
+
+    <p>The following members of the EPUB 3 Working Group contributed to the development of this specification:</p>
+
+    <ul class="ack">
+                <li>Shadi Abou-Zahra (Amazon)</li>
+        <li>Will AWAD (Newgen Knowledgeworks)</li>
+        <li>Noel Ray Barron (Apple Inc.)</li>
+        <li>Sofia Bautista (Legible Media Inc.)</li>
+        <li>Leah Brochu (National Network for Equitable Library Service)</li>
+        <li>Matthew C. Chan (House of Anansi Press)</li>
+        <li>Yu-Wei Chang (Taiwan Digital Publishing Forum)</li>
+        <li>Juan Corona (Legible Media Inc.)</li>
+        <li>Dave Cramer (W3C Invited Expert, chair)</li>
+        <li>Romain Deltour (DAISY Consortium)</li>
+        <li>Marisa DeMeglio (DAISY Consortium)</li>
+        <li>Brady Duga (Google LLC)</li>
+        <li>Reinaldo Ferraz (NIC.br - Brazilian Network Information Center)</li>
+        <li>Symon Flaming (Rakuten Group, Inc.)</li>
+        <li>John Foliot (W3C Invited Expert)</li>
+        <li>Teenya Franklin (Pearson plc)</li>
+        <li>Hadrien Gardeur (EDRLab)</li>
+        <li>Matt Garrish (DAISY Consortium)</li>
+        <li>Jen Goulden (Crawford Technologies)</li>
+        <li>David Hall (Apple Inc.)</li>
+        <li>Ivan Herman (W3C, staff contact)</li>
+        <li>Tetsu Hoshino (Kodansha, Publishers, Ltd.)</li>
+        <li>jasen huang (ByteDance)</li>
+        <li>Norikazu Ishizu (Kadokawa Corporation)</li>
+        <li>Norihito IYENAGA (Kodansha, Publishers, Ltd.)</li>
+        <li>Rick Johnson (VitalSource Technologies)</li>
+        <li>Ken Jones (Circular Software)</li>
+        <li>Antonio Kamiya (Dentsu Group Inc.)</li>
+        <li>Deborah Kaplan (W3C Invited Expert)</li>
+        <li>Bill Kasdorf (Book Industry Study Group)</li>
+        <li>Hiroshi Kawada (MEDIA DO Co., Ltd.)</li>
+        <li>George Kerscher (DAISY Consortium)</li>
+        <li>Kazuhito Kidachi (Mitsue-Links Co., Ltd.)</li>
+        <li>Masakazu Kitahara (Voyager Japan, Inc.)</li>
+        <li>Toshiaki Koike (Voyager Japan, Inc.)</li>
+        <li>Ryo Kuroda (ACCESS CO., LTD.)</li>
+        <li>Charles LaPierre (Benetech)</li>
+        <li>Dan Lazin (Google LLC)</li>
+        <li>Philippe Le Hegaret (W3C)</li>
+        <li>Laurent Le Meur (EDRLab)</li>
+        <li>YuYu Lin (Taiwan Digital Publishing Forum)</li>
+        <li>Farrah Little (National Network for Equitable Library Service)</li>
+        <li>Victor Lopes (Apple Inc.)</li>
+        <li>Karan  Malhotra (Newgen Knowledgeworks)</li>
+        <li>Makoto Murata (DAISY Consortium)</li>
+        <li>Cristina Mussinelli (Fondazione LIA)</li>
+        <li>Yoichiro Nagao (Kodansha, Publishers, Ltd.)</li>
+        <li>Theresa O'Connor (Apple Inc.)</li>
+        <li>Yoshinori Ohmura (SHUEISHA Inc.)</li>
+        <li>Rachel Osolen (National Network for Equitable Library Service)</li>
+        <li>Gregorio Pellegrino (Fondazione LIA)</li>
+        <li>Vijaya Gowri Perumal (Newgen Knowledgeworks)</li>
+        <li>Wendy Reid (Rakuten Group, Inc., chair)</li>
+        <li>John Roque (Apple Inc.)</li>
+        <li>Leonard Rosenthol (Adobe)</li>
+        <li>Shinobu Sato (Kadokawa Corporation)</li>
+        <li>Ben Schroeter (Pearson plc)</li>
+        <li>Daihei Shiohama (MEDIA DO Co., Ltd.)</li>
+        <li>Tzviya Siegman (Wiley)</li>
+        <li>Avneesh Singh (DAISY Consortium)</li>
+        <li>MOTOI SUZUKI (SHUEISHA Inc.)</li>
+        <li>Yutaka Suzuki (Kadokawa Corporation)</li>
+        <li>Kyrce Swenson (Pearson plc)</li>
+        <li>Shinya Takami (Kadokawa Corporation, chair)</li>
+        <li>Mateus Teixeira (W. W. Norton & Company)</li>
+        <li>Yukio Tomikura (Kodansha, Publishers, Ltd.)</li>
+        <li>Aimee Ubbink (Crawford Technologies)</li>
+        <li>xinyuan wang (ByteDance)</li>
+        <li>Daniel Weck (DAISY Consortium)</li>
+        <li>Fuqiao Xue (W3C)</li>
+        <li>Evan Yamanishi (W. W. Norton & Company)</li>
+        <li>Osamu Yoshiba (Kodansha, Publishers, Ltd.)</li>
+        <li>Junichi Yoshii (Kodansha, Publishers, Ltd.)</li>
+        <li>Naomi Yoshizawa (W3C)</li>
+        <li>Laurence Zaysser (EDRLab)</li>
+    </ul>
+    
 </section>

--- a/epub33/common/acknowledgements.html
+++ b/epub33/common/acknowledgements.html
@@ -4,26 +4,29 @@
     <p>The following members of the EPUB 3 Working Group contributed to the development of this specification:</p>
 
     <ul class="ack">
-                <li>Will AWAD (Newgen Knowledgeworks)</li>
+                <li>Shadi Abou-Zahra (Amazon)</li>
+        <li>Will AWAD (Newgen Knowledgeworks)</li>
+        <li>Noel Ray Barron (Apple Inc.)</li>
         <li>Sofia Bautista (Legible Media Inc.)</li>
-        <li>Laura Brady (Legible Media Inc.)</li>
         <li>Leah Brochu (National Network for Equitable Library Service)</li>
         <li>Matthew C. Chan (House of Anansi Press)</li>
         <li>Yu-Wei Chang (Taiwan Digital Publishing Forum)</li>
-        <li>Fred Chasen (Scribd)</li>
         <li>Juan Corona (Legible Media Inc.)</li>
         <li>Dave Cramer (W3C Invited Expert, chair)</li>
         <li>Romain Deltour (DAISY Consortium)</li>
         <li>Marisa DeMeglio (DAISY Consortium)</li>
         <li>Brady Duga (Google LLC)</li>
         <li>Reinaldo Ferraz (NIC.br - Brazilian Network Information Center)</li>
+        <li>Symon Flaming (Rakuten Group, Inc.)</li>
         <li>John Foliot (W3C Invited Expert)</li>
         <li>Teenya Franklin (Pearson plc)</li>
         <li>Hadrien Gardeur (EDRLab)</li>
         <li>Matt Garrish (DAISY Consortium)</li>
         <li>Jen Goulden (Crawford Technologies)</li>
+        <li>David Hall (Apple Inc.)</li>
         <li>Ivan Herman (W3C, staff contact)</li>
         <li>Tetsu Hoshino (Kodansha, Publishers, Ltd.)</li>
+        <li>jasen huang (ByteDance)</li>
         <li>Norikazu Ishizu (Kadokawa Corporation)</li>
         <li>Norihito IYENAGA (Kodansha, Publishers, Ltd.)</li>
         <li>Rick Johnson (VitalSource Technologies)</li>
@@ -31,6 +34,7 @@
         <li>Antonio Kamiya (Dentsu Group Inc.)</li>
         <li>Deborah Kaplan (W3C Invited Expert)</li>
         <li>Bill Kasdorf (Book Industry Study Group)</li>
+        <li>Hiroshi Kawada (MEDIA DO Co., Ltd.)</li>
         <li>George Kerscher (DAISY Consortium)</li>
         <li>Kazuhito Kidachi (Mitsue-Links Co., Ltd.)</li>
         <li>Masakazu Kitahara (Voyager Japan, Inc.)</li>
@@ -38,21 +42,22 @@
         <li>Ryo Kuroda (ACCESS CO., LTD.)</li>
         <li>Charles LaPierre (Benetech)</li>
         <li>Dan Lazin (Google LLC)</li>
+        <li>Philippe Le Hegaret (W3C)</li>
         <li>Laurent Le Meur (EDRLab)</li>
-        <li>Victoria Lee (Apple, Inc.)</li>
+        <li>YuYu Lin (Taiwan Digital Publishing Forum)</li>
         <li>Farrah Little (National Network for Equitable Library Service)</li>
-        <li>Victor Lopes (Apple, Inc.)</li>
+        <li>Victor Lopes (Apple Inc.)</li>
         <li>Karan  Malhotra (Newgen Knowledgeworks)</li>
         <li>Makoto Murata (DAISY Consortium)</li>
         <li>Cristina Mussinelli (Fondazione LIA)</li>
         <li>Yoichiro Nagao (Kodansha, Publishers, Ltd.)</li>
-        <li>Theresa O'Connor (Apple, Inc.)</li>
+        <li>Theresa O'Connor (Apple Inc.)</li>
         <li>Yoshinori Ohmura (SHUEISHA Inc.)</li>
         <li>Rachel Osolen (National Network for Equitable Library Service)</li>
         <li>Gregorio Pellegrino (Fondazione LIA)</li>
         <li>Vijaya Gowri Perumal (Newgen Knowledgeworks)</li>
         <li>Wendy Reid (Rakuten Group, Inc., chair)</li>
-        <li>John Roque (Apple, Inc.)</li>
+        <li>John Roque (Apple Inc.)</li>
         <li>Leonard Rosenthol (Adobe)</li>
         <li>Shinobu Sato (Kadokawa Corporation)</li>
         <li>Ben Schroeter (Pearson plc)</li>
@@ -66,8 +71,8 @@
         <li>Mateus Teixeira (W. W. Norton & Company)</li>
         <li>Yukio Tomikura (Kodansha, Publishers, Ltd.)</li>
         <li>Aimee Ubbink (Crawford Technologies)</li>
+        <li>xinyuan wang (ByteDance)</li>
         <li>Daniel Weck (DAISY Consortium)</li>
-        <li>Zheng Xu (Gardenia Corp)</li>
         <li>Fuqiao Xue (W3C)</li>
         <li>Evan Yamanishi (W. W. Norton & Company)</li>
         <li>Osamu Yoshiba (Kodansha, Publishers, Ltd.)</li>
@@ -77,4 +82,3 @@
     </ul>
     
 </section>
-


### PR DESCRIPTION
Adds a new acknowledgements file for the accessibility spec along with the dedication.

- [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/add-dedication/epub33/a11y/index.html)
- [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/add-dedication/epub33/a11y/index.html)
