### PR TITLE
Remove the temp entry for the exemption property

### DIFF
--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -84,15 +84,6 @@
 						"date": "05 January 2017",
 						"publisher": "IDPF"
 					},
-					"epub-a11y-exemption": {
-						"title": "The EPUB Accessibility exemption property",
-						"href": "https://w3c.github.io/epub-specs/epub33/a11y-exemption/",
-						"editors": [
-							"Matt Garrish",
-							"Gregorio Pellegrino"
-						],
-						"publisher": "W3C"
-					},
 					"marc21": {
 						"title": "MARC 21 XML",
 						"href": "https://www.loc.gov/standards/marcxml/"		


### PR DESCRIPTION
Opening so I don't forget to remove this later.

Not to be merged until after we publish the note and specref picks up the new reference.