### PR TITLE
Index page (plus an add-on to Overview)

### DIFF
--- a/epub33/index-page/index.html
+++ b/epub33/index-page/index.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+
+    <head>
+        <meta charset="utf-8" />
+        <title>EPUB 3.3</title>
+        <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+        <script class="remove">
+            var respecConfig = {
+                latestVersion: "https://www.w3.org/publishing/epub33/",
+                specStatus: "base",
+                noRecTrack: true,
+                shortName: "epub33",
+                edDraftURI: "https://w3c.github.io/epub-specs/epub33/index-page/",
+                copyrightStart: "2021",
+                editors: [
+                    {
+                        name: "Matt Garrish",
+                        company: "DAISY Consortium",
+                        companyURL: "https://daisy.org",
+                        w3cid: 51655
+                    },
+                    {
+                        name: "Ivan Herman",
+                        url: "https://www.w3.org/People/Ivan/",
+                        company: "W3C",
+                        w3cid: 7382,
+                        orcid: "0000-0003-0782-2704",
+                        companyURL: "https://www.w3.org",
+                    }
+                ],
+                processVersion: 2020,
+                includePermalinks: true,
+                permalinkEdge: true,
+                permalinkHide: false,
+                xref: {
+                    profile: "web-platform",
+                    specs: ["epub-rs-33", "epub-33"]
+                },
+                github: {
+                    repoURL: "https://github.com/w3c/epub-specs",
+                    branch: "main"
+                }
+            };
+        </script>
+    </head>
+
+    <body>
+        <section id="abstract">
+            <p>
+                EPUB® defines a distribution and interchange format for digital publications and documents. The EPUB
+                format provides a means of representing, packaging and encoding structured and semantically enhanced Web
+                content—including HTML, CSS, SVG and other resources—for distribution in a single-file container.
+            </p>
+        </section>
+        <section>
+            <h2>About EPUB 3.3</h2>
+            <p>
+                EPUB 3.3 is a revision of the EPUB 3 specification, which can be considered as a successor
+                to <a href="https://www.w3.org/publishing/epub32/">EPUB 3.2</a>. It is also the first W3C Recommendation
+                of the EPUB series of specifications.
+            </p>
+
+            <p>
+                EPUB 3.3 is backward compatible with EPUB 3.2, insofar as any EPUB 3.2 document is
+                also valid EPUB 3.3. In other words, moving from EPUB 3.2 to EPUB 3.3 does not require any changes to
+                current publication workflows.
+            </p>
+
+            <p>
+                The W3C process of standardization entails a thorough review of the specifications by Member experts,
+                including checking the specification’s impact on implementations for internationalization, security,
+                privacy, accessibility, and conformity to other Web standards. These reviews led to a number of small
+                but important technical changes such as additional features to address bidirectional text, and more
+                precise specification of security related details for scripts. The standard also includes detailed
+                guidelines for implementers on the possible privacy and security problems.
+            </p>
+
+            <p>
+                The Working Group has also created a comprehensive <a
+                    href="https://w3c.github.io/epub-tests/index.html">test suite</a>
+                that systematically tests all normative features of the specification.
+            </p>
+        </section>
+
+        <section id="app-documents">
+            <h2>EPUB 3 documents</h2>
+
+            <section id="sec-doc-rec">
+                <h3>Specifications</h3>
+
+                <p>EPUB 3 is currently defined by the following specifications:</p>
+
+                <ul>
+                    <li>EPUB 3.3 [[epub-33]]: defines the authoring format and requirements for EPUB publications,
+                        comprising features such as the <a data-cite="epub-33#sec-package-doc">package</a> and <a
+                            data-cite="epub-33#sec-nav">navigation</a> documents, <a data-cite="epub-33#sec-nav">EPUB content
+                            documents</a>, <a data-cite="epub-33#sec-fixed-layouts">fixed layouts</a>, <a
+                            data-cite="epub-33#sec-media-overlays">media overlays</a>, and the <a
+                            data-cite="epub-33#sec-ocf">container format</a>.
+                    </li>
+                    <li>EPUB Reading Systems 3.3 [[epub-rs-33]]: defines the conformance requirements for EPUB 3 reading
+                        systems — the user agents that render EPUB 3 Publications. </li>
+                    <li>EPUB Accessibility 1.1 [[epub-a11y-11]]: specifies content conformance requirements for
+                        verifying the accessibility of EPUB 3 Publications. </li>
+                </ul>
+
+                <div class="note"> The recommendation-track documents include detailed change logs on the substantive
+                    changes since the previous official releases. See the change log for <a
+                        data-cite="epub-33#change-log">EPUB 3.3</a>, <a data-cite="epub-rs-33#change-log">EPUB reading
+                        systems 3.3</a>, and <a data-cite="epub-a11y-11#change-log">EPUB Accessibility 1.1</a>,
+                    respectively. </div>
+            </section>
+
+            <section id="sec-doc-notes">
+                <h3>Notes</h3>
+
+                <p>Although the following documents are informative, they provide guidance related to implementing the
+                    EPUB 3 specifications as well as define experimental features.</p>
+
+                <ul>
+                    <li>
+                        EPUB 3 Overview [[epub-overview-33]]: gives a high level overview of the main EPUB 3.3 concepts
+                        and terms.
+                    </li>
+                    <li>
+                        EPUB Accessibility - EU Accessibility Act Mapping [[epub-a11y-eaa-mapping]]: aims to demonstrate
+                        that the technical requirements of the <a
+                            href="https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32019L0882">European
+                            Accessibility Act</a> related to ebooks are met by the EPUB standard.
+                    </li>
+                    <li>
+                        EPUB Accessibility Techniques 1.1 [[epub-a11y-tech-11]]: provides guidance on how to meet the
+                        EPUB Accessibility 1.1 [[epub-a11y-11]] discovery and accessibility requirements for EPUB
+                        publications. 
+                    </li>
+                    <li>
+                        EPUB Multiple-Rendition Publications 1.1 [[epub-multi-rend-11]]: defines the creation and
+                        rendering of EPUB publications consisting of more than one Rendition. 
+                    </li>
+                    <li>
+                        EPUB 3 Structural Semantics Vocabulary 1.1 [[epub-ssv-11]]: defines a set of properties relating
+                        to the description of structural semantics of written works.
+                    </li>
+                    <li>
+                        EPUB 3 Text-to-Speech Enhancements 1.0 [[epub-tts-10]]: describes authoring features and reading
+                        system support for improving the voicing of EPUB 3 publications. 
+                    </li>
+                    <li>
+                        EPUB Type to ARIA Role Authoring Guide 1.1 [[epub-aria-authoring-11]]: provides guidance for
+                        publishers looking to move from the use of the EPUB 3 epub:type attribute to ARIA roles for
+                        accessibility.
+                    </li>
+                </ul>
+            </section>
+        </section>
+
+        <section id="participate">
+
+            <h2>How to Participate</h2>
+
+            <p>
+                The EPUB 3.3 specification is developed by the <a
+                    href="hhttps://www.w3.org/publishing/groups/epub-wg/">W3C EPUB 3 Working Group</a>. All Working
+                Group activities are conducted in an "open source" manner: the EPUB 3 Community Group <a
+                    href="https://github.com/w3c/epub-specs/">project site</a> is publicly accessible and contains a
+                source code repository for specification and related work products.
+            </p>
+
+            <p>
+                All comments on EPUB 3 specifications should be submitted via the <a
+                    href="https://github.com/w3c/epub-specs/issues">EPUB 3 issue tracker</a> hosted on GitHub. (NOTE:
+                you must login via a GitHub Account in order to submit an issue.)
+            </p>
+        </section>
+
+
+
+    </body>
+
+</html>

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -626,6 +626,9 @@
 						to the description of structural semantics of written works.</li>
 					<li>EPUB 3 Text-to-Speech Enhancements 1.0 [[epub-tts-10]]: describes authoring features and reading
 						system support for improving the voicing of EPUB 3 publications. </li>
+					<li>EPUB Type to ARIA Role Authoring Guide 1.1 [[epub-aria-authoring-11]]: provides guidance for
+						publishers looking to move from the use of the EPUB 3 epub:type attribute to ARIA roles for
+						accessibility.</li>
 				</ul>
 			</section>
 		</section>


### PR DESCRIPTION
The new index page aims at replacing the `https://www.w3.org/publishing/epub32/` page and will be redirected to from `https://www.w3.org/publishing/epub3/` once the Recommendation is published. It provides a one stop URL for all EPUB 3 documents officially published on /TR.

The PR also includes an addition to the Overview Note; the reference to the latest note on ARIA mapping was missing...