### PR TITLE
Clarify decimal values are allowed in viewport meta declarations

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1340,8 +1340,8 @@
 						<h5>HTML <code>audio</code> and <code>video</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-media">[=EPUB creators=] MUST NOT use embedded
-							[[html]]&#160;[=flow content=] within a <a data-cite="html#media-elements">media
-								element</a> (i.e, <a data-cite="html#the-audio-element"><code>audio</code></a> or <a
+							[[html]]&#160;[=flow content=] within a <a data-cite="html#media-elements">media element</a>
+							(i.e, <a data-cite="html#the-audio-element"><code>audio</code></a> or <a
 								data-cite="html#the-video-element"><code>video</code></a>) as an intrinsic fallback for
 							audio [=foreign resources=]. Only child [^source^] elements&#160;[[html]] provide intrinsic
 							fallback capabilities.</p>
@@ -7700,10 +7700,10 @@ No Entry</pre>
 								<ul>
 									<li>the <code>height</code>
 										<a href="#viewport.ebnf.property">property</a> MUST have as its <a
-											href="#viewport.ebnf.value">value</a> a positive number or the keyword
-											<code>device-height</code>; and</li>
-									<li>the <code>width</code> property MUST have as its value a positive number or the
-										keyword <code>device-width</code>.</li>
+											href="#viewport.ebnf.value">value</a> a positive decimal number or the
+										keyword <code>device-height</code>; and</li>
+									<li>the <code>width</code> property MUST have as its value a positive decimal number
+										or the keyword <code>device-width</code>.</li>
 								</ul>
 								<p>The <code>device-width</code> and <code>device-height</code> values refer to the 100%
 									of the width and height, respectively, of the reading system's [=viewport=].</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -7700,10 +7700,12 @@ No Entry</pre>
 								<ul>
 									<li>the <code>height</code>
 										<a href="#viewport.ebnf.property">property</a> MUST have as its <a
-											href="#viewport.ebnf.value">value</a> a positive decimal number or the
-										keyword <code>device-height</code>; and</li>
-									<li>the <code>width</code> property MUST have as its value a positive decimal number
-										or the keyword <code>device-width</code>.</li>
+											href="#viewport.ebnf.value">value</a> a positive <a
+											data-cite="css2/syndata.html#numbers">number</a> [[css2]] or the keyword
+											<code>device-height</code>; and</li>
+									<li>the <code>width</code> property MUST have as its value a positive <a
+											data-cite="css2/syndata.html#numbers">number</a> [[css2]] or the keyword
+											<code>device-width</code>.</li>
 								</ul>
 								<p>The <code>device-width</code> and <code>device-height</code> values refer to the 100%
 									of the width and height, respectively, of the reading system's [=viewport=].</p>

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1666,14 +1666,16 @@
 								be treated as invalid.</p>
 							<p id="confreq-fxl-rs-xhtml-icb_invalid_meta" data-tests="#lay-fxl-xhtml-icb_invalid_meta">
 								Reading systems SHOULD attempt to extract <code>width</code> and <code>height</code>
-								values from a <code>viewport meta</code> tag even if its syntax is invalid. </p>
+								values from a <code>viewport meta</code> tag even if its syntax is invalid.</p>
 							<p id="confreq-fxl-rs-xhtml-icb_repeated-in-meta"
-								data-tests="#lay-fxl-xhtml-icb_repeated-in-meta"> Reading systems MUST use the first
+								data-tests="#lay-fxl-xhtml-icb_repeated-in-meta">Reading systems MUST use the first
 								declaration of a <code>width</code> and <code>height</code> property in a <code>viewport
-									meta</code> tag (i.e., ignore repeated declarations). </p>
-							<p> If the <code>viewport meta</code> does not contain a width or a height value, or if
+									meta</code> tag (i.e., ignore repeated declarations).</p>
+							<p id="confreq-fxl-rs-xhtml-icb-fractional">Reading systems MAY ignore fractional values in
+								the width or height values and use only the whole number.</p>
+							<p>If the <code>viewport meta</code> does not contain a width or a height value, or if
 								these values are invalid, reading systems MAY supply the values. For example, a reading
-								system may: </p>
+								system may:</p>
 							<ul>
 								<li>consider these as having the values <code>device-width</code> and
 										<code>device-height</code>, respectively; or</li>
@@ -2493,13 +2495,12 @@
 					the validation steps that usually occur. This could include running virus scans, validating external
 					links and remote resources, and other precautions.</p>
 
-				<p id="security-privacy-recommendations-sideloaded-consent" 
-					data-tests="#sec-untrusted-consent_network,#sec-untrusted-consent_scripting">Reading systems 
-					SHOULD treat content from any new source, including from an integrated bookstore, as insecure 
-					(e.g., prompt users to allow scripting and network access the first time the source is accessed).
-					If a reading system allows users to load their own content (e.g., through the process 
-					of "sideloading"), each instance SHOULD be treated as insecure.
-				</p>
+				<p id="security-privacy-recommendations-sideloaded-consent"
+					data-tests="#sec-untrusted-consent_network,#sec-untrusted-consent_scripting">Reading systems SHOULD
+					treat content from any new source, including from an integrated bookstore, as insecure (e.g., prompt
+					users to allow scripting and network access the first time the source is accessed). If a reading
+					system allows users to load their own content (e.g., through the process of "sideloading"), each
+					instance SHOULD be treated as insecure. </p>
 
 				<p>When processing XML documents, a reading system SHOULD NOT resolve <a data-cite="xml#NT-ExternalID"
 						>external identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[xml]]. Reading systems

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1666,14 +1666,14 @@
 								be treated as invalid.</p>
 							<p id="confreq-fxl-rs-xhtml-icb_invalid_meta" data-tests="#lay-fxl-xhtml-icb_invalid_meta">
 								Reading systems SHOULD attempt to extract <code>width</code> and <code>height</code>
-								values from a <code>viewport meta</code> tag even if its syntax is invalid.</p>
+								values from a <code>viewport meta</code> tag even if its syntax is invalid. </p>
 							<p id="confreq-fxl-rs-xhtml-icb_repeated-in-meta"
-								data-tests="#lay-fxl-xhtml-icb_repeated-in-meta">Reading systems MUST use the first
+								data-tests="#lay-fxl-xhtml-icb_repeated-in-meta"> Reading systems MUST use the first
 								declaration of a <code>width</code> and <code>height</code> property in a <code>viewport
-									meta</code> tag (i.e., ignore repeated declarations).</p>
-							<p>If the <code>viewport meta</code> does not contain a width or a height value, or if
+									meta</code> tag (i.e., ignore repeated declarations). </p>
+							<p> If the <code>viewport meta</code> does not contain a width or a height value, or if
 								these values are invalid, reading systems MAY supply the values. For example, a reading
-								system may:</p>
+								system may: </p>
 							<ul>
 								<li>consider these as having the values <code>device-width</code> and
 										<code>device-height</code>, respectively; or</li>
@@ -2493,12 +2493,13 @@
 					the validation steps that usually occur. This could include running virus scans, validating external
 					links and remote resources, and other precautions.</p>
 
-				<p id="security-privacy-recommendations-sideloaded-consent"
-					data-tests="#sec-untrusted-consent_network,#sec-untrusted-consent_scripting">Reading systems SHOULD
-					treat content from any new source, including from an integrated bookstore, as insecure (e.g., prompt
-					users to allow scripting and network access the first time the source is accessed). If a reading
-					system allows users to load their own content (e.g., through the process of "sideloading"), each
-					instance SHOULD be treated as insecure. </p>
+				<p id="security-privacy-recommendations-sideloaded-consent" 
+					data-tests="#sec-untrusted-consent_network,#sec-untrusted-consent_scripting">Reading systems 
+					SHOULD treat content from any new source, including from an integrated bookstore, as insecure 
+					(e.g., prompt users to allow scripting and network access the first time the source is accessed).
+					If a reading system allows users to load their own content (e.g., through the process 
+					of "sideloading"), each instance SHOULD be treated as insecure.
+				</p>
 
 				<p>When processing XML documents, a reading system SHOULD NOT resolve <a data-cite="xml#NT-ExternalID"
 						>external identifiers</a> in DOCTYPE, ENTITY and NOTATION declarations [[xml]]. Reading systems

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -1671,8 +1671,6 @@
 								data-tests="#lay-fxl-xhtml-icb_repeated-in-meta">Reading systems MUST use the first
 								declaration of a <code>width</code> and <code>height</code> property in a <code>viewport
 									meta</code> tag (i.e., ignore repeated declarations).</p>
-							<p id="confreq-fxl-rs-xhtml-icb-fractional">Reading systems MAY ignore fractional values in
-								the width or height values and use only the whole number.</p>
 							<p>If the <code>viewport meta</code> does not contain a width or a height value, or if
 								these values are invalid, reading systems MAY supply the values. For example, a reading
 								system may:</p>


### PR DESCRIPTION
Adds links to CSS2 definition of "number" for the viewport height and width.

Fixes #2557


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2573.html" title="Last updated on Jul 20, 2023, 7:24 PM UTC (72c568a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2573/0dd3160...72c568a.html" title="Last updated on Jul 20, 2023, 7:24 PM UTC (72c568a)">Diff</a>