### PR TITLE
Added a redirect function to the index page

### DIFF
--- a/epub33/index-page/index.html
+++ b/epub33/index-page/index.html
@@ -5,6 +5,30 @@
         <meta charset="utf-8" />
         <title>EPUB 3.3</title>
         <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+        <script>
+            const specs = [
+                "epub-33",
+                "epub-a11y-11",
+                "epub-a11y-eaa-mapping",
+                "epub-a11y-tech-11",
+                "epub-aria-authoring-11",
+                "epub-multi-rend-11",
+                "epub-overview-33",
+                "epub-rs-33",
+                "epub-ssv-11",
+                "epub-tts-10"
+            ];
+            function redirect() {
+                const ref = window.location.hash;
+                if (ref.length > 0 && ref.startsWith('#')) {
+                    const spec_ref = ref.slice(1);
+                    if (specs.includes(spec_ref)) {
+                        const tr = `https://www.w3.org/TR/${spec_ref}/`;
+                        window.location.replace(tr);
+                    }
+                }
+            }
+        </script>
         <script class="remove">
             var respecConfig = {
                 latestVersion: "https://www.w3.org/publishing/epub33/",
@@ -30,6 +54,7 @@
                     }
                 ],
                 processVersion: 2020,
+                preProcess:[redirect],
                 includePermalinks: true,
                 permalinkEdge: true,
                 permalinkHide: false,


### PR DESCRIPTION
At makes it possible to redirect (through the .htaccess trick), e.g.

`https://www.w3.org/publishing/epub33/epub-33` to `https://www.w3.org/TR/epub-33`

Just as

`https://www.w3.org/publishing/epub32/epub-contentdocs` went to the relevant 32 spec.