### PR TITLE
Clarify epub:type use and restrictions on svgs

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -91,7 +91,9 @@
 			<p>This specification defines the authoring requirements for [=EPUB publications=] and represents the third
 				major revision of the standard.</p>
 		</section>
-		<section id="sotd" class="updateable-rec"></section>
+		<section id="sotd" class="updateable-rec">
+			<p class="proposed correction">Proposed corrections are marked in the document.</p>
+		</section>
 		<section id="sec-introduction">
 			<h2>Introduction</h2>
 
@@ -5971,19 +5973,44 @@ No Entry</pre>
 						data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L910,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 						<h5>Embedded SVG</h5>
 
-						<p>[=XHTML content documents=] support the embedding of SVG:</p>
+						<div class="proposed correction" id="change_1">
+							<span class="marker">Proposed Correction 1</span>
+							<p data-cite="svg2">The current section does not clearly indicate that an SVG embedded by
+								reference is already required to be a conforming SVG content document (not a document
+								fragment) or that its requirements are defined in section 6.2. The only unique case here
+								is embedding by inclusion, as the [^svg^] element embedded in the HTML markup, although
+								a document fragment, still has to conform to the restrictions for SVG content documents.
+								This change breaks out the two cases to better explain these requirements. For more
+								information, refer to <a href="https://github.com/w3c/epub-specs/issues/2555">issue
+									2555</a>.</p>
+						</div>
 
-						<ul>
-							<li id="sec-xhtml-svg-reference"><em>by reference</em> &#8212; for example, from an [[html]]
-								[^img^] or [^object^] element. SVGs embedded by reference are <a href="#cmt-svg">SVG
-									core media types</a> so their requirements are already defined in <a href="#sec-svg"
-								></a>.</li>
-							<li id="sec-xhtml-svg-inclusion"><em>by inclusion</em> &#8212; via direct inclusion of an <a
+						<p>[=XHTML content documents=] support the embedding of <del cite="#change_1"><a
 									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
-									fragment</a> [[svg]] in an XHTML content document. SVGs embedded by inclusion have
-								the same content conformance constraints as those defined for [=SVG content documents=]
-								in <a href="#sec-svg-restrictions"></a>.</li>
-						</ul>
+									fragments</a> [[svg]] <em>by reference</em> (embedding via reference, for example,
+								from an <code>img</code> or <code>object</code> element) and <em>by inclusion</em>
+								(embedding via direct inclusion of the <code>svg</code> element in the XHTML content
+								document).</del><ins cite="#change_1">SVG:</ins></p>
+
+						<del cite="#change_1">
+							<p>The content conformance constraints for SVG embedded in XHTML content documents are the
+								same as defined for [=SVG content documents=] in <a href="#sec-svg-restrictions"
+								></a>.</p>
+						</del>
+
+						<ins cite="#change_1">
+							<ul>
+								<li id="sec-xhtml-svg-reference"><em>by reference</em> &#8212; for example, from an
+									[[html]] [^img^] or [^object^] element. SVGs embedded by reference are <a
+										href="#cmt-svg">SVG core media types</a> so their requirements are already
+									defined in <a href="#sec-svg"></a>.</li>
+								<li id="sec-xhtml-svg-inclusion"><em>by inclusion</em> &#8212; via direct inclusion of
+									an <a href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG
+										document fragment</a> [[svg]] in an XHTML content document. SVGs embedded by
+									inclusion have the same content conformance constraints as those defined for [=SVG
+									content documents=] in <a href="#sec-svg-restrictions"></a>.</li>
+							</ul>
+						</ins>
 
 						<div class="note">
 							<p>The <a href="#svg"><code>svg</code> property</a> of the [=EPUB manifest | manifest=]
@@ -6068,10 +6095,47 @@ No Entry</pre>
 					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L33,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L41,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L47,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 					<h4>SVG requirements</h4>
 
-					<p id="confreq-cd-svg-docprops-schema">An [=SVG content document=] MUST be a <a
-							href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles">conforming SVG
-							stand-alone file</a> [[svg]] and conform to all content conformance constraints expressed in
-							<a href="#sec-svg-restrictions"></a>.</p>
+					<div class="proposed correction" id="change_2">
+						<span class="marker">Proposed Correction 2</span>
+						<p data-cite="svg2">SVG already allows foreign-namespaced attributes to be used anywhere. The
+							two "MAY" bullets in the current text that allow the <code>epub:</code> namespaced
+							attributes are consequently not real requirements and are removed. That the attributes are
+							allowed on SVGs is now a note in the next section on the content model restrictions (see <a
+								href="#change_3">proposed correction 3</a>), as that is where the restriction in the
+							second bullet on what elements the <code>epub:type</code> attribute is allowed is moved. For
+							more information, refer to <a href="https://github.com/w3c/epub-specs/issues/2555">issue
+								2555</a>.</p>
+					</div>
+
+					<p id="confreq-cd-svg-docprops-schema">An [=SVG content document=]<del cite="#change_2">:</del>
+						<ins cite="#change_2">MUST be a <a
+								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles">conforming
+								SVG stand-alone file</a> [[svg]] and conform to all content conformance constraints
+							expressed in <a href="#sec-svg-restrictions"></a>.</ins></p>
+
+					<del cite="#change_2">
+						<ul class="conformance-list">
+							<li>
+								<p>MUST be a <a
+										href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles"
+										>conforming SVG stand-alone file</a> [[svg]] and conform to all content
+									conformance constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
+							</li>
+							<li>
+								<p>MAY include the [^/epub:type^] attribute for expressing <a
+										href="#app-structural-semantics">structural semantics</a>. When specified, the
+									attribute MUST only be included on <a
+										href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement"
+										>structural</a>, <a
+										href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
+										href="https://www.w3.org/TR/SVG11/text.html">text</a> elements [[svg]].</p>
+							</li>
+							<li>
+								<p id="confreq-svg-vocab-assoc">MAY include all applicable <a href="#sec-vocab-assoc"
+										>vocabulary association mechanisms</a>.</p>
+							</li>
+						</ul>
+					</del>
 
 					<div class="note">
 						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
@@ -6113,30 +6177,54 @@ No Entry</pre>
 							<p id="confreq-svg-title" data-cite="svg">If the [[svg]] [^title^] element contains
 								marked-up text, the markup MUST contain only elements declared in the <a
 									data-cite="infra#html-namespace">HTML namespace</a> [[infra]].</p>
-							<div class="note">
-								<p>Although the [[svg]] <code>title</code> element allows markup elements, support for
-									this feature is limited. [=EPUB creators=] are advised to use text-only titles for
-									maximum interoperability.</p>
-							</div>
+							<ins cite="#change_3">
+								<div class="note">
+									<p>Although the [[svg]] <code>title</code> element allows markup elements, support
+										for this feature is limited. [=EPUB creators=] are advised to use text-only
+										titles for maximum interoperability.</p>
+								</div>
+							</ins>
 						</li>
 						<li>
-							<p id="confreq-svg-structural-semantics">When specified, the [^/epub:type^] attribute MUST
-								only be included on <a
-									href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
-									<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
-									href="https://www.w3.org/TR/SVG11/text.html">text</a> elements [[svg]].</p>
-							<div class="note">
-								<p>The SVG content model allows authors to <a data-cite="svg#ForeignNamespaces">include
-										namespaced attributes</a>, so this specification does not need to allow the
-									[^/epub:type^] attribute or <a href="#sec-vocab-assoc">vocabulary association
-										mechanisms</a>.</p>
-								<p>One key difference between SVGs embedded by reference and by inclusion, however, is
-									that SVGs embedded by inclusion cannot have an <a href="#sec-prefix-attr"
-											><code>epub:prefix</code></a> attribute on their root [^svg^] element
-									[[svg]]. For more information, refer to <a href="#sec-prefix-attr"></a>.</p>
+							<div class="proposed correction" id="change_3">
+								<span class="marker">Proposed Correction 3</span>
+								<p>This correction adds the restriction on where the <code>epub:type</code> attribute is
+									allowed (refer to <a href="#change_2">proposed correction 2</a> for its former
+									placement). Moving the restriction into this section also makes it applicable to
+									SVGs embedded by inclusion in HTML documents, a requirement that was not clearly
+									established when the restriction was in the preceding section. For more information,
+									refer to <a href="https://github.com/w3c/epub-specs/issues/2555">issue 2555</a>.</p>
+								<p data-cite="svg2">This correction also addresses the list of elements the
+									[^/epub:type^] attribute is allowed on. The current list (see <a href="#change_2"
+										>proposed correction 2</a>) does not allow the attribute on the SVG [^a^]
+									element. The text is corrected to use the [[svg2]] definition of a renderable
+									element to avoid the problem of missing elements when selecting more granular
+									element classes. For more information, refer to <a
+										href="https://github.com/w3c/epub-specs/issues/2556">issue 2556</a>.</p>
 							</div>
+							<ins cite="#change_3">
+								<p id="confreq-svg-structural-semantics">When specified, the [^/epub:type^] attribute
+									MUST only be included on [=renderable elements=] [[svg]].</p>
+								<div class="note">
+									<p>The SVG content model allows authors to <a data-cite="svg#ForeignNamespaces"
+											>include namespaced attributes</a>, so this specification does not need to
+										allow the [^/epub:type^] attribute or <a href="#sec-vocab-assoc">vocabulary
+											association mechanisms</a>.</p>
+									<p>One key difference between SVGs embedded by reference and by inclusion, however,
+										is that SVGs embedded by inclusion cannot have an <a href="#sec-prefix-attr"
+												><code>epub:prefix</code></a> attribute on their root [^svg^] element
+										[[svg]]. For more information, refer to <a href="#sec-prefix-attr"></a>.</p>
+								</div>
+							</ins>
 						</li>
 					</ul>
+					<del cite="#change_3">
+						<div class="note">
+							<p>Although the [[svg]] <code>title</code> element allows markup elements, support for this
+								feature is limited. [=EPUB creators=] are advised to use text-only titles for maximum
+								interoperability.</p>
+						</div>
+					</del>
 				</section>
 			</section>
 
@@ -11884,26 +11972,36 @@ EPUB/images/cover.png</pre>
 			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
-					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> — those that affect the
-				conformance of [=EPUB publications=] or are similarly noteworthy.</p>
+					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> — those that may affect the
+				conformance of [=EPUB publications=].</p>
 
-			<p>For a list of all issues addressed during the revision, refer to the <a
+			<p>For a list of all issues addressed, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+-label%3ASpec-RS+"
 					>Working Group's issue tracker</a>.</p>
 
-			<section id="change-latest">
-				<h3>Substantive changes since <a href="https://www.w3.org/TR/2023/CR-epub-33-20230221/">Candidate
-						Recommendation</a> of 2023-02-21</h3>
+			<details id="changes-from-rec-20230523" open="">
+				<summary>Substantive changes since <a href="https://www.w3.org/TR/2023/REC-epub-33-20230525/"
+						>Recommendation</a> of 2023-05-25</summary>
+				<ul>
+					<li>25-July-2023: Updated where the <code>epub:type</code> is allowed on SVGs to use the definition
+						of a renderable element. See <a href="https://github.com/w3c/epub-specs/issues/2556">issue
+							2556</a>. </li>
+				</ul>
+			</details>
+
+			<details id="change-from-last-cr">
+				<summary>Substantive changes since <a href="https://www.w3.org/TR/2023/CR-epub-33-20230221/">Candidate
+						Recommendation</a> of 2023-02-21</summary>
 				<ul>
 					<li> 17-March-2023: replaced the deprecated JavaScript attribute <code>name</code> by
 							<code>hasFeature</code> in an example. See <a
 							href="https://github.com/w3c/epub-specs/issues/2543">issue 2543</a>. </li>
 				</ul>
-			</section>
-			<section id="change-previous-cr">
-				<h3>Substantive changes since <a href="https://www.w3.org/TR/2022/CR-epub-33-20220512/">Candidate
-						Recommendation</a> of 2022-05-12</h3>
+			</details>
 
+			<details id="change-previous-cr">
+				<summary>Substantive changes since <a href="https://www.w3.org/TR/2022/CR-epub-33-20220512/">Candidate
+						Recommendation</a> of 2022-05-12</summary>
 				<ul>
 					<li>11-Jan-2023: Marked the <code>dir</code> attribute under-implemented due to lack of support in
 						reading systems. See <a href="https://github.com/w3c/epub-specs/pull/2515">pull request
@@ -11995,11 +12093,11 @@ EPUB/images/cover.png</pre>
 					<li>17-May-2022: Added an index of terms. See <a
 							href="https://github.com/w3c/epub-specs/issues/2260">issue 2260</a>.</li>
 				</ul>
-			</section>
+			</details>
 
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub32/">EPUB 3.2</a></h3>
-
+			<details id="changes-older">
+				<summary>Substantive changes since <a href="https://www.w3.org/publishing/epub32/">EPUB
+					3.2</a></summary>
 				<ul>
 					<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and
 						updated the list of semantics to use for escaping to match the guidance. See <a
@@ -12254,7 +12352,7 @@ EPUB/images/cover.png</pre>
 						and Media Overlays specifications. A separate document, EPUB Reading Systems 3.3, consolidates
 						the reading system requirements from those documents.</li>
 				</ul>
-			</section>
+			</details>
 		</section>
 		<div data-include="../common/acknowledgements-dedication.html" data-include-replace="true"></div>
 	</body>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5971,7 +5971,7 @@ No Entry</pre>
 						data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L910,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 						<h5>Embedded SVG</h5>
 
-						<p>[=XHTML content documents=] support the embedding SVG:</p>
+						<p>[=XHTML content documents=] support the embedding of SVG:</p>
 
 						<ul>
 							<li id="sec-xhtml-svg-reference"><em>by reference</em> &#8212; for example, from an [[html]]
@@ -5985,19 +5985,10 @@ No Entry</pre>
 								in <a href="#sec-svg-restrictions"></a>.</li>
 						</ul>
 
-						<p>Although the XHTML content document definition allows the use of the [^/epub:type^] attribute
-							on [^svg^] elements, the attribute's <a href="#confreq-svg-structural-semantics">use is
-								restricted</a> within an included SVG in the same way as for SVG content documents.</p>
-
-						<div class="note">
-							<p>The <a href="#sec-prefix-attr"><code>prefix</code> attribute</a> is only allowed on the
-								root [^html^] element for SVG embedded by inclusion.</p>
-						</div>
-
 						<div class="note">
 							<p>The <a href="#svg"><code>svg</code> property</a> of the [=EPUB manifest | manifest=]
 								[^item^] element indicates that an XHTML content document contains embedded SVG (either
-								by reference or inclusion).</p>
+								by reference or by inclusion).</p>
 						</div>
 					</section>
 
@@ -6077,28 +6068,11 @@ No Entry</pre>
 					data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L33,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L41,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-svg.feature_L47,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 					<h4>SVG requirements</h4>
 
-					<p>An [=SVG content document=]:</p>
+					<p id="confreq-cd-svg-docprops-schema">An [=SVG content document=] MUST be a <a
+							href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles">conforming SVG
+							stand-alone file</a> [[svg]] and conform to all content conformance constraints expressed in
+							<a href="#sec-svg-restrictions"></a>.</p>
 
-					<ul class="conformance-list">
-						<li>
-							<p id="confreq-cd-svg-docprops-schema">MUST be a <a
-									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGStandAloneFiles"
-									>conforming SVG stand-alone file</a> [[svg]] and conform to all content conformance
-								constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
-						</li>
-						<li>
-							<p id="confreq-svg-structural-semantics">MAY include the [^/epub:type^] attribute for
-								expressing <a href="#app-structural-semantics">structural semantics</a>. When specified,
-								the attribute MUST only be included on <a
-									href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
-									<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
-									href="https://www.w3.org/TR/SVG11/text.html">text</a> elements [[svg]].</p>
-						</li>
-						<li>
-							<p id="confreq-svg-vocab-assoc">MAY include all applicable <a href="#sec-vocab-assoc"
-									>vocabulary association mechanisms</a>.</p>
-						</li>
-					</ul>
 					<div class="note">
 						<p>The recommendation that [=EPUB publications=] follow the accessibility requirements in
 							[[epub-a11y-11]] applies to SVG content documents. See <a href="#confreq-a11y"
@@ -6139,13 +6113,30 @@ No Entry</pre>
 							<p id="confreq-svg-title" data-cite="svg">If the [[svg]] [^title^] element contains
 								marked-up text, the markup MUST contain only elements declared in the <a
 									data-cite="infra#html-namespace">HTML namespace</a> [[infra]].</p>
+							<div class="note">
+								<p>Although the [[svg]] <code>title</code> element allows markup elements, support for
+									this feature is limited. [=EPUB creators=] are advised to use text-only titles for
+									maximum interoperability.</p>
+							</div>
+						</li>
+						<li>
+							<p id="confreq-svg-structural-semantics">When specified, the [^/epub:type^] attribute MUST
+								only be included on <a
+									href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
+									<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
+									href="https://www.w3.org/TR/SVG11/text.html">text</a> elements [[svg]].</p>
+							<div class="note">
+								<p>The SVG content model allows authors to <a data-cite="svg#ForeignNamespaces">include
+										namespaced attributes</a>, so this specification does not need to allow the
+									[^/epub:type^] attribute or <a href="#sec-vocab-assoc">vocabulary association
+										mechanisms</a>.</p>
+								<p>One key difference between SVGs embedded by reference and by inclusion, however, is
+									that SVGs embedded by inclusion cannot have an <a href="#sec-prefix-attr"
+											><code>epub:prefix</code></a> attribute on their root [^svg^] element
+									[[svg]]. For more information, refer to <a href="#sec-prefix-attr"></a>.</p>
+							</div>
 						</li>
 					</ul>
-					<div class="note">
-						<p>Although the [[svg]] <code>title</code> element allows markup elements, support for this
-							feature is limited. [=EPUB creators=] are advised to use text-only titles for maximum
-							interoperability.</p>
-					</div>
 				</section>
 			</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5981,7 +5981,7 @@ No Entry</pre>
 								their requirements are already defined in <a href="#sec-svg"></a>.</li>
 							<li><em>by inclusion</em> &#8212; via direct inclusion of an [^svg^] element in an XHTML
 								content document. SVGs embedded by inclusion have the same content conformance
-								constraints as those defined for [=SVG content documents=], as defined in <a
+								constraints as those defined for [=SVG content documents=] in <a
 									href="#sec-svg-restrictions"></a>.</li>
 						</ul>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1340,8 +1340,8 @@
 						<h5>HTML <code>audio</code> and <code>video</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-media">[=EPUB creators=] MUST NOT use embedded
-							[[html]]&#160;[=flow content=] within a <a data-cite="html#media-elements">media
-								element</a> (i.e, <a data-cite="html#the-audio-element"><code>audio</code></a> or <a
+							[[html]]&#160;[=flow content=] within a <a data-cite="html#media-elements">media element</a>
+							(i.e, <a data-cite="html#the-audio-element"><code>audio</code></a> or <a
 								data-cite="html#the-video-element"><code>video</code></a>) as an intrinsic fallback for
 							audio [=foreign resources=]. Only child [^source^] elements&#160;[[html]] provide intrinsic
 							fallback capabilities.</p>
@@ -5973,16 +5973,31 @@ No Entry</pre>
 
 						<p>[=XHTML content documents=] support the embedding of <a
 								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
-								fragments</a> [[svg]] <em>by reference</em> (embedding via reference, for example, from
-							an <code>img</code> or <code>object</code> element) and <em>by inclusion</em> (embedding via
-							direct inclusion of the <code>svg</code> element in the XHTML content document).</p>
+								fragments</a> [[svg]]:</p>
 
-						<p>The content conformance constraints for SVG embedded in XHTML content documents are the same
-							as defined for [=SVG content documents=] in <a href="#sec-svg-restrictions"></a>.</p>
+						<ul>
+							<li><em>by reference</em> &#8212; for example, from an [[html]] [^img^] or [^object^]
+								element. SVGs embedded by reference are <a href="#cmt-svg">SVG core media types</a> so
+								their requirements are already defined in <a href="#sec-svg"></a>.</li>
+							<li><em>by inclusion</em> &#8212; via direct inclusion of an [^svg^] element in an XHTML
+								content document. SVGs embedded by inclusion have the same content conformance
+								constraints as those defined for [=SVG content documents=], as defined in <a
+									href="#sec-svg-restrictions"></a>.</li>
+						</ul>
+
+						<p>Although the XHTML content document definition allows the use of the [^/epub:type^] attribute
+							on [^svg^] elements, the attribute's <a href="#confreq-svg-structural-semantics">use is
+								restricted</a> within an included SVG in the same way as for SVG content documents.</p>
+
+						<div class="note">
+							<p>The <a href="#sec-prefix-attr"><code>prefix</code> attribute</a> is only allowed on the
+								root [^html^] element for SVG embedded by inclusion.</p>
+						</div>
 
 						<div class="note">
 							<p>The <a href="#svg"><code>svg</code> property</a> of the [=EPUB manifest | manifest=]
-								[^item^] element indicates that an XHTML content document contains embedded SVG.</p>
+								[^item^] element indicates that an XHTML content document contains embedded SVG (either
+								by reference or inclusion).</p>
 						</div>
 					</section>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -5971,18 +5971,18 @@ No Entry</pre>
 						data-tests="https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L910,https://w3c.github.io/epub-structural-tests/#06-content-document_content-document-xhtml.feature_L923">
 						<h5>Embedded SVG</h5>
 
-						<p>[=XHTML content documents=] support the embedding of <a
-								href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
-								fragments</a> [[svg]]:</p>
+						<p>[=XHTML content documents=] support the embedding SVG:</p>
 
 						<ul>
-							<li><em>by reference</em> &#8212; for example, from an [[html]] [^img^] or [^object^]
-								element. SVGs embedded by reference are <a href="#cmt-svg">SVG core media types</a> so
-								their requirements are already defined in <a href="#sec-svg"></a>.</li>
-							<li><em>by inclusion</em> &#8212; via direct inclusion of an [^svg^] element in an XHTML
-								content document. SVGs embedded by inclusion have the same content conformance
-								constraints as those defined for [=SVG content documents=] in <a
-									href="#sec-svg-restrictions"></a>.</li>
+							<li id="sec-xhtml-svg-reference"><em>by reference</em> &#8212; for example, from an [[html]]
+								[^img^] or [^object^] element. SVGs embedded by reference are <a href="#cmt-svg">SVG
+									core media types</a> so their requirements are already defined in <a href="#sec-svg"
+								></a>.</li>
+							<li id="sec-xhtml-svg-inclusion"><em>by inclusion</em> &#8212; via direct inclusion of an <a
+									href="https://www.w3.org/TR/SVG/conform.html#ConformingSVGXMLFragments">SVG document
+									fragment</a> [[svg]] in an XHTML content document. SVGs embedded by inclusion have
+								the same content conformance constraints as those defined for [=SVG content documents=]
+								in <a href="#sec-svg-restrictions"></a>.</li>
 						</ul>
 
 						<p>Although the XHTML content document definition allows the use of the [^/epub:type^] attribute
@@ -6111,7 +6111,8 @@ No Entry</pre>
 					<h4>Restrictions on SVG</h4>
 
 					<p>This specification restricts the content model of [=SVG content documents=] and <a
-							href="#sec-xhtml-svg">SVG embedded in XHTML content documents</a> as follows:</p>
+							href="#sec-xhtml-svg-inclusion">SVG embedded by inclusion in XHTML content documents</a> as
+						follows:</p>
 
 					<ul class="conformance-list">
 						<li>
@@ -6123,9 +6124,9 @@ No Entry</pre>
 									<p id="confreq-svg-foreignObject-xhtml-content">MUST contain either [[html]] [=flow
 										content=] or exactly one [[html]] <a data-cite="html#the-body-element"
 												><code>body</code></a> element.</p>
-									<p class="note">In the case of <a href="#sec-xhtml-svg">embedded SVGs</a>, a
-											<code>body</code> element is not permitted per the <a data-cite="html#svg-0"
-											>restrictions on SVG</a> defined in [[html]].</p>
+									<p class="note">In the case of <a href="#sec-xhtml-svg-inclusion">SVGs embedded by
+											inclusion</a>, a <code>body</code> element is not permitted per the <a
+											data-cite="html#svg-0">restrictions on SVG</a> defined in [[html]].</p>
 								</li>
 								<li>
 									<p id="confreq-svg-foreignObject-xhtml-frag">MUST contain a valid document fragment
@@ -10251,8 +10252,8 @@ html.my-document-playing * {
 &lt;/html&gt;</pre>
 					</div>
 
-					<p>Note that for <a href="#sec-xhtml-svg">embedded SVG</a>, prefixes MUST be declared on the
-						[[html]] root [^html^] element.</p>
+					<p>Note that for <a href="#sec-xhtml-svg-inclusion">SVG embedded by inclusion</a>, prefixes MUST be
+						declared on the [[html]] root [^html^] element.</p>
 
 					<p>To avoid conflicts, EPUB creators MUST NOT use the <code>prefix</code> attribute to declare a
 						prefix that maps to a <a href="#sec-default-vocab">default vocabulary</a>.</p>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11986,6 +11986,9 @@ EPUB/images/cover.png</pre>
 					<li>25-July-2023: Updated where the <code>epub:type</code> is allowed on SVGs to use the definition
 						of a renderable element. See <a href="https://github.com/w3c/epub-specs/issues/2556">issue
 							2556</a>. </li>
+					<li>25-July-2023: Clarified the definitions of embedded SVGs and moved the restriction on where the
+							<code>epub:type</code> attribute is allowed to apply so it applies to all SVG definitions.
+						See <a href="https://github.com/w3c/epub-specs/issues/2555">issue 2555</a>. </li>
 				</ul>
 			</details>
 

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -11980,7 +11980,7 @@ EPUB/images/cover.png</pre>
 					>Working Group's issue tracker</a>.</p>
 
 			<details id="changes-from-rec-20230523" open="">
-				<summary>Substantive changes since <a href="https://www.w3.org/TR/2023/REC-epub-33-20230525/"
+				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2023/REC-epub-33-20230525/"
 						>Recommendation</a> of 2023-05-25</summary>
 				<ul>
 					<li>25-July-2023: Updated where the <code>epub:type</code> is allowed on SVGs to use the definition
@@ -11993,8 +11993,8 @@ EPUB/images/cover.png</pre>
 			</details>
 
 			<details id="change-from-last-cr">
-				<summary>Substantive changes since <a href="https://www.w3.org/TR/2023/CR-epub-33-20230221/">Candidate
-						Recommendation</a> of 2023-02-21</summary>
+				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2023/CR-epub-33-20230221/"
+						>Candidate Recommendation</a> of 2023-02-21</summary>
 				<ul>
 					<li> 17-March-2023: replaced the deprecated JavaScript attribute <code>name</code> by
 							<code>hasFeature</code> in an example. See <a
@@ -12003,8 +12003,8 @@ EPUB/images/cover.png</pre>
 			</details>
 
 			<details id="change-previous-cr">
-				<summary>Substantive changes since <a href="https://www.w3.org/TR/2022/CR-epub-33-20220512/">Candidate
-						Recommendation</a> of 2022-05-12</summary>
+				<summary>Substantive changes since the <a href="https://www.w3.org/TR/2022/CR-epub-33-20220512/"
+						>Candidate Recommendation</a> of 2022-05-12</summary>
 				<ul>
 					<li>11-Jan-2023: Marked the <code>dir</code> attribute under-implemented due to lack of support in
 						reading systems. See <a href="https://github.com/w3c/epub-specs/pull/2515">pull request


### PR DESCRIPTION
This largely implements the text in https://github.com/w3c/epub-specs/issues/2555#issuecomment-1630989881 but I tried to further clean up the section to make it more readable.

The big difference is I split the embedding definitions out into a list and included the requirements for each in the bullets. The definitions were hard to read in a single paragraph and having the requirements follow them made the section sound jumpy.

It also makes the fix in issue #2555 to allow the `epub:type` attribute on renderable elements.

Fixes #2555
Fixes #2556


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2574.html" title="Last updated on Aug 8, 2023, 9:01 PM UTC (0d07401)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2574/0dd3160...0d07401.html" title="Last updated on Aug 8, 2023, 9:01 PM UTC (0d07401)">Diff</a>