### PR TITLE
Clarify none and unknown are not valid features

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -478,8 +478,8 @@
 						href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature"
 							><code>accessibilityFeature</code> property</a> [[a11y-discov-vocab]] contains the values
 						"<code>none</code>" and "<code>unknown</code>", these terms cannot be used to meet the reporting
-					requirements for the property. Authors must indicate at least one feature to claim conformance to
-					EPUB Accessibility 1.1 [[epub-a11y-11]].</p>
+					requirements for the property. Authors must indicate at least one feature that is not one of these
+					values to claim conformance to EPUB Accessibility 1.1 [[epub-a11y-11]].</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature">The
 							<code>accessibilityFeature</code> Property</a> [[a11y-discov-vocab]] for more information

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -2364,8 +2364,11 @@
 					>working group's issue tracker</a>.</p>
 
 			<ul>
+				<li>27-Mar-2023: Clarified that the <code>none</code> and <code>unknown</code> terms do not meet the
+					reporting requirements for <code>accessibilityFeature </code>. See <a
+						href="https://github.com/w3c/epub-specs/issues/2537">issue 2537</a></li>
 				<li>08-Sept-2022: Clarified that only meeting the techniques in this document is not sufficient for
-					making claims of accessibility. <a href="https://github.com/w3c/epub-specs/issues/2407">issue
+					making claims of accessibility. See <a href="https://github.com/w3c/epub-specs/issues/2407">issue
 						2407</a></li>
 				<li>12-Aug-2022: Clarified guidance that an <code>xml:lang</code> attribute on an
 						<code>accessibilitySummary</code> property does not represent a translation. See <a

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -477,9 +477,11 @@
 				<p>Be aware that although the vocabulary for the <a
 						href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature"
 							><code>accessibilityFeature</code> property</a> [[a11y-discov-vocab]] contains the values
-						"<code>none</code>" and "<code>unknown</code>", these terms cannot be used to meet the reporting
-					requirements for the property. Authors must indicate at least one feature that is not one of these
-					values to claim conformance to EPUB Accessibility 1.1 [[epub-a11y-11]].</p>
+						"<a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#feature-none"><code>none</code></a>"
+					and "<a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#feature-unknown"
+							><code>unknown</code></a>", these terms cannot be used to meet the reporting requirements
+					for the property. Authors must indicate at least one feature that is not one of these values to
+					claim conformance to EPUB Accessibility 1.1 [[epub-a11y-11]].</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature">The
 							<code>accessibilityFeature</code> Property</a> [[a11y-discov-vocab]] for more information

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -478,7 +478,8 @@
 						href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature"
 							><code>accessibilityFeature</code> property</a> [[a11y-discov-vocab]] contains the values
 						"<code>none</code>" and "<code>unknown</code>", these terms cannot be used to meet the reporting
-					requirements for the property. Authors must indicate at least one feature.</p>
+					requirements for the property. Authors must indicate at least one feature to claim conformance to
+					EPUB Accessibility 1.1 [[epub-a11y-11]].</p>
 
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature">The
 							<code>accessibilityFeature</code> Property</a> [[a11y-discov-vocab]] for more information

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -474,6 +474,12 @@
 					aware what features are built into a format. Failing to include entries will reduce the
 					discoverability of the publication when users search for specific features.</p>
 
+				<p>Be aware that although the vocabulary for the <a
+						href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature"
+							><code>accessibilityFeature</code> property</a> [[a11y-discov-vocab]] contains the values
+						"<code>none</code>" and "<code>unknown</code>", these terms cannot be used to meet the reporting
+					requirements for the property. Authors must indicate at least one feature.</p>
+
 				<p>Refer to <a href="https://www.w3.org/2021/a11y-discov-vocab/latest/#accessibilityFeature">The
 							<code>accessibilityFeature</code> Property</a> [[a11y-discov-vocab]] for more information
 					about this property and its values.</p>


### PR DESCRIPTION
It doesn't make sense to require that features be specified but also allow these values, so this pull request adds a paragraph explaining that the values are not allowed to meet the reporting requirements.

Fixes #2537 

- [preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/feat-unknown-invalid/epub33/a11y-tech/index.html)
- [diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/feat-unknown-invalid/epub33/a11y-tech/index.html)
