### PR TITLE
Use definition of renderable elements for svg epub:type restriction

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -91,7 +91,9 @@
 			<p>This specification defines the authoring requirements for [=EPUB publications=] and represents the third
 				major revision of the standard.</p>
 		</section>
-		<section id="sotd" class="updateable-rec"></section>
+		<section id="sotd" class="updateable-rec">
+			<p class="proposed correction">Proposed corrections are marked in the document.</p>
+		</section>
 		<section id="sec-introduction">
 			<h2>Introduction</h2>
 
@@ -6072,9 +6074,22 @@ No Entry</pre>
 								constraints expressed in <a href="#sec-svg-restrictions"></a>.</p>
 						</li>
 						<li>
+							<div class="proposed correction" id="change_1">
+								<span class="marker">Proposed Correction 1</span>
+								<p data-cite="svg2">The current list of elements does not allow the [^/epub:type^]
+									attribute on the SVG [^a^] element. The proposed correction uses the SVG2 definition
+									of a renderable element to avoid the problem of missing elements when selecting more
+									granular element classes. For more information, refer to <a
+										href="https://github.com/w3c/epub-specs/issues/2556">issue 2556</a>.</p>
+							</div>
 							<p id="confreq-svg-structural-semantics">MAY include the [^/epub:type^] attribute for
 								expressing <a href="#app-structural-semantics">structural semantics</a>. When specified,
-								the attribute MUST only be included on [=renderable elements=] [[svg]].</p>
+								the attribute MUST only be included on <del cite="#change_1"><a
+										href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement"
+										>structural</a>, <a
+										href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
+										href="https://www.w3.org/TR/SVG11/text.html">text</a> elements</del>
+								<ins cite="#change_1">[=renderable elements=]</ins> [[svg]].</p>
 						</li>
 						<li>
 							<p id="confreq-svg-vocab-assoc">MAY include all applicable <a href="#sec-vocab-assoc"
@@ -11874,26 +11889,36 @@ EPUB/images/cover.png</pre>
 			<h2>Change log</h2>
 
 			<p>Note that this change log only identifies substantive changes since <a
-					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> — those that affect the
-				conformance of [=EPUB publications=] or are similarly noteworthy.</p>
+					href="https://www.w3.org/publishing/epub/epub-spec.html">EPUB 3.2</a> — those that may affect the
+				conformance of [=EPUB publications=].</p>
 
-			<p>For a list of all issues addressed during the revision, refer to the <a
+			<p>For a list of all issues addressed, refer to the <a
 					href="https://github.com/w3c/epub-specs/issues?q=is%3Aissue+is%3Aclosed+label%3AEPUB33+-label%3ASpec-RS+"
 					>Working Group's issue tracker</a>.</p>
 
-			<section id="change-latest">
-				<h3>Substantive changes since <a href="https://www.w3.org/TR/2023/CR-epub-33-20230221/">Candidate
-						Recommendation</a> of 2023-02-21</h3>
+			<details id="changes-from-rec-20230523" open="">
+				<summary>Substantive changes since <a href="https://www.w3.org/TR/2023/REC-epub-33-20230525/"
+						>Recommendation</a> of 2023-05-25</summary>
+				<ul>
+					<li>25-July-2023: Updated where the <code>epub:type</code> is allowed on SVGs to use the definition
+						of a renderable element. See <a href="https://github.com/w3c/epub-specs/issues/2556">issue
+							2556</a>. </li>
+				</ul>
+			</details>
+
+			<details id="change-from-last-cr">
+				<summary>Substantive changes since <a href="https://www.w3.org/TR/2023/CR-epub-33-20230221/">Candidate
+						Recommendation</a> of 2023-02-21</summary>
 				<ul>
 					<li> 17-March-2023: replaced the deprecated JavaScript attribute <code>name</code> by
 							<code>hasFeature</code> in an example. See <a
 							href="https://github.com/w3c/epub-specs/issues/2543">issue 2543</a>. </li>
 				</ul>
-			</section>
-			<section id="change-previous-cr">
-				<h3>Substantive changes since <a href="https://www.w3.org/TR/2022/CR-epub-33-20220512/">Candidate
-						Recommendation</a> of 2022-05-12</h3>
+			</details>
 
+			<details id="change-previous-cr">
+				<summary>Substantive changes since <a href="https://www.w3.org/TR/2022/CR-epub-33-20220512/">Candidate
+						Recommendation</a> of 2022-05-12</summary>
 				<ul>
 					<li>11-Jan-2023: Marked the <code>dir</code> attribute under-implemented due to lack of support in
 						reading systems. See <a href="https://github.com/w3c/epub-specs/pull/2515">pull request
@@ -11985,11 +12010,11 @@ EPUB/images/cover.png</pre>
 					<li>17-May-2022: Added an index of terms. See <a
 							href="https://github.com/w3c/epub-specs/issues/2260">issue 2260</a>.</li>
 				</ul>
-			</section>
+			</details>
 
-			<section id="changes-older">
-				<h3>Substantive changes since <a href="https://www.w3.org/publishing/epub32/">EPUB 3.2</a></h3>
-
+			<details id="changes-older">
+				<summary>Substantive changes since <a href="https://www.w3.org/publishing/epub32/">EPUB
+					3.2</a></summary>
 				<ul>
 					<li>12-Apr-2022: Added note about complexities of escaping from nested escapable structures and
 						updated the list of semantics to use for escaping to match the guidance. See <a
@@ -12244,7 +12269,7 @@ EPUB/images/cover.png</pre>
 						and Media Overlays specifications. A separate document, EPUB Reading Systems 3.3, consolidates
 						the reading system requirements from those documents.</li>
 				</ul>
-			</section>
+			</details>
 		</section>
 		<div data-include="../common/acknowledgements-dedication.html" data-include-replace="true"></div>
 	</body>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1340,8 +1340,8 @@
 						<h5>HTML <code>audio</code> and <code>video</code> fallbacks</h5>
 
 						<p id="confreq-resources-cd-fallback-media">[=EPUB creators=] MUST NOT use embedded
-							[[html]]&#160;[=flow content=] within a <a data-cite="html#media-elements">media
-								element</a> (i.e, <a data-cite="html#the-audio-element"><code>audio</code></a> or <a
+							[[html]]&#160;[=flow content=] within a <a data-cite="html#media-elements">media element</a>
+							(i.e, <a data-cite="html#the-audio-element"><code>audio</code></a> or <a
 								data-cite="html#the-video-element"><code>video</code></a>) as an intrinsic fallback for
 							audio [=foreign resources=]. Only child [^source^] elements&#160;[[html]] provide intrinsic
 							fallback capabilities.</p>
@@ -6074,10 +6074,7 @@ No Entry</pre>
 						<li>
 							<p id="confreq-svg-structural-semantics">MAY include the [^/epub:type^] attribute for
 								expressing <a href="#app-structural-semantics">structural semantics</a>. When specified,
-								the attribute MUST only be included on <a
-									href="https://www.w3.org/TR/SVG11/intro.html#TermStructuralElement">structural</a>,
-									<a href="https://www.w3.org/TR/SVG11/intro.html#TermShapeElement">shape</a>, or <a
-									href="https://www.w3.org/TR/SVG11/text.html">text</a> elements [[svg]].</p>
+								the attribute MUST only be included on [=renderable elements=] [[svg]].</p>
 						</li>
 						<li>
 							<p id="confreq-svg-vocab-assoc">MAY include all applicable <a href="#sec-vocab-assoc"


### PR DESCRIPTION
Fixes #2556


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2575.html" title="Last updated on Jul 25, 2023, 4:33 PM UTC (6f92b72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2575/0dd3160...6f92b72.html" title="Last updated on Jul 25, 2023, 4:33 PM UTC (6f92b72)">Diff</a>