### PR TITLE
Fix errata link text

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility Techniques 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
@@ -97,7 +98,8 @@
 						"href": "https://www.w3.org/TR/WCAG2/",
 						"publisher": "W3C"
 					}
-				}
+				},
+				postProcess: [fixErrataField]
 			};</script>
 		<style>
 			pre {

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/data-test-display.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
@@ -106,7 +107,7 @@
 					}
 				},
 				preProcess:[inlineCustomCSS],
-				postProcess: [data_test_display],
+				postProcess: [data_test_display, fixErrataField],
 				otherLinks: [
 					{
 						key: "This document is also available in this non-normative format:",

--- a/epub33/common/js/fix-errata.js
+++ b/epub33/common/js/fix-errata.js
@@ -1,0 +1,18 @@
+
+function fixErrataField() {
+	
+	var errataLink = 'https://w3c.github.io/epub-specs/epub33/errata.html';
+	
+	var errataField = document.querySelector('div.head > details > dl > dd > a[href="' + errataLink + '"]');
+	
+	if (!errataField) {
+		console.log('Errata field not found. Unable to repair link.');
+	}
+	
+	else {
+		errataField.innerHTML = errataLink;
+		
+		// remove trailing period
+		errataField.parentNode.innerHTML = errataField.parentNode.innerHTML.replace(/\.\s*$/,'');
+	}
+}

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5,6 +5,7 @@
 		<title>EPUB 3.3</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="./biblio.js" class="remove"></script>
+		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/add-caution-hd.js" class="remove"></script>
 		<script src="../common/js/data-test-display.js" class="remove"></script>
@@ -53,7 +54,7 @@
                 },
                 localBiblio: biblio,
                 preProcess:[inlineCustomCSS],
-                postProcess:[addCautionHeaders,data_test_display],
+                postProcess:[addCautionHeaders, data_test_display, fixErrataField],
                 testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
                 lint: {
                      "wpt-tests-exist": true,

--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB Accessibility - EU Accessibility Act Mapping</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
@@ -40,7 +41,8 @@
 				github: {
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
-				}
+				},
+				postProcess: [removeEmptyIndex,fixErrataField]
 			};
 		</script>
 		<style>

--- a/epub33/epub-a11y-eaa-mapping/index.html
+++ b/epub33/epub-a11y-eaa-mapping/index.html
@@ -42,7 +42,7 @@
 					repoURL: "https://github.com/w3c/epub-specs",
 					branch: "main"
 				},
-				postProcess: [removeEmptyIndex,fixErrataField]
+				postProcess: [fixErrataField]
 			};
 		</script>
 		<style>

--- a/epub33/epub-aria-authoring/index.html
+++ b/epub33/epub-aria-authoring/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB Type to ARIA Role Authoring Guide 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer="defer"></script>
+		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
@@ -46,7 +47,8 @@
 						"url": "https://www.w3.org/TR/wai-aria/",
 						"publisher": "W3C"
 					}
-				}
+				},
+				postProcess: [removeEmptyIndex,fixErrataField]
 			};
 		</script>
 		<style>

--- a/epub33/epub-aria-authoring/index.html
+++ b/epub33/epub-aria-authoring/index.html
@@ -48,7 +48,7 @@
 						"publisher": "W3C"
 					}
 				},
-				postProcess: [removeEmptyIndex,fixErrataField]
+				postProcess: [removeEmptyIndex]
 			};
 		</script>
 		<style>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -71,7 +71,7 @@
 					specs: ["epub-rs-33","epub-33"]
 				},
                 preProcess:[inlineCustomCSS],
-				postProcess: [removeEmptyIndex,fixErrataField]
+				postProcess: [fixErrataField]
             };//]]>
       </script>
 	</head>

--- a/epub33/multi-rend/index.html
+++ b/epub33/multi-rend/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB 3 Multiple-Rendition Publications 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
@@ -69,7 +70,8 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-                preProcess:[inlineCustomCSS]
+                preProcess:[inlineCustomCSS],
+				postProcess: [removeEmptyIndex,fixErrataField]
             };//]]>
       </script>
 	</head>

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -50,7 +50,7 @@
 				},
 				localBiblio: biblio,
 				preProcess:[inlineCustomCSS],
-				postProcess: [removeEmptyIndex,fixErrataField]
+				postProcess: [fixErrataField]
 			};</script>
 	</head>
 	<body>

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -50,7 +50,7 @@
 				},
 				localBiblio: biblio,
 				preProcess:[inlineCustomCSS],
-				postProcess: [fixErrataField]
+				postProcess: [removeEmptyIndex,fixErrataField]
 			};</script>
 	</head>
 	<body>

--- a/epub33/overview/index.html
+++ b/epub33/overview/index.html
@@ -6,6 +6,7 @@
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="./biblio.js" class="remove"></script>
 		<script src="../common/js/add-caution-hd.js" class="remove"></script>
+		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/remove-empty-index.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
@@ -49,7 +50,7 @@
 				},
 				localBiblio: biblio,
 				preProcess:[inlineCustomCSS],
-				postProcess: [removeEmptyIndex]
+				postProcess: [removeEmptyIndex,fixErrataField]
 			};</script>
 	</head>
 	<body>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB Reading Systems 3.3</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/data-test-display.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
@@ -108,7 +109,7 @@
 					},
 				},
 				preProcess:[inlineCustomCSS],
-				postProcess: [data_test_display],
+				postProcess: [data_test_display, fixErrataField],
 				testSuiteURI: "https://w3c.github.io/epub-tests/index.html",
 				lint: {
 					"wpt-tests-exist": true,

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB 3 Structural Semantics Vocabulary 1.1</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
+		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
@@ -92,7 +93,8 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-				preProcess:[inlineCustomCSS]
+				preProcess:[inlineCustomCSS],
+				postProcess: [removeEmptyIndex,fixErrataField]
 			};//]]>
 		</script>
 		<style>

--- a/epub33/ssv/index.html
+++ b/epub33/ssv/index.html
@@ -94,7 +94,7 @@
 					specs: ["epub-rs-33","epub-33"]
 				},
 				preProcess:[inlineCustomCSS],
-				postProcess: [removeEmptyIndex,fixErrataField]
+				postProcess: [fixErrataField]
 			};//]]>
 		</script>
 		<style>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8" />
 		<title>EPUB 3 Text-to-Speech Enhancements 1.0</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer=""></script>
+		<script src="../common/js/fix-errata.js" class="remove"></script>
 		<script src="../common/js/css-inline.js" class="remove"></script>
 		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
@@ -53,7 +54,8 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33","epub-33"]
 				},
-				preProcess:[inlineCustomCSS]
+				preProcess:[inlineCustomCSS],
+				postProcess: [removeEmptyIndex,fixErrataField]
 			};//]]>
 		</script>
 	</head>

--- a/epub33/tts/index.html
+++ b/epub33/tts/index.html
@@ -55,7 +55,7 @@
 					specs: ["epub-rs-33","epub-33"]
 				},
 				preProcess:[inlineCustomCSS],
-				postProcess: [removeEmptyIndex,fixErrataField]
+				postProcess: [fixErrataField]
 			};//]]>
 		</script>
 	</head>


### PR DESCRIPTION
This code changes the errata links from "Errata exists" to the URL to the errata file.

Ideally, we'll be able to strip this code whenever https://github.com/w3c/respec/issues/4446 is resolved, but all the live notes currently say errata exists for them.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2562.html" title="Last updated on May 19, 2023, 12:35 PM UTC (06ff243)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2562/497f245...06ff243.html" title="Last updated on May 19, 2023, 12:35 PM UTC (06ff243)">Diff</a>