### PR TITLE
Changed the reference to MO

### DIFF
--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -281,8 +281,7 @@
 								<p>Ensuring that, when an ebook contains audio in addition to text, it then provides
 									synchronised text and audio</p>
 							</blockquote>
-
-							<p>The audio synched to text feature is called <a data-cite="epub-a11y-11#sec-mo">media
+							<p>The audio synched to text feature is called <a data-cite="epub-33#sec-media-overlays">media
 									overlays</a> in the EPUB world and it provides an effective synchronization between
 								text and audio.</p>
 						</section>


### PR DESCRIPTION
It pointed to an erronous (read: non-existing) fragment ID in the A11 spec; changed it to the relevant section in the core spec.