### PR TITLE
Add links to wcag level definitions

### DIFF
--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -268,8 +268,8 @@
 					<li><code>textual</code> &#8212; setting this value indicates that the publication is screen-reader
 						friendly (i.e., all the content is available for text-to-speech rendering by an assistive
 						technology). EPUB creators can set this value for EPUB publications that conform to [[WCAG2]] <a
-							href="https://www.w3.org/TR/WCAG2/#cc1">Level A</a> or higher, for example, as there must be
-						textual alternatives for non-text content to meet these thresholds.</li>
+							href="https://www.w3.org/TR/WCAG2/#cc1_A">Level A</a> or higher, for example, as there must
+						be textual alternatives for non-text content to meet these thresholds.</li>
 					<li><code>auditory</code> &#8212; setting this value indicates that pre-recorded audio is available
 						for the publication. EPUB creators can set this value for EPUB publications that provide media
 						overlays for all the content.</li>
@@ -1592,10 +1592,10 @@
 					<h4>Use Unicode for text content</h4>
 
 					<p>[[wcag2]] <a data-cite="wcag2#non-text-content">Success Criterion 1.1.1</a> requires that text
-						equivalents be provided for all non-text content to meet Level A. In some regions (e.g., Asia),
-						it is not uncommon to find images of individual text characters, despite the availability of
-						Unicode character equivalents. This practice occurs for various reasons, such as ease of
-						translation of older documents and for compatibility across <a
+						equivalents be provided for all non-text content to meet <a data-cite="wcag2#cc1_A">Level A</a>.
+						In some regions (e.g., Asia), it is not uncommon to find images of individual text characters,
+						despite the availability of Unicode character equivalents. This practice occurs for various
+						reasons, such as ease of translation of older documents and for compatibility across <a
 							href="https://www.w3.org/TR/epub/#dfn-epub-reading-system">reading systems</a>. The use of
 						images in most instances leads to the text not being accessible to non-visual users,
 						however.</p>
@@ -1609,9 +1609,9 @@
 					<p>The use of Unicode characters for all text content avoids this problem, allowing content to
 						successfully meet the minimum requirement for Level A.</p>
 
-					<p>For compliance with Level AA, EPUB creators are directed to <a data-cite="wcag2#images-of-text"
-							>Success Criterion 1.4.5</a> which further restricts the use of images of text to only a set
-						of essential cases.</p>
+					<p>For compliance with <a data-cite="wcag2#cc1_AA">Level AA</a>, EPUB creators are directed to <a
+							data-cite="wcag2#images-of-text">Success Criterion 1.4.5</a> which further restricts the use
+						of images of text to only a set of essential cases.</p>
 				</section>
 			</section>
 

--- a/epub33/a11y-tech/index.html
+++ b/epub33/a11y-tech/index.html
@@ -8,8 +8,8 @@
 		<script src="../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			var respecConfig = {
-				group: "epub",
-				wgPublicList: "public-epub-wg",
+				group: "pm",
+				wgPublicList: "public-pm-wg",
 				specStatus: "ED",
 				shortName: "epub-a11y-tech-11",
 				noRecTrack: true,

--- a/epub33/a11y/index.html
+++ b/epub33/a11y/index.html
@@ -474,13 +474,13 @@
 
 						<li>
 							<p id="confreq-wcag-a">MUST, for whichever version of WCAG 2 selected, meet the requirements
-								of Level A, but it is strongly recommended that it meet the requirements of Level
-								AA.</p>
+								of <a data-cite="wcag2#cc1_A">Level A</a>, but it is strongly recommended that it meet
+								the requirements of <a data-cite="wcag2#cc1_AA">Level AA</a>.</p>
 							<div class="note">
-								<p>Although conforming at level AAA is not required by this specification, <a
-										href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB creators</a> are
-									encouraged to follow the practices detailed in AAA success criteria when producing
-									accessible EPUB publications.</p>
+								<p>Although conforming at <a data-cite="wcag2#cc1_AAA">level AAA</a> is not required by
+									this specification, <a href="https://www.w3.org/TR/epub/#dfn-epub-creator">EPUB
+										creators</a> are encouraged to follow the practices detailed in AAA success
+									criteria when producing accessible EPUB publications.</p>
 							</div>
 						</li>
 					</ul>


### PR DESCRIPTION
Adds `a` tags to the references in the Accessibility and Techniques documents and fixes a link that only referenced the parent section.

Fixes #2589 

- [Accessibility preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/link-wcag-levels/epub33/a11y/index.html)
- [Accessibility diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/link-wcag-levels/epub33/a11y/index.html)
- [Techniques preview](https://cdn.statically.io/gh/w3c/epub-specs/a11y/link-wcag-levels/epub33/a11y-tech/index.html)
- [Techniques diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://w3c.github.io/epub-specs/epub33/a11y-tech/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://cdn.statically.io/gh/w3c/epub-specs/a11y/link-wcag-levels/epub33/a11y-tech/index.html)

Edit: Fixed the broken diff links from the first post.