### PR TITLE
Changed the copyright modification to the respec-based cc statement

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -50,7 +50,7 @@
 					branch: "main"
 				},
 				profile: "web-platform",
-				postProcess: [modifyCopyright],
+				preProcess: [modifyCopyright],
 				localBiblio: {
 					"a11y-discov-vocab": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
@@ -105,6 +105,17 @@
 			}</style>
 	</head>
 	<body>
+		<p class="copyright">
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
+			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+			and
+			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+		</p>
 		<section id="abstract">
 			<p>EPUB Accessibility Techniques defines discovery and content accessibility requirements for EPUB®
 				Publications.</p>

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -50,7 +50,6 @@
 					branch: "main"
 				},
 				profile: "web-platform",
-				preProcess: [modifyCopyright],
 				localBiblio: {
 					"a11y-discov-vocab": {
 						"title": "Schema.org Accessibility Properties for Discoverability Vocabulary",
@@ -105,17 +104,7 @@
 			}</style>
 	</head>
 	<body>
-		<p class="copyright">
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
-			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-			and
-			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-		</p>
+		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
 		<section id="abstract">
 			<p>EPUB Accessibility Techniques defines discovery and content accessibility requirements for EPUB®
 				Publications.</p>
@@ -2415,7 +2404,6 @@
 					necessary to set. See <a href="https://github.com/w3c/epub-specs/issues/1286">issue 1286</a>.</li>
 			</ul>
 		</section>
-		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
-		></div>
+		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -103,8 +103,8 @@
 						"publisher": "W3C"
 					}
 				},
-				preProcess:[inlineCustomCSS,modifyCopyright],
-				postProcess: [data_test_display],
+				preProcess:[inlineCustomCSS],
+				postProcess: [data_test_display]
 			};</script>
 		<style>
 			.conf-pattern {
@@ -119,17 +119,7 @@
 			}</style>
 	</head>
 	<body>
-		<p class="copyright">
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
-			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-			and
-			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-		</p>
+		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
 		<section id="abstract">
 			<p>This specification specifies content conformance requirements for verifying the accessibility of EPUB®
 				Publications. It also specifies accessibility metadata requirements for the discoverability of EPUB
@@ -1969,7 +1959,6 @@
 				</ul>
 			</section>
 		</section>
-		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
-		></div>
+		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -103,8 +103,8 @@
 						"publisher": "W3C"
 					}
 				},
-				preProcess:[inlineCustomCSS],
-				postProcess: [data_test_display,modifyCopyright],
+				preProcess:[inlineCustomCSS,modifyCopyright],
+				postProcess: [data_test_display],
 			};</script>
 		<style>
 			.conf-pattern {
@@ -119,6 +119,17 @@
 			}</style>
 	</head>
 	<body>
+		<p class="copyright">
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
+			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+			and
+			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+		</p>
 		<section id="abstract">
 			<p>This specification specifies content conformance requirements for verifying the accessibility of EPUB®
 				Publications. It also specifies accessibility metadata requirements for the discoverability of EPUB

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1959,7 +1959,7 @@
 				</ul>
 			</section>
 		</section>
-		<div data-include="../common/acknowledgements-a11y-dedication.html" data-oninclude="fixIncludes" data-include-replace="true"
+		<div data-include="../common/acknowledgements-a11y-dedication.html"  data-include-replace="true"
 		></div>
 	</body>
 </html>

--- a/epub33/common/copyright.html
+++ b/epub33/common/copyright.html
@@ -1,0 +1,11 @@
+<p class="copyright">
+	<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-%thisyear%
+	<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+	and
+	<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+	<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+	<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+	<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+	<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+		title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+</p>

--- a/epub33/common/js/copyright.js
+++ b/epub33/common/js/copyright.js
@@ -1,22 +1,5 @@
 function modifyCopyright() {
-    // This is where the copyright statement resides...
-    const p = document.querySelector("p.copyright");
-
-    // get the years out of the text, because that can change...
-    const index = p.textContent.search(/[0-9]{4}-[0-9]{4}/)
-    const years = p.textContent.slice(index,index+9);
-
-    // Replacement text
-    p.innerHTML = `
-    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © ${years}
-    <a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-	and
-    <a href="https://www.w3.org/">World Wide Web Consortium</a>.
-    <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-    <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-    `
+    // find the place to put the current year
+    const span = document.getElementById("thisyear");
+    span.innerHTML = (new Date()).getFullYear();
 }
-
-// 1999-2022

--- a/epub33/common/js/copyright.js
+++ b/epub33/common/js/copyright.js
@@ -1,5 +1,6 @@
-function modifyCopyright() {
-    // find the place to put the current year
-    const span = document.getElementById("thisyear");
-    span.innerHTML = (new Date()).getFullYear();
+function modifyCopyright(utils, content, url) {
+	// find the place to put the current year
+    return content.replace("%thisyear%", (new Date()).getFullYear());
 }
+
+// 1999-2022

--- a/epub33/common/js/copyright.js
+++ b/epub33/common/js/copyright.js
@@ -2,5 +2,3 @@ function modifyCopyright(utils, content, url) {
 	// find the place to put the current year
     return content.replace("%thisyear%", (new Date()).getFullYear());
 }
-
-// 1999-2022

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -50,7 +50,7 @@
                     branch: "main"
                 },
                 localBiblio: biblio,
-                preProcess:[inlineCustomCSS,modifyCopyright],
+                preProcess:[inlineCustomCSS],
                 postProcess:[addCautionHeaders,data_test_display],
                 testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
                 lint: {
@@ -68,19 +68,7 @@
 			}</style>
 	</head>
 	<body>
-		<p class="copyright">
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
-			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-			and
-			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-		</p>
-
-
+		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
 		<section id="abstract">
 			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
@@ -2028,8 +2016,9 @@
 						<ul>
 							<li>relative URL strings starting with a <code>/</code> (<code>U+002F</code>) (for example,
 									<code>/EPUB/content.xhtml</code>) are disallowed; </li>
-							<li>relative URL strings containing more [=double-dot URL path segments=] than needed to reach
-								the target file (for example, <code>EPUB/../../../../config.xml</code>) are disallowed; </li>
+							<li>relative URL strings containing more [=double-dot URL path segments=] than needed to
+								reach the target file (for example, <code>EPUB/../../../../config.xml</code>) are
+								disallowed; </li>
 							<li>any other absolute or relative URL string is allowed.</li>
 						</ul>
 
@@ -8645,8 +8634,8 @@ No Entry</pre>
 
 						<p>EPUB creators should also be aware that [=reading system=] support for playback of both
 							reflowable and fixed-layout EPUB content documents is not guaranteed. Differences in reading
-							system pagination strategies mean that some reading systems will only support media
-							overlays in one or the other layout format.</p>
+							system pagination strategies mean that some reading systems will only support media overlays
+							in one or the other layout format.</p>
 					</div>
 
 					<section id="sec-media-overlays-structure">
@@ -10397,17 +10386,17 @@ html.my-document-playing * {
 				</dl>
 			</section>
 
-			<div data-include="vocab/meta-property.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+			<div data-include="vocab/meta-property.html" data-include-replace="true"></div>
 
-			<div data-include="vocab/link.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+			<div data-include="vocab/link.html" data-include-replace="true"></div>
 
-			<div data-include="vocab/rendering.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+			<div data-include="vocab/rendering.html" data-include-replace="true"></div>
 
-			<div data-include="vocab/item-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+			<div data-include="vocab/item-properties.html" data-include-replace="true"></div>
 
-			<div data-include="vocab/itemref-properties.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+			<div data-include="vocab/itemref-properties.html" data-include-replace="true"></div>
 
-			<div data-include="vocab/overlays.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
+			<div data-include="vocab/overlays.html" data-include-replace="true"></div>
 		</section>
 		<section id="css-prefixes" class="appendix">
 			<h2>Prefixed CSS properties</h2>
@@ -11883,12 +11872,11 @@ EPUB/images/cover.png</pre>
 
 			<section id="change-latest">
 				<h3>Substantive changes since <a href="https://www.w3.org/TR/2023/CR-epub-33-20230221/">Candidate
-					Recommendation</a> of 2023-02-21</h3>
+						Recommendation</a> of 2023-02-21</h3>
 				<ul>
-					<li>
-						17-March-2023: replaced the deprecated JavaScript attribute <code>name</code> by <code>hasFeature</code>
-						in an example. See <a href="https://github.com/w3c/epub-specs/issues/2543">issue 2543</a>.
-					</li>
+					<li> 17-March-2023: replaced the deprecated JavaScript attribute <code>name</code> by
+							<code>hasFeature</code> in an example. See <a
+							href="https://github.com/w3c/epub-specs/issues/2543">issue 2543</a>. </li>
 				</ul>
 			</section>
 			<section id="change-previous-cr">
@@ -12247,7 +12235,6 @@ EPUB/images/cover.png</pre>
 				</ul>
 			</section>
 		</section>
-		<div data-include="../common/acknowledgements-dedication.html" data-oninclude="fixIncludes" data-include-replace="true"></div>
-
-
-</body></html>
+		<div data-include="../common/acknowledgements-dedication.html" data-include-replace="true"></div>
+	</body>
+</html>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -50,8 +50,8 @@
                     branch: "main"
                 },
                 localBiblio: biblio,
-                preProcess:[inlineCustomCSS],
-                postProcess:[addCautionHeaders,data_test_display,modifyCopyright],
+                preProcess:[inlineCustomCSS,modifyCopyright],
+                postProcess:[addCautionHeaders,data_test_display],
                 testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
                 lint: {
                      "wpt-tests-exist": true,
@@ -68,6 +68,19 @@
 			}</style>
 	</head>
 	<body>
+		<p class="copyright">
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
+			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+			and
+			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+		</p>
+
+
 		<section id="abstract">
 			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced

--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -36,7 +36,6 @@
 				includePermalinks: true,
 				permalinkEdge: true,
 				permalinkHide: false,
-				postProcess: [],
 				github: {
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"

--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -5,7 +5,6 @@
 		<title>EPUB Accessibility - EU Accessibility Act Mapping</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
-		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
 				group: "epub",
@@ -37,7 +36,6 @@
 				includePermalinks: true,
 				permalinkEdge: true,
 				permalinkHide: false,
-				postProcess: [modifyCopyright],
 				github: {
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"

--- a/epub33/epub-aria-authoring/index.html
+++ b/epub33/epub-aria-authoring/index.html
@@ -28,8 +28,8 @@
                     repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
-                preProcess: [inlineCustomCSS],
-                postProcess: [modifyCopyright],
+                preProcess: [inlineCustomCSS,modifyCopyright],
+                postProcess: [],
 				localBiblio: {
 					"dpub-aria": {
 						"title": "Digital Publishing WAI-ARIA Module",
@@ -55,6 +55,17 @@
 			}</style>
 	</head>
 	<body>
+		<p class="copyright">
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
+			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+			and
+			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+		</p>
 		<section id="abstract">
 			<p>This document provides guidance for publishers looking to move from the use of the EPUB 3
 					<code>epub:type</code> attribute to ARIA roles for accessibility.</p>

--- a/epub33/epub-aria-authoring/index.html
+++ b/epub33/epub-aria-authoring/index.html
@@ -28,8 +28,7 @@
                     repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
-                preProcess: [inlineCustomCSS,modifyCopyright],
-                postProcess: [],
+                preProcess: [inlineCustomCSS]
 				localBiblio: {
 					"dpub-aria": {
 						"title": "Digital Publishing WAI-ARIA Module",
@@ -55,17 +54,7 @@
 			}</style>
 	</head>
 	<body>
-		<p class="copyright">
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
-			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-			and
-			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-		</p>
+		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
 		<section id="abstract">
 			<p>This document provides guidance for publishers looking to move from the use of the EPUB 3
 					<code>epub:type</code> attribute to ARIA roles for accessibility.</p>

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -78,13 +78,24 @@
 				branch: "main"
 			  },
 			  pluralize: true,
-			  preProcess:[inlineCustomCSS],
-			  postProcess: [modifyCopyright]
+			  preProcess:[inlineCustomCSS,modifyCopyright],
+			  postProcess: []
           };
          // ]]>
       </script>
 	</head>
 	<body>
+		<p class="copyright">
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
+			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+			and
+			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+		</p>
 		<section id="abstract">
 			<p id="sibling-specs">This specification, EPUB Canonical Fragment Identifier (epubcfi), defines a
 				standardized method for referencing arbitrary content within an EPUB® Publication through the use of

--- a/epub33/epubcfi/index.html
+++ b/epub33/epubcfi/index.html
@@ -78,24 +78,13 @@
 				branch: "main"
 			  },
 			  pluralize: true,
-			  preProcess:[inlineCustomCSS,modifyCopyright],
-			  postProcess: []
+			  preProcess:[inlineCustomCSS]
           };
          // ]]>
       </script>
 	</head>
 	<body>
-		<p class="copyright">
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
-			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-			and
-			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-		</p>
+		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
 		<section id="abstract">
 			<p id="sibling-specs">This specification, EPUB Canonical Fragment Identifier (epubcfi), defines a
 				standardized method for referencing arbitrary content within an EPUB® Publication through the use of

--- a/epub33/fxl-a11y/index.html
+++ b/epub33/fxl-a11y/index.html
@@ -40,8 +40,7 @@
 						"publisher": "W3C"
 					}
                 },
-                preProcess:[inlineCustomCSS],
-				postProcess: [modifyCopyright]
+                preProcess:[inlineCustomCSS]
             };//]]>
       </script>
         

--- a/epub33/locators/index.html
+++ b/epub33/locators/index.html
@@ -33,8 +33,7 @@
                     branch: "main"
                 },
                 pluralize: true,
-                preProcess:[inlineCustomCSS],
-                postProcess: [modifyCopyright]
+                preProcess:[inlineCustomCSS]
             };//]]>
       </script>
 	</head>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -68,23 +68,12 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-                preProcess:[inlineCustomCSS,modifyCopyright],
-				postProcess: []
+                preProcess:[inlineCustomCSS]
             };//]]>
       </script>
 	</head>
 	<body>
-		<p class="copyright">
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
-			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-			and
-			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-		</p>
+		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
 		<section id="abstract">
 			<p>This specification, EPUB Multiple-Rendition Publications, defines the creation and rendering of EPUB®
 				Publications consisting of more than one rendition.</p>
@@ -1305,7 +1294,6 @@
 						<a href="https://github.com/w3c/publ-epub-revision/issues/1436">issue 1436</a>.</li>
 			</ul>
 		</section>
-		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
-		></div>
+		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -68,12 +68,23 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-                preProcess:[inlineCustomCSS],
-				postProcess: [modifyCopyright]
+                preProcess:[inlineCustomCSS,modifyCopyright],
+				postProcess: []
             };//]]>
       </script>
 	</head>
 	<body>
+		<p class="copyright">
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
+			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+			and
+			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+		</p>
 		<section id="abstract">
 			<p>This specification, EPUB Multiple-Rendition Publications, defines the creation and rendering of EPUB®
 				Publications consisting of more than one rendition.</p>

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -47,11 +47,23 @@
 					specs: ["epub-rs-33","epub-33"]
 				},
 				localBiblio: biblio,
-				preProcess:[inlineCustomCSS],
-				postProcess: [removeEmptyIndex,modifyCopyright]
+				preProcess:[inlineCustomCSS,modifyCopyright],
+				postProcess: [removeEmptyIndex]
 			};</script>
 	</head>
 	<body>
+		<p class="copyright">
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
+			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+			and
+			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+		</p>
+
 		<section id="abstract">
 			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -47,23 +47,12 @@
 					specs: ["epub-rs-33","epub-33"]
 				},
 				localBiblio: biblio,
-				preProcess:[inlineCustomCSS,modifyCopyright],
+				preProcess:[inlineCustomCSS],
 				postProcess: [removeEmptyIndex]
 			};</script>
 	</head>
 	<body>
-		<p class="copyright">
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
-			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-			and
-			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-		</p>
-
+		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
 		<section id="abstract">
 			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
@@ -736,7 +725,6 @@
 			</section>
 		</section>
 		<section id="index" class="appendix"></section>
-		<div data-include="../common/acknowledgements-dedication.html" data-oninclude="fixIncludes"
-			data-include-replace="true"></div>
+		<div data-include="../common/acknowledgements-dedication.html" data-include-replace="true"></div>
 	</body>
 </html>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -105,8 +105,8 @@
 						"href": "https://www.w3.org/Consortium/Process/"
 					},
 				},
-				preProcess:[inlineCustomCSS],
-				postProcess: [data_test_display,modifyCopyright],
+				preProcess:[inlineCustomCSS,modifyCopyright],
+				postProcess: [data_test_display],
 				testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
 				lint: {
 					"wpt-tests-exist": true,
@@ -118,6 +118,18 @@
 			};//]]></script>
 	</head>
 	<body>
+		<p class="copyright">
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
+			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+			and
+			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+		</p>
+
 		<section id="abstract">
 			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -105,7 +105,7 @@
 						"href": "https://www.w3.org/Consortium/Process/"
 					},
 				},
-				preProcess:[inlineCustomCSS,modifyCopyright],
+				preProcess:[inlineCustomCSS],
 				postProcess: [data_test_display],
 				testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
 				lint: {
@@ -118,18 +118,7 @@
 			};//]]></script>
 	</head>
 	<body>
-		<p class="copyright">
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
-			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-			and
-			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-		</p>
-
+		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
 		<section id="abstract">
 			<p>EPUB® 3 defines a distribution and interchange format for digital publications and documents. The EPUB
 				format provides a means of representing, packaging, and encoding structured and semantically enhanced
@@ -358,8 +347,8 @@
 
 			<section id="sec-epub-rs-conf-file-urls">
 				<h4>File URLs</h4>
-				<p id="confreq-rs-file-urls" data-tests="#pub-file-urls">Reading Systems MUST prevent access to resources referenced via file
-					URLs [[rfc8089]].</p>
+				<p id="confreq-rs-file-urls" data-tests="#pub-file-urls">Reading Systems MUST prevent access to
+					resources referenced via file URLs [[rfc8089]].</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-xml">
@@ -1285,8 +1274,9 @@
 
 					<li>
 						<p id="confreq-rs-scripted-origin">
-							<span id="confreq-rs-scripted-origin-shared" data-tests="#scr-support_origin,#scr-support_origin_unique">It MUST assign
-								a unique <a data-cite="html#origin">origin</a> [[html]], shared by all <a
+							<span id="confreq-rs-scripted-origin-shared"
+								data-tests="#scr-support_origin,#scr-support_origin_unique">It MUST assign a unique <a
+									data-cite="html#origin">origin</a> [[html]], shared by all <a
 									data-cite="epub-33#sec-scripted-spine">spine-level scripts</a> of the [=EPUB
 								publication=].</span>
 							<span id="confreq-rs-scripted-origin-user" data-tests="#ocf-url_origin">That <a
@@ -1335,8 +1325,9 @@
 						data through <a data-cite="html#dom-document-cookie">cookies</a> and <a
 							data-cite="html#webstorage">web storage</a> [[html]].</p>
 
-					<p id="confreq-rs-scripted-storage-delete" data-tests="#scr-storage-delete">Reading systems that allow <a data-cite="html#dom-localstorage">local storage</a> [[html]] SHOULD
-						provide methods for users to inspect or delete that data.</p>
+					<p id="confreq-rs-scripted-storage-delete" data-tests="#scr-storage-delete">Reading systems that
+						allow <a data-cite="html#dom-localstorage">local storage</a> [[html]] SHOULD provide methods for
+						users to inspect or delete that data.</p>
 				</section>
 
 				<section id="sec-scripted-content-events">
@@ -2488,9 +2479,11 @@
 					the validation steps that usually occur. This could include running virus scans, validating external
 					links and remote resources, and other precautions.</p>
 
-				<p id="security-privacy-recommendations-sideloaded-consent" data-tests="#sec-untrusted-consent_network,#sec-untrusted-consent_scripting">Reading systems that allow users to load untrustworthy EPUB publications (e.g., unsigned EPUB
-					publications through the process of "sideloading") SHOULD treat such content as insecure (e.g.,
-					prompt users to allow scripting and network access).</p>
+				<p id="security-privacy-recommendations-sideloaded-consent"
+					data-tests="#sec-untrusted-consent_network,#sec-untrusted-consent_scripting">Reading systems that
+					allow users to load untrustworthy EPUB publications (e.g., unsigned EPUB publications through the
+					process of "sideloading") SHOULD treat such content as insecure (e.g., prompt users to allow
+					scripting and network access).</p>
 
 				<p>When processing XML documents, a reading system SHOULD NOT resolve <a data-cite="xml#NT-ExternalID"
 						>external identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[xml]]. Reading systems
@@ -2933,7 +2926,6 @@ alert("Feature " + feature + " supported?: " + conformTest);</pre>
 				</ul>
 			</section>
 		</section>
-		<div data-include="../common/acknowledgements-dedication.html" data-oninclude="fixIncludes"
-			data-include-replace="true"></div>
+		<div data-include="../common/acknowledgements-dedication.html" data-include-replace="true"></div>
 	</body>
 </html>

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -91,8 +91,7 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-				preProcess:[inlineCustomCSS,modifyCopyright],
-				postProcess: []
+				preProcess:[inlineCustomCSS]
 			};//]]>
 		</script>
 		<style>
@@ -109,17 +108,6 @@
 			}</style>
 	</head>
 	<body>
-		<p class="copyright">
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
-			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-			and
-			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-		</p>
 		<section id="abstract">
 			<p>This vocabulary, a part of EPUB® 3, defines a set of properties relating to the description of structural
 				semantics of written works.</p>
@@ -3007,7 +2995,7 @@
 				</dd>
 			</dl>
 		</section>
-		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
-		></div>
+		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>
+		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
 	</body>
 </html>

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -91,8 +91,8 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-				preProcess:[inlineCustomCSS],
-				postProcess: [modifyCopyright]
+				preProcess:[inlineCustomCSS,modifyCopyright],
+				postProcess: []
 			};//]]>
 		</script>
 		<style>
@@ -109,6 +109,17 @@
 			}</style>
 	</head>
 	<body>
+		<p class="copyright">
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
+			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+			and
+			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+		</p>
 		<section id="abstract">
 			<p>This vocabulary, a part of EPUB® 3, defines a set of properties relating to the description of structural
 				semantics of written works.</p>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -52,12 +52,24 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-				preProcess:[inlineCustomCSS],
-				postProcess: [modifyCopyright]
+				preProcess:[inlineCustomCSS,modifyCopyright],
+				postProcess: []
 			};//]]>
 		</script>
 	</head>
 	<body>
+		<p class="copyright">
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
+			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
+			and
+			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
+			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
+			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
+		</p>
+
 		<section id="abstract">
 			<p>This document describes authoring features and reading system support for improving the voicing of EPUB®
 				3 publications.</p>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -52,24 +52,12 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-				preProcess:[inlineCustomCSS,modifyCopyright],
-				postProcess: []
+				preProcess:[inlineCustomCSS]
 			};//]]>
 		</script>
 	</head>
 	<body>
-		<p class="copyright">
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 1999-<span id="thisyear"></span>
-			<a href="https://www.idpf.org">International Digital Publishing Forum</a> 
-			and
-			<a href="https://www.w3.org/">World Wide Web Consortium</a>.
-			<abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-			<a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-			<a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" 
-			  title="W3C Software and Document Notice and License">permissive document license</a> rules apply.   
-		</p>
-
+		<div data-include="../common/copyright.html" data-oninclude="modifyCopyright" data-include-replace="true"></div>
 		<section id="abstract">
 			<p>This document describes authoring features and reading system support for improving the voicing of EPUB®
 				3 publications.</p>
@@ -593,7 +581,6 @@
 						href="https://github.com/w3c/epub-specs/issues/1710">issue 1710</a>.</li>
 			</ul>
 		</section>
-		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true"
-		></div>
+		<div data-include="../common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>


### PR DESCRIPTION
There is still a small JS running to set today's year, but it is done
as a preprocess and not postprocess and is therefore significantly faster.

@mattgarrish, I am not sure what the optimal order is. Merge this one first and then the other PR-s, or do the others and then this one? We may get some merge conflicts no matter what...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2549.html" title="Last updated on Mar 30, 2023, 9:23 AM UTC (135d2b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2549/736a218...135d2b4.html" title="Last updated on Mar 30, 2023, 9:23 AM UTC (135d2b4)">Diff</a>