### PR TITLE
Change respec metadata to PM working group

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -11,8 +11,8 @@
 		<script class="remove">
 			var respecConfig = {
 				subtitle: "Conformance and Discoverability Requirements for EPUB publications",
-				group: "epub",
-				wgPublicList: "public-epub3",
+				group: "pm",
+                wgPublicList: "public-pm-wg",
 				specStatus: "ED",
 				shortName: "epub-a11y-11",
 				edDraftURI: "https://w3c.github.io/epub-specs/epub33/a11y/",

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -17,11 +17,9 @@
 				shortName: "epub-a11y-11",
 				edDraftURI: "https://w3c.github.io/epub-specs/epub33/a11y/",
                 implementationReportURI: "https://w3c.github.io/epub-specs/epub33/reports/",
-                crEnd: "2023-03-21",
-                prEnd: "2023-05-15",
-                previousPublishDate: "2021-07-12",
+                previousPublishDate: "2023-05-25",
 				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
-                previousMaturity: "PR",
+                previousMaturity: "REC",
                 copyrightStart: "2017",
 				editors:[ {
 					name: "Matt Garrish",

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -61,7 +61,7 @@
 					profile: "web-platform",
 					specs: ["epub-rs-33"]
 				},
-				otherLinks: [
+				/* otherLinks: [
 					{
 						key: "This document is also available in this non-normative format:",
 						data: [
@@ -71,7 +71,7 @@
 							}
 						]
 					}
-				]
+				] */
             };//]]>
 		</script>
 		<style>

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -19,10 +19,8 @@
                 shortName: "epub-33",
                 edDraftURI: "https://w3c.github.io/epub-specs/epub33/core/",
                 implementationReportURI: "https://w3c.github.io/epub-specs/epub33/reports/",
-                crEnd: "2023-03-21",
-                prEnd: "2023-05-15",
-                previousPublishDate: "2021-07-12",
-                previousMaturity: "PR",
+                previousPublishDate: "2023-05-25",
+                previousMaturity: "REC",
 				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
                 copyrightStart: "1999",
                 editors:[

--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -13,8 +13,8 @@
 		<script class="remove">
 			//<![CDATA[
             var respecConfig = {
-                group: "epub",
-                wgPublicList: "public-epub-wg",
+                group: "pm",
+                wgPublicList: "public-pm-wg",
                 specStatus: "ED",
                 shortName: "epub-33",
                 edDraftURI: "https://w3c.github.io/epub-specs/epub33/core/",

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -11,16 +11,14 @@
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
-				group: "epub",
-				wgPublicList: "public-epub-wg",
+				group: "pm",
+				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
 				shortName: "epub-rs-33",
 				edDraftURI: "https://w3c.github.io/epub-specs/epub33/rs/",
                 implementationReportURI: "https://w3c.github.io/epub-specs/epub33/reports/",
-                crEnd: "2023-03-21",
-                prEnd: "2023-05-15",
-				previousPublishDate: "2021-07-12",
-                previousMaturity: "PR",
+				previousPublishDate: "2023-05-25",
+                previousMaturity: "REC",
 				errata: "https://w3c.github.io/epub-specs/epub33/errata.html",
 				copyrightStart: "1999",
 				editors: [ 


### PR DESCRIPTION
As the title says.

Do we also want to republish the RS spec at the same time just to update the group info?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2577.html" title="Last updated on Aug 9, 2023, 10:06 AM UTC (53748b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2577/0dd3160...53748b4.html" title="Last updated on Aug 9, 2023, 10:06 AM UTC (53748b4)">Diff</a>