### PR TITLE
Replace references to obsolete rfc7230 with rfc9110

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -1445,7 +1445,7 @@
 					users access to the entire presentation regardless of connectivity status.</p>
 
 				<p>When resources have to be located outside the EPUB container, EPUB creators are RECOMMENDED to
-					reference them via the secure <code>https</code> URI scheme [rfc7230] to limit the threat of
+					reference them via the secure <code>https</code> URI scheme [[rfc9110]] to limit the threat of
 					exposing their publications, and users, to network attacks. [=Reading systems=] might not load
 					[=remote resources=] referenced using insecure schemes such as <code>http</code>.</p>
 

--- a/epub33/rs/index.html
+++ b/epub33/rs/index.html
@@ -342,7 +342,7 @@
 						data-cite="epub-33#sec-resource-locations">Resource locations</a> [[epub-33]].</p>
 
 				<p>To limit the risk of network attacks, reading systems SHOULD only load remote resources referenced
-					via the <code>https</code> URI scheme [[rfc7230]].</p>
+					via the <code>https</code> URI scheme [[rfc9110]].</p>
 			</section>
 
 			<section id="sec-epub-rs-conf-data-urls">


### PR DESCRIPTION
Fixes #2595


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2597.html" title="Last updated on Dec 6, 2023, 3:13 PM UTC (fb8e5c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2597/932fe2c...fb8e5c6.html" title="Last updated on Dec 6, 2023, 3:13 PM UTC (fb8e5c6)">Diff</a>