### PR TITLE
Add "none" as conformance option

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1209,22 +1209,36 @@
 							Recommendation</a>.</p>
 					</div>
 
-					<div class="note">
+					<section class="informative">
+						<h5>Other conformance claims</h5>
+
 						<p>The requirement to include a <code>dcterms:conformsTo</code> identifer does not prevent EPUB
 							publications from conforming to other standards, including other accessibility standards and
 							guidelines (e.g., a specification that covers specific natural language issues). An EPUB
-							publication may have multiple <code>dcterms:conformsTo</code> statements.</p>
+							publication can have multiple <code>dcterms:conformsTo</code> statements.</p>
 
-						<p>EPUB creators may also use a conformance URL, as defined in the <a
+						<p>For example, if an EPUB publication only meets WCAG conformance requirements (i.e., does not
+							fully conform to this specification), EPUB creators can add a <code>conformsTo</code>
+							property with a conformance URL defined in the <a
 								href="https://www.w3.org/TR/WCAG/#conformance-required">Required Components of a
-								Conformance Claim</a> [[wcag2]], with the <code>conformsTo</code> property for EPUB
-							publications that only meet WCAG conformance requirements (i.e., that do not fully conform
-							to this specification).</p>
+								Conformance Claim</a> [[wcag2]].</p>
 
-						<p>As [[wcag2]] does not define how to specify the conformance level in the URL, however, EPUB
-							creators will have to find an alternative means of relating this information when necessary
-							(e.g., through the accessibility summary).</p>
-					</div>
+						<div class="note">
+							<p>As [[wcag2]] does not define how to specify the conformance level in the URL, EPUB
+								creators will have to find an alternative means of relating this information when
+								necessary (e.g., through the accessibility summary).</p>
+						</div>
+
+						<p>Conversely, EPUB creators might need to indicate that an EPUB publication does not meet any
+							accessibility standards (e.g., in order to claim an exemption). In these cases, they can use
+							a <code>dcterms:conformsTo</code> property with value "<code>none</code>".</p>
+
+						<div class="note">
+							<p>For more information about claiming exemptions, refer to <a
+									href="https://www.w3.org/TR/epub-a11y-exemption">The EPUB Accessibility
+										<code>exemption</code> property</a> [[epub-a11y-exemption]].</p>
+						</div>
+					</section>
 				</section>
 
 				<section id="sec-conf-reporting-eval">
@@ -1973,7 +1987,6 @@
 				</ul>
 			</section>
 		</section>
-		<div data-include="../common/acknowledgements-a11y-dedication.html"  data-include-replace="true"
-		></div>
+		<div data-include="../common/acknowledgements-a11y-dedication.html" data-include-replace="true"></div>
 	</body>
 </html>

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -1218,8 +1218,8 @@
 							publication can have multiple <code>dcterms:conformsTo</code> statements.</p>
 
 						<p>For example, if an EPUB publication only meets WCAG conformance requirements (i.e., does not
-							fully conform to this specification), EPUB creators can add a <code>conformsTo</code>
-							property with a conformance URL defined in the <a
+							fully conform to this specification), EPUB creators can add a
+								<code>dcterms:conformsTo</code> property with a conformance URL defined in the <a
 								href="https://www.w3.org/TR/WCAG/#conformance-required">Required Components of a
 								Conformance Claim</a> [[wcag2]].</p>
 


### PR DESCRIPTION
This pull request adds text on using "none" as a value of a dcterms:conformsTo property when a publication does not meet accessibility standards.

This fits into the existing note about claiming conformance to WCAG or other standards, as I don't think we should try to write a normative requirement for something we can't enforce. Adding to that note would make it very large, however. Instead, I've changed the note into an informative subsection called "Other accessibility claims".

(Hopefully, changing an informative note to an informative section also keeps us in the scope of a class 2 change rather than a class 3.)

I was also able to work in a link to the exemption property we're defining in the other pull request, but we'll have to publish that first to make the reference valid.

I didn't add a change log entry, as I don't know if calling it a "substantive change" would trigger people to question the classification. Or at this stage do we need to document all changes in the logs @iherman?

Fixes #2569 