### PR TITLE
Add note and replace uri reference

### DIFF
--- a/epub33/core/index.html
+++ b/epub33/core/index.html
@@ -3836,8 +3836,16 @@
 							identifiers when making minor revisions such as updating metadata, fixing errata, or making
 							similar minor changes.</p>
 
-						<p>EPUB creators MAY specify additional identifiers. The identifiers should be fully qualified
-							URIs.</p>
+						<p>EPUB creators MAY specify additional identifiers.</p>
+
+						<div class="note">
+							<p>EPUB creators are advised to use <a
+									href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL strings</a>
+								[url] for identifiers whenever possible. The inclusion of a domain owned by the EPUB
+								creator can improve the uniqueness of the identifier, for example, while the use of a
+								URN with a <a href="https://datatracker.ietf.org/doc/html/rfc8141#section-2.1">namespace
+									identifier</a> [[rfc8141]] improves processing by reading systems.</p>
+						</div>
 
 						<p>EPUB creators MAY use the <a href="#identifier-type"><code>identifier-type</code>
 								property</a> to indicate that the value of a <code>dc:identifier</code> element conforms


### PR DESCRIPTION
This PR splits the sentence about using URIs for identifiers off into a separate note, fixes it to reference absolute-url strings, and adds some explanation for why these are preferable.

Looking at the Process document, clarifications of non-normative text - which is all this is - are called out in the class 2 description, so I think we're fine with the current issue categorization.

Fixes #2594


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/pull/2598.html" title="Last updated on Dec 7, 2023, 2:41 PM UTC (1315407)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/epub-specs/2598/932fe2c...1315407.html" title="Last updated on Dec 7, 2023, 2:41 PM UTC (1315407)">Diff</a>