### PR TITLE
Changed the example in H.2

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11241,7 +11241,9 @@ html.my-document-playing * {
     &lt;head&gt;
         …
         &lt;script type="text/javascript"&gt;
-            alert("Reading system name: " + navigator.epubReadingSystem.name);
+            const te = navigator.epubReadingSystem.hasFeature("touch-events");
+            const te_message = te ? "passes" : "does not pass";
+            alert(`The reading system ${te_message} touch events to the content.`);
         &lt;/script&gt;
     &lt;/head&gt;
     &lt;body&gt;
@@ -11867,8 +11869,18 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<section id="change-latest">
+				<h3>Substantive changes since <a href="https://www.w3.org/TR/2023/CR-epub-33-20230221/">Candidate
+					Recommendation</a> of 2023-02-21</h3>
+				<ul>
+					<li>
+						17-March-2023: replaced the deprecated JavaScript attribute <code>name</code> by <code>hasFeature</code>
+						in an example. See <a href="https://github.com/w3c/epub-specs/issues/2543">issue 2543</a>.
+					</li>
+				</ul>
+			</section>
+			<section id="change-previous-cr">
 				<h3>Substantive changes since <a href="https://www.w3.org/TR/2022/CR-epub-33-20220512/">Candidate
-						Recommendation</a></h3>
+						Recommendation</a> of 2022-05-12</h3>
 
 				<ul>
 					<li>11-Jan-2023: Marked the <code>dir</code> attribute under-implemented due to lack of support in


### PR DESCRIPTION
This is to fix #2543.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2544.html" title="Last updated on Mar 17, 2023, 11:55 AM UTC (1789955)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2544/4f3b0a2...1789955.html" title="Last updated on Mar 17, 2023, 11:55 AM UTC (1789955)">Diff</a>